### PR TITLE
zsnow: init at 0-unstable-2025-12-01

### DIFF
--- a/pkgs/by-name/zs/zsnow/package.nix
+++ b/pkgs/by-name/zs/zsnow/package.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  zig,
+  stdenv,
+  fetchFromGitHub,
+  pkg-config,
+  wayland,
+  wayland-scanner,
+  wayland-protocols,
+  wlr-protocols,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "zsnow";
+  version = "0-unstable-2025-12-01";
+
+  src = fetchFromGitHub {
+    owner = "DarkVanityOfLight";
+    repo = "ZSnoW";
+    rev = "db8491639e45dbb925652512cb5941f1ea1a1ec2";
+    hash = "sha256-h9o/6X2WPfeJrLIx3WnVo0l4i80zHnmO2KkYuVJY2Sk=";
+  };
+  zigWayland = fetchFromGitHub {
+    owner = "ifreund";
+    repo = "zig-wayland";
+    tag = "v0.4.0";
+    hash = "sha256-ulIII5iJpM/W/VJB0HcdktEO2eb9T9J0ln2A1Z94dU4=";
+  };
+
+  nativeBuildInputs = [
+    zig.hook
+    pkg-config
+    wayland-scanner
+  ];
+  buildInputs = [
+    wayland
+    wayland-protocols
+    wlr-protocols
+  ];
+
+  postPatch = ''
+    ln -s ${finalAttrs.zigWayland} ./zig-wayland
+
+    substituteInPlace build.zig \
+      --replace-fail \
+        'scanner.addCustomProtocol(.{ .cwd_relative = "/usr/share/wlr-protocols/unstable/wlr-layer-shell-unstable-v1.xml" });' \
+        'scanner.addCustomProtocol(.{ .cwd_relative = "${wlr-protocols}/share/wlr-protocols/unstable/wlr-layer-shell-unstable-v1.xml" });'
+
+    substituteInPlace build.zig.zon \
+      --replace-fail \
+        '.url = "https://github.com/ifreund/zig-wayland/archive/refs/tags/v0.4.0.zip",' \
+        '.path = "./zig-wayland",' \
+      --replace-fail \
+        '.hash = "wayland-0.4.0-lQa1khbMAQAsLS2eBR7M5lofyEGPIbu2iFDmoz8lPC27",' \
+        ""
+  '';
+
+  # no tests
+  dontUseZigCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "XSnow for Wayland";
+    homepage = "https://github.com/DarkVanityOfLight/ZSnoW";
+    license = lib.licenses.cc-by-nc-sa-40;
+    maintainers = [ lib.maintainers.adamperkowski ];
+    platforms = lib.platforms.linux;
+    mainProgram = "zsnow";
+  };
+})


### PR DESCRIPTION
XSnow for Wayland
[github repo](https://github.com/DarkVanityOfLight/ZSnoW)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
