### PR TITLE
treewide: update changed dotcolon download link and update meta.homepage

### DIFF
--- a/pkgs/by-name/ai/aileron/package.nix
+++ b/pkgs/by-name/ai/aileron/package.nix
@@ -13,7 +13,7 @@ stdenvNoCC.mkDerivation {
   version = "${majorVersion}.${minorVersion}";
 
   src = fetchzip {
-    url = "https://dotcolon.net/download/fonts/aileron_${majorVersion}${minorVersion}.zip";
+    url = "https://dotcolon.net/files/fonts/aileron_${majorVersion}${minorVersion}.zip";
     hash = "sha256-Ht48gwJZrn0djo1yl6jHZ4+0b710FVwStiC1Zk5YXME=";
     stripRoot = false;
   };
@@ -27,7 +27,7 @@ stdenvNoCC.mkDerivation {
   '';
 
   meta = {
-    homepage = "http://dotcolon.net/font/aileron/";
+    homepage = "https://dotcolon.net/font/aileron/";
     description = "Helvetica font in nine weights";
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/eu/eunomia/package.nix
+++ b/pkgs/by-name/eu/eunomia/package.nix
@@ -13,7 +13,7 @@ stdenvNoCC.mkDerivation {
   version = "${majorVersion}.${minorVersion}";
 
   src = fetchzip {
-    url = "https://dotcolon.net/download/fonts/eunomia_${majorVersion}${minorVersion}.zip";
+    url = "https://dotcolon.net/files/fonts/eunomia_${majorVersion}${minorVersion}.zip";
     hash = "sha256-Rd2EakaTWjzoEV00tHTgg/bXgJUFfPjCyQUWi7QhFG4=";
     stripRoot = false;
   };
@@ -27,7 +27,7 @@ stdenvNoCC.mkDerivation {
   '';
 
   meta = {
-    homepage = "http://dotcolon.net/font/eunomia/";
+    homepage = "https://dotcolon.net/font/eunomia/";
     description = "Futuristic decorative font";
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/f1/f1_8/package.nix
+++ b/pkgs/by-name/f1/f1_8/package.nix
@@ -28,7 +28,7 @@ stdenvNoCC.mkDerivation {
   '';
 
   meta = {
-    homepage = "http://dotcolon.net/font/f1_8/";
+    homepage = "https://dotcolon.net/font/f1_8/";
     description = "Weighted decorative font";
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [ minijackson ];

--- a/pkgs/by-name/f5/f5_6/package.nix
+++ b/pkgs/by-name/f5/f5_6/package.nix
@@ -13,7 +13,7 @@ stdenvNoCC.mkDerivation {
   version = "${majorVersion}.${minorVersion}";
 
   src = fetchzip {
-    url = "https://dotcolon.net/download/fonts/f5_6_${majorVersion}${minorVersion}.zip";
+    url = "https://dotcolon.net/files/fonts/f5_6_${majorVersion}${minorVersion}.zip";
     hash = "sha256-FeCU+mzR0iO5tixI72XUnhvpGj+WRfKyT3mhBtud3uE=";
     stripRoot = false;
   };
@@ -27,7 +27,7 @@ stdenvNoCC.mkDerivation {
   '';
 
   meta = {
-    homepage = "http://dotcolon.net/font/f5_6/";
+    homepage = "https://dotcolon.net/font/f5_6/";
     description = "Weighted decorative font";
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/fa/fa_1/package.nix
+++ b/pkgs/by-name/fa/fa_1/package.nix
@@ -13,7 +13,7 @@ stdenvNoCC.mkDerivation {
   version = "${majorVersion}.${minorVersion}";
 
   src = fetchzip {
-    url = "https://dotcolon.net/download/fonts/fa_1_${majorVersion}${minorVersion}.zip";
+    url = "https://dotcolon.net/files/fonts/fa_1_${majorVersion}${minorVersion}.zip";
     hash = "sha256-BPJ+wZMYXY/yg5oEgBc5YnswA6A7w6V0gdv+cac0qdc=";
     stripRoot = false;
   };
@@ -27,7 +27,7 @@ stdenvNoCC.mkDerivation {
   '';
 
   meta = {
-    homepage = "http://dotcolon.net/font/fa_1/";
+    homepage = "https://dotcolon.net/font/fa_1/";
     description = "Weighted decorative font";
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [ minijackson ];

--- a/pkgs/by-name/fe/ferrum/package.nix
+++ b/pkgs/by-name/fe/ferrum/package.nix
@@ -13,7 +13,7 @@ stdenvNoCC.mkDerivation {
   version = "${majorVersion}.${minorVersion}";
 
   src = fetchzip {
-    url = "https://dotcolon.net/download/fonts/ferrum_${majorVersion}${minorVersion}.zip";
+    url = "https://dotcolon.net/files/fonts/ferrum_${majorVersion}${minorVersion}.zip";
     hash = "sha256-NDJwgFWZgyhMkGRWlY55l2omEw6ju3e3dHCEsWNzQIc=";
     stripRoot = false;
   };

--- a/pkgs/by-name/fe/ferrum/package.nix
+++ b/pkgs/by-name/fe/ferrum/package.nix
@@ -27,7 +27,7 @@ stdenvNoCC.mkDerivation {
   '';
 
   meta = {
-    homepage = "http://dotcolon.net/font/ferrum/";
+    homepage = "https://dotcolon.net/font/ferrum/";
     description = "Decorative font";
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/me/medio/package.nix
+++ b/pkgs/by-name/me/medio/package.nix
@@ -13,7 +13,7 @@ stdenvNoCC.mkDerivation {
   version = "${majorVersion}.${minorVersion}";
 
   src = fetchzip {
-    url = "https://dotcolon.net/download/fonts/medio_${majorVersion}${minorVersion}.zip";
+    url = "https://dotcolon.net/files/fonts/medio_${majorVersion}${minorVersion}.zip";
     hash = "sha256-S+CcwD4zGVk7cIFD6K4NnpE/0mrJq4RnDJC576rhcLQ=";
     stripRoot = false;
   };
@@ -27,7 +27,7 @@ stdenvNoCC.mkDerivation {
   '';
 
   meta = {
-    homepage = "http://dotcolon.net/font/medio/";
+    homepage = "https://dotcolon.net/font/medio/";
     description = "Serif font designed by Sora Sagano";
     longDescription = ''
       Medio is a serif font designed by Sora Sagano, based roughly

--- a/pkgs/by-name/me/melete/package.nix
+++ b/pkgs/by-name/me/melete/package.nix
@@ -13,7 +13,7 @@ stdenvNoCC.mkDerivation {
   version = "${majorVersion}.${minorVersion}";
 
   src = fetchzip {
-    url = "https://dotcolon.net/download/fonts/melete_${majorVersion}${minorVersion}.zip";
+    url = "https://dotcolon.net/files/fonts/melete_${majorVersion}${minorVersion}.zip";
     hash = "sha256-y1xtNM1Oy92gOvbr9J71XNxb1JeTzOgxKms3G2YHK00=";
     stripRoot = false;
   };
@@ -27,7 +27,7 @@ stdenvNoCC.mkDerivation {
   '';
 
   meta = {
-    homepage = "http://dotcolon.net/font/melete/";
+    homepage = "https://dotcolon.net/font/melete/";
     description = "Headline typeface that could be used as a movie title";
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [ minijackson ];

--- a/pkgs/by-name/na/nacelle/package.nix
+++ b/pkgs/by-name/na/nacelle/package.nix
@@ -13,7 +13,7 @@ stdenvNoCC.mkDerivation {
   version = "${majorVersion}.${minorVersion}";
 
   src = fetchzip {
-    url = "https://dotcolon.net/download/fonts/nacelle_${majorVersion}${minorVersion}.zip";
+    url = "https://dotcolon.net/files/fonts/nacelle_${majorVersion}${minorVersion}.zip";
     hash = "sha256-e4QsPiyfWEAYHWdwR3CkGc2UzuA3hZPYYlWtIubY0Oo=";
     stripRoot = false;
   };
@@ -27,7 +27,7 @@ stdenvNoCC.mkDerivation {
   '';
 
   meta = {
-    homepage = "http://dotcolon.net/font/nacelle/";
+    homepage = "https://dotcolon.net/font/nacelle/";
     description = "Improved version of the Aileron font";
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [ minijackson ];

--- a/pkgs/by-name/pe/penna/package.nix
+++ b/pkgs/by-name/pe/penna/package.nix
@@ -13,7 +13,7 @@ stdenvNoCC.mkDerivation {
   version = "${majorVersion}.${minorVersion}";
 
   src = fetchzip {
-    url = "https://dotcolon.net/download/fonts/penna_${majorVersion}${minorVersion}.zip";
+    url = "https://dotcolon.net/files/fonts/penna_${majorVersion}${minorVersion}.zip";
     hash = "sha256-fmCJnEaoUGdW9JK3J7JSm5D4qOMRW7qVKPgVE7uCH5w=";
     stripRoot = false;
   };
@@ -27,7 +27,7 @@ stdenvNoCC.mkDerivation {
   '';
 
   meta = {
-    homepage = "http://dotcolon.net/font/penna/";
+    homepage = "https://dotcolon.net/font/penna/";
     description = "Geometric sans serif designed by Sora Sagano";
     longDescription = ''
       Penna is a geometric sans serif designed by Sora Sagano,

--- a/pkgs/by-name/ro/route159/package.nix
+++ b/pkgs/by-name/ro/route159/package.nix
@@ -13,7 +13,7 @@ stdenvNoCC.mkDerivation {
   version = "${majorVersion}.${minorVersion}";
 
   src = fetchzip {
-    url = "https://dotcolon.net/download/fonts/route159_${majorVersion}${minorVersion}.zip";
+    url = "https://dotcolon.net/files/fonts/route159_${majorVersion}${minorVersion}.zip";
     hash = "sha256-1InyBW1LGbp/IU/ql9mvT14W3MTxJdWThFwRH6VHpTU=";
     stripRoot = false;
   };
@@ -27,7 +27,7 @@ stdenvNoCC.mkDerivation {
   '';
 
   meta = {
-    homepage = "http://dotcolon.net/font/route159/";
+    homepage = "https://dotcolon.net/font/route159/";
     description = "Weighted sans serif font";
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/se/seshat/package.nix
+++ b/pkgs/by-name/se/seshat/package.nix
@@ -13,7 +13,7 @@ stdenvNoCC.mkDerivation {
   version = "${majorVersion}.${minorVersion}";
 
   src = fetchzip {
-    url = "https://dotcolon.net/download/fonts/seshat_${majorVersion}${minorVersion}.zip";
+    url = "https://dotcolon.net/files/fonts/seshat_${majorVersion}${minorVersion}.zip";
     hash = "sha256-XgprDhzAbcTzZw2QOwpCnzusYheYmSlM+ApU+Y0wO2Q=";
     stripRoot = false;
   };
@@ -27,7 +27,7 @@ stdenvNoCC.mkDerivation {
   '';
 
   meta = {
-    homepage = "http://dotcolon.net/font/seshat/";
+    homepage = "https://dotcolon.net/font/seshat/";
     description = "Roman body font designed for main text by Sora Sagano";
     longDescription = ''
       Seshat is a Roman body font designed for the main text. By

--- a/pkgs/by-name/te/tenderness/package.nix
+++ b/pkgs/by-name/te/tenderness/package.nix
@@ -13,7 +13,7 @@ stdenvNoCC.mkDerivation {
   version = "${majorVersion}.${minorVersion}";
 
   src = fetchzip {
-    url = "https://dotcolon.net/download/fonts/tenderness_${majorVersion}${minorVersion}.zip";
+    url = "https://dotcolon.net/files/fonts/tenderness_${majorVersion}${minorVersion}.zip";
     hash = "sha256-bwJKW+rY7/r2pBCSA6HYlaRMsI/U8UdW2vV4tmYuJww=";
     stripRoot = false;
   };
@@ -27,7 +27,7 @@ stdenvNoCC.mkDerivation {
   '';
 
   meta = {
-    homepage = "http://dotcolon.net/font/tenderness/";
+    homepage = "https://dotcolon.net/font/tenderness/";
     description = "Serif font designed by Sora Sagano with old-style figures";
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/ve/vegur/package.nix
+++ b/pkgs/by-name/ve/vegur/package.nix
@@ -25,7 +25,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    homepage = "http://dotcolon.net/fonts/vegur/";
+    homepage = "https://dotcolon.net/fonts/vegur/";
     description = "Humanist sans serif font";
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

download links go from `https://dotcolon.net/files/fonts` to `https://dotcolon.net/download/fonts`. Also, a bunch of the meta.homepage links were http not https. But, dotcolon.net supports https, so I added https.

In response to #471645 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
