### PR TITLE
fetchurl: builder.sh: handle `urls` as a Bash array

### DIFF
--- a/pkgs/build-support/fetchurl/builder.sh
+++ b/pkgs/build-support/fetchurl/builder.sh
@@ -124,10 +124,10 @@ tryHashedMirrors() {
 # URL list may contain ?. No glob expansion for that, please
 set -o noglob
 
-urls2=
+resolvedUrls=()
 for url in "${urls[@]}"; do
     if test "${url:0:9}" != "mirror://"; then
-        urls2="$urls2 $url"
+        resolvedUrls+=("$url")
     else
         url2="${url:9}"; echo "${url2/\// }" > split; read site fileName < split
         #varName="mirror_$site"
@@ -142,18 +142,17 @@ for url in "${urls[@]}"; do
             if test -n "${!varName}"; then mirrors="${!varName}"; fi
 
             for url3 in $mirrors; do
-                urls2="$urls2 $url3$fileName";
+                resolvedUrls+=("$url3$fileName");
             done
         fi
     fi
 done
-urls="$urls2"
 
 # Restore globbing settings
 set +o noglob
 
 if test -n "$showURLs"; then
-    echo "$urls" > $out
+    echo "${resolvedUrls[*]}" > $out
     exit 0
 fi
 
@@ -165,7 +164,7 @@ fi
 set -o noglob
 
 success=
-for url in $urls; do
+for url in "${resolvedUrls[@]}"; do
     if [ -z "$postFetch" ]; then
        case "$url" in
            https://github.com/*/archive/*)

--- a/pkgs/build-support/fetchurl/default.nix
+++ b/pkgs/build-support/fetchurl/default.nix
@@ -35,6 +35,28 @@ let
   # "gnu", etc.).
   sites = builtins.attrNames mirrors;
 
+  /**
+    Resolve a URL against the available mirrors.
+
+    If the input is a `"mirror://"` URL, it is normalized.
+    Otherwise, the URL is returned unmodified in a singleton list.
+
+    Mirror URLs should be formatted as:
+    ```
+    mirror://{mirror_name}/{path}
+    ```
+
+    The specified `mirror_name` must correspond to an entry in `pkgs/build-support/fetchurl/mirrors.nix`, otherwise an error is thrown.
+
+    # Inputs
+
+    `url` (String)
+    : A (possibly `"mirror://"`) URL to resolve.
+
+    # Output
+
+    A list of resolved URLs.
+  */
   resolveUrl =
     url:
     let

--- a/pkgs/build-support/fetchurl/default.nix
+++ b/pkgs/build-support/fetchurl/default.nix
@@ -227,11 +227,7 @@ lib.extendMkDerivation {
         let
           mirrorSplit = lib.match "mirror://([[:alpha:]]+)/(.+)" url;
           mirrorName = lib.head mirrorSplit;
-          mirrorList =
-            if lib.hasAttr mirrorName mirrors then
-              mirrors."${mirrorName}"
-            else
-              throw "unknown mirror:// site ${mirrorName}";
+          mirrorList = mirrors."${mirrorName}" or (throw "unknown mirror:// site ${mirrorName}");
         in
         if mirrorSplit == null || mirrorName == null then
           url

--- a/pkgs/build-support/fetchurl/tests.nix
+++ b/pkgs/build-support/fetchurl/tests.nix
@@ -6,6 +6,7 @@
   jq,
   moreutils,
   emptyFile,
+  hello,
   ...
 }:
 let
@@ -137,5 +138,14 @@ in
     # $downloadedFile, but here we know that because the URL is broken, it will
     # have to fallback to fetching the previously-built derivation from
     # tarballs.nixos.org, which provides pre-built derivation outputs.
+  };
+
+  urls-simple = testers.invalidateFetcherByDrvHash fetchurl {
+    name = "test-fetchurl-urls-simple";
+    urls = [
+      "http://broken"
+      hello.src.resolvedUrl
+    ];
+    hash = hello.src.outputHash;
   };
 }

--- a/pkgs/build-support/fetchurl/tests.nix
+++ b/pkgs/build-support/fetchurl/tests.nix
@@ -141,6 +141,24 @@ in
     # tarballs.nixos.org, which provides pre-built derivation outputs.
   };
 
+  showURLs-urls-mirrors = testers.invalidateFetcherByDrvHash fetchurl (finalAttrs: {
+    name = "test-fetchurl-showURLs-urls-mirrors";
+    showURLs = true;
+    urls = [
+      "http://broken"
+    ]
+    ++ hello.src.urls;
+    hash =
+      let
+        hashAlgo = lib.head (lib.splitString "-" lib.fakeHash);
+      in
+      hashAlgo
+      + ":"
+      + builtins.hashString hashAlgo (
+        lib.concatStringsSep " " (lib.concatMap fetchurl.resolveUrl finalAttrs.urls) + "\n"
+      );
+  });
+
   urls-simple = testers.invalidateFetcherByDrvHash fetchurl {
     name = "test-fetchurl-urls-simple";
     urls = [

--- a/pkgs/build-support/testers/default.nix
+++ b/pkgs/build-support/testers/default.nix
@@ -135,8 +135,15 @@
       drvPath = (f args).drvPath;
       # It's safe to discard the context, because we don't access the path.
       salt = builtins.unsafeDiscardStringContext (lib.substring 0 12 (baseNameOf drvPath));
+      saltName = name: "${name}-salted-${salt}";
+      getSaltedNames =
+        args:
+        if args.pname or null != null then
+          { pname = saltName args.pname; }
+        else
+          { name = saltName args.name or "source"; };
       # New derivation incorporating the original drv hash in the name
-      salted = f (args // { name = "${args.name or "source"}-salted-${salt}"; });
+      salted = f (args // getSaltedNames args);
       # Make sure we did change the derivation. If the fetcher ignores `name`,
       # `invalidateFetcherByDrvHash` doesn't work.
       checked =

--- a/pkgs/build-support/testers/default.nix
+++ b/pkgs/build-support/testers/default.nix
@@ -132,6 +132,7 @@
   invalidateFetcherByDrvHash =
     f: args:
     let
+      optionalFix = if lib.isFunction args then lib.id else lib.fix;
       unsalted = f args;
       drvPath = unsalted.drvPath;
       # It's safe to discard the context, because we don't access the path.
@@ -144,7 +145,7 @@
         else
           { name = saltName args.name or "source"; };
       # New derivation incorporating the original drv hash in the name
-      saltedByArgs = f (args // getSaltedNames args);
+      saltedByArgs = f (optionalFix (lib.extends (lib.toExtension getSaltedNames) (lib.toFunction args)));
       saltedByOverrideAttrs = unsalted.overrideAttrs (previousAttrs: getSaltedNames previousAttrs);
       saltedByOverrideAttrsForced = unsalted.overrideAttrs (previousAttrs: {
         name = saltName unsalted.name;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Clean up leftover for PR #464475.

~Revert and re-implement~ Continue the work of PR #470643 to address a Bash variable reassignment quirk:

```console
$ foo=(a b)
$ declare -p foo
declare -a foo=([0]="a" [1]="b")
$ foo="${foo[*]}"
$ declare -p foo
declare -a foo=([0]="a b" [1]="b")
$ declare foo="${foo[*]}"
$ declare -p foo
declare -a foo=([0]="a b b" [1]="b")
```

PR #470643 probably does make the mirror fetching. Even if it doesn't clean up the "mirror://" pseudo-URL, it does add the resolved URLs which `curl` will use to download the file. We revert and re-implement in the same PR to avoid re-introducing the breakage PR #470643 has fixed.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
