### PR TITLE
sbom2dot: Remove meta.mainProgram override; sbom4files: Set meta.mainProgram in python3Packages.sbom4files instead

### DIFF
--- a/pkgs/by-name/sb/sbom2dot/package.nix
+++ b/pkgs/by-name/sb/sbom2dot/package.nix
@@ -2,6 +2,4 @@
   python3Packages,
 }:
 
-(python3Packages.toPythonApplication python3Packages.sbom2dot).overrideAttrs (previousAttrs: {
-  meta.mainProgram = "sbom2dot";
-})
+python3Packages.toPythonApplication python3Packages.sbom2dot

--- a/pkgs/by-name/sb/sbom4files/package.nix
+++ b/pkgs/by-name/sb/sbom4files/package.nix
@@ -2,6 +2,4 @@
   python3Packages,
 }:
 
-(python3Packages.toPythonApplication python3Packages.sbom4files).overrideAttrs (previousAttrs: {
-  meta.mainProgram = "sbom4files";
-})
+python3Packages.toPythonApplication python3Packages.sbom4files

--- a/pkgs/development/python-modules/sbom4files/default.nix
+++ b/pkgs/development/python-modules/sbom4files/default.nix
@@ -37,6 +37,7 @@ buildPythonPackage rec {
     description = "SBOM generator for files within a directory";
     homepage = "https://github.com/anthonyharrison/sbom4files";
     license = lib.licenses.asl20;
+    mainProgram = "sbom4files";
     maintainers = [ ];
   };
 }


### PR DESCRIPTION
Quote from NixOS 25.11 release notes:

> meta.mainProgram is now used to determine the NIX_MAIN_PROGRAM environment variable. This means that changing it can now lead to a package rebuild.

Make sbom4files and python3Packages.sbom4files the same derivation again.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
