### PR TITLE
sdcc: fix build with gcc15

### DIFF
--- a/pkgs/by-name/sd/sdcc/package.nix
+++ b/pkgs/by-name/sd/sdcc/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  fetchpatch,
   autoconf,
   bison,
   boost,
@@ -68,6 +69,16 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals withGputils [
     gputils
+  ];
+
+  patches = [
+    # Fix build with gcc15
+    # https://sourceforge.net/p/sdcc/bugs/3846/
+    (fetchpatch {
+      name = "sdcc-fix-aslink-elf-signature.patch";
+      url = "https://src.fedoraproject.org/rpms/sdcc/raw/4a7c2a7e32369461eb451fc6f4d678a010135afc/f/sdcc-4.4.0-aslink.patch";
+      hash = "sha256-xGilNetecPBj2VV3ebmln5BKqs3OoWFf6y2S3TBTHMQ=";
+    })
   ];
 
   # sdcc 4.5.0 massively rewrote sim/ucsim/Makefile.in, and lost the `.PHONY`


### PR DESCRIPTION
- add patch from fedora changing signature from `elf()` to `elf(int)` in `aslink.h`:
https://src.fedoraproject.org/rpms/sdcc/raw/4a7c2a7e32369461eb451fc6f4d678a010135afc/f/sdcc-4.4.0-aslink.patch

Upstream issue:
https://sourceforge.net/p/sdcc/bugs/3846/

Fixes build failure with gcc15:
```
lklex.c: In function 'skip':
lkelf.c:857:1: error: conflicting types for 'elf'; have 'void(int)'
  857 | elf (int i)
      | ^~~
In file included from lkelf.c:25:
aslink.h:1315:25: note: previous declaration of 'elf' with type 'void(void)'
 1315 | extern  VOID            elf();
      |                         ^~~
lkout.c:115:17: error: too many arguments to function 'elf'; expected 0, have 1
  115 |                 elf(i);
      |                 ^~~ ~
In file included from lkout.c:30:
aslink.h:1315:25: note: declared here
 1315 | extern  VOID            elf();
      |                         ^~~
```

---

Part of fixes for gcc15 update:
https://github.com/NixOS/nixpkgs/pull/440456


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
