### PR TITLE
workflows/lint: fully skip the `commits` job in Merge Queues

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -126,6 +126,11 @@ jobs:
           fi
 
   commits:
+    # Only check commits if we have access to the pull_request context.
+    #
+    # Luckily there's no need to lint commit messages in the Merge Queue, because
+    # changes to the target branch can't change commit messages on the base branch.
+    if: ${{ github.event.pull_request.number }}
     runs-on: ubuntu-slim
     timeout-minutes: 5
     steps:

--- a/ci/github-script/lint-commits.js
+++ b/ci/github-script/lint-commits.js
@@ -9,8 +9,7 @@ const { classify } = require('../supportedBranches.js')
  * }} CheckCommitMessagesProps
  */
 async function checkCommitMessages({ github, context, core }) {
-  // Do not run on merge groups: it'd be much harder, and there is no need
-  // (changes to the target branch can't change commit messages on the base branch).
+  // This check should only be run when we have the pull_request context.
   const pull_number = context.payload.pull_request?.number
   if (!pull_number) {
     core.info('This is not a pull request. Skipping checks.')


### PR DESCRIPTION
Follow-up to https://github.com/NixOS/nixpkgs/pull/470523

While the JS script already returned early, we can save a few resources by skipping the job entirely when there's no `pull_request` context.

## Testing

If the `Test` workflow runs the `Lint / commits` job against this PR, then everything is working correctly.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
