### PR TITLE
spoofdpi: 0.12.0 -> 1.2.0

### DIFF
--- a/pkgs/by-name/sp/spoofdpi/package.nix
+++ b/pkgs/by-name/sp/spoofdpi/package.nix
@@ -1,26 +1,39 @@
 {
   lib,
-  fetchFromGitHub,
+  stdenv,
+  libpcap,
   buildGoModule,
+  fetchFromGitHub,
 }:
-
-buildGoModule rec {
-  pname = "SpoofDPI";
-  version = "0.12.0";
+buildGoModule (finalAttrs: {
+  pname = "spoofdpi";
+  version = "1.2.0";
 
   src = fetchFromGitHub {
     owner = "xvzc";
     repo = "SpoofDPI";
-    rev = "v${version}";
-    hash = "sha256-m4fhFhZLuWT1diDlDTmTsNrckKTjhEZbhciv44FZcro=";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-5NBOsklCAGDRPSdkglCDgkXQp2aeo2g0EcqecsLJT6o=";
   };
 
-  vendorHash = "sha256-47Gt5SI6VXq4+1T0LxFvQoYNk+JqTt3DonDXLfmFBzw=";
+  vendorHash = "sha256-WqIAE5j3pqyGg5fdA75h9r40QB/lLQO7lgJyI3P7Jgk=";
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
+    libpcap
+  ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${finalAttrs.version}"
+    "-X main.build=nixpkgs"
+  ];
 
   meta = {
     homepage = "https://github.com/xvzc/SpoofDPI";
     description = "Simple and fast anti-censorship tool written in Go";
+    mainProgram = "${finalAttrs.pname}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ s0me1newithhand7s ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

1. removed `rec` since it's a bad practice
2. added optional `libpcap` since it's [added](https://github.com/NixOS/nixpkgs/pull/464748#issuecomment-3655651204) as dependency
3. bumped to newer version
4. code cleaning, mostly

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
