### PR TITLE
fira-go: fix fetchzip usage

### DIFF
--- a/pkgs/by-name/fi/fira-go/package.nix
+++ b/pkgs/by-name/fi/fira-go/package.nix
@@ -13,6 +13,7 @@ stdenvNoCC.mkDerivation rec {
       lib.replaceStrings [ "." ] [ "" ] version
     }.zip";
     hash = "sha256-+lw4dh7G/Xv3pzGXdMUl9xNc2Nk7wUOAh+lq3K1LrXs=";
+    stripRoot = false;
   };
 
   installPhase = ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

fira-go was no longer building and reporting an error `error: zip file must contain a single file or directory.`

```
 nix-build -A fira-go
warning: Nix search path entry '/nix/var/nix/profiles/per-user/root/channels' does not exist, ignoring
these 2 derivations will be built:
  /nix/store/l3pxrb5s80j6bqsy8l8lnhw35gypqzlk-source.drv
  /nix/store/hnq4ajqnf37njz4lgslcdd0zc13mhnyc-fira-go-1.001.drv
building '/nix/store/l3pxrb5s80j6bqsy8l8lnhw35gypqzlk-source.drv'...
structuredAttrs is enabled

trying https://carrois.com/downloads/FiraGO/Download_Folder_FiraGO_1001.zip
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 52116k 100 52116k   0     0  7698k     0   0:00:06  0:00:06 --:--:-- 10850k
unpacking source archive /nix/var/nix/builds/nix-83461-703751278/Download_Folder_FiraGO_1001.zip
error: zip file must contain a single file or directory.
hint: Pass stripRoot=false; to fetchzip to assume flat list of files.
error: Cannot build '/nix/store/l3pxrb5s80j6bqsy8l8lnhw35gypqzlk-source.drv'.
       Reason: builder failed with exit code 1.
       Output paths:
         /nix/store/9kkm8gwpx57jxmia5ans27yzxb9yyb6d-source
       Last 9 log lines:
       > structuredAttrs is enabled
       >
       > trying https://carrois.com/downloads/FiraGO/Download_Folder_FiraGO_1001.zip
       >   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
       >                                  Dload  Upload   Total   Spent    Left  Speed
       > 100 52116k 100 52116k   0     0  7698k     0   0:00:06  0:00:06 --:--:-- 10850k
       > unpacking source archive /nix/var/nix/builds/nix-83461-703751278/Download_Folder_FiraGO_1001.zip
       > error: zip file must contain a single file or directory.
       > hint: Pass stripRoot=false; to fetchzip to assume flat list of files.
       For full logs, run:
         nix log /nix/store/l3pxrb5s80j6bqsy8l8lnhw35gypqzlk-source.drv
error: Cannot build '/nix/store/hnq4ajqnf37njz4lgslcdd0zc13mhnyc-fira-go-1.001.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/rscr9skqvx0smf64jybmcrc3zzzvxxf1-fira-go-1.001
```

This adds the stripRoot=false option.  

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
