### PR TITLE
nixos/homepage-dashboard: Allow multiple environmentFiles

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -97,6 +97,8 @@ of pulling the upstream container image from Docker Hub. If you want the old beh
 
 - `services.angrr` now uses TOML for configuration. Define policies with `services.angrr.settings` (generate TOML file) or point to a file using `services.angrr.configFile`. The legacy options `services.angrr.period`, `services.angrr.ownedOnly`, and `services.angrr.removeRoot` have been removed. See `man 5 angrr` and the description of `services.angrr.settings` options for examples and details.
 
+- `services.homepage-dashboard.environmentFile` has been renamed to `services.homepage-dashboard.environmentFiles`, and now expects a list of strings.
+
 - `services.pingvin-share` has been removed as the `pingvin-share.backend` package was broken and the project was archived upstream.
 
 ## Other Notable Changes {#sec-release-26.05-notable-changes}

--- a/nixos/modules/services/misc/homepage-dashboard.nix
+++ b/nixos/modules/services/misc/homepage-dashboard.nix
@@ -10,6 +10,14 @@ let
   settingsFormat = pkgs.formats.yaml { };
 in
 {
+  imports = [
+    (lib.mkChangedOptionModule
+      [ "services" "homepage-dashboard" "environmentFile" ]
+      [ "services" "homepage-dashboard" "environmentFiles" ]
+      (config: [ config.services.homepage-dashboard.environmentFile ])
+    )
+  ];
+
   options = {
     services.homepage-dashboard = {
       enable = lib.mkEnableOption "Homepage Dashboard, a highly customizable application dashboard";
@@ -41,10 +49,10 @@ in
         '';
       };
 
-      environmentFile = lib.mkOption {
-        type = lib.types.str;
+      environmentFiles = lib.mkOption {
+        type = lib.types.listOf lib.types.path;
         description = ''
-          The path to an environment file that contains environment variables to pass
+          A list of paths to environment files that contain environment variables to pass
           to the homepage-dashboard service, for the purpose of passing secrets to
           the service.
 
@@ -52,7 +60,7 @@ in
 
           <https://gethomepage.dev/installation/docker/#using-environment-secrets>
         '';
-        default = "";
+        default = [ ];
       };
 
       customCSS = lib.mkOption {
@@ -243,7 +251,7 @@ in
 
       serviceConfig = {
         Type = "simple";
-        EnvironmentFile = lib.mkIf (cfg.environmentFile != null) cfg.environmentFile;
+        EnvironmentFile = cfg.environmentFiles;
         StateDirectory = "homepage-dashboard";
         CacheDirectory = "homepage-dashboard";
         ExecStart = lib.getExe cfg.package;


### PR DESCRIPTION
Systemd supports passing a list to serviceConfig.EnvironmentFile to use multiple environment files, this is useful to have a separate secret file for each services listed on homepage, instead of one monolithic file.

This way homepage can be enabled and configured in one file, then the homepage.services definitions and environmentFile definitions can go in separate files and dynamically included with the services they point to. eg:

```nix
# main.nix
{ ... }:
{
  imports = [
    ./homepage.nix
    ./service1.nix
    # service2.nix is not imported so it doesn't show up in homepage, and it's secrets aren't passed either
  ];
}
```

```nix
# homepage.nix
{ ... }:
{
  services.homepage-dashboard = {
    enable = true;
    openFirewall = true;
  };
}
```

```nix
# service1.nix
{ config, ... }:
{
  age.secrets.service1.rekeyFile = ./service1.age;
  services.homepage-dashboard = {
    environmentFiles = [ config.age.secrets.service1.path ];
    services = [
      {
        "Stuff" = [
          {
            "service1" = {
              href = "/service1";
              widget = {
                type = "service1";
                url = "http://localhost:1234";
                key = "{{HOMEPAGE_VAR_SERVICE1_APIKEY}}";
              };
            };
          }
        ];
      }
    ];
  };
}
```

```nix
{ config, ... }:
{
  age.secrets.service2.rekeyFile = ./service2.age;
  services.homepage-dashboard = {
    environmentFiles = [ config.age.secrets.service2.path ];
    services = [
      {
        "Things" = [
          {
            "service2" = {
              href = "/service2";
              widget = {
                type = "service2";
                url = "http://localhost:5678";
                key = "{{HOMEPAGE_VAR_SERVICE2_APIKEY}}";
              };
            };
          }
        ];
      }
    ];
  };
}
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
