### PR TITLE
libfprint-goodixtls-27c6-521d: init at 1.94.9

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3047,6 +3047,12 @@
     githubId = 75235;
     name = "Michael Walker";
   };
+  barsikus007 = {
+    name = "barsikus007";
+    email = "barsikus07@gmail.com";
+    github = "barsikus007";
+    githubId = 37113583;
+  };
   bartoostveen = {
     name = "Bart Oostveen";
     github = "bartoostveen";

--- a/pkgs/by-name/li/libfprint-goodixtls-27c6-521d/package.nix
+++ b/pkgs/by-name/li/libfprint-goodixtls-27c6-521d/package.nix
@@ -1,0 +1,86 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  pkg-config,
+  cmake,
+  gtk-doc,
+  doctest,
+
+  glib,
+  gusb,
+  gobject-introspection,
+
+  pixman,
+  openssl,
+  libgudev,
+  libfprint,
+
+  withTests ? false,
+  cairo,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libfprint-goodixtls-27c6-521d";
+  version = "1.94.9";
+
+  src = fetchFromGitHub {
+    owner = "barsikus007";
+    repo = "libfprint";
+    rev = "merge/upstream-${finalAttrs.version}";
+    hash = "sha256-Zov/PfvKBfnoRUyUGsOsofrTt80kHq0eKCKlRXyvnio=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    cmake
+    gtk-doc
+    doctest
+  ];
+  buildInputs = [
+    glib
+    gusb
+    gobject-introspection
+
+    pixman
+    openssl
+    libgudev
+    libfprint
+  ]
+  ++ lib.optionals withTests [
+    cairo
+  ];
+
+  mesonBuildType = "release";
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  # https://gcc.gnu.org/gcc-14/porting_to.html#incompatible-pointer-types
+  env.NIX_CFLAGS_COMPILE = "-Wno-error=incompatible-pointer-types";
+
+  postPatch = ''
+    # disable building GObject Introspection repository
+    sed -i "8c       value: false)" ./meson_options.txt
+    # set correct udev rules path for nix
+    sed -i "16c       value: '$out/lib/udev')" ./meson_options.txt
+    # set correct udev hwdb path for nix
+    sed -i "24c       value: '$out/lib/udev')" ./meson_options.txt
+    # don't build API docs
+    sed -i "32c       value: false)" ./meson_options.txt
+  ''
+  + lib.strings.optionalString (!withTests) ''
+    # don't install tests
+    sed -i "36c       value: false)" ./meson_options.txt
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/infinytum/libfprint/tree/driver/goodix-521d";
+    description = "(27c6:521d) Library for fingerprint readers";
+    license = licenses.lgpl21Only;
+    maintainers = with maintainers; [ barsikus007 ];
+    platforms = platforms.linux;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
I finally made contribution with package, mentioned in #424877. Here is the summary:
1. There was a [fork of libfrint with 27c6-521d support](https://github.com/Infinytum/libfprint/tree/driver/goodix-521d), [AUR package of this fork](https://aur.archlinux.org/packages/libfprint-goodix-521d) and [nix package for 27c6-5110](https://github.com/lzc256/nur/blob/cfd1202a2b6988f408ef1116464c894f6d8d69be/pkgs/libfprint-27c6-5110/default.nix)
2. I made own 27c6-521d nix package, which stopped building after NixOS 25.05 release
3. To make it build I forked and merged original repo with libfrint upstream (1.94.9)

There is still a thing, that I don't know how to solve in terms of design:
Fingerprint firmware [needs to be patched](https://github.com/knauth/goodix-521d-explanation) after every boot to Windows with loaded goodix driver
[I made nix-shell with patching repo and correct tools](https://github.com/barsikus007/config/blob/75b5e3f33551909b22c30299afa740626013f06d/nix/packages/goodix-patch-521d.nix)
Maybe it is worth to make wiki entry [in corresponding section](https://wiki.nixos.org/wiki/Fingerprint_scanner) about that?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
