### PR TITLE
knot-resolver-manager_6: simplify handling of paths, including in the NixOS service

### DIFF
--- a/nixos/modules/services/networking/knot-resolver.nix
+++ b/nixos/modules/services/networking/knot-resolver.nix
@@ -36,9 +36,8 @@ in
         If you want to use knot-resolver 5, please use services.kresd.
       '';
     };
-    package = lib.mkPackageOption pkgs "knot-resolver-manager_6.kresd" { };
     managerPackage = lib.mkPackageOption pkgs "knot-resolver-manager_6" {
-      example = "knot-resolver_6.override { extraFeatures = true; }";
+      example = "pkgs.knot-resolver-manager_6.override { extraFeatures = true; }";
     };
     settings = lib.mkOption {
       type = lib.types.submodule {
@@ -113,16 +112,6 @@ in
     users.groups.knot-resolver = { };
     networking.resolvconf.useLocalResolver = lib.mkDefault true;
 
-    assertions = [
-      {
-        assertion = lib.versionAtLeast cfg.package.version "6.0.0";
-        message = ''
-          services.knot-resolver only works with knot-resolver 6 or later.
-          Please use services.kresd for knot-resolver 5.
-        '';
-      }
-    ];
-
     environment = {
       etc."knot-resolver/config.yaml".source = configFile;
       systemPackages = [
@@ -134,10 +123,9 @@ in
       ];
     };
 
-    systemd.packages = [ cfg.package ]; # the unit gets patched a bit just below
+    systemd.packages = [ cfg.managerPackage.kresd ]; # the unit gets patched a bit just below
     systemd.services."knot-resolver" = {
       wantedBy = [ "multi-user.target" ];
-      path = [ (lib.getBin cfg.package) ];
       stopIfChanged = false;
       reloadTriggers = [
         configFile

--- a/nixos/modules/services/networking/knot-resolver.nix
+++ b/nixos/modules/services/networking/knot-resolver.nix
@@ -36,10 +36,10 @@ in
         If you want to use knot-resolver 5, please use services.kresd.
       '';
     };
-    package = lib.mkPackageOption pkgs "knot-resolver-manager_6.knot-resolver" {
+    package = lib.mkPackageOption pkgs "knot-resolver-manager_6.kresd" { };
+    managerPackage = lib.mkPackageOption pkgs "knot-resolver-manager_6" {
       example = "knot-resolver_6.override { extraFeatures = true; }";
     };
-    managerPackage = lib.mkPackageOption pkgs "knot-resolver-manager_6" { };
     settings = lib.mkOption {
       type = lib.types.submodule {
         freeformType = (pkgs.formats.yaml { }).type;

--- a/pkgs/by-name/kn/knot-resolver-manager_6/package.nix
+++ b/pkgs/by-name/kn/knot-resolver-manager_6/package.nix
@@ -7,6 +7,7 @@
 let
   kresd = knot-resolver_6.finalPackage; # TODO: does the finalPackage help us?
 in
+assert lib.versionAtLeast kresd.version "6.0.0";
 python3Packages.buildPythonPackage {
   pname = "knot-resolver-manager_6";
   inherit (kresd) version src;

--- a/pkgs/by-name/kn/knot-resolver-manager_6/package.nix
+++ b/pkgs/by-name/kn/knot-resolver-manager_6/package.nix
@@ -23,7 +23,6 @@ python3Packages.buildPythonPackage {
   # But the install-time etc differs from a sensible run-time etc.
   postPatch = ''
     substitute '${knot-resolver.unwrapped.config_py}'/knot_resolver/constants.py ./python/knot_resolver/constants.py \
-      --replace-fail '${knot-resolver.unwrapped.out}/etc' '/etc' \
       --replace-fail '${knot-resolver.unwrapped.out}/sbin' '${knot-resolver}/bin'
   ''
   # On non-Linux let's simplify construction of the knot-resolver command line,

--- a/pkgs/by-name/kn/knot-resolver_6/package.nix
+++ b/pkgs/by-name/kn/knot-resolver_6/package.nix
@@ -56,20 +56,12 @@ let
         excludes = [ "NEWS" ];
         hash = "sha256-3w33v8UfhGdA50BlkfHpQLFxg+5ELk0lp7RzgvkSzK8=";
       })
+      # Install-time paths sometimes differ from run-time paths in nixpkgs.
+      ./paths.patch
     ];
 
-    # Path fixups for the NixOS service.
     # systemd Exec* options are difficult to override in NixOS *if present*, so we drop them.
     postPatch = ''
-      patch meson.build <<EOF
-      @@ -50,2 +50,3 @@
-      -systemd_work_dir = prefix / get_option('localstatedir') / 'lib' / 'knot-resolver'
-      -systemd_cache_dir = prefix / get_option('localstatedir') / 'cache' / 'knot-resolver'
-      +systemd_work_dir  = '/var/lib/knot-resolver'
-      +systemd_cache_dir = '/var/cache/knot-resolver'
-      +run_dir = '/run/knot-resolver'
-      EOF
-
       sed -e '/^ExecStart=/d' -e '/^ExecReload=/d' \
         -i systemd/knot-resolver.service.in
     ''

--- a/pkgs/by-name/kn/knot-resolver_6/package.nix
+++ b/pkgs/by-name/kn/knot-resolver_6/package.nix
@@ -26,14 +26,12 @@
   cmocka,
   which,
   cacert,
-  extraFeatures ? false, # catch-all if defaults aren't enough
 }:
 let
-  result = if extraFeatures then wrapped-full else unwrapped;
-
   inherit (lib) optional optionals optionalString;
   lua = luajitPackages;
 
+  # TODO: we could cut the `let` short here, but it would de-indent everything.
   unwrapped = stdenv.mkDerivation (finalAttrs: {
     pname = "knot-resolver_6";
     version = "6.0.17";
@@ -139,7 +137,8 @@ let
     '';
 
     passthru = {
-      unwrapped = finalAttrs.finalPackage;
+      inherit lua;
+      inherit (finalAttrs) finalPackage;
     };
 
     meta = {
@@ -155,42 +154,5 @@ let
     };
   });
 
-  wrapped-full =
-    runCommand unwrapped.name
-      {
-        nativeBuildInputs = [ makeWrapper ];
-        buildInputs = with luajitPackages; [
-          # For http module, prefill module, trust anchor bootstrap.
-          # It brings lots of deps; some are useful elsewhere (e.g. cqueues).
-          http
-          # used by policy.slice_randomize_psl()
-          psl
-        ];
-        preferLocalBuild = true;
-        allowSubstitutes = false;
-        inherit (unwrapped) version meta;
-        passthru = {
-          inherit unwrapped;
-        };
-      }
-      (
-        ''
-          mkdir -p "$out"/bin
-          makeWrapper '${unwrapped}/bin/kresd' "$out"/bin/kresd \
-            --set LUA_PATH  "$LUA_PATH" \
-            --set LUA_CPATH "$LUA_CPATH"
-
-          ln -sr '${unwrapped}/bin/kres-cache-gc' "$out"/bin/
-          ln -sr '${unwrapped}/share' "$out"/
-          ln -sr '${unwrapped}/lib'   "$out"/ # useful in NixOS service
-          ln -sr "$out"/{bin,sbin}
-        ''
-        + lib.optionalString unwrapped.doInstallCheck ''
-          echo "Checking that 'http' module loads, i.e. lua search paths work:"
-          echo "modules.load('http')" > test-http.lua
-          echo -e 'quit()' | env -i "$out"/bin/kresd -a 127.0.0.1#53535 -c test-http.lua
-        ''
-      );
-
 in
-result
+unwrapped

--- a/pkgs/by-name/kn/knot-resolver_6/paths.patch
+++ b/pkgs/by-name/kn/knot-resolver_6/paths.patch
@@ -1,0 +1,14 @@
+--- a/meson.build
++++ b/meson.build
+@@ -50,2 +50,3 @@
+-systemd_work_dir = prefix / get_option('localstatedir') / 'lib' / 'knot-resolver'
+-systemd_cache_dir = prefix / get_option('localstatedir') / 'cache' / 'knot-resolver'
++systemd_work_dir  = '/var/lib/knot-resolver'
++systemd_cache_dir = '/var/cache/knot-resolver'
++run_dir = '/run/knot-resolver'
+
+--- a/python/knot_resolver/constants.py.in
++++ b/python/knot_resolver/constants.py.in
+@@ -12 +12 @@
+-ETC_DIR = Path("@etc_dir@")
++ETC_DIR = Path("/etc/knot-resolver")


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] N/A Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
