### PR TITLE
hyprshutdown: init at 0-unstable-2026-01-11

### DIFF
--- a/pkgs/by-name/hy/hyprshutdown/package.nix
+++ b/pkgs/by-name/hy/hyprshutdown/package.nix
@@ -1,0 +1,71 @@
+{
+  lib,
+  gcc15Stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  hyprtoolkit,
+  hyprutils,
+  pixman,
+  libdrm,
+  glaze,
+  aquamarine,
+  hyprgraphics,
+  cairo,
+  nix-update-script,
+  testers,
+}:
+
+gcc15Stdenv.mkDerivation (finalAttrs: {
+  pname = "hyprshutdown";
+  version = "0-unstable-2026-01-11";
+
+  src = fetchFromGitHub {
+    owner = "hyprwm";
+    repo = "hyprshutdown";
+    rev = "0c9cec7809a715c5c9a99a585db0b596bfb96a59";
+    hash = "sha256-JMpLic41Jw6kDXXMtj6tEYUMu3QQ0Sg/M8EBxmAwapU=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    hyprtoolkit
+    hyprutils
+    pixman
+    libdrm
+    aquamarine
+    hyprgraphics
+    cairo
+    (glaze.override { enableSSL = false; })
+  ];
+
+  passthru = {
+    updateScript = nix-update-script {
+      # TODO: remove when stable release available
+      extraArgs = [ "--version=branch" ];
+    };
+    tests = {
+      help = testers.runCommand {
+        name = "${finalAttrs.pname}-help-test";
+        nativeBuildInputs = [ finalAttrs.finalPackage ];
+        script = ''
+          '${finalAttrs.meta.mainProgram}' --help && touch "$out"
+        '';
+      };
+    };
+  };
+
+  meta = {
+    description = "A graceful shutdown utility for Hyprland";
+    homepage = "https://github.com/hyprwm/hyprshutdown";
+    license = lib.licenses.bsd3;
+    maintainers = [ lib.maintainers.mithicspirit ];
+    teams = [ lib.teams.hyprland ];
+    mainProgram = "hyprshutdown";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
https://github.com/hyprwm/hyprshutdown

- [ ] Waiting on proper release
- [x]  #467824 (currently fails to build)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
