### PR TITLE
cerberus: 0-unstable-2025-11-26 -> 0-unstable-2025-12-15

### DIFF
--- a/pkgs/by-name/ce/cerberus/package.nix
+++ b/pkgs/by-name/ce/cerberus/package.nix
@@ -10,7 +10,7 @@
   testers,
   cerberus,
 }:
-ocamlPackages.buildDunePackage rec {
+ocamlPackages.buildDunePackage (finalAttrs: {
   pname = "cerberus";
   version = "0-unstable-2025-12-15";
 
@@ -35,7 +35,7 @@ ocamlPackages.buildDunePackage rec {
   # our version since git is impure
   postPatch = ''
     substituteInPlace tools/gen_version.ml \
-      --replace-fail '"unknown"' '"${version}"'
+      --replace-fail '"unknown"' '"${finalAttrs.version}"'
   '';
 
   minimalOCamlVersion = "4.12";
@@ -136,4 +136,4 @@ ocamlPackages.buildDunePackage rec {
     ];
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/by-name/ce/cerberus/package.nix
+++ b/pkgs/by-name/ce/cerberus/package.nix
@@ -12,13 +12,13 @@
 }:
 ocamlPackages.buildDunePackage rec {
   pname = "cerberus";
-  version = "0-unstable-2025-11-26";
+  version = "0-unstable-2025-12-15";
 
   src = fetchFromGitHub {
     owner = "rems-project";
     repo = "cerberus";
-    rev = "6d60ef25944ebcdab892158c949a8e05501557dc";
-    hash = "sha256-RucW01xuW5b6F9/O1OL99YJn3rSMCP7l7Cwjuv4PNIc=";
+    rev = "50621977ba282ac527e9259f7e9334d2c5bef41c";
+    hash = "sha256-CAZeLG1M9oBzl/5EsIYwyV3St5fdwmfkPApACbsIYAc=";
   };
 
   patches = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
