### PR TITLE
openldap: fix build with structuredAttrs, cleanup

### DIFF
--- a/pkgs/by-name/op/openldap/package.nix
+++ b/pkgs/by-name/op/openldap/package.nix
@@ -108,8 +108,8 @@ stdenv.mkDerivation rec {
   ];
 
   postBuild = ''
-    for module in $extraContribModules; do
-      make $makeFlags CC=$CC -C contrib/slapd-modules/$module
+    for module in ''${extraContribModules[@]}; do
+      make ''${makeFlags[@]} CC=$CC -C contrib/slapd-modules/$module
     done
   '';
 
@@ -144,8 +144,8 @@ stdenv.mkDerivation rec {
   ];
 
   postInstall = lib.optionalString withModules ''
-    for module in $extraContribModules; do
-      make $installFlags install -C contrib/slapd-modules/$module
+    for module in ''${extraContribModules[@]}; do
+      make ''${installFlags[@]} install -C contrib/slapd-modules/$module
     done
     chmod +x "$out"/lib/*.{so,dylib}
   '';

--- a/pkgs/by-name/op/openldap/package.nix
+++ b/pkgs/by-name/op/openldap/package.nix
@@ -115,7 +115,7 @@ stdenv.mkDerivation rec {
 
   preCheck = ''
     substituteInPlace tests/scripts/all \
-      --replace "/bin/rm" "rm"
+      --replace-fail "/bin/rm" "rm"
 
     # skip flaky tests
     # https://bugs.openldap.org/show_bug.cgi?id=8623


### PR DESCRIPTION


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
