### PR TITLE
bambu-studio: fix build with gcc15

### DIFF
--- a/pkgs/by-name/ba/bambu-studio/package.nix
+++ b/pkgs/by-name/ba/bambu-studio/package.nix
@@ -3,6 +3,7 @@
   lib,
   binutils,
   fetchFromGitHub,
+  fetchpatch,
   cmake,
   ninja,
   pkg-config,
@@ -121,6 +122,13 @@ stdenv.mkDerivation (finalAttrs: {
     ./patches/no-cereal.patch
     # Cmake 4 support
     ./patches/cmake.patch
+    # Fix build with gcc15
+    # https://github.com/bambulab/BambuStudio/pull/8555
+    (fetchpatch {
+      name = "bambu-studio-include-stdint-header.patch";
+      url = "https://github.com/bambulab/BambuStudio/commit/434752bf643933f22348d78335abe7f60550e736.patch";
+      hash = "sha256-vWqTM6IHL/gBncLk6gZHw+dFe0sdVuPdUqYeVJUbTis=";
+    })
   ];
 
   doCheck = true;


### PR DESCRIPTION
- add patch from merged upstream PR:
https://www.github.com/bambulab/BambuStudio/pull/8555
https://github.com/bambulab/BambuStudio/commit/434752bf643933f22348d78335abe7f60550e736

Fixes build failure with gcc15:
```
/build/source/src/mcut/source/math.cpp:660:15: error: 'uint32_t' does
not name a type
  660 |         const uint32_t N = polygon_vertices.size();
      |               ^~~~~~~~
/build/source/src/mcut/source/math.cpp:25:1: note: 'uint32_t' is
defined in header '<cstdint>'; this is probably fixable by
adding '#include <cstdint>'
   24 | #include <algorithm> // std::sort
  +++ |+#include <cstdint>
   25 | #include <cstdlib>
/build/source/src/mcut/source/math.cpp:661:20: error: 'N' was not
declared in this scope
  661 |         out.resize(N);
      |                    ^
/build/source/src/mcut/source/math.cpp:669:13: error: 'uint32_t' was not
declared in this scope
  669 |         for(uint32_t i =0; i < N; ++i)
      |             ^~~~~~~~
/build/source/src/mcut/source/math.cpp:669:13: note: 'uint32_t' is
defined in header '<cstdint>'; this is probably fixable by
adding '#include <cstdint>'
```

---

Part of fixes for gcc15 update:
https://github.com/NixOS/nixpkgs/pull/440456

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
