### PR TITLE
justbuild: Add upstream fix

### DIFF
--- a/pkgs/by-name/ju/justbuild/package.nix
+++ b/pkgs/by-name/ju/justbuild/package.nix
@@ -2,6 +2,7 @@
   gccStdenv,
   fetchFromGitHub,
   fetchurl,
+  fetchpatch2,
 
   fmt,
   nlohmann_json,
@@ -51,6 +52,14 @@ stdenv.mkDerivation rec {
     url = "https://github.com/googleapis/googleapis/archive/fe8ba054ad4f7eca946c2d14a63c3f07c0b586a0.tar.gz";
     hash = "sha256:1r33jj8yipxjgiarddcxr1yc5kmn98rwrjl9qxfx0fzn1bsg04q5";
   };
+
+  patches = [
+    (fetchpatch2 {
+      name = "blob-tree-add-hash.patch";
+      url = "https://github.com/just-buildsystem/justbuild/commit/c54a46de7df0c6b26b7d8f4a10d380103da634fb.patch?full_index=1";
+      hash = "sha256-hAi4YJmNAwfSl2SWjVCWBhk7VbQeNN1JhmHS9dy2GdU=";
+    })
+  ];
 
   nativeBuildInputs = [
     # Tools for the bootstrap process


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Fix build according to upstream merged fix: https://github.com/just-buildsystem/justbuild/issues/55

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
@aehlig

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
