### PR TITLE
gephgui-wry: init at 5.4.1

### DIFF
--- a/pkgs/by-name/ge/gephgui-wry/package.nix
+++ b/pkgs/by-name/ge/gephgui-wry/package.nix
@@ -1,0 +1,144 @@
+{
+  lib,
+  rustPlatform,
+  webkitgtk_4_1,
+  pkg-config,
+  buildNpmPackage,
+  makeDesktopItem,
+  fetchFromGitHub,
+  nix-update-script,
+  perl,
+  stdenv,
+  glib,
+  copyDesktopItems,
+  wrapGAppsHook4,
+  nodejs_22,
+}:
+let
+  pac-cmd = stdenv.mkDerivation {
+    pname = "pac-cmd";
+    version = "0-unstable-2020-01-07";
+
+    src = fetchFromGitHub {
+      owner = "getlantern";
+      repo = "pac-cmd";
+      rev = "495bad48b8601385daa8205ec4db504166dff18b";
+      hash = "sha256-T4g0FR20sOxJ20H4LTmhrA2EsRe8JYXj6MB2ImkbPsY=";
+    };
+
+    postPatch = ''
+      rm binaries/*/pac
+      substituteInPlace Makefile --replace-fail 'uname -p' 'uname -m'
+    '';
+
+    nativeBuildInputs = [ pkg-config ];
+    buildInputs = [ glib ];
+    installPhase = ''
+      runHook preInstall
+
+      install -Dm755 -t $out/bin binaries/*/pac
+
+      runHook postInstall
+    '';
+
+    meta = {
+      description = "Change proxy auto-config settings of operation system";
+      homepage = "https://github.com/getlantern/pac-cmd";
+      license = lib.licenses.asl20;
+      mainProgram = "pac";
+      platforms = lib.platforms.all;
+    };
+  };
+in
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "gephgui-wry";
+  version = "5.4.1";
+
+  src = fetchFromGitHub {
+    owner = "geph-official";
+    repo = "gephgui-pkg";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-nlWFiEFraI4sUBTs/ZxiHpaeYHert78oPiyFc6LKV30=";
+    fetchSubmodules = true;
+  };
+
+  gephgui = buildNpmPackage {
+    pname = "gephgui";
+    inherit (finalAttrs) version src;
+
+    sourceRoot = "${finalAttrs.src.name}/gephgui-wry/gephgui";
+    npmDepsHash = "sha256-dGzmdvzKp/JHCgDf3NJb0oolgW4Y/spagzpeVpMF28w=";
+
+    # npm dependency install fails with nodejs_24: https://github.com/NixOS/nixpkgs/issues/474535
+    nodejs = nodejs_22;
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out
+      cp -aR dist/* $out/
+
+      runHook postInstall
+    '';
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/gephgui-wry";
+  cargoHash = "sha256-7EJvcnltKlq94jahnMpvzdFJ8P12HjUGC6AOXirpcg4=";
+
+  nativeBuildInputs = [
+    pkg-config
+    perl
+    copyDesktopItems
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [ webkitgtk_4_1 ];
+
+  preBuild = ''
+    cp -r ${finalAttrs.gephgui}/ gephgui/dist/
+  '';
+
+  postInstall = ''
+    install -m 444 -D gephgui/public/gephlogo.png $out/share/icons/hicolor/512x512/apps/geph.png
+  '';
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --suffix PATH : ${lib.makeBinPath [ pac-cmd ]}
+    )
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "Geph";
+      desktopName = "Geph";
+      icon = "geph";
+      exec = "gephgui-wry";
+      categories = [ "Network" ];
+      comment = "Modular Internet censorship circumvention system designed specifically to deal with national filtering";
+      startupWMClass = "geph";
+    })
+  ];
+
+  passthru = {
+    inherit pac-cmd;
+    inherit (finalAttrs) gephgui;
+    updateScript = nix-update-script {
+      extraArgs = [
+        "--subpackage=gephgui"
+      ];
+    };
+  };
+
+  meta = {
+    description = "Modular Internet censorship circumvention system designed specifically to deal with national filtering";
+    homepage = "https://github.com/geph-official/gephgui-wry";
+    mainProgram = "gephgui-wry";
+    platforms = lib.platforms.linux;
+    license = lib.licenses.mpl20;
+    maintainers = with lib.maintainers; [
+      penalty1083
+      MCSeekeri
+    ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
[gephgui-wry](https://github.com/geph-official/gephgui-wry/), the official GUI for the current version of geph, replaces the [deprecated](https://github.com/geph-official/geph5/commit/f2221fb8386312daf2cef05483ebb353ff48bdb4) geph-client-gui component in the existing [geph](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/ge/geph/package.nix) package.
After this PR is merged, the geph-client-gui component within the existing geph package will be removed to align with upstream changes.
I hope to distinguish between these two—geph as CLI software and gephgui as GUI software.

The current name references the official repository's nomenclature; I haven't yet conceived a name that explicitly highlights this distinction.

Tested and functional on my device, but I feel the current packaging still doesn't fully align with best practices. Feedback on improvements is welcome.

@penalty1083 
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
