### PR TITLE
xen: 4.20.4 -> 4.22.0

### DIFF
--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -121,6 +121,8 @@
 
 - `arti` has been updated to major version 2, which removed the long-deprecated `proxy.socks_port` and `proxy.dns_port` and the legacy syntax for specifying directory authorities. For more information, see the [changelog for 2.0.0](https://gitlab.torproject.org/tpo/core/arti/-/blob/arti-v2.0.0/CHANGELOG.md).
 
+- The OCaml-based Xen Store Daemon has been split off the `xen` package, and is now present in the `ocamlPackages.oxenstored` package.
+
 - `kanata` now requires `karabiner-dk` version 6.0+ or later.
   The package has been updated to use the new `karabiner-dk` package and the `darwinDriver` output stays at the version defined in the package.
 

--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -117,6 +117,8 @@
 
 - `gh-actions-cache` has been removed since its functionality has been integrated directly into `gh` (`gh cache`). See [upstream readme](https://github.com/actions/gh-actions-cache).
 
+- The OCaml-based Xen Store Daemon has been split off the `xen` package, and is now present in the `ocamlPackages.oxenstored` package.
+
 - `requireFile` now sets `meta.license = lib.licenses.unfree` by default. Users of `requireFile`-based derivations that preserve this default will need to explicitly allow their evaluation as described in [](#sec-allow-unfree).
 
 - `texlive.combine` is deprecated and scheduled for removal in 27.05. Please migrate to `texliveSmall.withPackages` (see [](#sec-language-texlive-user-guide)).

--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -160,6 +160,8 @@
 - `temporal` has been updated to the 1.31 release line. Always consult the [upstream upgrade
   notes](https://docs.temporal.io/self-hosted-guide/upgrade-server) before upgrading between versions.
 
+- The Xen Project Hypervisor has been [updated to version 4.22](https://wiki.xenproject.org/wiki/Xen_Project_4.22_Release_Notes), after [version 4.21](https://wiki.xenproject.org/wiki/Xen_Project_4.21_Release_Notes) was skipped in 26.05. The module now has a separate option to customise the OCaml-based Xen Store Daemon package, `virtualisation.xen.store.package`.
+
 - The `shell_interact()` function on interactive runs of NixOS VM tests has been deprecated. Use the SSH backdoor instead.
 
 - [services.netbox](#opt-services.netbox.enable) has received a number of updates:

--- a/nixos/modules/virtualisation/xen-dom0.nix
+++ b/nixos/modules/virtualisation/xen-dom0.nix
@@ -353,8 +353,8 @@ in
     store = {
       path = mkOption {
         type = path;
-        default = "${cfg.package}/bin/oxenstored";
-        defaultText = literalExpression "\${config.virtualisation.xen.package}/bin/oxenstored";
+        default = "${cfg.store.package}/bin/oxenstored";
+        defaultText = literalExpression "\${config.virtualisation.xen.store.package}/bin/oxenstored";
         example = literalExpression "\${config.virtualisation.xen.package}/bin/xenstored";
         description = ''
           Path to the Xen Store Daemon. This option is useful to
@@ -371,6 +371,12 @@ in
         internal = true;
         readOnly = true;
         description = "Helper internal option that determines the type of the Xen Store Daemon based on cfg.store.path.";
+      };
+      package = mkPackageOption pkgs [ "ocamlPackages" "oxenstored" ] {
+        extraDescription = ''
+          This is only used if the Xen Store Daemon being used is the newer OCaml-based store.
+          The legacy C-based store is always included.
+        '';
       };
       settings = mkOption {
         default = { };
@@ -794,7 +800,8 @@ in
       systemPackages = [
         cfg.package
         (hiPrio cfg.qemu.package)
-      ];
+      ]
+      ++ optional (cfg.store.type == "ocaml") (hiPrio cfg.store.package);
       etc =
         # Set up Xen Domain 0 configuration files.
         {

--- a/pkgs/by-name/xe/xen/0001-makefile-efi-output-directory.patch
+++ b/pkgs/by-name/xe/xen/0001-makefile-efi-output-directory.patch
@@ -1,20 +1,9 @@
-From 7f802ceac03252ad5182ee8c69ebb01da24a307c Mon Sep 17 00:00:00 2001
-From: Fernando Rodrigues <alpha@sigmasquadron.net>
-Date: Fri, 4 Jul 2025 18:07:01 +0000
-Subject: [PATCH 1/2] xen/Makefile: patch .efi output directory
-
-This is necessary so the build does not fail when Xen tries to install
-.efi files to $boot/efi/nixos and panics when the directory doesn't
-exist. It also has the benefit of installing the files in a location
-that is easier to access.
-
-Signed-off-by: Fernando Rodrigues <alpha@sigmasquadron.net>
-
 diff --git a/xen/Makefile b/xen/Makefile
-index 6bf0b0ea9e..907cd89f7e 100644
+index 37ca2e657e..53c897d233 100644
 --- a/xen/Makefile
 +++ b/xen/Makefile
-@@ -527,6 +527,6 @@ _install: $(TARGET)$(CONFIG_XEN_INSTALL_SUFFIX)
+@@ -537,8 +537,8 @@
+ 		if [ -n '$(EFI_MOUNTPOINT)' -a -n '$(EFI_VENDOR)' ]; then \
  			$(if $(efi-strip-opt), \
  			     $(STRIP) $(efi-strip-opt) -p -o $(TARGET).efi.stripped $(TARGET).efi && \
 -			     $(INSTALL_DATA) $(TARGET).efi.stripped $(D)$(EFI_MOUNTPOINT)/efi/$(EFI_VENDOR)/$(T)-$(XEN_FULLVERSION).efi ||) \
@@ -23,13 +12,13 @@ index 6bf0b0ea9e..907cd89f7e 100644
 +			$(INSTALL_DATA) $(TARGET).efi $(D)$(BOOT_DIR)/$(T)-$(XEN_FULLVERSION).efi; \
  		elif [ "$(D)" = "$(patsubst $(shell cd $(XEN_ROOT) && pwd)/%,%,$(D))" ]; then \
  			echo 'EFI installation only partially done (EFI_VENDOR not set)' >&2; \
-@@ -560,5 +560,5 @@ _uninstall:
+ 		fi; \
+@@ -570,7 +570,7 @@
+ 	rm -f $(D)$(EFI_DIR)/$(T)-$(XEN_VERSION).efi
  	rm -f $(D)$(EFI_DIR)/$(T).efi
  	if [ -n '$(EFI_MOUNTPOINT)' -a -n '$(EFI_VENDOR)' ]; then \
 -		rm -f $(D)$(EFI_MOUNTPOINT)/efi/$(EFI_VENDOR)/$(T)-$(XEN_FULLVERSION).efi; \
 +		rm -f $(D)$(BOOT_DIR)/$(T)-$(XEN_FULLVERSION).efi; \
  	fi
-
---
-2.49.0
-
+ 
+ .PHONY: _debug

--- a/pkgs/by-name/xe/xen/0001-makefile-efi-output-directory.patch
+++ b/pkgs/by-name/xe/xen/0001-makefile-efi-output-directory.patch
@@ -1,20 +1,9 @@
-From 7f802ceac03252ad5182ee8c69ebb01da24a307c Mon Sep 17 00:00:00 2001
-From: Fernando Rodrigues <alpha@sigmasquadron.net>
-Date: Fri, 4 Jul 2025 18:07:01 +0000
-Subject: [PATCH 1/2] xen/Makefile: patch .efi output directory
-
-This is necessary so the build does not fail when Xen tries to install
-.efi files to $boot/efi/nixos and panics when the directory doesn't
-exist. It also has the benefit of installing the files in a location
-that is easier to access.
-
-Signed-off-by: Fernando Rodrigues <alpha@sigmasquadron.net>
-
 diff --git a/xen/Makefile b/xen/Makefile
-index 6bf0b0ea9e..907cd89f7e 100644
+index 725f220ee6..b73a623b23 100644
 --- a/xen/Makefile
 +++ b/xen/Makefile
-@@ -527,6 +527,6 @@ _install: $(TARGET)$(CONFIG_XEN_INSTALL_SUFFIX)
+@@ -537,8 +537,8 @@
+ 		if [ -n '$(EFI_MOUNTPOINT)' -a -n '$(EFI_VENDOR)' ]; then \
  			$(if $(efi-strip-opt), \
  			     $(STRIP) $(efi-strip-opt) -p -o $(TARGET).efi.stripped $(TARGET).efi && \
 -			     $(INSTALL_DATA) $(TARGET).efi.stripped $(D)$(EFI_MOUNTPOINT)/efi/$(EFI_VENDOR)/$(T)-$(XEN_FULLVERSION).efi ||) \
@@ -23,13 +12,13 @@ index 6bf0b0ea9e..907cd89f7e 100644
 +			$(INSTALL_DATA) $(TARGET).efi $(D)$(BOOT_DIR)/$(T)-$(XEN_FULLVERSION).efi; \
  		elif [ "$(D)" = "$(patsubst $(shell cd $(XEN_ROOT) && pwd)/%,%,$(D))" ]; then \
  			echo 'EFI installation only partially done (EFI_VENDOR not set)' >&2; \
-@@ -560,5 +560,5 @@ _uninstall:
+ 		fi; \
+@@ -570,7 +570,7 @@
+ 	rm -f $(D)$(EFI_DIR)/$(T)-$(XEN_VERSION).efi
  	rm -f $(D)$(EFI_DIR)/$(T).efi
  	if [ -n '$(EFI_MOUNTPOINT)' -a -n '$(EFI_VENDOR)' ]; then \
 -		rm -f $(D)$(EFI_MOUNTPOINT)/efi/$(EFI_VENDOR)/$(T)-$(XEN_FULLVERSION).efi; \
 +		rm -f $(D)$(BOOT_DIR)/$(T)-$(XEN_FULLVERSION).efi; \
  	fi
-
---
-2.49.0
-
+ 
+ .PHONY: _debug

--- a/pkgs/by-name/xe/xen/0002-scripts-external-executable-calls.patch
+++ b/pkgs/by-name/xe/xen/0002-scripts-external-executable-calls.patch
@@ -1,70 +1,73 @@
-From 4893cc08acc81bfc2f8730ea108574aedae909aa Mon Sep 17 00:00:00 2001
-From: Fernando Rodrigues <alpha@sigmasquadron.net>
-Date: Fri, 4 Jul 2025 20:09:06 +0000
-Subject: [PATCH 2/2] xen/tools/hotplug/Linux: patch external binary calls
-
-This patch replaces all instances of executable calls and static FHS
-paths in the hotplug scripts with at-padded variables that can be
-replaced by replaceVars during a Nix build.
-
-Signed-off-by: Fernando Rodrigues <alpha@sigmasquadron.net>
-
 diff --git a/tools/hotplug/Linux/block b/tools/hotplug/Linux/block
 index 2691b56951..bd41313bf8 100644
 --- a/tools/hotplug/Linux/block
 +++ b/tools/hotplug/Linux/block
-@@ -1,5 +1,5 @@
+@@ -1,6 +1,6 @@
  #!/bin/bash
-
+ 
 -dir=$(dirname "$0")
 +dir=$(@dirname@ "$0")
  . "$dir/block-common.sh"
-
-@@ -32,5 +32,5 @@ find_free_loopback_helper() {
+ 
+ expand_dev() {
+@@ -31,7 +31,7 @@
+ # Not all distros have "losetup -f"
  find_free_loopback_dev() {
    local loopdev
 -  loopdev=$(losetup -a | sed -e 's+^/dev/loop++' -e 's/:.*//' | find_free_loopback_helper)
 +  loopdev=$(@losetup@  -a | @sed@ -e 's+^/dev/loop++' -e 's/:.*//' | find_free_loopback_helper)
    if [ -n "$loopdev" ] && [ -b "$loopdev" ]; then
      echo "$loopdev"
-@@ -67,6 +67,6 @@ check_sharing()
+   fi
+@@ -66,8 +66,8 @@
+   then
      local inode="$4"
-
+ 
 -    shared_list=$(losetup -a |
 -          sed -n -e "s@^\([^:]\+\)\(:[[:blank:]]\[0*${dev}\]:${inode}[[:blank:]](.*)\)@\1@p" )
 +    shared_list=$(@losetup@  -a |
 +          @sed@ -n -e "s@^\([^:]\+\)\(:[[:blank:]]\[0*${dev}\]:${inode}[[:blank:]](.*)\)@\1@p" )
      for dev in $shared_list
      do
-@@ -95,5 +95,5 @@ check_sharing()
+       if [ -n "$dev" ]
+@@ -94,7 +94,7 @@
+     toskip="^[^ ]* [^ ]* [^ ]* ro[, ]"
    fi
-
+ 
 -  for file in $(cat /proc/mounts | grep -v "$toskip" | cut -f 1 -d ' ')
 +  for file in $(@cat@ /proc/mounts | @grep@ -v "$toskip" | @cut@ -f 1 -d ' ')
    do
      if [ -e "$file" ]
-@@ -268,5 +268,5 @@ case "$command" in
+     then
+@@ -267,7 +267,7 @@
+ 
          if [ -L "$dev" ]
          then
 -          dev=$(readlink -f "$dev") || fatal "$dev link does not exist."
 +          dev=$(@readlink@ -f "$dev") || fatal "$dev link does not exist."
          fi
          test -e "$dev" || fatal "$dev does not exist."
-@@ -283,5 +283,5 @@ case "$command" in
+         test -b "$dev" || fatal "$dev is not a block device."
+@@ -282,7 +282,7 @@
+       file)
          # Canonicalise the file, for sharing check comparison, and the mode
          # for ease of use here.
 -        file=$(readlink -f "$p") || fatal "$p does not exist."
 +        file=$(@readlink@ -f "$p") || fatal "$p does not exist."
          test -f "$file" || fatal "$file does not exist."
          mode=$(canonicalise_mode "$mode")
-@@ -298,5 +298,5 @@ case "$command" in
+ 
+@@ -297,7 +297,7 @@
+           fatal "Path closed or removed during hotplug add: $XENBUS_PATH state: $xenbus_state"
          fi
-
+ 
 -        if [ "$mode" = 'w' ] && ! stat "$file" -c %A | grep -q w
 +        if [ "$mode" = 'w' ] && ! @stat@ "$file" -c %A | @grep@ -q w
          then
            release_lock "block"
-@@ -308,6 +308,6 @@ mount it read-write in a guest domain."
+           ebusy \
+@@ -307,8 +307,8 @@
+ 
          if [ "x$mode" != 'x!' ]
          then
 -          inode=$(stat -c '%i' "$file")
@@ -73,57 +76,68 @@ index 2691b56951..bd41313bf8 100644
 +          dev=$(@stat@ -c '%D' "$file")
            if [ -z "$inode" ] || [ -z "$dev" ]
            then
-@@ -318,5 +318,5 @@ mount it read-write in a guest domain."
+             fatal "Unable to lookup $file: dev: $dev inode: $inode"
+@@ -317,20 +317,20 @@
+           check_file_sharing "$file" "$dev" "$mode" "$inode"
          fi
-
+ 
 -        loopdev=$(losetup -f 2>/dev/null || find_free_loopback_dev)
 +        loopdev=$(@losetup@  -f 2>/dev/null || find_free_loopback_dev)
          if [ "$loopdev" = '' ]
          then
-@@ -325,5 +325,5 @@ mount it read-write in a guest domain."
+           release_lock "block"
+           fatal 'Failed to find an unused loop device'
          fi
-
+ 
 -        if LANG=C losetup -h 2>&1 | grep read-only >/dev/null
 +        if LANG=C @losetup@  -h 2>&1 | @grep@ read-only >/dev/null
          then
            roflag="-$mode"; roflag="${roflag#-w}"; roflag="${roflag#-!}"
-@@ -331,5 +331,5 @@ mount it read-write in a guest domain."
+         else
            roflag=''
          fi
 -        do_or_die losetup $roflag "$loopdev" "$file"
 +        do_or_die @losetup@  $roflag "$loopdev" "$file"
          xenstore_write "$XENBUS_PATH/node" "$loopdev"
          write_dev "$loopdev"
-@@ -355,5 +355,5 @@ mount it read-write in a guest domain."
+         release_lock "block"
+@@ -354,7 +354,7 @@
+       file)
          claim_lock "block"
          node=$(xenstore_read "$XENBUS_PATH/node")
 -	losetup -d "$node"
 +	@losetup@  -d "$node"
          release_lock "block"
  	exit 0
+ 	;;
 diff --git a/tools/hotplug/Linux/block-common.sh b/tools/hotplug/Linux/block-common.sh
 index 5c80237d99..5e1c350555 100644
 --- a/tools/hotplug/Linux/block-common.sh
 +++ b/tools/hotplug/Linux/block-common.sh
-@@ -16,5 +16,5 @@
-
-
+@@ -15,7 +15,7 @@
+ #
+ 
+ 
 -dir=$(dirname "$0")
 +dir=$(@dirname@ "$0")
  . "$dir/xen-hotplug-common.sh"
-
-@@ -46,5 +46,5 @@ ebusy()
+ 
+ findCommand "$@"
+@@ -45,7 +45,7 @@
+ # separated by a colon.
  device_major_minor()
  {
 -  stat -L -c %t:%T "$1"
 +  @stat@ -L -c %t:%T "$1"
  }
-
+ 
+ 
 diff --git a/tools/hotplug/Linux/block-drbd-probe b/tools/hotplug/Linux/block-drbd-probe
 index 7b2968b6d9..ba246cd132 100755
 --- a/tools/hotplug/Linux/block-drbd-probe
 +++ b/tools/hotplug/Linux/block-drbd-probe
-@@ -32,6 +32,6 @@ function get_res_name()
+@@ -31,8 +31,8 @@
+ function get_res_name()
  {
      local drbd_dev=$1
 -    local drbd_dev_list=($(drbdadm sh-dev all))
@@ -132,121 +146,138 @@ index 7b2968b6d9..ba246cd132 100755
 +    local drbd_res_list=($(@drbdadm@ sh-resource all))
      local temp_drbd_dev temp_drbd_res
      local found=0
-@@ -49,5 +49,5 @@ function get_res_name()
-
+ 
+@@ -48,7 +48,7 @@
+     fi
+ 
      for temp_drbd_res in ${drbd_res_list[@]}; do
 -        temp_drbd_dev=$(drbdadm sh-dev $temp_drbd_res)
 +        temp_drbd_dev=$(@drbdadm@ sh-dev $temp_drbd_res)
          if [[ "$temp_drbd_dev" == "$drbd_dev" ]]; then
              drbd_res="$temp_drbd_res"
-@@ -67,5 +67,5 @@ fi
-
+             return 0
+@@ -66,19 +66,19 @@
+ fi
+ 
  # check protocol
 -drbdsetup $1 show | grep -q "protocol D;"
 +@drbdsetup@ $1 show | @grep@ -q "protocol D;"
  if [[ $? -ne 0 ]]; then
      exit 3
-@@ -73,5 +73,5 @@ fi
-
+ fi
+ 
  # check connect status
 -state=$(drbdadm cstate "$drbd_res")
 +state=$(@drbdadm@ cstate "$drbd_res")
  if [[ "$state" != "Connected" ]]; then
      exit 4
-@@ -79,5 +79,5 @@ fi
-
+ fi
+ 
  # check role
 -role=$(drbdadm role "$drbd_res")
 +role=$(@drbdadm@ role "$drbd_res")
  if [[ "$role" != "Primary/Secondary" ]]; then
      exit 4
+ fi
 diff --git a/tools/hotplug/Linux/block-dummy b/tools/hotplug/Linux/block-dummy
 index 57d40b5fce..50bbf09bb6 100644
 --- a/tools/hotplug/Linux/block-dummy
 +++ b/tools/hotplug/Linux/block-dummy
-@@ -23,10 +23,10 @@
+@@ -22,12 +22,12 @@
+ #
  # script=block-dummy,vdev=xvda,target=dummy:<file>
-
+ 
 -dir=$(dirname "$0")
 +dir=$(@dirname@ "$0")
  . "$dir/block-common.sh"
-
+ 
  check_tools()
  {
 -    if ! command -v losetup > /dev/null 2>&1; then
 +    if ! command -v @losetup@  > /dev/null 2>&1; then
          fatal "Unable to find losetup"
      fi
-@@ -56,5 +56,5 @@ add()
+ }
+@@ -55,20 +55,20 @@
+ {
      test -f "$file" || fatal "$file does not exist."
-
+ 
 -    loopdev=$(losetup -f 2>/dev/null || find_free_loopback_dev)
 +    loopdev=$(@losetup@  -f 2>/dev/null || find_free_loopback_dev)
      if [ "$loopdev" = '' ]
      then
-@@ -62,5 +62,5 @@ add()
+         fatal 'Failed to find an unused loop device'
      fi
      
 -    if LANG=C losetup -h 2>&1 | grep read-only >/dev/null
 +    if LANG=C @losetup@  -h 2>&1 | @grep@ read-only >/dev/null
      then
          roflag="-$mode"; roflag="${roflag#-w}"; roflag="${roflag#-!}"
-@@ -69,5 +69,5 @@ add()
+     else
+         roflag=''
      fi
-
+ 
 -    do_or_die losetup $roflag "$loopdev" "$file"
 +    do_or_die @losetup@  $roflag "$loopdev" "$file"
      # FIXME Is this OK?
      xenstore_write "$XENBUS_PATH/node" "$loopdev"
-@@ -79,5 +79,5 @@ remove()
+     write_dev "$loopdev"
+@@ -78,7 +78,7 @@
+ remove()
  {
      node=$(xenstore_read "$XENBUS_PATH/node")
 -    losetup -d "$node"
 +    @losetup@  -d "$node"
  }
-
+ 
+ command=$1
 diff --git a/tools/hotplug/Linux/block-enbd b/tools/hotplug/Linux/block-enbd
 index 67faa84268..77599ff6df 100644
 --- a/tools/hotplug/Linux/block-enbd
 +++ b/tools/hotplug/Linux/block-enbd
-@@ -8,5 +8,5 @@
+@@ -7,13 +7,13 @@
+ #
  # This assumes you're running a correctly configured server at the other end!
-
+ 
 -dir=$(dirname "$0")
 +dir=$(@dirname@ "$0")
  . "$dir/block-common.sh"
-
-@@ -14,5 +14,5 @@ case "$command" in
+ 
+ case "$command" in
    add)
      for dev in /dev/nd*; do
 -      if nbd-client $2:$3 $dev; then
 +      if @nbd-client@ $2:$3 $dev; then
          write_dev $dev
          exit 0
-@@ -22,5 +22,5 @@ case "$command" in
+       fi
+@@ -21,7 +21,7 @@
+     exit 1
      ;;
    remove)
 -    nbd-client -d $2
 +    @nbd-client@ -d $2
      exit 0
      ;;
+ esac
 diff --git a/tools/hotplug/Linux/block-iscsi b/tools/hotplug/Linux/block-iscsi
 index 3615905252..ad45a3685b 100644
 --- a/tools/hotplug/Linux/block-iscsi
 +++ b/tools/hotplug/Linux/block-iscsi
-@@ -24,18 +24,18 @@
+@@ -23,20 +23,20 @@
+ # Portal address must be in IP format.
  #
-
+ 
 -dir=$(dirname "$0")
 +dir=$(@dirname@ "$0")
  . "$dir/block-common.sh"
-
+ 
  remove_label()
  {
 -    echo $1 | sed "s/^\("$2"\)//"
 +    echo $1 | @sed@ "s/^\("$2"\)//"
  }
-
+ 
  check_tools()
  {
 -    if ! command -v iscsiadm > /dev/null 2>&1; then
@@ -257,14 +288,17 @@ index 3615905252..ad45a3685b 100644
 +    if [ "$multipath" = "y" ] && ! command -v @multipath@ > /dev/null 2>&1; then
          fatal "Unable to find multipath"
      fi
-@@ -75,5 +75,5 @@ find_device()
+ }
+@@ -74,19 +74,19 @@
+ {
      count=0
      while [ ! -e /dev/disk/by-path/*"$iqn"-lun-0 ]; do
 -        sleep 1
 +        @sleep@ 1
          count=`expr $count + 1`
          if [ count = 100 ]; then
-@@ -82,10 +82,10 @@ find_device()
+             # 10s timeout while waiting for iSCSI disk to settle
+             fatal "timeout waiting for iSCSI disk to settle"
          fi
      done
 -    sddev=$(readlink -f /dev/disk/by-path/*"$iqn"-lun-0 || true)
@@ -277,14 +311,18 @@ index 3615905252..ad45a3685b 100644
 +        mdev=$(@multipath@ -ll "$sddev" | @head@ -1 | @awk@ '{ print $1}')
          if [ ! -b /dev/mapper/"$mdev" ]; then
              fatal "Unable to find attached device multipath"
-@@ -101,5 +101,5 @@ find_device()
+         fi
+@@ -100,7 +100,7 @@
+ # multipath device
  attach()
  {
 -    do_or_die iscsiadm -m node --targetname "$iqn" -p "$portal" --login > /dev/null
 +    do_or_die @iscsiadm@ -m node --targetname "$iqn" -p "$portal" --login > /dev/null
      find_device
  }
-@@ -110,7 +110,7 @@ prepare()
+ 
+@@ -109,9 +109,9 @@
+ prepare()
  {
      # Check if target is already opened
 -    iscsiadm -m session 2>&1 | grep -q "$iqn" && fatal "Device already opened"
@@ -294,81 +332,96 @@ index 3615905252..ad45a3685b 100644
 +    @iscsiadm@ -m discovery -t st -p $portal 2>&1 | @grep@ -q "$iqn" || \
          fatal "No matching target iqn found"
  }
-@@ -128,5 +128,5 @@ remove()
+ 
+@@ -127,7 +127,7 @@
+ remove()
  {
      find_device
 -    do_or_die iscsiadm -m node --targetname "$iqn" -p "$portal" --logout > /dev/null
 +    do_or_die @iscsiadm@ -m node --targetname "$iqn" -p "$portal" --logout > /dev/null
  }
-
+ 
+ command=$1
 diff --git a/tools/hotplug/Linux/block-nbd b/tools/hotplug/Linux/block-nbd
 index b29b31564a..a98350b121 100644
 --- a/tools/hotplug/Linux/block-nbd
 +++ b/tools/hotplug/Linux/block-nbd
-@@ -8,5 +8,5 @@
+@@ -7,13 +7,13 @@
+ #
  # This assumes you're running a correctly configured server at the other end!
-
+ 
 -dir=$(dirname "$0")
 +dir=$(@dirname@ "$0")
  . "$dir/block-common.sh"
-
-@@ -14,5 +14,5 @@ case "$command" in
+ 
+ case "$command" in
    add)
      for dev in /dev/nbd*; do
 -      if nbd-client $2 $3 $dev; then
 +      if @nbd-client@ $2 $3 $dev; then
          write_dev $dev
          exit 0
-@@ -22,5 +22,5 @@ case "$command" in
+       fi
+@@ -21,7 +21,7 @@
+     exit 1
      ;;
    remove)
 -    nbd-client -d $2
 +    @nbd-client@ -d $2
      exit 0
      ;;
+ esac
 diff --git a/tools/hotplug/Linux/block-tap b/tools/hotplug/Linux/block-tap
 index 95970a61f6..a03a36f8b6 100755
 --- a/tools/hotplug/Linux/block-tap
 +++ b/tools/hotplug/Linux/block-tap
-@@ -29,10 +29,10 @@
+@@ -28,12 +28,12 @@
+ #
  # format/<type> is either "aio" (for raw files), or "vhd"
-
+ 
 -dir=$(dirname "$0")
 +dir=$(@dirname@ "$0")
  . "$dir/block-common.sh"
-
+ 
  remove_label()
  {
 -    echo $1 | sed "s/^\("$2"\)//"
 +    echo $1 | @sed@ "s/^\("$2"\)//"
  }
-
-@@ -102,5 +102,5 @@ count_using()
+ 
+ check_tools()
+@@ -101,7 +101,7 @@
+         for dev in $(xenstore-list "$base_path/$dom")
          do
              f=$(xenstore_read_default "$base_path/$dom/$dev/params" "")
 -            f=$(echo "$f" | cut -d ":" -f 2)
 +            f=$(echo "$f" | @cut@ -d ":" -f 2)
-
+ 
              if [ -n "$f" ] && [ "$file" = $f ] ; then
-@@ -131,5 +131,5 @@ check_tap_sharing()
+                 i=$(( i + 1 ))
+@@ -130,7 +130,7 @@
+     for dom in $(xenstore-list "$base_path") ; do
          for dev in $(xenstore-list "$base_path/$dom") ; do
              local f=$(xenstore_read_default "$base_path/$dom/$dev/params" "")
 -            f=$(echo "$f" | cut -d ":" -f 2)
 +            f=$(echo "$f" | @cut@ -d ":" -f 2)
-
+ 
              if [ -n "$f" ] && [ "$file" = "$f" ] ; then
+                 if [ "$mode" = 'w' ] ; then
 diff --git a/tools/hotplug/Linux/colo-proxy-setup b/tools/hotplug/Linux/colo-proxy-setup
 index d709146c47..e0f44364cc 100755
 --- a/tools/hotplug/Linux/colo-proxy-setup
 +++ b/tools/hotplug/Linux/colo-proxy-setup
-@@ -1,5 +1,5 @@
+@@ -1,6 +1,6 @@
  #! /bin/bash
-
+ 
 -dir=$(dirname "$0")
 +dir=$(@dirname@ "$0")
  . "$dir/xen-hotplug-common.sh"
  . "$dir/hotplugpath.sh"
-@@ -38,60 +38,60 @@ fi
+ 
+@@ -37,84 +37,84 @@
+ 
  function setup_primary()
  {
 -    do_without_error tc qdisc add dev $vifname root handle 1: prio
@@ -383,12 +436,12 @@ index d709146c47..e0f44364cc 100755
 +    do_without_error @tc@ filter add dev $vifname parent 1: protocol ipv6 prio \
          12 u32 match u32 0 0 flowid 1:2 action mirred egress mirror \
          dev $forwarddev
-
+ 
 -    do_without_error modprobe nf_conntrack_ipv4
 -    do_without_error modprobe xt_PMYCOLO sec_dev=$forwarddev
 +    do_without_error @modprobe@ nf_conntrack_ipv4
 +    do_without_error @modprobe@ xt_PMYCOLO sec_dev=$forwarddev
-
+ 
 -    iptables -t mangle -I PREROUTING -m physdev --physdev-in \
 +    @iptables@ -t mangle -I PREROUTING -m physdev --physdev-in \
          $vifname -j PMYCOLO --index $index
@@ -398,7 +451,7 @@ index d709146c47..e0f44364cc 100755
 -    do_without_error arptables -I INPUT -i $forwarddev -j MARK --set-mark $index
 +    do_without_error @arptables@ -I INPUT -i $forwarddev -j MARK --set-mark $index
  }
-
+ 
  function teardown_primary()
  {
 -    do_without_error tc filter del dev $vifname parent 1: protocol ip prio 10 u32 match u32 \
@@ -412,7 +465,7 @@ index d709146c47..e0f44364cc 100755
          0 0 flowid 1:2 action mirred egress mirror dev $forwarddev
 -    do_without_error tc qdisc del dev $vifname root handle 1: prio
 +    do_without_error @tc@ qdisc del dev $vifname root handle 1: prio
-
+ 
 -    do_without_error iptables -t mangle -D PREROUTING -m physdev --physdev-in \
 +    do_without_error @iptables@ -t mangle -D PREROUTING -m physdev --physdev-in \
          $vifname -j PMYCOLO --index $index
@@ -424,7 +477,7 @@ index d709146c47..e0f44364cc 100755
 +    do_without_error @arptables@ -F
 +    do_without_error @rmmod@ xt_PMYCOLO
  }
-
+ 
  function setup_secondary()
  {
 -    if which brctl >&/dev/null; then
@@ -451,7 +504,7 @@ index d709146c47..e0f44364cc 100755
 -    do_without_error modprobe xt_SECCOLO
 +    do_without_error @ip@ link set dev $forwardbr up
 +    do_without_error @modprobe@ xt_SECCOLO
-
+ 
 -    iptables -t mangle -I PREROUTING -m physdev --physdev-in \
 +    @iptables@ -t mangle -I PREROUTING -m physdev --physdev-in \
          $vifname -j SECCOLO --index $index
@@ -459,7 +512,7 @@ index d709146c47..e0f44364cc 100755
 +    @ip6tables@ -t mangle -I PREROUTING -m physdev --physdev-in \
          $vifname -j SECCOLO --index $index
  }
-@@ -99,21 +99,21 @@ function setup_secondary()
+ 
  function teardown_secondary()
  {
 -    if which brctl >&/dev/null; then
@@ -482,7 +535,7 @@ index d709146c47..e0f44364cc 100755
 +        do_without_error @ip@ link delete $forwardbr type bridge
 +        do_without_error @ip@ link set $vifname master $bridge
      fi
-
+ 
 -    do_without_error iptables -t mangle -D PREROUTING -m physdev --physdev-in \
 +    do_without_error @iptables@ -t mangle -D PREROUTING -m physdev --physdev-in \
          $vifname -j SECCOLO --index $index
@@ -492,75 +545,88 @@ index d709146c47..e0f44364cc 100755
 -    do_without_error rmmod xt_SECCOLO
 +    do_without_error @rmmod@ xt_SECCOLO
  }
-
+ 
+ case "$command" in
 diff --git a/tools/hotplug/Linux/external-device-migrate b/tools/hotplug/Linux/external-device-migrate
 index f5942a6a95..228917b784 100644
 --- a/tools/hotplug/Linux/external-device-migrate
 +++ b/tools/hotplug/Linux/external-device-migrate
-@@ -24,10 +24,10 @@ set -x
+@@ -23,12 +23,12 @@
+ # It handles the low-level command line parsing and some of the
  # synchronization
-
+ 
 -dir=$(dirname "$0")
 +dir=$(@dirname@ "$0")
  . "$dir/logging.sh"
-
-
+ 
+ 
  function ext_dev_migrate_usage() {
 -cat <<EOF
 +@cat@ <<EOF
  Pass the following command line parameters to the script:
-
+ 
+ -step <n>              : n-th migration step
 diff --git a/tools/hotplug/Linux/init.d/xen-watchdog.in b/tools/hotplug/Linux/init.d/xen-watchdog.in
 index a0bde199c4..cefa3b81f8 100644
 --- a/tools/hotplug/Linux/init.d/xen-watchdog.in
 +++ b/tools/hotplug/Linux/init.d/xen-watchdog.in
-@@ -26,5 +26,5 @@ test -f $xencommons_config/xencommons && . $xencommons_config/xencommons
+@@ -25,7 +25,7 @@
+ 
  test -n "$XENWATCHDOGD_ARGS" || XENWATCHDOGD_ARGS='30 15'
  DAEMON=${sbindir}/xenwatchdogd
 -base=$(basename $DAEMON)
 +base=$(@basename@ $DAEMON)
-
+ 
  # Source function library.
-@@ -64,5 +64,5 @@ stop() {
+ if [ -e  /etc/init.d/functions ] ; then
+@@ -63,7 +63,7 @@
+ 	local r
  	echo -n $"Stopping domain watchdog daemon: "
-
+ 
 -	killall -USR1 $base 2>/dev/null
 +	@killall@ -USR1 $base 2>/dev/null
  	r=$?
  	[ "$r" -eq 0 ] && success $"$base stop" || failure $"$base stop"
+ 	echo
 diff --git a/tools/hotplug/Linux/init.d/xencommons.in b/tools/hotplug/Linux/init.d/xencommons.in
 index 7fd6903b98..dcc8de631b 100644
 --- a/tools/hotplug/Linux/init.d/xencommons.in
 +++ b/tools/hotplug/Linux/init.d/xencommons.in
-@@ -39,5 +39,5 @@ fi
+@@ -38,7 +38,7 @@
+ # mount xenfs in dom0 or domU with a pv_ops kernel
  if test "x$1" = xstart && \
     ! test -f /proc/xen/capabilities && \
 -   ! grep '^xenfs ' /proc/mounts >/dev/null;
 +   ! @grep@ '^xenfs ' /proc/mounts >/dev/null;
  then
  	mount -t xenfs xenfs /proc/xen
-@@ -48,5 +48,5 @@ fi
+ fi
+@@ -47,18 +47,18 @@
+ # no capabilities file in xenlinux domU kernel
  # empty capabilities file in pv_ops domU kernel
  if test -f /proc/xen/capabilities && \
 -   ! grep -q "control_d" /proc/xen/capabilities ; then
 +   ! @grep@ -q "control_d" /proc/xen/capabilities ; then
  	exit 0
  fi
-@@ -55,9 +55,9 @@ do_start () {
+ 
+ do_start () {
  	local mod
-
+ 
 -	for mod in $BACKEND_MODULES ; do modprobe "$mod" &>/dev/null ; done
 +	for mod in $BACKEND_MODULES ; do @modprobe@ "$mod" &>/dev/null ; done
-
+ 
 -	mkdir -m700 -p ${XEN_RUN_DIR}
 -	mkdir -m700 -p ${XEN_LOCK_DIR}
 -	mkdir -p ${XEN_LOG_DIR}
 +	@mkdir@ -m700 -p ${XEN_RUN_DIR}
 +	@mkdir@ -m700 -p ${XEN_LOCK_DIR}
 +	@mkdir@ -p ${XEN_LOG_DIR}
-
+ 
  	@XEN_SCRIPT_DIR@/launch-xenstore || exit 1
-@@ -79,6 +79,6 @@ do_stop () {
+ 
+@@ -78,15 +78,15 @@
+         echo Stopping xenconsoled
  	if read 2>/dev/null <$XENCONSOLED_PIDFILE pid; then
  		kill $pid
 -		while kill -9 $pid >/dev/null 2>&1; do sleep 1; done
@@ -568,8 +634,8 @@ index 7fd6903b98..dcc8de631b 100644
 +		while kill -9 $pid >/dev/null 2>&1; do @sleep@ 1; done
 +		@rm@ -f $XENCONSOLED_PIDFILE
  	fi
-
-@@ -86,6 +86,6 @@ do_stop () {
+ 
+ 	echo Stopping QEMU
  	if read 2>/dev/null <$QEMU_PIDFILE pid; then
  		kill $pid
 -		while kill -9 $pid >/dev/null 2>&1; do sleep 1; done
@@ -577,33 +643,38 @@ index 7fd6903b98..dcc8de631b 100644
 +		while kill -9 $pid >/dev/null 2>&1; do @sleep@ 1; done
 +		@rm@ -f $QEMU_PIDFILE
  	fi
-
+ 
+ 	echo WARNING: Not stopping xenstored, as it cannot be restarted.
 diff --git a/tools/hotplug/Linux/init.d/xendriverdomain.in b/tools/hotplug/Linux/init.d/xendriverdomain.in
 index 17b381c3dc..064906f027 100644
 --- a/tools/hotplug/Linux/init.d/xendriverdomain.in
 +++ b/tools/hotplug/Linux/init.d/xendriverdomain.in
-@@ -35,5 +35,5 @@ fi
+@@ -34,7 +34,7 @@
+ # mount xenfs in dom0 or domU with a pv_ops kernel
  if test "x$1" = xstart && \
     ! test -f /proc/xen/capabilities && \
 -   ! grep '^xenfs ' /proc/mounts >/dev/null;
 +   ! @grep@ '^xenfs ' /proc/mounts >/dev/null;
  then
  	mount -t xenfs xenfs /proc/xen
-@@ -44,5 +44,5 @@ fi
+ fi
+@@ -43,21 +43,21 @@
+ # no capabilities file in xenlinux domU kernel
  # empty capabilities file in pv_ops domU kernel
  if ! test -f /proc/xen/capabilities || \
 -   grep -q "control_d" /proc/xen/capabilities ; then
 +   @grep@ -q "control_d" /proc/xen/capabilities ; then
  	exit 0
  fi
-@@ -50,5 +50,5 @@ fi
+ 
  do_start () {
  	echo Starting xl devd...
 -	mkdir -p "${XEN_RUN_DIR}"
 +	@mkdir@ -p "${XEN_RUN_DIR}"
  	${sbindir}/xl devd --pidfile=$XLDEVD_PIDFILE $XLDEVD_ARGS
  }
-@@ -57,6 +57,6 @@ do_stop () {
+ do_stop () {
+         echo Stopping xl devd...
  	if read 2>/dev/null <$XLDEVD_PIDFILE pid; then
  		kill $pid
 -		while kill -9 $pid >/dev/null 2>&1; do sleep 1; done
@@ -612,91 +683,111 @@ index 17b381c3dc..064906f027 100644
 +		@rm@ -f $XLDEVD_PIDFILE
  	fi
  }
+ 
 diff --git a/tools/hotplug/Linux/launch-xenstore.in b/tools/hotplug/Linux/launch-xenstore.in
 index da4eeca7c5..059036d899 100644
 --- a/tools/hotplug/Linux/launch-xenstore.in
 +++ b/tools/hotplug/Linux/launch-xenstore.in
-@@ -32,5 +32,5 @@ timeout_xenstore () {
+@@ -31,7 +31,7 @@
+ 	while [ $time -lt $timeout ] && ! test_xenstore ; do
  		echo -n .
  		time=$(($time+1))
 -		sleep 1
 +		@sleep@ 1
  	done
  	echo
-@@ -51,5 +51,5 @@ test -f @CONFIG_DIR@/@CONFIG_LEAF_DIR@/xencommons && . @CONFIG_DIR@/@CONFIG_LEAF
+  
+@@ -50,7 +50,7 @@
+ 
  [ "$XENSTORETYPE" = "" ] && XENSTORETYPE=daemon
-
+ 
 -/bin/mkdir -p @XEN_RUN_DIR@
 +@mkdir@ -p @XEN_RUN_DIR@
-
+ 
  [ "$XENSTORETYPE" = "daemon" ] && {
-@@ -72,5 +72,5 @@ test -f @CONFIG_DIR@/@CONFIG_LEAF_DIR@/xencommons && . @CONFIG_DIR@/@CONFIG_LEAF
+ 	[ -z "$XENSTORED_TRACE" ] || XENSTORED_ARGS="$XENSTORED_ARGS -T @XEN_LOG_DIR@/xenstored-trace.log"
+@@ -71,7 +71,7 @@
+ 		}
  	}
  	[ -r /proc/sys/fs/nr_open ] && {
 -		MAX_FDS=`cat /proc/sys/fs/nr_open`
 +		MAX_FDS=`@cat@ /proc/sys/fs/nr_open`
  		[ "$XENSTORED_MAX_OPEN_FDS" = "unlimited" ] && XENSTORED_MAX_OPEN_FDS=$MAX_FDS
  		[ $XENSTORED_MAX_OPEN_FDS -gt $MAX_FDS ] && {
-@@ -81,11 +81,11 @@ test -f @CONFIG_DIR@/@CONFIG_LEAF_DIR@/xencommons && . @CONFIG_DIR@/@CONFIG_LEAF
+ 			echo "XENSTORED_MAX_OPEN_FDS exceeds system limit."
+@@ -80,13 +80,13 @@
+ 		}
  	}
-
+ 
 -	rm -f @XEN_RUN_DIR@/xenstored.pid
 +	@rm@ -f @XEN_RUN_DIR@/xenstored.pid
-
+ 
  	echo -n Starting $XENSTORED...
 -	prlimit --nofile=$XENSTORED_MAX_OPEN_FDS $XENSTORED --pid-file @XEN_RUN_DIR@/xenstored.pid $XENSTORED_ARGS
 +	@prlimit@ --nofile=$XENSTORED_MAX_OPEN_FDS $XENSTORED --pid-file @XEN_RUN_DIR@/xenstored.pid $XENSTORED_ARGS
-
+ 
 -	systemd-notify --booted 2>/dev/null || timeout_xenstore $XENSTORED || exit 1
 -	XS_PID=`cat @XEN_RUN_DIR@/xenstored.pid`
 +	@systemd-notify@ --booted 2>/dev/null || timeout_xenstore $XENSTORED || exit 1
 +	XS_PID=`@cat@ @XEN_RUN_DIR@/xenstored.pid`
  	echo $XS_OOM_SCORE >/proc/$XS_PID/oom_score_adj
-
-@@ -103,5 +103,5 @@ test -f @CONFIG_DIR@/@CONFIG_LEAF_DIR@/xencommons && . @CONFIG_DIR@/@CONFIG_LEAF
+ 
+ 	exit 0
+@@ -102,7 +102,7 @@
+ 
  	echo -n Starting $XENSTORE_DOMAIN_KERNEL...
  	${LIBEXEC_BIN}/init-xenstore-domain $XENSTORE_DOMAIN_ARGS || exit 1
 -	systemd-notify --ready 2>/dev/null
 +	@systemd-notify@ --ready 2>/dev/null
-
+ 
  	exit 0
+ }
 diff --git a/tools/hotplug/Linux/locking.sh b/tools/hotplug/Linux/locking.sh
 index 2e6fb35f02..5860157657 100644
 --- a/tools/hotplug/Linux/locking.sh
 +++ b/tools/hotplug/Linux/locking.sh
-@@ -36,5 +36,5 @@ _setlockfd()
+@@ -35,7 +35,7 @@
+ 
  claim_lock()
  {
 -    mkdir -p "$LOCK_BASEDIR"
 +    @mkdir@ -p "$LOCK_BASEDIR"
      _setlockfd $1
      # The locking strategy is identical to that from with-lock-ex(1)
-@@ -45,5 +45,5 @@ claim_lock()
+     # from chiark-utils, except using flock.  It has the benefit of
+@@ -44,7 +44,7 @@
+     local stat
      while true; do
          eval "exec $_lockfd<>$_lockfile"
 -        flock -x $_lockfd || return $?
 +        @flock@ -x $_lockfd || return $?
          # Although /dev/stdin (i.e. /proc/self/fd/0) looks like a symlink,
          # stat(2) bypasses the synthetic symlink and directly accesses the
-@@ -53,5 +53,5 @@ claim_lock()
+         # underlying open-file.  So this works correctly even if the file
+@@ -52,7 +52,7 @@
+         # WW.XXX
          # YY.ZZZ
          # which need to be separated and compared.
 -        if stat=$( stat -L -c '%D.%i' /dev/stdin $_lockfile 0<&$_lockfd 2>/dev/null )
 +        if stat=$( @stat@ -L -c '%D.%i' /dev/stdin $_lockfile 0<&$_lockfd 2>/dev/null )
          then
              local file_stat
-@@ -75,5 +75,5 @@ release_lock()
+             local fd_stat
+@@ -74,7 +74,7 @@
+ release_lock()
  {
      _setlockfd $1
 -    rm "$_lockfile"
 +    @rm@ "$_lockfile"
  }
-
+ 
+ # Protocol and correctness proof:
 diff --git a/tools/hotplug/Linux/logging.sh b/tools/hotplug/Linux/logging.sh
 index 3e94df1a9e..fa99d8c4c7 100644
 --- a/tools/hotplug/Linux/logging.sh
 +++ b/tools/hotplug/Linux/logging.sh
-@@ -18,4 +18,4 @@ log() {
+@@ -17,5 +17,5 @@
+ log() {
    local level="$1"
    shift
 -  logger -p "daemon.$level" -- "$0:" "$@" || echo "$0 $@" >&2
@@ -706,15 +797,18 @@ diff --git a/tools/hotplug/Linux/remus-netbuf-setup b/tools/hotplug/Linux/remus-
 index 87dfa69778..fe4f7b6e36 100644
 --- a/tools/hotplug/Linux/remus-netbuf-setup
 +++ b/tools/hotplug/Linux/remus-netbuf-setup
-@@ -75,5 +75,5 @@
+@@ -74,7 +74,7 @@
+ 
  # Unlike other vif scripts, vif-common is not needed here as it executes vif
  #specific setup code such as renaming.
 -dir=$(dirname "$0")
 +dir=$(@dirname@ "$0")
  . "$dir/xen-hotplug-common.sh"
-
-@@ -93,11 +93,11 @@ evalVariables "$@"
-
+ 
+ findCommand "$@"
+@@ -92,13 +92,13 @@
+ : ${XENBUS_PATH:?}
+ 
  check_libnl_tools() {
 -    if ! command -v nl-qdisc-list > /dev/null 2>&1; then
 +    if ! command -v @nl-qdisc-list@ > /dev/null 2>&1; then
@@ -728,53 +822,64 @@ index 87dfa69778..fe4f7b6e36 100644
 +    if ! command -v @nl-qdisc-delete@ > /dev/null 2>&1; then
          fatal "Unable to find nl-qdisc-delete tool"
      fi
-@@ -111,5 +111,5 @@ check_modules() {
+ }
+@@ -110,7 +110,7 @@
+ check_modules() {
      for m in ifb sch_plug sch_ingress act_mirred cls_u32
      do
 -        if ! modinfo $m > /dev/null 2>&1; then
 +        if ! @modinfo@ $m > /dev/null 2>&1; then
              fatal "Unable to find $m kernel module"
          fi
-@@ -119,5 +119,5 @@ check_modules() {
+     done
+@@ -118,7 +118,7 @@
+ 
  #return 0 if the ifb is free
  check_ifb() {
 -    local installed=`nl-qdisc-list -d $1`
 +    local installed=`@nl-qdisc-list@ -d $1`
      [ -n "$installed" ] && return 1
-
-@@ -140,5 +140,5 @@ check_ifb() {
+ 
+     for domid in `xenstore-list "/local/domain" 2>/dev/null || true`
+@@ -139,7 +139,7 @@
+ 
  setup_ifb() {
-
+ 
 -    for ifb in `ifconfig -a -s|egrep ^ifb|cut -d ' ' -f1`
 +    for ifb in `@ifconfig@ -a -s|@egrep@ ^ifb|@cut@ -d ' ' -f1`
      do
          check_ifb "$ifb" || continue
-@@ -155,5 +155,5 @@ setup_ifb() {
+         REMUS_IFB="$ifb"
+@@ -154,21 +154,21 @@
+     #not using xenstore_write that automatically exits on error
      #because we need to cleanup
      xenstore_write "$XENBUS_PATH/ifb" "$REMUS_IFB"
 -    do_or_die ip link set dev "$REMUS_IFB" up
 +    do_or_die @ip@ link set dev "$REMUS_IFB" up
  }
-
-@@ -162,12 +162,12 @@ redirect_vif_traffic() {
+ 
+ redirect_vif_traffic() {
+     local vif=$1
      local ifb=$2
-
+ 
 -    do_or_die tc qdisc add dev "$vif" ingress
 +    do_or_die @tc@ qdisc add dev "$vif" ingress
-
+ 
 -    tc filter add dev "$vif" parent ffff: proto ip prio 10 \
 +    @tc@ filter add dev "$vif" parent ffff: proto ip prio 10 \
          u32 match u32 0 0 action mirred egress redirect dev "$ifb" >/dev/null 2>&1
-
+ 
      if [ $? -ne 0 ]
      then
 -        do_without_error tc qdisc del dev "$vif" ingress
 +        do_without_error @tc@ qdisc del dev "$vif" ingress
          fatal "Failed to redirect traffic from $vif to $ifb"
      fi
-@@ -178,13 +178,13 @@ add_plug_qdisc() {
+ }
+@@ -177,15 +177,15 @@
+     local vif=$1
      local ifb=$2
-
+ 
 -    nl-qdisc-add --dev="$ifb" --parent root plug >/dev/null 2>&1
 +    @nl-qdisc-add@ --dev="$ifb" --parent root plug >/dev/null 2>&1
      if [ $? -ne 0 ]
@@ -783,14 +888,16 @@ index 87dfa69778..fe4f7b6e36 100644
 +        do_without_error @tc@ qdisc del dev "$vif" ingress
          fatal "Failed to add plug qdisc to $ifb"
      fi
-
+ 
      #set ifb buffering limit in bytes. Its okay if this command fails
 -    nl-qdisc-add --dev="$ifb" --parent root \
 +    @nl-qdisc-add@ --dev="$ifb" --parent root \
          --update plug --limit=10000000 >/dev/null 2>&1 || true
  }
-@@ -201,9 +201,9 @@ teardown_netbuf() {
-
+ 
+@@ -200,11 +200,11 @@
+         local ifb2=`xenstore-read "$XENBUS_PATH/ifb" 2>/dev/null || true`
+ 
      if [[ "$ifb2" && "$ifb2" == "$ifb" ]]; then
 -        do_without_error ip link set dev "$ifb" down
 -        do_without_error nl-qdisc-delete --dev="$ifb" --parent root plug >/dev/null 2>&1
@@ -802,22 +909,26 @@ index 87dfa69778..fe4f7b6e36 100644
 +    do_without_error @tc@ qdisc del dev "$vif" ingress
      xenstore-rm -t "$XENBUS_PATH/hotplug-status" 2>/dev/null || true
      xenstore-rm -t "$XENBUS_PATH/hotplug-error" 2>/dev/null || true
+ }
 diff --git a/tools/hotplug/Linux/systemd/xen-init-dom0.service.in b/tools/hotplug/Linux/systemd/xen-init-dom0.service.in
 index 98779b8507..cc75339377 100644
 --- a/tools/hotplug/Linux/systemd/xen-init-dom0.service.in
 +++ b/tools/hotplug/Linux/systemd/xen-init-dom0.service.in
-@@ -9,5 +9,5 @@ Type=oneshot
+@@ -8,7 +8,7 @@
+ Type=oneshot
  RemainAfterExit=true
  EnvironmentFile=-@CONFIG_DIR@/@CONFIG_LEAF_DIR@/xencommons
 -ExecStartPre=/bin/grep -q control_d /proc/xen/capabilities
 +ExecStartPre=@grep@ -q control_d /proc/xen/capabilities
  ExecStart=@LIBEXEC_BIN@/xen-init-dom0 $XEN_DOM0_UUID
-
+ 
+ [Install]
 diff --git a/tools/hotplug/Linux/systemd/xen-qemu-dom0-disk-backend.service.in b/tools/hotplug/Linux/systemd/xen-qemu-dom0-disk-backend.service.in
 index f56775bc87..a9091047da 100644
 --- a/tools/hotplug/Linux/systemd/xen-qemu-dom0-disk-backend.service.in
 +++ b/tools/hotplug/Linux/systemd/xen-qemu-dom0-disk-backend.service.in
-@@ -10,6 +10,6 @@ ConditionPathExists=/proc/xen/capabilities
+@@ -9,8 +9,8 @@
+ [Service]
  Type=simple
  PIDFile=@XEN_RUN_DIR@/qemu-dom0.pid
 -ExecStartPre=/bin/grep -q control_d /proc/xen/capabilities
@@ -826,11 +937,13 @@ index f56775bc87..a9091047da 100644
 +ExecStartPre=@mkdir@ -p @XEN_RUN_DIR@
  ExecStart=@qemu_xen_systemd@ -xen-domid 0 \
  	-xen-attach -name dom0 -nographic -M xenpv -daemonize \
+ 	-monitor /dev/null -serial /dev/null -parallel /dev/null \
 diff --git a/tools/hotplug/Linux/systemd/xenconsoled.service.in b/tools/hotplug/Linux/systemd/xenconsoled.service.in
 index d84c09aa9c..68317246ae 100644
 --- a/tools/hotplug/Linux/systemd/xenconsoled.service.in
 +++ b/tools/hotplug/Linux/systemd/xenconsoled.service.in
-@@ -11,6 +11,6 @@ Environment=XENCONSOLED_TRACE=none
+@@ -10,8 +10,8 @@
+ Environment=XENCONSOLED_TRACE=none
  Environment=XENCONSOLED_LOG_DIR=@XEN_LOG_DIR@/console
  EnvironmentFile=-@CONFIG_DIR@/@CONFIG_LEAF_DIR@/xencommons
 -ExecStartPre=/bin/grep -q control_d /proc/xen/capabilities
@@ -838,42 +951,49 @@ index d84c09aa9c..68317246ae 100644
 +ExecStartPre=@grep@ -q control_d /proc/xen/capabilities
 +ExecStartPre=@mkdir@ -p ${XENCONSOLED_LOG_DIR} @XEN_RUN_DIR@
  ExecStart=@sbindir@/xenconsoled -i --log=${XENCONSOLED_TRACE} --log-dir=${XENCONSOLED_LOG_DIR} $XENCONSOLED_ARGS
-
+ 
+ [Install]
 diff --git a/tools/hotplug/Linux/systemd/xendomains.service.in b/tools/hotplug/Linux/systemd/xendomains.service.in
 index c7bfb61eb4..314ed9e91a 100644
 --- a/tools/hotplug/Linux/systemd/xendomains.service.in
 +++ b/tools/hotplug/Linux/systemd/xendomains.service.in
-@@ -11,5 +11,5 @@ Conflicts=libvirtd.service
+@@ -10,7 +10,7 @@
+ [Service]
  Type=oneshot
  RemainAfterExit=true
 -ExecStartPre=/bin/grep -q control_d /proc/xen/capabilities
 +ExecStartPre=@grep@ -q control_d /proc/xen/capabilities
  ExecStart=-@LIBEXEC_BIN@/xendomains start
  ExecStop=@LIBEXEC_BIN@/xendomains stop
+ ExecReload=@LIBEXEC_BIN@/xendomains restart
 diff --git a/tools/hotplug/Linux/systemd/xenstored.service.in b/tools/hotplug/Linux/systemd/xenstored.service.in
 index 261077dc92..7daf7369b8 100644
 --- a/tools/hotplug/Linux/systemd/xenstored.service.in
 +++ b/tools/hotplug/Linux/systemd/xenstored.service.in
-@@ -11,5 +11,5 @@ Type=notify
+@@ -10,7 +10,7 @@
+ Type=notify
  NotifyAccess=all
  RemainAfterExit=true
 -ExecStartPre=/bin/grep -q control_d /proc/xen/capabilities
 +ExecStartPre=@grep@ -q control_d /proc/xen/capabilities
  ExecStart=@XEN_SCRIPT_DIR@/launch-xenstore
-
+ 
+ [Install]
 diff --git a/tools/hotplug/Linux/vif-bridge b/tools/hotplug/Linux/vif-bridge
 index 906047e82f..e110013b14 100644
 --- a/tools/hotplug/Linux/vif-bridge
 +++ b/tools/hotplug/Linux/vif-bridge
-@@ -26,5 +26,5 @@
+@@ -25,17 +25,17 @@
+ # rules for its ip addresses (if any).
  #============================================================================
-
+ 
 -dir=$(dirname "$0")
 +dir=$(@dirname@ "$0")
  . "$dir/vif-common.sh"
-
-@@ -33,8 +33,8 @@ bridge=$(xenstore_read_default "$XENBUS_PATH/bridge" "$bridge")
-
+ 
+ bridge=${bridge:-}
+ bridge=$(xenstore_read_default "$XENBUS_PATH/bridge" "$bridge")
+ 
  if [ -z "$bridge" ]; then
 -    if which brctl >&/dev/null; then
 -        bridge=$(brctl show | awk 'NR==2{print$1}')
@@ -884,25 +1004,31 @@ index 906047e82f..e110013b14 100644
 +        bridge=$(@bridge@ link | @cut@ -d" " -f7)
      fi
    if [ -z "$bridge" ]
-@@ -71,5 +71,5 @@ fi
-
+   then
+@@ -70,7 +70,7 @@
+ fi
+ 
  RET=0
 -ip link show dev "$bridge" 1>/dev/null 2>&1 || RET=1
 +@ip@ link show dev "$bridge" 1>/dev/null 2>&1 || RET=1
  if [ "$RET" -eq 1 ]
  then
+     fatal "Could not find bridge device $bridge"
 diff --git a/tools/hotplug/Linux/vif-common.sh b/tools/hotplug/Linux/vif-common.sh
 index a8e65178f9..28eb851f94 100644
 --- a/tools/hotplug/Linux/vif-common.sh
 +++ b/tools/hotplug/Linux/vif-common.sh
-@@ -16,5 +16,5 @@
-
-
+@@ -15,7 +15,7 @@
+ #
+ 
+ 
 -dir=$(dirname "$0")
 +dir=$(@dirname@ "$0")
  . "$dir/xen-hotplug-common.sh"
  . "$dir/xen-network-common.sh"
-@@ -73,9 +73,9 @@ rename_vif() {
+ 
+@@ -72,11 +72,11 @@
+     # already exists, then stop, before messing up whatever is using
      # that interface (e.g. another running domU) because it's likely a
      # configuration error
 -    if ip link show "$vifname" >&/dev/null
@@ -913,8 +1039,10 @@ index a8e65178f9..28eb851f94 100644
 -    do_or_die ip link set "$dev" name "$vifname"
 +    do_or_die @ip@ link set "$dev" name "$vifname"
  }
-
-@@ -135,10 +135,10 @@ iptables_w()
+ 
+ if [ "$type_if" = vif ]; then
+@@ -134,12 +134,12 @@
+ iptables_w()
  {
      if ! $IPTABLES_WAIT_RUNE_CHECKED ; then
 -	iptables $IPTABLES_WAIT_RUNE -L -n >& /dev/null
@@ -927,46 +1055,58 @@ index a8e65178f9..28eb851f94 100644
 +	    @iptables@ -L -n >& /dev/null
  	    if [[ $? != 2 ]] ; then
  		# If we fail with PARAMETER_PROBLEM (2) with -w and
-@@ -150,5 +150,5 @@ iptables_w()
+ 		# don't fail with PARAMETER_PROBLEM without it, then
+@@ -149,7 +149,7 @@
+ 	    fi
  	fi
      fi
 -    iptables $IPTABLES_WAIT_RUNE "$@"
 +    @iptables@ $IPTABLES_WAIT_RUNE "$@"
  }
-
-@@ -221,5 +221,5 @@ handle_iptable()
+ 
+ frob_iptable()
+@@ -220,7 +220,7 @@
+ #
  ip_of()
  {
 -  ip -4 -o addr show primary dev "$1" | awk '$3 == "inet" {split($4,i,"/"); print i[1]; exit}'
 +  @ip@ -4 -o addr show primary dev "$1" | @awk@ '$3 == "inet" {split($4,i,"/"); print i[1]; exit}'
  }
-
+ 
+ 
 diff --git a/tools/hotplug/Linux/vif-nat b/tools/hotplug/Linux/vif-nat
 index fd34afbb96..8921de58f3 100644
 --- a/tools/hotplug/Linux/vif-nat
 +++ b/tools/hotplug/Linux/vif-nat
-@@ -22,5 +22,5 @@
-
-
+@@ -21,7 +21,7 @@
+ #============================================================================
+ 
+ 
 -dir=$(dirname "$0")
 +dir=$(@dirname@ "$0")
  . "$dir/vif-common.sh"
-
-@@ -62,5 +62,5 @@ ip_from_dom()
+ 
+ # turn on dhcp feature by default if dhcpd is installed
+@@ -61,7 +61,7 @@
+ 
  routing_ip()
  {
 -  echo $(echo $1 | awk -F. '{print $1"."$2"."$3"."$4 + 127}')
 +  echo $(echo $1 | @awk@ -F. '{print $1"."$2"."$3"."$4 + 127}')
  }
-
-@@ -84,5 +84,5 @@ router_ip=$(routing_ip "$ip")
-
+ 
+ 
+@@ -83,7 +83,7 @@
+ router_ip=$(routing_ip "$ip")
+ 
  # Split the given IP/bits pair.
 -vif_ip=`echo ${ip} | awk -F/ '{print $1}'`
 +vif_ip=`echo ${ip} | @awk@ -F/ '{print $1}'`
-
+ 
  hostname=dom$domid
-@@ -94,11 +94,11 @@ fi
+ if [ "$vifid" != "1" ]
+@@ -93,38 +93,38 @@
+ 
  dhcparg_remove_entry()
  {
 -  local tmpfile=$(mktemp)
@@ -982,8 +1122,8 @@ index fd34afbb96..8921de58f3 100644
 -  rm "$tmpfile"
 +  @rm@ "$tmpfile"
  }
-
-@@ -106,24 +106,24 @@ dhcparg_add_entry()
+ 
+ dhcparg_add_entry()
  {
    dhcparg_remove_entry
 -  local tmpfile=$(mktemp)
@@ -1004,7 +1144,7 @@ index fd34afbb96..8921de58f3 100644
 +     "$dhcpd_arg_file" >"$tmpfile" && @cp@ "$tmpfile" "$dhcpd_arg_file"
 +  @rm@ -f "$tmpfile"
  }
-
+ 
  dhcp_remove_entry()
  {
 -  local tmpfile=$(mktemp)
@@ -1021,16 +1161,18 @@ index fd34afbb96..8921de58f3 100644
 +  @rm@ "$tmpfile"
    dhcparg_remove_entry
  }
-@@ -159,5 +159,5 @@ dhcp_down()
+ 
+@@ -158,21 +158,21 @@
+ 
  case "$command" in
      online)
 -        if ip route | grep -q "dev ${dev}"
 +        if @ip@  route | @grep@ -q "dev ${dev}"
          then
            log debug "${dev} already up"
-@@ -165,7 +165,7 @@ case "$command" in
+           exit 0
          fi
-
+ 
 -        do_or_die ip link set dev "${dev}" up arp on
 -        do_or_die ip addr add "$router_ip" dev "${dev}"
 -        do_or_die ip route add "$vif_ip" dev "${dev}" src "$router_ip"
@@ -1039,24 +1181,26 @@ index fd34afbb96..8921de58f3 100644
 +        do_or_die @ip@ route add "$vif_ip" dev "${dev}" src "$router_ip"
          echo 1 >/proc/sys/net/ipv4/conf/${dev}/proxy_arp
          [ "$dhcp" != 'no' ] && dhcp_up
-@@ -173,5 +173,5 @@ case "$command" in
+         ;;
      offline)
          [ "$dhcp" != 'no' ] && dhcp_down
 -        do_without_error ifconfig "${dev}" down
 +        do_without_error @ifconfig@ "${dev}" down
          ;;
  esac
+ 
 diff --git a/tools/hotplug/Linux/vif-openvswitch b/tools/hotplug/Linux/vif-openvswitch
 index 18bfb6cefb..ea983481a3 100644
 --- a/tools/hotplug/Linux/vif-openvswitch
 +++ b/tools/hotplug/Linux/vif-openvswitch
-@@ -25,13 +25,13 @@
+@@ -24,15 +24,15 @@
+ # rules for its ip addresses (if any).
  #============================================================================
-
+ 
 -dir=$(dirname "$0")
 +dir=$(@dirname@ "$0")
  . "$dir/vif-common.sh"
-
+ 
  check_tools()
  {
 -    if ! command -v ovs-vsctl > /dev/null 2>&1; then
@@ -1067,9 +1211,11 @@ index 18bfb6cefb..ea983481a3 100644
 +    if ! command -v @ip@ > /dev/null 2>&1; then
          fatal "Unable to find ip tool"
      fi
-@@ -80,8 +80,8 @@ add_to_openvswitch () {
+ }
+@@ -79,10 +79,10 @@
+ 
      local vif_details="$(openvswitch_external_id_all $dev)"
-
+ 
 -    do_or_die ovs-vsctl --timeout=30 \
 +    do_or_die @ovs-vsctl@ --timeout=30 \
          -- --if-exists del-port $dev \
@@ -1077,9 +1223,11 @@ index 18bfb6cefb..ea983481a3 100644
 -    do_or_die ip link set $dev up
 +    do_or_die @ip@ link set $dev up
  }
-
-@@ -94,7 +94,7 @@ case "$command" in
-
+ 
+ case "$command" in
+@@ -93,9 +93,9 @@
+         ;;
+ 
      remove|offline)
 -        do_without_error ovs-vsctl --timeout=30 \
 +        do_without_error @ovs-vsctl@ --timeout=30 \
@@ -1088,91 +1236,109 @@ index 18bfb6cefb..ea983481a3 100644
 +        do_without_error @ip@ link set $dev down
          ;;
  esac
+ 
 diff --git a/tools/hotplug/Linux/vif-route b/tools/hotplug/Linux/vif-route
 index 9cd417a005..98d67a8659 100755
 --- a/tools/hotplug/Linux/vif-route
 +++ b/tools/hotplug/Linux/vif-route
-@@ -17,5 +17,5 @@
+@@ -16,14 +16,14 @@
+ #         this script).
  #============================================================================
-
+ 
 -dir=$(dirname "$0")
 +dir=$(@dirname@ "$0")
  . "${dir}/vif-common.sh"
-
-@@ -24,5 +24,5 @@ main_ip=$(dom0_ip)
+ 
+ main_ip=$(dom0_ip)
+ 
  case "${command}" in
      add|online)
 -        ifconfig ${dev} ${main_ip} netmask 255.255.255.255 up
 +        @ifconfig@ ${dev} ${main_ip} netmask 255.255.255.255 up
          echo 1 >/proc/sys/net/ipv4/conf/${dev}/proxy_arp
          ipcmd='add'
-@@ -51,5 +51,5 @@ esac
+         cmdprefix=''
+@@ -50,7 +50,7 @@
+ # If we've been given a list of IP addresses, then add routes from dom0 to
  # the guest using those addresses.
  for addr in ${ip} ; do
 -    ${cmdprefix} ip route ${ipcmd} ${addr} dev ${dev} src ${main_ip} metric ${metric}
 +    ${cmdprefix} @ip@ route ${ipcmd} ${addr} dev ${dev} src ${main_ip} metric ${metric}
  done
-
+ 
+ handle_iptable
 diff --git a/tools/hotplug/Linux/vscsi b/tools/hotplug/Linux/vscsi
 index 5ac26147ec..8f297e05df 100644
 --- a/tools/hotplug/Linux/vscsi
 +++ b/tools/hotplug/Linux/vscsi
-@@ -5,5 +5,5 @@
+@@ -4,7 +4,7 @@
+ # Based on the block scripts code.
  #
-
+ 
 -dir=$(dirname "$0")
 +dir=$(@dirname@ "$0")
  . "$dir/xen-hotplug-common.sh"
-
+ 
+ findCommand "$@"
 diff --git a/tools/hotplug/Linux/xen-hotplug-common.sh.in b/tools/hotplug/Linux/xen-hotplug-common.sh.in
 index 8c2cb9e25a..e9c64efcb0 100644
 --- a/tools/hotplug/Linux/xen-hotplug-common.sh.in
 +++ b/tools/hotplug/Linux/xen-hotplug-common.sh.in
-@@ -15,5 +15,5 @@
+@@ -14,7 +14,7 @@
+ # License along with this library; If not, see <http://www.gnu.org/licenses/>.
  #
-
+ 
 -dir=$(dirname "$0")
 +dir=$(@dirname@ "$0")
  . "$dir/hotplugpath.sh"
  . "$dir/logging.sh"
-@@ -26,5 +26,5 @@ export PATH="${bindir}:${sbindir}:${LIBEXEC_BIN}:/sbin:/bin:/usr/bin:/usr/sbin:$
+ . "$dir/xen-script-common.sh"
+@@ -25,7 +25,7 @@
+ export PATH="${bindir}:${sbindir}:${LIBEXEC_BIN}:/sbin:/bin:/usr/bin:/usr/sbin:$PATH"
  export LD_LIBRARY_PATH="${libdir}${LD_LIBRARY_PATH+:}$LD_LIBRARY_PATH"
  export LANG="POSIX"
 -unset $(set | grep ^LC_ | cut -d= -f1)
 +unset $(set | @grep@ ^LC_ | @cut@ -d= -f1)
-
+ 
  fatal() {
+   _xenstore_write "$XENBUS_PATH/hotplug-error" "$*" \
 diff --git a/tools/hotplug/Linux/xen-network-common.sh b/tools/hotplug/Linux/xen-network-common.sh
 index 42fa704e8d..f6cf1b11c0 100644
 --- a/tools/hotplug/Linux/xen-network-common.sh
 +++ b/tools/hotplug/Linux/xen-network-common.sh
-@@ -27,5 +27,5 @@
+@@ -26,7 +26,7 @@
+ #           that the virtual device will take once the physical device has
  #           been renamed.
-
+ 
 -if ! which ifup >/dev/null 2>/dev/null
 +if ! @which@ ifup >/dev/null 2>/dev/null
  then
    preiftransfer()
-@@ -85,5 +85,5 @@ _setup_bridge_port() {
-
+   {
+@@ -84,18 +84,18 @@
+     local virtual="$2"
+ 
      # take interface down ...
 -    ip link set dev ${dev} down
 +    @ip@ link set dev ${dev} down
-
+ 
      if [ $virtual -ne 0 ] ; then
-@@ -92,9 +92,9 @@ _setup_bridge_port() {
+         # Initialise a dummy MAC address. We choose the numerically
+         # largest non-broadcast address to prevent the address getting
          # stolen by an Ethernet bridge for STP purposes.
          # (FE:FF:FF:FF:FF:FF)
 -        ip link set dev ${dev} address fe:ff:ff:ff:ff:ff || true
 +        @ip@ link set dev ${dev} address fe:ff:ff:ff:ff:ff || true
      fi
-
+ 
      # ... and configure it
 -    ip address flush dev ${dev}
 +    @ip@ address flush dev ${dev}
  }
-
-@@ -112,10 +112,10 @@ create_bridge () {
+ 
+ setup_physical_bridge_port() {
+@@ -111,12 +111,12 @@
+ 
      # Don't create the bridge if it already exists.
      if [ ! -e "/sys/class/net/${bridge}/bridge" ]; then
 -        if which brctl >&/dev/null; then
@@ -1188,7 +1354,9 @@ index 42fa704e8d..f6cf1b11c0 100644
 +            @ip@ link add name ${bridge} type bridge stp_state 0 forward_delay 0
          fi
      fi
-@@ -130,8 +130,8 @@ add_to_bridge () {
+ }
+@@ -129,31 +129,31 @@
+     # Don't add $dev to $bridge if it's already on the bridge.
      if [ ! -e "/sys/class/net/${bridge}/brif/${dev}" ]; then
          log debug "adding $dev to bridge $bridge"
 -        if which brctl >&/dev/null; then
@@ -1200,19 +1368,20 @@ index 42fa704e8d..f6cf1b11c0 100644
 +            @ip@ link set ${dev} master ${bridge}
          fi
      else
-@@ -139,5 +139,5 @@ add_to_bridge () {
+         log debug "$dev already on bridge $bridge"
      fi
-
+ 
 -    ip link set dev ${dev} up
 +    @ip@ link set dev ${dev} up
  }
-
-@@ -146,13 +146,13 @@ remove_from_bridge () {
+ 
+ remove_from_bridge () {
+     local bridge=$1
      local dev=$2
-
+ 
 -    do_without_error ip link set dev ${dev} down
 +    do_without_error @ip@ link set dev ${dev} down
-
+ 
      # Don't remove $dev from $bridge if it's not on the bridge.
      if [ -e "/sys/class/net/${bridge}/brif/${dev}" ]; then
          log debug "removing $dev from bridge $bridge"
@@ -1225,53 +1394,65 @@ index 42fa704e8d..f6cf1b11c0 100644
 +            do_without_error @ip@ link set ${dev} nomaster
          fi
      else
-@@ -172,5 +172,5 @@ set_mtu () {
+         log debug "$dev not on bridge $bridge"
+@@ -171,7 +171,7 @@
+     local mtu=$(xenstore_read_default "$XENBUS_PATH/mtu" "")
      if [ -z "$mtu" ]
      then
 -        mtu="`ip link show dev ${bridge}| awk '/mtu/ { print $5 }'`"
 +        mtu="`@ip@ link show dev ${bridge}| @awk@ '/mtu/ { print $5 }'`"
          if [ -n "$mtu" ]
          then
-@@ -181,5 +181,5 @@ set_mtu () {
+             log debug "$bridge MTU is $mtu"
+@@ -180,7 +180,7 @@
+     if [ -n "$mtu" ] && [ "$mtu" -gt 0 ]
      then
          log debug "setting $dev MTU to $mtu"
 -        ip link set dev ${dev} mtu ${mtu} || :
 +        @ip@ link set dev ${dev} mtu ${mtu} || :
-
+ 
          if [ ${type_if} = vif ]
+         then
 diff --git a/tools/hotplug/Linux/xendomains.in b/tools/hotplug/Linux/xendomains.in
 index 70f4129ef4..b066404b0d 100644
 --- a/tools/hotplug/Linux/xendomains.in
 +++ b/tools/hotplug/Linux/xendomains.in
-@@ -151,5 +151,5 @@ else
+@@ -150,13 +150,13 @@
+     }
  fi
-
+ 
 -if ! which usleep >&/dev/null
 +if ! @which@ usleep >&/dev/null
  then
    usleep()
-@@ -157,5 +157,5 @@ then
+   {
      if [ -n "$1" ]
      then
 -      sleep $(( $1 / 1000000 ))
 +      @sleep@ $(( $1 / 1000000 ))
      fi
    }
-@@ -171,5 +171,5 @@ rc_reset
+ fi
+@@ -170,7 +170,7 @@
+ #
  contains_something()
  {
 -  if [ -d "$1" ] && [ `/bin/ls $1 | wc -l` -gt 0 ]
 +  if [ -d "$1" ] && [ `@ls@ $1 | wc -l` -gt 0 ]
    then
      return 0
-@@ -183,5 +183,5 @@ rdname()
+   else
+@@ -182,7 +182,7 @@
+ rdname()
  {
      NM=$($CMD create --quiet --dryrun --defconfig "$1" |
 -         sed -n 's/^.*(name \(.*\))$/\1/p;s/^.*"name": "\(.*\)",$/\1/p')
 +         @sed@ -n 's/^.*(name \(.*\))$/\1/p;s/^.*"name": "\(.*\)",$/\1/p')
  }
-
-@@ -218,11 +218,11 @@ parseln()
+ 
+ rdnames()
+@@ -217,13 +217,13 @@
+     if [[ "$1" =~ '(domain' ]] || [[ "$1" = "{" ]]; then
          name=;id=
      elif [[ "$1" =~ '(name' ]]; then
 -        name=$(echo $1 | sed -e 's/^.*(name \(.*\))$/\1/')
@@ -1286,36 +1467,46 @@ index 70f4129ef4..b066404b0d 100644
 -        id=$(echo $1 | sed -e 's/^.*"domid": \(.*\),$/\1/')
 +        id=$(echo $1 | @sed@ -e 's/^.*"domid": \(.*\),$/\1/')
      fi
-
-@@ -245,5 +245,5 @@ is_running()
+ 
+     [ -n "$name" -a -n "$id" ] && return 0 || return 1
+@@ -244,7 +244,7 @@
+ 		RC=0
  		;;
  	esac
 -    done < <($CMD list -l | grep "$LIST_GREP")
 +    done < <($CMD list -l | @grep@ "$LIST_GREP")
      return $RC
  }
-@@ -256,5 +256,5 @@ start()
+ 
+@@ -255,7 +255,7 @@
+ 	return;
      fi
-
+ 
 -    mkdir -p $(dirname "$LOCKFILE")
 +    @mkdir@ -p $(@dirname@ "$LOCKFILE")
      touch $LOCKFILE
-
-@@ -267,5 +267,5 @@ start()
+ 
+     saved_domains=" "
+@@ -266,7 +266,7 @@
+ 	saved_domains=`ls $XENDOMAINS_SAVE`
          for dom in $XENDOMAINS_SAVE/*; do
              if [ -f $dom ] ; then
 -                HEADER=`head -c 16 $dom | head -n 1 2> /dev/null`
 +                HEADER=`@head@ -c 16 $dom | @head@ -n 1 2> /dev/null`
                  if [ "$HEADER" = "$HEADCOMP" ]; then
                      echo -n " ${dom##*/}"
-@@ -278,5 +278,5 @@ start()
+                     XMR=`$CMD restore $dom 2>&1 1>/dev/null`
+@@ -277,7 +277,7 @@
+                         echo -e '!'
                      else
                          # mv $dom ${dom%/*}/.${dom##*/}
 -                        rm $dom
 +                        @rm@ $dom
                      fi
                  fi
-@@ -300,6 +300,6 @@ start()
+             fi
+@@ -299,8 +299,8 @@
+ 	# restore correctly it requires administrative attention.
  	for dom in $XENDOMAINS_AUTO/*; do
  	    echo -n " ${dom##*/}"
 -	    shortdom=$(echo $dom | sed -n 's/^.*\/\(.*\)$/\1/p')
@@ -1324,15 +1515,19 @@ index 70f4129ef4..b066404b0d 100644
 +	    echo $saved_domains | @grep@ -w $shortdom > /dev/null
  	    if [ $? -eq 0 ] || is_running $dom; then
  		echo -n "(skip)"
-@@ -329,5 +329,5 @@ all_zombies()
+ 	    else
+@@ -328,7 +328,7 @@
+ 	if test "$state" != "-b---d" -a "$state" != "-----d"; then
  	    return 1;
  	fi
 -    done < <($CMD list -l | grep "$LIST_GREP")
 +    done < <($CMD list -l | @grep@ "$LIST_GREP")
      return 0
  }
-@@ -346,14 +346,14 @@ watchdog_xencmd()
-
+ 
+@@ -345,16 +345,16 @@
+     fi
+ 
      usleep 20000
 -    for no in `seq 0 $XENDOMAINS_STOP_MAXWAIT`; do
 +    for no in `@seq@  0 $XENDOMAINS_STOP_MAXWAIT`; do
@@ -1350,41 +1545,49 @@ index 70f4129ef4..b066404b0d 100644
 +    @sleep@ 1
      read PSF PSUID PSPID PSPPID < <(echo "$PSAX")
      # kill $CMD $1
-@@ -435,5 +435,5 @@ stop()
+     kill $PSPID >/dev/null 2>&1
+@@ -434,7 +434,7 @@
+ 	    echo -n "(save)"
  	    watchdog_xencmd save &
  	    WDOG_PID=$!
 -	    mkdir -p "$XENDOMAINS_SAVE"
 +	    @mkdir@ -p "$XENDOMAINS_SAVE"
  	    XMR=`$CMD save $id $XENDOMAINS_SAVE/$name 2>&1 1>/dev/null`
  	    if test $? -ne 0; then
-@@ -462,5 +462,5 @@ stop()
+ 		echo -e "\nAn error occurred while saving domain:\n$XMR\n"
+@@ -461,7 +461,7 @@
+ 	    fi
  	    kill $WDOG_PID >/dev/null 2>&1
  	fi
 -    done < <($CMD list -l | grep "$LIST_GREP")
 +    done < <($CMD list -l | @grep@ "$LIST_GREP")
-
+ 
      # NB. this shuts down ALL Xen domains (politely), not just the ones in
-@@ -483,5 +483,5 @@ stop()
-
+     # AUTODIR/*
+@@ -482,7 +482,7 @@
+     fi
+ 
      # Unconditionally delete lock file
 -    rm -f $LOCKFILE
 +    @rm@ -f $LOCKFILE
-
+ 
      exec 2>&3
-@@ -499,5 +499,5 @@ check_domain_up()
+ }
+@@ -498,7 +498,7 @@
+ 		return 0
  		;;
  	esac
 -    done < <($CMD list -l | grep "$LIST_GREP")
 +    done < <($CMD list -l | @grep@ "$LIST_GREP")
      return 1
  }
-@@ -532,5 +532,5 @@ check_all_saved_domains_up()
+ 
+@@ -531,7 +531,7 @@
+     then
        return 0
      fi
 -    missing=`/bin/ls $XENDOMAINS_SAVE`
 +    missing=`@ls@ $XENDOMAINS_SAVE`
      echo -n " MISS SAVED: " $missing
      return 1
---
-2.49.0
-
+ }

--- a/pkgs/by-name/xe/xen/0002-scripts-external-executable-calls.patch
+++ b/pkgs/by-name/xe/xen/0002-scripts-external-executable-calls.patch
@@ -1,70 +1,73 @@
-From 4893cc08acc81bfc2f8730ea108574aedae909aa Mon Sep 17 00:00:00 2001
-From: Fernando Rodrigues <alpha@sigmasquadron.net>
-Date: Fri, 4 Jul 2025 20:09:06 +0000
-Subject: [PATCH 2/2] xen/tools/hotplug/Linux: patch external binary calls
-
-This patch replaces all instances of executable calls and static FHS
-paths in the hotplug scripts with at-padded variables that can be
-replaced by replaceVars during a Nix build.
-
-Signed-off-by: Fernando Rodrigues <alpha@sigmasquadron.net>
-
 diff --git a/tools/hotplug/Linux/block b/tools/hotplug/Linux/block
 index 2691b56951..bd41313bf8 100644
 --- a/tools/hotplug/Linux/block
 +++ b/tools/hotplug/Linux/block
-@@ -1,5 +1,5 @@
+@@ -1,6 +1,6 @@
  #!/bin/bash
-
+ 
 -dir=$(dirname "$0")
 +dir=$(@dirname@ "$0")
  . "$dir/block-common.sh"
-
-@@ -32,5 +32,5 @@ find_free_loopback_helper() {
+ 
+ expand_dev() {
+@@ -31,7 +31,7 @@
+ # Not all distros have "losetup -f"
  find_free_loopback_dev() {
    local loopdev
 -  loopdev=$(losetup -a | sed -e 's+^/dev/loop++' -e 's/:.*//' | find_free_loopback_helper)
 +  loopdev=$(@losetup@  -a | @sed@ -e 's+^/dev/loop++' -e 's/:.*//' | find_free_loopback_helper)
    if [ -n "$loopdev" ] && [ -b "$loopdev" ]; then
      echo "$loopdev"
-@@ -67,6 +67,6 @@ check_sharing()
+   fi
+@@ -66,8 +66,8 @@
+   then
      local inode="$4"
-
+ 
 -    shared_list=$(losetup -a |
 -          sed -n -e "s@^\([^:]\+\)\(:[[:blank:]]\[0*${dev}\]:${inode}[[:blank:]](.*)\)@\1@p" )
 +    shared_list=$(@losetup@  -a |
 +          @sed@ -n -e "s@^\([^:]\+\)\(:[[:blank:]]\[0*${dev}\]:${inode}[[:blank:]](.*)\)@\1@p" )
      for dev in $shared_list
      do
-@@ -95,5 +95,5 @@ check_sharing()
+       if [ -n "$dev" ]
+@@ -94,7 +94,7 @@
+     toskip="^[^ ]* [^ ]* [^ ]* ro[, ]"
    fi
-
+ 
 -  for file in $(cat /proc/mounts | grep -v "$toskip" | cut -f 1 -d ' ')
 +  for file in $(@cat@ /proc/mounts | @grep@ -v "$toskip" | @cut@ -f 1 -d ' ')
    do
      if [ -e "$file" ]
-@@ -268,5 +268,5 @@ case "$command" in
+     then
+@@ -267,7 +267,7 @@
+ 
          if [ -L "$dev" ]
          then
 -          dev=$(readlink -f "$dev") || fatal "$dev link does not exist."
 +          dev=$(@readlink@ -f "$dev") || fatal "$dev link does not exist."
          fi
          test -e "$dev" || fatal "$dev does not exist."
-@@ -283,5 +283,5 @@ case "$command" in
+         test -b "$dev" || fatal "$dev is not a block device."
+@@ -282,7 +282,7 @@
+       file)
          # Canonicalise the file, for sharing check comparison, and the mode
          # for ease of use here.
 -        file=$(readlink -f "$p") || fatal "$p does not exist."
 +        file=$(@readlink@ -f "$p") || fatal "$p does not exist."
          test -f "$file" || fatal "$file does not exist."
          mode=$(canonicalise_mode "$mode")
-@@ -298,5 +298,5 @@ case "$command" in
+ 
+@@ -297,7 +297,7 @@
+           fatal "Path closed or removed during hotplug add: $XENBUS_PATH state: $xenbus_state"
          fi
-
+ 
 -        if [ "$mode" = 'w' ] && ! stat "$file" -c %A | grep -q w
 +        if [ "$mode" = 'w' ] && ! @stat@ "$file" -c %A | @grep@ -q w
          then
            release_lock "block"
-@@ -308,6 +308,6 @@ mount it read-write in a guest domain."
+           ebusy \
+@@ -307,8 +307,8 @@
+ 
          if [ "x$mode" != 'x!' ]
          then
 -          inode=$(stat -c '%i' "$file")
@@ -73,57 +76,68 @@ index 2691b56951..bd41313bf8 100644
 +          dev=$(@stat@ -c '%D' "$file")
            if [ -z "$inode" ] || [ -z "$dev" ]
            then
-@@ -318,5 +318,5 @@ mount it read-write in a guest domain."
+             fatal "Unable to lookup $file: dev: $dev inode: $inode"
+@@ -317,20 +317,20 @@
+           check_file_sharing "$file" "$dev" "$mode" "$inode"
          fi
-
+ 
 -        loopdev=$(losetup -f 2>/dev/null || find_free_loopback_dev)
 +        loopdev=$(@losetup@  -f 2>/dev/null || find_free_loopback_dev)
          if [ "$loopdev" = '' ]
          then
-@@ -325,5 +325,5 @@ mount it read-write in a guest domain."
+           release_lock "block"
+           fatal 'Failed to find an unused loop device'
          fi
-
+ 
 -        if LANG=C losetup -h 2>&1 | grep read-only >/dev/null
 +        if LANG=C @losetup@  -h 2>&1 | @grep@ read-only >/dev/null
          then
            roflag="-$mode"; roflag="${roflag#-w}"; roflag="${roflag#-!}"
-@@ -331,5 +331,5 @@ mount it read-write in a guest domain."
+         else
            roflag=''
          fi
 -        do_or_die losetup $roflag "$loopdev" "$file"
 +        do_or_die @losetup@  $roflag "$loopdev" "$file"
          xenstore_write "$XENBUS_PATH/node" "$loopdev"
          write_dev "$loopdev"
-@@ -355,5 +355,5 @@ mount it read-write in a guest domain."
+         release_lock "block"
+@@ -354,7 +354,7 @@
+       file)
          claim_lock "block"
          node=$(xenstore_read "$XENBUS_PATH/node")
 -	losetup -d "$node"
 +	@losetup@  -d "$node"
          release_lock "block"
  	exit 0
+ 	;;
 diff --git a/tools/hotplug/Linux/block-common.sh b/tools/hotplug/Linux/block-common.sh
 index 5c80237d99..5e1c350555 100644
 --- a/tools/hotplug/Linux/block-common.sh
 +++ b/tools/hotplug/Linux/block-common.sh
-@@ -16,5 +16,5 @@
-
-
+@@ -15,7 +15,7 @@
+ #
+ 
+ 
 -dir=$(dirname "$0")
 +dir=$(@dirname@ "$0")
  . "$dir/xen-hotplug-common.sh"
-
-@@ -46,5 +46,5 @@ ebusy()
+ 
+ findCommand "$@"
+@@ -45,7 +45,7 @@
+ # separated by a colon.
  device_major_minor()
  {
 -  stat -L -c %t:%T "$1"
 +  @stat@ -L -c %t:%T "$1"
  }
-
+ 
+ 
 diff --git a/tools/hotplug/Linux/block-drbd-probe b/tools/hotplug/Linux/block-drbd-probe
 index 7b2968b6d9..ba246cd132 100755
 --- a/tools/hotplug/Linux/block-drbd-probe
 +++ b/tools/hotplug/Linux/block-drbd-probe
-@@ -32,6 +32,6 @@ function get_res_name()
+@@ -31,8 +31,8 @@
+ function get_res_name()
  {
      local drbd_dev=$1
 -    local drbd_dev_list=($(drbdadm sh-dev all))
@@ -132,121 +146,138 @@ index 7b2968b6d9..ba246cd132 100755
 +    local drbd_res_list=($(@drbdadm@ sh-resource all))
      local temp_drbd_dev temp_drbd_res
      local found=0
-@@ -49,5 +49,5 @@ function get_res_name()
-
+ 
+@@ -48,7 +48,7 @@
+     fi
+ 
      for temp_drbd_res in ${drbd_res_list[@]}; do
 -        temp_drbd_dev=$(drbdadm sh-dev $temp_drbd_res)
 +        temp_drbd_dev=$(@drbdadm@ sh-dev $temp_drbd_res)
          if [[ "$temp_drbd_dev" == "$drbd_dev" ]]; then
              drbd_res="$temp_drbd_res"
-@@ -67,5 +67,5 @@ fi
-
+             return 0
+@@ -66,19 +66,19 @@
+ fi
+ 
  # check protocol
 -drbdsetup $1 show | grep -q "protocol D;"
 +@drbdsetup@ $1 show | @grep@ -q "protocol D;"
  if [[ $? -ne 0 ]]; then
      exit 3
-@@ -73,5 +73,5 @@ fi
-
+ fi
+ 
  # check connect status
 -state=$(drbdadm cstate "$drbd_res")
 +state=$(@drbdadm@ cstate "$drbd_res")
  if [[ "$state" != "Connected" ]]; then
      exit 4
-@@ -79,5 +79,5 @@ fi
-
+ fi
+ 
  # check role
 -role=$(drbdadm role "$drbd_res")
 +role=$(@drbdadm@ role "$drbd_res")
  if [[ "$role" != "Primary/Secondary" ]]; then
      exit 4
+ fi
 diff --git a/tools/hotplug/Linux/block-dummy b/tools/hotplug/Linux/block-dummy
 index 57d40b5fce..50bbf09bb6 100644
 --- a/tools/hotplug/Linux/block-dummy
 +++ b/tools/hotplug/Linux/block-dummy
-@@ -23,10 +23,10 @@
+@@ -22,12 +22,12 @@
+ #
  # script=block-dummy,vdev=xvda,target=dummy:<file>
-
+ 
 -dir=$(dirname "$0")
 +dir=$(@dirname@ "$0")
  . "$dir/block-common.sh"
-
+ 
  check_tools()
  {
 -    if ! command -v losetup > /dev/null 2>&1; then
 +    if ! command -v @losetup@  > /dev/null 2>&1; then
          fatal "Unable to find losetup"
      fi
-@@ -56,5 +56,5 @@ add()
+ }
+@@ -55,20 +55,20 @@
+ {
      test -f "$file" || fatal "$file does not exist."
-
+ 
 -    loopdev=$(losetup -f 2>/dev/null || find_free_loopback_dev)
 +    loopdev=$(@losetup@  -f 2>/dev/null || find_free_loopback_dev)
      if [ "$loopdev" = '' ]
      then
-@@ -62,5 +62,5 @@ add()
+         fatal 'Failed to find an unused loop device'
      fi
      
 -    if LANG=C losetup -h 2>&1 | grep read-only >/dev/null
 +    if LANG=C @losetup@  -h 2>&1 | @grep@ read-only >/dev/null
      then
          roflag="-$mode"; roflag="${roflag#-w}"; roflag="${roflag#-!}"
-@@ -69,5 +69,5 @@ add()
+     else
+         roflag=''
      fi
-
+ 
 -    do_or_die losetup $roflag "$loopdev" "$file"
 +    do_or_die @losetup@  $roflag "$loopdev" "$file"
      # FIXME Is this OK?
      xenstore_write "$XENBUS_PATH/node" "$loopdev"
-@@ -79,5 +79,5 @@ remove()
+     write_dev "$loopdev"
+@@ -78,7 +78,7 @@
+ remove()
  {
      node=$(xenstore_read "$XENBUS_PATH/node")
 -    losetup -d "$node"
 +    @losetup@  -d "$node"
  }
-
+ 
+ command=$1
 diff --git a/tools/hotplug/Linux/block-enbd b/tools/hotplug/Linux/block-enbd
 index 67faa84268..77599ff6df 100644
 --- a/tools/hotplug/Linux/block-enbd
 +++ b/tools/hotplug/Linux/block-enbd
-@@ -8,5 +8,5 @@
+@@ -7,13 +7,13 @@
+ #
  # This assumes you're running a correctly configured server at the other end!
-
+ 
 -dir=$(dirname "$0")
 +dir=$(@dirname@ "$0")
  . "$dir/block-common.sh"
-
-@@ -14,5 +14,5 @@ case "$command" in
+ 
+ case "$command" in
    add)
      for dev in /dev/nd*; do
 -      if nbd-client $2:$3 $dev; then
 +      if @nbd-client@ $2:$3 $dev; then
          write_dev $dev
          exit 0
-@@ -22,5 +22,5 @@ case "$command" in
+       fi
+@@ -21,7 +21,7 @@
+     exit 1
      ;;
    remove)
 -    nbd-client -d $2
 +    @nbd-client@ -d $2
      exit 0
      ;;
+ esac
 diff --git a/tools/hotplug/Linux/block-iscsi b/tools/hotplug/Linux/block-iscsi
 index 3615905252..ad45a3685b 100644
 --- a/tools/hotplug/Linux/block-iscsi
 +++ b/tools/hotplug/Linux/block-iscsi
-@@ -24,18 +24,18 @@
+@@ -23,20 +23,20 @@
+ # Portal address must be in IP format.
  #
-
+ 
 -dir=$(dirname "$0")
 +dir=$(@dirname@ "$0")
  . "$dir/block-common.sh"
-
+ 
  remove_label()
  {
 -    echo $1 | sed "s/^\("$2"\)//"
 +    echo $1 | @sed@ "s/^\("$2"\)//"
  }
-
+ 
  check_tools()
  {
 -    if ! command -v iscsiadm > /dev/null 2>&1; then
@@ -257,14 +288,17 @@ index 3615905252..ad45a3685b 100644
 +    if [ "$multipath" = "y" ] && ! command -v @multipath@ > /dev/null 2>&1; then
          fatal "Unable to find multipath"
      fi
-@@ -75,5 +75,5 @@ find_device()
+ }
+@@ -74,19 +74,19 @@
+ {
      count=0
      while [ ! -e /dev/disk/by-path/*"$iqn"-lun-0 ]; do
 -        sleep 1
 +        @sleep@ 1
          count=`expr $count + 1`
          if [ count = 100 ]; then
-@@ -82,10 +82,10 @@ find_device()
+             # 10s timeout while waiting for iSCSI disk to settle
+             fatal "timeout waiting for iSCSI disk to settle"
          fi
      done
 -    sddev=$(readlink -f /dev/disk/by-path/*"$iqn"-lun-0 || true)
@@ -277,14 +311,18 @@ index 3615905252..ad45a3685b 100644
 +        mdev=$(@multipath@ -ll "$sddev" | @head@ -1 | @awk@ '{ print $1}')
          if [ ! -b /dev/mapper/"$mdev" ]; then
              fatal "Unable to find attached device multipath"
-@@ -101,5 +101,5 @@ find_device()
+         fi
+@@ -100,7 +100,7 @@
+ # multipath device
  attach()
  {
 -    do_or_die iscsiadm -m node --targetname "$iqn" -p "$portal" --login > /dev/null
 +    do_or_die @iscsiadm@ -m node --targetname "$iqn" -p "$portal" --login > /dev/null
      find_device
  }
-@@ -110,7 +110,7 @@ prepare()
+ 
+@@ -109,9 +109,9 @@
+ prepare()
  {
      # Check if target is already opened
 -    iscsiadm -m session 2>&1 | grep -q "$iqn" && fatal "Device already opened"
@@ -294,81 +332,96 @@ index 3615905252..ad45a3685b 100644
 +    @iscsiadm@ -m discovery -t st -p $portal 2>&1 | @grep@ -q "$iqn" || \
          fatal "No matching target iqn found"
  }
-@@ -128,5 +128,5 @@ remove()
+ 
+@@ -127,7 +127,7 @@
+ remove()
  {
      find_device
 -    do_or_die iscsiadm -m node --targetname "$iqn" -p "$portal" --logout > /dev/null
 +    do_or_die @iscsiadm@ -m node --targetname "$iqn" -p "$portal" --logout > /dev/null
  }
-
+ 
+ command=$1
 diff --git a/tools/hotplug/Linux/block-nbd b/tools/hotplug/Linux/block-nbd
 index b29b31564a..a98350b121 100644
 --- a/tools/hotplug/Linux/block-nbd
 +++ b/tools/hotplug/Linux/block-nbd
-@@ -8,5 +8,5 @@
+@@ -7,13 +7,13 @@
+ #
  # This assumes you're running a correctly configured server at the other end!
-
+ 
 -dir=$(dirname "$0")
 +dir=$(@dirname@ "$0")
  . "$dir/block-common.sh"
-
-@@ -14,5 +14,5 @@ case "$command" in
+ 
+ case "$command" in
    add)
      for dev in /dev/nbd*; do
 -      if nbd-client $2 $3 $dev; then
 +      if @nbd-client@ $2 $3 $dev; then
          write_dev $dev
          exit 0
-@@ -22,5 +22,5 @@ case "$command" in
+       fi
+@@ -21,7 +21,7 @@
+     exit 1
      ;;
    remove)
 -    nbd-client -d $2
 +    @nbd-client@ -d $2
      exit 0
      ;;
+ esac
 diff --git a/tools/hotplug/Linux/block-tap b/tools/hotplug/Linux/block-tap
 index 95970a61f6..a03a36f8b6 100755
 --- a/tools/hotplug/Linux/block-tap
 +++ b/tools/hotplug/Linux/block-tap
-@@ -29,10 +29,10 @@
+@@ -28,12 +28,12 @@
+ #
  # format/<type> is either "aio" (for raw files), or "vhd"
-
+ 
 -dir=$(dirname "$0")
 +dir=$(@dirname@ "$0")
  . "$dir/block-common.sh"
-
+ 
  remove_label()
  {
 -    echo $1 | sed "s/^\("$2"\)//"
 +    echo $1 | @sed@ "s/^\("$2"\)//"
  }
-
-@@ -102,5 +102,5 @@ count_using()
+ 
+ check_tools()
+@@ -101,7 +101,7 @@
+         for dev in $(xenstore-list "$base_path/$dom")
          do
              f=$(xenstore_read_default "$base_path/$dom/$dev/params" "")
 -            f=$(echo "$f" | cut -d ":" -f 2)
 +            f=$(echo "$f" | @cut@ -d ":" -f 2)
-
+ 
              if [ -n "$f" ] && [ "$file" = $f ] ; then
-@@ -131,5 +131,5 @@ check_tap_sharing()
+                 i=$(( i + 1 ))
+@@ -130,7 +130,7 @@
+     for dom in $(xenstore-list "$base_path") ; do
          for dev in $(xenstore-list "$base_path/$dom") ; do
              local f=$(xenstore_read_default "$base_path/$dom/$dev/params" "")
 -            f=$(echo "$f" | cut -d ":" -f 2)
 +            f=$(echo "$f" | @cut@ -d ":" -f 2)
-
+ 
              if [ -n "$f" ] && [ "$file" = "$f" ] ; then
+                 if [ "$mode" = 'w' ] ; then
 diff --git a/tools/hotplug/Linux/colo-proxy-setup b/tools/hotplug/Linux/colo-proxy-setup
 index d709146c47..e0f44364cc 100755
 --- a/tools/hotplug/Linux/colo-proxy-setup
 +++ b/tools/hotplug/Linux/colo-proxy-setup
-@@ -1,5 +1,5 @@
+@@ -1,6 +1,6 @@
  #! /bin/bash
-
+ 
 -dir=$(dirname "$0")
 +dir=$(@dirname@ "$0")
  . "$dir/xen-hotplug-common.sh"
  . "$dir/hotplugpath.sh"
-@@ -38,60 +38,60 @@ fi
+ 
+@@ -37,84 +37,84 @@
+ 
  function setup_primary()
  {
 -    do_without_error tc qdisc add dev $vifname root handle 1: prio
@@ -383,12 +436,12 @@ index d709146c47..e0f44364cc 100755
 +    do_without_error @tc@ filter add dev $vifname parent 1: protocol ipv6 prio \
          12 u32 match u32 0 0 flowid 1:2 action mirred egress mirror \
          dev $forwarddev
-
+ 
 -    do_without_error modprobe nf_conntrack_ipv4
 -    do_without_error modprobe xt_PMYCOLO sec_dev=$forwarddev
 +    do_without_error @modprobe@ nf_conntrack_ipv4
 +    do_without_error @modprobe@ xt_PMYCOLO sec_dev=$forwarddev
-
+ 
 -    iptables -t mangle -I PREROUTING -m physdev --physdev-in \
 +    @iptables@ -t mangle -I PREROUTING -m physdev --physdev-in \
          $vifname -j PMYCOLO --index $index
@@ -398,7 +451,7 @@ index d709146c47..e0f44364cc 100755
 -    do_without_error arptables -I INPUT -i $forwarddev -j MARK --set-mark $index
 +    do_without_error @arptables@ -I INPUT -i $forwarddev -j MARK --set-mark $index
  }
-
+ 
  function teardown_primary()
  {
 -    do_without_error tc filter del dev $vifname parent 1: protocol ip prio 10 u32 match u32 \
@@ -412,7 +465,7 @@ index d709146c47..e0f44364cc 100755
          0 0 flowid 1:2 action mirred egress mirror dev $forwarddev
 -    do_without_error tc qdisc del dev $vifname root handle 1: prio
 +    do_without_error @tc@ qdisc del dev $vifname root handle 1: prio
-
+ 
 -    do_without_error iptables -t mangle -D PREROUTING -m physdev --physdev-in \
 +    do_without_error @iptables@ -t mangle -D PREROUTING -m physdev --physdev-in \
          $vifname -j PMYCOLO --index $index
@@ -424,7 +477,7 @@ index d709146c47..e0f44364cc 100755
 +    do_without_error @arptables@ -F
 +    do_without_error @rmmod@ xt_PMYCOLO
  }
-
+ 
  function setup_secondary()
  {
 -    if which brctl >&/dev/null; then
@@ -451,7 +504,7 @@ index d709146c47..e0f44364cc 100755
 -    do_without_error modprobe xt_SECCOLO
 +    do_without_error @ip@ link set dev $forwardbr up
 +    do_without_error @modprobe@ xt_SECCOLO
-
+ 
 -    iptables -t mangle -I PREROUTING -m physdev --physdev-in \
 +    @iptables@ -t mangle -I PREROUTING -m physdev --physdev-in \
          $vifname -j SECCOLO --index $index
@@ -459,7 +512,7 @@ index d709146c47..e0f44364cc 100755
 +    @ip6tables@ -t mangle -I PREROUTING -m physdev --physdev-in \
          $vifname -j SECCOLO --index $index
  }
-@@ -99,21 +99,21 @@ function setup_secondary()
+ 
  function teardown_secondary()
  {
 -    if which brctl >&/dev/null; then
@@ -482,7 +535,7 @@ index d709146c47..e0f44364cc 100755
 +        do_without_error @ip@ link delete $forwardbr type bridge
 +        do_without_error @ip@ link set $vifname master $bridge
      fi
-
+ 
 -    do_without_error iptables -t mangle -D PREROUTING -m physdev --physdev-in \
 +    do_without_error @iptables@ -t mangle -D PREROUTING -m physdev --physdev-in \
          $vifname -j SECCOLO --index $index
@@ -492,75 +545,66 @@ index d709146c47..e0f44364cc 100755
 -    do_without_error rmmod xt_SECCOLO
 +    do_without_error @rmmod@ xt_SECCOLO
  }
-
+ 
+ case "$command" in
 diff --git a/tools/hotplug/Linux/external-device-migrate b/tools/hotplug/Linux/external-device-migrate
 index f5942a6a95..228917b784 100644
 --- a/tools/hotplug/Linux/external-device-migrate
 +++ b/tools/hotplug/Linux/external-device-migrate
-@@ -24,10 +24,10 @@ set -x
+@@ -23,12 +23,12 @@
+ # It handles the low-level command line parsing and some of the
  # synchronization
-
+ 
 -dir=$(dirname "$0")
 +dir=$(@dirname@ "$0")
  . "$dir/logging.sh"
-
-
+ 
+ 
  function ext_dev_migrate_usage() {
 -cat <<EOF
 +@cat@ <<EOF
  Pass the following command line parameters to the script:
-
-diff --git a/tools/hotplug/Linux/init.d/xen-watchdog.in b/tools/hotplug/Linux/init.d/xen-watchdog.in
-index a0bde199c4..cefa3b81f8 100644
---- a/tools/hotplug/Linux/init.d/xen-watchdog.in
-+++ b/tools/hotplug/Linux/init.d/xen-watchdog.in
-@@ -26,5 +26,5 @@ test -f $xencommons_config/xencommons && . $xencommons_config/xencommons
- test -n "$XENWATCHDOGD_ARGS" || XENWATCHDOGD_ARGS='30 15'
- DAEMON=${sbindir}/xenwatchdogd
--base=$(basename $DAEMON)
-+base=$(@basename@ $DAEMON)
-
- # Source function library.
-@@ -64,5 +64,5 @@ stop() {
- 	echo -n $"Stopping domain watchdog daemon: "
-
--	killall -USR1 $base 2>/dev/null
-+	@killall@ -USR1 $base 2>/dev/null
- 	r=$?
- 	[ "$r" -eq 0 ] && success $"$base stop" || failure $"$base stop"
+ 
+ -step <n>              : n-th migration step
 diff --git a/tools/hotplug/Linux/init.d/xencommons.in b/tools/hotplug/Linux/init.d/xencommons.in
 index 7fd6903b98..dcc8de631b 100644
 --- a/tools/hotplug/Linux/init.d/xencommons.in
 +++ b/tools/hotplug/Linux/init.d/xencommons.in
-@@ -39,5 +39,5 @@ fi
+@@ -38,7 +38,7 @@
+ # mount xenfs in dom0 or domU with a pv_ops kernel
  if test "x$1" = xstart && \
     ! test -f /proc/xen/capabilities && \
 -   ! grep '^xenfs ' /proc/mounts >/dev/null;
 +   ! @grep@ '^xenfs ' /proc/mounts >/dev/null;
  then
  	mount -t xenfs xenfs /proc/xen
-@@ -48,5 +48,5 @@ fi
+ fi
+@@ -47,18 +47,18 @@
+ # no capabilities file in xenlinux domU kernel
  # empty capabilities file in pv_ops domU kernel
  if test -f /proc/xen/capabilities && \
 -   ! grep -q "control_d" /proc/xen/capabilities ; then
 +   ! @grep@ -q "control_d" /proc/xen/capabilities ; then
  	exit 0
  fi
-@@ -55,9 +55,9 @@ do_start () {
+ 
+ do_start () {
  	local mod
-
+ 
 -	for mod in $BACKEND_MODULES ; do modprobe "$mod" &>/dev/null ; done
 +	for mod in $BACKEND_MODULES ; do @modprobe@ "$mod" &>/dev/null ; done
-
+ 
 -	mkdir -m700 -p ${XEN_RUN_DIR}
 -	mkdir -m700 -p ${XEN_LOCK_DIR}
 -	mkdir -p ${XEN_LOG_DIR}
 +	@mkdir@ -m700 -p ${XEN_RUN_DIR}
 +	@mkdir@ -m700 -p ${XEN_LOCK_DIR}
 +	@mkdir@ -p ${XEN_LOG_DIR}
-
+ 
  	@XEN_SCRIPT_DIR@/launch-xenstore || exit 1
-@@ -79,6 +79,6 @@ do_stop () {
+ 
+@@ -78,15 +78,15 @@
+         echo Stopping xenconsoled
  	if read 2>/dev/null <$XENCONSOLED_PIDFILE pid; then
  		kill $pid
 -		while kill -9 $pid >/dev/null 2>&1; do sleep 1; done
@@ -568,8 +612,8 @@ index 7fd6903b98..dcc8de631b 100644
 +		while kill -9 $pid >/dev/null 2>&1; do @sleep@ 1; done
 +		@rm@ -f $XENCONSOLED_PIDFILE
  	fi
-
-@@ -86,6 +86,6 @@ do_stop () {
+ 
+ 	echo Stopping QEMU
  	if read 2>/dev/null <$QEMU_PIDFILE pid; then
  		kill $pid
 -		while kill -9 $pid >/dev/null 2>&1; do sleep 1; done
@@ -577,33 +621,38 @@ index 7fd6903b98..dcc8de631b 100644
 +		while kill -9 $pid >/dev/null 2>&1; do @sleep@ 1; done
 +		@rm@ -f $QEMU_PIDFILE
  	fi
-
+ 
+ 	echo WARNING: Not stopping xenstored, as it cannot be restarted.
 diff --git a/tools/hotplug/Linux/init.d/xendriverdomain.in b/tools/hotplug/Linux/init.d/xendriverdomain.in
 index 17b381c3dc..064906f027 100644
 --- a/tools/hotplug/Linux/init.d/xendriverdomain.in
 +++ b/tools/hotplug/Linux/init.d/xendriverdomain.in
-@@ -35,5 +35,5 @@ fi
+@@ -34,7 +34,7 @@
+ # mount xenfs in dom0 or domU with a pv_ops kernel
  if test "x$1" = xstart && \
     ! test -f /proc/xen/capabilities && \
 -   ! grep '^xenfs ' /proc/mounts >/dev/null;
 +   ! @grep@ '^xenfs ' /proc/mounts >/dev/null;
  then
  	mount -t xenfs xenfs /proc/xen
-@@ -44,5 +44,5 @@ fi
+ fi
+@@ -43,21 +43,21 @@
+ # no capabilities file in xenlinux domU kernel
  # empty capabilities file in pv_ops domU kernel
  if ! test -f /proc/xen/capabilities || \
 -   grep -q "control_d" /proc/xen/capabilities ; then
 +   @grep@ -q "control_d" /proc/xen/capabilities ; then
  	exit 0
  fi
-@@ -50,5 +50,5 @@ fi
+ 
  do_start () {
  	echo Starting xl devd...
 -	mkdir -p "${XEN_RUN_DIR}"
 +	@mkdir@ -p "${XEN_RUN_DIR}"
  	${sbindir}/xl devd --pidfile=$XLDEVD_PIDFILE $XLDEVD_ARGS
  }
-@@ -57,6 +57,6 @@ do_stop () {
+ do_stop () {
+         echo Stopping xl devd...
  	if read 2>/dev/null <$XLDEVD_PIDFILE pid; then
  		kill $pid
 -		while kill -9 $pid >/dev/null 2>&1; do sleep 1; done
@@ -612,91 +661,133 @@ index 17b381c3dc..064906f027 100644
 +		@rm@ -f $XLDEVD_PIDFILE
  	fi
  }
+ 
+diff --git a/tools/hotplug/Linux/init.d/xen-watchdog.in b/tools/hotplug/Linux/init.d/xen-watchdog.in
+index a0bde199c4..cefa3b81f8 100644
+--- a/tools/hotplug/Linux/init.d/xen-watchdog.in
++++ b/tools/hotplug/Linux/init.d/xen-watchdog.in
+@@ -25,7 +25,7 @@
+ 
+ test -n "$XENWATCHDOGD_ARGS" || XENWATCHDOGD_ARGS='30 15'
+ DAEMON=${sbindir}/xenwatchdogd
+-base=$(basename $DAEMON)
++base=$(@basename@ $DAEMON)
+ 
+ # Source function library.
+ if [ -e  /etc/init.d/functions ] ; then
+@@ -63,7 +63,7 @@
+ 	local r
+ 	echo -n $"Stopping domain watchdog daemon: "
+ 
+-	killall -USR1 $base 2>/dev/null
++	@killall@ -USR1 $base 2>/dev/null
+ 	r=$?
+ 	[ "$r" -eq 0 ] && success $"$base stop" || failure $"$base stop"
+ 	echo
 diff --git a/tools/hotplug/Linux/launch-xenstore.in b/tools/hotplug/Linux/launch-xenstore.in
 index da4eeca7c5..059036d899 100644
 --- a/tools/hotplug/Linux/launch-xenstore.in
 +++ b/tools/hotplug/Linux/launch-xenstore.in
-@@ -32,5 +32,5 @@ timeout_xenstore () {
+@@ -31,7 +31,7 @@
+ 	while [ $time -lt $timeout ] && ! test_xenstore ; do
  		echo -n .
  		time=$(($time+1))
 -		sleep 1
 +		@sleep@ 1
  	done
  	echo
-@@ -51,5 +51,5 @@ test -f @CONFIG_DIR@/@CONFIG_LEAF_DIR@/xencommons && . @CONFIG_DIR@/@CONFIG_LEAF
+  
+@@ -50,7 +50,7 @@
+ 
  [ "$XENSTORETYPE" = "" ] && XENSTORETYPE=daemon
-
+ 
 -/bin/mkdir -p @XEN_RUN_DIR@
 +@mkdir@ -p @XEN_RUN_DIR@
-
+ 
  [ "$XENSTORETYPE" = "daemon" ] && {
-@@ -72,5 +72,5 @@ test -f @CONFIG_DIR@/@CONFIG_LEAF_DIR@/xencommons && . @CONFIG_DIR@/@CONFIG_LEAF
+ 	[ -z "$XENSTORED_TRACE" ] || XENSTORED_ARGS="$XENSTORED_ARGS -T @XEN_LOG_DIR@/xenstored-trace.log"
+@@ -71,7 +71,7 @@
+ 		}
  	}
  	[ -r /proc/sys/fs/nr_open ] && {
 -		MAX_FDS=`cat /proc/sys/fs/nr_open`
 +		MAX_FDS=`@cat@ /proc/sys/fs/nr_open`
  		[ "$XENSTORED_MAX_OPEN_FDS" = "unlimited" ] && XENSTORED_MAX_OPEN_FDS=$MAX_FDS
  		[ $XENSTORED_MAX_OPEN_FDS -gt $MAX_FDS ] && {
-@@ -81,11 +81,11 @@ test -f @CONFIG_DIR@/@CONFIG_LEAF_DIR@/xencommons && . @CONFIG_DIR@/@CONFIG_LEAF
+ 			echo "XENSTORED_MAX_OPEN_FDS exceeds system limit."
+@@ -80,13 +80,13 @@
+ 		}
  	}
-
+ 
 -	rm -f @XEN_RUN_DIR@/xenstored.pid
 +	@rm@ -f @XEN_RUN_DIR@/xenstored.pid
-
+ 
  	echo -n Starting $XENSTORED...
 -	prlimit --nofile=$XENSTORED_MAX_OPEN_FDS $XENSTORED --pid-file @XEN_RUN_DIR@/xenstored.pid $XENSTORED_ARGS
 +	@prlimit@ --nofile=$XENSTORED_MAX_OPEN_FDS $XENSTORED --pid-file @XEN_RUN_DIR@/xenstored.pid $XENSTORED_ARGS
-
+ 
 -	systemd-notify --booted 2>/dev/null || timeout_xenstore $XENSTORED || exit 1
 -	XS_PID=`cat @XEN_RUN_DIR@/xenstored.pid`
 +	@systemd-notify@ --booted 2>/dev/null || timeout_xenstore $XENSTORED || exit 1
 +	XS_PID=`@cat@ @XEN_RUN_DIR@/xenstored.pid`
  	echo $XS_OOM_SCORE >/proc/$XS_PID/oom_score_adj
-
-@@ -103,5 +103,5 @@ test -f @CONFIG_DIR@/@CONFIG_LEAF_DIR@/xencommons && . @CONFIG_DIR@/@CONFIG_LEAF
+ 
+ 	exit 0
+@@ -102,7 +102,7 @@
+ 
  	echo -n Starting $XENSTORE_DOMAIN_KERNEL...
  	${LIBEXEC_BIN}/init-xenstore-domain $XENSTORE_DOMAIN_ARGS || exit 1
 -	systemd-notify --ready 2>/dev/null
 +	@systemd-notify@ --ready 2>/dev/null
-
+ 
  	exit 0
+ }
 diff --git a/tools/hotplug/Linux/locking.sh b/tools/hotplug/Linux/locking.sh
 index 2e6fb35f02..5860157657 100644
 --- a/tools/hotplug/Linux/locking.sh
 +++ b/tools/hotplug/Linux/locking.sh
-@@ -36,5 +36,5 @@ _setlockfd()
+@@ -35,7 +35,7 @@
+ 
  claim_lock()
  {
 -    mkdir -p "$LOCK_BASEDIR"
 +    @mkdir@ -p "$LOCK_BASEDIR"
      _setlockfd $1
      # The locking strategy is identical to that from with-lock-ex(1)
-@@ -45,5 +45,5 @@ claim_lock()
+     # from chiark-utils, except using flock.  It has the benefit of
+@@ -44,7 +44,7 @@
+     local stat
      while true; do
          eval "exec $_lockfd<>$_lockfile"
 -        flock -x $_lockfd || return $?
 +        @flock@ -x $_lockfd || return $?
          # Although /dev/stdin (i.e. /proc/self/fd/0) looks like a symlink,
          # stat(2) bypasses the synthetic symlink and directly accesses the
-@@ -53,5 +53,5 @@ claim_lock()
+         # underlying open-file.  So this works correctly even if the file
+@@ -52,7 +52,7 @@
+         # WW.XXX
          # YY.ZZZ
          # which need to be separated and compared.
 -        if stat=$( stat -L -c '%D.%i' /dev/stdin $_lockfile 0<&$_lockfd 2>/dev/null )
 +        if stat=$( @stat@ -L -c '%D.%i' /dev/stdin $_lockfile 0<&$_lockfd 2>/dev/null )
          then
              local file_stat
-@@ -75,5 +75,5 @@ release_lock()
+             local fd_stat
+@@ -74,7 +74,7 @@
+ release_lock()
  {
      _setlockfd $1
 -    rm "$_lockfile"
 +    @rm@ "$_lockfile"
  }
-
+ 
+ # Protocol and correctness proof:
 diff --git a/tools/hotplug/Linux/logging.sh b/tools/hotplug/Linux/logging.sh
 index 3e94df1a9e..fa99d8c4c7 100644
 --- a/tools/hotplug/Linux/logging.sh
 +++ b/tools/hotplug/Linux/logging.sh
-@@ -18,4 +18,4 @@ log() {
+@@ -17,5 +17,5 @@
+ log() {
    local level="$1"
    shift
 -  logger -p "daemon.$level" -- "$0:" "$@" || echo "$0 $@" >&2
@@ -706,15 +797,18 @@ diff --git a/tools/hotplug/Linux/remus-netbuf-setup b/tools/hotplug/Linux/remus-
 index 87dfa69778..fe4f7b6e36 100644
 --- a/tools/hotplug/Linux/remus-netbuf-setup
 +++ b/tools/hotplug/Linux/remus-netbuf-setup
-@@ -75,5 +75,5 @@
+@@ -74,7 +74,7 @@
+ 
  # Unlike other vif scripts, vif-common is not needed here as it executes vif
  #specific setup code such as renaming.
 -dir=$(dirname "$0")
 +dir=$(@dirname@ "$0")
  . "$dir/xen-hotplug-common.sh"
-
-@@ -93,11 +93,11 @@ evalVariables "$@"
-
+ 
+ findCommand "$@"
+@@ -92,13 +92,13 @@
+ : ${XENBUS_PATH:?}
+ 
  check_libnl_tools() {
 -    if ! command -v nl-qdisc-list > /dev/null 2>&1; then
 +    if ! command -v @nl-qdisc-list@ > /dev/null 2>&1; then
@@ -728,53 +822,64 @@ index 87dfa69778..fe4f7b6e36 100644
 +    if ! command -v @nl-qdisc-delete@ > /dev/null 2>&1; then
          fatal "Unable to find nl-qdisc-delete tool"
      fi
-@@ -111,5 +111,5 @@ check_modules() {
+ }
+@@ -110,7 +110,7 @@
+ check_modules() {
      for m in ifb sch_plug sch_ingress act_mirred cls_u32
      do
 -        if ! modinfo $m > /dev/null 2>&1; then
 +        if ! @modinfo@ $m > /dev/null 2>&1; then
              fatal "Unable to find $m kernel module"
          fi
-@@ -119,5 +119,5 @@ check_modules() {
+     done
+@@ -118,7 +118,7 @@
+ 
  #return 0 if the ifb is free
  check_ifb() {
 -    local installed=`nl-qdisc-list -d $1`
 +    local installed=`@nl-qdisc-list@ -d $1`
      [ -n "$installed" ] && return 1
-
-@@ -140,5 +140,5 @@ check_ifb() {
+ 
+     for domid in `xenstore-list "/local/domain" 2>/dev/null || true`
+@@ -139,7 +139,7 @@
+ 
  setup_ifb() {
-
+ 
 -    for ifb in `ifconfig -a -s|egrep ^ifb|cut -d ' ' -f1`
 +    for ifb in `@ifconfig@ -a -s|@egrep@ ^ifb|@cut@ -d ' ' -f1`
      do
          check_ifb "$ifb" || continue
-@@ -155,5 +155,5 @@ setup_ifb() {
+         REMUS_IFB="$ifb"
+@@ -154,21 +154,21 @@
+     #not using xenstore_write that automatically exits on error
      #because we need to cleanup
      xenstore_write "$XENBUS_PATH/ifb" "$REMUS_IFB"
 -    do_or_die ip link set dev "$REMUS_IFB" up
 +    do_or_die @ip@ link set dev "$REMUS_IFB" up
  }
-
-@@ -162,12 +162,12 @@ redirect_vif_traffic() {
+ 
+ redirect_vif_traffic() {
+     local vif=$1
      local ifb=$2
-
+ 
 -    do_or_die tc qdisc add dev "$vif" ingress
 +    do_or_die @tc@ qdisc add dev "$vif" ingress
-
+ 
 -    tc filter add dev "$vif" parent ffff: proto ip prio 10 \
 +    @tc@ filter add dev "$vif" parent ffff: proto ip prio 10 \
          u32 match u32 0 0 action mirred egress redirect dev "$ifb" >/dev/null 2>&1
-
+ 
      if [ $? -ne 0 ]
      then
 -        do_without_error tc qdisc del dev "$vif" ingress
 +        do_without_error @tc@ qdisc del dev "$vif" ingress
          fatal "Failed to redirect traffic from $vif to $ifb"
      fi
-@@ -178,13 +178,13 @@ add_plug_qdisc() {
+ }
+@@ -177,15 +177,15 @@
+     local vif=$1
      local ifb=$2
-
+ 
 -    nl-qdisc-add --dev="$ifb" --parent root plug >/dev/null 2>&1
 +    @nl-qdisc-add@ --dev="$ifb" --parent root plug >/dev/null 2>&1
      if [ $? -ne 0 ]
@@ -783,14 +888,16 @@ index 87dfa69778..fe4f7b6e36 100644
 +        do_without_error @tc@ qdisc del dev "$vif" ingress
          fatal "Failed to add plug qdisc to $ifb"
      fi
-
+ 
      #set ifb buffering limit in bytes. Its okay if this command fails
 -    nl-qdisc-add --dev="$ifb" --parent root \
 +    @nl-qdisc-add@ --dev="$ifb" --parent root \
          --update plug --limit=10000000 >/dev/null 2>&1 || true
  }
-@@ -201,9 +201,9 @@ teardown_netbuf() {
-
+ 
+@@ -200,11 +200,11 @@
+         local ifb2=`xenstore-read "$XENBUS_PATH/ifb" 2>/dev/null || true`
+ 
      if [[ "$ifb2" && "$ifb2" == "$ifb" ]]; then
 -        do_without_error ip link set dev "$ifb" down
 -        do_without_error nl-qdisc-delete --dev="$ifb" --parent root plug >/dev/null 2>&1
@@ -802,22 +909,54 @@ index 87dfa69778..fe4f7b6e36 100644
 +    do_without_error @tc@ qdisc del dev "$vif" ingress
      xenstore-rm -t "$XENBUS_PATH/hotplug-status" 2>/dev/null || true
      xenstore-rm -t "$XENBUS_PATH/hotplug-error" 2>/dev/null || true
+ }
+diff --git a/tools/hotplug/Linux/systemd/xenconsoled.service.in b/tools/hotplug/Linux/systemd/xenconsoled.service.in
+index d84c09aa9c..68317246ae 100644
+--- a/tools/hotplug/Linux/systemd/xenconsoled.service.in
++++ b/tools/hotplug/Linux/systemd/xenconsoled.service.in
+@@ -10,8 +10,8 @@
+ Environment=XENCONSOLED_TRACE=none
+ Environment=XENCONSOLED_LOG_DIR=@XEN_LOG_DIR@/console
+ EnvironmentFile=-@CONFIG_DIR@/@CONFIG_LEAF_DIR@/xencommons
+-ExecStartPre=/bin/grep -q control_d /proc/xen/capabilities
+-ExecStartPre=/bin/mkdir -p ${XENCONSOLED_LOG_DIR} @XEN_RUN_DIR@
++ExecStartPre=@grep@ -q control_d /proc/xen/capabilities
++ExecStartPre=@mkdir@ -p ${XENCONSOLED_LOG_DIR} @XEN_RUN_DIR@
+ ExecStart=@sbindir@/xenconsoled -i --log=${XENCONSOLED_TRACE} --log-dir=${XENCONSOLED_LOG_DIR} $XENCONSOLED_ARGS
+ 
+ [Install]
+diff --git a/tools/hotplug/Linux/systemd/xendomains.service.in b/tools/hotplug/Linux/systemd/xendomains.service.in
+index c7bfb61eb4..314ed9e91a 100644
+--- a/tools/hotplug/Linux/systemd/xendomains.service.in
++++ b/tools/hotplug/Linux/systemd/xendomains.service.in
+@@ -10,7 +10,7 @@
+ [Service]
+ Type=oneshot
+ RemainAfterExit=true
+-ExecStartPre=/bin/grep -q control_d /proc/xen/capabilities
++ExecStartPre=@grep@ -q control_d /proc/xen/capabilities
+ ExecStart=-@LIBEXEC_BIN@/xendomains start
+ ExecStop=@LIBEXEC_BIN@/xendomains stop
+ ExecReload=@LIBEXEC_BIN@/xendomains restart
 diff --git a/tools/hotplug/Linux/systemd/xen-init-dom0.service.in b/tools/hotplug/Linux/systemd/xen-init-dom0.service.in
 index 98779b8507..cc75339377 100644
 --- a/tools/hotplug/Linux/systemd/xen-init-dom0.service.in
 +++ b/tools/hotplug/Linux/systemd/xen-init-dom0.service.in
-@@ -9,5 +9,5 @@ Type=oneshot
+@@ -8,7 +8,7 @@
+ Type=oneshot
  RemainAfterExit=true
  EnvironmentFile=-@CONFIG_DIR@/@CONFIG_LEAF_DIR@/xencommons
 -ExecStartPre=/bin/grep -q control_d /proc/xen/capabilities
 +ExecStartPre=@grep@ -q control_d /proc/xen/capabilities
  ExecStart=@LIBEXEC_BIN@/xen-init-dom0 $XEN_DOM0_UUID
-
+ 
+ [Install]
 diff --git a/tools/hotplug/Linux/systemd/xen-qemu-dom0-disk-backend.service.in b/tools/hotplug/Linux/systemd/xen-qemu-dom0-disk-backend.service.in
 index f56775bc87..a9091047da 100644
 --- a/tools/hotplug/Linux/systemd/xen-qemu-dom0-disk-backend.service.in
 +++ b/tools/hotplug/Linux/systemd/xen-qemu-dom0-disk-backend.service.in
-@@ -10,6 +10,6 @@ ConditionPathExists=/proc/xen/capabilities
+@@ -9,8 +9,8 @@
+ [Service]
  Type=simple
  PIDFile=@XEN_RUN_DIR@/qemu-dom0.pid
 -ExecStartPre=/bin/grep -q control_d /proc/xen/capabilities
@@ -826,54 +965,35 @@ index f56775bc87..a9091047da 100644
 +ExecStartPre=@mkdir@ -p @XEN_RUN_DIR@
  ExecStart=@qemu_xen_systemd@ -xen-domid 0 \
  	-xen-attach -name dom0 -nographic -M xenpv -daemonize \
-diff --git a/tools/hotplug/Linux/systemd/xenconsoled.service.in b/tools/hotplug/Linux/systemd/xenconsoled.service.in
-index d84c09aa9c..68317246ae 100644
---- a/tools/hotplug/Linux/systemd/xenconsoled.service.in
-+++ b/tools/hotplug/Linux/systemd/xenconsoled.service.in
-@@ -11,6 +11,6 @@ Environment=XENCONSOLED_TRACE=none
- Environment=XENCONSOLED_LOG_DIR=@XEN_LOG_DIR@/console
- EnvironmentFile=-@CONFIG_DIR@/@CONFIG_LEAF_DIR@/xencommons
--ExecStartPre=/bin/grep -q control_d /proc/xen/capabilities
--ExecStartPre=/bin/mkdir -p ${XENCONSOLED_LOG_DIR} @XEN_RUN_DIR@
-+ExecStartPre=@grep@ -q control_d /proc/xen/capabilities
-+ExecStartPre=@mkdir@ -p ${XENCONSOLED_LOG_DIR} @XEN_RUN_DIR@
- ExecStart=@sbindir@/xenconsoled -i --log=${XENCONSOLED_TRACE} --log-dir=${XENCONSOLED_LOG_DIR} $XENCONSOLED_ARGS
-
-diff --git a/tools/hotplug/Linux/systemd/xendomains.service.in b/tools/hotplug/Linux/systemd/xendomains.service.in
-index c7bfb61eb4..314ed9e91a 100644
---- a/tools/hotplug/Linux/systemd/xendomains.service.in
-+++ b/tools/hotplug/Linux/systemd/xendomains.service.in
-@@ -11,5 +11,5 @@ Conflicts=libvirtd.service
- Type=oneshot
- RemainAfterExit=true
--ExecStartPre=/bin/grep -q control_d /proc/xen/capabilities
-+ExecStartPre=@grep@ -q control_d /proc/xen/capabilities
- ExecStart=-@LIBEXEC_BIN@/xendomains start
- ExecStop=@LIBEXEC_BIN@/xendomains stop
+ 	-monitor /dev/null -serial /dev/null -parallel /dev/null \
 diff --git a/tools/hotplug/Linux/systemd/xenstored.service.in b/tools/hotplug/Linux/systemd/xenstored.service.in
 index 261077dc92..7daf7369b8 100644
 --- a/tools/hotplug/Linux/systemd/xenstored.service.in
 +++ b/tools/hotplug/Linux/systemd/xenstored.service.in
-@@ -11,5 +11,5 @@ Type=notify
+@@ -10,7 +10,7 @@
+ Type=notify
  NotifyAccess=all
  RemainAfterExit=true
 -ExecStartPre=/bin/grep -q control_d /proc/xen/capabilities
 +ExecStartPre=@grep@ -q control_d /proc/xen/capabilities
  ExecStart=@XEN_SCRIPT_DIR@/launch-xenstore
-
+ 
+ [Install]
 diff --git a/tools/hotplug/Linux/vif-bridge b/tools/hotplug/Linux/vif-bridge
-index 906047e82f..e110013b14 100644
+index 6164c7a52f..e219ae1b47 100644
 --- a/tools/hotplug/Linux/vif-bridge
 +++ b/tools/hotplug/Linux/vif-bridge
-@@ -26,5 +26,5 @@
+@@ -25,17 +25,17 @@
+ # rules for its ip addresses (if any).
  #============================================================================
-
+ 
 -dir=$(dirname "$0")
 +dir=$(@dirname@ "$0")
  . "$dir/vif-common.sh"
-
-@@ -33,8 +33,8 @@ bridge=$(xenstore_read_default "$XENBUS_PATH/bridge" "$bridge")
-
+ 
+ bridge=${bridge:-}
+ bridge=$(xenstore_read_default "$XENBUS_PATH/bridge" "$bridge")
+ 
  if [ -z "$bridge" ]; then
 -    if which brctl >&/dev/null; then
 -        bridge=$(brctl show | awk 'NR==2{print$1}')
@@ -884,25 +1004,31 @@ index 906047e82f..e110013b14 100644
 +        bridge=$(@bridge@ link | @cut@ -d" " -f7)
      fi
    if [ -z "$bridge" ]
-@@ -71,5 +71,5 @@ fi
-
+   then
+@@ -70,7 +70,7 @@
+ fi
+ 
  RET=0
 -ip link show dev "$bridge" 1>/dev/null 2>&1 || RET=1
 +@ip@ link show dev "$bridge" 1>/dev/null 2>&1 || RET=1
  if [ "$RET" -eq 1 ]
  then
+     fatal "Could not find bridge device $bridge"
 diff --git a/tools/hotplug/Linux/vif-common.sh b/tools/hotplug/Linux/vif-common.sh
 index a8e65178f9..28eb851f94 100644
 --- a/tools/hotplug/Linux/vif-common.sh
 +++ b/tools/hotplug/Linux/vif-common.sh
-@@ -16,5 +16,5 @@
-
-
+@@ -15,7 +15,7 @@
+ #
+ 
+ 
 -dir=$(dirname "$0")
 +dir=$(@dirname@ "$0")
  . "$dir/xen-hotplug-common.sh"
  . "$dir/xen-network-common.sh"
-@@ -73,9 +73,9 @@ rename_vif() {
+ 
+@@ -72,11 +72,11 @@
+     # already exists, then stop, before messing up whatever is using
      # that interface (e.g. another running domU) because it's likely a
      # configuration error
 -    if ip link show "$vifname" >&/dev/null
@@ -913,8 +1039,10 @@ index a8e65178f9..28eb851f94 100644
 -    do_or_die ip link set "$dev" name "$vifname"
 +    do_or_die @ip@ link set "$dev" name "$vifname"
  }
-
-@@ -135,10 +135,10 @@ iptables_w()
+ 
+ if [ "$type_if" = vif ]; then
+@@ -134,12 +134,12 @@
+ iptables_w()
  {
      if ! $IPTABLES_WAIT_RUNE_CHECKED ; then
 -	iptables $IPTABLES_WAIT_RUNE -L -n >& /dev/null
@@ -927,46 +1055,58 @@ index a8e65178f9..28eb851f94 100644
 +	    @iptables@ -L -n >& /dev/null
  	    if [[ $? != 2 ]] ; then
  		# If we fail with PARAMETER_PROBLEM (2) with -w and
-@@ -150,5 +150,5 @@ iptables_w()
+ 		# don't fail with PARAMETER_PROBLEM without it, then
+@@ -149,7 +149,7 @@
+ 	    fi
  	fi
      fi
 -    iptables $IPTABLES_WAIT_RUNE "$@"
 +    @iptables@ $IPTABLES_WAIT_RUNE "$@"
  }
-
-@@ -221,5 +221,5 @@ handle_iptable()
+ 
+ frob_iptable()
+@@ -220,7 +220,7 @@
+ #
  ip_of()
  {
 -  ip -4 -o addr show primary dev "$1" | awk '$3 == "inet" {split($4,i,"/"); print i[1]; exit}'
 +  @ip@ -4 -o addr show primary dev "$1" | @awk@ '$3 == "inet" {split($4,i,"/"); print i[1]; exit}'
  }
-
+ 
+ 
 diff --git a/tools/hotplug/Linux/vif-nat b/tools/hotplug/Linux/vif-nat
 index fd34afbb96..8921de58f3 100644
 --- a/tools/hotplug/Linux/vif-nat
 +++ b/tools/hotplug/Linux/vif-nat
-@@ -22,5 +22,5 @@
-
-
+@@ -21,7 +21,7 @@
+ #============================================================================
+ 
+ 
 -dir=$(dirname "$0")
 +dir=$(@dirname@ "$0")
  . "$dir/vif-common.sh"
-
-@@ -62,5 +62,5 @@ ip_from_dom()
+ 
+ # turn on dhcp feature by default if dhcpd is installed
+@@ -61,7 +61,7 @@
+ 
  routing_ip()
  {
 -  echo $(echo $1 | awk -F. '{print $1"."$2"."$3"."$4 + 127}')
 +  echo $(echo $1 | @awk@ -F. '{print $1"."$2"."$3"."$4 + 127}')
  }
-
-@@ -84,5 +84,5 @@ router_ip=$(routing_ip "$ip")
-
+ 
+ 
+@@ -83,7 +83,7 @@
+ router_ip=$(routing_ip "$ip")
+ 
  # Split the given IP/bits pair.
 -vif_ip=`echo ${ip} | awk -F/ '{print $1}'`
 +vif_ip=`echo ${ip} | @awk@ -F/ '{print $1}'`
-
+ 
  hostname=dom$domid
-@@ -94,11 +94,11 @@ fi
+ if [ "$vifid" != "1" ]
+@@ -93,38 +93,38 @@
+ 
  dhcparg_remove_entry()
  {
 -  local tmpfile=$(mktemp)
@@ -982,8 +1122,8 @@ index fd34afbb96..8921de58f3 100644
 -  rm "$tmpfile"
 +  @rm@ "$tmpfile"
  }
-
-@@ -106,24 +106,24 @@ dhcparg_add_entry()
+ 
+ dhcparg_add_entry()
  {
    dhcparg_remove_entry
 -  local tmpfile=$(mktemp)
@@ -1004,7 +1144,7 @@ index fd34afbb96..8921de58f3 100644
 +     "$dhcpd_arg_file" >"$tmpfile" && @cp@ "$tmpfile" "$dhcpd_arg_file"
 +  @rm@ -f "$tmpfile"
  }
-
+ 
  dhcp_remove_entry()
  {
 -  local tmpfile=$(mktemp)
@@ -1021,16 +1161,18 @@ index fd34afbb96..8921de58f3 100644
 +  @rm@ "$tmpfile"
    dhcparg_remove_entry
  }
-@@ -159,5 +159,5 @@ dhcp_down()
+ 
+@@ -158,21 +158,21 @@
+ 
  case "$command" in
      online)
 -        if ip route | grep -q "dev ${dev}"
 +        if @ip@  route | @grep@ -q "dev ${dev}"
          then
            log debug "${dev} already up"
-@@ -165,7 +165,7 @@ case "$command" in
+           exit 0
          fi
-
+ 
 -        do_or_die ip link set dev "${dev}" up arp on
 -        do_or_die ip addr add "$router_ip" dev "${dev}"
 -        do_or_die ip route add "$vif_ip" dev "${dev}" src "$router_ip"
@@ -1039,24 +1181,26 @@ index fd34afbb96..8921de58f3 100644
 +        do_or_die @ip@ route add "$vif_ip" dev "${dev}" src "$router_ip"
          echo 1 >/proc/sys/net/ipv4/conf/${dev}/proxy_arp
          [ "$dhcp" != 'no' ] && dhcp_up
-@@ -173,5 +173,5 @@ case "$command" in
+         ;;
      offline)
          [ "$dhcp" != 'no' ] && dhcp_down
 -        do_without_error ifconfig "${dev}" down
 +        do_without_error @ifconfig@ "${dev}" down
          ;;
  esac
+ 
 diff --git a/tools/hotplug/Linux/vif-openvswitch b/tools/hotplug/Linux/vif-openvswitch
-index 18bfb6cefb..ea983481a3 100644
+index a8aea2acb5..a08b0b6628 100644
 --- a/tools/hotplug/Linux/vif-openvswitch
 +++ b/tools/hotplug/Linux/vif-openvswitch
-@@ -25,13 +25,13 @@
+@@ -24,15 +24,15 @@
+ # rules for its ip addresses (if any).
  #============================================================================
-
+ 
 -dir=$(dirname "$0")
 +dir=$(@dirname@ "$0")
  . "$dir/vif-common.sh"
-
+ 
  check_tools()
  {
 -    if ! command -v ovs-vsctl > /dev/null 2>&1; then
@@ -1067,9 +1211,11 @@ index 18bfb6cefb..ea983481a3 100644
 +    if ! command -v @ip@ > /dev/null 2>&1; then
          fatal "Unable to find ip tool"
      fi
-@@ -80,8 +80,8 @@ add_to_openvswitch () {
+ }
+@@ -79,10 +79,10 @@
+ 
      local vif_details="$(openvswitch_external_id_all $dev)"
-
+ 
 -    do_or_die ovs-vsctl --timeout=30 \
 +    do_or_die @ovs-vsctl@ --timeout=30 \
          -- --if-exists del-port $dev \
@@ -1077,9 +1223,11 @@ index 18bfb6cefb..ea983481a3 100644
 -    do_or_die ip link set $dev up
 +    do_or_die @ip@ link set $dev up
  }
-
-@@ -94,7 +94,7 @@ case "$command" in
-
+ 
+ case "$command" in
+@@ -93,9 +93,9 @@
+         ;;
+ 
      remove|offline)
 -        do_without_error ovs-vsctl --timeout=30 \
 +        do_without_error @ovs-vsctl@ --timeout=30 \
@@ -1088,190 +1236,90 @@ index 18bfb6cefb..ea983481a3 100644
 +        do_without_error @ip@ link set $dev down
          ;;
  esac
+ 
 diff --git a/tools/hotplug/Linux/vif-route b/tools/hotplug/Linux/vif-route
 index 9cd417a005..98d67a8659 100755
 --- a/tools/hotplug/Linux/vif-route
 +++ b/tools/hotplug/Linux/vif-route
-@@ -17,5 +17,5 @@
+@@ -16,14 +16,14 @@
+ #         this script).
  #============================================================================
-
+ 
 -dir=$(dirname "$0")
 +dir=$(@dirname@ "$0")
  . "${dir}/vif-common.sh"
-
-@@ -24,5 +24,5 @@ main_ip=$(dom0_ip)
+ 
+ main_ip=$(dom0_ip)
+ 
  case "${command}" in
      add|online)
 -        ifconfig ${dev} ${main_ip} netmask 255.255.255.255 up
 +        @ifconfig@ ${dev} ${main_ip} netmask 255.255.255.255 up
          echo 1 >/proc/sys/net/ipv4/conf/${dev}/proxy_arp
          ipcmd='add'
-@@ -51,5 +51,5 @@ esac
+         cmdprefix=''
+@@ -50,7 +50,7 @@
+ # If we've been given a list of IP addresses, then add routes from dom0 to
  # the guest using those addresses.
  for addr in ${ip} ; do
 -    ${cmdprefix} ip route ${ipcmd} ${addr} dev ${dev} src ${main_ip} metric ${metric}
 +    ${cmdprefix} @ip@ route ${ipcmd} ${addr} dev ${dev} src ${main_ip} metric ${metric}
  done
-
+ 
+ handle_iptable
 diff --git a/tools/hotplug/Linux/vscsi b/tools/hotplug/Linux/vscsi
 index 5ac26147ec..8f297e05df 100644
 --- a/tools/hotplug/Linux/vscsi
 +++ b/tools/hotplug/Linux/vscsi
-@@ -5,5 +5,5 @@
+@@ -4,7 +4,7 @@
+ # Based on the block scripts code.
  #
-
+ 
 -dir=$(dirname "$0")
 +dir=$(@dirname@ "$0")
  . "$dir/xen-hotplug-common.sh"
-
-diff --git a/tools/hotplug/Linux/xen-hotplug-common.sh.in b/tools/hotplug/Linux/xen-hotplug-common.sh.in
-index 8c2cb9e25a..e9c64efcb0 100644
---- a/tools/hotplug/Linux/xen-hotplug-common.sh.in
-+++ b/tools/hotplug/Linux/xen-hotplug-common.sh.in
-@@ -15,5 +15,5 @@
- #
-
--dir=$(dirname "$0")
-+dir=$(@dirname@ "$0")
- . "$dir/hotplugpath.sh"
- . "$dir/logging.sh"
-@@ -26,5 +26,5 @@ export PATH="${bindir}:${sbindir}:${LIBEXEC_BIN}:/sbin:/bin:/usr/bin:/usr/sbin:$
- export LD_LIBRARY_PATH="${libdir}${LD_LIBRARY_PATH+:}$LD_LIBRARY_PATH"
- export LANG="POSIX"
--unset $(set | grep ^LC_ | cut -d= -f1)
-+unset $(set | @grep@ ^LC_ | @cut@ -d= -f1)
-
- fatal() {
-diff --git a/tools/hotplug/Linux/xen-network-common.sh b/tools/hotplug/Linux/xen-network-common.sh
-index 42fa704e8d..f6cf1b11c0 100644
---- a/tools/hotplug/Linux/xen-network-common.sh
-+++ b/tools/hotplug/Linux/xen-network-common.sh
-@@ -27,5 +27,5 @@
- #           been renamed.
-
--if ! which ifup >/dev/null 2>/dev/null
-+if ! @which@ ifup >/dev/null 2>/dev/null
- then
-   preiftransfer()
-@@ -85,5 +85,5 @@ _setup_bridge_port() {
-
-     # take interface down ...
--    ip link set dev ${dev} down
-+    @ip@ link set dev ${dev} down
-
-     if [ $virtual -ne 0 ] ; then
-@@ -92,9 +92,9 @@ _setup_bridge_port() {
-         # stolen by an Ethernet bridge for STP purposes.
-         # (FE:FF:FF:FF:FF:FF)
--        ip link set dev ${dev} address fe:ff:ff:ff:ff:ff || true
-+        @ip@ link set dev ${dev} address fe:ff:ff:ff:ff:ff || true
-     fi
-
-     # ... and configure it
--    ip address flush dev ${dev}
-+    @ip@ address flush dev ${dev}
- }
-
-@@ -112,10 +112,10 @@ create_bridge () {
-     # Don't create the bridge if it already exists.
-     if [ ! -e "/sys/class/net/${bridge}/bridge" ]; then
--        if which brctl >&/dev/null; then
--            brctl addbr ${bridge}
--            brctl stp ${bridge} off
--            brctl setfd ${bridge} 0
-+        if @which@ @brctl@ >&/dev/null; then
-+            @brctl@ addbr ${bridge}
-+            @brctl@ stp ${bridge} off
-+            @brctl@ setfd ${bridge} 0
-         else
--            ip link add name ${bridge} type bridge stp_state 0 forward_delay 0
-+            @ip@ link add name ${bridge} type bridge stp_state 0 forward_delay 0
-         fi
-     fi
-@@ -130,8 +130,8 @@ add_to_bridge () {
-     if [ ! -e "/sys/class/net/${bridge}/brif/${dev}" ]; then
-         log debug "adding $dev to bridge $bridge"
--        if which brctl >&/dev/null; then
--            brctl addif ${bridge} ${dev}
-+        if @which@ @brctl@ >&/dev/null; then
-+            @brctl@ addif ${bridge} ${dev}
-         else
--            ip link set ${dev} master ${bridge}
-+            @ip@ link set ${dev} master ${bridge}
-         fi
-     else
-@@ -139,5 +139,5 @@ add_to_bridge () {
-     fi
-
--    ip link set dev ${dev} up
-+    @ip@ link set dev ${dev} up
- }
-
-@@ -146,13 +146,13 @@ remove_from_bridge () {
-     local dev=$2
-
--    do_without_error ip link set dev ${dev} down
-+    do_without_error @ip@ link set dev ${dev} down
-
-     # Don't remove $dev from $bridge if it's not on the bridge.
-     if [ -e "/sys/class/net/${bridge}/brif/${dev}" ]; then
-         log debug "removing $dev from bridge $bridge"
--        if which brctl >&/dev/null; then
--            do_without_error brctl delif ${bridge} ${dev}
-+        if @which@ @brctl@ >&/dev/null; then
-+            do_without_error @brctl@ delif ${bridge} ${dev}
-         else
--            do_without_error ip link set ${dev} nomaster
-+            do_without_error @ip@ link set ${dev} nomaster
-         fi
-     else
-@@ -172,5 +172,5 @@ set_mtu () {
-     if [ -z "$mtu" ]
-     then
--        mtu="`ip link show dev ${bridge}| awk '/mtu/ { print $5 }'`"
-+        mtu="`@ip@ link show dev ${bridge}| @awk@ '/mtu/ { print $5 }'`"
-         if [ -n "$mtu" ]
-         then
-@@ -181,5 +181,5 @@ set_mtu () {
-     then
-         log debug "setting $dev MTU to $mtu"
--        ip link set dev ${dev} mtu ${mtu} || :
-+        @ip@ link set dev ${dev} mtu ${mtu} || :
-
-         if [ ${type_if} = vif ]
+ 
+ findCommand "$@"
 diff --git a/tools/hotplug/Linux/xendomains.in b/tools/hotplug/Linux/xendomains.in
 index 70f4129ef4..b066404b0d 100644
 --- a/tools/hotplug/Linux/xendomains.in
 +++ b/tools/hotplug/Linux/xendomains.in
-@@ -151,5 +151,5 @@ else
+@@ -150,13 +150,13 @@
+     }
  fi
-
+ 
 -if ! which usleep >&/dev/null
 +if ! @which@ usleep >&/dev/null
  then
    usleep()
-@@ -157,5 +157,5 @@ then
+   {
      if [ -n "$1" ]
      then
 -      sleep $(( $1 / 1000000 ))
 +      @sleep@ $(( $1 / 1000000 ))
      fi
    }
-@@ -171,5 +171,5 @@ rc_reset
+ fi
+@@ -170,7 +170,7 @@
+ #
  contains_something()
  {
 -  if [ -d "$1" ] && [ `/bin/ls $1 | wc -l` -gt 0 ]
 +  if [ -d "$1" ] && [ `@ls@ $1 | wc -l` -gt 0 ]
    then
      return 0
-@@ -183,5 +183,5 @@ rdname()
+   else
+@@ -182,7 +182,7 @@
+ rdname()
  {
      NM=$($CMD create --quiet --dryrun --defconfig "$1" |
 -         sed -n 's/^.*(name \(.*\))$/\1/p;s/^.*"name": "\(.*\)",$/\1/p')
 +         @sed@ -n 's/^.*(name \(.*\))$/\1/p;s/^.*"name": "\(.*\)",$/\1/p')
  }
-
-@@ -218,11 +218,11 @@ parseln()
+ 
+ rdnames()
+@@ -217,13 +217,13 @@
+     if [[ "$1" =~ '(domain' ]] || [[ "$1" = "{" ]]; then
          name=;id=
      elif [[ "$1" =~ '(name' ]]; then
 -        name=$(echo $1 | sed -e 's/^.*(name \(.*\))$/\1/')
@@ -1286,36 +1334,46 @@ index 70f4129ef4..b066404b0d 100644
 -        id=$(echo $1 | sed -e 's/^.*"domid": \(.*\),$/\1/')
 +        id=$(echo $1 | @sed@ -e 's/^.*"domid": \(.*\),$/\1/')
      fi
-
-@@ -245,5 +245,5 @@ is_running()
+ 
+     [ -n "$name" -a -n "$id" ] && return 0 || return 1
+@@ -244,7 +244,7 @@
+ 		RC=0
  		;;
  	esac
 -    done < <($CMD list -l | grep "$LIST_GREP")
 +    done < <($CMD list -l | @grep@ "$LIST_GREP")
      return $RC
  }
-@@ -256,5 +256,5 @@ start()
+ 
+@@ -255,7 +255,7 @@
+ 	return;
      fi
-
+ 
 -    mkdir -p $(dirname "$LOCKFILE")
 +    @mkdir@ -p $(@dirname@ "$LOCKFILE")
      touch $LOCKFILE
-
-@@ -267,5 +267,5 @@ start()
+ 
+     saved_domains=" "
+@@ -266,7 +266,7 @@
+ 	saved_domains=`ls $XENDOMAINS_SAVE`
          for dom in $XENDOMAINS_SAVE/*; do
              if [ -f $dom ] ; then
 -                HEADER=`head -c 16 $dom | head -n 1 2> /dev/null`
 +                HEADER=`@head@ -c 16 $dom | @head@ -n 1 2> /dev/null`
                  if [ "$HEADER" = "$HEADCOMP" ]; then
                      echo -n " ${dom##*/}"
-@@ -278,5 +278,5 @@ start()
+                     XMR=`$CMD restore $dom 2>&1 1>/dev/null`
+@@ -277,7 +277,7 @@
+                         echo -e '!'
                      else
                          # mv $dom ${dom%/*}/.${dom##*/}
 -                        rm $dom
 +                        @rm@ $dom
                      fi
                  fi
-@@ -300,6 +300,6 @@ start()
+             fi
+@@ -299,8 +299,8 @@
+ 	# restore correctly it requires administrative attention.
  	for dom in $XENDOMAINS_AUTO/*; do
  	    echo -n " ${dom##*/}"
 -	    shortdom=$(echo $dom | sed -n 's/^.*\/\(.*\)$/\1/p')
@@ -1324,15 +1382,19 @@ index 70f4129ef4..b066404b0d 100644
 +	    echo $saved_domains | @grep@ -w $shortdom > /dev/null
  	    if [ $? -eq 0 ] || is_running $dom; then
  		echo -n "(skip)"
-@@ -329,5 +329,5 @@ all_zombies()
+ 	    else
+@@ -328,7 +328,7 @@
+ 	if test "$state" != "-b---d" -a "$state" != "-----d"; then
  	    return 1;
  	fi
 -    done < <($CMD list -l | grep "$LIST_GREP")
 +    done < <($CMD list -l | @grep@ "$LIST_GREP")
      return 0
  }
-@@ -346,14 +346,14 @@ watchdog_xencmd()
-
+ 
+@@ -345,16 +345,16 @@
+     fi
+ 
      usleep 20000
 -    for no in `seq 0 $XENDOMAINS_STOP_MAXWAIT`; do
 +    for no in `@seq@  0 $XENDOMAINS_STOP_MAXWAIT`; do
@@ -1350,41 +1412,180 @@ index 70f4129ef4..b066404b0d 100644
 +    @sleep@ 1
      read PSF PSUID PSPID PSPPID < <(echo "$PSAX")
      # kill $CMD $1
-@@ -435,5 +435,5 @@ stop()
+     kill $PSPID >/dev/null 2>&1
+@@ -434,7 +434,7 @@
+ 	    echo -n "(save)"
  	    watchdog_xencmd save &
  	    WDOG_PID=$!
 -	    mkdir -p "$XENDOMAINS_SAVE"
 +	    @mkdir@ -p "$XENDOMAINS_SAVE"
  	    XMR=`$CMD save $id $XENDOMAINS_SAVE/$name 2>&1 1>/dev/null`
  	    if test $? -ne 0; then
-@@ -462,5 +462,5 @@ stop()
+ 		echo -e "\nAn error occurred while saving domain:\n$XMR\n"
+@@ -461,7 +461,7 @@
+ 	    fi
  	    kill $WDOG_PID >/dev/null 2>&1
  	fi
 -    done < <($CMD list -l | grep "$LIST_GREP")
 +    done < <($CMD list -l | @grep@ "$LIST_GREP")
-
+ 
      # NB. this shuts down ALL Xen domains (politely), not just the ones in
-@@ -483,5 +483,5 @@ stop()
-
+     # AUTODIR/*
+@@ -482,7 +482,7 @@
+     fi
+ 
      # Unconditionally delete lock file
 -    rm -f $LOCKFILE
 +    @rm@ -f $LOCKFILE
-
+ 
      exec 2>&3
-@@ -499,5 +499,5 @@ check_domain_up()
+ }
+@@ -498,7 +498,7 @@
+ 		return 0
  		;;
  	esac
 -    done < <($CMD list -l | grep "$LIST_GREP")
 +    done < <($CMD list -l | @grep@ "$LIST_GREP")
      return 1
  }
-@@ -532,5 +532,5 @@ check_all_saved_domains_up()
+ 
+@@ -531,7 +531,7 @@
+     then
        return 0
      fi
 -    missing=`/bin/ls $XENDOMAINS_SAVE`
 +    missing=`@ls@ $XENDOMAINS_SAVE`
      echo -n " MISS SAVED: " $missing
      return 1
---
-2.49.0
-
+ }
+diff --git a/tools/hotplug/Linux/xen-hotplug-common.sh.in b/tools/hotplug/Linux/xen-hotplug-common.sh.in
+index 8c2cb9e25a..e9c64efcb0 100644
+--- a/tools/hotplug/Linux/xen-hotplug-common.sh.in
++++ b/tools/hotplug/Linux/xen-hotplug-common.sh.in
+@@ -14,7 +14,7 @@
+ # License along with this library; If not, see <http://www.gnu.org/licenses/>.
+ #
+ 
+-dir=$(dirname "$0")
++dir=$(@dirname@ "$0")
+ . "$dir/hotplugpath.sh"
+ . "$dir/logging.sh"
+ . "$dir/xen-script-common.sh"
+@@ -25,7 +25,7 @@
+ export PATH="${bindir}:${sbindir}:${LIBEXEC_BIN}:/sbin:/bin:/usr/bin:/usr/sbin:$PATH"
+ export LD_LIBRARY_PATH="${libdir}${LD_LIBRARY_PATH+:}$LD_LIBRARY_PATH"
+ export LANG="POSIX"
+-unset $(set | grep ^LC_ | cut -d= -f1)
++unset $(set | @grep@ ^LC_ | @cut@ -d= -f1)
+ 
+ fatal() {
+   _xenstore_write "$XENBUS_PATH/hotplug-error" "$*" \
+diff --git a/tools/hotplug/Linux/xen-network-common.sh b/tools/hotplug/Linux/xen-network-common.sh
+index 0150a4840e..c5a2bbe749 100644
+--- a/tools/hotplug/Linux/xen-network-common.sh
++++ b/tools/hotplug/Linux/xen-network-common.sh
+@@ -26,7 +26,7 @@
+ #           that the virtual device will take once the physical device has
+ #           been renamed.
+ 
+-if ! which ifup >/dev/null 2>/dev/null
++if ! @which@ ifup >/dev/null 2>/dev/null
+ then
+   preiftransfer()
+   {
+@@ -83,16 +83,16 @@
+     local dev="$1"
+ 
+     # take interface down ...
+-    ip link set dev ${dev} down
++    @ip@ link set dev ${dev} down
+ 
+     # Initialise a dummy MAC address. We choose the numerically
+     # largest non-broadcast address to prevent the address getting
+     # stolen by an Ethernet bridge for STP purposes.
+     # (FE:FF:FF:FF:FF:FF)
+-    ip link set dev ${dev} address fe:ff:ff:ff:ff:ff || true
++    @ip@ link set dev ${dev} address fe:ff:ff:ff:ff:ff || true
+ 
+     # ... and configure it
+-    ip address flush dev ${dev}
++    @ip@ address flush dev ${dev}
+ }
+ 
+ # Usage: create_bridge bridge
+@@ -101,12 +101,12 @@
+ 
+     # Don't create the bridge if it already exists.
+     if [ ! -e "/sys/class/net/${bridge}/bridge" ]; then
+-        if which brctl >&/dev/null; then
+-            brctl addbr ${bridge}
+-            brctl stp ${bridge} off
+-            brctl setfd ${bridge} 0
++        if @which@ @brctl@ >&/dev/null; then
++            @brctl@ addbr ${bridge}
++            @brctl@ stp ${bridge} off
++            @brctl@ setfd ${bridge} 0
+         else
+-            ip link add name ${bridge} type bridge stp_state 0 forward_delay 0
++            @ip@ link add name ${bridge} type bridge stp_state 0 forward_delay 0
+         fi
+     fi
+ }
+@@ -119,31 +119,31 @@
+     # Don't add $dev to $bridge if it's already on the bridge.
+     if [ ! -e "/sys/class/net/${bridge}/brif/${dev}" ]; then
+         log debug "adding $dev to bridge $bridge"
+-        if which brctl >&/dev/null; then
+-            brctl addif ${bridge} ${dev}
++        if @which@ @brctl@ >&/dev/null; then
++            @brctl@ addif ${bridge} ${dev}
+         else
+-            ip link set ${dev} master ${bridge}
++            @ip@ link set ${dev} master ${bridge}
+         fi
+     else
+         log debug "$dev already on bridge $bridge"
+     fi
+ 
+-    ip link set dev ${dev} up
++    @ip@ link set dev ${dev} up
+ }
+ 
+ remove_from_bridge () {
+     local bridge=$1
+     local dev=$2
+ 
+-    do_without_error ip link set dev ${dev} down
++    do_without_error @ip@ link set dev ${dev} down
+ 
+     # Don't remove $dev from $bridge if it's not on the bridge.
+     if [ -e "/sys/class/net/${bridge}/brif/${dev}" ]; then
+         log debug "removing $dev from bridge $bridge"
+-        if which brctl >&/dev/null; then
+-            do_without_error brctl delif ${bridge} ${dev}
++        if @which@ @brctl@ >&/dev/null; then
++            do_without_error @brctl@ delif ${bridge} ${dev}
+         else
+-            do_without_error ip link set ${dev} nomaster
++            do_without_error @ip@ link set ${dev} nomaster
+         fi
+     else
+         log debug "$dev not on bridge $bridge"
+@@ -161,7 +161,7 @@
+     local mtu=$(xenstore_read_default "$XENBUS_PATH/mtu" "")
+     if [ -z "$mtu" ]
+     then
+-        mtu="`ip link show dev ${bridge}| awk '/mtu/ { print $5 }'`"
++        mtu="`@ip@ link show dev ${bridge}| @awk@ '/mtu/ { print $5 }'`"
+         if [ -n "$mtu" ]
+         then
+             log debug "$bridge MTU is $mtu"
+@@ -170,7 +170,7 @@
+     if [ -n "$mtu" ] && [ "$mtu" -gt 0 ]
+     then
+         log debug "setting $dev MTU to $mtu"
+-        ip link set dev ${dev} mtu ${mtu} || :
++        @ip@ link set dev ${dev} mtu ${mtu} || :
+ 
+         if [ ${type_if} = vif ]
+         then

--- a/pkgs/by-name/xe/xen/package.nix
+++ b/pkgs/by-name/xe/xen/package.nix
@@ -236,6 +236,7 @@ stdenv.mkDerivation (finalAttrs: {
     "doc"
     "dev"
     "boot"
+    "ocaml"
   ];
 
   src = fetchFromGitHub {
@@ -340,6 +341,31 @@ stdenv.mkDerivation (finalAttrs: {
   + ''
     find dist/install/boot -type f -name '*.gz' -print -exec gunzip -k '{}' ';'
     cp -prvd dist/install/boot $boot
+  ''
+  # Copy the xsd_glue OCaml plugin interface to the ocaml output.
+  # This allows other derivations (namely oxenstored) to depend on the
+  # canonical plugin interface without pulling in the entire xen package,
+  # and avoiding issues that arise when the plugin interface is built twice,
+  # once in this package, and again in the oxenstored package, leading to
+  # a mismatch in hash between the two interfaces and the plugin not being
+  # able to load in oxenstored.
+  + ''
+    mkdir -p $ocaml/lib/ocaml
+    if [ -d $out/lib/ocaml/*/site-lib/xsd_glue ]; then
+      ocamlVersion=$(ls $out/lib/ocaml/)
+      mkdir -p $ocaml/lib/ocaml/$ocamlVersion/site-lib
+      cp -prvd $out/lib/ocaml/$ocamlVersion/site-lib/xsd_glue $ocaml/lib/ocaml/$ocamlVersion/site-lib/
+    fi
+  ''
+  # Also provide the canonical plugin_interface_v1 source files so
+  # downstream packages can build ABI-compatible OCaml modules against
+  # the versions built in the xen derivation. The dependency on the Xen
+  # package in this way also keeps the plugin, interface, oxenstored
+  # and xen packages coupled.
+  + ''
+    mkdir -p $ocaml/share/xen/ocaml/xsd_glue
+    cp -v tools/ocaml/libs/xsd_glue/plugin_interface_v1.ml $ocaml/share/xen/ocaml/xsd_glue/
+    cp -v tools/ocaml/libs/xsd_glue/plugin_interface_v1.mli $ocaml/share/xen/ocaml/xsd_glue/
 
     runHook postInstall
   '';

--- a/pkgs/by-name/xe/xen/package.nix
+++ b/pkgs/by-name/xe/xen/package.nix
@@ -173,7 +173,7 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "xen";
-  version = "4.20.2";
+  version = "4.20.3";
 
   # This attribute can be overriden to correct the file paths in
   # `passthru` when building an unstable Xen.
@@ -186,28 +186,28 @@ stdenv.mkDerivation (finalAttrs: {
 
     (replaceVars ./0002-scripts-external-executable-calls.patch scriptDeps)
 
-    # XSA #477
+    # XSA #483
     (fetchpatch {
-      url = "https://xenbits.xenproject.org/xsa/xsa477.patch";
-      hash = "sha256-c9i61GvHPiLwMGvd+5IKgUwyu/NPub+mtnxUPHW/HhI=";
+      url = "https://xenbits.xenproject.org/xsa/xsa483.patch";
+      hash = "sha256-pZkSQKAjEIa/EHlCa2hD+3kofzpVHtFxcdp/TiWu9i8=";
     })
 
-    # XSA #479
+    # XSA #484
     (fetchpatch {
-      url = "https://xenbits.xenproject.org/xsa/xsa479.patch";
-      hash = "sha256-2o6RYyT4Nrg1le6BUOQ3AwedorCvxvKao2uMYWrUV1Y=";
+      url = "https://xenbits.xenproject.org/xsa/xsa484.patch";
+      hash = "sha256-6zkTBHKfpAK2poSycEFSb3pE9pDpZwBxAe5Jf862j+U=";
     })
 
-    # XSA #480
+    # XSA #486
     (fetchpatch {
-      url = "https://xenbits.xenproject.org/xsa/xsa480.patch";
-      hash = "sha256-mHoY+Y8klwLYOo4LZCwYcNsB1BcBbSa1nQOn3NueDdI=";
+      url = "https://xenbits.xenproject.org/xsa/xsa486.patch";
+      hash = "sha256-8EC1lv2JAYqchX5sHbO3NbP7haEyu1V0/72KwALG+BA=";
     })
 
-    # XSA #481
+    # XSA #488
     (fetchpatch {
-      url = "https://xenbits.xenproject.org/xsa/xsa481.patch";
-      hash = "sha256-QpRXS4rFuML2TawH7yhUmg8U4C1ATt4xiLLs91duuO8=";
+      url = "https://xenbits.xenproject.org/xsa/xsa488-4.20.patch";
+      hash = "sha256-QttKWdmWC6Zn5k2hd6RIMCpLWv71HB/A9mCbDP+i8to=";
     })
 
     # patch `libxl` to search for `qemu-system-i386` properly. (Before 4.21)
@@ -228,8 +228,8 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "xen-project";
     repo = "xen";
-    tag = "RELEASE-4.20.2";
-    hash = "sha256-ZDPjsEAEH5bW0156MVvOKUeqg+mwdce0GFdUTBH39Qc=";
+    tag = "RELEASE-4.20.3";
+    hash = "sha256-+qTHIsDD2A5lVwmpJ7artnzdviT1XN05CYeu7JFxfqc=";
   };
 
   strictDeps = true;

--- a/pkgs/by-name/xe/xen/package.nix
+++ b/pkgs/by-name/xe/xen/package.nix
@@ -16,6 +16,7 @@
   dev86,
   e2fsprogs,
   flex,
+  json_c,
   libnl,
   libuuid,
   lzo,
@@ -71,6 +72,7 @@ let
     genAttrs
     getExe
     getExe'
+    hasPrefix
     licenses
     optionalString
     optionals
@@ -79,14 +81,31 @@ let
     versionOlder
     versions
     warn
+    withFeature
+    withFeatureAs
     ;
   inherit (systems.inspect.patterns) isLinux isAarch64;
+  inherit (versions) majorMinor;
   inherit (licenses)
     cc-by-40
     gpl2Only
     lgpl21Only
     mit
     ;
+
+  # Xen has a ternary system for enabling and disabling optional firmwares.
+  # - If we want a built-in firmware, then the correct flag to use is
+  #   '--enable-X', or (withXenFeature true "X" null).
+  # - If we want Xen to use a system firmware, then the correct to use is
+  #   '--with-system-X=/path/to/firmware', or (withXenFeature true "X" drv).
+  # - If we do not want Xen to use any firmware, then the correct flag to use is
+  #   '--disable-X', or (withXenFeature false "X" null).
+  withXenFeature =
+    bool: key: value:
+    if (bool && !isNull value) then
+      (withFeatureAs bool "system-${key}" value)
+    else
+      (enableFeature bool key);
 
   # Mark versions older than minSupportedVersion as EOL.
   minSupportedVersion = "4.17";
@@ -173,7 +192,7 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "xen";
-  version = "4.20.3";
+  version = "4.21.1";
 
   # This attribute can be overriden to correct the file paths in
   # `passthru` when building an unstable Xen.
@@ -206,14 +225,8 @@ stdenv.mkDerivation (finalAttrs: {
 
     # XSA #488
     (fetchpatch {
-      url = "https://xenbits.xenproject.org/xsa/xsa488-4.20.patch";
-      hash = "sha256-QttKWdmWC6Zn5k2hd6RIMCpLWv71HB/A9mCbDP+i8to=";
-    })
-
-    # patch `libxl` to search for `qemu-system-i386` properly. (Before 4.21)
-    (fetchpatch {
-      url = "https://github.com/xen-project/xen/commit/f6281291704aa356489f4bd927cc7348a920bd01.diff?full_index=1";
-      hash = "sha256-LH+68kxH/gxdyh45kYCPxKwk+9cztLrScpC2pCNQV2M=";
+      url = "https://xenbits.xenproject.org/xsa/xsa488.patch";
+      hash = "sha256-R3FzMLBNrZSc8ZKrP0x+6+94zaAZLmPG4c9ykrsmeyE=";
     })
   ];
 
@@ -228,8 +241,8 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "xen-project";
     repo = "xen";
-    tag = "RELEASE-4.20.3";
-    hash = "sha256-+qTHIsDD2A5lVwmpJ7artnzdviT1XN05CYeu7JFxfqc=";
+    tag = "RELEASE-4.21.1";
+    hash = "sha256-yQCmyCa6sN7s1VtoM3Vf1AbbaabvdzFg32pYiXzWpmM=";
   };
 
   strictDeps = true;
@@ -244,11 +257,12 @@ stdenv.mkDerivation (finalAttrs: {
     pandoc
     perl
     pkg-config
-
-    # oxenstored
-    ocamlPackages.findlib
-    ocamlPackages.ocaml
   ]
+  ++ (with ocamlPackages; [
+    findlib
+    ocaml
+    ocamlbuild
+  ])
   ++ (with python3Packages; [
     python
     setuptools
@@ -259,6 +273,7 @@ stdenv.mkDerivation (finalAttrs: {
     bash
     bzip2
     e2fsprogs.dev
+    json_c
     libnl
     libuuid
     lzo
@@ -268,16 +283,15 @@ stdenv.mkDerivation (finalAttrs: {
     zlib
     zstd
   ]
-  ++ optionals withFlask [ checkpolicy ]
-  ++ optionals (versionOlder finalAttrs.version "4.19") [ systemd ];
+  ++ optionals withFlask [ checkpolicy ];
 
   configureFlags = [
-    "--enable-systemd"
-    "--disable-qemu-traditional"
-    "--with-system-qemu"
-    (if withSeaBIOS then "--with-system-seabios=${seabios-qemu.firmware}" else "--disable-seabios")
-    (if withOVMF then "--with-system-ovmf=${OVMF.mergedFirmware}" else "--disable-ovmf")
-    (if withIPXE then "--with-system-ipxe=${ipxe.firmware}" else "--disable-ipxe")
+    (enableFeature true "systemd")
+    (withFeature true "system-qemu")
+    (withFeatureAs true "systemd-sleep" "$out/lib/systemd/system-sleep")
+    (withXenFeature withSeaBIOS "seabios" seabios-qemu.firmware)
+    (withXenFeature withOVMF "ovmf" OVMF.mergedFirmware)
+    (withXenFeature withIPXE "ipxe" ipxe.firmware)
     (enableFeature withFlask "xsmpolicy")
   ];
 
@@ -312,15 +326,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
-  env.NIX_CFLAGS_COMPILE = toString [
-    "-Wno-error=maybe-uninitialized"
-    "-Wno-error=array-bounds"
-  ];
-
   dontUseCmakeConfigure = true;
-
-  # Remove in-tree QEMU sources, we don't need them in any circumstance.
-  prePatch = "rm -rf tools/qemu-xen tools/qemu-xen-traditional";
 
   installPhase = ''
     runHook preInstall
@@ -328,8 +334,10 @@ stdenv.mkDerivation (finalAttrs: {
     mkdir -p $out $out/share $boot
     cp -prvd dist/install/nix/store/*/* $out/
     cp -prvd dist/install/etc $out
-    # Decompresses the multiboot binary so it's present for bootloaders such as Limine
-    # The find command is used instead of a simple file glob so we skip processing symlinks
+  ''
+  # Decompresses the multiboot binary so it's present for bootloaders such as Limine
+  # The find command is used instead of a simple file glob so we skip processing symlinks
+  + ''
     find dist/install/boot -type f -name '*.gz' -print -exec gunzip -k '{}' ';'
     cp -prvd dist/install/boot $boot
 
@@ -378,6 +386,7 @@ stdenv.mkDerivation (finalAttrs: {
           "xenguest"
           "xenhypfs"
           "xenlight"
+          "xenmanage"
           "xenstat"
           "xenstore"
           "xentoolcore"
@@ -390,7 +399,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   meta = {
-    branch = versions.majorMinor finalAttrs.version;
+    branch = majorMinor finalAttrs.version;
 
     description = "Type-1 hypervisor intended for embedded and hyperscale use cases";
     longDescription = ''

--- a/pkgs/by-name/xe/xen/package.nix
+++ b/pkgs/by-name/xe/xen/package.nix
@@ -216,6 +216,7 @@ stdenv.mkDerivation (finalAttrs: {
     "doc"
     "dev"
     "boot"
+    "ocaml"
   ];
 
   src = fetchFromGitHub {
@@ -321,6 +322,31 @@ stdenv.mkDerivation (finalAttrs: {
   + ''
     find dist/install/boot -type f -name '*.gz' -print -exec gunzip -k '{}' ';'
     cp -prvd dist/install/boot $boot
+  ''
+  # Copy the xsd_glue OCaml plugin interface to the ocaml output.
+  # This allows other derivations (namely oxenstored) to depend on the
+  # canonical plugin interface without pulling in the entire xen package,
+  # and avoiding issues that arise when the plugin interface is built twice,
+  # once in this package, and again in the oxenstored package, leading to
+  # a mismatch in hash between the two interfaces and the plugin not being
+  # able to load in oxenstored.
+  + ''
+    mkdir -p $ocaml/lib/ocaml
+    if [ -d $out/lib/ocaml/*/site-lib/xsd_glue ]; then
+      ocamlVersion=$(ls $out/lib/ocaml/)
+      mkdir -p $ocaml/lib/ocaml/$ocamlVersion/site-lib
+      cp -prvd $out/lib/ocaml/$ocamlVersion/site-lib/xsd_glue $ocaml/lib/ocaml/$ocamlVersion/site-lib/
+    fi
+  ''
+  # Also provide the canonical plugin_interface_v1 source files so
+  # downstream packages can build ABI-compatible OCaml modules against
+  # the versions built in the xen derivation. The dependency on the Xen
+  # package in this way also keeps the plugin, interface, oxenstored
+  # and xen packages coupled.
+  + ''
+    mkdir -p $ocaml/share/xen/ocaml/xsd_glue
+    cp -v tools/ocaml/libs/xsd_glue/plugin_interface_v1.ml $ocaml/share/xen/ocaml/xsd_glue/
+    cp -v tools/ocaml/libs/xsd_glue/plugin_interface_v1.mli $ocaml/share/xen/ocaml/xsd_glue/
 
     runHook postInstall
   '';

--- a/pkgs/by-name/xe/xen/package.nix
+++ b/pkgs/by-name/xe/xen/package.nix
@@ -16,6 +16,7 @@
   dev86,
   e2fsprogs,
   flex,
+  json_c,
   libnl,
   libuuid,
   lzo,
@@ -71,22 +72,37 @@ let
     genAttrs
     getExe
     getExe'
-    licenses
     optionalString
     optionals
-    systems
     teams
+    versionAtLeast
     versionOlder
-    versions
     warn
+    withFeature
+    withFeatureAs
     ;
-  inherit (systems.inspect.patterns) isLinux isAarch64;
-  inherit (licenses)
+  inherit (lib.systems.inspect.patterns) isLinux isAarch64;
+  inherit (lib.versions) majorMinor;
+  inherit (lib.licenses)
     cc-by-40
     gpl2Only
     lgpl21Only
     mit
     ;
+
+  # Xen has a ternary system for enabling and disabling optional firmwares.
+  # - If we want a built-in firmware, then the correct flag to use is
+  #   '--enable-X', or (withXenFeature true "X" null).
+  # - If we want Xen to use a system firmware, then the correct to use is
+  #   '--with-system-X=/path/to/firmware', or (withXenFeature true "X" drv).
+  # - If we do not want Xen to use any firmware, then the correct flag to use is
+  #   '--disable-X', or (withXenFeature false "X" null).
+  withXenFeature =
+    bool: key: value:
+    if (bool && !isNull value) then
+      (withFeatureAs bool "system-${key}" value)
+    else
+      (enableFeature bool key);
 
   # Mark versions older than minSupportedVersion as EOL.
   minSupportedVersion = "4.17";
@@ -173,7 +189,7 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "xen";
-  version = "4.20.4";
+  version = "4.22.0";
 
   # This attribute can be overriden to correct the file paths in
   # `passthru` when building an unstable Xen.
@@ -206,7 +222,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "xen-project";
     repo = "xen";
     tag = "RELEASE-${finalAttrs.version}";
-    hash = "sha256-dO9Y7W6NIVbXwWdlnQawpmV6MtemczwgbZdi9gGu190=";
+    hash = "sha256-airf4+QjornWQ9aH+cCpKzgVoLbsNduurXySDAv8clY=";
   };
 
   strictDeps = true;
@@ -221,11 +237,12 @@ stdenv.mkDerivation (finalAttrs: {
     pandoc
     perl
     pkg-config
-
-    # oxenstored
-    ocamlPackages.findlib
-    ocamlPackages.ocaml
   ]
+  ++ (with ocamlPackages; [
+    findlib
+    ocaml
+    ocamlbuild
+  ])
   ++ (with python3Packages; [
     python
     setuptools
@@ -246,15 +263,16 @@ stdenv.mkDerivation (finalAttrs: {
     zstd
   ]
   ++ optionals withFlask [ checkpolicy ]
-  ++ optionals (versionOlder finalAttrs.version "4.19") [ systemd ];
+  ++ optionals (versionOlder finalAttrs.version "4.19") [ systemd ]
+  ++ optionals (versionAtLeast finalAttrs.version "4.21") [ json_c ];
 
   configureFlags = [
-    "--enable-systemd"
-    "--disable-qemu-traditional"
-    "--with-system-qemu"
-    (if withSeaBIOS then "--with-system-seabios=${seabios-qemu.firmware}" else "--disable-seabios")
-    (if withOVMF then "--with-system-ovmf=${OVMF-xen.mergedFirmware}" else "--disable-ovmf")
-    (if withIPXE then "--with-system-ipxe=${ipxe.firmware}" else "--disable-ipxe")
+    (enableFeature true "systemd")
+    (withFeature true "system-qemu")
+    (withFeatureAs true "systemd-sleep" "$out/lib/systemd/system-sleep")
+    (withXenFeature withSeaBIOS "seabios" seabios-qemu.firmware)
+    (withXenFeature withOVMF "ovmf" OVMF-xen.mergedFirmware)
+    (withXenFeature withIPXE "ipxe" ipxe.firmware)
     (enableFeature withFlask "xsmpolicy")
   ];
 
@@ -289,15 +307,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
-  env.NIX_CFLAGS_COMPILE = toString [
-    "-Wno-error=maybe-uninitialized"
-    "-Wno-error=array-bounds"
-  ];
-
   dontUseCmakeConfigure = true;
-
-  # Remove in-tree QEMU sources, we don't need them in any circumstance.
-  prePatch = "rm -rf tools/qemu-xen tools/qemu-xen-traditional";
 
   installPhase = ''
     runHook preInstall
@@ -305,8 +315,10 @@ stdenv.mkDerivation (finalAttrs: {
     mkdir -p $out $out/share $boot
     cp -prvd dist/install/nix/store/*/* $out/
     cp -prvd dist/install/etc $out
-    # Decompresses the multiboot binary so it's present for bootloaders such as Limine
-    # The find command is used instead of a simple file glob so we skip processing symlinks
+  ''
+  # Decompresses the multiboot binary so it's present for bootloaders such as Limine
+  # The find command is used instead of a simple file glob so we skip processing symlinks
+  + ''
     find dist/install/boot -type f -name '*.gz' -print -exec gunzip -k '{}' ';'
     cp -prvd dist/install/boot $boot
 
@@ -355,6 +367,7 @@ stdenv.mkDerivation (finalAttrs: {
           "xenguest"
           "xenhypfs"
           "xenlight"
+          "xenmanage"
           "xenstat"
           "xenstore"
           "xentoolcore"
@@ -367,7 +380,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   meta = {
-    branch = versions.majorMinor finalAttrs.version;
+    branch = majorMinor finalAttrs.version;
 
     description = "Type-1 hypervisor intended for embedded and hyperscale use cases";
     longDescription = ''

--- a/pkgs/development/ocaml-modules/oxenstored/default.nix
+++ b/pkgs/development/ocaml-modules/oxenstored/default.nix
@@ -1,0 +1,71 @@
+{
+  lib,
+  buildDunePackage,
+  fetchFromGitHub,
+  replaceVars,
+  dune-site,
+  fmt,
+  xen,
+  alcotest,
+}:
+
+buildDunePackage (finalAttrs: {
+  pname = "oxenstored";
+  version = "25.3.0";
+
+  outputs = [
+    "out"
+    "doc"
+  ];
+
+  src = fetchFromGitHub {
+    owner = "xapi-project";
+    repo = "oxenstored";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-+JXgVO6m63sPzVTwpq/ztDBx/x/g5vtU1Xbcd+t5ons=";
+  };
+
+  patches = [ (replaceVars ./xen-paths.patch { inherit xen; }) ];
+
+  buildInputs = [
+    dune-site
+    fmt
+    xen
+  ];
+
+  checkInputs = [
+    alcotest
+  ];
+
+  # The xen package builds both plugin_interface_v1 (the xsd_glue library)
+  # and domain_getinfo_v1.cmxs (the plugin) together, ensuring they share
+  # the same .cmi hashes. If we don't use the xen package's interface
+  # and plugin, oxenstored will refuse to dynamically load it, given
+  # the different interface hashes and build environments (make vs dune,
+  # lead to different file hashes), the dynamic load refuses to load the
+  # library from the xen package altogether.
+  # This removes oxenstored's local copy of xsd_glue and instead uses
+  # xen's pre-compiled version found via OCAMLPATH to make sure everything
+  # is consistent and xenstored is built with the same plugin & interface
+  # as the xen package, allowing the plugin to load and interface with
+  # the xen package's libraries.
+  postPatch = ''
+    rm -rf xsd_glue
+  '';
+
+  doCheck = true;
+
+  meta = {
+    description = "OCaml implementation of Xenstore";
+    longDescription = ''
+      Formerly developed in the monolithic Xen repository, `oxenstored` was
+      forked during the development cycle of Xen 4.20 and is now built separately.
+
+      Uses the `xsd_glue` plugin interface from the `xen` package to ensure ABI
+      compatibility with Xen's `domain_getinfo_v1` plugin.
+    '';
+    license = lib.licenses.lgpl21Only;
+    teams = [ lib.teams.xen ];
+    homepage = "https://github.com/xapi-project/oxenstored";
+  };
+})

--- a/pkgs/development/ocaml-modules/oxenstored/xen-paths.patch
+++ b/pkgs/development/ocaml-modules/oxenstored/xen-paths.patch
@@ -1,0 +1,16 @@
+diff --git a/oxenstored/configure.ml b/oxenstored/configure.ml
+index 0b56e90..18069a6 100644
+--- a/oxenstored/configure.ml
++++ b/oxenstored/configure.ml
+@@ -4,9 +4,9 @@
+
+ let xen_log_dir = ref "/var/log/xen/"
+
+-let xen_config_dir = ref "/etc/xen"
++let xen_config_dir = ref "@xen@/etc/xen"
+
+-let libexec = ref "/usr/local/lib/xen"
++let libexec = ref "@xen@/libexec/xen"
+
+ let args =
+   [

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1687,6 +1687,8 @@ let
 
         owl-base = callPackage ../development/ocaml-modules/owl-base { };
 
+        oxenstored = callPackage ../development/ocaml-modules/oxenstored { };
+
         ### P ###
 
         pacomb = callPackage ../development/ocaml-modules/pacomb { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1717,6 +1717,8 @@ let
 
         owl-base = callPackage ../development/ocaml-modules/owl-base { };
 
+        oxenstored = callPackage ../development/ocaml-modules/oxenstored { };
+
         ### P ###
 
         pacomb = callPackage ../development/ocaml-modules/pacomb { };


### PR DESCRIPTION
Updates Xen to 4.22, skipping 4.21. Some minor improvements to the builder while we're at it.
Includes a NixOS module change that should make the hypervisor use the new Ocaml store daemon.
Might still need to override the upstream oxenstored systemd service.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Fits the automation policy (PR created before the change, but I never use the slop machine anyway so it doesn't really matter)

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
