### PR TITLE
fuse-zip: init at 0.7.2

### DIFF
--- a/pkgs/by-name/fu/fuse-zip/package.nix
+++ b/pkgs/by-name/fu/fuse-zip/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  stdenv,
+  fetchFromBitbucket,
+  pkg-config,
+  fuse,
+  libzip,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "fuse-zip";
+  version = "0.7.2";
+
+  src = fetchFromBitbucket {
+    owner = "agalanin";
+    repo = "fuse-zip";
+    tag = finalAttrs.version;
+    hash = "sha256-o1OEOAmo0r/qUyKTgpvJe2XDWgpvash2+oyqdiEq2a8=";
+  };
+
+  __structuredAttrs = true;
+  enableParallelBuilding = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    fuse
+    libzip
+  ];
+
+  makeFlags = [
+    "prefix=$(out)"
+  ];
+
+  buildFlags = [
+    "release"
+  ];
+
+  # Missing TCL libraries and TCL libraries that are in Nixpkgs that need additional configuration.
+  doCheck = false;
+
+  meta = {
+    homepage = "https://bitbucket.org/agalanin/fuse-zip";
+    changelog = "https://bitbucket.org/agalanin/fuse-zip/src/${finalAttrs.version}/changelog";
+    description = "FUSE filesystem for mounting ZIP archives with write support";
+    mainProgram = "fuse-zip";
+    license = lib.licenses.gpl3Plus;
+    maintainers = [ lib.maintainers.RossSmyth ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Adds fuse-zip, a FUSE that allows writing to zip files as well as reading. 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
