### PR TITLE
github/labeler: do not auto-tag backports for backport

### DIFF
--- a/.github/labeler-no-sync.yml
+++ b/.github/labeler-no-sync.yml
@@ -23,21 +23,23 @@
               - nixos/doc/**/*
 
 "backport release-25.05":
-  - any:
+  - all:
       - changed-files:
           - any-glob-to-any-file:
               - .github/actions/*
               - .github/workflows/*
               - ci/**/*.*
               - maintainers/github-teams.json
+      - base-branch: ['master']
 
 "backport release-25.11":
-  - any:
+  - all:
       - changed-files:
           - any-glob-to-any-file:
               - .github/actions/*
               - .github/workflows/*
               - ci/**/*.*
               - maintainers/github-teams.json
+      - base-branch: ['master']
 
 # keep-sorted end


### PR DESCRIPTION
E.g. #472009, #472010, #472184, #472185

Labeler docs: https://github.com/actions/labeler

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
