### PR TITLE
[25.11] nixos/facter: fix collectDrivers returning nested lists

### DIFF
--- a/nixos/modules/hardware/facter/lib.nix
+++ b/nixos/modules/hardware/facter/lib.nix
@@ -28,7 +28,7 @@ let
     ) cpus;
 
   # Extract all driver_modules from a list of hardware entries
-  collectDrivers = list: lib.catAttrs "driver_modules" list;
+  collectDrivers = list: lib.foldl' (lst: value: lst ++ value.driver_modules or [ ]) [ ] list;
 
   # Convert number to zero-padded 4-digit hex string (for USB device IDs)
   toZeroPaddedHex =

--- a/nixos/tests/facter/facter.json
+++ b/nixos/tests/facter/facter.json
@@ -14,6 +14,18 @@
         "model": 33
       }
     ],
+    "graphics_card": [
+      {
+        "driver_modules": [
+          "i915"
+        ]
+      }
+    ],
+    "monitor": [
+      {
+        "model": "Test Monitor"
+      }
+    ],
     "system": {
       "form_factor": "desktop"
     }


### PR DESCRIPTION
The collectDrivers function was using lib.catAttrs which extracts attribute values into a list. Since driver_modules is already a list, this resulted in nested lists like [["i915"]] instead of ["i915"], causing boot.initrd.kernelModules to fail with:

  error: expected a string but found a list: [ "i915" ]

Restore the original foldl' implementation from nixos-facter-modules that properly concatenates driver_modules lists into a flat result.

Add graphics_card and monitor entries to test data to catch this regression.

Fixes: https://github.com/NixOS/nixpkgs/pull/466808#issuecomment-2749380083 (cherry picked from commit f1498c9c56f02c697a962180e9a5ad0249962ce0)

Fixes: https://github.com/NixOS/nixpkgs/issues/468710


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
