### PR TITLE
python3Packages.keras: 3.12.0 -> 3.13.0

### DIFF
--- a/pkgs/development/python-modules/dm-sonnet/default.nix
+++ b/pkgs/development/python-modules/dm-sonnet/default.nix
@@ -67,6 +67,12 @@ buildPythonPackage rec {
     export TF_USE_LEGACY_KERAS=True
   '';
 
+  enabledTestPaths = [
+    # Prevent collecting docs/ext/link_tf_api_test.py which fails with:
+    # ModuleNotFoundError: No module named 'docs.ext'
+    "sonnet"
+  ];
+
   disabledTests = [
     # AssertionError: 2 != 0 : 2 doctests failed
     "test_doctest_sonnet.functional"

--- a/pkgs/development/python-modules/flax/default.nix
+++ b/pkgs/development/python-modules/flax/default.nix
@@ -83,6 +83,11 @@ buildPythonPackage rec {
     tensorflow
   ];
 
+  pytestFlags = [
+    # FutureWarning: In the future `np.object` will be defined as the corresponding NumPy scalar.
+    "-Wignore::FutureWarning"
+  ];
+
   disabledTestPaths = [
     # Docs test, needs extra deps + we're not interested in it.
     "docs/_ext/codediff_test.py"

--- a/pkgs/development/python-modules/keras/default.nix
+++ b/pkgs/development/python-modules/keras/default.nix
@@ -14,14 +14,15 @@
   ml-dtypes,
   namex,
   numpy,
-  tf2onnx,
   onnxruntime,
   optree,
+  orbax-checkpoint,
   packaging,
   pythonAtLeast,
   rich,
   scikit-learn,
   tensorflow,
+  tf2onnx,
 
   # tests
   dm-tree,
@@ -36,25 +37,15 @@
 
 buildPythonPackage rec {
   pname = "keras";
-  version = "3.12.0";
+  version = "3.13.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "keras-team";
     repo = "keras";
     tag = "v${version}";
-    hash = "sha256-xuCxeQD8NAn7zlqCG+GyFjL6NlnIkGie+4GxzLGsyUg=";
+    hash = "sha256-JsWmwJbIJIF3eEj7wYzNOSAiNHQkQ5LHKrE0lVQtU/U=";
   };
-
-  # Use a raw string to prevent LaTeX codes from being interpreted as escape sequences.
-  # SyntaxError: invalid escape sequence '\h
-  # Fix submitted upstream: https://github.com/keras-team/keras/pull/21790
-  postPatch = ''
-    substituteInPlace keras/src/quantizers/gptq_test.py \
-      --replace-fail \
-        'CALIBRATION_TEXT = """' \
-        'CALIBRATION_TEXT = r"""'
-  '';
 
   build-system = [
     setuptools
@@ -66,13 +57,14 @@ buildPythonPackage rec {
     ml-dtypes
     namex
     numpy
-    tf2onnx
     onnxruntime
     optree
+    orbax-checkpoint
     packaging
     rich
     scikit-learn
     tensorflow
+    tf2onnx
   ]
   ++ lib.optionals (pythonAtLeast "3.12") [ distutils ];
 
@@ -122,84 +114,6 @@ buildPythonPackage rec {
 
     # TypeError: this __dict__ descriptor does not support '_DictWrapper' objects
     "test_reloading_default_saved_model"
-
-    # E       AssertionError:
-    # E       - float32
-    # E       + float64
-    "test_angle_bool"
-    "test_angle_int16"
-    "test_angle_int32"
-    "test_angle_int8"
-    "test_angle_uint16"
-    "test_angle_uint32"
-    "test_angle_uint8"
-    "test_bartlett_bfloat16"
-    "test_bartlett_bool"
-    "test_bartlett_float16"
-    "test_bartlett_float32"
-    "test_bartlett_float64"
-    "test_bartlett_int16"
-    "test_bartlett_int32"
-    "test_bartlett_int64"
-    "test_bartlett_int8"
-    "test_bartlett_none"
-    "test_bartlett_uint16"
-    "test_bartlett_uint32"
-    "test_bartlett_uint8"
-    "test_blackman_bfloat16"
-    "test_blackman_bool"
-    "test_blackman_float16"
-    "test_blackman_float32"
-    "test_blackman_float64"
-    "test_blackman_int16"
-    "test_blackman_int32"
-    "test_blackman_int64"
-    "test_blackman_int8"
-    "test_blackman_none"
-    "test_blackman_uint16"
-    "test_blackman_uint32"
-    "test_blackman_uint8"
-    "test_eye_none"
-    "test_hamming_bfloat16"
-    "test_hamming_bool"
-    "test_hamming_float16"
-    "test_hamming_float32"
-    "test_hamming_float64"
-    "test_hamming_int16"
-    "test_hamming_int32"
-    "test_hamming_int64"
-    "test_hamming_int8"
-    "test_hamming_none"
-    "test_hamming_uint16"
-    "test_hamming_uint32"
-    "test_hamming_uint8"
-    "test_hanning_bfloat16"
-    "test_hanning_bool"
-    "test_hanning_float16"
-    "test_hanning_float32"
-    "test_hanning_float64"
-    "test_hanning_int16"
-    "test_hanning_int32"
-    "test_hanning_int64"
-    "test_hanning_int8"
-    "test_hanning_none"
-    "test_hanning_uint16"
-    "test_hanning_uint32"
-    "test_hanning_uint8"
-    "test_identity_none"
-    "test_kaiser_bfloat16"
-    "test_kaiser_bool"
-    "test_kaiser_float16"
-    "test_kaiser_float32"
-    "test_kaiser_float64"
-    "test_kaiser_int16"
-    "test_kaiser_int32"
-    "test_kaiser_int64"
-    "test_kaiser_int8"
-    "test_kaiser_none"
-    "test_kaiser_uint16"
-    "test_kaiser_uint32"
-    "test_kaiser_uint8"
   ]
   ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [
     # Hangs forever

--- a/pkgs/development/python-modules/mtcnn/default.nix
+++ b/pkgs/development/python-modules/mtcnn/default.nix
@@ -46,6 +46,15 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
+  disabledTests = [
+    # Failing since keras 3.13.0.
+    # ValueError: Exception encountered when calling Conv2D.call().
+    # The convolution operation resulted in an empty output. Output shape: (0, 48, 48, 3).
+    # This can happen if the input is too small for the given kernel size, strides, dilation rate,
+    # and padding mode. Please check the input shape and convolution parameters.
+    "test_detect_no_faces"
+  ];
+
   meta = {
     description = "MTCNN face detection implementation for TensorFlow";
     homepage = "https://github.com/ipazc/mtcnn";


### PR DESCRIPTION
## Things done

- **python3Packages.keras: 3.12.0 -> 3.13.0**
    Diff: https://github.com/keras-team/keras/compare/v3.12.0...v3.13.0
    Changelog: https://github.com/keras-team/keras/releases/tag/v3.13.0
- **python3Packages.mtcnn: skip failing test**
- **python3Packages.dm-sonnet: only collect tests under sonnet/**
- **python3Packages.flax: ignore FutureWarning in tests (present since keras 3.13.0)**

---

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc