### PR TITLE
chromium,chromedriver: 143.0.7499.146 -> 143.0.7499.169

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -1,10 +1,10 @@
 {
   "chromium": {
-    "version": "143.0.7499.146",
+    "version": "143.0.7499.169",
     "chromedriver": {
-      "version": "143.0.7499.147",
-      "hash_darwin": "sha256-bsyTxvmiIDdV/ivUjbLk3K+Ve03DvVZG3HF/y4X9JUU=",
-      "hash_darwin_aarch64": "sha256-j5PbvqUsR+XlYZU7xB2MTPJncfSgCIy9tE298ww8Ux4="
+      "version": "143.0.7499.170",
+      "hash_darwin": "sha256-1/wdCF7ADdn3JL2ZIxdpjxMqCdLB00vXjXI9vSrPk2I=",
+      "hash_darwin_aarch64": "sha256-aKOt2lgQ3133kDFDfHnvUhEycw8aYMgg/uJQHtiud7c="
     },
     "deps": {
       "depot_tools": {
@@ -21,8 +21,8 @@
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "c1224fc40c96e7f17f0cdeb87a8f4c64b93c0d74",
-        "hash": "sha256-Sn4j7vs7g/D9GnL+BMCyg73iEeGn7Miq0k42mV6Z3hM=",
+        "rev": "164b20aab62509dad21fd46383951aeec084ad1e",
+        "hash": "sha256-WqpZXjcklOyPIvEmWi23bC8D/vVXMLkAmFrQQ13Iy6o=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {


### PR DESCRIPTION
https://chromereleases.googleblog.com/2025/12/stable-channel-update-for-desktop_18.html

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test