### PR TITLE
[Backport 25.11] yarn-berry-fetcher: vendor in libzip patch

### DIFF
--- a/pkgs/by-name/ya/yarn-berry/fetcher/default.nix
+++ b/pkgs/by-name/ya/yarn-berry/fetcher/default.nix
@@ -50,9 +50,9 @@ let
             withZlibCompat = true;
           };
         }).overrideAttrs
-          (oA: {
-            patches = (oA.patches or [ ]) ++ [
-              (final.yarn-berry-fetcher.src + "/libzip-revert-to-old-versionneeded-behavior.patch")
+          (old: {
+            patches = (old.patches or [ ]) ++ [
+              ./libzip-revert-to-old-versionneeded-behavior.patch
             ];
           });
     };

--- a/pkgs/by-name/ya/yarn-berry/fetcher/libzip-revert-to-old-versionneeded-behavior.patch
+++ b/pkgs/by-name/ya/yarn-berry/fetcher/libzip-revert-to-old-versionneeded-behavior.patch
@@ -1,0 +1,15 @@
+diff --git a/lib/zip_dirent.c b/lib/zip_dirent.c
+index 7476ac0..b825609 100644
+--- a/lib/zip_dirent.c
++++ b/lib/zip_dirent.c
+@@ -1241,7 +1241,9 @@ bool _zip_dirent_apply_attributes(zip_dirent_t *de, zip_file_attributes_t *attri
+     }
+ 
+     if (attributes->valid & ZIP_FILE_ATTRIBUTES_VERSION_NEEDED) {
+-        version_needed = ZIP_MAX(version_needed, attributes->version_needed);
++	if (attributes->version_needed > de->version_needed) {
++	    de->version_needed = attributes->version_needed;
++	}
+     }
+ 
+     if (de->version_needed != version_needed) {


### PR DESCRIPTION
This is working around a problem with the version provided in nixpkgs, so we can ship the patch there. Fetching it from the yarn-berry sources causes a libzip rebuild whenever we change yarn-berry-fetcher sources, even if there's no changes in the libzip patch.

(cherry picked from commit 3183e7b33fb88514770c624ad54b45e4cbeb14d6)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
