### PR TITLE
nix-sweep: init at 0.8.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13294,6 +13294,12 @@
     githubId = 20658981;
     name = "Jarosław Wygoda";
   };
+  jzbor = {
+    email = "jzbor@posteo.net";
+    github = "jzbor";
+    githubId = 48366877;
+    name = "Julian";
+  };
   jzellner = {
     email = "jeffz@eml.cc";
     github = "sofuture";

--- a/pkgs/by-name/ni/nix-sweep/package.nix
+++ b/pkgs/by-name/ni/nix-sweep/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  rustPlatform,
+  installShellFiles,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "nix-sweep";
+  version = "0.8.0";
+
+  src = fetchFromGitHub {
+    owner = "jzbor";
+    repo = "nix-sweep";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-C83AtqexEzx+8cNZXZyYUtg4gAUyam00IM0eXO8xOgA=";
+  };
+
+  cargoHash = "sha256-etqSdtoiSPMQLuMgBK/nnJM8dDTdmRk+MT++zu/9IjM=";
+
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
+  outputs = [
+    "out"
+    "man"
+  ];
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    mkdir ./manpages
+    $out/bin/nix-sweep man ./manpages
+    installManPage ./manpages/*
+    mkdir ./completions
+    $out/bin/nix-sweep completions ./completions
+    installShellCompletion completions/nix-sweep.{bash,fish,zsh}
+  '';
+
+  meta = {
+    description = "Utility to clean up old Nix profile generations and left-over garbage collection roots";
+    homepage = "https://github.com/jzbor/nix-sweep";
+    changelog = "https://github.com/jzbor/nix-sweep/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    mainProgram = "nix-sweep";
+    maintainers = with lib.maintainers; [
+      jzbor
+    ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Initialize [nix-sweep](https://github.com/jzbor/nix-sweep) at version 0.8.0. nix-sweep is a tool to manage profiles and garbage collection and analyze the nix store. I was hesitant to submit the package myself, but there does seem to be [demand](https://github.com/jzbor/nix-sweep/issues/5) and as far as I can tell nixpkgs has no rule against maintaining your own packages. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
