### PR TITLE
[Backport release-25.11] ruby_3_4: 3.4.7 -> 3.4.8 

### DIFF
--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -190,27 +190,13 @@ let
           # make: *** [uncommon.mk:373: do-install-all] Error 1
           enableParallelInstalling = false;
 
-          patches =
-            op useBaseRuby ./do-not-update-gems-baseruby-3.2.patch
-            ++ [
-              # When using a baseruby, ruby always sets "libdir" to the build
-              # directory, which nix rejects due to a reference in to /build/ in
-              # the final product. Removing this reference doesn't seem to break
-              # anything and fixes cross compilation.
-              ./dont-refer-to-build-dir.patch
-            ]
-            ++ ops (lib.versionAtLeast ver.majMin "3.4" && lib.versionOlder ver.majMin "3.5") [
-              (fetchpatch {
-                name = "ruby-3.4-fix-gcc-15-llvm-21-1.patch";
-                url = "https://github.com/ruby/ruby/commit/846bb760756a3bf1ab12d56d8909e104f16e6940.patch";
-                hash = "sha256-+f0mzHsGAe9FT9NWE345BxzaB6vmWzMTvEfWF84uFOs=";
-              })
-              (fetchpatch {
-                name = "ruby-3.4-fix-gcc-15-llvm-21-2.patch";
-                url = "https://github.com/ruby/ruby/commit/18e176659e8afe402cab7d39972f2d56f2cf378f.patch";
-                hash = "sha256-TKPG1hcC1G2WmUkvNV6QSnvUpTEDqrYKrIk/4fAS8QE=";
-              })
-            ];
+          patches = op useBaseRuby ./do-not-update-gems-baseruby-3.2.patch ++ [
+            # When using a baseruby, ruby always sets "libdir" to the build
+            # directory, which nix rejects due to a reference in to /build/ in
+            # the final product. Removing this reference doesn't seem to break
+            # anything and fixes cross compilation.
+            ./dont-refer-to-build-dir.patch
+          ];
 
           cargoRoot = opString yjitSupport "yjit";
 
@@ -421,8 +407,8 @@ in
   };
 
   ruby_3_4 = generic {
-    version = rubyVersion "3" "4" "7" "";
-    hash = "sha256-I4FabQlWlveRkJD9w+L5RZssg9VyJLLkRs4fX3Mz7zY=";
+    version = rubyVersion "3" "4" "8" "";
+    hash = "sha256-U8TdrUH7thifH17g21elHVS9H4f4dVs9aGBBVqNbBFs=";
     cargoHash = "sha256-5Tp8Kth0yO89/LIcU8K01z6DdZRr8MAA0DPKqDEjIt0=";
   };
 


### PR DESCRIPTION
https://github.com/ruby/ruby/releases/tag/v3_4_8
(cherry picked from commit ee218ba24025850d34f0fc9594a4e58e2fb48b29)

This is a manual backport for ruby_3_4 from https://github.com/NixOS/nixpkgs/pull/471824. The main reason I did this was because I was getting openssl errors like this

```
/nix/store/74fhsx12rxmw4iq2p0fi25jcfy9pn2yv-ruby3.4-net-protocol-0.2.2/lib/ruby/gems/3.4.0/gems/net-protocol-0.2.2/lib/net/protocol.rb:46:in 'OpenSSL::SSL::SSLSocket#connect_nonblock': SSL_connect returned=1 errno=0 peeraddr=23.92.30.150:25 state=error: certificate verify failed (unable to get certificate CRL) (OpenSSL::SSL::SSLError)
```

and the fix was released in 3.4.8 and tracked by https://bugs.ruby-lang.org/issues/21631. 


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc