### PR TITLE
home-assistant-custom-components.solarman: use alternative component

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/solarman/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/solarman/package.nix
@@ -1,33 +1,42 @@
 {
+  aiofiles,
+  aiohttp,
   buildHomeAssistantComponent,
   fetchFromGitHub,
   lib,
-  pysolarmanv5,
+  propcache,
   pyyaml,
 }:
 
 buildHomeAssistantComponent rec {
-  owner = "StephanJoubert";
+  owner = "davidrapan";
   domain = "solarman";
-  version = "1.5.1";
+  version = "25.08.16";
 
   src = fetchFromGitHub {
-    owner = "StephanJoubert";
-    repo = "home_assistant_solarman";
-    tag = version;
-    hash = "sha256-+znRq7LGIxbxMEypIRqbIMgV8H4OyiOakmExx1aHEl8=";
+    owner = "davidrapan";
+    repo = "ha-solarman";
+    tag = "v${version}";
+    hash = "sha256-SsUObH3g3i9xQ4JvRDcCm1Fg2giH+MN3rC3NMPYO5m0=";
   };
 
   dependencies = [
-    pysolarmanv5
+    aiofiles
+    aiohttp
+    propcache
     pyyaml
   ];
 
   meta = {
-    description = "Home Assistant component for Solarman collectors used with a variety of inverters";
-    changelog = "https://github.com/StephanJoubert/home_assistant_solarman/releases/tag/${version}";
-    homepage = "https://github.com/StephanJoubert/home_assistant_solarman";
+    description = "Home Assistant component for Solarman Stick Loggers";
+    changelog = "https://github.com/davidrapan/ha-solarman/releases/tag/${version}";
+    homepage = "https://github.com/davidrapan/ha-solarman";
     maintainers = with lib.maintainers; [ Scrumplex ];
-    license = lib.licenses.asl20;
+    # `license` and `custom_components/solarman/pysolarman/license` are MIT
+    # `custom_components/solarman/pysolarman/umodbus/license` is MPL 2.0
+    license = with lib.licenses; [
+      mit
+      mpl20
+    ];
   };
 }


### PR DESCRIPTION
ha-solarman is much more up-to-date and has better compatibility the former component. This could break some installations, but is mostly a drop-in replacement.

https://github.com/davidrapan/ha-solarman


I personally stopped using the other solarman integration I have packaged a while ago, as it stopped working with a newer logger I got. As it seems inactive, we could remove it at some point.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
