### PR TITLE
splix: modernize

### DIFF
--- a/pkgs/by-name/sp/splix/package.nix
+++ b/pkgs/by-name/sp/splix/package.nix
@@ -8,16 +8,14 @@
   jbigkit,
   zlib,
 }:
-
 let
-
   color-profiles = stdenv.mkDerivation {
     pname = "splix-color-profiles";
-    version = "unstable-2007-06-25";
+    version = "0-unstable-2007-06-25";
 
     src = fetchurl {
-      url = "http://splix.ap2c.org/samsung_cms.tar.bz2";
-      sha256 = "1156flics5m9m7a4hdmcc2nphbdyary6dfmbcrmsp9xb7ivsypdl";
+      url = "https://web.archive.org/web/20170518031609if_/http://splix.ap2c.org/samsung_cms.tar.bz2";
+      hash = "sha256-tF2vdzyrp6trZqu6ZnxWvi14rWCsNkjUqakWzSJ1poQ=";
     };
 
     installPhase = ''
@@ -25,7 +23,6 @@ let
       cp * $out/share/cups/profiles/samsung/
     '';
   };
-
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "splix-svn";
@@ -36,7 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
     # although the community has been adding some new printer models.
     url = "svn://svn.code.sf.net/p/splix/code/splix";
     rev = finalAttrs.version;
-    sha256 = "16wbm4xnz35ca3mw2iggf5f4jaxpyna718ia190ka6y4ah932jxl";
+    hash = "sha256-tEsxElTEGzVBCiqicJT1tytJXHHvRcHrUKyMbzupi5s=";
   };
 
   postPatch = ''
@@ -60,7 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "CUPS drivers for SPL (Samsung Printer Language) printers";
-    homepage = "http://splix.ap2c.org";
+    homepage = "https://web.archive.org/web/20220729010458/http://splix.ap2c.org/";
     license = lib.licenses.gpl2Only;
     platforms = lib.platforms.linux;
     maintainers = [ ];


### PR DESCRIPTION
Also some links are replaced with Wayback Machine snapshots.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
