### PR TITLE
xcur2png: fix build with gcc15

### DIFF
--- a/pkgs/by-name/xc/xcur2png/malloc.diff
+++ b/pkgs/by-name/xc/xcur2png/malloc.diff
@@ -16,7 +16,7 @@
  #include <X11/Xcursor/Xcursor.h>
 
 +
-+void *malloc ();
++void *malloc (size_t __size);
 +
 +/* Allocate an N-byte block of memory from the heap.
 +   If N is zero, allocate a 1-byte block.  */


### PR DESCRIPTION
- change `malloc` declaration in `malloc.diff` patch from `void *malloc()` to `void *malloc(size_t __size)`

PR for that patch is still unmerged upstream:
https://www.github.com/eworm-de/xcur2png/pull/3

Fixes build failure with gcc15:
```
xcur2png.c:41:7: error: conflicting types for 'malloc';
have 'void *(void)'
   41 | void *malloc ();
      |       ^~~~~~
In file included from xcur2png.c:26:
/nix/store/i1qha7him4faq593wwl1zmhg2pc6lz98-glibc-2.40-66-dev/include/stdlib.h:672:14:
note: previous declaration of 'malloc' with type 'void *(long unsigned int)'
  672 | extern void *malloc (size_t __size) __THROW __attribute_malloc__
      |              ^~~~~~
xcur2png.c: In function 'rpl_malloc':
xcur2png.c:50:10: error: too many arguments to function 'malloc';
expected 0, have 1
   50 |   return malloc (n);
      |          ^~~~~~  ~
xcur2png.c:41:7: note: declared here
   41 | void *malloc ();
      |       ^~~~~~
xcur2png.c: In function 'makeConfPath':
xcur2png.c:246:11: error: too many arguments to function 'malloc';
expected 0, have 1
  246 |     ret = malloc ((strlen (rawname) + 6) * sizeof (char)); /* rawname + ".conf\0" */
      |           ^~~~~~  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

---

Tested build with:
```bash
nix-build -A pkgsCross.aarch64-multiplatform.xcur2png
nix-build -A pkgsCross.riscv64.xcur2png
```
(examples from #343074 that added this patch)

Part of fixes for gcc15 update:
https://github.com/NixOS/nixpkgs/pull/440456

Fixes build failure of `xcur2png` on current `staging-next`: https://github.com/NixOS/nixpkgs/pull/471587

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
