### PR TITLE
unoconv: remove compatibility for very old LO OO

### DIFF
--- a/pkgs/by-name/un/unoconv/0001-Remove-compatibility-fixes-for-very-old-LO-OO.patch
+++ b/pkgs/by-name/un/unoconv/0001-Remove-compatibility-fixes-for-very-old-LO-OO.patch
@@ -1,0 +1,48 @@
+From 363d17cec4d097a8160926467db33978da4001cf Mon Sep 17 00:00:00 2001
+From: flakeuser <2792697+Jdogzz@users.noreply.github.com>
+Date: Wed, 17 Dec 2025 17:44:21 -0800
+Subject: [PATCH] Remove compatibility fixes for very old LO/OO.
+
+---
+ unoconv | 11 ++---------
+ 1 file changed, 2 insertions(+), 9 deletions(-)
+
+diff --git a/unoconv b/unoconv
+index 6aa1bfa..ae2159f 100755
+--- a/unoconv
++++ b/unoconv
+@@ -16,7 +16,6 @@
+ 
+ from __future__ import print_function
+ 
+-from distutils.version import LooseVersion
+ import getopt
+ import glob
+ import os
+@@ -857,10 +856,7 @@ class Convertor:
+             info(3, "Launching our own listener using %s." % office.binary)
+             try:
+                 product = self.svcmgr.createInstance("com.sun.star.configuration.ConfigurationProvider").createInstanceWithArguments("com.sun.star.configuration.ConfigurationAccess", UnoProps(nodepath="/org.openoffice.Setup/Product"))
+-                if product.ooName not in ('LibreOffice', 'LOdev') or LooseVersion(product.ooSetupVersion) <= LooseVersion('3.3'):
+-                    args = [office.binary, "-headless", "-invisible", "-nocrashreport", "-nodefault", "-nofirststartwizard", "-nologo", "-norestore", "-accept=%s" % op.connection]
+-                else:
+-                    args = [office.binary, "--headless", "--invisible", "--nocrashreport", "--nodefault", "--nofirststartwizard", "--nologo", "--norestore", "--accept=%s" % op.connection]
++                args = [office.binary, "--headless", "--invisible", "--nocrashreport", "--nodefault", "--nofirststartwizard", "--nologo", "--norestore", "--accept=%s" % op.connection]
+                 if op.userProfile:
+                     args.append("-env:UserInstallation=file://" + realpath(op.userProfile))
+                 info(2, '%s listener arguments are %s.' % (product.ooName, args))
+@@ -1287,10 +1283,7 @@ def die(ret, msg=None):
+         if convertor.desktop.getCurrentFrame():
+             info(2, 'Trying to stop %s GUI listener.' % product.ooName)
+             try:
+-                if product.ooName != "LibreOffice" or product.ooSetupVersion <= 3.3:
+-                    subprocess.Popen([office.binary, "-headless", "-invisible", "-nocrashreport", "-nodefault", "-nofirststartwizard", "-nologo", "-norestore", "-unaccept=%s" % op.connection], env=os.environ)
+-                else:
+-                    subprocess.Popen([office.binary, "--headless", "--invisible", "--nocrashreport", "--nodefault", "--nofirststartwizard", "--nologo", "--norestore", "--unaccept=%s" % op.connection], env=os.environ)
++                subprocess.Popen([office.binary, "--headless", "--invisible", "--nocrashreport", "--nodefault", "--nofirststartwizard", "--nologo", "--norestore", "--unaccept=%s" % op.connection], env=os.environ)
+                 ooproc.wait()
+                 info(2, '%s listener successfully disabled.' % product.ooName)
+             except Exception as e:
+-- 
+2.51.2
+

--- a/pkgs/by-name/un/unoconv/package.nix
+++ b/pkgs/by-name/un/unoconv/package.nix
@@ -20,6 +20,8 @@ stdenv.mkDerivation rec {
     sha256 = "1akx64686in8j8arl6vsgp2n3bv770q48pfv283c6fz6wf9p8fvr";
   };
 
+  patches = [ ./0001-Remove-compatibility-fixes-for-very-old-LO-OO.patch ];
+
   nativeBuildInputs = [
     asciidoc
     makeWrapper


### PR DESCRIPTION
Removing compatibility for very old LO/OO versions. This is because the dependency distutils responsible for that compatibility has been removed on recent python versions, causing unoconv to crash immediately on run. See for example [this issue](https://github.com/NixOS/nixpkgs/issues/408713).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
