### PR TITLE
pkdns: init at 0.7.1

### DIFF
--- a/pkgs/by-name/pk/pkdns/package.nix
+++ b/pkgs/by-name/pk/pkdns/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  nix-update-script,
+  versionCheckHook,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "pkdns";
+  version = "0.7.1";
+
+  src = fetchFromGitHub {
+    owner = "pubky";
+    repo = "pkdns";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-2bLOl4xDSoNwmGzaaGVmjlzifJjftRID5iSof4D/SfU=";
+  };
+
+  cargoHash = "sha256-sbJb+rdrabmbHsv9ijc/APvTtRrZHSrgAlSPzYrgLTc=";
+
+  # skip tests, which rely on an external network
+  checkFlags = [
+    "--skip=dns_over_https"
+    "--skip=external_ip"
+    "--skip=resolution::dns_socket"
+    "--skip=resolution::pkd::bootstrap_nodes"
+    "--skip=resolution::pkd::pkarr_resolver::tests::pkarr_invalid_packet1"
+    "--skip=resolution::pkd::pkarr_resolver::tests::query"
+    "--skip=resolution::pkd::query_matcher"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
+
+  meta = {
+    description = "DNS server resolving pkarr self-sovereign domains";
+    homepage = "https://github.com/pubky/pkdns";
+    license = [ lib.licenses.mit ];
+    maintainers = with lib.maintainers; [ arikgrahl ];
+    mainProgram = "pkdns";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
DNS server resolving pkarr self-sovereign domains

https://github.com/pubky/pkdns

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
