### PR TITLE
Revert "ed: 1.22.2 -> 1.22.3"

### DIFF
--- a/pkgs/by-name/ed/ed/package.nix
+++ b/pkgs/by-name/ed/ed/package.nix
@@ -14,11 +14,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "ed";
-  version = "1.22.3";
+  version = "1.22.2";
 
   src = fetchurl {
     url = "mirror://gnu/ed/ed-${finalAttrs.version}.tar.lz";
-    hash = "sha256-R6Vd38UtSh/291WfvQDPlIoWts8VHsUgOSdhrq5Ol74=";
+    hash = "sha256-9Y0VJCBW4Vr3bxPzTGDYkPoqLVywq++RwRXk2DeU/+M=";
   };
 
   nativeBuildInputs = [ lzip ];


### PR DESCRIPTION
Reverts NixOS/nixpkgs#466552

This breaks darwin stdenv, see https://github.com/NixOS/nixpkgs/pull/466552#issuecomment-3664119639.