### PR TITLE
python3Packages.libxc: init at 7.0.0

### DIFF
--- a/pkgs/by-name/li/libxc/package.nix
+++ b/pkgs/by-name/li/libxc/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitLab,
+  fetchpatch,
   cmake,
   gfortran,
   perl,
@@ -26,6 +27,14 @@ stdenv.mkDerivation rec {
     hash = versionHashes."${version}";
   };
 
+  patches = [
+    # Fix build with newer CMake versions
+    (fetchpatch {
+      url = "https://gitlab.com/libxc/libxc/-/commit/450202adb8a3d698841dca853f2999b1befd932e.patch";
+      sha256 = "sha256-XDt7+TzszSu+X6/PS+T8Q9BP76+bAXC9FzkA6ueo/OA=";
+    })
+  ];
+
   # Timeout increase has already been included upstream in master.
   # Check upon updates if this can be removed.
   postPatch = ''
@@ -49,7 +58,6 @@ stdenv.mkDerivation rec {
   '';
 
   cmakeFlags = [
-    "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
     "-DENABLE_FORTRAN=ON"
     "-DBUILD_SHARED_LIBS=ON"
     "-DENABLE_XHOST=OFF"

--- a/pkgs/by-name/li/libxc/python.nix
+++ b/pkgs/by-name/li/libxc/python.nix
@@ -1,0 +1,34 @@
+{
+  buildPythonPackage,
+  lib,
+  libxc,
+  setuptools,
+  cmake,
+  numpy,
+}:
+
+buildPythonPackage {
+  inherit (libxc)
+    pname
+    version
+    src
+    patches
+    meta
+    nativeBuildInputs
+    ;
+
+  pyproject = true;
+
+  build-system = [
+    setuptools
+    cmake
+  ];
+
+  dependencies = [
+    numpy
+  ];
+
+  dontUseCmakeConfigure = true;
+
+  pythonImportsCheck = [ "pylibxc" ];
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8655,6 +8655,10 @@ self: super: with self; {
 
   libvirt = callPackage ../development/python-modules/libvirt { inherit (pkgs) libvirt; };
 
+  libxc = callPackage ../by-name/li/libxc/python.nix {
+    libxc = pkgs.libxc_7;
+  };
+
   libxml2 =
     (toPythonModule (
       pkgs.libxml2.override {


### PR DESCRIPTION
Adds the python bindings of the LibXC library as of version 7.0.0. The 6.x branches do not yet support pyproject builds.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
