### PR TITLE
roslyn-ls: 5.3.0-2.25603.1 -> 5.3.0-2.25604.5

### DIFF
--- a/pkgs/by-name/ro/roslyn-ls/deps.json
+++ b/pkgs/by-name/ro/roslyn-ls/deps.json
@@ -127,9 +127,9 @@
   },
   {
     "pname": "Microsoft.DotNet.Arcade.Sdk",
-    "version": "11.0.0-beta.25578.1",
-    "hash": "sha256-c8IWX17rJM4aOxvPEbMUDzeLR6kEwWWTstm4waw3d80=",
-    "url": "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/1a5f89f6-d8da-4080-b15f-242650c914a8/nuget/v3/flat2/microsoft.dotnet.arcade.sdk/11.0.0-beta.25578.1/microsoft.dotnet.arcade.sdk.11.0.0-beta.25578.1.nupkg"
+    "version": "11.0.0-beta.25603.2",
+    "hash": "sha256-xXwq/ffFnDXjMnrzKUAT3Du31tKso7aNW4VBvABHX4M=",
+    "url": "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/1a5f89f6-d8da-4080-b15f-242650c914a8/nuget/v3/flat2/microsoft.dotnet.arcade.sdk/11.0.0-beta.25603.2/microsoft.dotnet.arcade.sdk.11.0.0-beta.25603.2.nupkg"
   },
   {
     "pname": "Microsoft.DotNet.FileBasedPrograms",
@@ -139,9 +139,9 @@
   },
   {
     "pname": "Microsoft.DotNet.XliffTasks",
-    "version": "11.0.0-beta.25578.1",
-    "hash": "sha256-EPo2bgR7oW/a8htIps64UrAPuoyyuIYYG54cZRoknUY=",
-    "url": "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/1a5f89f6-d8da-4080-b15f-242650c914a8/nuget/v3/flat2/microsoft.dotnet.xlifftasks/11.0.0-beta.25578.1/microsoft.dotnet.xlifftasks.11.0.0-beta.25578.1.nupkg"
+    "version": "11.0.0-beta.25603.2",
+    "hash": "sha256-qLUHUextwX33sSm4oK0N4qpbGEZpz6qOw5kabpJ9Xkk=",
+    "url": "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/1a5f89f6-d8da-4080-b15f-242650c914a8/nuget/v3/flat2/microsoft.dotnet.xlifftasks/11.0.0-beta.25603.2/microsoft.dotnet.xlifftasks.11.0.0-beta.25603.2.nupkg"
   },
   {
     "pname": "Microsoft.Extensions.Configuration",

--- a/pkgs/by-name/ro/roslyn-ls/package.nix
+++ b/pkgs/by-name/ro/roslyn-ls/package.nix
@@ -6,16 +6,18 @@
   stdenvNoCC,
   testers,
   jq,
-  writeText,
   runCommand,
   expect,
 }:
 let
   pname = "roslyn-ls";
+  # see https://github.com/dotnet/roslyn/blob/main/eng/targets/TargetFrameworks.props
   dotnet-sdk =
     with dotnetCorePackages;
+    # required sdk
     sdk_10_0
     // {
+      # with additional packages to minimize deps.json
       inherit
         (combinePackages [
           sdk_9_0
@@ -25,45 +27,29 @@ let
         targetPackages
         ;
     };
-  # need sdk on runtime as well
-  dotnet-runtime = dotnetCorePackages.sdk_10_0;
+  # should match the default NetVSCode property
+  # see https://github.com/dotnet/roslyn/blob/main/eng/targets/TargetFrameworks.props
+  dotnet-runtime = dotnetCorePackages.sdk_10_0.runtime;
+
   rid = dotnetCorePackages.systemToDotnetRid stdenvNoCC.targetPlatform.system;
 
   project = "Microsoft.CodeAnalysis.LanguageServer";
-
-  targets = writeText "versions.targets" ''
-    <Project>
-      <ItemGroup>
-        <KnownFrameworkReference Update="@(KnownFrameworkReference)">
-          <LatestRuntimeFrameworkVersion Condition="'%(TargetFramework)' == 'net8.0'">${dotnetCorePackages.sdk_8_0.runtime.version}</LatestRuntimeFrameworkVersion>
-          <LatestRuntimeFrameworkVersion Condition="'%(TargetFramework)' == 'net9.0'">${dotnetCorePackages.sdk_9_0.runtime.version}</LatestRuntimeFrameworkVersion>
-          <TargetingPackVersion Condition="'%(TargetFramework)' == 'net8.0'">${dotnetCorePackages.sdk_8_0.runtime.version}</TargetingPackVersion>
-          <TargetingPackVersion Condition="'%(TargetFramework)' == 'net9.0'">${dotnetCorePackages.sdk_9_0.runtime.version}</TargetingPackVersion>
-        </KnownFrameworkReference>
-        <KnownAppHostPack Update="@(KnownAppHostPack)">
-          <AppHostPackVersion Condition="'%(TargetFramework)' == 'net8.0'">${dotnetCorePackages.sdk_8_0.runtime.version}</AppHostPackVersion>
-          <AppHostPackVersion Condition="'%(TargetFramework)' == 'net9.0'">${dotnetCorePackages.sdk_9_0.runtime.version}</AppHostPackVersion>
-        </KnownAppHostPack>
-      </ItemGroup>
-    </Project>
-  '';
-
 in
 buildDotnetModule (finalAttrs: rec {
   inherit pname dotnet-sdk dotnet-runtime;
 
-  vsVersion = "2.103.33-prerelease";
+  vsVersion = "2.111.2-prerelease";
   src = fetchFromGitHub {
     owner = "dotnet";
     repo = "roslyn";
     rev = "VSCode-CSharp-${vsVersion}";
-    hash = "sha256-uz0V4vTwfmeY5qPv9K30eB0MZTCpPee3PgIdlrXL/qs=";
+    hash = "sha256-oP+mKOvsbc+/NnqJvounE75BlE6UJTIAnmYTBNQlMFA=";
   };
 
   # versioned independently from vscode-csharp
   # "roslyn" in here:
   # https://github.com/dotnet/vscode-csharp/blob/main/package.json
-  version = "5.3.0-2.25603.1";
+  version = "5.3.0-2.25604.5";
   projectFile = "src/LanguageServer/${project}/${project}.csproj";
   useDotnetFromEnv = true;
   nugetDeps = ./deps.json;
@@ -80,23 +66,34 @@ buildDotnetModule (finalAttrs: rec {
     # Upstream uses rollForward = latestPatch, which pins to an *exact* .NET SDK version.
     jq '.sdk.rollForward = "latestMinor"' < global.json > global.json.tmp
     mv global.json.tmp global.json
-
-    substituteInPlace Directory.Build.targets \
-      --replace-fail '</Project>' '<Import Project="${targets}" /></Project>'
   '';
 
+  # don't build binary
+  useAppHost = false;
   dotnetFlags = [
     "-p:TargetRid=${rid}"
+    # we don't want to build the binary
+    # and useAppHost is not enough, need to explicilty set to false
+    "-p:UseAppHost=false"
+    # avoid platform-specific crossgen packages
+    "-p:PublishReadyToRun=false"
     # this removes the Microsoft.WindowsDesktop.App.Ref dependency
     "-p:EnableWindowsTargeting=false"
-    # this is needed for the KnownAppHostPack changes to work
-    "-p:EnableAppHostPackDownload=true"
+    # avoid unnecessary packages in deps.json
+    "-p:EnableAppHostPackDownload=false"
+    "-p:EnableRuntimePackDownload=false"
   ];
 
-  # two problems solved here:
-  # 1. --no-build removed -> BuildHost project within roslyn is running Build target during publish
-  # 2. missing crossgen2 7.* in local nuget directory when PublishReadyToRun=true
-  # the latter should be fixable here but unsure how
+  executables = [ project ];
+
+  postInstall = ''
+    # fake executable that we substitute in postFixup
+    touch $out/lib/$pname/${project}
+    chmod +x $out/lib/$pname/${project}
+  '';
+
+  # problem and solution:
+  # BuildHost project within roslyn is running Build target during publish -> --no-build removed
   installPhase = ''
     runHook preInstall
 
@@ -104,9 +101,8 @@ buildDotnetModule (finalAttrs: rec {
         -p:ContinuousIntegrationBuild=true \
         -p:Deterministic=true \
         -p:InformationalVersion=$version \
-        -p:UseAppHost=true \
         -p:PublishTrimmed=false \
-        -p:PublishReadyToRun=false \
+        -p:OverwriteReadOnlyFiles=true \
         --configuration Release \
         --no-self-contained \
         --output "$out/lib/$pname" \
@@ -116,6 +112,14 @@ buildDotnetModule (finalAttrs: rec {
         ''${dotnetFlags[@]}
 
     runHook postInstall
+  '';
+
+  # force dotnet-runtime to run the dll
+  # but keep the wrapper created with useDotnetFromEnv to allow LS to work properly on codebases
+  postFixup = ''
+    rm -f $out/lib/$pname/${project}
+    substituteInPlace $out/bin/${project} \
+      --replace-fail "$out/lib/$pname/${project}" "${lib.getExe dotnet-runtime}\" \"$out/lib/$pname/${project}.dll"
   '';
 
   passthru = {
@@ -151,6 +155,7 @@ buildDotnetModule (finalAttrs: rec {
       in
       {
         # Make sure we can run with any supported SDK version, as well as without
+        with-net8-sdk = with-sdk dotnetCorePackages.sdk_8_0;
         with-net9-sdk = with-sdk dotnetCorePackages.sdk_9_0;
         with-net10-sdk = with-sdk dotnetCorePackages.sdk_10_0;
         no-sdk = with-sdk null;


### PR DESCRIPTION
Problem
- upstream changed TargetFramework (NetVSCode) to `net10.0`
- caused `with-net9-sdk` test to fail

Solution
- https://github.com/NixOS/nixpkgs/pull/471327#discussion_r2632337039
- this also allowed to bring back `with-net8-sdk` test, so we can test all still supported SDK versions

Also removed `versions.targets` workaround since apparently it causes 0 changes to deps.json currently.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
