### PR TITLE
gcc: improve support for structuredAttrs

### DIFF
--- a/pkgs/development/compilers/gcc/common/builder.nix
+++ b/pkgs/development/compilers/gcc/common/builder.nix
@@ -144,45 +144,33 @@ originalAttrs:
           # the startfiles.
           # FLAGS_FOR_TARGET are needed for the target libraries to receive the -Bxxx
           # for the startfiles.
-          makeFlagsArray+=(
-              "BUILD_SYSTEM_HEADER_DIR=$NIX_FIXINC_DUMMY_FOR_BUILD"
-              "SYSTEM_HEADER_DIR=$NIX_FIXINC_DUMMY_FOR_BUILD"
-              "NATIVE_SYSTEM_HEADER_DIR=$NIX_FIXINC_DUMMY"
-
-              "LDFLAGS_FOR_BUILD=$EXTRA_LDFLAGS_FOR_BUILD"
-              #"LDFLAGS=$EXTRA_LDFLAGS"
-              "LDFLAGS_FOR_TARGET=$EXTRA_LDFLAGS_FOR_TARGET"
-
-              "CFLAGS_FOR_BUILD=$EXTRA_FLAGS_FOR_BUILD $EXTRA_LDFLAGS_FOR_BUILD"
-              "CXXFLAGS_FOR_BUILD=$EXTRA_FLAGS_FOR_BUILD $EXTRA_LDFLAGS_FOR_BUILD"
-              "FLAGS_FOR_BUILD=$EXTRA_FLAGS_FOR_BUILD $EXTRA_LDFLAGS_FOR_BUILD"
-
-              # It seems there is a bug in GCC 5
-              #"CFLAGS=$EXTRA_FLAGS $EXTRA_LDFLAGS"
-              #"CXXFLAGS=$EXTRA_FLAGS $EXTRA_LDFLAGS"
-
-              "CFLAGS_FOR_TARGET=$EXTRA_FLAGS_FOR_TARGET $EXTRA_LDFLAGS_FOR_TARGET"
-              "CXXFLAGS_FOR_TARGET=$EXTRA_FLAGS_FOR_TARGET $EXTRA_LDFLAGS_FOR_TARGET"
+          appendToVar makeFlags \
+              "BUILD_SYSTEM_HEADER_DIR=$NIX_FIXINC_DUMMY_FOR_BUILD" \
+              "SYSTEM_HEADER_DIR=$NIX_FIXINC_DUMMY_FOR_BUILD" \
+              "NATIVE_SYSTEM_HEADER_DIR=$NIX_FIXINC_DUMMY" \
+              "LDFLAGS_FOR_BUILD=$EXTRA_LDFLAGS_FOR_BUILD" \
+              "LDFLAGS_FOR_TARGET=$EXTRA_LDFLAGS_FOR_TARGET" \
+              "CFLAGS_FOR_BUILD=$EXTRA_FLAGS_FOR_BUILD $EXTRA_LDFLAGS_FOR_BUILD" \
+              "CXXFLAGS_FOR_BUILD=$EXTRA_FLAGS_FOR_BUILD $EXTRA_LDFLAGS_FOR_BUILD" \
+              "FLAGS_FOR_BUILD=$EXTRA_FLAGS_FOR_BUILD $EXTRA_LDFLAGS_FOR_BUILD" \
+              "CFLAGS_FOR_TARGET=$EXTRA_FLAGS_FOR_TARGET $EXTRA_LDFLAGS_FOR_TARGET" \
+              "CXXFLAGS_FOR_TARGET=$EXTRA_FLAGS_FOR_TARGET $EXTRA_LDFLAGS_FOR_TARGET" \
               "FLAGS_FOR_TARGET=$EXTRA_FLAGS_FOR_TARGET $EXTRA_LDFLAGS_FOR_TARGET"
-          )
 
           if test -z "''${targetConfig-}"; then
-              makeFlagsArray+=(
-                  "BOOT_CFLAGS=$EXTRA_FLAGS $EXTRA_LDFLAGS"
+              appendToVar makeFlags \
+                  "BOOT_CFLAGS=$EXTRA_FLAGS $EXTRA_LDFLAGS" \
                   "BOOT_LDFLAGS=$EXTRA_FLAGS_FOR_TARGET $EXTRA_LDFLAGS_FOR_TARGET"
-              )
           fi
 
           if test "$withoutTargetLibc" == 1; then
               # We don't want the gcc build to assume there will be a libc providing
               # limits.h in this stage
-              makeFlagsArray+=(
+              appendToVar makeFlags \
                   'LIMITS_H_TEST=false'
-              )
           else
-              makeFlagsArray+=(
+              appendToVar makeFlags \
                   'LIMITS_H_TEST=true'
-              )
           fi
       fi
 
@@ -372,5 +360,7 @@ originalAttrs:
         ln -s "$lib/$targetConfig/lib" "$lib/lib"
       fi
     '';
+
+    # __structuredAttrs = true;
   }
 ))

--- a/pkgs/development/compilers/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/default.nix
@@ -291,10 +291,8 @@ pipe
         )
       )
       + optionalString targetPlatform.isAvr ''
-        makeFlagsArray+=(
-           '-s' # workaround for hitting hydra log limit
-           'LIMITS_H_TEST=false'
-        )
+        # workaround for hitting hydra log limit
+        appendToVar makeFlags '-s' 'LIMITS_H_TEST=false'
       '';
 
       inherit


### PR DESCRIPTION
Trying to extract changes from my config to make this work - some variant of gcc fails with `__structuredAttrs = true;` and this fixes it, but only if indeed this is forced to be true. This now breaks the escaping of the `makeFlags`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
