### PR TITLE
aspell: stop using `or` identifier unquoted

### DIFF
--- a/pkgs/development/libraries/aspell/dictionaries.nix
+++ b/pkgs/development/libraries/aspell/dictionaries.nix
@@ -811,7 +811,7 @@ rec {
     meta.license = lib.licenses.gpl2Only;
   };
 
-  or = buildOfficialDict {
+  "or" = buildOfficialDict {
     language = "or";
     version = "0.03-1";
     fullName = "Oriya";


### PR DESCRIPTION
This is to be deprecated in Lix:
https://gerrit.lix.systems/c/lix/+/4764/6

The Oriya language is spoken by about 37 million people in India according to Wikipedia, but I am guessing the dictionary is not actually used that often by nixpkgs users. Either way quoting it in nixpkgs is totally non-breaking for users of nixpkgs.
