### PR TITLE
gelly: init at 0.11.0

### DIFF
--- a/pkgs/by-name/ge/gelly/package.nix
+++ b/pkgs/by-name/ge/gelly/package.nix
@@ -1,0 +1,80 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  dbus,
+  glib,
+  wrapGAppsHook4,
+  glib-networking,
+  gst_all_1,
+  gtk4,
+  libadwaita,
+  libseccomp,
+  openssl,
+  bubblewrap,
+  glycin-loaders,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "gelly";
+  version = "0.11.0";
+
+  src = fetchFromGitHub {
+    owner = "Fingel";
+    repo = "gelly";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-fZrSfxbWkHX5yUwC4NkDmXcNDTvsdwceEBkmUmxWcoQ=";
+  };
+
+  cargoHash = "sha256-vnFbRvq+EPIcJ4w+QKpkXrl5BLr/KbELbmpRGQwcaUE=";
+
+  nativeBuildInputs = [
+    pkg-config
+    glib # for `glib-compile-schemas` and `glib-compile-resources` (used in upstream's `build.rs`)
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    dbus
+    # Very important, so that gstreamer supports TLS
+    glib-networking
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good
+    gst_all_1.gst-plugins-bad
+    gst_all_1.gst-plugins-ugly
+    gst_all_1.gst-plugins-rs
+    gtk4
+    libadwaita
+    libseccomp
+    openssl
+  ];
+
+  # Adapted from upstream's `justfile`
+  postInstall = ''
+    install -Dm644 resources/io.m51.Gelly.desktop $out/share/applications/io.m51.Gelly.desktop
+    install -Dm644 resources/io.m51.Gelly.metainfo.xml $out/share/metainfo/io.m51.Gelly.metainfo.xml
+    install -Dm644 resources/io.m51.Gelly.svg $out/share/icons/hicolor/scalable/apps/io.m51.Gelly.svg
+
+    # Use the gschemas location as specified in the glib hook
+    install -Dm644 resources/io.m51.Gelly.gschema.xml $out/share/gsettings-schemas/$name/glib-2.0/schemas/io.m51.Gelly.gschema.xml
+    glib-compile-schemas $out/share/gsettings-schemas/$name/glib-2.0/schemas/
+  '';
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix PATH : "$out/bin:${lib.makeBinPath [ bubblewrap ]}"
+      --prefix XDG_DATA_DIRS : "${glycin-loaders}/share"
+    )
+  '';
+
+  meta = {
+    description = "A Jellyfin GTK client for Linux focused on music";
+    homepage = "https://github.com/Fingel/gelly";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ minijackson ];
+    mainProgram = "gelly";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Packaging of the Gelly Jellyfin GTK client: https://github.com/Fingel/gelly

I don't want to admit how much time I spent on the missing `glib-networking` library.

For future reference, if someone ever sees this kind of error while trying to play an HTTPS stream with GStreamer:

```
[2025-12-16T22:05:39Z ERROR gelly::application] Audio error: Gstreamer error from Some("/GstPipeline:pipeline0/GstPlayBin:playbin0/GstURIDecodeBin:uridecodebin0/GstSoupHTTPSrc:source"): Internal data stream error. (../libs/gst/base/gstbasesrc.c(3187): gst_base_src_loop (): /GstPipeline:pipeline0/GstPlayBin:playbin0/GstURIDecodeBin:uridecodebin0/GstSoupHTTPSrc:source:
    streaming stopped, reason error (-5))
[2025-12-16T22:05:39Z ERROR gelly::application] Audio error: Gstreamer error from Some("/GstPipeline:pipeline0/GstPlayBin:playbin0/GstURIDecodeBin:uridecodebin0/GstTypeFindElement:typefindelement0"): Stream doesn't contain enough data. (../plugins/elements/gsttypefindelement.c(1012): gst_type_find_element_chain_do_typefinding (): /GstPipeline:pipeline0/GstPlayBin:playbin0/GstURIDecodeBin:uridecodebin0/GstTypeFindElement:typefindelement0:
    Can't typefind stream)
```

let it be known that you need to add `glib-networking` as a dependency.

Maybe this package will be of interest to other Jellyfin maintainers: @nyanloutre @purcell @jojosch 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
