### PR TITLE
gomuks-web: 0.2025.11-unstable-2025-11-01 -> 0.2601.0

### DIFF
--- a/pkgs/by-name/go/gomuks-web/package.nix
+++ b/pkgs/by-name/go/gomuks-web/package.nix
@@ -11,17 +11,15 @@
 buildGoModule (
   finalAttrs:
   let
-    ver = "0.2025.11";
-    revDate = "2025-11-01";
-    rev = "be0d4487871c196d0c47bb1b6ac7ce9252d424de";
-    srcHash = "sha256-x7M7d8obnt8mpH1ZRev8c39PE5ZlgssgusGvrLaF/vg=";
-    vendorHash = "sha256-TDvTZ0n324pNPAPMZMhWq0LdDUqFrzBXNVNdfMlxqeQ=";
-    npmDepsHash = "sha256-4Ir4uq9Hg6Hwj21P/H7xWdVPzYrDrXiouEtjnLJj4Ko=";
+    rev = "9de4eb7fe537b6a8c40977ea99b7e9a5816d62f4";
+    srcHash = "sha256-CC4CNizoi91dfyoNsaIqxAuBB62j8JB076QEIpncky0=";
+    vendorHash = "sha256-opx/NlWgLk1rUHbLJ6Vp2dMLheBdOtL+NgCmWE89H9g=";
+    npmDepsHash = "sha256-mYeT07XfdAFYjwD4EfLRAgCZY0S8zj68p8UNGBpcpmQ=";
 
   in
   {
     pname = "gomuks-web";
-    version = "${ver}-unstable-${revDate}";
+    version = "0.2512.0";
 
     inherit vendorHash;
 
@@ -47,7 +45,7 @@ buildGoModule (
 
     postPatch = ''
       substituteInPlace ./web/build-wasm.sh \
-        --replace-fail 'go.mau.fi/gomuks/version.Tag=$(git describe --exact-match --tags 2>/dev/null)' "go.mau.fi/gomuks/version.Tag=v${ver}" \
+        --replace-fail 'go.mau.fi/gomuks/version.Tag=$(git describe --exact-match --tags 2>/dev/null)' "go.mau.fi/gomuks/version.Tag=v${finalAttrs.version}" \
         --replace-fail 'go.mau.fi/gomuks/version.Commit=$(git rev-parse HEAD)' "go.mau.fi/gomuks/version.Commit=${rev}"
     '';
 
@@ -56,7 +54,7 @@ buildGoModule (
     tags = [ "goolm" ];
 
     ldflags = [
-      "-X 'go.mau.fi/gomuks/version.Tag=v${ver}'"
+      "-X 'go.mau.fi/gomuks/version.Tag=v${finalAttrs.version}'"
       "-X 'go.mau.fi/gomuks/version.Commit=${rev}'"
       "-X \"go.mau.fi/gomuks/version.BuildTime=$(date -Iseconds)\""
       "-X \"maunium.net/go/mautrix.GoModVersion=$(cat go.mod | grep 'maunium.net/go/mautrix ' | head -n1 | awk '{ print $2 })\""

--- a/pkgs/by-name/go/gomuks-web/package.nix
+++ b/pkgs/by-name/go/gomuks-web/package.nix
@@ -11,15 +11,15 @@
 buildGoModule (
   finalAttrs:
   let
-    rev = "9de4eb7fe537b6a8c40977ea99b7e9a5816d62f4";
-    srcHash = "sha256-CC4CNizoi91dfyoNsaIqxAuBB62j8JB076QEIpncky0=";
+    rev = "82abf26775d59c642fa7ea5274cf8631cd6942c6";
+    srcHash = "sha256-CC4CNizoi91dfyoNsaIqxAuBB62j8JB076QEIpncky1=";
     vendorHash = "sha256-opx/NlWgLk1rUHbLJ6Vp2dMLheBdOtL+NgCmWE89H9g=";
     npmDepsHash = "sha256-mYeT07XfdAFYjwD4EfLRAgCZY0S8zj68p8UNGBpcpmQ=";
 
   in
   {
     pname = "gomuks-web";
-    version = "0.2512.0";
+    version = "0.2601.0";
 
     inherit vendorHash;
 


### PR DESCRIPTION
Update gomuks-web to new release: ~~[v0.2512.0](https://github.com/gomuks/gomuks/releases/tag/v0.2512.0)~~ [v0.2601.0](https://github.com/gomuks/gomuks/releases/tag/v0.2601.0)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
