### PR TITLE
 libgit2: fix gitstats test 

### DIFF
--- a/pkgs/by-name/gi/gitstatus/package.nix
+++ b/pkgs/by-name/gi/gitstatus/package.nix
@@ -8,6 +8,9 @@
   zlib,
   runtimeShell,
 }:
+let
+  romkatv_libgit2 = callPackage ./romkatv_libgit2.nix { };
+in
 stdenv.mkDerivation rec {
   pname = "gitstatus";
   version = "1.5.5";
@@ -28,8 +31,8 @@ stdenv.mkDerivation rec {
   );
 
   buildInputs = [
+    romkatv_libgit2
     zlib
-    (callPackage ./romkatv_libgit2.nix { })
   ];
 
   postPatch = ''
@@ -114,6 +117,10 @@ stdenv.mkDerivation rec {
     ZDOTDIR=. zsh -d -i &
     wait $!
   '';
+
+  passthru = {
+    inherit romkatv_libgit2;
+  };
 
   meta = {
     description = "10x faster implementation of `git status` command";

--- a/pkgs/by-name/gi/gitstatus/romkatv_libgit2.nix
+++ b/pkgs/by-name/gi/gitstatus/romkatv_libgit2.nix
@@ -1,6 +1,17 @@
 { fetchFromGitHub, libgit2, ... }:
 
 libgit2.overrideAttrs (oldAttrs: {
+  pname = "romkatv_libgit2";
+
+  src = fetchFromGitHub {
+    owner = "romkatv";
+    repo = "libgit2";
+    rev = "tag-2ecf33948a4df9ef45a66c68b8ef24a5e60eaac6";
+    hash = "sha256-Bm3Gj9+AhNQMvkIqdrTkK5D9vrZ1qq6CS8Wrn9kfKiw=";
+  };
+
+  patches = [ ];
+
   cmakeFlags = oldAttrs.cmakeFlags ++ [
     "-DBUILD_CLAR=OFF"
     "-DBUILD_SHARED_LIBS=OFF"
@@ -13,16 +24,7 @@ libgit2.overrideAttrs (oldAttrs: {
     "-DZERO_NSEC=ON"
   ];
 
-  src = fetchFromGitHub {
-    owner = "romkatv";
-    repo = "libgit2";
-    rev = "tag-2ecf33948a4df9ef45a66c68b8ef24a5e60eaac6";
-    hash = "sha256-Bm3Gj9+AhNQMvkIqdrTkK5D9vrZ1qq6CS8Wrn9kfKiw=";
-  };
-
   # this is a heavy fork of the original libgit2
   # the original checkPhase does not work for this fork
   doCheck = false;
-
-  patches = [ ];
 })

--- a/pkgs/by-name/li/libgit2/package.nix
+++ b/pkgs/by-name/li/libgit2/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   cmake,
   pkg-config,
   python3,
@@ -93,7 +92,7 @@ stdenv.mkDerivation (finalAttrs: {
   passthru.tests = lib.mapAttrs (_: v: v.override { libgit2 = finalAttrs.finalPackage; }) {
     inherit libgit2-glib;
     inherit (python3Packages) pygit2;
-    inherit gitstatus;
+    inherit (gitstatus) romkatv_libgit2;
   };
 
   meta = {


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
