### PR TITLE
nixos/reaction: systemd harden, improve nixostest

### DIFF
--- a/nixos/tests/reaction-firewall.nix
+++ b/nixos/tests/reaction-firewall.nix
@@ -24,44 +24,44 @@
   testScript = # py
     ''
       start_all()
-      machine.wait_for_unit("multi-user.target")
 
-      # Verify both services start successfully
+      machine.wait_for_unit("multi-user.target")
       machine.wait_for_unit("firewall.service")
       machine.wait_for_unit("reaction.service")
 
-      # Check reaction chain exists in iptables
-      output = machine.succeed("iptables -w -L -n")
-      assert "reaction" in output, "reaction chain not found in iptables"
+      def check_reaction_in_iptables(context = ""):
+        with subtest("check reaction chain exists"):
+          machine.sleep(3)
+          output = machine.succeed("iptables -nvL")
+          assert "reaction" in output, f"error: reaction chain missing in iptables, {context}"
 
-      # Reload firewall and verify there's no issues due to reaction chain
-      machine.succeed("systemctl reload firewall")
-      output = machine.succeed("journalctl -u reaction.service -u firewall.service --no-pager")
-      assert "ERROR" not in output, "firewall reload failed due to reaction"
+      check_reaction_in_iptables()
 
-      # Verify reaction chain still exists after reload
-      output = machine.succeed("iptables -w -L -n")
-      assert "reaction" in output, "reaction chain missing after firewall reload"
+      with subtest("reload firewall"):
+        machine.succeed("systemctl reload firewall")
+        output = machine.succeed("journalctl -u firewall.service --no-pager")
+        assert "ERROR" not in output, "firewall reload failed due to reaction"
 
-      # Restart firewall and verify reaction restarts as well
-      machine.succeed("systemctl restart firewall")
-      output = machine.succeed("journalctl -u reaction.service -u firewall.service --no-pager")
-      assert "INFO stop command" in output and "INFO start command" in output, "reaction did not restart when firewall was restarted"
+        check_reaction_in_iptables(context="after firewall reload")
 
-      output = machine.succeed("iptables -w -L -n")
-      assert "reaction" in output, "reaction chain missing after firewall restart"
+      with subtest("restart firewall"):
+        machine.succeed("systemctl restart firewall")
+        output = machine.succeed("journalctl -u reaction.service --no-pager")
+        assert "INFO stop command" in output and "INFO start command" in output, "reaction did not restart when firewall was restarted"
 
-      # Stop reaction manually and verify chains are cleaned up
-      machine.succeed("systemctl stop reaction")
-      output = machine.succeed("iptables -w -L -n || true")
-      assert "reaction" not in output, "reaction chain still exists after stop"
+        check_reaction_in_iptables(context="after firewall restart")
 
-      # Start reaction again and verify it works
-      machine.succeed("systemctl start reaction")
-      machine.wait_for_unit("reaction.service")
+      with subtest("stop reaction manually and verify chains are cleaned up"):
+        machine.succeed("systemctl stop reaction")
+        machine.sleep(3)
+        output = machine.succeed("iptables -nvL")
+        assert "reaction" not in output, "reaction chain still exists after the service was stopped"
 
-      output = machine.succeed("iptables -w -L -n")
-      assert "reaction" in output, "reaction chain not recreated"
+        with subtest("start reaction again and verify it works"):
+          machine.succeed("systemctl start reaction")
+          machine.wait_for_unit("reaction.service")
+
+          check_reaction_in_iptables()
     '';
 
   # Debug interactively with:


### PR DESCRIPTION
followup to #468019 

```bash
nix build -f . nixosTests.reaction-firewall
for i in $(seq 1 100); do
        nix build -f . nixosTests.reaction-firewall --rebuild
        if test $? -eq 1; then
                echo "$i/100 failed"
                break
        fi
done
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
