### PR TITLE
pretix.plugins.oidc: init at 2.3.1

### DIFF
--- a/pkgs/by-name/pr/pretix/package.nix
+++ b/pkgs/by-name/pr/pretix/package.nix
@@ -156,6 +156,7 @@ python.pkgs.buildPythonApplication rec {
       cryptography
       css-inline
       defusedcsv
+      dictlib
       django
       django-bootstrap3
       django-compressor

--- a/pkgs/by-name/pr/pretix/plugins/oidc/package.nix
+++ b/pkgs/by-name/pr/pretix/plugins/oidc/package.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  pretix-plugin-build,
+  setuptools,
+
+  # dependencies
+  dictlib,
+  oic,
+
+  # tests
+  django-scopes,
+  pretix,
+  pytest-django,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "pretix-oidc";
+  version = "2.3.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "thegcat";
+    repo = "pretix-oidc";
+    tag = "v${version}";
+    hash = "sha256-qG2N9KGizAe8C1hQV1kgLAPhg64PgVNtiazeeOlPzCI=";
+  };
+
+  build-system = [
+    pretix-plugin-build
+    setuptools
+  ];
+
+  dependencies = [
+    "dictlib"
+    "oic"
+  ];
+
+  pythonImportsCheck = [
+    "pretix_oidc"
+  ];
+
+  nativeCheckInputs = [
+    django-scopes
+    pretix
+    pytest-django
+    pytestCheckHook
+  ];
+
+  preCheck = ''
+    export DJANGO_SETTINGS_MODULE=pretix.testutils.settings
+  '';
+
+  meta = {
+    description = "OIDC authentication plugin for Pretix";
+    homepage = "https://github.com/thegcat/pretix-oidc";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ bbenno ];
+  };
+}

--- a/pkgs/development/python-modules/dictlib/default.nix
+++ b/pkgs/development/python-modules/dictlib/default.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+}:
+
+buildPythonPackage {
+  pname = "dictlib";
+  version = "1.1.5";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "srevenant";
+    repo = "dictlib";
+    # The project does not provide versioned Git tags.
+    # This commit sets the package version to 1.1.5 and was the latest commit at the time of packaging (2025).
+    rev = "f8b073cca2a4e5ac955c6818961a4e5146a5eb1e";
+    hash = "sha256-iYnCtjccZyDZOKW4VKouKLMH93/lpuVp7GwNQLFpkBc=";
+  };
+
+  build-system = [ setuptools ];
+
+  doCheck = true;
+
+  meta = {
+    description = "Lightweight add-on for dictionaries";
+    homepage = "https://github.com/srevenant/dictlib";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ bbenno ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3811,6 +3811,8 @@ self: super: with self; {
 
   dictionaries = callPackage ../development/python-modules/dictionaries { };
 
+  dictlib = callPackage ../development/python-modules/dictlib { };
+
   dicttoxml = callPackage ../development/python-modules/dicttoxml { };
 
   dicttoxml2 = callPackage ../development/python-modules/dicttoxml2 { };


### PR DESCRIPTION
This pull request introduces the pretix [OpenID Connect authentication plugin](https://github.com/thegcat/pretix-oidc) together with the Python package **dictlib**, which is required as a runtime dependency of the plugin.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
