### PR TITLE
git2cl: modernize & unstable-2008-08-27 -> 3.0

### DIFF
--- a/pkgs/by-name/gi/git2cl/package.nix
+++ b/pkgs/by-name/gi/git2cl/package.nix
@@ -1,24 +1,25 @@
 {
-  fetchgit,
+  fetchFromGitLab,
   lib,
-  stdenv,
   perl,
+  stdenv,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "git2cl";
-  version = "unstable-2008-08-27";
+  version = "3.0";
 
-  src = fetchgit {
-    url = "git://repo.or.cz/git2cl.git";
-    rev = "8373c9f74993e218a08819cbcdbab3f3564bbeba";
-    sha256 = "b0d39379640c8a12821442431e2121f7908ce1cc88ec8ec6bede218ea8c21f2f";
+  src = fetchFromGitLab {
+    owner = "jas";
+    repo = "git2cl";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-KEEUKSP7+05VIb/EhuCy0t1qP/UU0iqNzU4AacbdpTg=";
   };
 
   buildInputs = [ perl ];
   installPhase = ''
     install -D -m755 git2cl $out/bin/git2cl
-    install -D -m644 README $out/share/doc/git2cl/README
+    install -D -m644 README.md $out/share/doc/git2cl/README.md
   '';
 
   meta = {
@@ -27,4 +28,4 @@ stdenv.mkDerivation {
     platforms = lib.platforms.unix;
     mainProgram = "git2cl";
   };
-}
+})


### PR DESCRIPTION
According to the README.md of the linked source repo from https://savannah.nongnu.org/projects/git2cl:
> There is a [Savannah git2cl project](https://savannah.nongnu.org/projects/git2cl/) and a [GitLab git2cl project](https://gitlab.com/jas/git2cl). An old repository is still at [http://repo.or.cz/w/git2cl.git].

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [X] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
