### PR TITLE
krita: split unwrapped package, prepare for qt6 build

### DIFF
--- a/pkgs/by-name/kr/krita-plugin-gmic/package.nix
+++ b/pkgs/by-name/kr/krita-plugin-gmic/package.nix
@@ -5,7 +5,7 @@
   cmake,
   extra-cmake-modules,
   fftw,
-  krita,
+  krita-unwrapped,
   libsForQt5,
 }:
 
@@ -36,7 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     fftw
-    krita.unwrapped
+    krita-unwrapped
     libsForQt5.kcoreaddons
   ];
 

--- a/pkgs/by-name/kr/krita-unwrapped/package.nix
+++ b/pkgs/by-name/kr/krita-unwrapped/package.nix
@@ -1,70 +1,48 @@
 {
-  mkDerivation,
-  lib,
   stdenv,
-  fetchpatch,
-  fetchurl,
-  cmake,
-  extra-cmake-modules,
-  karchive,
-  kconfig,
-  kwidgetsaddons,
-  kcompletion,
-  kcoreaddons,
-  kguiaddons,
-  ki18n,
-  kitemmodels,
-  kitemviews,
-  kwindowsystem,
-  kio,
-  kcrash,
-  breeze-icons,
+  SDL2,
   boost,
-  libraw,
-  fftw,
+  cmake,
+  curl,
   eigen,
   exiv2,
+  extra-cmake-modules,
+  fetchpatch,
+  fetchurl,
+  fftw,
   fribidi,
-  libaom,
-  libheif,
-  #libkdcraw,
-  lcms2,
-  gsl,
-  openexr,
   giflib,
-  libjxl,
-  mlt,
-  openjpeg,
-  opencolorio,
-  xsimd,
-  poppler,
-  curl,
+  gsl,
   ilmbase,
   immer,
   kseexpr,
   lager,
+  lcms2,
+  lib,
+  libaom,
+  libheif,
+  libjxl,
   libmypaint,
+  libraw,
+  libsForQt5,
   libunibreak,
   libwebp,
-  qtmultimedia,
-  qtx11extras,
-  quazip,
-  SDL2,
-  zug,
+  opencolorio,
+  openexr,
+  openjpeg,
   pkg-config,
   python3Packages,
-  version,
-  kde-channel,
-  hash,
+  xsimd,
+  zug,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "krita-unwrapped";
-  inherit version;
 
+  version = "5.2.14";
   src = fetchurl {
-    url = "mirror://kde/${kde-channel}/krita/${version}/krita-${version}.tar.gz";
-    inherit hash;
+    url = "mirror://kde/stable/krita/${version}/krita-${version}.tar.gz";
+    hash = "sha256-VWkAcmwv8U5g97rB6OkVAQDyzZJmnKXcdKxYUe+sKIc=";
   };
 
   patches = [
@@ -81,22 +59,10 @@ mkDerivation rec {
     extra-cmake-modules
     pkg-config
     python3Packages.sip
+    libsForQt5.wrapQtAppsHook
   ];
 
   buildInputs = [
-    karchive
-    kconfig
-    kwidgetsaddons
-    kcompletion
-    kcoreaddons
-    kguiaddons
-    ki18n
-    kitemmodels
-    kitemviews
-    kwindowsystem
-    kio
-    kcrash
-    breeze-icons
     boost
     libraw
     fftw
@@ -109,14 +75,12 @@ mkDerivation rec {
     lager
     libaom
     libheif
-    #libkdcraw
+
     giflib
     libjxl
-    mlt
     openjpeg
     opencolorio
     xsimd
-    poppler
     curl
     ilmbase
     immer
@@ -124,13 +88,33 @@ mkDerivation rec {
     libmypaint
     libunibreak
     libwebp
-    qtmultimedia
-    qtx11extras
-    quazip
     SDL2
     zug
     python3Packages.pyqt5
-  ];
+  ]
+  ++ (with libsForQt5; [
+    breeze-icons
+    karchive
+    kcompletion
+    kconfig
+    kcoreaddons
+    kcrash
+    kguiaddons
+    ki18n
+    kio
+    kitemmodels
+    kitemviews
+    kwidgetsaddons
+    kwindowsystem
+    mlt
+    poppler
+    qtmultimedia
+    qtx11extras
+    quazip
+
+    # TODO: reenable libkdcraw when migrating to Qt6, see #430298
+    # libkdcraw
+  ]);
 
   env.NIX_CFLAGS_COMPILE = toString (lib.optional stdenv.cc.isGNU "-Wno-deprecated-copy");
 

--- a/pkgs/by-name/kr/krita/default.nix
+++ b/pkgs/by-name/kr/krita/default.nix
@@ -1,7 +1,0 @@
-{ callPackage, ... }:
-
-callPackage ./generic.nix {
-  version = "5.2.14";
-  kde-channel = "stable";
-  hash = "sha256-VWkAcmwv8U5g97rB6OkVAQDyzZJmnKXcdKxYUe+sKIc=";
-}

--- a/pkgs/by-name/kr/krita/package.nix
+++ b/pkgs/by-name/kr/krita/package.nix
@@ -2,24 +2,23 @@
   lib,
   libsForQt5,
   symlinkJoin,
-  unwrapped ? libsForQt5.callPackage ./. { },
   krita-plugin-gmic,
   binaryPlugins ? [
     # Default plugins provided by upstream appimage
     krita-plugin-gmic
   ],
+  krita-unwrapped,
 }:
-
 symlinkJoin {
-  name = lib.replaceStrings [ "-unwrapped" ] [ "" ] unwrapped.name;
-  inherit (unwrapped)
+  name = lib.replaceStrings [ "-unwrapped" ] [ "" ] krita-unwrapped.name;
+  inherit (krita-unwrapped)
     version
     buildInputs
     nativeBuildInputs
     meta
     ;
 
-  paths = [ unwrapped ] ++ binaryPlugins;
+  paths = [ krita-unwrapped ] ++ binaryPlugins;
 
   postBuild = ''
     wrapQtApp "$out/bin/krita" \
@@ -28,6 +27,7 @@ symlinkJoin {
   '';
 
   passthru = {
-    inherit unwrapped binaryPlugins;
+    inherit binaryPlugins;
+    unwrapped = krita-unwrapped;
   };
 }


### PR DESCRIPTION
This addresses the complaint about not able to have krita's build environment when using nix shell, and also refactors for krita's qt6 build.

1. Unwrapped package is separated so user can access the build environment with nix shell
2. Avoids the usage of `libsForQt5.callPackage`, organize qt dependency for easier switch to qt6.

This change should be no-op, although the nix derivation hash changed, I checked the krita binary and compare with the old version, there is only 31 bytes difference (probably some kind of hash reference?). Also tested the binary to make sure it still works.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
