### PR TITLE
python3Packages.torch-geometric: disable tests that fail on Darwin

### DIFF
--- a/pkgs/development/python-modules/torch-geometric/default.nix
+++ b/pkgs/development/python-modules/torch-geometric/default.nix
@@ -251,6 +251,19 @@ buildPythonPackage rec {
     "test_feature_store"
   ];
 
+  disabledTestPaths = lib.optionals stdenv.hostPlatform.isDarwin [
+    # MPS (Metal) tests are failing when using `libtorch_cpu`.
+    # Crashes in `structured_cat_out_mps`
+    "test/nn/models/test_deep_graph_infomax.py::test_infomax_predefined_model[mps]"
+    "test/nn/norm/test_instance_norm.py::test_instance_norm[True-mps]"
+    "test/nn/norm/test_instance_norm.py::test_instance_norm[False-mps]"
+    "test/nn/norm/test_layer_norm.py::test_layer_norm[graph-True-mps]"
+    "test/nn/norm/test_layer_norm.py::test_layer_norm[graph-False-mps]"
+    "test/nn/norm/test_layer_norm.py::test_layer_norm[node-True-mps]"
+    "test/nn/norm/test_layer_norm.py::test_layer_norm[node-False-mps]"
+    "test/utils/test_scatter.py::test_group_cat[mps]"
+  ];
+
   meta = {
     description = "Graph Neural Network Library for PyTorch";
     homepage = "https://github.com/pyg-team/pytorch_geometric";

--- a/pkgs/development/python-modules/torch-geometric/default.nix
+++ b/pkgs/development/python-modules/torch-geometric/default.nix
@@ -231,6 +231,9 @@ buildPythonPackage rec {
     "test_multiprocessing"
     "test_share_memory"
     "test_storage_tensor_methods"
+
+    # NotImplementedError: The operator 'aten::logspace.out' is not currently implemented for the MPS device.
+    "test_positional_encoding"
   ]
   ++ lib.optionals (pythonAtLeast "3.13") [
     # RuntimeError: Dynamo is not supported on Python 3.13+
@@ -246,10 +249,6 @@ buildPythonPackage rec {
 
     # RuntimeError: Boolean value of Tensor with more than one value is ambiguous
     "test_feature_store"
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    # NotImplementedError: The operator 'aten::logspace.out' is not currently implemented for the MPS device.
-    "test_positional_encoding"
   ];
 
   meta = {


### PR DESCRIPTION
Multiple tests that use the `mps` device (Metal on Darwin) fail `Trace/BPT Trap 5` indicating a crashed thread:

```sh
Thread 0 Crashed::  Dispatch queue: cache queue
0   libtorch_cpu.dylib            	       0x11f854fd0 std::__1::__function::__func<at::native::structured_cat_out_mps::impl(c10::IListRef<at::Tensor> const&, long long, long long, bool, bool, bool, c10::MemoryFormat, at::Tensor const&)::$_1, std::__1::allocator<at::native::structured_cat_out_mps::impl(c10::IListRef<at::Tensor> const&, long long, long long, bool, bool, bool, c10::MemoryFormat, at::Tensor const&)::$_1>, void (MPSGraph*, at::native::structured_cat_out_mps::impl(c10::IListRef<at::Tensor> const&, long long, long long, bool, bool, bool, c10::MemoryFormat, at::Tensor const&)::CachedGraph*)>::operator()(MPSGraph*&&, at::native::structured_cat_out_mps::impl(c10::IListRef<at::Tensor> const&, long long, long long, bool, bool, bool, c10::MemoryFormat, at::Tensor const&)::CachedGraph*&&) + 852
1   libtorch_cpu.dylib            	       0x11f85497c invocation function for block in at::native::structured_cat_out_mps::impl(c10::IListRef<at::Tensor> const&, long long, long long, bool, bool, bool, c10::MemoryFormat, at::Tensor const&)::CachedGraph* at::native::mps::LookUpOrCreateCachedGraph<at::native::structured_cat_out_mps::impl(c10::IListRef<at::Tensor> const&, long long, long long, bool, bool, bool, c10::MemoryFormat, at::Tensor const&)::CachedGraph>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::function<void (MPSGraph*, at::native::structured_cat_out_mps::impl(c10::IListRef<at::Tensor> const&, long long, long long, bool, bool, bool, c10::MemoryFormat, at::Tensor const&)::CachedGraph*)>) + 144
2   libtorch_cpu.dylib            	       0x11f74f990 invocation function for block in at::native::mps::MPSGraphCache::CreateCachedGraph(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, at::native::mps::MPSCachedGraph* () block_pointer) + 260
3   libtorch_cpu.dylib            	       0x11f732720 invocation function for block in at::native::mps::dispatch_sync_with_rethrow(NSObject<OS_dispatch_queue>*, void () block_pointer) + 48
4   libdispatch.dylib             	       0x199436ad4 _dispatch_client_callout + 16
5   libdispatch.dylib             	       0x19942c940 _dispatch_lane_barrier_sync_invoke_and_complete + 56
6   libtorch_cpu.dylib            	       0x11f732668 at::native::mps::dispatch_sync_with_rethrow(NSObject<OS_dispatch_queue>*, void () block_pointer) + 100
7   libtorch_cpu.dylib            	       0x11f74f814 at::native::mps::MPSGraphCache::CreateCachedGraph(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, at::native::mps::MPSCachedGraph* () block_pointer) + 176
8   libtorch_cpu.dylib            	       0x11f852834 at::native::structured_cat_out_mps::impl(c10::IListRef<at::Tensor> const&, long long, long long, bool, bool, bool, c10::MemoryFormat, at::Tensor const&) + 3248
9   libtorch_cpu.dylib            	       0x11c153f34 at::(anonymous namespace)::wrapper_MPS_cat(c10::IListRef<at::Tensor> const&, long long) + 136
10  libtorch_cpu.dylib            	       0x11d940810 c10::impl::wrap_kernel_functor_unboxed_<c10::impl::detail::WrapFunctionIntoFunctor_<c10::CompileTimeFunctionPointer<at::Tensor (c10::DispatchKeySet, c10::IListRef<at::Tensor> const&, long long), &torch::autograd::VariableType::(anonymous namespace)::cat(c10::DispatchKeySet, c10::IListRef<at::Tensor> const&, long long)>, at::Tensor, c10::guts::typelist::typelist<c10::DispatchKeySet, c10::IListRef<at::Tensor> const&, long long>>, at::Tensor (c10::DispatchKeySet, c10::IListRef<at::Tensor> const&, long long)>::call(c10::OperatorKernel*, c10::DispatchKeySet, c10::IListRef<at::Tensor> const&, long long) + 936
11  libtorch_cpu.dylib            	       0x11ad6722c at::_ops::cat::call(c10::IListRef<at::Tensor> const&, long long) + 216
12  libtorch_python.dylib         	       0x10cb95050 torch::autograd::THPVariable_cat(_object*, _object*, _object*) + 608
13  libpython3.12.dylib           	       0x1055b607c cfunction_call + 148
14  libpython3.12.dylib           	       0x10553c90c _PyObject_MakeTpCall + 356
15  libpython3.12.dylib           	       0x1056aa6ec _PyEval_EvalFrameDefault + 44324
16  libpython3.12.dylib           	       0x10553c5e4 _PyObject_FastCallDictTstate + 160
17  libpython3.12.dylib           	       0x1055e6890 slot_tp_call + 292
18  libpython3.12.dylib           	       0x10553c90c _PyObject_MakeTpCall + 356
19  libpython3.12.dylib           	       0x1056aa6ec _PyEval_EvalFrameDefault + 44324
20  libpython3.12.dylib           	       0x10553c5e4 _PyObject_FastCallDictTstate + 160
21  libpython3.12.dylib           	       0x1055e6890 slot_tp_call + 292
22  libpython3.12.dylib           	       0x10553d768 _PyObject_Call + 188
23  libpython3.12.dylib           	       0x1056ac088 _PyEval_EvalFrameDefault + 50880
24  libpython3.12.dylib           	       0x10553c5e4 _PyObject_FastCallDictTstate + 160
25  libpython3.12.dylib           	       0x1055e6890 slot_tp_call + 292
26  libpython3.12.dylib           	       0x10553c90c _PyObject_MakeTpCall + 356
27  libpython3.12.dylib           	       0x1056aa6ec _PyEval_EvalFrameDefault + 44324
28  libpython3.12.dylib           	       0x10553c5e4 _PyObject_FastCallDictTstate + 160
29  libpython3.12.dylib           	       0x1055e6890 slot_tp_call + 292
30  libpython3.12.dylib           	       0x10553c90c _PyObject_MakeTpCall + 356
31  libpython3.12.dylib           	       0x1056aa6ec _PyEval_EvalFrameDefault + 44324
32  libpython3.12.dylib           	       0x10553c5e4 _PyObject_FastCallDictTstate + 160
33  libpython3.12.dylib           	       0x1055e6890 slot_tp_call + 292
34  libpython3.12.dylib           	       0x10553c90c _PyObject_MakeTpCall + 356
35  libpython3.12.dylib           	       0x1056aa6ec _PyEval_EvalFrameDefault + 44324
36  libpython3.12.dylib           	       0x10569f4b0 PyEval_EvalCode + 512
37  libpython3.12.dylib           	       0x10569b154 builtin_exec + 1840
38  libpython3.12.dylib           	       0x1055b5470 cfunction_vectorcall_FASTCALL_KEYWORDS + 152
39  libpython3.12.dylib           	       0x10553d4b4 PyObject_Vectorcall + 88
40  libpython3.12.dylib           	       0x1056aa6ec _PyEval_EvalFrameDefault + 44324
41  libpython3.12.dylib           	       0x105757284 pymain_run_module + 244
42  libpython3.12.dylib           	       0x105756b50 Py_RunMain + 2224
43  libpython3.12.dylib           	       0x105757050 pymain_main + 724
44  libpython3.12.dylib           	       0x10575715c Py_BytesMain + 60
45  dyld                          	       0x199211d54 start + 7184
```

1. Disabled the failing tests on Darwin only.
2. Merged two conditional blocks (both `lib.optionals stdenv.hostPlatform.isDarwin`) under `disabledTests`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
