### PR TITLE
auto-patchelf: add --preserve-origin feature, add test

### DIFF
--- a/pkgs/test/auto-patchelf-hook-preserve-origin/default.nix
+++ b/pkgs/test/auto-patchelf-hook-preserve-origin/default.nix
@@ -1,0 +1,91 @@
+{
+  lib,
+  stdenv,
+  tests,
+  autoPatchelfHook,
+  patchelf,
+}:
+
+let
+  foo = tests.stdenv-inputs.foo;
+  bar = tests.stdenv-inputs.bar;
+
+  # similar to lib-check in stdenv-inputs, but we ship
+  # binary and libraries in the same output, and only
+  # $ORIGIN/../lib in RUNPATH.
+  lib-check = stdenv.mkDerivation {
+    name = "lib-check-bundle";
+
+    buildInputs = [
+      foo
+      bar
+    ];
+
+    nativeBuildInputs = [
+      patchelf
+    ];
+
+    buildCommand = ''
+      $CC -lfoo -lbar -Wl,-rpath,'$ORIGIN/../lib' -o lib-check ${./lib-main.c}
+
+      # Shrink RUNPATH to only keep the $ORIGIN/../lib one,
+      # dropping references to foo and bar store path.
+      patchelf --shrink-rpath --allowed-rpath-prefixes '$ORIGIN/../lib' lib-check
+
+
+      mkdir -p $out/lib $out/bin
+      cp ${lib.getDev foo}/lib/* ${lib.getDev bar}/lib/* $out/lib/
+      cp lib-check $out/bin/
+
+      # Make sure the binary still works
+      $out/bin/lib-check
+    '';
+
+    disallowedReferences = [
+      (lib.getDev foo)
+      (lib.getDev bar)
+    ];
+  };
+  # We treat `lib-check` as binaries and libraries coming from somewhere,
+  # and run `autoPatchelfHook` on them, but setting `--preserve-origin`.
+  # If we wouldn't,`autoPatchelfHook` would replace `RUNPATH` with a
+  # (self-)reference.
+  lib-check-autopatchelfed = stdenv.mkDerivation {
+    name = "lib-check-autopatchelfed";
+
+    nativeBuildInputs = [
+      autoPatchelfHook
+    ];
+
+    autoPatchelfFlags = [ "--preserve-origin" ];
+
+    dontUnpack = true;
+
+    # we don't set buildCommand because we want to ensure fixupPhase
+    # (containing autoPatchelfHook) is run.
+    installPhase = ''
+      mkdir -p $out
+      cp -R ${lib-check}/* $out
+    '';
+
+    # Should not refer to our source nor to itself.
+    disallowedReferences = [
+      lib-check
+      "out"
+    ];
+  };
+in
+stdenv.mkDerivation {
+  name = "auto-patchelf-hook-preserve-origin";
+
+  buildCommand = ''
+    # Ensure the binary still works
+    ${lib-check-autopatchelfed}/bin/lib-check
+    touch $out
+  '';
+
+  meta.platforms = lib.platforms.all;
+  passthru = {
+    inherit lib-check lib-check-autopatchelfed;
+  };
+}

--- a/pkgs/test/auto-patchelf-hook-preserve-origin/lib-main.c
+++ b/pkgs/test/auto-patchelf-hook-preserve-origin/lib-main.c
@@ -1,0 +1,14 @@
+#include <stdio.h>
+
+extern unsigned int foo(void);
+extern unsigned int bar(void);
+
+int main(int argc, char **argv)
+{
+  if (foo() != 42)
+    return 1;
+  if (bar() != 42)
+    return 1;
+  fprintf(stderr, "ok\n");
+  return 0;
+}

--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -225,6 +225,8 @@ in
 
   auto-patchelf-hook = callPackage ./auto-patchelf-hook { };
 
+  auto-patchelf-hook-preserve-origin = callPackage ./auto-patchelf-hook-preserve-origin { };
+
   # Accumulate all passthru.tests from arrayUtilities into a single attribute set.
   arrayUtilities = recurseIntoAttrs (
     concatMapAttrs (

--- a/pkgs/test/stdenv-inputs/default.nix
+++ b/pkgs/test/stdenv-inputs/default.nix
@@ -70,4 +70,7 @@ stdenv.mkDerivation {
   '';
 
   meta.platforms = lib.platforms.all;
+  passthru = {
+    inherit foo bar;
+  };
 }


### PR DESCRIPTION
This teaches `auto-patchelf` a `--preserve-origin` feature, which will preserve `$ORIGIN` `RUNPATH` entries if they resolve.
The feature is not enabled by default, but can be by setting `autoPatchelfFlags = [ "--preserve-origin" ];`.

I also added a test to `tests.auto-patchelf-hook-preserve-origin`.

In some cases, it can reduce the amount of self-references.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
