### PR TITLE
fclones[-gui]: add progrm_jarvis to maintainers

### DIFF
--- a/pkgs/by-name/fc/fclones-gui/package.nix
+++ b/pkgs/by-name/fc/fclones-gui/package.nix
@@ -7,6 +7,7 @@
   gdk-pixbuf,
   gtk4,
   libadwaita,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -39,6 +40,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
     install -Dm 0644 snap/gui/fclones-gui.desktop -t $out/share/applications
     install -Dm 0644 snap/gui/fclones-gui.png -t $out/share/icons/hicolor/256x256/apps
   '';
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Interactive duplicate file remover";

--- a/pkgs/by-name/fc/fclones-gui/package.nix
+++ b/pkgs/by-name/fc/fclones-gui/package.nix
@@ -46,6 +46,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/pkolaczk/fclones-gui";
     changelog = "https://github.com/pkolaczk/fclones-gui/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.progrm_jarvis ];
   };
 })

--- a/pkgs/by-name/fc/fclones/package.nix
+++ b/pkgs/by-name/fc/fclones/package.nix
@@ -57,6 +57,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       cyounkins
+      progrm_jarvis
     ];
     mainProgram = "fclones";
   };


### PR DESCRIPTION
`fclones`:
  * added myself to maintainers;
  * migrated to `finalAttrs` idiom;
  * added `nix-update-script`;

`fclones-gui`:
  * added myself to maintainers;
  * added `nix-update-script`.

This continues the effort of #458096.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
