### PR TITLE
sudo-rs: 0.2.10 -> 0.2.11

### DIFF
--- a/pkgs/by-name/su/sudo-rs/package.nix
+++ b/pkgs/by-name/su/sudo-rs/package.nix
@@ -7,29 +7,28 @@
   versionCheckHook,
   pam,
   rustPlatform,
-  tzdata,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "sudo-rs";
-  version = "0.2.10";
+  version = "0.2.11";
 
   src = fetchFromGitHub {
     owner = "trifectatechfoundation";
     repo = "sudo-rs";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-DGoEHeVs7EbzpfbmJQEIsL/eWXBvUCbaSPAGD65Op7k=";
+    hash = "sha256-F1JwVP2GDzKCfiJXh8PXTBghNwWeD8a+TMiEaPx6wGg=";
   };
 
-  cargoHash = "sha256-fn97cKdaIsbozI794CAeWQooC7evTErRJOg6cEjzvjY=";
+  cargoHash = "sha256-6NhyPdOAk2va8Vibsfpfq3xGLIzDBRmqxj4bZhQT9bY=";
 
   nativeBuildInputs = [ installShellFiles ];
 
   buildInputs = [ pam ];
 
   postPatch = ''
-    substituteInPlace build.rs \
-      --replace-fail "/usr/share/zoneinfo" "${tzdata}/share/zoneinfo"
+    substituteInPlace src/system/audit.rs \
+      --replace-fail "/usr/share/zoneinfo" "/etc/zoneinfo"
   '';
 
   postInstall = ''
@@ -62,6 +61,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "system::interface::test::test_unix_user"
     "system::tests::test_get_user_and_group_by_id"
 
+    # Assumes runtime zoneinfo paths
+    "sudo::env::environment::tests::test_tzinfo"
+
     # Unsure why those are failing
     "env::tests::test_environment_variable_filtering"
     "su::context::tests::invalid_shell"
@@ -80,11 +82,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   '';
 
   passthru = {
-    updateScript = nix-update-script {
-      extraArgs = [
-        "--version-regex=^v([0-9]+\\.[0-9]+\\.[0-9])$"
-      ];
-    };
+    updateScript = nix-update-script { };
     tests = nixosTests.sudo-rs;
   };
 

--- a/pkgs/by-name/su/sudo-rs/package.nix
+++ b/pkgs/by-name/su/sudo-rs/package.nix
@@ -7,6 +7,7 @@
   versionCheckHook,
   pam,
   rustPlatform,
+  tzdata,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -28,7 +29,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   postPatch = ''
     substituteInPlace src/system/audit.rs \
-      --replace-fail "/usr/share/zoneinfo" "/etc/zoneinfo"
+      --replace-fail '/usr/share/zoneinfo' '/etc/zoneinfo' \
+      --replace-fail '/usr/share/lib/zoneinfo' '${tzdata}/share/zoneinfo'
   '';
 
   postInstall = ''
@@ -61,7 +63,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "system::interface::test::test_unix_user"
     "system::tests::test_get_user_and_group_by_id"
 
-    # Assumes runtime zoneinfo paths
+    # Store paths are not owned by root in the build sandbox, so the zoneinfo path
+    # doesn't pass the validations done by sudo-rs.
+    # This is not an issue at runtime, since there the zoneinfo path is owned by root.
     "sudo::env::environment::tests::test_tzinfo"
 
     # Unsure why those are failing


### PR DESCRIPTION
Changelog: https://github.com/trifectatechfoundation/sudo-rs/blob/v0.2.11/CHANGELOG.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
