### PR TITLE
dragonfly-reverb: cleanup; add build options; disable vst2; add mrtnvgr to maintainers

### DIFF
--- a/pkgs/by-name/dr/dragonfly-reverb/package.nix
+++ b/pkgs/by-name/dr/dragonfly-reverb/package.nix
@@ -9,9 +9,9 @@
 
   buildStandalone ? true,
   buildVST3 ? true,
-  buildVST2 ? true,
   buildLV2 ? true,
   buildCLAP ? true,
+  buildVST2 ? false, # can't distribute
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -31,9 +31,9 @@ stdenv.mkDerivation (finalAttrs: {
       targets = lib.concatStringsSep " " [
         (lib.optionalString buildStandalone "jack")
         (lib.optionalString buildVST3 "vst3")
-        (lib.optionalString buildVST2 "vst2")
         (lib.optionalString buildLV2 "lv2_sep")
         (lib.optionalString buildCLAP "clap")
+        (lib.optionalString buildVST2 "vst2")
       ];
     in
     ''
@@ -75,16 +75,16 @@ stdenv.mkDerivation (finalAttrs: {
           cp -r $bin.vst3 $out/lib/vst3
         ''}
 
-        ${lib.optionalString buildVST2 ''
-          install -Dm755 $bin-vst.so -t $out/lib/vst
-        ''}
-
         ${lib.optionalString buildLV2 ''
           cp -r $bin.lv2 $out/lib/lv2
         ''}
 
         ${lib.optionalString buildCLAP ''
           cp -r $bin.clap $out/lib/clap
+        ''}
+
+        ${lib.optionalString buildVST2 ''
+          install -Dm755 $bin-vst.so -t $out/lib/vst
         ''}
       done
     popd

--- a/pkgs/by-name/dr/dragonfly-reverb/package.nix
+++ b/pkgs/by-name/dr/dragonfly-reverb/package.nix
@@ -8,14 +8,14 @@
   libx11,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "dragonfly-reverb";
   version = "3.2.10";
 
   src = fetchFromGitHub {
     owner = "michaelwillis";
     repo = "dragonfly-reverb";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-YXJ4U5J8Za+DlXvp6QduvCHIVC2eRJ3+I/KPihCaIoY=";
     fetchSubmodules = true;
   };
@@ -54,6 +54,7 @@ stdenv.mkDerivation rec {
     description = "Hall-style reverb based on freeverb3 algorithms";
     maintainers = [ lib.maintainers.magnetophon ];
     license = lib.licenses.gpl3Plus;
-    platforms = [ "x86_64-linux" ];
+    platforms = lib.platforms.linux;
+    badPlatforms = [ lib.systems.inspect.patterns.isAarch ];
   };
-}
+})

--- a/pkgs/by-name/dr/dragonfly-reverb/package.nix
+++ b/pkgs/by-name/dr/dragonfly-reverb/package.nix
@@ -95,7 +95,10 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     homepage = "https://github.com/michaelwillis/dragonfly-reverb";
     description = "Hall-style reverb based on freeverb3 algorithms";
-    maintainers = [ lib.maintainers.magnetophon ];
+    maintainers = with lib.maintainers; [
+      magnetophon
+      mrtnvgr
+    ];
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.linux;
     badPlatforms = [ lib.systems.inspect.patterns.isAarch ];


### PR DESCRIPTION
This PR makes several changes to the dragonfly-reverb package, see individual commits :)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
