### PR TITLE
ghw: init at 0.21.2

### DIFF
--- a/pkgs/by-name/gh/ghw/package.nix
+++ b/pkgs/by-name/gh/ghw/package.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+buildGoModule (finalAttrs: {
+  pname = "ghw";
+  version = "0.21.2";
+
+  src = fetchFromGitHub {
+    owner = "jaypipes";
+    repo = "ghw";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-WZGEhrgHmJ/4puvDPYLq3iU+Ddf1PnptRj0ehcDbjZQ=";
+  };
+  vendorHash = "sha256-lItNgi65HQASNQufUdhvEoNtrltkW+0hBHUlFZjfneE=";
+
+  subPackages = [ "cmd/..." ];
+  doCheck = false; # wants to read from /sys and other places not allowed
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Go HardWare discovery/inspection library";
+    mainProgram = "ghwc";
+    homepage = "https://github.com/jaypipes/ghw";
+    maintainers = [ lib.maintainers.mmlb ];
+    license = lib.licenses.asl20;
+  };
+})


### PR DESCRIPTION
Add new package [ghw@v0.21.2](https://github.com/jaypipes/ghw) (`Go HardWare discovery/inspection library`)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
