### PR TITLE
shine: 3.1.1 -> 3.1.1-unstable-2023-01-01

### DIFF
--- a/pkgs/by-name/sh/shine/package.nix
+++ b/pkgs/by-name/sh/shine/package.nix
@@ -5,15 +5,15 @@
   autoreconfHook,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "shine";
-  version = "3.1.1";
+  version = "3.1.1-unstable-2023-01-01";
 
   src = fetchFromGitHub {
     owner = "toots";
     repo = "shine";
-    rev = version;
-    sha256 = "06nwylqqji0i1isdprm2m5qsdj4qiywcgnp69c5b55pnw43f07qg";
+    rev = "ab5e3526b64af1a2eaa43aa6f441a7312e013519";
+    hash = "sha256-rlKWVgIl/WVIzwwMuPyWaiwvbpZi5HvKXU3S6qLoN3I=";
   };
 
   nativeBuildInputs = [ autoreconfHook ];


### PR DESCRIPTION
Diff: https://github.com/toots/shine/compare/3.1.1..ab5e3526b64af1a2eaa43aa6f441a7312e013519

Changelog: https://github.com/toots/shine/blob/ab5e3526b64af1a2eaa43aa6f441a7312e013519/ChangeLog

New version contains commit fixing build with gcc15:
https://github.com/toots/shine/commit/098b9aaa6770a41bdf3f9c049307c1398f04d2d3

Fixes build failure with gcc15:
```
src/lib/l3mdct.c:33:6: error: conflicting types for 'shine_mdct_initialise';
have 'void(shine_global_config *)' {aka 'void(struct shine_global_flags *)'}
   33 | void shine_mdct_initialise(shine_global_config *config)
      |      ^~~~~~~~~~~~~~~~~~~~~
In file included from src/lib/l3mdct.c:4:
src/lib/l3mdct.h:4:6: note: previous declaration of 'shine_mdct_initialise'
with type 'void(void)'
    4 | void shine_mdct_initialise();
      |      ^~~~~~~~~~~~~~~~~~~~~
```

---

Tested build with:
```bash
nix-build --expr 'with import ./. {}; shine.override { stdenv = gcc15Stdenv; }'
```

Part of fixes for gcc15 update:
https://github.com/NixOS/nixpkgs/pull/440456


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
