### PR TITLE
filebrowser-quantum: init at 1.1.0-stable

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12556,6 +12556,12 @@
     githubId = 3967312;
     name = "Jocelyn Thode";
   };
+  jocimsus = {
+    email = "joe.susatiyo@gmail.com";
+    github = "JocimSus";
+    githubId = 123136424;
+    name = "Joachim Susatiyo";
+  };
   joedevivo = {
     github = "joedevivo";
     githubId = 55951;

--- a/pkgs/by-name/fi/filebrowser-quantum/package.nix
+++ b/pkgs/by-name/fi/filebrowser-quantum/package.nix
@@ -1,0 +1,79 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildGoModule,
+  buildNpmPackage,
+}:
+
+let
+  version = "1.1.0-stable";
+
+  src = fetchFromGitHub {
+    owner = "gtsteffaniak";
+    repo = "filebrowser";
+    tag = "v${version}";
+    hash = "sha256-S3MtqIqmFYDY053HX8yYGxHc6ev0Y8eXbe24TL8PtYQ=";
+  };
+
+  frontend = buildNpmPackage {
+    pname = "filebrowser-quantum-frontend";
+    inherit version src;
+
+    sourceRoot = "${src.name}/frontend";
+    npmDepsHash = "sha256-pJR5m1XrqeHwOADWMnFDtHivaKCBqqdG2O6fWql7ugA=";
+
+    buildPhase = ''
+      runHook preBuild
+
+      npm run build:docker
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out
+      cp -r dist/* $out
+
+      runHook postInstall
+    '';
+  };
+
+in
+buildGoModule {
+  pname = "filebrowser-quantum";
+  inherit version src;
+
+  sourceRoot = "${src.name}/backend";
+
+  vendorHash = "sha256-t4cREfkj+z+EvgXjzqYc8xs0jhTMUZMjcHxkkuuLpZs=";
+
+  preBuild = ''
+    mkdir -p http/embed
+    cp -r ${frontend}/* http/embed/
+  '';
+
+  postInstall = ''
+    mv $out/bin/backend $out/bin/filebrowser-quantum
+  '';
+
+  ldflags = [
+    "-w"
+    "-s"
+    "-X github.com/gtsteffaniak/filebrowser/backend/version.CommitSHA=testingCommit"
+    "-X github.com/gtsteffaniak/filebrowser/backend/version.Version=testing"
+  ];
+
+  meta = {
+    description = "Access and manage your files from the web";
+    homepage = "https://github.com/gtsteffaniak/filebrowser";
+    changelog = "https://github.com/gtsteffaniak/filebrowser/blob/v${version}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      jocimsus
+      denperidge
+    ];
+    mainProgram = "filebrowser-quantum";
+  };
+}


### PR DESCRIPTION
This PR is based on the now outdated #419206, hopefully finally bringing filebrowser-quantum onto nixpkgs!

## Things done

- Updated version
- Updated package-lock.json
- Added myself to maintainers
---
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
