### PR TITLE
ethr: init at 1.0.0-unstable-2025-12-10

### DIFF
--- a/pkgs/by-name/et/ethr/package.nix
+++ b/pkgs/by-name/et/ethr/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule {
+  pname = "ethr";
+  version = "1.0.0-unstable-2025-12-10";
+
+  src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = "ethr";
+    rev = "86e07049d11357f69da89317d55f11bed62e0007";
+    hash = "sha256-lkhqPq2EDI3J8jiNx0Gygf8fDZvtZ2Pw3rRSt4HVBq8=";
+  };
+
+  vendorHash = "sha256-UHZNe6vlqdYaHzt2IZ5HTQxqR0sf8m9Lfo5tXvpiFlg=";
+
+  # Strip symbol table and DWARF debug info to reduce binary size
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  meta = {
+    description = "Comprehensive Network Measurement Tool for TCP, UDP & ICMP";
+    homepage = "https://github.com/microsoft/ethr";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.philiptaron ];
+    mainProgram = "ethr";
+  };
+}


### PR DESCRIPTION
Ethr is a comprehensive network performance measurement tool that operates in three distinct modes:

*   **Server Mode** (`-s`)
    *   Runs Ethr as a server listener to accept incoming connections for performance tests.
    *   Supports binding to specific IPs and ports.
    *   Includes a Text UI (`-ui`) option and an option to exit after handling a single client connection (similar to iPerf3 behavior) for precise synchronization.

*   **Client Mode** (`-c <server>`)
    *   Connects to an Ethr server to perform comprehensive performance benchmarks.
    *   **Supported Protocols:** TCP, UDP, HTTP, HTTPS, and ICMP.
    *   **Measurement Capabilities:**
        *   **Bandwidth:** Measure throughput with options for throttling (`-b`), buffer length (`-l`), and reverse direction (`-r`).
        *   **Connections/s:** Benchmark connection establishment rates.
        *   **Packets/s:** Measure packet processing rates.
        *   **Latency & Loss:** Detailed analysis of latency, packet loss, and jitter.
    *   **Diagnostics:** Supports TraceRoute and MyTraceRoute (MTR).
    *   Supports multi-threaded parallel sessions (`-n`).

*   **External Mode** (`-x <destination>`)
    *   Allows Ethr to test against non-Ethr endpoints (standard URLs or Host:Port combinations).
    *   **Use Cases:** Testing connectivity against public websites or standard services (e.g., `www.microsoft.com:443`).
    *   **Supported Tests:**
        *   **TCP/ICMP:** Connection establishment rates and connectivity checks.
        *   **Ping:** Loss and latency measurements.
        *   **TraceRoute:** Standard and MTR-style path analysis.

I used the most recent commit as the last release was 5 years ago.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
