### PR TITLE
nixpkgs-plugin-update: no token fallback

### DIFF
--- a/pkgs/development/python-modules/nixpkgs-plugin-update/nixpkgs-plugin-update/src/nixpkgs_plugin_update/__init__.py
+++ b/pkgs/development/python-modules/nixpkgs-plugin-update/nixpkgs-plugin-update/src/nixpkgs_plugin_update/__init__.py
@@ -288,6 +288,14 @@ class RepoGitHub(Repo):
     @retry(urllib.error.URLError, tries=4, delay=3, backoff=2)
     def get_latest_tag(self) -> str | None:
         try:
+            if not self.token or self.token == "":
+                log.info(
+                    "No GitHub token available for %s/%s, using git ls-remote fallback",
+                    self.owner,
+                    self.repo,
+                )
+                return super().get_latest_tag()
+
             # FIXME: This fetches all tags. We need to find a way to check if a tag exists in
             # an ancestor of the default branch.
             query = """


### PR DESCRIPTION
GraphQL endpoint introduced in previous tagging work requires a GITHUB_TOKEN. Fallback to `git ls-remote` when we don't have a token to work with. I was able to unset my tokens and use it to get a new plugin added/updated.

Follow up to https://github.com/NixOS/nixpkgs/pull/470251#issuecomment-3661115785 @PerchunPak does this work for you?

Before: 

```bash
nix build .#vimPluginsUpdater && ./result/bin/vim-plugins-updater add https://github.com/rodrigoscc/nurl.nvim
WARNING:root:Error fetching version info for rodrigoscc/nurl.nvim: HTTP Error 403: rate limit exceeded
Traceback (most recent call last):
  File "/nix/store/q6n6kynf42xa8icw5qh375zlaf1s9bnb-python3.13-nixpkgs-plugin-update-0.1.0/lib/python3.13/site-packages/nixpkgs_plugin_update/__init__.py", line 317, in get_latest_tag
    data = self._execute_graphql(
        query, {"owner": self.owner, "name": self.repo}
    )
  File "/nix/store/q6n6kynf42xa8icw5qh375zlaf1s9bnb-python3.13-nixpkgs-plugin-update-0.1.0/lib/python3.13/site-packages/nixpkgs_plugin_update/__init__.py", line 274, in _execute_graphql
    with urllib.request.urlopen(req, timeout=10) as response:
         ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/nix/store/3lll9y925zz9393sa59h653xik66srjb-python3-3.13.9/lib/python3.13/urllib/request.py", line 189, in urlopen
    return opener.open(url, data, timeout)
           ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/3lll9y925zz9393sa59h653xik66srjb-python3-3.13.9/lib/python3.13/urllib/request.py", line 495, in open
    response = meth(req, response)
  File "/nix/store/3lll9y925zz9393sa59h653xik66srjb-python3-3.13.9/lib/python3.13/urllib/request.py", line 604, in http_response
    response = self.parent.error(
        'http', request, response, code, msg, hdrs)
  File "/nix/store/3lll9y925zz9393sa59h653xik66srjb-python3-3.13.9/lib/python3.13/urllib/request.py", line 533, in error
    return self._call_chain(*args)
           ~~~~~~~~~~~~~~~~^^^^^^^
  File "/nix/store/3lll9y925zz9393sa59h653xik66srjb-python3-3.13.9/lib/python3.13/urllib/request.py", line 466, in _call_chain
    result = func(*args)
  File "/nix/store/3lll9y925zz9393sa59h653xik66srjb-python3-3.13.9/lib/python3.13/urllib/request.py", line 613, in http_error_default
    raise HTTPError(req.full_url, code, msg, hdrs, fp)
urllib.error.HTTPError: HTTP Error 403: rate limit exceeded
path is '/nix/store/hmgmyyciqszqmgnc4nbxql95ra90b3jl-4f046706abc454bb4190ee3fd43afafc3c744d7e.tar.gz'
WARNING:root:Error fetching version info for rodrigoscc/nurl.nvim: HTTP Error 403: rate limit exceeded
Traceback (most recent call last):
  File "/nix/store/q6n6kynf42xa8icw5qh375zlaf1s9bnb-python3.13-nixpkgs-plugin-update-0.1.0/lib/python3.13/site-packages/nixpkgs_plugin_update/__init__.py", line 317, in get_latest_tag
    data = self._execute_graphql(
        query, {"owner": self.owner, "name": self.repo}
    )
  File "/nix/store/q6n6kynf42xa8icw5qh375zlaf1s9bnb-python3.13-nixpkgs-plugin-update-0.1.0/lib/python3.13/site-packages/nixpkgs_plugin_update/__init__.py", line 274, in _execute_graphql
    with urllib.request.urlopen(req, timeout=10) as response:
         ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/nix/store/3lll9y925zz9393sa59h653xik66srjb-python3-3.13.9/lib/python3.13/urllib/request.py", line 189, in urlopen
    return opener.open(url, data, timeout)
           ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/3lll9y925zz9393sa59h653xik66srjb-python3-3.13.9/lib/python3.13/urllib/request.py", line 495, in open
    response = meth(req, response)
  File "/nix/store/3lll9y925zz9393sa59h653xik66srjb-python3-3.13.9/lib/python3.13/urllib/request.py", line 604, in http_response
    response = self.parent.error(
        'http', request, response, code, msg, hdrs)
  File "/nix/store/3lll9y925zz9393sa59h653xik66srjb-python3-3.13.9/lib/python3.13/urllib/request.py", line 533, in error
    return self._call_chain(*args)
           ~~~~~~~~~~~~~~~~^^^^^^^
  File "/nix/store/3lll9y925zz9393sa59h653xik66srjb-python3-3.13.9/lib/python3.13/urllib/request.py", line 466, in _call_chain
    result = func(*args)
  File "/nix/store/3lll9y925zz9393sa59h653xik66srjb-python3-3.13.9/lib/python3.13/urllib/request.py", line 613, in http_error_default
    raise HTTPError(req.full_url, code, msg, hdrs, fp)
urllib.error.HTTPError: HTTP Error 403: rate limit exceeded
1 of 1767 were checked
updated pkgs/applications/editors/vim/plugins/generated.nix
committing to nixpkgs "vimPlugins.nurl-nvim: init at 0-unstable-2025-12-10"
```

After

```bash
nix build .#vimPluginsUpdater && ./result/bin/vim-plugins-updater add https://github.com/rodrigoscc/nurl.nvim
path is '/nix/store/hmgmyyciqszqmgnc4nbxql95ra90b3jl-4f046706abc454bb4190ee3fd43afafc3c744d7e.tar.gz'
path is '/nix/store/hmgmyyciqszqmgnc4nbxql95ra90b3jl-4f046706abc454bb4190ee3fd43afafc3c744d7e.tar.gz'
1 of 1767 were checked
updated pkgs/applications/editors/vim/plugins/generated.nix
committing to nixpkgs "vimPlugins.nurl-nvim: init at 0.3.0-unstable-2025-12-10"
```
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
