### PR TITLE
python313Packages.streamlit-kpi-card: init at 0.1.2

### DIFF
--- a/pkgs/development/python-modules/streamlit-kpi-card/default.nix
+++ b/pkgs/development/python-modules/streamlit-kpi-card/default.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  pandas,
+  streamlit,
+}:
+
+buildPythonPackage rec {
+  pname = "streamlit-kpi-card";
+  version = "0.1.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "pjoachims";
+    repo = "streamlit-kpi-card";
+    tag = version;
+    hash = "sha256-w2hUEad6sMFq/KbYnNX7E/vOkIqsLwJZmzdgQTSVMm4=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "setuptools>=45,<70" "setuptools"
+  '';
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    pandas
+    streamlit
+  ];
+
+  pythonImportsCheck = [ "streamlit_kpi_card" ];
+
+  # Module has no tests
+  doCheck = false;
+
+  meta = {
+    description = "KPI cards for Streamlit";
+    homepage = "https://github.com/pjoachims/streamlit-kpi-card";
+    changelog = "https://github.com/pjoachims/streamlit-kpi-card/releases/tag/${src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18182,6 +18182,8 @@ self: super: with self; {
 
   streamlit-folium = callPackage ../development/python-modules/streamlit-folium { };
 
+  streamlit-kpi-card = callPackage ../development/python-modules/streamlit-kpi-card { };
+
   streamlit-notify = callPackage ../development/python-modules/streamlit-notify { };
 
   streamz = callPackage ../development/python-modules/streamz { };


### PR DESCRIPTION
KPI cards for Streamlit

https://github.com/pjoachims/streamlit-kpi-card


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
