### PR TITLE
opencascade-occt: move 404-ing src to github

### DIFF
--- a/pkgs/by-name/op/opencascade-occt/package.nix
+++ b/pkgs/by-name/op/opencascade-occt/package.nix
@@ -22,12 +22,11 @@
 stdenv.mkDerivation (finalAttrs: {
   pname = "opencascade-occt";
   version = "7.8.1";
-  commit = "V${builtins.replaceStrings [ "." ] [ "_" ] finalAttrs.version}";
 
   src = fetchFromGitHub {
     owner = "Open-Cascade-SAS";
     repo = "OCCT";
-    tag = finalAttrs.commit;
+    tag = "V${builtins.replaceStrings [ "." ] [ "_" ] finalAttrs.version}";
     hash = "sha256-tg71cFx9HZ471T/3No9CeEHi8VSo0ZITIuNfTSNB2qU=";
   };
 

--- a/pkgs/by-name/op/opencascade-occt/package.nix
+++ b/pkgs/by-name/op/opencascade-occt/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
   fetchpatch,
   cmake,
   ninja,
@@ -19,15 +19,16 @@
   # used in passthru.tests
   opencascade-occt,
 }:
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "opencascade-occt";
   version = "7.8.1";
-  commit = "V${builtins.replaceStrings [ "." ] [ "_" ] version}";
+  commit = "V${builtins.replaceStrings [ "." ] [ "_" ] finalAttrs.version}";
 
-  src = fetchurl {
-    name = "occt-${commit}.tar.gz";
-    url = "https://git.dev.opencascade.org/gitweb/?p=occt.git;a=snapshot;h=${commit};sf=tgz";
-    hash = "sha256-AGMZqTLLjXbzJFW/RSTsohAGV8sMxlUmdU/Y2oOzkk8=";
+  src = fetchFromGitHub {
+    owner = "Open-Cascade-SAS";
+    repo = "OCCT";
+    tag = finalAttrs.commit;
+    hash = "sha256-tg71cFx9HZ471T/3No9CeEHi8VSo0ZITIuNfTSNB2qU=";
   };
 
   patches = [
@@ -89,4 +90,4 @@ stdenv.mkDerivation rec {
     maintainers = with lib.maintainers; [ amiloradovsky ];
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7924,14 +7924,14 @@ with pkgs;
 
   openal = openalSoft;
 
-  opencascade-occt_7_6 = opencascade-occt.overrideAttrs rec {
+  opencascade-occt_7_6 = opencascade-occt.overrideAttrs {
     pname = "opencascade-occt";
     version = "7.6.2";
-    commit = "V${builtins.replaceStrings [ "." ] [ "_" ] version}";
-    src = fetchurl {
-      name = "occt-${commit}.tar.gz";
-      url = "https://git.dev.opencascade.org/gitweb/?p=occt.git;a=snapshot;h=${commit};sf=tgz";
-      hash = "sha256-n3KFrN/mN1SVXfuhEUAQ1fJzrCvhiclxfEIouyj9Z18=";
+    src = fetchFromGitHub {
+      owner = "Open-Cascade-SAS";
+      repo = "OCCT";
+      tag = "V7_6_2";
+      hash = "sha256-tg71cFx9HZ471T/3No9CeEHi8VSo0ZITIuNfTSNB2qU=";
     };
     patches = [
       # Backport GCC 14 build fix


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Partially address #471645 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
