### PR TITLE
nixos/vector: Tweak journald/clickhouse test

### DIFF
--- a/nixos/tests/vector/journald-clickhouse.nix
+++ b/nixos/tests/vector/journald-clickhouse.nix
@@ -199,11 +199,11 @@ in
         )
 
       clickhouse.fail(
-        "cat ${selectQuery} | clickhouse-client --user vector --password helloclickhouseworld | grep 2"
+        "cat ${selectQuery} | clickhouse-client --user vector --password helloclickhouseworld | grep -v 0"
       )
 
       clickhouse.wait_until_succeeds(
-        "cat ${selectQuery} | clickhouse-client --user grafana --password helloclickhouseworld2 | grep 2"
+        "cat ${selectQuery} | clickhouse-client --user grafana --password helloclickhouseworld2 | grep -v 0"
       )
     '';
 }


### PR DESCRIPTION
Check the absence of zero results instead

Fixes small race-condition between database being ready and Vector being able to log into it and then the result number changing


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
