### PR TITLE
python3Packages.cron-descriptor: 1.4.5 -> 2.0.6

### DIFF
--- a/pkgs/development/python-modules/cron-descriptor/default.nix
+++ b/pkgs/development/python-modules/cron-descriptor/default.nix
@@ -2,33 +2,28 @@
   lib,
   fetchFromGitHub,
   buildPythonPackage,
-  unittestCheckHook,
-  mock,
+  pytestCheckHook,
   setuptools,
+  typing-extensions,
 }:
 
 buildPythonPackage rec {
   pname = "cron-descriptor";
-  version = "1.4.5";
+  version = "2.0.6";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Salamek";
     repo = "cron-descriptor";
     tag = version;
-    hash = "sha256-ElYma6RH2u1faIgOvGpMQA26dSIibWcO4mWU6NAA5PQ=";
+    hash = "sha256-f7TQ3wvcHrzefZowUvxl1T0LCGeCnvpPI/IZn4XcDa4=";
   };
-
-  # remove tests_require, as we don't do linting anyways
-  postPatch = ''
-    sed -i "/'pep8\|flake8\|pep8-naming',/d" setup.py
-  '';
 
   build-system = [ setuptools ];
 
   nativeCheckInputs = [
-    mock
-    unittestCheckHook
+    pytestCheckHook
+    typing-extensions
   ];
 
   pythonImportsCheck = [ "cron_descriptor" ];


### PR DESCRIPTION
closes #471100

changelog: https://github.com/Salamek/cron-descriptor/compare/1.4.5...2.0.6

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
