### PR TITLE
nixos/openssh: set many defaults to null

### DIFF
--- a/nixos/modules/programs/ssh.nix
+++ b/nixos/modules/programs/ssh.nix
@@ -317,7 +317,7 @@ in
     programs.ssh.setXAuthLocation = lib.mkDefault (
       config.services.xserver.enable
       || config.programs.ssh.forwardX11 == true
-      || config.services.openssh.settings.X11Forwarding
+      || config.services.openssh.settings.X11Forwarding == true
     );
 
     assertions = [

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -485,7 +485,7 @@ in
                     "DEBUG3"
                   ]
                 );
-                default = "INFO"; # upstream default
+                default = null;
                 description = ''
                   Gives the verbosity level that is used when logging messages from {manpage}`sshd(8)`. Logging with a DEBUG level
                   violates the privacy of users and is not recommended.
@@ -497,7 +497,7 @@ in
               };
               UseDns = lib.mkOption {
                 type = lib.types.nullOr lib.types.bool;
-                default = false;
+                default = null;
                 description = ''
                   Specifies whether {manpage}`sshd(8)` should look up the remote host name, and to check that the resolved host name for
                   the remote IP address maps back to the very same IP address.
@@ -507,7 +507,7 @@ in
               };
               X11Forwarding = lib.mkOption {
                 type = lib.types.nullOr lib.types.bool;
-                default = false;
+                default = null;
                 description = ''
                   Whether to allow X11 connections to be forwarded.
                 '';
@@ -520,7 +520,7 @@ in
                 '';
               };
               PermitRootLogin = lib.mkOption {
-                default = "prohibit-password";
+                default = null;
                 type = lib.types.nullOr (
                   lib.types.enum [
                     "yes"
@@ -536,14 +536,14 @@ in
               };
               KbdInteractiveAuthentication = lib.mkOption {
                 type = lib.types.nullOr lib.types.bool;
-                default = true;
+                default = null;
                 description = ''
                   Specifies whether keyboard-interactive authentication is allowed.
                 '';
               };
               GatewayPorts = lib.mkOption {
                 type = lib.types.nullOr lib.types.str;
-                default = "no";
+                default = null;
                 description = ''
                   Specifies whether remote hosts are allowed to connect to
                   ports forwarded for the client.  See
@@ -587,7 +587,7 @@ in
               };
               StrictModes = lib.mkOption {
                 type = lib.types.nullOr (lib.types.bool);
-                default = true;
+                default = null;
                 description = ''
                   Whether sshd should check file modes and ownership of directories
                 '';
@@ -857,7 +857,7 @@ in
 
       assertions = [
         {
-          assertion = if cfg.settings.X11Forwarding then cfgc.setXAuthLocation else true;
+          assertion = if cfg.settings.X11Forwarding == true then cfgc.setXAuthLocation else true;
           message = "cannot enable X11 forwarding without setting xauth location";
         }
         {


### PR DESCRIPTION
Motivation: Having a shorter /etc/ssh/sshd_config, thus making it easier to audit.

Since we default to upstream's defaults, we can safely default these to null.

Per https://man.openbsd.org/sshd_config :

* LogLevel default is INFO.
* UseDNS default is "no".
* X11Forwarding default is "no".
* PermitRootLogin default is "prohibit-password".
* KbdInteractiveAuthentication default is "yes".
* GatewayPorts default is "no".
* StrictModes default is "yes".


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
