### PR TITLE
ramalama: wrap all deps when withPodman==false, except podman

### DIFF
--- a/pkgs/by-name/ra/ramalama/package.nix
+++ b/pkgs/by-name/ra/ramalama/package.nix
@@ -50,21 +50,21 @@ python3Packages.buildPythonApplication (finalAttrs: {
     make docs
   '';
 
-  postInstall = lib.optionalString withPodman ''
-    wrapProgram $out/bin/ramalama \
-      --prefix PATH : ${
-        lib.makeBinPath (
-          [
-            llama-cpp-vulkan
-            podman
-          ]
-          ++ (with python3Packages; [
-            huggingface-hub
-            mlx-lm
-          ])
-        )
-      }
-  '';
+  postInstall =
+    let
+      binPackages = [
+        llama-cpp-vulkan
+      ]
+      ++ (with python3Packages; [
+        huggingface-hub
+        mlx-lm
+      ])
+      ++ lib.optional withPodman podman;
+    in
+    ''
+      wrapProgram $out/bin/ramalama \
+        --prefix PATH : ${lib.makeBinPath binPackages}
+    '';
 
   pythonImportsCheck = [
     "ramalama"

--- a/pkgs/by-name/ra/ramalama/package.nix
+++ b/pkgs/by-name/ra/ramalama/package.nix
@@ -48,21 +48,21 @@ python3Packages.buildPythonApplication rec {
     make docs
   '';
 
-  postInstall = lib.optionalString withPodman ''
-    wrapProgram $out/bin/ramalama \
-      --prefix PATH : ${
-        lib.makeBinPath (
-          [
-            llama-cpp-vulkan
-            podman
-          ]
-          ++ (with python3Packages; [
-            huggingface-hub
-            mlx-lm
-          ])
-        )
-      }
-  '';
+  postInstall =
+    let
+      binPackages = [
+        llama-cpp-vulkan
+      ]
+      ++ (with python3Packages; [
+        huggingface-hub
+        mlx-lm
+      ])
+      ++ lib.optional withPodman podman;
+    in
+    ''
+      wrapProgram $out/bin/ramalama \
+        --prefix PATH : ${lib.makeBinPath binPackages}
+    '';
 
   pythonImportsCheck = [
     "ramalama"


### PR DESCRIPTION
Before the change, ramalama erroneously excluded all deps from
wrapProgram if withPodman was false. Now only podman inclusion in the
closure is controlled by withPodman argument; other deps are always
included.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
