### PR TITLE
python3Packages.cma: 4.4.0 -> 4.4.1 ; python312Packages.pymoo: disable test that fails on Darwin due to numeric precision differences (python 3.12 only)

### DIFF
--- a/pkgs/development/python-modules/cma/default.nix
+++ b/pkgs/development/python-modules/cma/default.nix
@@ -15,14 +15,14 @@
 
 buildPythonPackage rec {
   pname = "cma";
-  version = "4.4.0";
+  version = "4.4.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "CMA-ES";
     repo = "pycma";
     tag = "r${version}";
-    hash = "sha256-2uCn5CZma9RLK8zaaPhiQCqnK+2dWgLNr5+Ck2cV6vI=";
+    hash = "sha256-06QPs2hbrIbrPRWidlZYf0jcMGdcDYfg89Ad+4IX/Co=";
   };
 
   # setuptools.errors.PackageDiscoveryError:

--- a/pkgs/development/python-modules/pymoo/default.nix
+++ b/pkgs/development/python-modules/pymoo/default.nix
@@ -63,7 +63,6 @@ buildPythonPackage rec {
         "file://${pymoo_data}/"
   '';
 
-  pythonRelaxDeps = [ "cma" ];
   pythonRemoveDeps = [ "alive-progress" ];
 
   build-system = [

--- a/pkgs/development/python-modules/pymoo/default.nix
+++ b/pkgs/development/python-modules/pymoo/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
 
@@ -114,10 +115,16 @@ buildPythonPackage rec {
     # AttributeError: 'ZDT3' object has no attribute 'elementwise'
     "test_kktpm_correctness"
   ];
+
   disabledTestPaths = [
     # sensitive to float precision
     "tests/algorithms/test_no_modfication.py"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # sensitive to float precision
+    "tests/misc/test_kktpm.py::test_kktpm_correctness[zdt3-params3]"
   ];
+
   # Avoid crashing sandboxed build on macOS
   env.MATPLOTLIBRC = writeText "" ''
     backend: Agg


### PR DESCRIPTION
`python3.ax-platform` fails to build on Darwin due to build failures in dependencies `cma` and `pymoo`. This fixes that.

python312Packages.pymoo fails on Darwin with an AssertionError in `tests/misc/test_kktpm.py::test_kktpm_correctness[zdt3-params3]`

The test array has a difference of 1.54e05 to the expected array values. This only happens on python 3.12.

1. Updated the embedded copy of `pymoo_data` to [latest available](https://github.com/anyoptimization/pymoo-data/commit/8dae7d02078def161ee109184399adc3db25265b). This didn't change the outcome above.
2. Removed `pythonRelaxDeps` around `cma` as the dependency spec now accepts it.
3. Disabled the failing test on Darwin.
4. Updated `python3Packages.cma: 4.4.0 -> 4.4.1`
  CHANGELOG: https://github.com/CMA-ES/pycma/releases/tag/r4.4.1
  DIFF: https://github.com/CMA-ES/pycma/compare/r4.4.0...r4.4.1

Closes #471489

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
