### PR TITLE
scraper: 0.24.0 -> 0.25.0, modernize

### DIFF
--- a/pkgs/by-name/sc/scraper/package.nix
+++ b/pkgs/by-name/sc/scraper/package.nix
@@ -41,6 +41,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/rust-scraper/scraper";
     changelog = "https://github.com/rust-scraper/scraper/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.isc;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [
+      kachick
+    ];
   };
 })

--- a/pkgs/by-name/sc/scraper/package.nix
+++ b/pkgs/by-name/sc/scraper/package.nix
@@ -1,17 +1,20 @@
 {
   lib,
   rustPlatform,
-  fetchCrate,
+  fetchFromGitHub,
   installShellFiles,
+  nix-update-script,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "scraper";
   version = "0.24.0";
 
-  src = fetchCrate {
-    inherit pname version;
-    hash = "sha256-/WdzwqwxTZiWyLV/W0nsMgVJ+o3wJU6u0gOMZva+WSM=";
+  src = fetchFromGitHub {
+    owner = "rust-scraper";
+    repo = "scraper";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-T4a5eRWapDPctF8Nc2kIlgJGTckqlvt2ujARsNZH06k=";
   };
 
   cargoHash = "sha256-0k8tYJbsWRAWn7stsodC8qkzzl3O8AZ1QrQ7i/n2YzY=";
@@ -19,15 +22,19 @@ rustPlatform.buildRustPackage rec {
   nativeBuildInputs = [ installShellFiles ];
 
   postInstall = ''
-    installManPage scraper.1
+    installManPage scraper/scraper.1
   '';
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
 
   meta = {
     description = "Tool to query HTML files with CSS selectors";
     mainProgram = "scraper";
-    homepage = "https://github.com/causal-agent/scraper";
-    changelog = "https://github.com/causal-agent/scraper/releases/tag/v${version}";
+    homepage = "https://github.com/rust-scraper/scraper";
+    changelog = "https://github.com/rust-scraper/scraper/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.isc;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/by-name/sc/scraper/package.nix
+++ b/pkgs/by-name/sc/scraper/package.nix
@@ -3,27 +3,33 @@
   rustPlatform,
   fetchFromGitHub,
   installShellFiles,
+  versionCheckHook,
   nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "scraper";
-  version = "0.24.0";
+  version = "0.25.0";
 
   src = fetchFromGitHub {
     owner = "rust-scraper";
     repo = "scraper";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-T4a5eRWapDPctF8Nc2kIlgJGTckqlvt2ujARsNZH06k=";
+    hash = "sha256-SGYusb+8MKz4vXjZZlM+bpmrshmts+FZLjR44DyHYqg=";
   };
 
-  cargoHash = "sha256-0k8tYJbsWRAWn7stsodC8qkzzl3O8AZ1QrQ7i/n2YzY=";
+  cargoHash = "sha256-vbJMOVur2QE0rFo1OJkSsuNzTOzn22ty5Py3gozDEzs=";
 
   nativeBuildInputs = [ installShellFiles ];
 
   postInstall = ''
     installManPage scraper/scraper.1
   '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
 
   passthru = {
     updateScript = nix-update-script { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Diff: https://github.com/rust-scraper/scraper/compare/v0.24.0...v0.25.0

Changelog: https://github.com/rust-scraper/scraper/releases/tag/v0.25.0

Adopt the package as a part of: https://github.com/NixOS/nixpkgs/issues/458096

Checked the basic behavior with:

```console
> curl -s https://learn.microsoft.com/en-gb/typography/opentype/spec/scripttags | ./result/bin/scraper 'tbody tr td:nth-child(2)' | tail
<td>'toto'</td>
<td>'tutg'</td>
<td>'ugar'</td>
<td>'vai '</td>
<td>'vith'</td>
<td>'wcho'</td>
<td>'wara'</td>
<td>'yezi'</td>
<td>'yi&nbsp;&nbsp;'</td>
<td>'zanb'</td>
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
