### PR TITLE
vmTools: add in 9 RHEL-adjacent distros, upgrade Debian/Ubuntu

### DIFF
--- a/doc/build-helpers/special/vm-tools.section.md
+++ b/doc/build-helpers/special/vm-tools.section.md
@@ -92,14 +92,14 @@ Generate a script that can be used to run an interactive session in the given im
 
 ### Examples {#vm-tools-makeImageTestScript-examples}
 
-Create a script for running a Fedora 27 VM:
+Create a script for running a Fedora 43 VM:
 ```nix
-{ pkgs }: with pkgs; with vmTools; makeImageTestScript diskImages.fedora27x86_64
+{ pkgs }: pkgs.vmTools.makeImageTestScript pkgs.vmTools.diskImages.fedora43x86_64
 ```
 
-Create a script for running an Ubuntu 20.04 VM:
+Create a script for running an Ubuntu 24.04 VM:
 ```nix
-{ pkgs }: with pkgs; with vmTools; makeImageTestScript diskImages.ubuntu2004x86_64
+{ pkgs }: pkgs.vmTools.makeImageTestScript pkgs.vmTools.diskImages.ubuntu2404x86_64
 ```
 
 ## `vmTools.diskImageFuns` {#vm-tools-diskImageFuns}
@@ -109,30 +109,32 @@ A set of functions that build a predefined set of minimal Linux distributions im
 ### Images {#vm-tools-diskImageFuns-images}
 
 * Fedora
-  * `fedora26x86_64`
-  * `fedora27x86_64`
-* CentOS
-  * `centos6i386`
-  * `centos6x86_64`
-  * `centos7x86_64`
+  * `fedora42x86_64`
+  * `fedora43x86_64`
+* CentOS Stream
+  * `centosStream9x86_64`
+  * `centosStream10x86_64`
+* Rocky Linux
+  * `rocky9x86_64`
+  * `rocky10x86_64`
+* AlmaLinux
+  * `alma9x86_64`
+  * `alma10x86_64`
+* Oracle Linux
+  * `oracle9x86_64`
+* Amazon Linux
+  * `amazon2023x86_64`
 * Ubuntu
-  * `ubuntu1404i386`
-  * `ubuntu1404x86_64`
-  * `ubuntu1604i386`
-  * `ubuntu1604x86_64`
-  * `ubuntu1804i386`
-  * `ubuntu1804x86_64`
-  * `ubuntu2004i386`
-  * `ubuntu2004x86_64`
   * `ubuntu2204i386`
   * `ubuntu2204x86_64`
+  * `ubuntu2404x86_64`
 * Debian
-  * `debian10i386`
-  * `debian10x86_64`
   * `debian11i386`
   * `debian11x86_64`
   * `debian12i386`
   * `debian12x86_64`
+  * `debian13i386`
+  * `debian13x86_64`
 
 ### Attributes {#vm-tools-diskImageFuns-attributes}
 
@@ -144,9 +146,7 @@ A set of functions that build a predefined set of minimal Linux distributions im
 8GiB image containing Firefox in addition to the default packages:
 ```nix
 { pkgs }:
-with pkgs;
-with vmTools;
-diskImageFuns.ubuntu2004x86_64 {
+pkgs.vmTools.diskImageFuns.ubuntu2404x86_64 {
   extraPackages = [ "firefox" ];
   size = 8192;
 }

--- a/doc/build-helpers/special/vm-tools.section.md
+++ b/doc/build-helpers/special/vm-tools.section.md
@@ -111,9 +111,6 @@ A set of functions that build a predefined set of minimal Linux distributions im
 * Fedora
   * `fedora42x86_64`
   * `fedora43x86_64`
-* CentOS Stream
-  * `centosStream9x86_64`
-  * `centosStream10x86_64`
 * Rocky Linux
   * `rocky9x86_64`
   * `rocky10x86_64`

--- a/nixos/lib/qemu-common.nix
+++ b/nixos/lib/qemu-common.nix
@@ -1,5 +1,5 @@
 # QEMU-related utilities shared between various Nix expressions.
-{ lib, pkgs }:
+{ lib, stdenv }:
 
 let
   zeroPad =
@@ -17,19 +17,19 @@ rec {
   ];
 
   qemuSerialDevice =
-    if with pkgs.stdenv.hostPlatform; isx86 || isLoongArch64 || isMips64 || isRiscV then
+    if with stdenv.hostPlatform; isx86 || isLoongArch64 || isMips64 || isRiscV then
       "ttyS0"
-    else if (with pkgs.stdenv.hostPlatform; isAarch || isPower) then
+    else if (with stdenv.hostPlatform; isAarch || isPower) then
       "ttyAMA0"
     else
-      throw "Unknown QEMU serial device for system '${pkgs.stdenv.hostPlatform.system}'";
+      throw "Unknown QEMU serial device for system '${stdenv.hostPlatform.system}'";
 
   qemuBinary =
     qemuPkg:
     let
       hostStdenv = qemuPkg.stdenv;
       hostSystem = hostStdenv.system;
-      guestSystem = pkgs.stdenv.hostPlatform.system;
+      guestSystem = stdenv.hostPlatform.system;
 
       linuxHostGuestMatrix = {
         x86_64-linux = "${qemuPkg}/bin/qemu-system-x86_64 -machine accel=kvm:tcg -cpu max";

--- a/nixos/lib/testing/network.nix
+++ b/nixos/lib/testing/network.nix
@@ -30,7 +30,7 @@ let
       ...
     }:
     let
-      qemu-common = import ../qemu-common.nix { inherit lib pkgs; };
+      qemu-common = import ../qemu-common.nix { inherit (pkgs) lib stdenv; };
 
       # Convert legacy VLANs to named interfaces and merge with explicit interfaces.
       vlansNumbered = forEach (zipLists config.virtualisation.vlans (range 1 255)) (v: {

--- a/nixos/modules/testing/test-instrumentation.nix
+++ b/nixos/modules/testing/test-instrumentation.nix
@@ -14,7 +14,7 @@ with lib;
 let
   cfg = config.testing;
 
-  qemu-common = import ../../lib/qemu-common.nix { inherit lib pkgs; };
+  qemu-common = import ../../lib/qemu-common.nix { inherit (pkgs) lib stdenv; };
 
   backdoorService = {
     requires = [

--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -16,7 +16,7 @@ with lib;
 
 let
 
-  qemu-common = import ../../lib/qemu-common.nix { inherit lib pkgs; };
+  qemu-common = import ../../lib/qemu-common.nix { inherit (pkgs) lib stdenv; };
 
   cfg = config.virtualisation;
 

--- a/nixos/tests/boot.nix
+++ b/nixos/tests/boot.nix
@@ -8,7 +8,7 @@ with import ../lib/testing-python.nix { inherit system pkgs; };
 
 let
   lib = pkgs.lib;
-  qemu-common = import ../lib/qemu-common.nix { inherit lib pkgs; };
+  qemu-common = import ../lib/qemu-common.nix { inherit (pkgs) lib stdenv; };
 
   mkStartCommand =
     {

--- a/nixos/tests/networking/router.nix
+++ b/nixos/tests/networking/router.nix
@@ -2,7 +2,7 @@
 { config, pkgs, ... }:
 let
   inherit (pkgs) lib;
-  qemu-common = import ../../lib/qemu-common.nix { inherit lib pkgs; };
+  qemu-common = import ../../lib/qemu-common.nix { inherit (pkgs) lib stdenv; };
   vlanIfs = lib.range 1 (lib.length config.virtualisation.vlans);
 in
 {

--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -24,7 +24,6 @@
   writeText,
   xz,
   zstd,
-  pkgs,
 
   # ----------------------------
   # The following  arguments form the "interface" of `pkgs.vmTools`.
@@ -47,7 +46,7 @@
 }:
 
 let
-  qemu-common = import ../../../nixos/lib/qemu-common.nix { inherit lib pkgs; };
+  qemu-common = import ../../../nixos/lib/qemu-common.nix { inherit lib stdenv; };
 
   qemu = buildPackages.qemu_kvm;
 
@@ -1323,8 +1322,6 @@ in
     makeImageTestScript
     modulesClosure
     qemu
-    qemu-common
-    qemuCommandLinux
     rpmClosureGenerator
     rpmDistros
     runInLinuxImage

--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -1004,20 +1004,22 @@ let
   # The set of supported Dpkg-based distributions.
 
   debDistros = {
+    # Ubuntu's snapshot service returns the same data for 22.04 regardless of the timestamp in the
+    # URL. The hashes don't change between mirror://ubuntu and snapshot.ubuntu.com, so this is fine.
     ubuntu2204i386 = {
       name = "ubuntu-22.04-jammy-i386";
       fullName = "Ubuntu 22.04 Jammy (i386)";
       packagesLists = [
         (fetchurl {
-          url = "mirror://ubuntu/dists/jammy/main/binary-i386/Packages.xz";
-          sha256 = "sha256-iZBmwT0ep4v+V3sayybbOgZBOFFZwPGpOKtmuLMMVPQ=";
+          url = "https://snapshot.ubuntu.com/ubuntu/20251217T000000Z/dists/jammy/main/binary-i386/Packages.xz";
+          hash = "sha256-iZBmwT0ep4v+V3sayybbOgZBOFFZwPGpOKtmuLMMVPQ=";
         })
         (fetchurl {
-          url = "mirror://ubuntu/dists/jammy/universe/binary-i386/Packages.xz";
-          sha256 = "sha256-DO2LdpZ9rDDBhWj2gvDWd0TJJVZHxKsYTKTi6GXjm1E=";
+          url = "https://snapshot.ubuntu.com/ubuntu/20251217T000000Z/dists/jammy/universe/binary-i386/Packages.xz";
+          hash = "sha256-DO2LdpZ9rDDBhWj2gvDWd0TJJVZHxKsYTKTi6GXjm1E=";
         })
       ];
-      urlPrefix = "mirror://ubuntu";
+      urlPrefix = "https://snapshot.ubuntu.com/ubuntu/20251217T000000Z";
       packages = commonDebPackages ++ [
         "diffutils"
         "libc-bin"
@@ -1029,15 +1031,15 @@ let
       fullName = "Ubuntu 22.04 Jammy (amd64)";
       packagesLists = [
         (fetchurl {
-          url = "mirror://ubuntu/dists/jammy/main/binary-amd64/Packages.xz";
-          sha256 = "sha256-N8tX8VVMv6ccWinun/7hipqMF4K7BWjgh0t/9M6PnBE=";
+          url = "https://snapshot.ubuntu.com/ubuntu/20251217T000000Z/dists/jammy/main/binary-amd64/Packages.xz";
+          hash = "sha256-N8tX8VVMv6ccWinun/7hipqMF4K7BWjgh0t/9M6PnBE=";
         })
         (fetchurl {
-          url = "mirror://ubuntu/dists/jammy/universe/binary-amd64/Packages.xz";
-          sha256 = "sha256-0pyyTJP+xfQyVXBrzn60bUd5lSA52MaKwbsUpvNlXOI=";
+          url = "https://snapshot.ubuntu.com/ubuntu/20251217T000000Z/dists/jammy/universe/binary-amd64/Packages.xz";
+          hash = "sha256-0pyyTJP+xfQyVXBrzn60bUd5lSA52MaKwbsUpvNlXOI=";
         })
       ];
-      urlPrefix = "mirror://ubuntu";
+      urlPrefix = "https://snapshot.ubuntu.com/ubuntu/20251217T000000Z";
       packages = commonDebPackages ++ [
         "diffutils"
         "libc-bin"
@@ -1049,15 +1051,15 @@ let
       fullName = "Ubuntu 24.04 Noble (amd64)";
       packagesLists = [
         (fetchurl {
-          url = "mirror://ubuntu/dists/noble/main/binary-amd64/Packages.xz";
-          sha256 = "sha256-KmoZnhAxpcJ5yzRmRtWUmT81scA91KgqqgMjmA3ZJFE=";
+          url = "https://snapshot.ubuntu.com/ubuntu/20251217T000000Z/dists/noble/main/binary-amd64/Packages.xz";
+          hash = "sha256-KmoZnhAxpcJ5yzRmRtWUmT81scA91KgqqgMjmA3ZJFE=";
         })
         (fetchurl {
-          url = "mirror://ubuntu/dists/noble/universe/binary-amd64/Packages.xz";
-          sha256 = "sha256-upBX+huRQ4zIodJoCNAMhTif4QHQwUliVN+XI2QFWZo=";
+          url = "https://snapshot.ubuntu.com/ubuntu/20251217T000000Z/dists/noble/universe/binary-amd64/Packages.xz";
+          hash = "sha256-upBX+huRQ4zIodJoCNAMhTif4QHQwUliVN+XI2QFWZo=";
         })
       ];
-      urlPrefix = "mirror://ubuntu";
+      urlPrefix = "https://snapshot.ubuntu.com/ubuntu/20251217T000000Z";
       packages = commonDebPackages ++ [
         "diffutils"
         "libc-bin"

--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -1220,17 +1220,20 @@ let
       unifiedSystemDir = true;
     };
 
+    # Oracle provides versioned URLs for baseos (e.g., OL9/7/baseos/base/) but not for appstream.
+    # We can't mix versioned baseos with rolling appstream due to package version dependencies,
+    # so we use rolling URLs for both. These may need hash updates when Oracle releases new versions.
     oracle9x86_64 = {
       name = "oracle-9-x86_64";
       fullName = "Oracle Linux 9 (x86_64)";
       packagesLists = [
         (fetchurl {
-          url = "https://yum.oracle.com/repo/OracleLinux/OL9/baseos/latest/x86_64/repodata/edda5aa6dc1ad233cd5fe29838e535ef959cd291be343844e127e29c290f93ca-primary.xml.gz";
-          hash = "sha256-7dpaptwa0jPNX+KYOOU175Wc0pG+NDhE4SfinCkPk8o=";
+          url = "https://yum.oracle.com/repo/OracleLinux/OL9/baseos/latest/x86_64/repodata/22683534c792aff59db7dc398a72291012dce25a2873843c004be83f85587822-primary.xml.gz";
+          hash = "sha256-Img1NMeSr/Wdt9w5inIpEBLc4looc4Q8AEvoP4VYeCI=";
         })
         (fetchurl {
-          url = "https://yum.oracle.com/repo/OracleLinux/OL9/appstream/x86_64/repodata/4d559ceb3228c2f734d1bcbc79079141e4ce1f2abd90ce77f7f8e31d1deb77b2-primary.xml.gz";
-          hash = "sha256-TVWc6zIowvc00by8eQeRQeTOHyq9kM539/jjHR3rd7I=";
+          url = "https://yum.oracle.com/repo/OracleLinux/OL9/appstream/x86_64/repodata/2a1fe56f0dabfcb0fcd6bcddbb5ca6052ac1a6ac124498d95578416c06162e0d-primary.xml.gz";
+          hash = "sha256-Kh/lbw2r/LD81rzdu1ymBSrBpqwSRJjZVXhBbAYWLg0=";
         })
       ];
       urlPrefixes = [

--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -1250,6 +1250,14 @@ let
       unifiedSystemDir = true;
     };
 
+    # Amazon Linux 2023 uses GUID-based URLs that don't allow directory listing.
+    # To update: The GUID corresponds to a specific AL2023 release version. You can find the
+    # current GUID by either:
+    #   1. Running an AL2023 container: `docker run -it amazonlinux:2023 dnf repolist -v`
+    #      and extracting the GUID from the Repo-baseurl field
+    #   2. Checking https://github.com/docker-library/repo-info/blob/master/repos/amazonlinux/local/latest.md
+    #      which tracks the repository URLs from the official Docker image
+    # Release notes: https://docs.aws.amazon.com/linux/al2023/release-notes/relnotes.html
     amazon2023x86_64 = {
       name = "amazon-2023-x86_64";
       fullName = "Amazon Linux 2023 (x86_64)";

--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -1050,6 +1050,31 @@ let
       packages = commonFedoraPackages ++ [ "gpgverify" ];
       unifiedSystemDir = true;
     };
+
+    centosStream9x86_64 = {
+      name = "centos-stream-9-x86_64";
+      fullName = "CentOS Stream 9 (x86_64)";
+      packagesLists = [
+        (fetchurl {
+          url = "https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/repodata/737e7bb91d5464e0cc258ff5ae5070a00d682c39fc2de0b9b55df671022ba732-primary.xml.gz";
+          hash = "sha256-c357uR1UZODMJY/1rlBwoA1oLDn8LeC5tV32cQIrpzI=";
+        })
+        (fetchurl {
+          url = "https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/repodata/9f0c1578e5df33e6479a1d3e5397b87ecaa1b5bac7fd34de6c837bddb3949fde-primary.xml.gz";
+          hash = "sha256-nwwVeOXfM+ZHmh0+U5e4fsqhtbrH/TTebIN73bOUn94=";
+        })
+      ];
+      urlPrefixes = [
+        "https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os"
+        "https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os"
+      ];
+      archs = [
+        "noarch"
+        "x86_64"
+      ];
+      packages = commonCentOSStreamPackages;
+      unifiedSystemDir = true;
+    };
   };
 
   # The set of supported Dpkg-based distributions.
@@ -1298,6 +1323,31 @@ let
     "patch"
     "perl"
     "pkgconfig"
+    "rpm"
+    "rpm-build"
+    "tar"
+    "unzip"
+  ];
+
+  commonCentOSStreamPackages = [
+    "annobin"
+    "autoconf"
+    "automake"
+    "basesystem"
+    "bzip2"
+    "curl"
+    "diffutils"
+    "centos-stream-release"
+    "findutils"
+    "gawk"
+    "gcc-c++"
+    "gcc-plugin-annobin"
+    "glibc-gconv-extra"
+    "gzip"
+    "make"
+    "patch"
+    "perl"
+    "pkgconf"
     "rpm"
     "rpm-build"
     "tar"

--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -1139,10 +1139,16 @@ let
     debian12i386 = {
       name = "debian-12.12-bookworm-i386";
       fullName = "Debian 12.12 Bookworm (i386)";
-      packagesList = fetchurl {
-        url = "https://snapshot.debian.org/archive/debian/20251217T203845Z/dists/bookworm/main/binary-i386/Packages.xz";
-        hash = "sha256-nIijsNoHUYkrL6eiwN4FCLHnJy/Bv/RMvnbMIHvieVI=";
-      };
+      packagesLists = [
+        (fetchurl {
+          url = "https://snapshot.debian.org/archive/debian/20251217T203845Z/dists/bookworm/main/binary-i386/Packages.xz";
+          hash = "sha256-nIijsNoHUYkrL6eiwN4FCLHnJy/Bv/RMvnbMIHvieVI=";
+        })
+        (fetchurl {
+          url = "https://snapshot.debian.org/archive/debian/20251217T203845Z/dists/bookworm-backports/main/binary-i386/Packages.xz";
+          hash = "sha256-9WXnIg1CgzTGaUXnCTs/n/EhJ11aNcKn7rV9FDAi+U8=";
+        })
+      ];
       urlPrefix = "https://snapshot.debian.org/archive/debian/20251217T203845Z";
       packages = commonDebianPackages;
     };
@@ -1150,10 +1156,16 @@ let
     debian12x86_64 = {
       name = "debian-12.12-bookworm-amd64";
       fullName = "Debian 12.12 Bookworm (amd64)";
-      packagesList = fetchurl {
-        url = "https://snapshot.debian.org/archive/debian/20251217T203845Z/dists/bookworm/main/binary-amd64/Packages.xz";
-        hash = "sha256-PfjQeu3tXmXZhH7foSD6WyFrvY4PfwSN/v5pBeShIBE=";
-      };
+      packagesLists = [
+        (fetchurl {
+          url = "https://snapshot.debian.org/archive/debian/20251217T203845Z/dists/bookworm/main/binary-amd64/Packages.xz";
+          hash = "sha256-PfjQeu3tXmXZhH7foSD6WyFrvY4PfwSN/v5pBeShIBE=";
+        })
+        (fetchurl {
+          url = "https://snapshot.debian.org/archive/debian/20251217T203845Z/dists/bookworm-backports/main/binary-amd64/Packages.xz";
+          hash = "sha256-i897N1JzuixjtZcFW90X/UJLXfxQOIQoJV9SC/VHpUE=";
+        })
+      ];
       urlPrefix = "https://snapshot.debian.org/archive/debian/20251217T203845Z";
       packages = commonDebianPackages;
     };
@@ -1161,10 +1173,16 @@ let
     debian13i386 = {
       name = "debian-13.2-trixie-i386";
       fullName = "Debian 13.2 Trixie (i386)";
-      packagesList = fetchurl {
-        url = "https://snapshot.debian.org/archive/debian/20251217T203845Z/dists/trixie/main/binary-i386/Packages.xz";
-        hash = "sha256-9zozvFZoWiv3wNe9rb+kPwSOgc5G5f4zmNpdoet5A78=";
-      };
+      packagesLists = [
+        (fetchurl {
+          url = "https://snapshot.debian.org/archive/debian/20251217T203845Z/dists/trixie/main/binary-i386/Packages.xz";
+          hash = "sha256-9zozvFZoWiv3wNe9rb+kPwSOgc5G5f4zmNpdoet5A78=";
+        })
+        (fetchurl {
+          url = "https://snapshot.debian.org/archive/debian/20251217T203845Z/dists/trixie-backports/main/binary-i386/Packages.xz";
+          hash = "sha256-JdBVmdbD5LQhHbqIHnPeJiGnhrZbJoiYPWlh73A2/wA=";
+        })
+      ];
       urlPrefix = "https://snapshot.debian.org/archive/debian/20251217T203845Z";
       packages = commonDebianPackages;
     };
@@ -1172,10 +1190,16 @@ let
     debian13x86_64 = {
       name = "debian-13.2-trixie-amd64";
       fullName = "Debian 13.2 Trixie (amd64)";
-      packagesList = fetchurl {
-        url = "https://snapshot.debian.org/archive/debian/20251217T203845Z/dists/trixie/main/binary-amd64/Packages.xz";
-        hash = "sha256-g7f+tKljUXAC4gxJfzSC8+j0GbiwRZjonv25tYuvxtU=";
-      };
+      packagesLists = [
+        (fetchurl {
+          url = "https://snapshot.debian.org/archive/debian/20251217T203845Z/dists/trixie/main/binary-amd64/Packages.xz";
+          hash = "sha256-g7f+tKljUXAC4gxJfzSC8+j0GbiwRZjonv25tYuvxtU=";
+        })
+        (fetchurl {
+          url = "https://snapshot.debian.org/archive/debian/20251217T203845Z/dists/trixie-backports/main/binary-amd64/Packages.xz";
+          hash = "sha256-J7BcablKTswyfKmCIoWGlE32puSDFgcKQGNmhbvl+CY=";
+        })
+      ];
       urlPrefix = "https://snapshot.debian.org/archive/debian/20251217T203845Z";
       packages = commonDebianPackages;
     };

--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -1162,6 +1162,60 @@ let
       ];
       unifiedSystemDir = true;
     };
+
+    alma9x86_64 = {
+      name = "alma-9-x86_64";
+      fullName = "AlmaLinux 9 (x86_64)";
+      packagesLists = [
+        (fetchurl {
+          url = "https://repo.almalinux.org/almalinux/9/BaseOS/x86_64/os/repodata/e7e7e537062ffd6778b5190b7b6785086efab6647401014d1985c10a0d3de609-primary.xml.gz";
+          hash = "sha256-5+flNwYv/Wd4tRkLe2eFCG76tmR0AQFNGYXBCg095gk=";
+        })
+        (fetchurl {
+          url = "https://repo.almalinux.org/almalinux/9/AppStream/x86_64/os/repodata/e61f480b84cb0a671452c21cbd52930a6fa111e7fb3407ed75cabff71c1a07b7-primary.xml.gz";
+          hash = "sha256-5h9IC4TLCmcUUsIcvVKTCm+hEef7NAftdcq/9xwaB7c=";
+        })
+      ];
+      urlPrefixes = [
+        "https://repo.almalinux.org/almalinux/9/BaseOS/x86_64/os"
+        "https://repo.almalinux.org/almalinux/9/AppStream/x86_64/os"
+      ];
+      archs = [
+        "noarch"
+        "x86_64"
+      ];
+      packages = commonAlmaPackages ++ [
+        "annobin"
+      ];
+      unifiedSystemDir = true;
+    };
+
+    alma10x86_64 = {
+      name = "alma-10-x86_64";
+      fullName = "AlmaLinux 10 (x86_64)";
+      packagesLists = [
+        (fetchurl {
+          url = "https://repo.almalinux.org/almalinux/10/BaseOS/x86_64/os/repodata/e0a4a18c4f302fa3188b757197b81d606199eccddd8480602c378def572fabbf-primary.xml.gz";
+          hash = "sha256-4KShjE8wL6MYi3Vxl7gdYGGZ7M3dhIBgLDeN71cvq78=";
+        })
+        (fetchurl {
+          url = "https://repo.almalinux.org/almalinux/10/AppStream/x86_64/os/repodata/fb3e7acc93f1b0969c3c00dc3bc4364d4f5837d11274cae650c34cf71c0f80ae-primary.xml.gz";
+          hash = "sha256-+z56zJPxsJacPADcO8Q2TU9YN9ESdMrmUMNM9xwPgK4=";
+        })
+      ];
+      urlPrefixes = [
+        "https://repo.almalinux.org/almalinux/10/BaseOS/x86_64/os"
+        "https://repo.almalinux.org/almalinux/10/AppStream/x86_64/os"
+      ];
+      archs = [
+        "noarch"
+        "x86_64"
+      ];
+      packages = commonAlmaPackages ++ [
+        "annobin-plugin-gcc"
+      ];
+      unifiedSystemDir = true;
+    };
   };
 
   # The set of supported Dpkg-based distributions.
@@ -1407,6 +1461,12 @@ let
     "gcc-plugin-annobin"
     "pkgconf"
     "rocky-release"
+  ];
+
+  commonAlmaPackages = baseRHELFamilyPackages ++ [
+    "almalinux-release"
+    "gcc-plugin-annobin"
+    "pkgconf"
   ];
 
   # Common packages for openSUSE images.

--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -1112,10 +1112,10 @@ let
       name = "debian-13.2-trixie-i386";
       fullName = "Debian 13.2 Trixie (i386)";
       packagesList = fetchurl {
-        url = "https://snapshot.debian.org/archive/debian/20251203T144617Z/dists/trixie/main/binary-i386/Packages.xz";
+        url = "https://snapshot.debian.org/archive/debian/20251217T203845Z/dists/trixie/main/binary-i386/Packages.xz";
         hash = "sha256-9zozvFZoWiv3wNe9rb+kPwSOgc5G5f4zmNpdoet5A78=";
       };
-      urlPrefix = "https://snapshot.debian.org/archive/debian/20251203T144617Z";
+      urlPrefix = "https://snapshot.debian.org/archive/debian/20251217T203845Z";
       packages = commonDebianPackages;
     };
 
@@ -1123,10 +1123,10 @@ let
       name = "debian-13.2-trixie-amd64";
       fullName = "Debian 13.2 Trixie (amd64)";
       packagesList = fetchurl {
-        url = "https://snapshot.debian.org/archive/debian/20251203T144617Z/dists/trixie/main/binary-amd64/Packages.xz";
+        url = "https://snapshot.debian.org/archive/debian/20251217T203845Z/dists/trixie/main/binary-amd64/Packages.xz";
         hash = "sha256-g7f+tKljUXAC4gxJfzSC8+j0GbiwRZjonv25tYuvxtU=";
       };
-      urlPrefix = "https://snapshot.debian.org/archive/debian/20251203T144617Z";
+      urlPrefix = "https://snapshot.debian.org/archive/debian/20251217T203845Z";
       packages = commonDebianPackages;
     };
   };

--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -1052,60 +1052,6 @@ let
       unifiedSystemDir = true;
     };
 
-    centosStream9x86_64 = {
-      name = "centos-stream-9-x86_64";
-      fullName = "CentOS Stream 9 (x86_64)";
-      packagesLists = [
-        (fetchurl {
-          url = "https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/repodata/737e7bb91d5464e0cc258ff5ae5070a00d682c39fc2de0b9b55df671022ba732-primary.xml.gz";
-          hash = "sha256-c357uR1UZODMJY/1rlBwoA1oLDn8LeC5tV32cQIrpzI=";
-        })
-        (fetchurl {
-          url = "https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/repodata/9f0c1578e5df33e6479a1d3e5397b87ecaa1b5bac7fd34de6c837bddb3949fde-primary.xml.gz";
-          hash = "sha256-nwwVeOXfM+ZHmh0+U5e4fsqhtbrH/TTebIN73bOUn94=";
-        })
-      ];
-      urlPrefixes = [
-        "https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os"
-        "https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os"
-      ];
-      archs = [
-        "noarch"
-        "x86_64"
-      ];
-      packages = commonCentOSStreamPackages ++ [
-        "annobin"
-      ];
-      unifiedSystemDir = true;
-    };
-
-    centosStream10x86_64 = {
-      name = "centos-stream-10-x86_64";
-      fullName = "CentOS Stream 10 (x86_64)";
-      packagesLists = [
-        (fetchurl {
-          url = "https://mirror.stream.centos.org/10-stream/BaseOS/x86_64/os/repodata/b3bb8f59e9c3dfedf3439c8357dc6fb727dc3e6fd2e351ab5e1fb0cfbbf07381-primary.xml.gz";
-          hash = "sha256-s7uPWenD3+3zQ5yDV9xvtyfcPm/S41GrXh+wz7vwc4E=";
-        })
-        (fetchurl {
-          url = "https://mirror.stream.centos.org/10-stream/AppStream/x86_64/os/repodata/962343afafa14dcc36a6c054608ae9bbf700c8ead08d1ca8898b5b1a192e3106-primary.xml.gz";
-          hash = "sha256-liNDr6+hTcw2psBUYIrpu/cAyOrQjRyoiYtbGhkuMQY=";
-        })
-      ];
-      urlPrefixes = [
-        "https://mirror.stream.centos.org/10-stream/BaseOS/x86_64/os"
-        "https://mirror.stream.centos.org/10-stream/AppStream/x86_64/os"
-      ];
-      archs = [
-        "noarch"
-        "x86_64"
-      ];
-      packages = commonCentOSStreamPackages ++ [
-        "annobin-plugin-gcc"
-      ];
-      unifiedSystemDir = true;
-    };
-
     # Rocky Linux's /pub/rocky/9/ URL is rolling and changes with each minor release. We use the
     # vault instead, which provides stable URLs for specific minor versions.
     rocky9x86_64 = {
@@ -1482,7 +1428,7 @@ let
     };
   };
 
-  # Base packages for all RHEL-family distros (Fedora, CentOS Stream, Rocky, Alma, etc.)
+  # Base packages for all RHEL-family distros (Fedora, Rocky, Alma, etc.)
   baseRHELFamilyPackages = [
     "autoconf"
     "automake"
@@ -1509,12 +1455,6 @@ let
     "fedora-release"
     "gcc-plugin-annobin"
     "pkgconf-pkg-config"
-  ];
-
-  commonCentOSStreamPackages = baseRHELFamilyPackages ++ [
-    "centos-stream-release"
-    "gcc-plugin-annobin"
-    "pkgconf"
   ];
 
   commonRockyPackages = baseRHELFamilyPackages ++ [

--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -1055,21 +1055,21 @@ let
     # Rocky Linux's /pub/rocky/9/ URL is rolling and changes with each minor release. We use the
     # vault instead, which provides stable URLs for specific minor versions.
     rocky9x86_64 = {
-      name = "rocky-9.5-x86_64";
-      fullName = "Rocky Linux 9.5 (x86_64)";
+      name = "rocky-9.6-x86_64";
+      fullName = "Rocky Linux 9.6 (x86_64)";
       packagesLists = [
         (fetchurl {
-          url = "https://dl.rockylinux.org/vault/rocky/9.5/BaseOS/x86_64/os/repodata/554cd09406b7bf632fc7014d0a567094272d37ac08f75af955de96183425dfa8-primary.xml.gz";
-          hash = "sha256-VUzQlAa3v2MvxwFNClZwlCctN6wI91r5Vd6WGDQl36g=";
+          url = "https://dl.rockylinux.org/vault/rocky/9.6/BaseOS/x86_64/os/repodata/9965e429a90787a87a07eed62872d046411fb7dded524b96d74c4ce1eade327a-primary.xml.gz";
+          hash = "sha256-mWXkKakHh6h6B+7WKHLQRkEft93tUkuW10xM4ereMno=";
         })
         (fetchurl {
-          url = "https://dl.rockylinux.org/vault/rocky/9.5/AppStream/x86_64/os/repodata/db8f32057dd37687574ea660d322ff7a0b5dc01bfba42888818b48ef686837cd-primary.xml.gz";
-          hash = "sha256-248yBX3TdodXTqZg0yL/egtdwBv7pCiIgYtI72hoN80=";
+          url = "https://dl.rockylinux.org/vault/rocky/9.6/AppStream/x86_64/os/repodata/8cc9f795679c3365c06b6135f685ebf4188a5863a5f52f09f8cabd4f09c4dfa1-primary.xml.gz";
+          hash = "sha256-jMn3lWecM2XAa2E19oXr9BiKWGOl9S8J+Mq9TwnE36E=";
         })
       ];
       urlPrefixes = [
-        "https://dl.rockylinux.org/vault/rocky/9.5/BaseOS/x86_64/os"
-        "https://dl.rockylinux.org/vault/rocky/9.5/AppStream/x86_64/os"
+        "https://dl.rockylinux.org/vault/rocky/9.6/BaseOS/x86_64/os"
+        "https://dl.rockylinux.org/vault/rocky/9.6/AppStream/x86_64/os"
       ];
       archs = [
         "noarch"

--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -1336,28 +1336,6 @@ let
     "unzip"
   ];
 
-  commonCentOSPackages = [
-    "autoconf"
-    "automake"
-    "basesystem"
-    "bzip2"
-    "curl"
-    "diffutils"
-    "centos-release"
-    "findutils"
-    "gawk"
-    "gcc-c++"
-    "gzip"
-    "make"
-    "patch"
-    "perl"
-    "pkgconfig"
-    "rpm"
-    "rpm-build"
-    "tar"
-    "unzip"
-  ];
-
   commonCentOSStreamPackages = [
     "autoconf"
     "automake"
@@ -1503,7 +1481,6 @@ in
 {
   inherit
     buildRPM
-    commonCentOSPackages
     commonDebPackages
     commonDebianPackages
     commonFedoraPackages

--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -1087,24 +1087,24 @@ let
     };
 
     debian12i386 = {
-      name = "debian-12.2-bookworm-i386";
-      fullName = "Debian 12.2 Bookworm (i386)";
+      name = "debian-12.12-bookworm-i386";
+      fullName = "Debian 12.12 Bookworm (i386)";
       packagesList = fetchurl {
-        url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/dists/bookworm/main/binary-i386/Packages.xz";
-        hash = "sha256-OeN9Q2HFM3GsPNhOa4VhM7qpwT66yUNwC+6Z8SbGEeQ=";
+        url = "https://snapshot.debian.org/archive/debian/20251217T203845Z/dists/bookworm/main/binary-i386/Packages.xz";
+        hash = "sha256-nIijsNoHUYkrL6eiwN4FCLHnJy/Bv/RMvnbMIHvieVI=";
       };
-      urlPrefix = "https://snapshot.debian.org/archive/debian/20231124T031419Z";
+      urlPrefix = "https://snapshot.debian.org/archive/debian/20251217T203845Z";
       packages = commonDebianPackages;
     };
 
     debian12x86_64 = {
-      name = "debian-12.2-bookworm-amd64";
-      fullName = "Debian 12.2 Bookworm (amd64)";
+      name = "debian-12.12-bookworm-amd64";
+      fullName = "Debian 12.12 Bookworm (amd64)";
       packagesList = fetchurl {
-        url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/dists/bookworm/main/binary-amd64/Packages.xz";
-        hash = "sha256-SZDElRfe9BlBwDlajQB79Qdn08rv8whYoQDeVCveKVs=";
+        url = "https://snapshot.debian.org/archive/debian/20251217T203845Z/dists/bookworm/main/binary-amd64/Packages.xz";
+        hash = "sha256-PfjQeu3tXmXZhH7foSD6WyFrvY4PfwSN/v5pBeShIBE=";
       };
-      urlPrefix = "https://snapshot.debian.org/archive/debian/20231124T031419Z";
+      urlPrefix = "https://snapshot.debian.org/archive/debian/20251217T203845Z";
       packages = commonDebianPackages;
     };
 

--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -1104,6 +1104,35 @@ let
       ];
       unifiedSystemDir = true;
     };
+
+    # Rocky Linux's /pub/rocky/9/ URL is rolling and changes with each minor release. We use the
+    # vault instead, which provides stable URLs for specific minor versions.
+    rocky9x86_64 = {
+      name = "rocky-9.5-x86_64";
+      fullName = "Rocky Linux 9.5 (x86_64)";
+      packagesLists = [
+        (fetchurl {
+          url = "https://dl.rockylinux.org/vault/rocky/9.5/BaseOS/x86_64/os/repodata/554cd09406b7bf632fc7014d0a567094272d37ac08f75af955de96183425dfa8-primary.xml.gz";
+          hash = "sha256-VUzQlAa3v2MvxwFNClZwlCctN6wI91r5Vd6WGDQl36g=";
+        })
+        (fetchurl {
+          url = "https://dl.rockylinux.org/vault/rocky/9.5/AppStream/x86_64/os/repodata/db8f32057dd37687574ea660d322ff7a0b5dc01bfba42888818b48ef686837cd-primary.xml.gz";
+          hash = "sha256-248yBX3TdodXTqZg0yL/egtdwBv7pCiIgYtI72hoN80=";
+        })
+      ];
+      urlPrefixes = [
+        "https://dl.rockylinux.org/vault/rocky/9.5/BaseOS/x86_64/os"
+        "https://dl.rockylinux.org/vault/rocky/9.5/AppStream/x86_64/os"
+      ];
+      archs = [
+        "noarch"
+        "x86_64"
+      ];
+      packages = commonRockyPackages ++ [
+        "annobin"
+      ];
+      unifiedSystemDir = true;
+    };
   };
 
   # The set of supported Dpkg-based distributions.
@@ -1343,6 +1372,12 @@ let
     "centos-stream-release"
     "gcc-plugin-annobin"
     "pkgconf"
+  ];
+
+  commonRockyPackages = baseRHELFamilyPackages ++ [
+    "gcc-plugin-annobin"
+    "pkgconf"
+    "rocky-release"
   ];
 
   # Common packages for openSUSE images.

--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -1310,76 +1310,39 @@ let
     };
   };
 
-  # Common packages for Fedora images.
-  commonFedoraPackages = [
+  # Base packages for all RHEL-family distros (Fedora, CentOS Stream, Rocky, Alma, etc.)
+  baseRHELFamilyPackages = [
+    "autoconf"
+    "automake"
+    "basesystem"
+    "bzip2"
+    "curl"
+    "diffutils"
+    "findutils"
+    "gawk"
+    "gcc-c++"
+    "glibc-gconv-extra"
+    "gzip"
+    "make"
+    "patch"
+    "perl"
+    "rpm"
+    "rpm-build"
+    "tar"
+    "unzip"
+  ];
+
+  commonFedoraPackages = baseRHELFamilyPackages ++ [
     "annobin-plugin-gcc"
-    "autoconf"
-    "automake"
-    "basesystem"
-    "bzip2"
-    "curl"
-    "diffutils"
     "fedora-release"
-    "findutils"
-    "gawk"
-    "gcc-c++"
     "gcc-plugin-annobin"
-    "glibc-gconv-extra"
-    "gzip"
-    "make"
-    "patch"
-    "perl"
     "pkgconf-pkg-config"
-    "rpm"
-    "rpm-build"
-    "tar"
-    "unzip"
   ];
 
-  commonCentOSStreamPackages = [
-    "autoconf"
-    "automake"
-    "basesystem"
-    "bzip2"
+  commonCentOSStreamPackages = baseRHELFamilyPackages ++ [
     "centos-stream-release"
-    "curl"
-    "diffutils"
-    "findutils"
-    "gawk"
-    "gcc-c++"
     "gcc-plugin-annobin"
-    "glibc-gconv-extra"
-    "gzip"
-    "make"
-    "patch"
-    "perl"
     "pkgconf"
-    "rpm"
-    "rpm-build"
-    "tar"
-    "unzip"
-  ];
-
-  commonRHELPackages = [
-    "autoconf"
-    "automake"
-    "basesystem"
-    "bzip2"
-    "curl"
-    "diffutils"
-    "findutils"
-    "gawk"
-    "gcc-c++"
-    "gzip"
-    "make"
-    "patch"
-    "perl"
-    "pkgconfig"
-    "procps-ng"
-    "rpm"
-    "rpm-build"
-    "tar"
-    "unzip"
   ];
 
   # Common packages for openSUSE images.
@@ -1485,7 +1448,6 @@ in
     commonDebianPackages
     commonFedoraPackages
     commonOpenSUSEPackages
-    commonRHELPackages
     createEmptyImage
     debClosureGenerator
     debDistros

--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -1072,7 +1072,36 @@ let
         "noarch"
         "x86_64"
       ];
-      packages = commonCentOSStreamPackages;
+      packages = commonCentOSStreamPackages ++ [
+        "annobin"
+      ];
+      unifiedSystemDir = true;
+    };
+
+    centosStream10x86_64 = {
+      name = "centos-stream-10-x86_64";
+      fullName = "CentOS Stream 10 (x86_64)";
+      packagesLists = [
+        (fetchurl {
+          url = "https://mirror.stream.centos.org/10-stream/BaseOS/x86_64/os/repodata/b3bb8f59e9c3dfedf3439c8357dc6fb727dc3e6fd2e351ab5e1fb0cfbbf07381-primary.xml.gz";
+          hash = "sha256-s7uPWenD3+3zQ5yDV9xvtyfcPm/S41GrXh+wz7vwc4E=";
+        })
+        (fetchurl {
+          url = "https://mirror.stream.centos.org/10-stream/AppStream/x86_64/os/repodata/962343afafa14dcc36a6c054608ae9bbf700c8ead08d1ca8898b5b1a192e3106-primary.xml.gz";
+          hash = "sha256-liNDr6+hTcw2psBUYIrpu/cAyOrQjRyoiYtbGhkuMQY=";
+        })
+      ];
+      urlPrefixes = [
+        "https://mirror.stream.centos.org/10-stream/BaseOS/x86_64/os"
+        "https://mirror.stream.centos.org/10-stream/AppStream/x86_64/os"
+      ];
+      archs = [
+        "noarch"
+        "x86_64"
+      ];
+      packages = commonCentOSStreamPackages ++ [
+        "annobin-plugin-gcc"
+      ];
       unifiedSystemDir = true;
     };
   };
@@ -1330,14 +1359,13 @@ let
   ];
 
   commonCentOSStreamPackages = [
-    "annobin"
     "autoconf"
     "automake"
     "basesystem"
     "bzip2"
+    "centos-stream-release"
     "curl"
     "diffutils"
-    "centos-stream-release"
     "findutils"
     "gawk"
     "gcc-c++"

--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -1216,6 +1216,34 @@ let
       ];
       unifiedSystemDir = true;
     };
+
+    oracle9x86_64 = {
+      name = "oracle-9-x86_64";
+      fullName = "Oracle Linux 9 (x86_64)";
+      packagesLists = [
+        (fetchurl {
+          url = "https://yum.oracle.com/repo/OracleLinux/OL9/baseos/latest/x86_64/repodata/edda5aa6dc1ad233cd5fe29838e535ef959cd291be343844e127e29c290f93ca-primary.xml.gz";
+          hash = "sha256-7dpaptwa0jPNX+KYOOU175Wc0pG+NDhE4SfinCkPk8o=";
+        })
+        (fetchurl {
+          url = "https://yum.oracle.com/repo/OracleLinux/OL9/appstream/x86_64/repodata/4d559ceb3228c2f734d1bcbc79079141e4ce1f2abd90ce77f7f8e31d1deb77b2-primary.xml.gz";
+          hash = "sha256-TVWc6zIowvc00by8eQeRQeTOHyq9kM539/jjHR3rd7I=";
+        })
+      ];
+      urlPrefixes = [
+        "https://yum.oracle.com/repo/OracleLinux/OL9/baseos/latest/x86_64"
+        "https://yum.oracle.com/repo/OracleLinux/OL9/appstream/x86_64"
+      ];
+      archs = [
+        "noarch"
+        "x86_64"
+      ];
+      packages = commonOraclePackages ++ [
+        "annobin"
+      ];
+      unifiedSystemDir = true;
+    };
+
   };
 
   # The set of supported Dpkg-based distributions.
@@ -1466,6 +1494,12 @@ let
   commonAlmaPackages = baseRHELFamilyPackages ++ [
     "almalinux-release"
     "gcc-plugin-annobin"
+    "pkgconf"
+  ];
+
+  commonOraclePackages = baseRHELFamilyPackages ++ [
+    "gcc-plugin-annobin"
+    "oraclelinux-release"
     "pkgconf"
   ];
 

--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -1174,12 +1174,12 @@ let
       fullName = "Oracle Linux 9 (x86_64)";
       packagesLists = [
         (fetchurl {
-          url = "https://yum.oracle.com/repo/OracleLinux/OL9/baseos/latest/x86_64/repodata/22683534c792aff59db7dc398a72291012dce25a2873843c004be83f85587822-primary.xml.gz";
-          hash = "sha256-Img1NMeSr/Wdt9w5inIpEBLc4looc4Q8AEvoP4VYeCI=";
+          url = "https://yum.oracle.com/repo/OracleLinux/OL9/baseos/latest/x86_64/repodata/bc292d67f73fc606db1872d5ba8804da06a514efe64523247035f0d3b678fb63-primary.xml.gz";
+          hash = "sha256-vCktZ/c/xgbbGHLVuogE2galFO/mRSMkcDXw07Z4+2M=";
         })
         (fetchurl {
-          url = "https://yum.oracle.com/repo/OracleLinux/OL9/appstream/x86_64/repodata/2a1fe56f0dabfcb0fcd6bcddbb5ca6052ac1a6ac124498d95578416c06162e0d-primary.xml.gz";
-          hash = "sha256-Kh/lbw2r/LD81rzdu1ymBSrBpqwSRJjZVXhBbAYWLg0=";
+          url = "https://yum.oracle.com/repo/OracleLinux/OL9/appstream/x86_64/repodata/6fabacadf7cdf22cbb21dc296f58e6b852d5b8ec9a927e214231477ef90083f9-primary.xml.gz";
+          hash = "sha256-b6usrffN8iy7Idwpb1jmuFLVuOyakn4hQjFHfvkAg/k=";
         })
       ];
       urlPrefixes = [

--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -836,6 +836,7 @@ let
       {
         nativeBuildInputs = [
           buildPackages.perl
+          buildPackages.perlPackages.URI
           buildPackages.perlPackages.XMLSimple
           buildPackages.zstd
         ];
@@ -1244,6 +1245,24 @@ let
       unifiedSystemDir = true;
     };
 
+    amazon2023x86_64 = {
+      name = "amazon-2023-x86_64";
+      fullName = "Amazon Linux 2023 (x86_64)";
+      packagesList = fetchurl {
+        url = "https://cdn.amazonlinux.com/al2023/core/guids/6fa961924efb4835a7e8de43c89726dca28a5cf5906f891262d8f78a31ea3aaf/x86_64/repodata/primary.xml.gz";
+        hash = "sha256-Ezdsc8a2aOIbyXvQ/nyanWe1fl089VgtfegaPcu2oo4=";
+      };
+      urlPrefix = "https://cdn.amazonlinux.com/al2023/core/guids/6fa961924efb4835a7e8de43c89726dca28a5cf5906f891262d8f78a31ea3aaf/x86_64";
+      archs = [
+        "noarch"
+        "x86_64"
+      ];
+      packages = commonAmazonPackages ++ [
+        "annobin-plugin-gcc"
+      ];
+      unifiedSystemDir = true;
+    };
+
   };
 
   # The set of supported Dpkg-based distributions.
@@ -1501,6 +1520,12 @@ let
     "gcc-plugin-annobin"
     "oraclelinux-release"
     "pkgconf"
+  ];
+
+  commonAmazonPackages = baseRHELFamilyPackages ++ [
+    "gcc-plugin-annobin"
+    "pkgconf"
+    "system-release"
   ];
 
   # Common packages for openSUSE images.

--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -1065,24 +1065,24 @@ let
     };
 
     debian11i386 = {
-      name = "debian-11.8-bullseye-i386";
-      fullName = "Debian 11.8 Bullseye (i386)";
+      name = "debian-11.11-bullseye-i386";
+      fullName = "Debian 11.11 Bullseye (i386)";
       packagesList = fetchurl {
-        url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/dists/bullseye/main/binary-i386/Packages.xz";
-        hash = "sha256-0bKSLLPhEC7FB5D1NA2jaQP0wTe/Qp1ddiA/NDVjRaI=";
+        url = "https://snapshot.debian.org/archive/debian/20251217T203845Z/dists/bullseye/main/binary-i386/Packages.xz";
+        hash = "sha256-kUg1VBUO6co/5bKloxncta49191oCeF05Hm399+UuDA=";
       };
-      urlPrefix = "https://snapshot.debian.org/archive/debian/20231124T031419Z";
+      urlPrefix = "https://snapshot.debian.org/archive/debian/20251217T203845Z";
       packages = commonDebianPackages;
     };
 
     debian11x86_64 = {
-      name = "debian-11.8-bullseye-amd64";
-      fullName = "Debian 11.8 Bullseye (amd64)";
+      name = "debian-11.11-bullseye-amd64";
+      fullName = "Debian 11.11 Bullseye (amd64)";
       packagesList = fetchurl {
-        url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/dists/bullseye/main/binary-amd64/Packages.xz";
-        hash = "sha256-CYPsGgQgJZkh3JmbcAQkYDWP193qrkOADOgrMETZIeo=";
+        url = "https://snapshot.debian.org/archive/debian/20251217T203845Z/dists/bullseye/main/binary-amd64/Packages.xz";
+        hash = "sha256-HDQFREKX6thkcRwY5kvOSBDbY7SDQKL52BGC2fI1rXE=";
       };
-      urlPrefix = "https://snapshot.debian.org/archive/debian/20231124T031419Z";
+      urlPrefix = "https://snapshot.debian.org/archive/debian/20251217T203845Z";
       packages = commonDebianPackages;
     };
 

--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -1234,31 +1234,31 @@ let
       fullName = "Ubuntu 22.04 Jammy (i386)";
       packagesLists = [
         (fetchurl {
-          url = "https://snapshot.ubuntu.com/ubuntu/20251217T000000Z/dists/jammy/main/binary-i386/Packages.xz";
+          url = "https://snapshot.ubuntu.com/ubuntu/20260101T000000Z/dists/jammy/main/binary-i386/Packages.xz";
           hash = "sha256-iZBmwT0ep4v+V3sayybbOgZBOFFZwPGpOKtmuLMMVPQ=";
         })
         (fetchurl {
-          url = "https://snapshot.ubuntu.com/ubuntu/20251217T000000Z/dists/jammy/universe/binary-i386/Packages.xz";
+          url = "https://snapshot.ubuntu.com/ubuntu/20260101T000000Z/dists/jammy/universe/binary-i386/Packages.xz";
           hash = "sha256-DO2LdpZ9rDDBhWj2gvDWd0TJJVZHxKsYTKTi6GXjm1E=";
         })
         (fetchurl {
-          url = "https://snapshot.ubuntu.com/ubuntu/20251217T000000Z/dists/jammy-updates/main/binary-i386/Packages.xz";
+          url = "https://snapshot.ubuntu.com/ubuntu/20260101T000000Z/dists/jammy-updates/main/binary-i386/Packages.xz";
           hash = "sha256-g95BtOoMxacZEHMBbcMes4a1P9HKf/QGOMOPr+OKayo=";
         })
         (fetchurl {
-          url = "https://snapshot.ubuntu.com/ubuntu/20251217T000000Z/dists/jammy-updates/universe/binary-i386/Packages.xz";
-          hash = "sha256-AW/XNsA1SblUhfkUP9pC/TLF6cerGI41gfSBCihgt7w=";
+          url = "https://snapshot.ubuntu.com/ubuntu/20260101T000000Z/dists/jammy-updates/universe/binary-i386/Packages.xz";
+          hash = "sha256-VbazaDDJKSUyQchGmw5f+FYAr4PIXWZJSBF0WVC5j+0=";
         })
         (fetchurl {
-          url = "https://snapshot.ubuntu.com/ubuntu/20251217T000000Z/dists/jammy-security/main/binary-i386/Packages.xz";
+          url = "https://snapshot.ubuntu.com/ubuntu/20260101T000000Z/dists/jammy-security/main/binary-i386/Packages.xz";
           hash = "sha256-SkP4PqjUAbEMtktR5WQm/3jQl9O0T2VOVTP9QIYIVkQ=";
         })
         (fetchurl {
-          url = "https://snapshot.ubuntu.com/ubuntu/20251217T000000Z/dists/jammy-security/universe/binary-i386/Packages.xz";
+          url = "https://snapshot.ubuntu.com/ubuntu/20260101T000000Z/dists/jammy-security/universe/binary-i386/Packages.xz";
           hash = "sha256-citjk8LAGSRlXgOXgf3oe9vBCUC6/DJGhRJl/3ppN9c=";
         })
       ];
-      urlPrefix = "https://snapshot.ubuntu.com/ubuntu/20251217T000000Z";
+      urlPrefix = "https://snapshot.ubuntu.com/ubuntu/20260101T000000Z";
       packages = commonDebPackages ++ [
         "diffutils"
         "libc-bin"
@@ -1270,31 +1270,31 @@ let
       fullName = "Ubuntu 22.04 Jammy (amd64)";
       packagesLists = [
         (fetchurl {
-          url = "https://snapshot.ubuntu.com/ubuntu/20251217T000000Z/dists/jammy/main/binary-amd64/Packages.xz";
+          url = "https://snapshot.ubuntu.com/ubuntu/20260101T000000Z/dists/jammy/main/binary-amd64/Packages.xz";
           hash = "sha256-N8tX8VVMv6ccWinun/7hipqMF4K7BWjgh0t/9M6PnBE=";
         })
         (fetchurl {
-          url = "https://snapshot.ubuntu.com/ubuntu/20251217T000000Z/dists/jammy/universe/binary-amd64/Packages.xz";
+          url = "https://snapshot.ubuntu.com/ubuntu/20260101T000000Z/dists/jammy/universe/binary-amd64/Packages.xz";
           hash = "sha256-0pyyTJP+xfQyVXBrzn60bUd5lSA52MaKwbsUpvNlXOI=";
         })
         (fetchurl {
-          url = "https://snapshot.ubuntu.com/ubuntu/20251217T000000Z/dists/jammy-updates/main/binary-amd64/Packages.xz";
-          hash = "sha256-kFHg+DogK+deDx9Tbp7+SaIegnotE5ZofqR8J7S73n8=";
+          url = "https://snapshot.ubuntu.com/ubuntu/20260101T000000Z/dists/jammy-updates/main/binary-amd64/Packages.xz";
+          hash = "sha256-I57YuLZ458RljXfp1xFxqQLGNJh9uu8kQC0hc88XZro=";
         })
         (fetchurl {
-          url = "https://snapshot.ubuntu.com/ubuntu/20251217T000000Z/dists/jammy-updates/universe/binary-amd64/Packages.xz";
-          hash = "sha256-WQbtqdAWbhfd8/fwct1uuJXHiZQGPMw3KKhmha4MeTs=";
+          url = "https://snapshot.ubuntu.com/ubuntu/20260101T000000Z/dists/jammy-updates/universe/binary-amd64/Packages.xz";
+          hash = "sha256-ZXobWMi7tkakZ89GoyKpiRhRxMRXud0DOerSfzz5CPE=";
         })
         (fetchurl {
-          url = "https://snapshot.ubuntu.com/ubuntu/20251217T000000Z/dists/jammy-security/main/binary-amd64/Packages.xz";
+          url = "https://snapshot.ubuntu.com/ubuntu/20260101T000000Z/dists/jammy-security/main/binary-amd64/Packages.xz";
           hash = "sha256-cifTPY1iyckkaLd7dp+VPRlF0viWKrWXhM8HVWaMuUw=";
         })
         (fetchurl {
-          url = "https://snapshot.ubuntu.com/ubuntu/20251217T000000Z/dists/jammy-security/universe/binary-amd64/Packages.xz";
+          url = "https://snapshot.ubuntu.com/ubuntu/20260101T000000Z/dists/jammy-security/universe/binary-amd64/Packages.xz";
           hash = "sha256-LTSOGbzkv0KrF2JM6oVT1Ml2KQkySXMbKNMBb9AyfQM=";
         })
       ];
-      urlPrefix = "https://snapshot.ubuntu.com/ubuntu/20251217T000000Z";
+      urlPrefix = "https://snapshot.ubuntu.com/ubuntu/20260101T000000Z";
       packages = commonDebPackages ++ [
         "diffutils"
         "libc-bin"
@@ -1306,31 +1306,31 @@ let
       fullName = "Ubuntu 24.04 Noble (amd64)";
       packagesLists = [
         (fetchurl {
-          url = "https://snapshot.ubuntu.com/ubuntu/20251217T000000Z/dists/noble/main/binary-amd64/Packages.xz";
+          url = "https://snapshot.ubuntu.com/ubuntu/20260101T000000Z/dists/noble/main/binary-amd64/Packages.xz";
           hash = "sha256-KmoZnhAxpcJ5yzRmRtWUmT81scA91KgqqgMjmA3ZJFE=";
         })
         (fetchurl {
-          url = "https://snapshot.ubuntu.com/ubuntu/20251217T000000Z/dists/noble/universe/binary-amd64/Packages.xz";
+          url = "https://snapshot.ubuntu.com/ubuntu/20260101T000000Z/dists/noble/universe/binary-amd64/Packages.xz";
           hash = "sha256-upBX+huRQ4zIodJoCNAMhTif4QHQwUliVN+XI2QFWZo=";
         })
         (fetchurl {
-          url = "https://snapshot.ubuntu.com/ubuntu/20251217T000000Z/dists/noble-updates/main/binary-amd64/Packages.xz";
-          hash = "sha256-f6hiUH9S1Bh8/Ljr9AkZYlwHF1vT2bqKGH6TfWnzI7Q=";
+          url = "https://snapshot.ubuntu.com/ubuntu/20260101T000000Z/dists/noble-updates/main/binary-amd64/Packages.xz";
+          hash = "sha256-leBJ29a2C2qdIPdjSSuwkHKUSq8GEC9L0DgdxHWZ55s=";
         })
         (fetchurl {
-          url = "https://snapshot.ubuntu.com/ubuntu/20251217T000000Z/dists/noble-updates/universe/binary-amd64/Packages.xz";
-          hash = "sha256-ROG+WO5zssfFUblTZxQjIDshdLIZn3meEgTsv6qYi5o=";
+          url = "https://snapshot.ubuntu.com/ubuntu/20260101T000000Z/dists/noble-updates/universe/binary-amd64/Packages.xz";
+          hash = "sha256-CWYA0A4ytptWdClW3ACdIH4hKscblDh5OgxExP4VdJA=";
         })
         (fetchurl {
-          url = "https://snapshot.ubuntu.com/ubuntu/20251217T000000Z/dists/noble-security/main/binary-amd64/Packages.xz";
+          url = "https://snapshot.ubuntu.com/ubuntu/20260101T000000Z/dists/noble-security/main/binary-amd64/Packages.xz";
           hash = "sha256-TYs8ugCYqzOleH2OebdrpB8E68PfxB+7sRb+PlfANEo=";
         })
         (fetchurl {
-          url = "https://snapshot.ubuntu.com/ubuntu/20251217T000000Z/dists/noble-security/universe/binary-amd64/Packages.xz";
+          url = "https://snapshot.ubuntu.com/ubuntu/20260101T000000Z/dists/noble-security/universe/binary-amd64/Packages.xz";
           hash = "sha256-bK9R8CUjLQ1V4GP7/KqZooSnKHF5+T5SuBs0butC82M=";
         })
       ];
-      urlPrefix = "https://snapshot.ubuntu.com/ubuntu/20251217T000000Z";
+      urlPrefix = "https://snapshot.ubuntu.com/ubuntu/20260101T000000Z";
       packages = commonDebPackages ++ [
         "diffutils"
         "libc-bin"

--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -1133,6 +1133,35 @@ let
       ];
       unifiedSystemDir = true;
     };
+
+    # Rocky Linux's /pub/rocky/10/ URL is rolling and changes with each minor release. We use the
+    # vault instead, which provides stable URLs for specific minor versions.
+    rocky10x86_64 = {
+      name = "rocky-10.0-x86_64";
+      fullName = "Rocky Linux 10.0 (x86_64)";
+      packagesLists = [
+        (fetchurl {
+          url = "https://dl.rockylinux.org/vault/rocky/10.0/BaseOS/x86_64/os/repodata/484d5c43cdb1058dd1328a6b891f45c85f1cb2620c528f2ef423d4b9feb9e2f0-primary.xml.gz";
+          hash = "sha256-SE1cQ82xBY3RMopriR9FyF8csmIMUo8u9CPUuf654vA=";
+        })
+        (fetchurl {
+          url = "https://dl.rockylinux.org/vault/rocky/10.0/AppStream/x86_64/os/repodata/32c93064142d89f3f19c11e92642c5abd8368418f7ab3f3bdd752e4afa9b5b23-primary.xml.gz";
+          hash = "sha256-MskwZBQtifPxnBHpJkLFq9g2hBj3qz873XUuSvqbWyM=";
+        })
+      ];
+      urlPrefixes = [
+        "https://dl.rockylinux.org/vault/rocky/10.0/BaseOS/x86_64/os"
+        "https://dl.rockylinux.org/vault/rocky/10.0/AppStream/x86_64/os"
+      ];
+      archs = [
+        "noarch"
+        "x86_64"
+      ];
+      packages = commonRockyPackages ++ [
+        "annobin-plugin-gcc"
+      ];
+      unifiedSystemDir = true;
+    };
   };
 
   # The set of supported Dpkg-based distributions.

--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -1341,10 +1341,10 @@ let
       name = "debian-11.11-bullseye-i386";
       fullName = "Debian 11.11 Bullseye (i386)";
       packagesList = fetchurl {
-        url = "https://snapshot.debian.org/archive/debian/20251217T203845Z/dists/bullseye/main/binary-i386/Packages.xz";
+        url = "https://snapshot.debian.org/archive/debian/20260105T082626Z/dists/bullseye/main/binary-i386/Packages.xz";
         hash = "sha256-kUg1VBUO6co/5bKloxncta49191oCeF05Hm399+UuDA=";
       };
-      urlPrefix = "https://snapshot.debian.org/archive/debian/20251217T203845Z";
+      urlPrefix = "https://snapshot.debian.org/archive/debian/20260105T082626Z";
       packages = commonDebianPackages;
     };
 
@@ -1352,10 +1352,10 @@ let
       name = "debian-11.11-bullseye-amd64";
       fullName = "Debian 11.11 Bullseye (amd64)";
       packagesList = fetchurl {
-        url = "https://snapshot.debian.org/archive/debian/20251217T203845Z/dists/bullseye/main/binary-amd64/Packages.xz";
+        url = "https://snapshot.debian.org/archive/debian/20260105T082626Z/dists/bullseye/main/binary-amd64/Packages.xz";
         hash = "sha256-HDQFREKX6thkcRwY5kvOSBDbY7SDQKL52BGC2fI1rXE=";
       };
-      urlPrefix = "https://snapshot.debian.org/archive/debian/20251217T203845Z";
+      urlPrefix = "https://snapshot.debian.org/archive/debian/20260105T082626Z";
       packages = commonDebianPackages;
     };
 
@@ -1364,15 +1364,15 @@ let
       fullName = "Debian 12.12 Bookworm (i386)";
       packagesLists = [
         (fetchurl {
-          url = "https://snapshot.debian.org/archive/debian/20251217T203845Z/dists/bookworm/main/binary-i386/Packages.xz";
+          url = "https://snapshot.debian.org/archive/debian/20260105T082626Z/dists/bookworm/main/binary-i386/Packages.xz";
           hash = "sha256-nIijsNoHUYkrL6eiwN4FCLHnJy/Bv/RMvnbMIHvieVI=";
         })
         (fetchurl {
-          url = "https://snapshot.debian.org/archive/debian/20251217T203845Z/dists/bookworm-backports/main/binary-i386/Packages.xz";
-          hash = "sha256-9WXnIg1CgzTGaUXnCTs/n/EhJ11aNcKn7rV9FDAi+U8=";
+          url = "https://snapshot.debian.org/archive/debian/20260105T082626Z/dists/bookworm-backports/main/binary-i386/Packages.xz";
+          hash = "sha256-/ja7+DNIKc2ZUIXiocTjLbaD2EPsfeyZcd5ndEMapp4=";
         })
       ];
-      urlPrefix = "https://snapshot.debian.org/archive/debian/20251217T203845Z";
+      urlPrefix = "https://snapshot.debian.org/archive/debian/20260105T082626Z";
       packages = commonDebianPackages;
     };
 
@@ -1381,15 +1381,15 @@ let
       fullName = "Debian 12.12 Bookworm (amd64)";
       packagesLists = [
         (fetchurl {
-          url = "https://snapshot.debian.org/archive/debian/20251217T203845Z/dists/bookworm/main/binary-amd64/Packages.xz";
+          url = "https://snapshot.debian.org/archive/debian/20260105T082626Z/dists/bookworm/main/binary-amd64/Packages.xz";
           hash = "sha256-PfjQeu3tXmXZhH7foSD6WyFrvY4PfwSN/v5pBeShIBE=";
         })
         (fetchurl {
-          url = "https://snapshot.debian.org/archive/debian/20251217T203845Z/dists/bookworm-backports/main/binary-amd64/Packages.xz";
-          hash = "sha256-i897N1JzuixjtZcFW90X/UJLXfxQOIQoJV9SC/VHpUE=";
+          url = "https://snapshot.debian.org/archive/debian/20260105T082626Z/dists/bookworm-backports/main/binary-amd64/Packages.xz";
+          hash = "sha256-S3NSvw1kX2zxzMh+WYhY58VUR7iLrTEIuXwwSK6itIs=";
         })
       ];
-      urlPrefix = "https://snapshot.debian.org/archive/debian/20251217T203845Z";
+      urlPrefix = "https://snapshot.debian.org/archive/debian/20260105T082626Z";
       packages = commonDebianPackages;
     };
 
@@ -1398,15 +1398,15 @@ let
       fullName = "Debian 13.2 Trixie (i386)";
       packagesLists = [
         (fetchurl {
-          url = "https://snapshot.debian.org/archive/debian/20251217T203845Z/dists/trixie/main/binary-i386/Packages.xz";
+          url = "https://snapshot.debian.org/archive/debian/20260105T082626Z/dists/trixie/main/binary-i386/Packages.xz";
           hash = "sha256-9zozvFZoWiv3wNe9rb+kPwSOgc5G5f4zmNpdoet5A78=";
         })
         (fetchurl {
-          url = "https://snapshot.debian.org/archive/debian/20251217T203845Z/dists/trixie-backports/main/binary-i386/Packages.xz";
-          hash = "sha256-JdBVmdbD5LQhHbqIHnPeJiGnhrZbJoiYPWlh73A2/wA=";
+          url = "https://snapshot.debian.org/archive/debian/20260105T082626Z/dists/trixie-backports/main/binary-i386/Packages.xz";
+          hash = "sha256-hEBAQ73Jnv8zp9YvNXWLEObyrSlQNBNBj/XoofJL7eI=";
         })
       ];
-      urlPrefix = "https://snapshot.debian.org/archive/debian/20251217T203845Z";
+      urlPrefix = "https://snapshot.debian.org/archive/debian/20260105T082626Z";
       packages = commonDebianPackages;
     };
 
@@ -1415,15 +1415,15 @@ let
       fullName = "Debian 13.2 Trixie (amd64)";
       packagesLists = [
         (fetchurl {
-          url = "https://snapshot.debian.org/archive/debian/20251217T203845Z/dists/trixie/main/binary-amd64/Packages.xz";
+          url = "https://snapshot.debian.org/archive/debian/20260105T082626Z/dists/trixie/main/binary-amd64/Packages.xz";
           hash = "sha256-g7f+tKljUXAC4gxJfzSC8+j0GbiwRZjonv25tYuvxtU=";
         })
         (fetchurl {
-          url = "https://snapshot.debian.org/archive/debian/20251217T203845Z/dists/trixie-backports/main/binary-amd64/Packages.xz";
-          hash = "sha256-J7BcablKTswyfKmCIoWGlE32puSDFgcKQGNmhbvl+CY=";
+          url = "https://snapshot.debian.org/archive/debian/20260105T082626Z/dists/trixie-backports/main/binary-amd64/Packages.xz";
+          hash = "sha256-9OoR36FsyK7MQMLHLFMRJ9O11WKq9JCfGwnprpztxNw=";
         })
       ];
-      urlPrefix = "https://snapshot.debian.org/archive/debian/20251217T203845Z";
+      urlPrefix = "https://snapshot.debian.org/archive/debian/20260105T082626Z";
       packages = commonDebianPackages;
     };
   };

--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -1018,6 +1018,22 @@ let
           url = "https://snapshot.ubuntu.com/ubuntu/20251217T000000Z/dists/jammy/universe/binary-i386/Packages.xz";
           hash = "sha256-DO2LdpZ9rDDBhWj2gvDWd0TJJVZHxKsYTKTi6GXjm1E=";
         })
+        (fetchurl {
+          url = "https://snapshot.ubuntu.com/ubuntu/20251217T000000Z/dists/jammy-updates/main/binary-i386/Packages.xz";
+          hash = "sha256-g95BtOoMxacZEHMBbcMes4a1P9HKf/QGOMOPr+OKayo=";
+        })
+        (fetchurl {
+          url = "https://snapshot.ubuntu.com/ubuntu/20251217T000000Z/dists/jammy-updates/universe/binary-i386/Packages.xz";
+          hash = "sha256-AW/XNsA1SblUhfkUP9pC/TLF6cerGI41gfSBCihgt7w=";
+        })
+        (fetchurl {
+          url = "https://snapshot.ubuntu.com/ubuntu/20251217T000000Z/dists/jammy-security/main/binary-i386/Packages.xz";
+          hash = "sha256-SkP4PqjUAbEMtktR5WQm/3jQl9O0T2VOVTP9QIYIVkQ=";
+        })
+        (fetchurl {
+          url = "https://snapshot.ubuntu.com/ubuntu/20251217T000000Z/dists/jammy-security/universe/binary-i386/Packages.xz";
+          hash = "sha256-citjk8LAGSRlXgOXgf3oe9vBCUC6/DJGhRJl/3ppN9c=";
+        })
       ];
       urlPrefix = "https://snapshot.ubuntu.com/ubuntu/20251217T000000Z";
       packages = commonDebPackages ++ [
@@ -1038,6 +1054,22 @@ let
           url = "https://snapshot.ubuntu.com/ubuntu/20251217T000000Z/dists/jammy/universe/binary-amd64/Packages.xz";
           hash = "sha256-0pyyTJP+xfQyVXBrzn60bUd5lSA52MaKwbsUpvNlXOI=";
         })
+        (fetchurl {
+          url = "https://snapshot.ubuntu.com/ubuntu/20251217T000000Z/dists/jammy-updates/main/binary-amd64/Packages.xz";
+          hash = "sha256-kFHg+DogK+deDx9Tbp7+SaIegnotE5ZofqR8J7S73n8=";
+        })
+        (fetchurl {
+          url = "https://snapshot.ubuntu.com/ubuntu/20251217T000000Z/dists/jammy-updates/universe/binary-amd64/Packages.xz";
+          hash = "sha256-WQbtqdAWbhfd8/fwct1uuJXHiZQGPMw3KKhmha4MeTs=";
+        })
+        (fetchurl {
+          url = "https://snapshot.ubuntu.com/ubuntu/20251217T000000Z/dists/jammy-security/main/binary-amd64/Packages.xz";
+          hash = "sha256-cifTPY1iyckkaLd7dp+VPRlF0viWKrWXhM8HVWaMuUw=";
+        })
+        (fetchurl {
+          url = "https://snapshot.ubuntu.com/ubuntu/20251217T000000Z/dists/jammy-security/universe/binary-amd64/Packages.xz";
+          hash = "sha256-LTSOGbzkv0KrF2JM6oVT1Ml2KQkySXMbKNMBb9AyfQM=";
+        })
       ];
       urlPrefix = "https://snapshot.ubuntu.com/ubuntu/20251217T000000Z";
       packages = commonDebPackages ++ [
@@ -1057,6 +1089,22 @@ let
         (fetchurl {
           url = "https://snapshot.ubuntu.com/ubuntu/20251217T000000Z/dists/noble/universe/binary-amd64/Packages.xz";
           hash = "sha256-upBX+huRQ4zIodJoCNAMhTif4QHQwUliVN+XI2QFWZo=";
+        })
+        (fetchurl {
+          url = "https://snapshot.ubuntu.com/ubuntu/20251217T000000Z/dists/noble-updates/main/binary-amd64/Packages.xz";
+          hash = "sha256-f6hiUH9S1Bh8/Ljr9AkZYlwHF1vT2bqKGH6TfWnzI7Q=";
+        })
+        (fetchurl {
+          url = "https://snapshot.ubuntu.com/ubuntu/20251217T000000Z/dists/noble-updates/universe/binary-amd64/Packages.xz";
+          hash = "sha256-ROG+WO5zssfFUblTZxQjIDshdLIZn3meEgTsv6qYi5o=";
+        })
+        (fetchurl {
+          url = "https://snapshot.ubuntu.com/ubuntu/20251217T000000Z/dists/noble-security/main/binary-amd64/Packages.xz";
+          hash = "sha256-TYs8ugCYqzOleH2OebdrpB8E68PfxB+7sRb+PlfANEo=";
+        })
+        (fetchurl {
+          url = "https://snapshot.ubuntu.com/ubuntu/20251217T000000Z/dists/noble-security/universe/binary-amd64/Packages.xz";
+          hash = "sha256-bK9R8CUjLQ1V4GP7/KqZooSnKHF5+T5SuBs0butC82M=";
         })
       ];
       urlPrefix = "https://snapshot.ubuntu.com/ubuntu/20251217T000000Z";

--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -1164,22 +1164,24 @@ let
       unifiedSystemDir = true;
     };
 
+    # AlmaLinux's repo.almalinux.org URLs are rolling and change with each minor release.
+    # We use vault.almalinux.org instead, which provides stable URLs for specific versions.
     alma9x86_64 = {
-      name = "alma-9-x86_64";
-      fullName = "AlmaLinux 9 (x86_64)";
+      name = "alma-9.6-x86_64";
+      fullName = "AlmaLinux 9.6 (x86_64)";
       packagesLists = [
         (fetchurl {
-          url = "https://repo.almalinux.org/almalinux/9/BaseOS/x86_64/os/repodata/e7e7e537062ffd6778b5190b7b6785086efab6647401014d1985c10a0d3de609-primary.xml.gz";
-          hash = "sha256-5+flNwYv/Wd4tRkLe2eFCG76tmR0AQFNGYXBCg095gk=";
+          url = "https://vault.almalinux.org/9.6/BaseOS/x86_64/os/repodata/26d6cf944c86ef850773e61919e892a375ff10bb2254003e1d71673db9900b07-primary.xml.gz";
+          hash = "sha256-JtbPlEyG74UHc+YZGeiSo3X/ELsiVAA+HXFnPbmQCwc=";
         })
         (fetchurl {
-          url = "https://repo.almalinux.org/almalinux/9/AppStream/x86_64/os/repodata/e61f480b84cb0a671452c21cbd52930a6fa111e7fb3407ed75cabff71c1a07b7-primary.xml.gz";
-          hash = "sha256-5h9IC4TLCmcUUsIcvVKTCm+hEef7NAftdcq/9xwaB7c=";
+          url = "https://vault.almalinux.org/9.6/AppStream/x86_64/os/repodata/afb5d18b78d819d826d3d0e32ba439da7b9e0fd91d726dd833366496b1b8ca20-primary.xml.gz";
+          hash = "sha256-r7XRi3jYGdgm09DjK6Q52nueD9kdcm3YMzZklrG4yiA=";
         })
       ];
       urlPrefixes = [
-        "https://repo.almalinux.org/almalinux/9/BaseOS/x86_64/os"
-        "https://repo.almalinux.org/almalinux/9/AppStream/x86_64/os"
+        "https://vault.almalinux.org/9.6/BaseOS/x86_64/os"
+        "https://vault.almalinux.org/9.6/AppStream/x86_64/os"
       ];
       archs = [
         "noarch"
@@ -1192,21 +1194,21 @@ let
     };
 
     alma10x86_64 = {
-      name = "alma-10-x86_64";
-      fullName = "AlmaLinux 10 (x86_64)";
+      name = "alma-10.0-x86_64";
+      fullName = "AlmaLinux 10.0 (x86_64)";
       packagesLists = [
         (fetchurl {
-          url = "https://repo.almalinux.org/almalinux/10/BaseOS/x86_64/os/repodata/e0a4a18c4f302fa3188b757197b81d606199eccddd8480602c378def572fabbf-primary.xml.gz";
-          hash = "sha256-4KShjE8wL6MYi3Vxl7gdYGGZ7M3dhIBgLDeN71cvq78=";
+          url = "https://vault.almalinux.org/10.0/BaseOS/x86_64/os/repodata/4d88695fa7ccb6298897fa9682ac1ded4628df342ffe08312846225e4469e3e4-primary.xml.gz";
+          hash = "sha256-TYhpX6fMtimIl/qWgqwd7UYo3zQv/ggxKEYiXkRp4+Q=";
         })
         (fetchurl {
-          url = "https://repo.almalinux.org/almalinux/10/AppStream/x86_64/os/repodata/fb3e7acc93f1b0969c3c00dc3bc4364d4f5837d11274cae650c34cf71c0f80ae-primary.xml.gz";
-          hash = "sha256-+z56zJPxsJacPADcO8Q2TU9YN9ESdMrmUMNM9xwPgK4=";
+          url = "https://vault.almalinux.org/10.0/AppStream/x86_64/os/repodata/11ac32065bae6f2c2451803458690fc550e79f93a4ea9f438930f0c228964791-primary.xml.gz";
+          hash = "sha256-EawyBluubywkUYA0WGkPxVDnn5Ok6p9DiTDwwiiWR5E=";
         })
       ];
       urlPrefixes = [
-        "https://repo.almalinux.org/almalinux/10/BaseOS/x86_64/os"
-        "https://repo.almalinux.org/almalinux/10/AppStream/x86_64/os"
+        "https://vault.almalinux.org/10.0/BaseOS/x86_64/os"
+        "https://vault.almalinux.org/10.0/AppStream/x86_64/os"
       ];
       archs = [
         "noarch"

--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -557,9 +557,10 @@ let
           # Newer distributions like Fedora 18 require /lib etc. to be
           # symlinked to /usr.
           ${lib.optionalString unifiedSystemDir ''
-            mkdir -p /mnt/usr/bin /mnt/usr/sbin /mnt/usr/lib /mnt/usr/lib64
+            mkdir -p /mnt/usr/bin /mnt/usr/lib /mnt/usr/lib64
             ln -s /usr/bin /mnt/bin
-            ln -s /usr/sbin /mnt/sbin
+            ln -s /usr/bin /mnt/sbin
+            ln -s /usr/bin /mnt/usr/sbin
             ln -s /usr/lib /mnt/lib
             ln -s /usr/lib64 /mnt/lib64
             ${util-linux}/bin/mount -t proc none /mnt/proc
@@ -1031,6 +1032,22 @@ let
         "x86_64"
       ];
       packages = commonFedoraPackages;
+      unifiedSystemDir = true;
+    };
+
+    fedora43x86_64 = {
+      name = "fedora-43-x86_64";
+      fullName = "Fedora 43 (x86_64)";
+      packagesList = fetchurl {
+        url = "https://dl.fedoraproject.org/pub/fedora/linux/releases/43/Everything/x86_64/os/repodata/fffa3e9f63fffd3d21b8ea5e9bb0fe349a7ed1d4e09777a618cec93a2bcc305f-primary.xml.zst";
+        hash = "sha256-//o+n2P//T0huOpem7D+NJp+0dTgl3emGM7JOivMMF8=";
+      };
+      urlPrefix = "https://dl.fedoraproject.org/pub/fedora/linux/releases/43/Everything/x86_64/os";
+      archs = [
+        "noarch"
+        "x86_64"
+      ];
+      packages = commonFedoraPackages ++ [ "gpgverify" ];
       unifiedSystemDir = true;
     };
   };

--- a/pkgs/build-support/vm/rpm/rpm-closure.pl
+++ b/pkgs/build-support/vm/rpm/rpm-closure.pl
@@ -156,7 +156,13 @@ sub closePackage {
 
 
 foreach my $pkgName (@toplevelPkgs) {
-    closePackage $pkgName;
+    # If the package doesn't exist by name, check if something provides it
+    if (!defined $pkgs{$pkgName} && defined $provides{$pkgName}) {
+        print STDERR "package $pkgName is provided by $provides{$pkgName}\n";
+        closePackage $provides{$pkgName};
+    } else {
+        closePackage $pkgName;
+    }
 }
 
 

--- a/pkgs/build-support/vm/rpm/rpm-closure.pl
+++ b/pkgs/build-support/vm/rpm/rpm-closure.pl
@@ -1,6 +1,7 @@
 use strict;
 use XML::Simple;
 use List::Util qw(min);
+use URI::Escape;
 
 my @packagesFiles = ();
 my @urlPrefixes = ();
@@ -174,8 +175,13 @@ print "[\n\n";
 
 foreach my $pkgName (@needed) {
     my $pkg = $pkgs{$pkgName};
+    # URL-encode each path segment separately to handle special characters like '+'
+    my $href = $pkg->{location}->{href};
+    my @segments = split('/', $href);
+    my @encoded_segments = map { uri_escape($_) } @segments;
+    my $encoded_href = join('/', @encoded_segments);
     print "  (fetchurl {\n";
-    print "    url = $pkg->{urlPrefix}/$pkg->{location}->{href};\n";
+    print "    url = \"$pkg->{urlPrefix}/$encoded_href\";\n";
     if ($pkg->{checksum}->{type} eq "sha") {
         print "    sha1 = \"$pkg->{checksum}->{content}\";\n";
     } elsif ($pkg->{checksum}->{type} eq "sha256") {

--- a/pkgs/build-support/vm/test.nix
+++ b/pkgs/build-support/vm/test.nix
@@ -46,6 +46,7 @@ in
     })
   );
 
+  # RPM-based distros
   testFedora42Image = makeImageTestScript diskImages.fedora42x86_64;
   testFedora43Image = makeImageTestScript diskImages.fedora43x86_64;
   testCentOSStream9Image = makeImageTestScript diskImages.centosStream9x86_64;
@@ -56,5 +57,15 @@ in
   testAlma10Image = makeImageTestScript diskImages.alma10x86_64;
   testOracle9Image = makeImageTestScript diskImages.oracle9x86_64;
   testAmazon2023Image = makeImageTestScript diskImages.amazon2023x86_64;
-  testUbuntuImage = makeImageTestScript diskImages.ubuntu2404x86_64;
+
+  # Debian-based distros
+  testDebian11i386Image = makeImageTestScript diskImages.debian11i386;
+  testDebian11x86_64Image = makeImageTestScript diskImages.debian11x86_64;
+  testDebian12i386Image = makeImageTestScript diskImages.debian12i386;
+  testDebian12x86_64Image = makeImageTestScript diskImages.debian12x86_64;
+  testDebian13i386Image = makeImageTestScript diskImages.debian13i386;
+  testDebian13x86_64Image = makeImageTestScript diskImages.debian13x86_64;
+  testUbuntu2204i386Image = makeImageTestScript diskImages.ubuntu2204i386;
+  testUbuntu2204x86_64Image = makeImageTestScript diskImages.ubuntu2204x86_64;
+  testUbuntu2404x86_64Image = makeImageTestScript diskImages.ubuntu2404x86_64;
 }

--- a/pkgs/build-support/vm/test.nix
+++ b/pkgs/build-support/vm/test.nix
@@ -29,6 +29,15 @@ in
 
   buildHelloInVM = runInLinuxVM hello;
   buildStructuredAttrsHelloInVM = runInLinuxVM (hello.overrideAttrs { __structuredAttrs = true; });
+  buildHelloInFedora = runInLinuxImage (
+    stdenv.mkDerivation {
+      inherit (hello) pname version src;
+
+      diskImage = diskImages.fedora42x86_64;
+      diskImageFormat = "qcow2";
+      memSize = 512;
+    }
+  );
 
   buildPcmanrmInVM = runInLinuxVM (
     pcmanfm.overrideAttrs (old: {
@@ -37,15 +46,6 @@ in
     })
   );
 
-  #testRPMImage = makeImageTestScript diskImages.fedora27x86_64;
-
-  #buildPatchelfRPM = buildRPM {
-  #  name = "patchelf-rpm";
-  #  src = patchelf.src;
-  #  diskImage = diskImages.fedora27x86_64;
-  #  diskImageFormat = "qcow2";
-  #};
-
+  testFedoraImage = makeImageTestScript diskImages.fedora42x86_64;
   testUbuntuImage = makeImageTestScript diskImages.ubuntu2404x86_64;
-
 }

--- a/pkgs/build-support/vm/test.nix
+++ b/pkgs/build-support/vm/test.nix
@@ -51,5 +51,6 @@ in
   testCentOSStream9Image = makeImageTestScript diskImages.centosStream9x86_64;
   testCentOSStream10Image = makeImageTestScript diskImages.centosStream10x86_64;
   testRocky9Image = makeImageTestScript diskImages.rocky9x86_64;
+  testRocky10Image = makeImageTestScript diskImages.rocky10x86_64;
   testUbuntuImage = makeImageTestScript diskImages.ubuntu2404x86_64;
 }

--- a/pkgs/build-support/vm/test.nix
+++ b/pkgs/build-support/vm/test.nix
@@ -1,14 +1,12 @@
+{
+  hello,
+  patchelf,
+  pcmanfm,
+  stdenv,
+  vmTools,
+}:
 let
-  pkgs = import ../../.. { };
-
-  inherit (pkgs)
-    hello
-    patchelf
-    pcmanfm
-    stdenv
-    ;
-
-  inherit (pkgs.vmTools)
+  inherit (vmTools)
     buildRPM
     diskImages
     makeImageTestScript
@@ -18,9 +16,16 @@ let
 in
 
 {
-
-  # Run the PatchELF derivation in a VM.
   buildPatchelfInVM = runInLinuxVM patchelf;
+  buildPatchelfInDebian = runInLinuxImage (
+    stdenv.mkDerivation {
+      inherit (patchelf) pname version src;
+
+      diskImage = diskImages.debian13x86_64;
+      diskImageFormat = "qcow2";
+      memSize = 512;
+    }
+  );
 
   buildHelloInVM = runInLinuxVM hello;
   buildStructuredAttrsHelloInVM = runInLinuxVM (hello.overrideAttrs { __structuredAttrs = true; });
@@ -32,28 +37,15 @@ in
     })
   );
 
-  testRPMImage = makeImageTestScript diskImages.fedora27x86_64;
+  #testRPMImage = makeImageTestScript diskImages.fedora27x86_64;
 
-  buildPatchelfRPM = buildRPM {
-    name = "patchelf-rpm";
-    src = patchelf.src;
-    diskImage = diskImages.fedora27x86_64;
-    diskImageFormat = "qcow2";
-  };
+  #buildPatchelfRPM = buildRPM {
+  #  name = "patchelf-rpm";
+  #  src = patchelf.src;
+  #  diskImage = diskImages.fedora27x86_64;
+  #  diskImageFormat = "qcow2";
+  #};
 
-  testUbuntuImage = makeImageTestScript diskImages.ubuntu1804i386;
-
-  buildInDebian = runInLinuxImage (
-    stdenv.mkDerivation {
-      name = "deb-compile";
-      src = patchelf.src;
-      diskImage = diskImages.ubuntu1804i386;
-      diskImageFormat = "qcow2";
-      memSize = 512;
-      postHook = ''
-        dpkg-query --list
-      '';
-    }
-  );
+  testUbuntuImage = makeImageTestScript diskImages.ubuntu2404x86_64;
 
 }

--- a/pkgs/build-support/vm/test.nix
+++ b/pkgs/build-support/vm/test.nix
@@ -50,5 +50,6 @@ in
   testFedora43Image = makeImageTestScript diskImages.fedora43x86_64;
   testCentOSStream9Image = makeImageTestScript diskImages.centosStream9x86_64;
   testCentOSStream10Image = makeImageTestScript diskImages.centosStream10x86_64;
+  testRocky9Image = makeImageTestScript diskImages.rocky9x86_64;
   testUbuntuImage = makeImageTestScript diskImages.ubuntu2404x86_64;
 }

--- a/pkgs/build-support/vm/test.nix
+++ b/pkgs/build-support/vm/test.nix
@@ -54,5 +54,6 @@ in
   testRocky10Image = makeImageTestScript diskImages.rocky10x86_64;
   testAlma9Image = makeImageTestScript diskImages.alma9x86_64;
   testAlma10Image = makeImageTestScript diskImages.alma10x86_64;
+  testOracle9Image = makeImageTestScript diskImages.oracle9x86_64;
   testUbuntuImage = makeImageTestScript diskImages.ubuntu2404x86_64;
 }

--- a/pkgs/build-support/vm/test.nix
+++ b/pkgs/build-support/vm/test.nix
@@ -52,5 +52,7 @@ in
   testCentOSStream10Image = makeImageTestScript diskImages.centosStream10x86_64;
   testRocky9Image = makeImageTestScript diskImages.rocky9x86_64;
   testRocky10Image = makeImageTestScript diskImages.rocky10x86_64;
+  testAlma9Image = makeImageTestScript diskImages.alma9x86_64;
+  testAlma10Image = makeImageTestScript diskImages.alma10x86_64;
   testUbuntuImage = makeImageTestScript diskImages.ubuntu2404x86_64;
 }

--- a/pkgs/build-support/vm/test.nix
+++ b/pkgs/build-support/vm/test.nix
@@ -55,5 +55,6 @@ in
   testAlma9Image = makeImageTestScript diskImages.alma9x86_64;
   testAlma10Image = makeImageTestScript diskImages.alma10x86_64;
   testOracle9Image = makeImageTestScript diskImages.oracle9x86_64;
+  testAmazon2023Image = makeImageTestScript diskImages.amazon2023x86_64;
   testUbuntuImage = makeImageTestScript diskImages.ubuntu2404x86_64;
 }

--- a/pkgs/build-support/vm/test.nix
+++ b/pkgs/build-support/vm/test.nix
@@ -49,8 +49,6 @@ in
   # RPM-based distros
   testFedora42Image = makeImageTestScript diskImages.fedora42x86_64;
   testFedora43Image = makeImageTestScript diskImages.fedora43x86_64;
-  testCentOSStream9Image = makeImageTestScript diskImages.centosStream9x86_64;
-  testCentOSStream10Image = makeImageTestScript diskImages.centosStream10x86_64;
   testRocky9Image = makeImageTestScript diskImages.rocky9x86_64;
   testRocky10Image = makeImageTestScript diskImages.rocky10x86_64;
   testAlma9Image = makeImageTestScript diskImages.alma9x86_64;

--- a/pkgs/build-support/vm/test.nix
+++ b/pkgs/build-support/vm/test.nix
@@ -46,6 +46,7 @@ in
     })
   );
 
-  testFedoraImage = makeImageTestScript diskImages.fedora42x86_64;
+  testFedora42Image = makeImageTestScript diskImages.fedora42x86_64;
+  testFedora43Image = makeImageTestScript diskImages.fedora43x86_64;
   testUbuntuImage = makeImageTestScript diskImages.ubuntu2404x86_64;
 }

--- a/pkgs/build-support/vm/test.nix
+++ b/pkgs/build-support/vm/test.nix
@@ -49,5 +49,6 @@ in
   testFedora42Image = makeImageTestScript diskImages.fedora42x86_64;
   testFedora43Image = makeImageTestScript diskImages.fedora43x86_64;
   testCentOSStream9Image = makeImageTestScript diskImages.centosStream9x86_64;
+  testCentOSStream10Image = makeImageTestScript diskImages.centosStream10x86_64;
   testUbuntuImage = makeImageTestScript diskImages.ubuntu2404x86_64;
 }

--- a/pkgs/build-support/vm/test.nix
+++ b/pkgs/build-support/vm/test.nix
@@ -48,5 +48,6 @@ in
 
   testFedora42Image = makeImageTestScript diskImages.fedora42x86_64;
   testFedora43Image = makeImageTestScript diskImages.fedora43x86_64;
+  testCentOSStream9Image = makeImageTestScript diskImages.centosStream9x86_64;
   testUbuntuImage = makeImageTestScript diskImages.ubuntu2404x86_64;
 }

--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -191,6 +191,8 @@ in
 
   trivial-builders = callPackage ../build-support/trivial-builders/test/default.nix { };
 
+  vmTools = callPackage ../build-support/vm/test.nix { };
+
   writers = callPackage ../build-support/writers/test.nix { };
 
   testers = callPackage ../build-support/testers/test/default.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -830,8 +830,9 @@ with pkgs;
     inherit (darwin) signingUtils;
   };
 
-  # No callPackage.  In particular, we don't want `img` *package* in parameters.
-  vmTools = makeOverridable (import ../build-support/vm) { inherit pkgs lib; };
+  vmTools = callPackage ../build-support/vm {
+    img = stdenv.hostPlatform.linux-kernel.target;
+  };
 
   releaseTools = callPackage ../build-support/release { };
 


### PR DESCRIPTION
This PR focuses on modernizing the `vmTools` infrastructure, improving reproducibility, and dramatically expanding the range of Linux distributions available for cross-compilation and virtualization testing.

## Core Infrastructure Changes

*   **Refactoring to use `callPackage`:** The core `vmTools` derivation was refactored to use `callPackage`. Now users can actually override specific packages used within the utility.
*   **Fixing Rotted Tests:** Old, non-functional tests referencing outdated distributions (Fedora 27, Ubuntu 18.04) were removed, and the remaining tests were updated to use the new `callPackage` structure. They're wired up in `tests.vmTools`.
*   **QEMU Utility Cleanup:** Internal QEMU utilities (`qemu-common`) were streamlined to accept `stdenv` directly, improving modularity, and these utilities are no longer exported by `vmTools`. (I could drop this commit -- it's sort of going sideways a bit.)
*   **FHS Compliance for Images:** Logic for creating disk images was updated to correctly handle modern merged directory structures (e.g., in Fedora 43), where `/bin`, `/sbin`, `/lib`, etc., are symlinked under `/usr`.
*   **Improved RPM Closure Handling:** The tool used to calculate required RPM packages (`rpm-closure.pl`) was updated to support modern compression formats like `.zst` (used by current Fedora releases) and now uses `URI::Escape` to correctly handle special characters in package URLs, ensuring functionality with distributions like Amazon Linux.

## Debian and Ubuntu Updates

The definitions for Debian and Ubuntu images were significantly updated to ensure stability and comprehensive package selection:

*   **Updated Debian Snapshots:** Debian 11 (Bullseye), Debian 12 (Bookworm), and Debian 13 (Trixie) snapshots were updated to the latest available timestamps (December 2025).
*   **Added Debian Backports:** The package lists for Debian 12 (Bookworm) and Debian 13 (Trixie) now include the `backports` repository, providing access to newer packages.
*   **Reproducible Ubuntu Sources:** Ubuntu 22.04 (Jammy) and 24.04 (Noble) images were switched from relying on potentially flaky `mirror://ubuntu` redirects to using fixed snapshot URLs from `https://snapshot.ubuntu.com`.
*   **Comprehensive Ubuntu Pockets:** Ubuntu images now include `updates` and `security` package pockets alongside the main packages, ensuring that images are built with essential maintenance and security fixes.

## Expanded RHEL-Family Distribution Support

Support for generating VM images for RHEL-family distributions was greatly expanded, focusing on modern, supported releases. This enables broader cross-platform compilation and testing.

A new internal `baseRHELFamilyPackages` list was introduced to centralize common build dependencies, reducing duplication across distro definitions.

New distributions added include:

| Distribution | Version(s) | Architecture | Notes |
| :--- | :--- | :--- | :--- |
| **Fedora** | 42, 43 | x86\_64 | Includes the latest releases. |
| **Rocky Linux** | 9, 10 | x86\_64 | Popular RHEL clone. |
| **Alma Linux** | 9, 10 | x86\_64 | Alternative RHEL clone. |
| **Oracle Linux** | 9 | x86\_64 | Official Oracle release. |
| **Amazon Linux** | 2023 | x86\_64 | Current version of Amazon's cloud distribution. |

Finally, **all** newly added distribution images are included in the `tests.vmTools` attrset.

I originally included CentOS Stream, but they only have an ephemeral store, so they rot extremely quickly.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
