### PR TITLE
atuin-desktop: 0.2.5 -> 0.2.11

### DIFF
--- a/pkgs/by-name/at/atuin-desktop/package.nix
+++ b/pkgs/by-name/at/atuin-desktop/package.nix
@@ -19,22 +19,23 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "atuin-desktop";
-  version = "0.2.5";
+  # TODO When updating the version, check if the version-mismatch workaround in preBuild is still needed
+  version = "0.2.11";
 
   src = fetchFromGitHub {
     owner = "atuinsh";
     repo = "desktop";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-VDIC1BGgaFTiTnydJdEhVeUgVrH43MzpF4VkfgQ+Nas=";
+    hash = "sha256-tVIT3GUJ1qcv6HSvO+nqAz+VMfd8g9AjgaqE6+GSa+I=";
   };
 
   cargoRoot = "./.";
-  cargoHash = "sha256-gYYmtxMWst0ZB/YzJf/0FGOedoVpMgTq5qq+3m2R7T8=";
+  cargoHash = "sha256-T3cPvwph71lpqlGcugAO4Ua8Y5TNZSySbQatxcvoT4E=";
 
   pnpmDeps = pnpm.fetchDeps {
     inherit (finalAttrs) pname version src;
     fetcherVersion = 2;
-    hash = "sha256-Tdcdghhc4cH+cYIeUy3inChgPfb1i9E7F1mpxxWoW4Q=";
+    hash = "sha256-XqKGAx2Q9cWO1oG4mP1cKM2Y9Pib5haFYEaq0PAfAdQ=";
   };
 
   nativeBuildInputs = [
@@ -68,6 +69,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
     tauriBuildFlags+=(
       "--config"
       "$tauriConfPath"
+      # Skips the version mismatch check (and accepts the consequences)
+      # ref: https://github.com/atuinsh/desktop/issues/313
+      "--ignore-version-mismatches"
     )
   '';
 


### PR DESCRIPTION
Currently this package is failing on master:

https://hydra.nixos.org/build/315639993

This PR aims to repair this package. What i've done:
- Bump the version to 0.2.11
- Also removing the cargo-tauri dependency, because this project does not build with the newest tauri, and should be using the older tauri binary downloaded by pnpm instead

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
