### PR TITLE
python3Packages.curl-cffi: 0.14.0b2 -> 0.14.0

### DIFF
--- a/pkgs/development/python-modules/curl-cffi/default.nix
+++ b/pkgs/development/python-modules/curl-cffi/default.nix
@@ -18,40 +18,19 @@
   python-multipart,
   trustme,
   uvicorn,
+  websockets,
   writableTmpDirAsHomeHook,
 }:
-let
-  # This is only used for testing and requires 12.0 specifically
-  # due to incompatible API changes in later versions.
-  websockets = buildPythonPackage rec {
-    pname = "websockets";
-    version = "12.0";
-    pyproject = true;
-
-    src = fetchFromGitHub {
-      owner = "aaugustin";
-      repo = "websockets";
-      tag = version;
-      hash = "sha256-sOL3VI9Ib/PncZs5KN4dAIHOrBc7LfXqT15LO4M6qKg=";
-    };
-
-    build-system = [ setuptools ];
-
-    doCheck = false;
-
-    pythonImportsCheck = [ "websockets" ];
-  };
-in
 buildPythonPackage rec {
   pname = "curl-cffi";
-  version = "0.14.0b2";
+  version = "0.14.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "lexiforest";
     repo = "curl_cffi";
     tag = "v${version}";
-    hash = "sha256-JXfqZTf26kl2P0OMAw/aTdjQaGtdyTpNnhRPlwMiZNw=";
+    hash = "sha256-5Q9oHAOjefihxj6xU1UGVTl6Ib31XqhrxLtOgI5VABs=";
   };
 
   patches = [ ./use-system-libs.patch ];
@@ -114,6 +93,8 @@ buildPythonPackage rec {
     # FIXME ImpersonateError: Impersonating chrome136 is not supported
     "test_impersonate_without_version"
     "test_with_impersonate"
+    # Impersonating chrome142 is not supported
+    "test_cli"
     # InvalidURL: Invalid URL component 'path'
     "test_update_params"
     # tests access network


### PR DESCRIPTION
CHANGELOG: https://github.com/lexiforest/curl_cffi/releases/tag/v0.14.0
DIFF: https://github.com/lexiforest/curl_cffi/compare/v0.14.0b2...v0.14.0


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
