### PR TITLE
mochi: 1.18.11 -> 1.20.5

### DIFF
--- a/pkgs/by-name/mo/mochi/package.nix
+++ b/pkgs/by-name/mo/mochi/package.nix
@@ -2,7 +2,6 @@
   _7zz,
   appimageTools,
   fetchurl,
-  fetchzip,
   lib,
   stdenvNoCC,
   xorg,
@@ -10,14 +9,16 @@
 
 let
   pname = "mochi";
-  version = "1.18.11";
+  version = "1.20.5";
+
+  appName = "Mochi";
 
   linux = appimageTools.wrapType2 rec {
     inherit pname version meta;
 
     src = fetchurl {
-      url = "https://mochi.cards/releases/Mochi-${version}.AppImage";
-      hash = "sha256-NQ591KtWQz8hlXPhV83JEwGm+Au26PIop5KVzsyZKp4=";
+      url = "https://download.mochi.cards/releases/Mochi-${version}.AppImage";
+      hash = "sha256-QOJ1bigmoUm+CEW5gKB73arCTF4yG8RWsJ22NHv8YCo=";
     };
 
     appimageContents = appimageTools.extractType2 { inherit pname version src; };
@@ -33,29 +34,40 @@ let
   };
 
   darwin = stdenvNoCC.mkDerivation {
-    inherit pname version meta;
+    inherit
+      pname
+      version
+      meta
+      appName
+      ;
 
-    src = fetchzip {
-      url = "https://mochi.cards/releases/Mochi-${version}.dmg";
-      hash = "sha256-5RM4eqHQoYfO5JiUH9ol+3XxOk4VX4ocE3Yia82sovI=";
-      stripRoot = false;
-      nativeBuildInputs = [ _7zz ];
+    src = fetchurl {
+      url = "https://download.mochi.cards/releases/Mochi-${version}.dmg";
+      hash = "sha256-+fhsjr6Ek0wzZLHFi3oJEZxXhCliEjO+5/5HN4ehw1w=";
     };
+
+    sourceRoot = "${appName}.app";
+    nativeBuildInputs = [ _7zz ];
 
     installPhase = ''
       runHook preInstall
 
-      mkdir -p $out/Applications
-      cp -r *.app $out/Applications
+      mkdir -p $out/Applications/Mochi.app
+      cp -r . $out/Applications/Mochi.app
 
       runHook postInstall
     '';
+
+    dontUpdateAutotoolsGnuConfigScripts = true;
+    dontConfigure = true;
+    dontFixup = true;
   };
 
   meta = {
     description = "Simple markdown-powered SRS app";
     homepage = "https://mochi.cards/";
-    changelog = "https://mochi.cards/changelog.html";
+    changelog = "https://mochi.cards/changelog";
+    mainProgram = "mochi";
     license = lib.licenses.unfree;
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     maintainers = with lib.maintainers; [ poopsicles ];


### PR DESCRIPTION
Summary:
- bump `mochi` version from 1.18.11 to 1.20.5
- fix the `url` for `fetchurl`, the old URL 404s for any release, incl. the currently set version.

Changelogs:
- [`1.18.12`](https://mochi.cards/changelog/#1.18.12)
- [`1.18.13`](https://mochi.cards/changelog/#1.18.13)
- [`1.19.1`](https://mochi.cards/changelog/#1.19.1)
- [`1.19.2`](https://mochi.cards/changelog/#1.19.2)
- [`1.19.3`](https://mochi.cards/changelog/#1.19.3)
- [`1.19.4`](https://mochi.cards/changelog/#1.19.4)
- [`1.19.5`](https://mochi.cards/changelog/#1.19.5)
- [`1.19.6`](https://mochi.cards/changelog/#1.19.6)
- [`1.19.7`](https://mochi.cards/changelog/#1.19.7)
- [`1.20.5`](https://mochi.cards/changelog/#1.20.5) (*for some reason, there's no changelog entries between `1.19.7` and `1.20.5`*)
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] ~~aarch64-linux~~
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] ~~[NixOS tests] in [nixos/tests].~~
  - [ ] ~~[Package tests] at `passthru.tests`.~~
  - [ ] ~~Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.~~
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs. (*as far as I can tell?*)

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
