### PR TITLE
keycloak: add plugin, updates, and support for Unix socket auth

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1813,6 +1813,13 @@
     githubId = 6091755;
     name = "Anirrudh Krishnan";
   };
+  anish = {
+    email = "i@anish.land";
+    github = "ap-1";
+    githubId = 67872951;
+    name = "Anish Pallati";
+    keys = [ { fingerprint = "2A0A 16F5 E026 BE3B A47F B7A6 841A FB68 9A5B ACCB"; } ];
+  };
   ankhers = {
     email = "me@ankhers.dev";
     github = "ankhers";

--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -62,6 +62,9 @@
   "module-boot-plymouth-tpm2-totp-quick-start-enable": [
     "index.html#module-boot-plymouth-tpm2-totp-quick-start-enable"
   ],
+  "module-services-keycloak-unix-socket": [
+    "index.html#module-services-keycloak-unix-socket"
+  ],
   "module-services-tandoor-recipes-migrating-media-option-1": [
     "index.html#module-services-tandoor-recipes-migrating-media-option-1"
   ],

--- a/nixos/modules/services/web-apps/keycloak.md
+++ b/nixos/modules/services/web-apps/keycloak.md
@@ -54,6 +54,30 @@ The path should be provided as a string, not a Nix path, since Nix
 paths are copied into the world readable Nix store.
 :::
 
+## Unix socket authentication {#module-services-keycloak-unix-socket}
+
+For PostgreSQL, Keycloak can connect via Unix socket using peer
+authentication, avoiding the need for a database password.
+
+To use Unix sockets, set [](#opt-services.keycloak.database.host)
+to the PostgreSQL socket directory (e.g., `/run/postgresql`) and
+add the required junixsocket plugins:
+```nix
+{
+  services.keycloak = {
+    database.host = "/run/postgresql";
+    plugins = with pkgs.keycloak.plugins; [
+      junixsocket-common
+      junixsocket-native-common
+    ];
+  };
+}
+```
+
+::: {.note}
+Unix socket authentication is only supported for PostgreSQL.
+:::
+
 ## Hostname {#module-services-keycloak-hostname}
 
 The hostname is used to build the public URL used as base for

--- a/nixos/modules/services/web-apps/keycloak.nix
+++ b/nixos/modules/services/web-apps/keycloak.nix
@@ -167,6 +167,11 @@ in
           default = "localhost";
           description = ''
             Hostname of the database to connect to.
+
+            For PostgreSQL, this can also be a path to a Unix socket
+            directory (e.g., `/run/postgresql`) to use peer authentication.
+            This requires adding `junixsocket-common` and `junixsocket-native-common`
+            to [](#opt-services.keycloak.plugins).
           '';
         };
 
@@ -189,11 +194,12 @@ in
 
         useSSL = mkOption {
           type = bool;
-          default = cfg.database.host != "localhost";
-          defaultText = literalExpression ''config.${opt.database.host} != "localhost"'';
+          default = cfg.database.host != "localhost" && !hasPrefix "/" cfg.database.host;
+          defaultText = literalExpression ''config.${opt.database.host} != "localhost" && !lib.hasPrefix "/" config.${opt.database.host}'';
           description = ''
-            Whether the database connection should be secured by SSL /
-            TLS.
+            Whether the database connection should be secured by SSL / TLS.
+
+            Defaults to `false` for localhost and Unix socket connections.
           '';
         };
 
@@ -252,11 +258,15 @@ in
         };
 
         passwordFile = mkOption {
-          type = path;
+          type = nullOr path;
+          default = null;
           example = "/run/keys/db_password";
           apply = assertStringPath "passwordFile";
           description = ''
             The path to a file containing the database password.
+
+            Not required when using Unix socket authentication (peer auth)
+            by setting `host` to a socket path like `/run/postgresql`.
           '';
         };
       };
@@ -553,6 +563,13 @@ in
             for more information.
           '';
         }
+        {
+          assertion = cfg.database.passwordFile != null || hasPrefix "/" cfg.database.host;
+          message = ''
+            services.keycloak.database.passwordFile must be set unless using
+            Unix socket authentication (host starting with /).
+          '';
+        }
       ];
 
       environment.systemPackages = [ keycloakBuild ];
@@ -582,19 +599,32 @@ in
               "trustCertificateKeyStorePassword=notsosecretpassword"
             ]
           );
+
+          dbName = if databaseActuallyCreateLocally then "keycloak" else cfg.database.name;
           dbProps = if cfg.database.type == "postgresql" then postgresParams else mariadbParams;
+
+          # Unix socket connection requires junixsocket library and special JDBC URL
+          isUnixSocket = hasPrefix "/" cfg.database.host;
+          unixSocketUrl = "jdbc:postgresql://localhost/${dbName}?socketFactory=org.newsclub.net.unix.AFUNIXSocketFactory$FactoryArg&socketFactoryArg=${cfg.database.host}/.s.PGSQL.${toString cfg.database.port}&sslMode=disable";
         in
         mkMerge [
           {
             db = if cfg.database.type == "postgresql" then "postgres" else cfg.database.type;
             db-username = if databaseActuallyCreateLocally then "keycloak" else cfg.database.username;
-            db-password._secret = cfg.database.passwordFile;
+            db-password = mkIf (cfg.database.passwordFile != null) {
+              _secret = cfg.database.passwordFile;
+            };
+          }
+          (mkIf isUnixSocket {
+            db-url = unixSocketUrl;
+          })
+          (mkIf (!isUnixSocket) {
             db-url-host = cfg.database.host;
             db-url-port = toString cfg.database.port;
-            db-url-database = if databaseActuallyCreateLocally then "keycloak" else cfg.database.name;
+            db-url-database = dbName;
             db-url-properties = prefixUnlessEmpty "?" dbProps;
             db-url = null;
-          }
+          })
           (mkIf (cfg.sslCertificate != null && cfg.sslCertificateKey != null) {
             https-certificate-file = "/run/keycloak/ssl/ssl_cert";
             https-certificate-key-file = "/run/keycloak/ssl/ssl_key";
@@ -778,5 +808,8 @@ in
     };
 
   meta.doc = ./keycloak.md;
-  meta.maintainers = [ maintainers.talyz ];
+  meta.maintainers = with maintainers; [
+    talyz
+    anish
+  ];
 }

--- a/pkgs/by-name/ke/keycloak/all-plugins.nix
+++ b/pkgs/by-name/ke/keycloak/all-plugins.nix
@@ -7,6 +7,7 @@
   keycloak-magic-link = callPackage ./keycloak-magic-link { };
   keycloak-metrics-spi = callPackage ./keycloak-metrics-spi { };
   keycloak-restrict-client-auth = callPackage ./keycloak-restrict-client-auth { };
+  keycloak-remember-me-authenticator = callPackage ./keycloak-remember-me-authenticator { };
 
   # These could theoretically be used by something other than Keycloak, but
   # there are no other quarkus apps in nixpkgs (as of 2023-08-21)

--- a/pkgs/by-name/ke/keycloak/all-plugins.nix
+++ b/pkgs/by-name/ke/keycloak/all-plugins.nix
@@ -1,4 +1,9 @@
-{ callPackage, fetchMavenArtifact }:
+{
+  callPackage,
+  fetchMavenArtifact,
+  junixsocket-common,
+  junixsocket-native-common,
+}:
 
 {
   scim-for-keycloak = callPackage ./scim-for-keycloak { };
@@ -8,6 +13,11 @@
   keycloak-metrics-spi = callPackage ./keycloak-metrics-spi { };
   keycloak-restrict-client-auth = callPackage ./keycloak-restrict-client-auth { };
   keycloak-remember-me-authenticator = callPackage ./keycloak-remember-me-authenticator { };
+
+  # junixsocket provides Unix domain socket support for JDBC connections,
+  # which is required for connecting to PostgreSQL via Unix socket.
+  junixsocket-common = junixsocket-common.passthru.jar;
+  junixsocket-native-common = junixsocket-native-common.passthru.jar;
 
   # These could theoretically be used by something other than Keycloak, but
   # there are no other quarkus apps in nixpkgs (as of 2023-08-21)

--- a/pkgs/by-name/ke/keycloak/keycloak-discord/default.nix
+++ b/pkgs/by-name/ke/keycloak/keycloak-discord/default.nix
@@ -11,7 +11,7 @@ maven.buildMavenPackage rec {
   src = fetchFromGitHub {
     owner = "wadahiro";
     repo = "keycloak-discord";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-BA7x28k/aMI3VPQmEgNhKD9N34DdYqadAD/m4cxLSYg=";
   };
 

--- a/pkgs/by-name/ke/keycloak/keycloak-discord/default.nix
+++ b/pkgs/by-name/ke/keycloak/keycloak-discord/default.nix
@@ -24,7 +24,8 @@ maven.buildMavenPackage rec {
         "x86_64-linux" = "sha256-uhm++MGgTN32/xbHNd+Z3Hes9Q5tl8ztIQ92LxMWKjg=";
       };
     in
-    mvnHashes.${stdenv.hostPlatform.system};
+    mvnHashes.${stdenv.hostPlatform.system}
+      or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/by-name/ke/keycloak/keycloak-discord/default.nix
+++ b/pkgs/by-name/ke/keycloak/keycloak-discord/default.nix
@@ -1,32 +1,44 @@
 {
   stdenv,
+  maven,
   lib,
-  fetchurl,
+  fetchFromGitHub,
 }:
-
-stdenv.mkDerivation rec {
+maven.buildMavenPackage rec {
   pname = "keycloak-discord";
-  version = "0.5.0";
+  version = "0.6.1";
 
-  src = fetchurl {
-    url = "https://github.com/wadahiro/keycloak-discord/releases/download/v${version}/keycloak-discord-${version}.jar";
-    hash = "sha256-radvUu2a6t0lbo5f/ADqy7+I/ONXB7/8pk2d1BtYzQA=";
+  src = fetchFromGitHub {
+    owner = "wadahiro";
+    repo = "keycloak-discord";
+    rev = "v${version}";
+    hash = "sha256-BA7x28k/aMI3VPQmEgNhKD9N34DdYqadAD/m4cxLSYg=";
   };
 
-  dontUnpack = true;
-  dontBuild = true;
+  mvnHash =
+    let
+      mvnHashes = {
+        "aarch64-darwin" = "sha256-Or7VOZwz4NfDtb0kmHbbTYE/avAc+H8+Y6JPw+HGjxs=";
+        "x86_64-darwin" = "sha256-sX10vYlb2hWArTLZsPTcKYHHsPffQKtBxpcI42wcZZA=";
+        "aarch64-linux" = "sha256-I5qjhfAXPXMb+1SPG29t/IKH/zBQqdnu3U7dYSQhTL8=";
+        "x86_64-linux" = "sha256-uhm++MGgTN32/xbHNd+Z3Hes9Q5tl8ztIQ92LxMWKjg=";
+      };
+    in
+    mvnHashes.${stdenv.hostPlatform.system};
 
   installPhase = ''
     runHook preInstall
-    install -Dm444 "$src" "$out/keycloak-discord-$version.jar"
+    install -Dm444 target/keycloak-discord-${version}.jar "$out/keycloak-discord-${version}.jar"
     runHook postInstall
   '';
 
   meta = {
     homepage = "https://github.com/wadahiro/keycloak-discord";
-    description = "Keycloak Social Login extension for Discord";
+    description = "Keycloak Identity Provider extension for Discord";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ mkg20001 ];
-    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
+    maintainers = with lib.maintainers; [
+      mkg20001
+      anish
+    ];
   };
 }

--- a/pkgs/by-name/ke/keycloak/keycloak-magic-link/default.nix
+++ b/pkgs/by-name/ke/keycloak/keycloak-magic-link/default.nix
@@ -6,16 +6,16 @@
 }:
 maven.buildMavenPackage rec {
   pname = "keycloak-magic-link";
-  version = "0.38";
+  version = "0.52";
 
   src = fetchFromGitHub {
     owner = "p2-inc";
     repo = "keycloak-magic-link";
     tag = "v${version}";
-    hash = "sha256-+fhWxAUlt9UVM81Ua2Mwek3D5Kzzk/Tsugbo0fLyxiA=";
+    hash = "sha256-giKhcK/bRSYUfix0ttuk9gs2q3A+4dDlayN15tuJhcY=";
   };
 
-  mvnHash = "sha256-edBdooR+KqY0JKwxdwTd5AxJ0qn3MV9xLrqYukIq2oY=";
+  mvnHash = "sha256-x9o83Azzep27jQXjxJoTga6B+mELSAtho568yHKz42k=";
 
   installPhase = ''
     runHook preInstall
@@ -29,6 +29,9 @@ maven.buildMavenPackage rec {
     homepage = "https://github.com/p2-inc/keycloak-magic-link";
     description = "Magic Link Authentication for Keycloak";
     license = lib.licenses.elastic20;
-    maintainers = with lib.maintainers; [ lykos153 ];
+    maintainers = with lib.maintainers; [
+      lykos153
+      anish
+    ];
   };
 }

--- a/pkgs/by-name/ke/keycloak/keycloak-metrics-spi/default.nix
+++ b/pkgs/by-name/ke/keycloak/keycloak-metrics-spi/default.nix
@@ -1,21 +1,30 @@
 {
   maven,
   lib,
+  stdenv,
   fetchFromGitHub,
 }:
-
 maven.buildMavenPackage rec {
   pname = "keycloak-metrics-spi";
-  version = "6.0.0";
+  version = "7.0.0";
 
   src = fetchFromGitHub {
     owner = "aerogear";
     repo = "keycloak-metrics-spi";
-    rev = "refs/tags/${version}";
-    hash = "sha256-MMonBRau8FpfCqija6NEdvp4zJfEub2Kwk4MA7FYWHI=";
+    tag = version;
+    hash = "sha256-C6ueYhSMVMGpjHF5QQj9jfaS9sGTZ3wKZq2xmNgTmAg=";
   };
 
-  mvnHash = "sha256-u+UAbKDqtlBEwrzh6LRgs8sZfMZ1u2TAluzOxsBrb/k=";
+  mvnHash =
+    let
+      mvnHashes = {
+        "aarch64-darwin" = "sha256-L+LVJGBVhkaWOdXpHep9f2s7hLr3enf5POm8U+Y7I1w=";
+        "x86_64-darwin" = "sha256-G/e0mgAGP+6zvX3b0EuI95bdLT7Bzwh1GgcAfxzsIhE=";
+        "aarch64-linux" = "sha256-Nrs+gqRYPKXWRr0COAsKmOrNaza2fxhEAJ5x896tKvA=";
+        "x86_64-linux" = "sha256-oHMkzXHR4mETH6VsxhFuap3AcjvTXytNkKlLY/mzT3g=";
+      };
+    in
+    mvnHashes.${stdenv.hostPlatform.system};
 
   installPhase = ''
     runHook preInstall
@@ -27,7 +36,9 @@ maven.buildMavenPackage rec {
     homepage = "https://github.com/aerogear/keycloak-metrics-spi";
     description = "Keycloak Service Provider that adds a metrics endpoint";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ benley ];
-    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [
+      benley
+      anish
+    ];
   };
 }

--- a/pkgs/by-name/ke/keycloak/keycloak-metrics-spi/default.nix
+++ b/pkgs/by-name/ke/keycloak/keycloak-metrics-spi/default.nix
@@ -24,7 +24,8 @@ maven.buildMavenPackage rec {
         "x86_64-linux" = "sha256-oHMkzXHR4mETH6VsxhFuap3AcjvTXytNkKlLY/mzT3g=";
       };
     in
-    mvnHashes.${stdenv.hostPlatform.system};
+    mvnHashes.${stdenv.hostPlatform.system}
+      or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/by-name/ke/keycloak/keycloak-remember-me-authenticator/default.nix
+++ b/pkgs/by-name/ke/keycloak/keycloak-remember-me-authenticator/default.nix
@@ -10,7 +10,7 @@ maven.buildMavenPackage rec {
   src = fetchFromGitHub {
     owner = "Herdo";
     repo = "keycloak-remember-me-authenticator";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-zIFWbv02wbf3D6Weyc8N4YM+fFFxnve0ti5yS52KN3c=";
   };
 

--- a/pkgs/by-name/ke/keycloak/keycloak-remember-me-authenticator/default.nix
+++ b/pkgs/by-name/ke/keycloak/keycloak-remember-me-authenticator/default.nix
@@ -1,0 +1,31 @@
+{
+  maven,
+  lib,
+  fetchFromGitHub,
+}:
+maven.buildMavenPackage rec {
+  pname = "keycloak-remember-me-authenticator";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "Herdo";
+    repo = "keycloak-remember-me-authenticator";
+    rev = "v${version}";
+    hash = "sha256-zIFWbv02wbf3D6Weyc8N4YM+fFFxnve0ti5yS52KN3c=";
+  };
+
+  mvnHash = "sha256-9wvBTA9RYPJz9zeimo4tmEjoHfKVGtPPAdNTe5BKdOs=";
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm444 -t "$out" target/keycloak-remember-me-authenticator-${version}.jar
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://github.com/Herdo/keycloak-remember-me-authenticator";
+    description = "Custom authenticator for remembering the user logging in, even if no \"Remember me\" flag is set";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ anish ];
+  };
+}

--- a/pkgs/by-name/ke/keycloak/package.nix
+++ b/pkgs/by-name/ke/keycloak/package.nix
@@ -101,6 +101,7 @@ stdenv.mkDerivation (finalAttrs: {
       talyz
       nickcao
       leona
+      anish
     ];
   };
 })

--- a/pkgs/by-name/ke/keycloak/scim-keycloak-user-storage-spi/default.nix
+++ b/pkgs/by-name/ke/keycloak/scim-keycloak-user-storage-spi/default.nix
@@ -3,19 +3,18 @@
   fetchFromGitHub,
   maven,
 }:
-
-maven.buildMavenPackage {
+maven.buildMavenPackage rec {
   pname = "scim-keycloak-user-storage-spi";
-  version = "unstable-2024-02-14";
+  version = "kc25_0_4";
 
   src = fetchFromGitHub {
     owner = "justin-stephenson";
     repo = "scim-keycloak-user-storage-spi";
-    rev = "6c59915836d9a559983326bbb87f895324bb75e4";
-    hash = "sha256-BSso9lU542Aroxu0RIX6NARc10lGZ04A/WIWOVtdxHw=";
+    rev = version;
+    hash = "sha256-xEnYblL5lxs1pebxGy4pXiZrMJT0KwIZqB4dztRyz/A=";
   };
 
-  mvnHash = "sha256-xbGlVZl3YtbF372kCDh+UdK5pLe6C6WnGgbEXahlyLw=";
+  mvnHash = "sha256-UUJXHQRqshaMpr4g8m2hdBy/dpl/IImkY+KGnUF1jAs=";
 
   installPhase = ''
     install -D "target/scim-user-spi-0.0.1-SNAPSHOT.jar" "$out/scim-user-spi-0.0.1-SNAPSHOT.jar"
@@ -23,11 +22,14 @@ maven.buildMavenPackage {
 
   meta = {
     homepage = "https://github.com/justin-stephenson/scim-keycloak-user-storage-spi";
-    description = "Third party module that extends Keycloak, allow for user storage in an external scimv2 server";
+    description = "Keycloak module that allows for user storage in an external SCIM 2.0 server";
     sourceProvenance = with lib.sourceTypes; [
       fromSource
     ];
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ s1341 ];
+    maintainers = with lib.maintainers; [
+      s1341
+      anish
+    ];
   };
 }

--- a/pkgs/by-name/ke/keycloak/scim-keycloak-user-storage-spi/default.nix
+++ b/pkgs/by-name/ke/keycloak/scim-keycloak-user-storage-spi/default.nix
@@ -10,7 +10,7 @@ maven.buildMavenPackage rec {
   src = fetchFromGitHub {
     owner = "justin-stephenson";
     repo = "scim-keycloak-user-storage-spi";
-    rev = version;
+    tag = version;
     hash = "sha256-xEnYblL5lxs1pebxGy4pXiZrMJT0KwIZqB4dztRyz/A=";
   };
 


### PR DESCRIPTION
### Plugins

* Adds the [keycloak-remember-me-authenticator](https://github.com/Herdo/keycloak-remember-me-authenticator) plugin for Keycloak. This plugin enables "Remember Me" functionality for users logging in via identity providers which don't natively support the Remember Me flag.
* Updates the `keycloak-magic-link`, `keycloak-discord`, `keycloak-metrics-spi`, and `scim-keycloak-user-storage-spi` plugins
  * For `keycloak-discord` in particular, we switch from downloading the jar to building from source with maven (for consistency with the other plugins).
  * `scim-keycloak-user-storage-spi` updated from an unstable version to a stable version.
  * (I believe) `keycloak-metrics-spi` incorrectly had `platforms = lib.platforms.linux;`, so that line is removed.
* Adds the junixsocket-common, junixsocket-native-common plugins, which are needed for Unix socket authentication (peer auth). 

### Module

* When using Unix sockets, constructs a custom JDBC URL and uses that instead. Describes how to use Unix socket auth in the docs.
* Makes `services.keycloak.database.passwordFile` optional when using Unix sockets. When `database.host` is a path (e.g., `/run/postgresql`), PostgreSQL doesn't require a password. This supports the pattern of using `ensureUsers` with `ensureDBOwnership` and peer auth for local PostgreSQL connections.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
