### PR TITLE
python313Packages.streamlit-echarts: init at 0.4.0

### DIFF
--- a/pkgs/development/python-modules/pyecharts/default.nix
+++ b/pkgs/development/python-modules/pyecharts/default.nix
@@ -8,7 +8,6 @@
   pillow,
   prettytable,
   pytestCheckHook,
-  pythonOlder,
   requests,
   setuptools,
   simplejson,
@@ -18,8 +17,6 @@ buildPythonPackage rec {
   pname = "pyecharts";
   version = "2.0.9";
   pyproject = true;
-
-  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "pyecharts";
@@ -60,7 +57,7 @@ buildPythonPackage rec {
   meta = {
     description = "Python Echarts Plotting Library";
     homepage = "https://github.com/pyecharts/pyecharts";
-    changelog = "https://github.com/pyecharts/pyecharts/releases/tag/v${version}";
+    changelog = "https://github.com/pyecharts/pyecharts/releases/tag/${src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
   };

--- a/pkgs/development/python-modules/streamlit-echarts/default.nix
+++ b/pkgs/development/python-modules/streamlit-echarts/default.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pyecharts,
+  setuptools,
+  streamlit,
+}:
+
+buildPythonPackage rec {
+  pname = "streamlit-echarts";
+  version = "0.4.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "andfanilo";
+    repo = "streamlit-echarts";
+    tag = "v${version}";
+    hash = "sha256-VNliCZPkAYUx+TacBc6PrS4C4bjM5fmVx/Sj6aSw2Yc=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    pyecharts
+    streamlit
+  ];
+
+  pythonImportsCheck = [ "streamlit_echarts" ];
+
+  # Module has no tests
+  doCheck = false;
+
+  meta = {
+    description = "Streamlit component to render ECharts";
+    homepage = "https://github.com/andfanilo/streamlit-echarts";
+    changelog = "https://github.com/andfanilo/streamlit-echarts/blob/${src.tag}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18200,6 +18200,8 @@ self: super: with self; {
 
   streamlit-card = callPackage ../development/python-modules/streamlit-card { };
 
+  streamlit-echarts = callPackage ../development/python-modules/streamlit-echarts { };
+
   streamlit-folium = callPackage ../development/python-modules/streamlit-folium { };
 
   streamlit-kpi-card = callPackage ../development/python-modules/streamlit-kpi-card { };


### PR DESCRIPTION
Streamlit component to render ECharts

https://github.com/andfanilo/streamlit-echarts


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
