### PR TITLE
pell: change rev which does not exist

### DIFF
--- a/pkgs/by-name/pe/pell/package.nix
+++ b/pkgs/by-name/pe/pell/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "ebzzry";
     repo = "pell";
-    rev = "f251625ece6bb5517227970287119e7d2dfcea8b";
+    rev = "3b8a9a59c4a8671705805edb7be7c35b1654971f";
     sha256 = "0k8m1lv2kyrs8fylxmbgxg3jn65g57frf2bndc82gkr5svwb554a";
   };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The rev listed doesn't exist. Seems to have been introduced [here](https://github.com/NixOS/nixpkgs/commit/e20def225f1df3cdc94fc447ec12c71743683f09). I do not know how this could have ever built successfully? 

I don't see much source changes:

```
✦ ❯ difft /nix/store/xss2ryxv6kvayj3y66dnpcm0nb6hxj4b-source ./pell
.gitignore --- Text
File permissions changed from 100444 to 100644.
No changes.

LICENSE.md --- Text
File permissions changed from 100444 to 100644.
No changes.

README.md --- Text
File permissions changed from 100444 to 100644.
No changes.

resources/online.mp3 --- Binary
No changes.

resources/offline.mp3 --- Binary
No changes.

pell --- Bash
File permissions changed from 100555 to 100755.
No changes.
```

Permissions changes are likely because one of the files is in the /nix/store and the other one is in a git clone outside the store. Note that the nix store path is the src drv pulled from cache.nixos.org, and `./pell` is a local clone with the HEAD of master.

Relevant issue: #471645

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
