### PR TITLE
writers: add optional mypy support to makePythonWriter

### DIFF
--- a/pkgs/build-support/writers/scripts.nix
+++ b/pkgs/build-support/writers/scripts.nix
@@ -1180,7 +1180,10 @@ rec {
     {
       libraries ? [ ],
       flakeIgnore ? [ ],
+      mypyStrict ? false,
       doCheck ? true,
+      doCheckFlake8 ? doCheck && true,
+      doCheckMypy ? doCheck && true,
       ...
     }@args:
     let
@@ -1192,7 +1195,10 @@ rec {
       (removeAttrs args [
         "libraries"
         "flakeIgnore"
+        "mypyIgnore"
         "doCheck"
+        "doCheckFlake8"
+        "doCheckMypy"
       ])
       // {
         interpreter =
@@ -1203,9 +1209,17 @@ rec {
           else
             (python.withPackages (ps: libraries)).interpreter;
         check = optionalString (python.isPy3k && doCheck) (
-          writeDash "pythoncheck.sh" ''
-            exec ${buildPythonPackages.flake8}/bin/flake8 --show-source ${ignoreAttribute} "$1"
-          ''
+          writeDash "pythoncheck.sh" (
+            optionalString doCheckFlake8 ''
+              ${lib.getExe buildPythonPackages.flake8} --show-source ${ignoreAttribute} "$1"
+            ''
+            + optionalString doCheckMypy ''
+              ${lib.getExe buildPythonPackages.mypy}      \
+                --show-error-context --no-error-summary   \
+                ${optionalString mypyStrict "--strict"} \
+                "$1"
+            ''
+          )
         );
       }
     ) name;


### PR DESCRIPTION
An attempt at adding mypy as requested by:
  - https://github.com/NixOS/nixpkgs/issues/468086

I kept `doCheck`, and added 2 sub options to enable mypy & flake8 individually.
Do we want mypy to run by default?


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
