### PR TITLE
kdePackages.plasma-vault: refresh patch

### DIFF
--- a/pkgs/kde/plasma/plasma-vault/hardcode-paths.patch
+++ b/pkgs/kde/plasma/plasma-vault/hardcode-paths.patch
@@ -1,5 +1,5 @@
 diff --git a/kded/engine/backends/cryfs/cryfsbackend.cpp b/kded/engine/backends/cryfs/cryfsbackend.cpp
-index f425eb3..5b8cd43 100644
+index 64138b6..5d249aa 100644
 --- a/kded/engine/backends/cryfs/cryfsbackend.cpp
 +++ b/kded/engine/backends/cryfs/cryfsbackend.cpp
 @@ -207,7 +207,7 @@ QProcess *CryFsBackend::cryfs(const QStringList &arguments) const
@@ -44,7 +44,7 @@ index b992f6f..eb828dd 100644
  
  QString GocryptfsBackend::getConfigFilePath(const Device &device) const
 diff --git a/kded/engine/fusebackend_p.cpp b/kded/engine/fusebackend_p.cpp
-index 8763304..e6860d2 100644
+index 714b660..61d8bf5 100644
 --- a/kded/engine/fusebackend_p.cpp
 +++ b/kded/engine/fusebackend_p.cpp
 @@ -90,7 +90,7 @@ QProcess *FuseBackend::process(const QString &executable, const QStringList &arg
@@ -57,19 +57,19 @@ index 8763304..e6860d2 100644
  
  FutureResult<> FuseBackend::initialize(const QString &name, const Device &device, const MountPoint &mountPoint, const Vault::Payload &payload)
 diff --git a/kded/engine/vault.cpp b/kded/engine/vault.cpp
-index c101079..67c8a83 100644
+index a7a4741..773b671 100644
 --- a/kded/engine/vault.cpp
 +++ b/kded/engine/vault.cpp
-@@ -485,7 +485,7 @@ FutureResult<> Vault::close()
-             } else {
-                 // We want to check whether there is an application
-                 // that is accessing the vault
--                AsynQt::Process::getOutput(QStringLiteral("lsof"), {QStringLiteral("-t"), mountPoint().data()}) | cast<QString>() | onError([this] {
-+                AsynQt::Process::getOutput(QStringLiteral("@lsof@"), {QStringLiteral("-t"), mountPoint().data()}) | cast<QString>() | onError([this] {
-                     d->updateMessage(i18n("Unable to lock the vault because an application is using it"));
-                 }) | onSuccess([this](const QString &result) {
-                     // based on ksolidnotify.cpp
-@@ -538,7 +538,7 @@ FutureResult<> Vault::forceClose()
+@@ -490,7 +490,7 @@ FutureResult<> Vault::close()
+                 } else {
+                     // We want to check whether there is an application
+                     // that is accessing the vault
+-                    AsynQt::Process::getOutput(QStringLiteral("lsof"), { QStringLiteral("-t"), mountPoint().data() })
++                    AsynQt::Process::getOutput(QStringLiteral("@lsof@"), { QStringLiteral("-t"), mountPoint().data() })
+                         | cast<QString>()
+                         | onError([this] {
+                             d->updateMessage(i18n("Unable to close the vault because an application is using it"));
+@@ -546,7 +546,7 @@ FutureResult<> Vault::forceClose()
      using namespace AsynQt::operators;
  
      AsynQt::await(


### PR DESCRIPTION
No idea how this happened. Fixes #471276.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
