### PR TITLE
pinact: sync go patch version

### DIFF
--- a/pkgs/by-name/pi/pinact/package.nix
+++ b/pkgs/by-name/pi/pinact/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  go,
   buildGoModule,
   installShellFiles,
   versionCheckHook,
@@ -23,6 +24,16 @@ buildGoModule (finalAttrs: {
   };
 
   vendorHash = "sha256-EqfhHy9OUiaoCI/VFjUJlm917un3Lf4/cUmeHG7w9Bg=";
+
+  # Upstream updates the Go version quickly. In nixpkgs, these updates remain in the staging branch for a while before reaching master.
+  # This adjusts go.mod to match the version available in nixpkgs, but only if they share the same major/minor version.
+  postPatch = ''
+    mod_major_minor="$(grep --only-matching --perl-regexp '^go \K([0-9]+\.[0-9]+)' go.mod)"
+
+    if [[ "$mod_major_minor" == '${lib.versions.majorMinor go.version}' ]]; then
+      '${lib.getExe go}' mod edit -go='${go.version}'
+    fi
+  '';
 
   env.CGO_ENABLED = 0;
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

nixpkgs-update frequently fails for this package due to the delay in Go patch version updates on the master branch.

Attempting to update version often leads to this error:

```
       > Running phase: buildPhase
       > go: go.mod requires go >= 1.25.5 (running go 1.25.4; GOTOOLCHAIN=local)
```

For example:

- https://github.com/NixOS/nixpkgs/pull/430707#pullrequestreview-3082311726
- https://nixpkgs-update-logs.nix-community.org/pinact/2025-07-26.log
- https://nixpkgs-update-logs.nix-community.org/pinact/2025-11-22.log
- https://nixpkgs-update-logs.nix-community.org/pinact/2025-12-17.log
- https://nixpkgs-update-logs.nix-community.org/pinact/2026-02-08.log # `3.8.0 -> 3.9.0` was blocked by `go: go.mod requires go >= 1.25.6 (running go 1.25.5; GOTOOLCHAIN=local)
- https://nixpkgs-update-logs.nix-community.org/pinact/2026-02-15.log # same as above


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
