### PR TITLE
krita6: init at 6.0.0-prealpha-5a2359089a

### DIFF
--- a/pkgs/by-name/kr/krita/package.nix
+++ b/pkgs/by-name/kr/krita/package.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  libsForQt5,
   symlinkJoin,
   krita-plugin-gmic,
   binaryPlugins ? [

--- a/pkgs/by-name/kr/krita6/package.nix
+++ b/pkgs/by-name/kr/krita6/package.nix
@@ -1,0 +1,26 @@
+{
+  lib,
+  fetchFromGitLab,
+  symlinkJoin,
+  binaryPlugins ? [
+    # TODO: Add Qt6 version of krita-plugin-gmic
+  ],
+  krita,
+  krita-unwrapped,
+}:
+krita.override {
+  krita-unwrapped = (krita-unwrapped.override { isQt6 = true; }).overrideAttrs (
+    finalAttrs: _: {
+      version = "6.0.0-prealpha-5a2359089a";
+      src = fetchFromGitLab {
+        domain = "invent.kde.org";
+        owner = "graphics";
+        repo = "krita";
+        rev = "5a2359089a0b24f67c548cf7a3ce820bc3f930f0";
+        hash = "sha256-SsFD0fuGRYWETcYByET9LUpYM1aoahTWqN1/rUBWAw4=";
+      };
+      patches = [ ];
+    }
+  );
+  inherit binaryPlugins;
+}


### PR DESCRIPTION
Depends on #471324

Krita's unstable branch allows you to build against qt6, although not officially supported, it could be preferable as it provides native Wayland support, enabling 10-bit color and color management. Some distro supports both qt5 and qt6 build. Also qt5 libkdcraw have been dropped in nixpkgs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
