### PR TITLE
typst: Allow namespace configuration of packages, propogate more overrides, simplify env building

### DIFF
--- a/pkgs/by-name/ty/typst/build-universe-package.nix
+++ b/pkgs/by-name/ty/typst/build-universe-package.nix
@@ -5,7 +5,6 @@
   typstPackages,
 }:
 lib.extendMkDerivation {
-  inheritFunctionArgs = false;
   constructDrv = buildTypstPackage;
 
   excludeDrvArgNames = [

--- a/pkgs/by-name/ty/typst/package.nix
+++ b/pkgs/by-name/ty/typst/package.nix
@@ -8,6 +8,7 @@
   nix-update-script,
   versionCheckHook,
   callPackage,
+  testers,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -69,6 +70,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
   nativeInstallCheckInputs = [ versionCheckHook ];
 
   passthru = {
+    tests.wrapped = testers.testVersion {
+      package = finalAttrs.finalPackage.withPackages (p: [
+        p.note-me
+        p.abiding-ifacconf
+      ]);
+    };
     updateScript = nix-update-script { };
     packages = callPackage ./typst-packages.nix { };
     wrapper = callPackage ./wrapper.nix {

--- a/pkgs/by-name/ty/typst/package.nix
+++ b/pkgs/by-name/ty/typst/package.nix
@@ -71,8 +71,15 @@ rustPlatform.buildRustPackage (finalAttrs: {
   passthru = {
     updateScript = nix-update-script { };
     packages = callPackage ./typst-packages.nix { };
-    wrapper = callPackage ./wrapper.nix { };
-    withPackages = ps: finalAttrs.passthru.wrapper { packages = ps; };
+    wrapper = callPackage ./wrapper.nix {
+      typstPackages = finalAttrs.passthru.packages;
+      typst = finalAttrs.finalPackage;
+    };
+    withPackages =
+      f:
+      finalAttrs.passthru.wrapper {
+        packages = f;
+      };
   };
 
   meta = {

--- a/pkgs/by-name/ty/typst/wrapper.nix
+++ b/pkgs/by-name/ty/typst/wrapper.nix
@@ -31,7 +31,11 @@ lib.extendMkDerivation {
       paths = [ typst ] ++ lib.concatMap (p: [ p ] ++ p.propagatedBuildInputs) selectedPkgs;
 
       pathsToLink = [
+        # The packages
         "/lib/typst-packages"
+        # The Typst executable & completions
+        "/bin"
+        "/share"
       ];
 
       derivationArgs = {
@@ -41,16 +45,8 @@ lib.extendMkDerivation {
       };
 
       postBuild = ''
-        export TYPST_LIB_DIR="$out/lib/typst/packages"
-        mkdir -p $TYPST_LIB_DIR
-
-        mv $out/lib/typst-packages $TYPST_LIB_DIR/preview
-
-        cp -r ${typst}/share $out/share
-        mkdir -p $out/bin
-
-        makeWrapper "${lib.getExe typst}" "$out/bin/typst" \
-          --set TYPST_PACKAGE_CACHE_PATH "$TYPST_LIB_DIR" \
+        wrapProgram "$out/bin/typst" \
+          --set-default TYPST_PACKAGE_CACHE_PATH "$out/lib/typst-packages" \
           --set-default TYPST_FONT_PATHS "$(IFS=":"; echo "''${typstWrapperArgs[*]}")" \
           --add-flags "''${typstWrapperArgs[*]}"
       '';

--- a/pkgs/by-name/ty/typst/wrapper.nix
+++ b/pkgs/by-name/ty/typst/wrapper.nix
@@ -5,41 +5,56 @@
   makeBinaryWrapper,
   typst,
 }:
+lib.extendMkDerivation {
+  constructDrv = buildEnv;
+  excludeDrvArgNames = [
+    "packages"
+    "fonts"
+    "extraWrapperArgs"
+  ];
 
-lib.makeOverridable (
-  { ... }@typstPkgs:
-  {
-    packages ? (ps: [ ]),
-    fonts ? [ ],
-    extraWrapperArgs ? [ ],
-  }:
-  buildEnv {
-    inherit (typst) meta;
-    name = "${typst.name}-env";
+  extendDrvArgs =
+    finalAttrs:
+    {
+      packages ? (ps: [ ]),
+      fonts ? [ ],
+      extraWrapperArgs ? [ ],
+    }:
+    let
+      # Apply the selector
+      selectedPkgs = packages typstPackages;
+    in
+    {
+      inherit (typst) version;
+      pname = typst.pname + "-env";
 
-    paths = lib.foldl' (acc: p: acc ++ lib.singleton p ++ p.propagatedBuildInputs) [ ] (
-      packages typstPkgs
-    );
+      paths = [ typst ] ++ lib.concatMap (p: [ p ] ++ p.propagatedBuildInputs) selectedPkgs;
 
-    pathsToLink = [ "/lib/typst-packages" ];
+      pathsToLink = [
+        "/lib/typst-packages"
+      ];
 
-    nativeBuildInputs = [ makeBinaryWrapper ];
+      derivationArgs = {
+        nativeBuildInputs = [ makeBinaryWrapper ];
+        typstFonts = fonts;
+        typstWrapperArgs = extraWrapperArgs;
+      };
 
-    postBuild = ''
-      export TYPST_LIB_DIR="$out/lib/typst/packages"
-      mkdir -p $TYPST_LIB_DIR
+      postBuild = ''
+        export TYPST_LIB_DIR="$out/lib/typst/packages"
+        mkdir -p $TYPST_LIB_DIR
 
-      mv $out/lib/typst-packages $TYPST_LIB_DIR/preview
+        mv $out/lib/typst-packages $TYPST_LIB_DIR/preview
 
-      cp -r ${typst}/share $out/share
-      mkdir -p $out/bin
+        cp -r ${typst}/share $out/share
+        mkdir -p $out/bin
 
-      TYPST_FONT_PATHS=${lib.escapeShellArg (lib.concatStringsSep ":" fonts)}
+        makeWrapper "${lib.getExe typst}" "$out/bin/typst" \
+          --set TYPST_PACKAGE_CACHE_PATH "$TYPST_LIB_DIR" \
+          --set-default TYPST_FONT_PATHS "$(IFS=":"; echo "''${typstWrapperArgs[*]}")" \
+          --add-flags "''${typstWrapperArgs[*]}"
+      '';
 
-      makeWrapper "${lib.getExe typst}" "$out/bin/typst" \
-        --set TYPST_PACKAGE_CACHE_PATH $TYPST_LIB_DIR \
-        ''${TYPST_FONT_PATHS:+--set TYPST_FONT_PATHS "$TYPST_FONT_PATHS"} \
-        ${lib.escapeShellArgs extraWrapperArgs}
-    '';
-  }
-) typstPackages
+      meta = builtins.removeAttrs typst.meta [ "position" ];
+    };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

1. Allow the Typst package namespace to be configurable
   *  Previously it only put them in the `local` namespace (in the builder). This works for all `typstPackages` from Typst Universe, but may not be desirable for non-Universe packages
3. Simplify the environment building
   * Bring it more in-line with other environment builders. `makeOverridable` doesn't really do anything with the wrapper, we want to use the final package used in the Typst package, and we want to use the final Typst package. Also rather than a fold, we can just use `concatMap` to make the path expression easier to read.
5. Propagate more potential finalAttrs overrides
   *  Scattered around. We use the final Typst & typstPackage in the wrapper
   * We use the final propagatedBuildInputs for the passed thru typstDeps in `buildTypstPackage`
   * Propagate pname and version from the universe builder
7. Set `name` in the wrapper
   * Just make it a bit more idiomatic
8. Add a passthru tester for the wrapper

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
