### PR TITLE
git-now: init at 0.1.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23046,6 +23046,11 @@
     githubId = 3280280;
     name = "Ryne Everett";
   };
+  ryoppippi = {
+    github = "ryoppippi";
+    githubId = 1560508;
+    name = "ryoppippi";
+  };
   ryota-ka = {
     email = "ok@ryota-ka.me";
     github = "ryota-ka";

--- a/pkgs/by-name/gi/git-now/package.nix
+++ b/pkgs/by-name/gi/git-now/package.nix
@@ -1,0 +1,68 @@
+{
+  fetchFromGitHub,
+  git,
+  lib,
+  makeWrapper,
+  stdenv,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "git-now";
+  version = "0.1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "iwata";
+    repo = "git-now";
+    rev = "v${version}";
+    hash = "sha256-r1Xl9i2SXkaxVBjChdsnqgsex8f+AyVsPbBMwLHOVpM=";
+  };
+
+  shFlagsSrc = fetchFromGitHub {
+    owner = "nvie";
+    repo = "shFlags";
+    rev = "2fb06af13de884e9680f14a00c82e52a67c867f1";
+    hash = "sha256-Xp+2MOIRpe06DoD4+QV8pE+oEdgFQB7/J0jgfV/6WqQ=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/share/git-now
+
+    # Copy shFlags library
+    cp $shFlagsSrc/src/shflags $out/share/git-now/
+
+    # Copy common file and shFlags symlink to bin (where scripts expect them)
+    cp gitnow-common $out/bin/
+    ln -s $out/share/git-now/shflags $out/bin/gitnow-shFlags
+
+    # Copy main scripts
+    cp git-now $out/bin/
+    cp git-now-add $out/bin/
+    cp git-now-grep $out/bin/
+    cp git-now-push $out/bin/
+    cp git-now-rebase $out/bin/
+
+    # Make main script executable (subcommands are sourced, not executed directly)
+    chmod +x $out/bin/git-now
+
+    # Only wrap the main git-now script - subcommands are sourced by it
+    wrapProgram "$out/bin/git-now" \
+      --prefix PATH : "${lib.makeBinPath [ git ]}"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Git command for light and temporary commits";
+    homepage = "https://github.com/iwata/git-now";
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ ryoppippi ];
+    platforms = lib.platforms.unix;
+    mainProgram = "git-now";
+  };
+}


### PR DESCRIPTION
git-now is a command-line tool for creating light and temporary commits. It allows quick snapshot commits during development that can later be rebased into proper commits.

https://github.com/iwata/git-now

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test