### PR TITLE
nixos/limine: add uki support

### DIFF
--- a/nixos/modules/system/boot/loader/limine/limine-install.py
+++ b/nixos/modules/system/boot/loader/limine/limine-install.py
@@ -35,6 +35,7 @@ class BootSpec:
     toplevel: str
     specialisations: Dict[str, "BootSpec"]
     xen: XenBootSpec | None
+    uki: Dict[str, any] | None
     initrd: str | None = None
     initrdSecrets: str | None = None
 
@@ -114,28 +115,43 @@ def get_dest_path(path: str, target: str) -> str:
     return os.path.join(str(limine_install_dir), target, dest_file)
 
 
-def get_copied_path_uri(path: str, target: str) -> str:
-    result = ''
+def get_path_relative_to_limine_dir(path: str) -> str:
+    if path.startswith(str(limine_install_dir)):
+        reduced_path = path.replace(str(limine_install_dir), '', 1)
+        while reduced_path.startswith('/'):
+            reduced_path = reduced_path.replace('/', '', 1)
+        return reduced_path
+    raise Exception('Logic Error: Tried to make path outside of limine install directory relative to limine install directory')
 
-    dest_file = get_dest_file(path)
-    dest_path = get_dest_path(path, target)
+def get_uri(path: str) -> str:
+    file = get_path_relative_to_limine_dir(path)
+    full_path = os.path.join(str(limine_install_dir), file)
 
-    if not os.path.exists(dest_path):
-        copy_file(path, dest_path)
-    else:
-        paths[dest_path] = True
+    if not os.path.exists(full_path):
+        raise Exception('Logic Error: Trying to get URI for non-existent file')
 
-    path_with_prefix = os.path.join('/limine', target, dest_file)
-    result = f'boot():{path_with_prefix}'
+    paths[full_path] = True
+
+    path = os.path.join('/limine', file)
+    result = f'boot():{path}'
 
     if config('validateChecksums'):
-        with open(path, 'rb') as file:
+        with open(full_path, 'rb') as file:
             b2sum = hashlib.blake2b()
             b2sum.update(file.read())
 
             result += f'#{b2sum.hexdigest()}'
 
     return result
+
+
+def get_copied_path_uri(path: str, target: str) -> str:
+    dest_path = get_dest_path(path, target)
+
+    if not os.path.exists(dest_path):
+        copy_file(path, dest_path)
+
+    return get_uri(dest_path)
 
 
 def get_path_uri(path: str) -> str:
@@ -157,10 +173,14 @@ def bootjson_to_bootspec(bootjson: dict) -> BootSpec:
     xen = None
     if 'org.xenproject.bootspec.v2' in bootjson:
         xen = bootjson['org.xenproject.bootspec.v2']
+    uki = None
+    if 'org.limine.uki.v1' in bootjson:
+        uki = bootjson['org.limine.uki.v1']
     return BootSpec(
         **bootjson['org.nixos.bootspec.v1'],
         specialisations=specialisations,
         xen=xen,
+        uki=uki,
     )
 
 def generate_xen_efi_files(
@@ -285,42 +305,91 @@ def xen_config_entry(
             entry += 'module_path: ' + get_kernel_uri(bootspec.initrd) + '\n'
     return entry
 
-def config_entry(levels: int, bootspec: BootSpec, label: str, time: str) -> str:
+def config_entry(levels: int, bootspec: BootSpec, label: str, time: str, profile: str, gen: int, spec: str|None) -> str:
+    useUki = config('uki', 'buildUki') and ((bootspec.uki and bootspec.uki['useUki']) or config('uki', 'forceAll'))
     entry = '/' * levels + label + '\n'
-    entry += 'protocol: linux\n'
+    entry += 'protocol: ' + ('linux' if not useUki else 'efi') + '\n'
     entry += f'comment: {bootspec.label}, built on {time}\n'
-    entry += 'kernel_path: ' + get_kernel_uri(bootspec.kernel) + '\n'
-    entry += 'cmdline: ' + ' '.join(['init=' + bootspec.init] + bootspec.kernelParams).strip() + '\n'
 
-    # Set framebuffer resolution for Linux boot entries if configured
-    resolution = config('resolution')
-    if resolution is not None:
-        entry += f'resolution: {resolution}\n'
+    if not useUki:
+        resolution = config('resolution')
+        if resolution is not None:
+            entry += f'resolution: {resolution}\n'
 
-    if bootspec.initrd:
-        entry += f'module_path: ' + get_kernel_uri(bootspec.initrd) + '\n'
+    kernel = bootspec.kernel
+    initrd = bootspec.initrd
+    cmdline = ' '.join(['init=' + bootspec.init] + bootspec.kernelParams).strip()
 
+    initrd_secrets_path = os.path.join(str(limine_install_dir), 'kernels', os.path.basename(bootspec.toplevel) + '-secrets')
+    initrd_secrets_path_temp = initrd_secrets_path + '.tmp'
     if bootspec.initrdSecrets:
-        base_path = str(limine_install_dir) + '/kernels/'
-        initrd_secrets_path = base_path + os.path.basename(bootspec.toplevel) + '-secrets'
-        if not os.path.exists(base_path):
-            os.makedirs(base_path)
-
         old_umask = os.umask(0o137)
-        initrd_secrets_path_temp = tempfile.mktemp(os.path.basename(bootspec.toplevel) + '-secrets')
 
         if os.system(bootspec.initrdSecrets + " " + initrd_secrets_path_temp) != 0:
-            print(f'warning: failed to create initrd secrets for "{label}"', file=sys.stderr)
+            print(f'warning: failed to create initrd secrets for generation {gen}' + (f' (specialisation {spec})' if spec else ''), file=sys.stderr)
             print(f'note: if this is an older generation there is nothing to worry about')
 
-        if os.path.exists(initrd_secrets_path_temp):
-            copy_file(initrd_secrets_path_temp, initrd_secrets_path)
-            os.unlink(initrd_secrets_path_temp)
-            entry += 'module_path: ' + get_kernel_uri(initrd_secrets_path) + '\n'
-
         os.umask(old_umask)
-    return entry
 
+    if useUki:
+        uki_file = os.path.join(str(limine_install_dir), 'kernels', os.path.basename(bootspec.toplevel) + '-uki.efi')
+        # This check ensures the UKI for identical generations is only created once
+        if not (uki_file in paths and paths[uki_file]):
+            ukify = os.path.join(str(config('ukify')), 'bin', 'ukify')
+            if not os.path.exists(os.path.dirname(uki_file)):
+                os.makedirs(os.path.dirname(uki_file))
+            uki_args = [
+                    ukify, 'build', '--output', uki_file,
+                    '--linux', kernel, # Pass linux kernel
+                    '--cmdline', cmdline, # Pass assembled cmdline
+                    '--os-release', '' # Force disable the .osrel section as it doesn't reflect the information for the generation being built
+            ]
+            if initrd:
+                uki_args.extend(['--initrd', initrd])
+
+            if os.path.exists(initrd_secrets_path_temp):
+                uki_args.extend(['--initrd', initrd_secrets_path_temp])
+
+            try:
+                subprocess.run(uki_args)
+            except:
+                print('error: failed to build uki', file=sys.stderr)
+                sys.exit(1)
+
+            if config('secureBoot', 'enable'):
+                sbctl = os.path.join(str(config('secureBoot', 'sbctl')), 'bin', 'sbctl')
+                try:
+                    subprocess.run([sbctl, 'sign', uki_file])
+                except:
+                    print('error: failed to sign uki', file=sys.stderr)
+                    sys.exit(1)
+        entry += 'path: ' + get_uri(uki_file) + '\n'
+
+    if (not useUki) or config('biosSupport'):
+        if useUki:
+            entry = '/' * levels + label + '\n'
+            entry += 'protocol: linux\n'
+            entry += f'comment: {bootspec.label}, built on {time}\n'
+            entry += f'if_fw_type: BIOS\n' # Hide fallback entries when using UEFI
+
+            # Set framebuffer resolution for Linux boot entries if configured
+            if resolution is not None:
+                entry += f'resolution: {resolution}\n'
+
+        entry += 'kernel_path: ' + get_kernel_uri(kernel) + '\n'
+        entry += f'cmdline: {cmdline} \n'
+        if initrd:
+            entry += f'module_path: ' + get_kernel_uri(initrd) + '\n'
+
+        if os.path.exists(initrd_secrets_path_temp):
+            old_umask = os.umask(0o137)
+            copy_file(initrd_secrets_path_temp, initrd_secrets_path)
+            entry += 'module_path: ' + get_kernel_uri(initrd_secrets_path) + '\n'
+            os.umask(old_umask)
+
+    if os.path.exists(initrd_secrets_path_temp):
+        os.unlink(initrd_secrets_path_temp)
+    return entry
 
 def generate_config_entry(profile: str, gen: str, special: bool) -> str:
     time = datetime.datetime.fromtimestamp(os.stat(get_system_path(profile,gen), follow_symlinks=False).st_mtime).strftime("%F %H:%M:%S")
@@ -346,12 +415,12 @@ def generate_config_entry(profile: str, gen: str, special: bool) -> str:
             entry += '+'
 
         entry += f'Generation {gen}' + '\n'
-        entry += config_entry(depth, boot_spec, f'Default', str(time))
+        entry += config_entry(depth, boot_spec, f'Default', str(time), profile, gen, None)
     else:
-        entry += config_entry(depth, boot_spec, f'Generation {gen}', str(time))
+        entry += config_entry(depth, boot_spec, f'Generation {gen}', str(time), profile, gen, None)
 
     for spec, spec_boot_spec in specialisation_list:
-        entry += config_entry(depth, spec_boot_spec, f'{spec}', str(time))
+        entry += config_entry(depth, spec_boot_spec, f'{spec}', str(time), profile, gen, spec)
 
     return entry
 
@@ -433,6 +502,23 @@ def install_bootloader() -> None:
     if config('secureBoot', 'enable') and not config('secureBoot', 'autoGenerateKeys') and not os.path.exists("/var/lib/sbctl"):
         print("There are no sbctl secure boot keys present. Please generate some.")
         sys.exit(1)
+
+    if config('secureBoot', 'enable') and not os.path.exists("/var/lib/sbctl") and config('secureBoot', 'autoGenerateKeys'):
+        sbctl = os.path.join(str(config('secureBoot', 'sbctl')), 'bin', 'sbctl')
+        print('auto generating keys')
+        try:
+            subprocess.run([sbctl, 'create-keys'])
+        except:
+            print('error: failed to create keys', file=sys.stderr)
+            sys.exit(1)
+        if config('secureBoot', 'autoEnrollKeys', 'enable'):
+            try:
+                command = [sbctl, 'enroll-keys']
+                command.extend(config('secureBoot', 'autoEnrollKeys', 'extraArgs'))
+                subprocess.run(command)
+            except:
+                print('error: failed to enroll keys', file=sys.stderr)
+                sys.exit(1)
 
     if not os.path.exists(limine_install_dir):
         os.makedirs(limine_install_dir)
@@ -559,22 +645,6 @@ def install_bootloader() -> None:
 
         if config('secureBoot', 'enable'):
             sbctl = os.path.join(str(config('secureBoot', 'sbctl')), 'bin', 'sbctl')
-            if not os.path.exists("/var/lib/sbctl") and config('secureBoot', 'autoGenerateKeys'):
-                print('auto generating keys')
-                try:
-                    subprocess.run([sbctl, 'create-keys'])
-                except:
-                    print('error: failed to create keys', file=sys.stderr)
-                    sys.exit(1)
-                if config('secureBoot', 'autoEnrollKeys', 'enable'):
-                    try:
-                        command = [sbctl, 'enroll-keys']
-                        command.extend(config('secureBoot', 'autoEnrollKeys', 'extraArgs'))
-                        subprocess.run(command)
-                    except:
-                        print('error: failed to enroll keys', file=sys.stderr)
-                        sys.exit(1)
-
             print('signing limine...')
             try:
                 subprocess.run([sbctl, 'sign', dest_path])

--- a/nixos/modules/system/boot/loader/limine/limine.nix
+++ b/nixos/modules/system/boot/loader/limine/limine.nix
@@ -20,6 +20,10 @@ let
       efiSupport = cfg.efiSupport;
       efiRemovable = cfg.efiInstallAsRemovable;
       secureBoot = cfg.secureBoot;
+      uki = {
+        inherit (cfg.uki) enable forceAll buildUki;
+      };
+      ukify = if cfg.uki.buildUki then pkgs.systemdUkify else null;
       biosSupport = cfg.biosSupport;
       biosDevice = cfg.biosDevice;
       partitionIndex = cfg.partitionIndex;
@@ -246,6 +250,39 @@ in
       sbctl = lib.mkPackageOption pkgs "sbctl" { };
     };
 
+    uki = {
+      enable = lib.mkEnableOption null // {
+        description = ''
+          Use UKI to store the kernel and initrd.
+
+          ::: {.note}
+          This is still experimental
+
+          This uses significantly more storage than storing kernel, initrd and command line separately.
+          :::
+        '';
+      };
+
+      forceAll = lib.mkEnableOption null // {
+        description = ''
+          Force all generations to use a UKI image independent of what the bootspec extension says.
+
+          ::: {.note}
+          This is experimental
+          :::
+        '';
+      };
+
+      buildUki = lib.mkEnableOption null // {
+        default = true;
+        description = ''
+          Whether to actually build UKIs or not.
+        '';
+      };
+
+      package = lib.mkPackageOption pkgs "systemdUkify" { };
+    };
+
     style = {
       wallpapers = lib.mkOption {
         default = [ ];
@@ -450,6 +487,29 @@ in
             python3 = pkgs.python3.withPackages (python-packages: [ python-packages.psutil ]);
             configPath = limineInstallConfig;
           };
+        };
+      };
+    })
+    (lib.mkIf (cfg.enable && cfg.uki.enable) {
+      assertions = [
+        {
+          assertion = !cfg.uki.forceAll || cfg.uki.buildUki;
+          message = "boot.loader.limine.uki.forceAll requires UKIs to be built, but boot.loader.limine.uki.buildUki is set to false";
+        }
+      ];
+
+      warnings =
+        (lib.optional (
+          cfg.biosSupport && cfg.efiSupport
+        ) "Both BIOS support and UKI are enabled, kernel and initrd will be stored double")
+        ++ (lib.optional (!cfg.efiSupport) "System is BIOS-only, no UKI will be built")
+        ++ (lib.optional (
+          !cfg.uki.buildUki
+        ) "boot.loader.limine.uki.buildUki is set to false, no UKIs will actually be built");
+
+      boot.bootspec.extensions = {
+        "org.limine.uki.v1" = {
+          useUki = true;
         };
       };
     })

--- a/nixos/tests/limine/default.nix
+++ b/nixos/tests/limine/default.nix
@@ -9,4 +9,6 @@
   specialisations = runTest ./specialisations.nix;
   uefi = runTest ./uefi.nix;
   distroName = runTest ./distroName.nix;
+  secureBootWithUki = runTest ./secure-boot-with-uki.nix;
+  specialisationsWithUki = runTest ./specialisations-with-uki.nix;
 }

--- a/nixos/tests/limine/secure-boot-with-uki.nix
+++ b/nixos/tests/limine/secure-boot-with-uki.nix
@@ -1,0 +1,40 @@
+{ lib, pkgs, ... }:
+{
+  name = "secureBootwithUki";
+  meta = {
+    inherit (pkgs.limine.meta) maintainers;
+  };
+
+  meta.platforms = [
+    "aarch64-linux"
+    "i686-linux"
+    "x86_64-linux"
+  ];
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      virtualisation.useBootLoader = true;
+      virtualisation.useEFIBoot = true;
+      virtualisation.useSecureBoot = true;
+      virtualisation.efi.OVMF = pkgs.OVMFFull.fd;
+      virtualisation.efi.keepVariables = true;
+
+      boot.loader.efi.canTouchEfiVariables = true;
+
+      boot.loader.limine.enable = true;
+      boot.loader.limine.efiSupport = true;
+      boot.loader.limine.secureBoot.enable = true;
+      boot.loader.limine.secureBoot.autoGenerateKeys = true;
+      boot.loader.limine.secureBoot.autoEnrollKeys.enable = true;
+      boot.loader.limine.secureBoot.autoEnrollKeys.extraArgs = [ "--yes-this-might-brick-my-machine" ];
+      boot.loader.limine.uki.enable = true;
+      boot.loader.timeout = 0;
+
+      environment.systemPackages = [ pkgs.mokutil ];
+    };
+
+  testScript = ''
+    machine.start()
+    assert "SecureBoot enabled" in machine.succeed("mokutil --sb-state")
+  '';
+}

--- a/nixos/tests/limine/specialisations-with-uki.nix
+++ b/nixos/tests/limine/specialisations-with-uki.nix
@@ -1,0 +1,28 @@
+{ lib, pkgs, ... }:
+{
+  name = "specialisationsWithUki";
+  meta = {
+    inherit (pkgs.limine.meta) maintainers;
+  };
+
+  nodes.machine =
+    { ... }:
+    {
+      virtualisation.useBootLoader = true;
+      virtualisation.useEFIBoot = true;
+
+      specialisation.test = { };
+
+      boot.loader.efi.canTouchEfiVariables = true;
+      boot.loader.limine.enable = true;
+      boot.loader.limine.efiSupport = true;
+      boot.loader.limine.uki.enable = true;
+      boot.loader.timeout = 0;
+    };
+
+  testScript = ''
+    machine.start()
+    with subtest('Machine boots correctly'):
+      machine.wait_for_unit('multi-user.target')
+  '';
+}


### PR DESCRIPTION
Added a limine UKI module.

The UKI is built in the install script to prevent problems related to recursion.

A warning will be displayed if uki.enable is used while efiSupport is disabled.
UKI generation is bound to efiSupport, uki.build and uki.enable (for the specific generation) or uki.forceAll (to force enable UKI generation for all generations).
If biosSupport and uki.enable are enabled together a warning will be shown and the script will generate fallback entries for BIOS.
If uki.buildUki is disabled while uki.forceAll is enabled evaluation will fail.

Key generation for tests has been moved to before the config is generated.

Feedback is appreciated.

Closes #413039 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
- [x] Tested on real machine
- NixOS Release Notes (Does this qualify?)
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
