### PR TITLE
copyq: add dependency to fix clipboard saving on wayland

### DIFF
--- a/pkgs/applications/misc/copyq/default.nix
+++ b/pkgs/applications/misc/copyq/default.nix
@@ -13,6 +13,7 @@
   libXtst,
   qtwayland,
   wayland,
+  wayland-scanner,
   pkg-config,
   wrapQtAppsHook,
   kdePackages,
@@ -46,6 +47,7 @@ stdenv.mkDerivation rec {
     libXtst
     qtwayland
     wayland
+    wayland-scanner
     kdePackages.kconfig
     kdePackages.kstatusnotifieritem
     kdePackages.knotifications


### PR DESCRIPTION
Two months ago, I ran into some issues with CopyQ after updating to KDE Plasma 6.5. The problems were similar to those described in the following GitHub issue: https://github.com/hluk/CopyQ/issues/3276.
CopyQ no longer automatically saved items to the clipboard history. Initially, I thought this was because CopyQ was not using the newer Wayland clipboard data sharing API, as some of the older APIs had been deprecated or removed in Plasma 6.5.  However, after experimenting with using CopyQ with QT5 instead of QT6, I discovered that CopyQ lacks the necessary protocol information during building. I don't fully understand the Wayland thingy, but I'm currently using the following in my configuration, which resolves the aforementioned issue:
```Nix
pkgs.copyq.overrideAttrs (final: prev: {
  buildInputs = prev.buildInputs ++ [ pkgs.wayland-scanner ];
});
```
Thus, I thought I could upstream this, because this should affect other people using at least a combination of KDE Plasma 6.5 + Wayland + CopyQ.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
