### PR TITLE
karakeep: v0.27.1 -> v0.29.3

### DIFF
--- a/pkgs/by-name/ka/karakeep/helpers/karakeep
+++ b/pkgs/by-name/ka/karakeep/helpers/karakeep
@@ -1,5 +1,3 @@
 #!/usr/bin/env bash
 set -eu -o pipefail
-KARAKEEP_LIB_PATH=
-NODEJS=
-exec "$NODEJS/bin/node" "$KARAKEEP_LIB_PATH/apps/cli/dist/index.mjs" "$@"
+exec @NODEJS@/bin/node "@KARAKEEP_LIB_PATH@"/apps/cli/dist/index.mjs "$@"

--- a/pkgs/by-name/ka/karakeep/helpers/migrate
+++ b/pkgs/by-name/ka/karakeep/helpers/migrate
@@ -1,13 +1,11 @@
 #!/usr/bin/env bash
 set -eu -o pipefail
-KARAKEEP_LIB_PATH=
-RELEASE=
-NODE_ENV=production
+export RELEASE=@VERSION@
+export NODE_ENV=production
 
 [[ -d "$DATA_DIR" ]]	# Ensure DATA_DIR is defined and exists
 
 # Drizzle will look for configuration in the working directory
-cd "$KARAKEEP_LIB_PATH/packages/db"
+cd "@KARAKEEP_LIB_PATH@"/packages/db
 
-export RELEASE NODE_ENV
-exec "$KARAKEEP_LIB_PATH/node_modules/.bin/drizzle-kit" migrate
+exec "@KARAKEEP_LIB_PATH@"/node_modules/.bin/drizzle-kit migrate

--- a/pkgs/by-name/ka/karakeep/helpers/start-web
+++ b/pkgs/by-name/ka/karakeep/helpers/start-web
@@ -1,11 +1,10 @@
 #!/usr/bin/env bash
 set -eu -o pipefail
-KARAKEEP_LIB_PATH=
-RELEASE=
-NODEJS=
-NODE_ENV=production
 
 [[ -d "$DATA_DIR" ]]	# Ensure DATA_DIR is defined and exists
 
-export RELEASE NODE_ENV
-exec "$NODEJS/bin/node" "$KARAKEEP_LIB_PATH/apps/web/.next/standalone/apps/web/server.js"
+export RELEASE=@VERSION@
+export NODE_ENV=production
+
+exec @NODEJS@/bin/node  \
+     "@KARAKEEP_LIB_PATH@"/apps/web/.next/standalone/apps/web/server.js

--- a/pkgs/by-name/ka/karakeep/helpers/start-workers
+++ b/pkgs/by-name/ka/karakeep/helpers/start-workers
@@ -1,14 +1,12 @@
 #!/usr/bin/env bash
 set -eu -o pipefail
-KARAKEEP_LIB_PATH=
-RELEASE=
-NODEJS=
-NODE_ENV=production
-NODE_PATH="$KARAKEEP_LIB_PATH/apps/workers"
 
 [[ -d "$DATA_DIR" ]]	# Ensure DATA_DIR is defined and exists
 
-cd "$KARAKEEP_LIB_PATH/apps/workers"
+export RELEASE=@VERSION@
+export NODE_ENV=production
+export NODE_PATH="@KARAKEEP_LIB_PATH@"/apps/workers
 
-export RELEASE NODE_ENV NODE_PATH
-exec "$NODEJS/bin/node" "$KARAKEEP_LIB_PATH/apps/workers/dist/index.js"
+cd "$NODE_PATH"
+
+exec @NODEJS@/bin/node "$NODE_PATH"/dist/index.js

--- a/pkgs/by-name/ka/karakeep/package.nix
+++ b/pkgs/by-name/ka/karakeep/package.nix
@@ -18,13 +18,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "karakeep";
-  version = "0.29.1";
+  version = "0.29.3";
 
   src = fetchFromGitHub {
     owner = "karakeep-app";
     repo = "karakeep";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-mOIX9pNVESRPD2Jjdr014NyYO/3rSvYpr4RP34RKE8c=";
+    hash = "sha256-MmurmQ/z8ME7Y6lpEWGaf7sFRSYhwd8flM4f0GBbUIM=";
   };
 
   patches = [
@@ -65,7 +65,7 @@ stdenv.mkDerivation (finalAttrs: {
     };
 
     fetcherVersion = 1;
-    hash = "sha256-rFMLmqPEvP6Vn7VNmE2tGsnv9YPMaL1aktwTsnjv5+M=";
+    hash = "sha256-p2J7GBncw+ZQBNBcPwPh5TfzNi1LO4oEnUJQXlqw+gQ=";
   };
   buildPhase = ''
     runHook preBuild

--- a/pkgs/by-name/ka/karakeep/package.nix
+++ b/pkgs/by-name/ka/karakeep/package.nix
@@ -64,8 +64,8 @@ stdenv.mkDerivation (finalAttrs: {
       '';
     };
 
-    fetcherVersion = 1;
-    hash = "sha256-p2J7GBncw+ZQBNBcPwPh5TfzNi1LO4oEnUJQXlqw+gQ=";
+    fetcherVersion = 3;
+    hash = "sha256-LEdI9chVuOli4XiA0VRV9h8L3ho0IRbPsXtAyQM6Du8=";
   };
   buildPhase = ''
     runHook preBuild

--- a/pkgs/by-name/ka/karakeep/package.nix
+++ b/pkgs/by-name/ka/karakeep/package.nix
@@ -121,9 +121,9 @@ stdenv.mkDerivation (finalAttrs: {
       HELPER_SCRIPT_NAME="$(basename "$HELPER_SCRIPT")"
       cp "$HELPER_SCRIPT" "$KARAKEEP_LIB_PATH/"
       substituteInPlace "$KARAKEEP_LIB_PATH/$HELPER_SCRIPT_NAME" \
-        --replace-warn "KARAKEEP_LIB_PATH=" "KARAKEEP_LIB_PATH=$KARAKEEP_LIB_PATH" \
-        --replace-warn "RELEASE=" "RELEASE=${finalAttrs.version}" \
-        --replace-warn "NODEJS=" "NODEJS=${nodejs}"
+        --subst-var-by KARAKEEP_LIB_PATH "$KARAKEEP_LIB_PATH" \
+        --subst-var-by VERSION "${finalAttrs.version}" \
+        --subst-var-by NODEJS "${nodejs}"
       chmod +x "$KARAKEEP_LIB_PATH/$HELPER_SCRIPT_NAME"
       patchShebangs "$KARAKEEP_LIB_PATH/$HELPER_SCRIPT_NAME"
     done


### PR DESCRIPTION
## Changelog (from https://github.com/karakeep-app/karakeep/releases)

### v0.29.3

Well. Upgrading Nextjs one more time to patch [CVE-2025-67779](https://github.com/advisories/GHSA-7gmr-mq3h-m5h9).

### v0.29. 2

Upgrading Nextjs to patch two new vulnerabilities in react [CVE-2025-55184](https://github.com/advisories/GHSA-2m3v-v2m8-q956) & [CVE-2025-55183](https://github.com/advisories/GHSA-925w-6v3x-g4j4). This is on top of the critical vulnerability ([CVE-2025-66478](https://github.com/vercel/next.js/security/advisories/GHSA-9qr9-h5gf-34mp)) that was patched in 0.29.1.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
