### PR TITLE
minimal-bootstrap.gcc-glibc: init at 13.2.0

### DIFF
--- a/pkgs/os-specific/linux/minimal-bootstrap/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/default.nix
@@ -166,12 +166,17 @@ lib.makeScope
         gawk = gawk-mes;
       };
 
+      gcc-glibc = callPackage ./gcc/glibc.nix {
+        gcc = gcc-latest;
+        gnumake = gnumake-musl;
+        gnutar = gnutar-latest;
+      };
+
       glibc = callPackage ./glibc {
         gcc = gcc-latest;
         gnumake = gnumake-musl;
         gnutar = gnutar-latest;
         gnugrep = gnugrep-static;
-        gawk = gawk-static;
       };
 
       gnugrep = callPackage ./gnugrep {
@@ -388,6 +393,7 @@ lib.makeScope
         echo ${gcc46-cxx.tests.hello-world}
         echo ${gcc8.tests.hello-world}
         echo ${gcc-latest.tests.hello-world}
+        echo ${gcc-glibc.tests.hello-world}
         echo ${glibc.tests.hello-world}
         echo ${gnugrep.tests.get-version}
         echo ${gnugrep-static.tests.get-version}

--- a/pkgs/os-specific/linux/minimal-bootstrap/gcc/glibc.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gcc/glibc.nix
@@ -1,0 +1,149 @@
+{
+  lib,
+  buildPlatform,
+  hostPlatform,
+  fetchurl,
+  bash,
+  coreutils,
+  gcc,
+  glibc,
+  musl,
+  binutils,
+  gnumake,
+  gnused,
+  gnugrep,
+  gawk,
+  diffutils,
+  findutils,
+  gnutar,
+  gzip,
+  bzip2,
+  xz,
+}:
+let
+  pname = "gcc";
+  version = "13.2.0";
+  linkerName =
+    {
+      i686-linux = "ld-linux.so.2";
+      x86_64-linux = "ld-linux-x86-64.so.2";
+    }
+    .${hostPlatform.system};
+
+  src = fetchurl {
+    url = "mirror://gnu/gcc/gcc-${version}/gcc-${version}.tar.xz";
+    hash = "sha256-4nXnZEKmBnNBon8Exca4PYYTFEAEwEE1KIY9xrXHQ9o=";
+  };
+
+  gmpVersion = "6.3.0";
+  gmp = fetchurl {
+    url = "mirror://gnu/gmp/gmp-${gmpVersion}.tar.xz";
+    hash = "sha256-o8K4AgG4nmhhb0rTC8Zq7kknw85Q4zkpyoGdXENTiJg=";
+  };
+
+  mpfrVersion = "4.2.1";
+  mpfr = fetchurl {
+    url = "mirror://gnu/mpfr/mpfr-${mpfrVersion}.tar.xz";
+    hash = "sha256-J3gHNTpnJpeJlpRa8T5Sgp46vXqaW3+yeTiU4Y8fy7I=";
+  };
+
+  mpcVersion = "1.3.1";
+  mpc = fetchurl {
+    url = "mirror://gnu/mpc/mpc-${mpcVersion}.tar.gz";
+    hash = "sha256-q2QkkvXPiCt0qgy3MM1BCoHtzb7IlRg86TDnBsHHWbg=";
+  };
+
+  islVersion = "0.24";
+  isl = fetchurl {
+    url = "https://gcc.gnu.org/pub/gcc/infrastructure/isl-${islVersion}.tar.bz2";
+    hash = "sha256-/PeN2WVsEOuM+fvV9ZoLawE4YgX+GTSzsoegoYmBRcA=";
+  };
+in
+bash.runCommand "${pname}-${version}"
+  {
+    inherit pname version;
+
+    nativeBuildInputs = [
+      gcc
+      binutils
+      gnumake
+      gnused
+      gnugrep
+      gawk
+      diffutils
+      findutils
+      gnutar
+      gzip
+      bzip2
+      xz
+    ];
+
+    passthru.tests.hello-world =
+      result:
+      bash.runCommand "${pname}-simple-program-${version}"
+        {
+          nativeBuildInputs = [
+            binutils
+            result
+          ];
+        }
+        ''
+          cat <<EOF >> test.c
+          #include <stdio.h>
+          int main() {
+            printf("Hello World!\n");
+            return 0;
+          }
+          EOF
+          gcc -o test test.c
+          ./test
+          mkdir $out
+        '';
+
+    meta = {
+      description = "GNU Compiler Collection, version ${version}";
+      homepage = "https://gcc.gnu.org";
+      license = lib.licenses.gpl3Plus;
+      teams = [ lib.teams.minimal-bootstrap ];
+      platforms = lib.platforms.unix;
+      mainProgram = "gcc";
+    };
+  }
+  ''
+    # Unpack
+    tar xf ${src}
+    tar xf ${gmp}
+    tar xf ${mpfr}
+    tar xf ${mpc}
+    tar xf ${isl}
+    cd gcc-${version}
+
+    ln -s ../gmp-${gmpVersion} gmp
+    ln -s ../mpfr-${mpfrVersion} mpfr
+    ln -s ../mpc-${mpcVersion} mpc
+    ln -s ../isl-${islVersion} isl
+
+    # Configure
+    export CC="gcc -Wl,-dynamic-linker -Wl,${musl}/lib/libc.so"
+    export CXX="g++ -Wl,-dynamic-linker -Wl,${musl}/lib/libc.so"
+
+    bash ./configure \
+      --prefix=$out \
+      --build=${buildPlatform.config} \
+      --host=${hostPlatform.config} \
+      --with-native-system-header-dir=${glibc}/include \
+      --enable-languages=c,c++ \
+      --disable-bootstrap \
+      --disable-dependency-tracking \
+      --disable-libsanitizer \
+      --disable-lto \
+      --disable-multilib \
+      --disable-plugin \
+      --with-specs="%x{-dynamic-linker=${glibc}/lib/${linkerName}} %x{-L${glibc}/lib/} -B${glibc}/lib"
+
+    # Build
+    make -j $NIX_BUILD_CORES
+
+    # Install
+    make -j $NIX_BUILD_CORES install-strip
+  ''

--- a/pkgs/os-specific/linux/minimal-bootstrap/glibc/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/glibc/default.nix
@@ -108,5 +108,6 @@ bash.runCommand "${pname}-${version}"
 
     # Install
     make -j $NIX_BUILD_CORES INSTALL_UNCOMPRESSED=yes install
+    ln -s $(ls -d ${linux-headers}/include/* | grep -v scsi\$) $out/include/
     find $out/{bin,sbin,lib,libexec} -type f -exec strip --strip-unneeded {} + || true
   ''


### PR DESCRIPTION
In this PR, the minimal-bootstrap scope gets a version of GCC that is linked to musl, but which produces output code linked with glibc. This will eventually be useful for bootstrapping glibc-based stdenvs.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] i686-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
