### PR TITLE
python313Packages.streamlit-folium: init at 0.25.3

### DIFF
--- a/pkgs/development/python-modules/streamlit-folium/default.nix
+++ b/pkgs/development/python-modules/streamlit-folium/default.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  branca,
+  buildPythonPackage,
+  fetchFromGitHub,
+  folium,
+  jinja2,
+  pytest-playwright,
+  pytest-rerunfailures,
+  pytestCheckHook,
+  streamlit,
+  uv-build,
+  writableTmpDirAsHomeHook,
+}:
+
+buildPythonPackage rec {
+  pname = "streamlit-folium";
+  version = "0.25.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "randyzwitch";
+    repo = "streamlit-folium";
+    tag = "v${version}";
+    hash = "sha256-ACllvlT2zPyV7IS00LVgnf2u5jMChVJlDgNlWk0c9fo=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "uv_build>=0.8.4,<0.9" "uv_build"
+  '';
+
+  build-system = [ uv-build ];
+
+  dependencies = [
+    branca
+    folium
+    jinja2
+    streamlit
+  ];
+
+  nativeCheckInputs = [
+    pytest-playwright
+    pytest-rerunfailures
+    pytestCheckHook
+    streamlit
+    writableTmpDirAsHomeHook
+  ];
+
+  pythonImportsCheck = [ "streamlit_folium" ];
+
+  preCheck = ''
+    export PATH="$PATH:$out/bin";
+  '';
+
+  disabledTestPaths = [
+    # Don't run tests that require chromium
+    "tests/test_frontend.py"
+  ];
+
+  meta = {
+    description = "Streamlit Component for rendering Folium maps";
+    homepage = "https://github.com/randyzwitch/streamlit-folium";
+    changelog = "https://github.com/randyzwitch/streamlit-folium/releases/tag/${src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18138,6 +18138,8 @@ self: super: with self; {
 
   streamlit = callPackage ../development/python-modules/streamlit { };
 
+  streamlit-folium = callPackage ../development/python-modules/streamlit-folium { };
+
   streamz = callPackage ../development/python-modules/streamz { };
 
   strenum = callPackage ../development/python-modules/strenum { };


### PR DESCRIPTION
Streamlit Component for rendering Folium maps

https://github.com/randyzwitch/streamlit-folium


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
