### PR TITLE
gobject-introspection: improve support for structuredAttrs

### DIFF
--- a/pkgs/by-name/li/libxmlb/package.nix
+++ b/pkgs/by-name/li/libxmlb/package.nix
@@ -85,6 +85,8 @@ stdenv.mkDerivation rec {
     };
   };
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Library to help create and query binary XML blobs";
     mainProgram = "xb-tool";

--- a/pkgs/development/libraries/gobject-introspection/absolute_shlib_path.patch
+++ b/pkgs/development/libraries/gobject-introspection/absolute_shlib_path.patch
@@ -2,15 +2,12 @@ diff --git a/giscanner/scannermain.py b/giscanner/scannermain.py
 index 64575557..1eb0a2b4 100644
 --- a/giscanner/scannermain.py
 +++ b/giscanner/scannermain.py
-@@ -95,6 +95,39 @@ def get_windows_option_group(parser):
+@@ -95,6 +95,36 @@ def get_windows_option_group(parser):
      return group
  
  
 +def _get_default_fallback_libpath():
-+    # Newer multiple-output-optimized stdenv has an environment variable
-+    # $outputLib which in turn specifies another variable which then is used as
-+    # the destination for the library contents (${!outputLib}/lib).
-+    store_path = os.environ.get(os.environ.get("outputLib")) if "outputLib" in os.environ else None
++    store_path = os.environ.get("NIX_GOBJECT_INTROSPECTION_DEFAULT_FALLBACK_LIBPATH")
 +    if store_path is None:
 +        outputs = os.environ.get("outputs", "out").split()
 +        if "lib" in outputs:

--- a/pkgs/development/libraries/gobject-introspection/setup-hook.sh
+++ b/pkgs/development/libraries/gobject-introspection/setup-hook.sh
@@ -10,7 +10,17 @@ make_gobject_introspection_find_gir_files() {
     fi
 }
 
+export_gobject_introspection_fallback_path() {
+    # Newer multiple-output-optimized stdenv has a variable $outputLib,
+    # which in turn specifies another variable which then is used as
+    # the destination for the library contents (${!outputLib}/lib).
+    # We export this so it is available to subprocesses, such as giscanner,
+    # which we patch to prioritize this variable if available.
+    export NIX_GOBJECT_INTROSPECTION_DEFAULT_FALLBACK_LIBPATH=${!outputLib}
+}
+
 addEnvHooks "$targetOffset" make_gobject_introspection_find_gir_files
+addEnvHooks "$targetOffset" export_gobject_introspection_fallback_path
 
 giDiscoverSelf() {
     if [ -d "$prefix/lib/girepository-1.0" ]; then


### PR DESCRIPTION
With `__structuredAttrs = true;` `$outputLib` is not available as an exported environment variable.
To avoid polluting the env with a generic variable that could be abused, use a bespoke and easily greppable variable.

Alternative to https://github.com/NixOS/nixpkgs/pull/471627

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
