### PR TITLE
gradle: handle missing release version in dependencies

### DIFF
--- a/pkgs/development/tools/build-managers/gradle/fetch-deps.nix
+++ b/pkgs/development/tools/build-managers/gradle/fetch-deps.nix
@@ -176,14 +176,14 @@ let
                   uniqueVersions' = map (x: x.version) uniqueVersionFiles;
                   releaseVersions = map (x: x.version) (builtins.filter (x: !x.isSnapshot) uniqueVersionFiles);
                   latestVer = v.latest or v.release or (lib.last uniqueVersions');
-                  releaseVer = v.release or (lib.last releaseVersions);
+                  releaseVer = v.release or (if releaseVersions != [ ] then lib.last releaseVersions else null);
 
                   # The very latest version isn't necessarily used by Gradle, so it may not be present in the MITM data.
                   # In order to generate better metadata xml, if the latest version is known but wasn't fetched by Gradle,
                   # add it anyway.
                   uniqueVersions =
                     uniqueVersions'
-                    ++ lib.optional (!builtins.elem releaseVer uniqueVersions') releaseVer
+                    ++ lib.optional (releaseVer != null && !builtins.elem releaseVer uniqueVersions') releaseVer
                     ++ lib.optional (!builtins.elem latestVer uniqueVersions' && releaseVer != latestVer) latestVer;
 
                   lastUpdated =
@@ -235,7 +235,7 @@ let
                   ''
                 else
                   assert !containsSpecialXmlChars latestVer;
-                  assert !containsSpecialXmlChars releaseVer;
+                  assert releaseVer == null || !containsSpecialXmlChars releaseVer;
                   ''
                     <?xml version="1.0" encoding="UTF-8"?>
                     <metadata modelVersion="1.1.0">
@@ -243,7 +243,7 @@ let
                       <artifactId>${artifactId}</artifactId>
                       <versioning>
                         <latest>${latestVer}</latest>
-                        <release>${releaseVer}</release>
+                    ${lib.optionalString (releaseVer != null) "    <release>${releaseVer}</release>"}
                         <versions>
                     ${builtins.concatStringsSep "\n" (map (x: "      <version>${x}</version>") uniqueVersions)}
                         </versions>


### PR DESCRIPTION
When a gradle package's `deps.json` has an entry that does not have a release version,
for example, this one:

```json
 "https://central.sonatype.com": {
  "repository/maven-snapshots/org/mongodb/bson/maven-metadata": {
   "xml": {
    "groupId": "org.mongodb",
    "lastUpdated": "20251211011041",
    "latest": "5.7.0-SNAPSHOT"
   }
  }
 },
```

... it fails to evaluate because of the attempt to call `lib.last` on an empty list:

https://github.com/NixOS/nixpkgs/blob/0fc6414b45da07a3f57a64f4ce6426b1fd015c1f/pkgs/development/tools/build-managers/gradle/fetch-deps.nix#L179-L179

To fix this, this PR sets `releaseVer` to `null` if there are no release versions and adds checks wherever `releaseVer` is used.

Tested on a package that I am currently working on upstreaming to nixpkgs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
