### PR TITLE
nixos/websurfx: init module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1757,6 +1757,7 @@
   ./services/web-apps/vikunja.nix
   ./services/web-apps/wakapi.nix
   ./services/web-apps/weblate.nix
+  ./services/web-apps/websurfx.nix
   ./services/web-apps/whitebophir.nix
   ./services/web-apps/whoami.nix
   ./services/web-apps/wiki-js.nix

--- a/nixos/modules/services/web-apps/websurfx.nix
+++ b/nixos/modules/services/web-apps/websurfx.nix
@@ -1,0 +1,115 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.websurfx;
+  settingsFormat = pkgs.formats.lua { asBindings = true; };
+  settingsFile = settingsFormat.generate "config.lua" cfg.settings;
+in
+{
+  options = {
+    services.websurfx = {
+      enable = lib.mkEnableOption "Websurfx, a metasearch engine";
+      package = lib.mkPackageOption pkgs "websurfx" { };
+      openFirewall = lib.mkEnableOption "Whether to open the used port in the firewall";
+      settings = lib.mkOption {
+        type = lib.types.submodule {
+          freeformType = settingsFormat.type;
+
+          options.binding_ip = lib.mkOption {
+            type = lib.types.str;
+            default = "127.0.0.1";
+            description = "IP address on which the server should be launched";
+          };
+          options.port = lib.mkOption {
+            type = lib.types.port;
+            default = 4567;
+            description = "Port on which the server should be launched";
+          };
+        };
+        default = { };
+        description = ''
+          Configuration options for Websurfx, see
+          [websurfx/config.lua](https://github.com/neon-mmd/websurfx/blob/rolling/websurfx/config.lua)
+          for supported values.
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    services.websurfx.settings = {
+      # General
+      logging = lib.mkDefault true;
+      debug = lib.mkDefault false;
+      threads = lib.mkDefault 10;
+
+      # Server
+      production_use = lib.mkDefault false;
+      request_timeout = lib.mkDefault 30;
+      tcp_connection_keep_alive = lib.mkDefault 30;
+      pool_idle_connection_timeout = lib.mkDefault 30;
+      rate_limiter = {
+        number_of_requests = lib.mkDefault 20;
+        time_limit = lib.mkDefault 3;
+      };
+      https_adaptive_window_size = lib.mkDefault true;
+
+      operating_system_tls_certificates = lib.mkDefault true;
+
+      number_of_https_connections = lib.mkDefault 10;
+      client_connection_keep_alive = lib.mkDefault 120;
+
+      # Search
+      safe_search = lib.mkDefault 2;
+
+      # Website
+      colorscheme = lib.mkDefault "catppuccin-mocha";
+      theme = lib.mkDefault "simple";
+      animation = lib.mkDefault "simple-frosted-glow";
+
+      # Caching
+      #redis_url = "redis://127.0.0.1:8082"; # The nixpkgs build doesn't have the redis-cache feature enabled
+      cache_expiry_time = lib.mkDefault 600;
+
+      # Search Engines
+      upstream_search_engines = {
+        DuckDuckGo = lib.mkDefault true;
+        Searx = lib.mkDefault false;
+        Brave = lib.mkDefault false;
+        Startpage = lib.mkDefault false;
+        LibreX = lib.mkDefault false;
+        Mojeek = lib.mkDefault false;
+        Bing = lib.mkDefault false;
+        Wikipedia = lib.mkDefault true;
+        Yahoo = lib.mkDefault false;
+      };
+
+      proxy = lib.mkDefault null;
+    };
+
+    networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewall [ cfg.settings.port ];
+
+    systemd.services.websurfx = {
+      description = "Websurfx, a metasearch engine";
+
+      serviceConfig = {
+        ExecStart = lib.getExe cfg.package;
+        DynamicUser = true;
+        RuntimeDirectory = "websurfx";
+        Environment = [ "HOME=%t/websurfx" ];
+        BindReadOnlyPaths = [ "${settingsFile}:%t/websurfx/.config/websurfx/config.lua" ];
+      };
+
+      wants = [ "network-online.target" ];
+      after = [ "network-online.target" ];
+      wantedBy = [ "multi-user.target" ];
+    };
+  };
+
+  meta.maintainers = [ lib.maintainers.SchweGELBin ];
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Hello, I've created a module for the websurfx package.
You can enable the website, the redis server and configure the settings.

There are two problems with this module, so I'll keep it in draft for now and hope that someone can help me.
1. The default configuration is hardcoded here and it would be better to import it somehow from the package.
2. The service uses the configuration from the package instead of the one that the module creates, but from my understanding, the nix package only modifies the second vector entry in [this file](https://github.com/neon-mmd/websurfx/blob/v1.24.27/src/handler.rs) and the first entry should be preferred.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
