### PR TITLE
servo: Link against our ICU

### DIFF
--- a/pkgs/by-name/se/servo/mozjs-use-system-icu.patch
+++ b/pkgs/by-name/se/servo/mozjs-use-system-icu.patch
@@ -1,0 +1,39 @@
+diff --git a/build.rs b/build.rs
+index 7e2904394..1e7186804 100644
+--- a/build.rs
++++ b/build.rs
+@@ -27,6 +27,7 @@ const ENV_VARS: &'static [&'static str] = &[
+     "MOZJS_CREATE_ARCHIVE",
+     "MOZJS_FORCE_RERUN",
+     "MOZJS_FROM_SOURCE",
++    "MOZJS_USE_SYSTEM_ICU",
+     "PYTHON",
+     "STLPORT_LIBS",
+ ];
+@@ -457,6 +458,11 @@ fn should_build_from_source() -> bool {
+             "Environment variable MOZJS_CREATE_ARCHIVE is set. Building from source directly."
+         );
+         true
++    } else if env::var_os("MOZJS_USE_SYSTEM_ICU").is_some() {
++        println!(
++            "Environment variable MOZJS_USE_SYSTEM_ICU is set. Building from source directly."
++        );
++        true
+     } else if env::var_os("MOZJS_ARCHIVE").is_some() {
+         false
+     } else if env::var_os("CARGO_FEATURE_DEBUGMOZJS").is_some() {
+diff --git a/makefile.cargo b/makefile.cargo
+index 4dd2c7ad6..ecfdb6a2c 100644
+--- a/makefile.cargo
++++ b/makefile.cargo
+@@ -45,6 +45,10 @@ ifneq (,$(CCACHE))
+ 	CONFIGURE_FLAGS += --with-ccache=$(CCACHE)
+ endif
+ 
++ifneq (,$(MOZJS_USE_SYSTEM_ICU))
++	CONFIGURE_FLAGS += --with-system-icu
++endif
++
+ 
+ ifneq (,$(MACOS_SDK_PATH))
+ 	CONFIGURE_FLAGS += --with-macos-sdk=$(MACOS_SDK_PATH)

--- a/pkgs/by-name/se/servo/servo-use-system-icu.patch
+++ b/pkgs/by-name/se/servo/servo-use-system-icu.patch
@@ -1,0 +1,16 @@
+diff --git a/ports/servoshell/build.rs b/ports/servoshell/build.rs
+index e59c002d30d..e90aad23aeb 100644
+--- a/ports/servoshell/build.rs
++++ b/ports/servoshell/build.rs
+@@ -74,6 +74,11 @@ fn main() -> Result<(), Box<dyn Error>> {
+         println!("cargo:rustc-link-search=native={}", out.display());
+     }
+ 
++    if std::env::var_os("MOZJS_USE_SYSTEM_ICU").is_some() {
++        println!("cargo:rustc-link-lib=icuuc");
++        println!("cargo:rustc-link-lib=icui18n");
++    }
++
+     match git_sha() {
+         Ok(hash) => println!("cargo:rustc-env=GIT_SHA={}", hash),
+         Err(error) => {


### PR DESCRIPTION
Building `mozjs-sys` crate on ppc64 fails due to… I'm not quite sure. There's a reference to a file that doesn't exist in the bundled ICU.
  We likely don't want to use the bundled ICU anyway, same as in our spidermonkey package:
  https://github.com/NixOS/nixpkgs/blob/c8cfcd6ccd422e41cc631a0b73ed4d5a925c393d/pkgs/development/interpreters/spidermonkey/common.nix#L111
  Patches implement what's described in https://github.com/servo/servo/issues/33137. Will submit to upstream(s?) when I figure out smth that works - I'm really not a Rust person.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
