### PR TITLE
nixos/sshd: add enableRecommendedAlgorithms option

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -342,6 +342,8 @@ See <https://github.com/NixOS/nixpkgs/issues/481673>.
 
 - `services.openssh` now supports generating host SSH keys by setting `services.openssh.generateHostKeys = true` while leaving `services.openssh.enable` disabled.  This is particularly useful for systems that have no need of an SSH daemon but want SSH host keys for other purposes such as using agenix or sops-nix.
 
+- `services.openssh.enableRecommendedAlgorithms` has been added to allow users to opt out of NixOS's curated set of recommended algorithms. This set to true by default, and thus is not a breaking change. Users may want to set this to false if they prefer upstream's default algorithms. See <https://github.com/NixOS/nixpkgs/pull/471330>.
+
 - IPVLAN interfaces can now be configured through the `networking.ipvlans` option in the networking module.
 
 - `services.caddy` now supports setting `httpPort` and `httpsPort` and opening them in the firewall via `openFirewall`.

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -412,6 +412,16 @@ in
         '';
       };
 
+      enableRecommendedAlgorithms = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = ''
+          Use algorithms curated and recommended by NixOS.
+
+          Set to false to use upstream's default algorithms.
+        '';
+      };
+
       authorizedKeysFiles = lib.mkOption {
         type = lib.types.listOf lib.types.str;
         default = [ ];
@@ -571,37 +581,64 @@ in
               };
               KexAlgorithms = lib.mkOption {
                 type = lib.types.nullOr (lib.types.listOf lib.types.str);
-                default = [
-                  "mlkem768x25519-sha256"
-                  "sntrup761x25519-sha512"
-                  "sntrup761x25519-sha512@openssh.com"
-                  "curve25519-sha256"
-                  "curve25519-sha256@libssh.org"
-                  "diffie-hellman-group-exchange-sha256"
-                ];
+                default =
+                  if config.services.openssh.enableRecommendedAlgorithms then
+                    [
+                      "mlkem768x25519-sha256"
+                      "sntrup761x25519-sha512"
+                      "sntrup761x25519-sha512@openssh.com"
+                      "curve25519-sha256"
+                      "curve25519-sha256@libssh.org"
+                      "diffie-hellman-group-exchange-sha256"
+                    ]
+                  else
+                    null;
+                defaultText = ''
+                  if config.services.openssh.enableRecommendedAlgorithms then
+                    [
+                      "mlkem768x25519-sha256"
+                      "sntrup761x25519-sha512"
+                      "sntrup761x25519-sha512@openssh.com"
+                      "curve25519-sha256"
+                      "curve25519-sha256@libssh.org"
+                      "diffie-hellman-group-exchange-sha256"
+                    ]
+                  else
+                    null;
+                '';
                 description = ''
                   Allowed key exchange algorithms
 
-                  Uses the lower bound recommended in both
-                  <https://stribika.github.io/2015/01/04/secure-secure-shell.html>
-                  and
-                  <https://infosec.mozilla.org/guidelines/openssh#modern-openssh-67>
+                  Defaults to a curated set of algorithms.
+                  Set enableRecommendedAlgorithms to false to use upstream's defaults.
                 '';
               };
               Macs = lib.mkOption {
                 type = lib.types.nullOr (lib.types.listOf lib.types.str);
-                default = [
-                  "hmac-sha2-512-etm@openssh.com"
-                  "hmac-sha2-256-etm@openssh.com"
-                  "umac-128-etm@openssh.com"
-                ];
+                default =
+                  if config.services.openssh.enableRecommendedAlgorithms then
+                    [
+                      "hmac-sha2-512-etm@openssh.com"
+                      "hmac-sha2-256-etm@openssh.com"
+                      "umac-128-etm@openssh.com"
+                    ]
+                  else
+                    null;
+                defaultText = ''
+                  if config.services.openssh.enableRecommendedAlgorithms then
+                    [
+                      "hmac-sha2-512-etm@openssh.com"
+                      "hmac-sha2-256-etm@openssh.com"
+                      "umac-128-etm@openssh.com"
+                    ]
+                  else
+                    null;
+                '';
                 description = ''
                   Allowed MACs
 
-                  Defaults to recommended settings from both
-                  <https://stribika.github.io/2015/01/04/secure-secure-shell.html>
-                  and
-                  <https://infosec.mozilla.org/guidelines/openssh#modern-openssh-67>
+                  Defaults to a curated set of algorithms.
+                  Set enableRecommendedAlgorithms to false to use upstream's defaults.
                 '';
               };
               StrictModes = lib.mkOption {
@@ -613,21 +650,36 @@ in
               };
               Ciphers = lib.mkOption {
                 type = lib.types.nullOr (lib.types.listOf lib.types.str);
-                default = [
-                  "chacha20-poly1305@openssh.com"
-                  "aes256-gcm@openssh.com"
-                  "aes128-gcm@openssh.com"
-                  "aes256-ctr"
-                  "aes192-ctr"
-                  "aes128-ctr"
-                ];
+                default =
+                  if config.services.openssh.enableRecommendedAlgorithms then
+                    [
+                      "chacha20-poly1305@openssh.com"
+                      "aes256-gcm@openssh.com"
+                      "aes128-gcm@openssh.com"
+                      "aes256-ctr"
+                      "aes192-ctr"
+                      "aes128-ctr"
+                    ]
+                  else
+                    null;
+                defaultText = ''
+                  if config.services.openssh.enableRecommendedAlgorithms then
+                    [
+                      "chacha20-poly1305@openssh.com"
+                      "aes256-gcm@openssh.com"
+                      "aes128-gcm@openssh.com"
+                      "aes256-ctr"
+                      "aes192-ctr"
+                      "aes128-ctr"
+                    ]
+                  else
+                    null;
+                '';
                 description = ''
                   Allowed ciphers
 
-                  Defaults to recommended settings from both
-                  <https://stribika.github.io/2015/01/04/secure-secure-shell.html>
-                  and
-                  <https://infosec.mozilla.org/guidelines/openssh#modern-openssh-67>
+                  Defaults to a curated set of algorithms.
+                  Set enableRecommendedAlgorithms to false to use upstream's defaults.
                 '';
               };
               AllowUsers = lib.mkOption {

--- a/nixos/tests/openssh.nix
+++ b/nixos/tests/openssh.nix
@@ -90,9 +90,11 @@ in
         ];
       };
 
-    server-lazy-socket = {
+    # IP addresses are allocated according to the alphabetical order of the machine name, and since tests rely on the IP address of this machine, let's name it so it's order (and thus address) is predictable.
+    aaa-server-lazy-socket = {
       virtualisation.vlans = [
         1
+        # Allocate another VLAN so we can exercise listening on a non-standard address.
         2
       ];
       services.openssh = {
@@ -302,7 +304,7 @@ in
 
     server_lazy.wait_for_unit("sshd.socket", timeout=60)
     server_localhost_only_lazy.wait_for_unit("sshd.socket", timeout=60)
-    server_lazy_socket.wait_for_unit("sshd.socket", timeout=60)
+    aaa_server_lazy_socket.wait_for_unit("sshd.socket", timeout=60)
 
     # sshd-keygen is a oneshot unit, so just wait for multi-user.target, which
     # pulls it in.
@@ -340,14 +342,14 @@ in
             timeout=30
         )
 
-    with subtest("socket activation on a non-standard port"):
+    with subtest("socket activation on a non-standard address and port"):
         client.succeed(
             "cat ${snakeOilPrivateKey} > privkey.snakeoil"
         )
         client.succeed("chmod 600 privkey.snakeoil")
         # The final segment in this IP is allocated according to the alphabetical order of machines in this test.
         client.succeed(
-            "ssh -p 2222 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i privkey.snakeoil root@192.168.2.5 true",
+            "ssh -p 2222 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i privkey.snakeoil root@192.168.2.1 true",
             timeout=30
         )
 


### PR DESCRIPTION
Prior to this commit, NixOS enabled a set of curated algorithms for OpenSSH.

This commit allows users to opt-out of this curation, and instead use the upstream algorithms. This also allows users to set Ciphers/KexAlgorithms/Macs themselves without lib.mkForce (and thus wield NixOS modules to build the list).

Tests have been added to ensure test this new option works.

I removed the part of the description that mentioned https://stribika.github.io/2015/01/04/secure-secure-shell.html and https://infosec.mozilla.org/guidelines/openssh#modern-openssh-67 since we have long since deviated from those.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
