### PR TITLE
nixos/tribler: init module

### DIFF
--- a/nixos/modules/services/web-apps/tribler.nix
+++ b/nixos/modules/services/web-apps/tribler.nix
@@ -1,0 +1,116 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.tribler;
+in
+{
+  options = with lib; {
+    services.tribler = {
+      enable = mkEnableOption "Tribler, a privacy enhanced BitTorrent client with P2P content discovery";
+
+      package = mkPackageOption pkgs "tribler" { };
+
+      port = mkOption {
+        description = ''
+          The TCP port Tribler WebUI/API will listen on.
+          Default host is 127.0.0.1. Host can be configured in the
+          <dataDir>/.Tribler/8.0/configuration.json file's
+          api/http_host setting.
+        '';
+        default = 10099;
+        type = types.port;
+      };
+
+      dataDir = mkOption {
+        description = ''
+          Tribler's internal data storage, must be an absolute path that
+          already exists if set. The download location is set in the tribler web-gui's Settings.
+        '';
+        default = "/var/lib/tribler";
+        example = "/mnt/triblerdata";
+        type = types.str;
+      };
+
+      apikeyFile = mkOption {
+        description = ''
+          A file outside of the nix store containing a single string to use as the API Key for API.
+          If set, add '?key=<yourkeyhere>' to end of web-gui url.
+          ex: http://localhost:10099/ui/#/downloads/all?key=<yourkeyhere>.'';
+        default = null;
+        type = types.nullOr types.path;
+      };
+
+      user = mkOption {
+        description = "User account under which tribler runs.";
+        default = "tribler";
+        type = types.str;
+      };
+
+      group = mkOption {
+        description = "Group under which tribler runs.";
+        default = "tribler";
+        type = types.str;
+      };
+
+      openFirewall = mkOption {
+        description = "Open port in the firewall for the tribler web interface.";
+        default = false;
+        type = types.bool;
+      };
+
+    };
+  };
+
+  config =
+    with lib;
+    mkIf cfg.enable {
+      environment.systemPackages = [ cfg.package ];
+
+      systemd.services.tribler = {
+        description = "Tribler, a privacy enhanced BitTorrent client with P2P content discovery";
+
+        after = [ "network.target" ];
+        wantedBy = [ "multi-user.target" ];
+
+        environment = {
+          APPDATA = cfg.dataDir;
+          CORE_API_PORT = toString cfg.port;
+          CORE_API_KEY = (if cfg.apikeyFile != null then lib.readFile cfg.apikeyFile else "");
+        };
+
+        serviceConfig = {
+          Type = "simple";
+          User = cfg.user;
+          Group = cfg.group;
+          StateDirectory = mkIf (lib.hasPrefix "/var/lib/" cfg.dataDir) "tribler";
+          WorkingDirectory = cfg.dataDir;
+          ReadWritePaths = cfg.dataDir;
+          ExecStart = "${lib.getExe cfg.package} -s";
+          Restart = "on-failure";
+        };
+      };
+
+      users.users = mkIf (cfg.user == "tribler") {
+        tribler = {
+          isSystemUser = true;
+          group = cfg.group;
+          home = cfg.dataDir;
+        };
+      };
+
+      users.groups = mkIf (cfg.group == "tribler") {
+        tribler = { };
+      };
+
+      networking.firewall = mkIf cfg.openFirewall {
+        allowedTCPPorts = [ cfg.port ];
+      };
+    };
+
+  meta.maintainers = with lib; [ maintainers.JollyDevelopment ];
+  meta.doc = ./tribler.md;
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This adds a service module to run [Tribler](https://www.tribler.org/)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

##### Reviewed points

- [x] module path fits the guidelines
- [ ] module tests, if any, succeed on ARCHITECTURE
- [ ] module tests, if any, are added to package `passthru.tests`
- [x] options have appropriate types
- [x] options have default
- [x] options have example
- [x] options have descriptions
- [ ] No unneeded package is added to `environment.systemPackages`
- [x] `meta.maintainers` is set
- [x] module documentation is declared in `meta.doc`


[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
