### PR TITLE
python3Packages.vegafusion: init at 2.0.3

### DIFF
--- a/pkgs/development/python-modules/vegafusion/default.nix
+++ b/pkgs/development/python-modules/vegafusion/default.nix
@@ -1,0 +1,101 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  rustPlatform,
+  pytestCheckHook,
+  # Deps
+  arro3-core,
+  protobuf,
+  psutil,
+  altair,
+  ipywidgets,
+  vl-convert-python,
+  anywidget,
+  polars,
+  grpcio,
+  pyarrow,
+  # optional-dependencies
+  duckdb,
+  vega-datasets,
+  scikit-image,
+  jupytext,
+  ipykernel,
+  selenium,
+  flaky,
+  tenacity,
+}:
+buildPythonPackage rec {
+  pname = "vegafusion";
+  version = "2.0.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "hex-inc";
+    repo = "vegafusion";
+    tag = "v${version}";
+    hash = "sha256-yiECw9WGd+03KFOWa+bwR10gQFqzx4Riy6uw2zwdc3s=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit src;
+    name = "${pname}-${version}";
+    hash = "sha256-T/4k4ZWiO/AQvCxsbjyLMvV/zKq8ywy2rAQYMsJ73t4=";
+  };
+
+  buildAndTestSubdir = "vegafusion-python";
+
+  buildInputs = [ protobuf ];
+
+  nativeBuildInputs = with rustPlatform; [
+    cargoSetupHook
+    maturinBuildHook
+  ];
+
+  dependencies = [
+    arro3-core
+    psutil
+    altair
+    ipywidgets
+    vl-convert-python
+    anywidget
+    polars
+    grpcio
+    pyarrow
+  ];
+
+  optional-dependencies = {
+    test = [
+      duckdb
+      vega-datasets
+      scikit-image
+      jupytext
+      ipykernel
+      selenium
+      flaky
+      tenacity
+    ];
+  };
+
+  pythonImportsCheck = [ "vegafusion" ];
+
+  nativeCheckInputs = [ pytestCheckHook ] ++ optional-dependencies.test;
+
+  disabledTests = [
+    # Require network access
+    "test_input_utc"
+    "test_pretransform"
+    "test_pretransform_specs"
+    "test_transformed_data"
+
+    # Relies on selenium's chromedriver_binary
+    "test_jupyter_widget"
+  ];
+
+  meta = with lib; {
+    description = "Core tools for using VegaFusion from Python";
+    homepage = "https://github.com/hex-inc/vegafusion";
+    license = lib.licenses.bsd3;
+    maintainers = with maintainers; [ wariuccio ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20366,6 +20366,8 @@ self: super: with self; {
 
   vega-datasets = callPackage ../development/python-modules/vega-datasets { };
 
+  vegafusion = callPackage ../development/python-modules/vegafusion { };
+
   vegehub = callPackage ../development/python-modules/vegehub { };
 
   vehicle = callPackage ../development/python-modules/vehicle { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Added the Python package `vegafusion`. I executed `nix-build . -A python3Packages.vegafusion` and confirmed it worked correctly and tested it by using in a Jupyter notebook.

I added all the [runtime dependencies](https://github.com/vega/vegafusion/blob/41030050e5130564788bbb6ce22b92430bb9849c/pixi.toml#L149:L159) of the project.
Additionally, I added `arro3-core` because without it I would get this error message:
```
> Executing pythonRuntimeDepsCheck
> Checking runtime dependencies for vegafusion-2.0.3-cp39-abi3-linux_x86_64.whl
>   - arro3-core not installed
```

I tried to enable the tests but unfortunately most of them require network access to fetch data from `vega-datasets` (e.g. https://github.com/vega/vegafusion/blob/41030050e5130564788bbb6ce22b92430bb9849c/vegafusion-python/tests/altair_mocks/interactive/casestudy-airport_connections/mock.py#L6:L8).
Other tests use Selenium's Chromium webdriver and I am not sure how to get it to work.



<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
