### PR TITLE
pkgs/build-support/node/build-npm-package: enable structuredAttrs

### DIFF
--- a/pkgs/build-support/node/build-npm-package/default.nix
+++ b/pkgs/build-support/node/build-npm-package/default.nix
@@ -111,6 +111,8 @@ lib.extendMkDerivation {
       # Stripping takes way too long with the amount of files required by a typical Node.js project.
       dontStrip = args.dontStrip or true;
 
+      __structuredAttrs = true;
+
       meta = (args.meta or { }) // {
         platforms = args.meta.platforms or nodejs.meta.platforms;
       };

--- a/pkgs/build-support/node/build-npm-package/hooks/npm-build-hook.sh
+++ b/pkgs/build-support/node/build-npm-package/hooks/npm-build-hook.sh
@@ -14,7 +14,7 @@ npmBuildHook() {
         exit 1
     fi
 
-    if ! npm run ${npmWorkspace+--workspace=$npmWorkspace} "$npmBuildScript" $npmBuildFlags "${npmBuildFlagsArray[@]}" $npmFlags "${npmFlagsArray[@]}"; then
+    if ! npm run ${npmWorkspace+--workspace=$npmWorkspace} "$npmBuildScript" "${npmBuildFlags[@]}" "${npmFlags[@]}"; then
         echo
         echo 'ERROR: `npm build` failed'
         echo

--- a/pkgs/build-support/node/build-npm-package/hooks/npm-config-hook.sh
+++ b/pkgs/build-support/node/build-npm-package/hooks/npm-config-hook.sh
@@ -95,7 +95,8 @@ npmConfigHook() {
     fi
 
     export CACHE_MAP_PATH="$TMP/MEOW"
-    @prefetchNpmDeps@ --map-cache
+
+    @prefetchNpmDeps@ --map-cache "$npmDeps"
 
     @prefetchNpmDeps@ --fixup-lockfile "$srcLockfile"
 
@@ -122,7 +123,7 @@ npmConfigHook() {
 
     echo "Installing dependencies"
 
-    if ! npm ci --ignore-scripts $npmInstallFlags "${npmInstallFlagsArray[@]}" $npmFlags "${npmFlagsArray[@]}"; then
+    if ! npm ci --ignore-scripts "${npmInstallFlags[@]}" "${npmFlags[@]}"; then
         echo
         echo "ERROR: npm failed to install dependencies"
         echo
@@ -138,7 +139,7 @@ npmConfigHook() {
 
     patchShebangs node_modules
 
-    npm rebuild $npmRebuildFlags "${npmRebuildFlagsArray[@]}" $npmFlags "${npmFlagsArray[@]}"
+    npm rebuild "${npmRebuildFlags[@]}" "${npmFlags[@]}"
 
     patchShebangs node_modules
 

--- a/pkgs/build-support/node/build-npm-package/hooks/npm-install-hook.sh
+++ b/pkgs/build-support/node/build-npm-package/hooks/npm-install-hook.sh
@@ -12,7 +12,7 @@ npmInstallHook() {
         local dest="$packageOut/$(dirname "$file")"
         mkdir -p "$dest"
         cp "${npmWorkspace-.}/$file" "$dest"
-    done < <(@jq@ --raw-output '.[0].files | map(.path | select(. | startswith("node_modules/") | not)) | join("\n")' <<< "$(npm_config_cache="$HOME/.npm" npm pack --json --dry-run --loglevel=warn --no-foreground-scripts ${npmWorkspace+--workspace=$npmWorkspace} $npmPackFlags "${npmPackFlagsArray[@]}" $npmFlags "${npmFlagsArray[@]}")")
+    done < <(@jq@ --raw-output '.[0].files | map(.path | select(. | startswith("node_modules/") | not)) | join("\n")' <<< "$(npm_config_cache="$HOME/.npm" npm pack --json --dry-run --loglevel=warn --no-foreground-scripts ${npmWorkspace+--workspace=$npmWorkspace} "${npmPackFlags[@]}" "${npmFlags[@]}")")
 
     nodejsInstallExecutables "${npmWorkspace-.}/package.json"
 
@@ -22,7 +22,7 @@ npmInstallHook() {
 
     if [ ! -d "$nodeModulesPath" ]; then
         if [ -z "${dontNpmPrune-}" ]; then
-            if ! npm prune --omit=dev --no-save ${npmWorkspace+--workspace=$npmWorkspace} $npmPruneFlags "${npmPruneFlagsArray[@]}" $npmFlags "${npmFlagsArray[@]}"; then
+            if ! npm prune --omit=dev --no-save ${npmWorkspace+--workspace=$npmWorkspace} "${npmPruneFlags[@]}" "${npmFlags[@]}"; then
               echo
               echo
               echo "ERROR: npm prune step failed"


### PR DESCRIPTION
Otherwise, we get

```
       > thread 'main' (23) panicked at src/main.rs:159:58:
       > called `Option::unwrap()` on a `None` value
       > stack backtrace:
       >    0: __rustc::rust_begin_unwind
       >    1: core::panicking::panic_fmt
       >    2: core::panicking::panic
       >    3: core::option::unwrap_failed
       >    4: prefetch_npm_deps::main
```

which is `    let content_path = Path::new(&env::var_os("npmDeps").unwrap()).join("_cacache/index-v5");`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
