### PR TITLE
python3Packages.complexipy: init at 5.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -26775,6 +26775,12 @@
       }
     ];
   };
+  traphi = {
+    email = "trauthp@gmail.com";
+    github = "drazhar";
+    githubId = 3040689;
+    name = "Philip Trauth";
+  };
   traverseda = {
     email = "traverse.da@gmail.com";
     github = "traverseda";

--- a/pkgs/development/python-modules/complexipy/default.nix
+++ b/pkgs/development/python-modules/complexipy/default.nix
@@ -34,8 +34,28 @@ buildPythonPackage rec {
     maturinBuildHook
   ];
 
+  nativeCheckInputs = [
+    pytest
+  ];
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    export PYTHONPATH="$out/${python.sitePackages}"
+    pytest ${src}/tests/main.py
+
+    # mirror upstream CLI test
+    export PATH="$out/bin:$PATH"
+    complexipy complexipy --failed
+
+    runHook postInstallCheck
+  '';
+
+  pythonImportsCheck = [ "complexipy" ];
+
   meta = {
-    description = "Blazingly fast cognitive complexity analysis for Python, written in Rust.";
+    description = "Blazingly fast cognitive complexity analysis for Python, written in Rust";
     homepage = "https://github.com/rohaquinlop/complexipy";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ traphi ];

--- a/pkgs/development/python-modules/complexipy/default.nix
+++ b/pkgs/development/python-modules/complexipy/default.nix
@@ -1,11 +1,12 @@
-{
-  lib,
-  buildPythonPackage,
-  fetchFromGitHub,
-  rustPlatform,
-  # Dependencies
-  tomli,
-  typer,
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, rustPlatform
+, pytest
+, python
+, tomli
+, typer
+,
 }:
 buildPythonPackage rec {
   pname = "complexipy";

--- a/pkgs/development/python-modules/complexipy/default.nix
+++ b/pkgs/development/python-modules/complexipy/default.nix
@@ -1,12 +1,12 @@
-{ lib
-, buildPythonPackage
-, fetchFromGitHub
-, rustPlatform
-, pytest
-, python
-, tomli
-, typer
-,
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  rustPlatform,
+  pytest,
+  python,
+  tomli,
+  typer,
 }:
 buildPythonPackage rec {
   pname = "complexipy";

--- a/pkgs/development/python-modules/complexipy/default.nix
+++ b/pkgs/development/python-modules/complexipy/default.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  rustPlatform,
+  # Dependencies
+  tomli,
+  typer,
+}:
+buildPythonPackage rec {
+  pname = "complexipy";
+  version = "5.1.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "rohaquinlop";
+    repo = "complexipy";
+    tag = version;
+    hash = "sha256-M2u8qfc0B5UPzEEGFPpE5chLnAz/jCsvPjj+nAfbXSs=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit pname version src;
+    hash = "sha256-m+ibMqwWf1CNKz1RhG7+GA601WmncQnRSxB+F8/3NRw=";
+  };
+
+  dependencies = [
+    tomli
+    typer
+  ];
+
+  nativeBuildInputs = with rustPlatform; [
+    cargoSetupHook
+    maturinBuildHook
+  ];
+
+  meta = {
+    description = "Blazingly fast cognitive complexity analysis for Python, written in Rust.";
+    homepage = "https://github.com/rohaquinlop/complexipy";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ traphi ];
+    mainProgram = "complexipy";
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3016,6 +3016,8 @@ self: super: with self; {
 
   compit-inext-api = callPackage ../development/python-modules/compit-inext-api { };
 
+  complexipy = callPackage ../development/python-modules/complexipy { };
+
   compliance-trestle = callPackage ../development/python-modules/compliance-trestle { };
 
   complycube = callPackage ../development/python-modules/complycube { };


### PR DESCRIPTION
Packaged the [Complexipy](https://github.com/rohaquinlop/complexipy) Python library. Primarily to see the packaging process and because I quite like Complexipy.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test