### PR TITLE
gh-do: init at 0.5.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23058,6 +23058,11 @@
     githubId = 3280280;
     name = "Ryne Everett";
   };
+  ryoppippi = {
+    github = "ryoppippi";
+    githubId = 1560508;
+    name = "ryoppippi";
+  };
   ryota-ka = {
     email = "ok@ryota-ka.me";
     github = "ryota-ka";

--- a/pkgs/by-name/gh/gh-do/package.nix
+++ b/pkgs/by-name/gh/gh-do/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildGoModule,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "gh-do";
+  version = "0.5.4";
+
+  src = fetchFromGitHub {
+    owner = "k1LoW";
+    repo = "gh-do";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-TzdaQ/E9D3gB1Q84SCRetLoA95c/BjJlgfZGbntjCVU=";
+  };
+
+  vendorHash = "sha256-TPHDiMzJtXXRBFd8lacXeMC+AB1Gc1pMyJPJeVLCkKo=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${finalAttrs.version}"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Do and undo and notify with GitHub CLI";
+    homepage = "https://github.com/k1LoW/gh-do";
+    changelog = "https://github.com/k1LoW/gh-do/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ryoppippi ];
+    mainProgram = "gh-do";
+  };
+})


### PR DESCRIPTION
Add new package `gh-do` version 0.5.4 and maintainer entry for ryoppippi.

gh-do is a GitHub CLI extension that allows you to "do and undo and notify" with the GitHub CLI. It provides commands to perform actions on GitHub resources with the ability to easily revert those actions.

Written in Go, it integrates seamlessly with the `gh` command line tool.

**Homepage:** https://github.com/k1LoW/gh-do

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc