### PR TITLE
kicad: 9.0.5 -> 9.0.6

### DIFF
--- a/pkgs/by-name/ki/kicad/versions.nix
+++ b/pkgs/by-name/ki/kicad/versions.nix
@@ -3,23 +3,23 @@
 {
   "kicad" = {
     kicadVersion = {
-      version = "9.0.5";
+      version = "9.0.6";
       src = {
-        rev = "3e59813c21b4d0a00c08978e86b5f2189ec27864";
-        sha256 = "0wmnkiyqv32c5nz4nvz94dld3rk5ir49nh71cycig6clvjvy11r5";
+        rev = "878335d000462f1498adc4267854bb594a21bd36";
+        sha256 = "0mfnlx0dlpk3jz1b8pard6b7ax1ycyv069k4vg89ph2bia1a9d98";
       };
     };
     libVersion = {
-      version = "9.0.5";
+      version = "9.0.6";
       libSources = {
-        symbols.rev = "884133df0afba238567e2be6c31e7d3b4a9d90be";
-        symbols.sha256 = "0msgq8p3zlfc3glqr1h8n0a1agk4hjdqxqdiny5b4d0hgiy6hhmx";
-        templates.rev = "204b42307fc78cf0b3ebec4e19eba9d710e392f4";
+        symbols.rev = "e92aabf81dc1af151fa452a33679dcb42b93fcbd";
+        symbols.sha256 = "03k3y86mgc10ir5l1gdzc0r7w1gg7iavb1zl31kgfh9hnfmgv06w";
+        templates.rev = "710c895e2f3be0ec366139bf33c9ca711c990630";
         templates.sha256 = "0zs29zn8qjgxv0w1vyr8yxmj02m8752zagn4vcraqgik46dwg2id";
-        footprints.rev = "873e3e9dbad8371d664e57261efa516d42328161";
-        footprints.sha256 = "179y7xmz7mwsfsv4dcw2dx689xfzqk8y38d21s69yiaalyxflhh1";
-        packages3d.rev = "c25dce5aadce68076ac035edb0c792608f5f597c";
-        packages3d.sha256 = "1y7yhynrr87q80gcb8qlkyrdccz1sllsxqymrnghhxbfk4wbwwn8";
+        footprints.rev = "0836ca140b415055e373de97c466961088d8972a";
+        footprints.sha256 = "0jzkrmzkxv3kqqmkpq5dpp3shy9ajfg1b1yzhk4ddzvy8l05qym4";
+        packages3d.rev = "1e24671163ce0f44bf57b46445c7e7be1a95977d";
+        packages3d.sha256 = "04hw6b4hyl2plfgynin3dv7siqml4341264wz2wngddszq8z32ki";
       };
     };
   };


### PR DESCRIPTION
Rebased version of https://github.com/NixOS/nixpkgs/pull/458106

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
