### PR TITLE
way-edges: init at 0.11.1

### DIFF
--- a/pkgs/by-name/wa/way-edges/package.nix
+++ b/pkgs/by-name/wa/way-edges/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  pkg-config,
+  libxkbcommon,
+  libpulseaudio,
+  cairo,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "way-edges";
+  version = "0.11.1";
+
+  src = fetchFromGitHub {
+    owner = "way-edges";
+    repo = "way-edges";
+    tag = finalAttrs.version;
+    hash = "sha256-1P4iOsoQolxfVGZEe+x0DvcDwB5bdBqR0OsfL+y3qQM=";
+  };
+  cargoHash = "sha256-RSCBQUZp6mxZcwsvr6OwQeXa5CmEhN8QUezv0By5j/s=";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+  buildInputs = [
+    cairo
+    libxkbcommon
+    libpulseaudio
+  ];
+
+  RUSTFLAGS = [
+    "--cfg tokio_unstable"
+    "--cfg tokio_uring"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Wayland client focusing on widgets hidden in your screen edge";
+    homepage = "https://github.com/way-edges/way-edges";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ denperidge ];
+    mainProgram = "way-edges";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Want some wayland widgets that hide in the edges of your screen? Here you go!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
