### PR TITLE
cargotom: init at 2.3.13

### DIFF
--- a/pkgs/by-name/ca/cargotom/package.nix
+++ b/pkgs/by-name/ca/cargotom/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  pkg-config,
+  openssl,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "cargotom";
+  version = "2.3.13";
+
+  src = fetchFromGitHub {
+    owner = "frederik-uni";
+    repo = "cargotom";
+    # first commit with mit license
+    # todo: use tag = finalAttrs.version after next release
+    rev = "c55177d35cb6db05a52f4af6bf6836fd2f99035f";
+    hash = "sha256-v9Fb7y9Oa7zpWYUXw9ltFLuMZOhrrt77cDj3/KUMWVs=";
+  };
+
+  cargoHash = "sha256-vEU6Y6bafP3y76l1xCj25BUfbEcGdxnARauz2o/jiE0=";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    openssl
+  ];
+
+  env = {
+    OPENSSL_NO_VENDOR = true;
+  };
+
+  # html2md sets crate-type = ["rlib", "dylib", "staticlib"]
+  # this causes cargo to also create .so file which links to rustc
+  # this causes nix to add rustc to closure bumping its size to 1.5G
+  #
+  # see https://gitlab.com/Kanedias/html2md/-/blob/master/Cargo.toml
+  postInstall = ''
+    rm $out/lib/libhtml2md.so
+    rmdir $out/lib
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Cargo.toml LSP";
+    homepage = "https://github.com/frederik-uni/cargotom";
+    changelog = "https://github.com/frederik-uni/cargotom/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ istudyatuni ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/frederik-uni/cargotom

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
