### PR TITLE
Cinnamon updates 2025-12-16

### DIFF
--- a/pkgs/by-name/ci/cinnamon-desktop/package.nix
+++ b/pkgs/by-name/ci/cinnamon-desktop/package.nix
@@ -21,13 +21,13 @@
 
 stdenv.mkDerivation rec {
   pname = "cinnamon-desktop";
-  version = "6.6.0";
+  version = "6.6.1";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "cinnamon-desktop";
     tag = version;
-    hash = "sha256-9qgt+E5qbzq+x9fJKkoSBFgA96HBDLysQvg6b04WbMU=";
+    hash = "sha256-vBRaUXsPAPOpMEs2pl6AaaKIMeeXB0UdCb1hzYd43KY=";
   };
 
   outputs = [

--- a/pkgs/by-name/ci/cinnamon-screensaver/package.nix
+++ b/pkgs/by-name/ci/cinnamon-screensaver/package.nix
@@ -28,13 +28,13 @@
 
 stdenv.mkDerivation rec {
   pname = "cinnamon-screensaver";
-  version = "6.6.0";
+  version = "6.6.1";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "cinnamon-screensaver";
     tag = version;
-    hash = "sha256-Jo9GRsiPvqGZ2ITaewV5H4VMc5EotTTXIaqzXwDA+Z4=";
+    hash = "sha256-NK33cIrcTicLs59eJ550FghjuWS93yD642ObAS55Dtk=";
   };
 
   patches = [

--- a/pkgs/by-name/ci/cinnamon/package.nix
+++ b/pkgs/by-name/ci/cinnamon/package.nix
@@ -74,13 +74,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "cinnamon";
-  version = "6.6.0";
+  version = "6.6.2";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "cinnamon";
     tag = version;
-    hash = "sha256-DiAc1Ng03xzNYYpf79g9p338syPScKftmviNw6Y5i5o=";
+    hash = "sha256-evjXa42mo7wkLh5HDax+2Tsc/x/oG3tPHU1tczoxmJU=";
   };
 
   patches = [

--- a/pkgs/by-name/mi/mint-l-theme/package.nix
+++ b/pkgs/by-name/mi/mint-l-theme/package.nix
@@ -8,13 +8,13 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "mint-l-theme";
-  version = "2.0.3";
+  version = "2.0.4";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "mint-l-theme";
     rev = version;
-    hash = "sha256-RdcojX+8SQDJ9LPb81iMzdoCZBpoypf/+aQcgotnVGE=";
+    hash = "sha256-jrNVeeqOBDf77Lz68qyjHllA4C3PQRySYQH7Sva2UHU=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/mi/mint-themes/package.nix
+++ b/pkgs/by-name/mi/mint-themes/package.nix
@@ -8,13 +8,13 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "mint-themes";
-  version = "2.3.4";
+  version = "2.3.5";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "mint-themes";
     rev = version;
-    hash = "sha256-A4k9iy0d9pGPSYa4m3tAv2GKhFuJPrQODbv+LcP/YXU=";
+    hash = "sha256-folnnA4By1Dd1amriGiTl5mOxpcnaFjdp/UsjacE8GA=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ne/nemo/package.nix
+++ b/pkgs/by-name/ne/nemo/package.nix
@@ -14,6 +14,7 @@
   cinnamon-desktop,
   xapp,
   xapp-symbolic-icons,
+  xdg-user-dirs,
   libexif,
   json-glib,
   exempi,
@@ -36,13 +37,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "nemo";
-  version = "6.6.1";
+  version = "6.6.2";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "nemo";
     rev = version;
-    hash = "sha256-oJvGuPm6FOknSe+5TDLNf0eoE3xC+i78SkYdJUBY4PU=";
+    hash = "sha256-5jgD2C71sQkqnAGsnsjK8W9qaLtNtGeYLXsV2+7u2jU=";
   };
 
   patches = [
@@ -95,13 +96,19 @@ stdenv.mkDerivation rec {
 
   preFixup = ''
     gappsWrapperArgs+=(
-       --prefix XDG_DATA_DIRS : ${
+       --prefix XDG_DATA_DIRS : "${
          lib.makeSearchPath "share" [
            # For non-fd.o icons.
            xapp
            xapp-symbolic-icons
          ]
-       }
+       }"
+       --prefix PATH : "${
+         lib.makeBinPath [
+           # For xdg-user-dirs-update.
+           xdg-user-dirs
+         ]
+       }"
     )
   '';
 


### PR DESCRIPTION
<!--

nemo: 6.6.1 -> 6.6.2
mint-themes: 2.3.4 -> 2.3.5
mint-l-theme: 2.0.3 -> 2.0.4
cinnamon-screensaver: 6.6.0 -> 6.6.1
cinnamon-desktop: 6.6.0 -> 6.6.1
cinnamon: 6.6.0 -> 6.6.1

nemo: 6.6.1 -> 6.6.3
mint-themes: 2.3.4 -> 2.3.6
mint-l-theme: 2.0.3 -> 2.0.5
cinnamon-screensaver: 6.6.0 -> 6.6.2
cinnamon-desktop: 6.6.0 -> 6.6.2
cinnamon: 6.6.0 -> 6.6.2
cinnamon: 6.6.0 -> 6.6.3
cinnamon: 6.6.0 -> 6.6.4

-->


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

