### PR TITLE
bitcoin-knots-bip110: init at 29.2.knots20251110+bip110-v0.1rc1

### DIFF
--- a/pkgs/applications/blockchains/bitcoin-knots-bip110/default.nix
+++ b/pkgs/applications/blockchains/bitcoin-knots-bip110/default.nix
@@ -1,0 +1,202 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  installShellFiles,
+  autoSignDarwinBinariesHook,
+  wrapQtAppsHook ? null,
+  boost,
+  libevent,
+  libsodium,
+  zeromq,
+  zlib,
+  db48,
+  sqlite,
+  qrencode,
+  libsystemtap,
+  qtbase ? null,
+  qttools ? null,
+  python3,
+  versionCheckHook,
+  withGui,
+  withWallet ? true,
+  enableTracing ? stdenv.hostPlatform.isLinux && !stdenv.hostPlatform.isStatic,
+  gnupg,
+  imagemagick,
+  librsvg,
+  libicns,
+  # Signatures from the following GPG public keys checked during verification of the source code.
+  # The list can be found at https://github.com/bitcoinknots/guix.sigs/tree/knots/builder-keys
+  builderKeys ? [
+    "DAED928C727D3E613EC46635F5073C4F4882FFFC" # leo-haf.gpg
+  ],
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = if withGui then "bitcoin-knots-bip110" else "bitcoind-knots-bip110";
+  version = "29.2.knots20251110+bip110-v0.1rc1";
+
+  src = fetchurl {
+    url = "https://github.com/dathonohm/bitcoin/releases/download/v29.2.knots20251110%2Bbip110-v0.1rc1/bitcoin-${finalAttrs.version}.tar.gz";
+    # hash retrieved from signed SHA256SUMS
+    hash = "sha256-mOWUTsT65I4yGJogGieZbIxNSkSbCw+1x+LYGY1UJd8=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    installShellFiles
+    gnupg
+  ]
+  ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) [
+    autoSignDarwinBinariesHook
+  ]
+  ++ lib.optionals withGui [
+    imagemagick # for convert
+    librsvg # for rsvg-convert
+    wrapQtAppsHook
+  ]
+  ++ lib.optionals (stdenv.hostPlatform.isDarwin && withGui) [
+    libicns # for png2icns
+  ];
+
+  buildInputs = [
+    boost
+    libevent
+    libsodium
+    zeromq
+    zlib
+  ]
+  ++ lib.optionals enableTracing [ libsystemtap ]
+  ++ lib.optionals withWallet [ sqlite ]
+  # building with db48 (for legacy descriptor wallet support) is broken on Darwin
+  ++ lib.optionals (withWallet && !stdenv.hostPlatform.isDarwin) [ db48 ]
+  ++ lib.optionals withGui [
+    qrencode
+    qtbase
+    qttools
+  ];
+
+  preUnpack =
+    let
+      majorVersion = lib.versions.major finalAttrs.version;
+
+      publicKeys = fetchFromGitHub {
+        owner = "bitcoinknots";
+        repo = "guix.sigs";
+        rev = "cc710f4715ff5ff74a9e89d8b6798884fe1e9d40";
+        sha256 = "sha256-PVvsqY//75dv+VrtapCNroD1z1zUaA/UBGvfq3zNySo=";
+      };
+
+      checksums = fetchurl {
+        url = "https://raw.githubusercontent.com/dathonohm/guix.sigs/refs/heads/bip110/29.2.knots20251110%2Bbip110-v0.1rc1/leo-haf/all.SHA256SUMS";
+        hash = "sha256-1PXYBQuR8UI0ysLj9d/Vlvu/EQ/WoMne10cmjbYLJKM=";
+      };
+
+      signatures = fetchurl {
+        url = "https://raw.githubusercontent.com/dathonohm/guix.sigs/refs/heads/bip110/29.2.knots20251110%2Bbip110-v0.1rc1/leo-haf/all.SHA256SUMS.asc";
+        hash = "sha256-SMtyjDyYE65NR/bJh+0Lla+ItpXP8wqPQeGUN57LZHM=";
+      };
+
+      verifyBuilderKeys =
+        let
+          script = publicKey: ''
+            echo "Checking if public key ${publicKey} signed the checksum file..."
+            grep "^\[GNUPG:\] VALIDSIG .* ${publicKey}$" verify.log > /dev/null
+            echo "OK"
+          '';
+        in
+        builtins.concatStringsSep "\n" (map script builderKeys);
+    in
+    ''
+      pushd $(mktemp -d)
+      export GNUPGHOME=$PWD/gnupg
+      mkdir -m 700 -p $GNUPGHOME
+      gpg --no-autostart --batch --import ${publicKeys}/builder-keys/*
+      ln -s ${checksums} ./all.SHA256SUMS
+      ln -s ${signatures} ./all.SHA256SUMS.asc
+      ln -s $src ./bitcoin-${finalAttrs.version}.tar.gz
+      gpg --no-autostart --batch --verify --status-fd 1 all.SHA256SUMS.asc all.SHA256SUMS > verify.log
+      ${verifyBuilderKeys}
+      echo "Checking ${checksums} for bitcoin-${finalAttrs.version}.tar.gz..."
+      grep bitcoin-${finalAttrs.version}.tar.gz all.SHA256SUMS > all.SHA256SUMS.filtered
+      echo "Verifying the checksum of bitcoin-${finalAttrs.version}.tar.gz..."
+      sha256sum -c all.SHA256SUMS.filtered
+      popd
+    '';
+
+  postInstall = ''
+    cd ..
+    installShellCompletion --bash contrib/completions/bash/bitcoin-cli.bash
+    installShellCompletion --bash contrib/completions/bash/bitcoind.bash
+    installShellCompletion --bash contrib/completions/bash/bitcoin-tx.bash
+
+    installShellCompletion --fish contrib/completions/fish/bitcoin-cli.fish
+    installShellCompletion --fish contrib/completions/fish/bitcoind.fish
+    installShellCompletion --fish contrib/completions/fish/bitcoin-tx.fish
+    installShellCompletion --fish contrib/completions/fish/bitcoin-util.fish
+    installShellCompletion --fish contrib/completions/fish/bitcoin-wallet.fish
+  ''
+  + lib.optionalString withGui ''
+    installShellCompletion --fish contrib/completions/fish/bitcoin-qt.fish
+  '';
+
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_BENCH" false)
+    (lib.cmakeBool "WITH_ZMQ" true)
+    # building with db48 (for legacy wallet support) is broken on Darwin
+    (lib.cmakeBool "WITH_BDB" (withWallet && !stdenv.hostPlatform.isDarwin))
+    (lib.cmakeBool "WITH_USDT" enableTracing)
+  ]
+  ++ lib.optionals (!finalAttrs.doCheck) [
+    (lib.cmakeBool "BUILD_TESTS" false)
+    (lib.cmakeBool "BUILD_FUZZ_BINARY" false)
+    (lib.cmakeBool "BUILD_GUI_TESTS" false)
+  ]
+  ++ lib.optionals (!withWallet) [
+    (lib.cmakeBool "ENABLE_WALLET" false)
+  ]
+  ++ lib.optionals withGui [
+    (lib.cmakeBool "BUILD_GUI" true)
+  ];
+
+  NIX_LDFLAGS = lib.optionals (
+    stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isStatic
+  ) "-levent_core";
+
+  nativeCheckInputs = [ python3 ];
+
+  doCheck = true;
+
+  checkFlags = [
+    "LC_ALL=en_US.UTF-8"
+  ]
+  # QT_PLUGIN_PATH needs to be set when executing QT, which is needed when testing Bitcoin's GUI.
+  # See also https://github.com/NixOS/nixpkgs/issues/24256
+  ++ lib.optional withGui "QT_PLUGIN_PATH=${qtbase}/${qtbase.qtPluginPrefix}";
+
+  enableParallelBuilding = true;
+
+  __darwinAllowLocalNetworking = true;
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgram = "${placeholder "out"}/bin/bitcoin-cli";
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
+
+  meta = {
+    description = "Derivative of Bitcoin Knots with BIP 110";
+    homepage = "https://github.com/dathonohm/bips/blob/ff8f8d6415dd24daacc73294d4f933b6ce1ef199/bip-0110.mediawiki";
+    maintainers = with lib.maintainers; [
+      prusnak
+      mmahut
+    ];
+    license = lib.licenses.mit;
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12558,6 +12558,16 @@ with pkgs;
     inherit (darwin) autoSignDarwinBinariesHook;
   };
 
+  bitcoin-knots-bip110 = libsForQt5.callPackage ../applications/blockchains/bitcoin-knots-bip110 {
+    withGui = true;
+    inherit (darwin) autoSignDarwinBinariesHook;
+  };
+
+  bitcoind-knots-bip110 = callPackage ../applications/blockchains/bitcoin-knots-bip110 {
+    withGui = false;
+    inherit (darwin) autoSignDarwinBinariesHook;
+  };
+
   elements = libsForQt5.callPackage ../applications/blockchains/elements {
     withGui = true;
     inherit (darwin) autoSignDarwinBinariesHook;


### PR DESCRIPTION
This package is temporary, it should be remove once [BIP 110](https://github.com/dathonohm/bips/blob/ff8f8d6415dd24daacc73294d4f933b6ce1ef199/bip-0110.mediawiki) is successfully activated/rejected.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
