### PR TITLE
libparse-python: init at 0-unstable-2025-12-15

### DIFF
--- a/pkgs/development/python-modules/libparse-python/package.nix
+++ b/pkgs/development/python-modules/libparse-python/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytestCheckHook,
+  setuptools,
+  pybind11,
+}:
+
+buildPythonPackage {
+  pname = "libparse-python";
+  version = "0-unstable-2025-08-30";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "librelane";
+    repo = "libparse-python";
+    rev = "ff5b26da3d66affb60696fd6c4af7f8726729c8c";
+    fetchSubmodules = true;
+    hash = "sha256-H2UHh5RbxJ65yTbLybCEanl5qA4o0e/0rAQKmIhvXeQ=";
+  };
+
+  postPatch = ''
+    substituteInPlace yosys/passes/techmap/libparse.cc \
+        --replace-fail \
+          "void LibertyParser::error" \
+          "__attribute__((weak)) void LibertyParser::error"
+  '';
+
+  build-system = [
+    pybind11
+    setuptools
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "libparse" ];
+
+  meta = {
+    description = "Python library for parsing Yosys output";
+    homepage = "https://github.com/librelane/libparse-python";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ gonsolo ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8520,6 +8520,8 @@ self: super: with self; {
     }
   );
 
+  libparse-python = callPackage ../development/python-modules/libparse-python/package.nix { };
+
   libpass = callPackage ../development/python-modules/libpass { };
 
   libpcap = callPackage ../development/python-modules/libpcap {


### PR DESCRIPTION
A SWIG-based Python wrapper around [Yosys](https://github.com/yosyshq/yosys)'s libparse, for all your dotlib file parsing needs.
https://github.com/librelane/libparse-python

This is a prerequisite for librelane, coming later.

~It depends on https://github.com/NixOS/nixpkgs/pull/471062.~

- Built on platform:
  - [x ] x86_64-linux