### PR TITLE
pypy: remove explicit darwin minimum SDK

### DIFF
--- a/pkgs/development/interpreters/python/pypy/darwin_version_min.patch
+++ b/pkgs/development/interpreters/python/pypy/darwin_version_min.patch
@@ -1,0 +1,19 @@
+diff --git a/rpython/translator/platform/darwin.py b/rpython/translator/platform/darwin.py
+index 8c824a8459..f407fb6c07 100644
+--- a/rpython/translator/platform/darwin.py
++++ b/rpython/translator/platform/darwin.py
+@@ -26,12 +26,12 @@ class Darwin(posix.BasePosix):
+     standalone_only = ('-mdynamic-no-pic',)
+     shared_only = ()
+ 
+-    link_flags = (DARWIN_VERSION_MIN,)
++    link_flags = ()
+     cflags = ('-O3',
+               '-fomit-frame-pointer',
+               # The parser turns 'const char *const *includes' into 'const const char **includes'
+               '-Wno-duplicate-decl-specifier',
+-              DARWIN_VERSION_MIN,)
++              )
+ 
+     so_ext = 'dylib'
+     DEFAULT_CC = 'clang'

--- a/pkgs/development/interpreters/python/pypy/default.nix
+++ b/pkgs/development/interpreters/python/pypy/default.nix
@@ -171,6 +171,11 @@ stdenv.mkDerivation rec {
       inherit (sqlite) out dev;
       libsqlite = "${sqlite.out}/lib/libsqlite3${stdenv.hostPlatform.extensions.sharedLibrary}";
     })
+
+    # PyPy sets an explicit minimum SDK version for darwin that is much older
+    # than what we default to on nixpkgs.
+    # Simply removing the explicit flag makes it use our default instead.
+    ./darwin_version_min.patch
   ];
 
   postPatch = ''


### PR DESCRIPTION
PyPy sets an explicit minimum SDK version for darwin that is much older than what we we default to on nixpkgs (currently 14.0). Simply removing the explicit flag makes it use our default instead.

This fixes a build failure where PyPy tries to access APIs that are not available in the macOS SDK it is targetting.
This is technically not relevant for upstream as this is an opt-in warning which we have recently enabled by default (as error) on nixpkgs, but they too should bump the minimum target to at least 10.15 from their current target of 10.13.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
