### PR TITLE
nixos/facter: add debug utilities

### DIFF
--- a/nixos/modules/hardware/facter/debug.nix
+++ b/nixos/modules/hardware/facter/debug.nix
@@ -1,0 +1,81 @@
+{
+  lib,
+  pkgs,
+  config,
+  extendModules,
+  ...
+}:
+{
+
+  options = {
+
+    system.build = {
+      noFacter = lib.mkOption {
+        type = lib.types.unspecified;
+        description = "A version of the system closure with facter disabled";
+      };
+    };
+
+    hardware.facter.debug = {
+      nvd = lib.mkOption {
+        type = lib.types.package;
+        description = ''
+          A shell application which will produce an nvd diff of the system closure with and without facter enabled.
+        '';
+      };
+      nix-diff = lib.mkOption {
+        type = lib.types.package;
+        description = ''
+          A shell application which will produce a nix-diff of the system closure with and without facter enabled.
+        '';
+      };
+    };
+
+  };
+
+  config.system.build = {
+    noFacter = extendModules {
+      modules = [
+        {
+          # we 'disable' facter by overriding the report and setting it to empty with one caveat: hostPlatform
+          config.hardware.facter.report = lib.mkForce {
+            system = config.nixpkgs.hostPlatform;
+          };
+        }
+      ];
+    };
+  };
+
+  config.hardware.facter.debug = {
+
+    nvd = pkgs.writeShellApplication {
+      name = "facter-nvd-diff";
+      runtimeInputs = [
+        config.nix.package
+        pkgs.nvd
+      ];
+      text = ''
+        nvd diff \
+          ${config.system.build.noFacter.config.system.build.toplevel} \
+          ${config.system.build.toplevel} \
+          "$@"
+      '';
+    };
+
+    nix-diff = pkgs.writeShellApplication {
+      name = "facter-nix-diff";
+      runtimeInputs = [
+        config.nix.package
+        pkgs.nix-diff
+      ];
+      text = ''
+        nix-diff \
+          ${config.system.build.noFacter.config.system.build.toplevel} \
+          ${config.system.build.toplevel} \
+          "$@"
+      '';
+    };
+
+  };
+
+}

--- a/nixos/modules/hardware/facter/default.nix
+++ b/nixos/modules/hardware/facter/default.nix
@@ -7,6 +7,7 @@
   imports = [
     ./bluetooth.nix
     ./camera
+    ./debug.nix
     ./disk.nix
     ./fingerprint
     ./firmware.nix

--- a/pkgs/by-name/ni/nixos-facter/package.nix
+++ b/pkgs/by-name/ni/nixos-facter/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   buildGoModule,
+  callPackage,
   fetchFromGitHub,
   hwinfo,
   libusb1,
@@ -64,6 +65,8 @@ buildGoModule rec {
 
   passthru.tests = {
     inherit (nixosTests) facter;
+    debug-nvd = callPackage ./test-debug-nvd.nix { };
+    debug-nix-diff = nixosTests.facter.nodes.machine.hardware.facter.debug.nix-diff;
   };
 
   meta = {

--- a/pkgs/by-name/ni/nixos-facter/test-debug-nvd.nix
+++ b/pkgs/by-name/ni/nixos-facter/test-debug-nvd.nix
@@ -1,0 +1,52 @@
+{
+  runCommand,
+  jq,
+  nix,
+  nixosTests,
+}:
+let
+  facterDebug = nixosTests.facter.nodes.machine.hardware.facter.debug;
+  withFacter = nixosTests.facter.nodes.machine.system.build.toplevel;
+  noFacter = nixosTests.facter.nodes.machine.system.build.noFacter.config.system.build.toplevel;
+in
+runCommand "facter-debug-nvd-test"
+  {
+    nativeBuildInputs = [
+      facterDebug.nvd
+      jq
+      nix
+    ];
+    __structuredAttrs = true;
+    unsafeDiscardReferences.out = true;
+    exportReferencesGraph.withFacter = [ withFacter ];
+    exportReferencesGraph.noFacter = [ noFacter ];
+  }
+  ''
+    # Set up nix environment with read-only store but writable state
+    mkdir -p "$TMPDIR/nix"/{var/nix,var/log/nix,etc}
+
+    export NIX_REMOTE=""
+    export NIX_STATE_DIR="$TMPDIR/nix/var/nix"
+    export NIX_LOG_DIR="$TMPDIR/nix/var/log/nix"
+    export NIX_CONF_DIR="$TMPDIR/nix/etc"
+    cat > "$TMPDIR/nix/etc/nix.conf" <<EOF
+    substituters =
+    sandbox = false
+    EOF
+
+    # Initialize store database and register paths from exportReferencesGraph
+    nix-store --init
+
+    # Convert exportReferencesGraph JSON to nix-store --load-db format
+    jq -r '(.withFacter + .noFacter)[] | "\(.path)\n\(.narHash)\n\(.narSize)\n\n\(.references | length)\(if .references | length > 0 then "\n" + (.references | join("\n")) else "" end)"' \
+      < "$NIX_ATTRS_JSON_FILE" | nix-store --load-db
+
+    # Run nvd and verify it produces output
+    facter-nvd-diff > nvd-output.txt
+    if [ ! -s nvd-output.txt ]; then
+      echo "facter-nvd-diff produced no output"
+      exit 1
+    fi
+    cat nvd-output.txt
+    echo "nvd debug utility works correctly" > $out
+  ''


### PR DESCRIPTION
This adds debugging tools for comparing system configurations with and without facter-based hardware detection:

Example usage:
  nix-build '<nixpkgs/nixos>' -A config.hardware.facter.debug.nvd
  ./result/bin/facter-diff

Builds on PR #466808 (camera support).
This is the last pr of incremental upstreaming from nixos-facter-modules.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
