### PR TITLE
google-sans-flex: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10348,6 +10348,12 @@
     githubId = 13461702;
     name = "Heitor Pascoal de Bittencourt";
   };
+  heizu = {
+    email = "heizunix@gmail.com";
+    github = "he1zu";
+    githubId = 248294479;
+    name = "heizu";
+  };
   hekazu = {
     name = "Henri Peurasaari";
     email = "henri.peurasaari@helsinki.fi";

--- a/pkgs/by-name/go/google-sans-flex/package.nix
+++ b/pkgs/by-name/go/google-sans-flex/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "google-sans-flex";
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "he1zu";
+    repo = "google-sans-flex";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-r0OpOnxuYnC0ttYuzuFDobfpnkSb0dlFqvFrqKXdHTM=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 *.ttf -t $out/share/fonts/truetype
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Google Sans Flex variable font";
+    homepage = "https://fonts.google.com/specimen/Google+Sans+Flex";
+    license = lib.licenses.ofl;
+    maintainers = with lib.maintainers; [ heizu ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
Add Google Sans Flex font

Google Sans Flex is a variable font released by Google under the SIL Open Font License 1.1

This is my first contribution!


## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

