### PR TITLE
arrow-cpp: fix arrow-azurefs-test

### DIFF
--- a/pkgs/by-name/ar/arrow-cpp/package.nix
+++ b/pkgs/by-name/ar/arrow-cpp/package.nix
@@ -18,6 +18,7 @@
     ];
   },
   azure-sdk-for-cpp,
+  azurite,
   boost,
   brotli,
   bzip2,
@@ -284,7 +285,8 @@ stdenv.mkDerivation (finalAttrs: {
     sqlite
   ]
   ++ lib.optionals enableS3 [ minio ]
-  ++ lib.optionals enableFlight [ python3 ];
+  ++ lib.optionals enableFlight [ python3 ]
+  ++ lib.optionals enableAzure [ azurite ];
 
   installCheckPhase =
     let


### PR DESCRIPTION
- add `azurite` to `nativeInstallCheckInputs` with `enableAzure`

Fixes run of `arrow-azurefs-test`:
```
[----------] 6 tests from TestAzureFileSystemOnAllEnvs/0, where
TypeParam = arrow::fs::TestingScenario<arrow::fs::AzuriteEnv,false>
[ RUN      ] TestAzureFileSystemOnAllEnvs/0.DetectHierarchicalNamespace
/build/source/cpp/src/arrow/filesystem/azurefs_test.cc:901: Failure
Value of: _st.ok()
  Actual: false
Expected: true
'_error_or_value58.status()' failed with IOError: Failed to find 'azurite' in PATH
/build/source/cpp/src/arrow/filesystem/azurefs_test.cc:174  self->server_process_->SetExecutable("azurite")
/build/source/cpp/src/arrow/filesystem/azurefs_test.cc:108  AzureEnvClass::Make()
/build/source/cpp/src/arrow/filesystem/azurefs_test.cc:892  GetAzureEnv()

WARNING: Logging before InitGoogleLogging() is written to STDERR
F20251218 15:54:18.988654 140737274596864 result.cc:27] ValueOrDie
called on an error: IOError: Failed to find 'azurite' in PATH
/build/source/cpp/src/arrow/filesystem/azurefs_test.cc:174  self->server_process_->SetExecutable("azurite")
/build/source/cpp/src/arrow/filesystem/azurefs_test.cc:108  AzureEnvClass::Make()
/build/source/cpp/src/arrow/filesystem/azurefs_test.cc:892  GetAzureEnv()
*** Check failure stack trace: ***
/build/source/cpp/build/src/arrow/filesystem
...
The following tests FAILED:
         76 - arrow-azurefs-test (Failed)                       arrow-tests filesystem unittest
Errors while running CTest
```

---

Probably related to addition of `enableAzure` in #469433

Tested build of both default (`enableAzure = true`) and:
```bash
nix-build --expr 'with import ./. {}; arrow-cpp.override { enableAzure = false; }'
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
