### PR TITLE
deskreen: 2.0.4 -> 3.2.1

### DIFF
--- a/pkgs/by-name/de/deskreen/package.nix
+++ b/pkgs/by-name/de/deskreen/package.nix
@@ -7,20 +7,32 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "deskreen";
-  version = "2.0.4";
+  version = "3.2.1";
 
-  src = fetchurl {
-    url = "https://github.com/pavlobu/deskreen/releases/download/v${finalAttrs.version}/Deskreen-${finalAttrs.version}.AppImage";
-    hash = "sha256-0jI/mbXaXanY6ay2zn+dPWGvsqWRcF8aYHRvfGVsObE=";
-  };
+  src =
+    let
+      sources = {
+        x86_64-linux = {
+          arch = "x86_64";
+          hash = "sha256-yuz6F/sTWgH8YA710BxsCNTMYXUnC++f8DcefmugkvM=";
+        };
+        aarch64-linux = {
+          arch = "arm64";
+          hash = "sha256-SqbDHkXQHRbrH723ECHhyrYJcJnDG+9LawEWED6xT/k=";
+        };
+        # TODO more sources could be added
+      };
+    in
+    fetchurl {
+      url = "https://github.com/pavlobu/deskreen/releases/download/v${finalAttrs.version}/deskreen-ce-${finalAttrs.version}-${
+        sources.${stdenvNoCC.hostPlatform.system}.arch
+      }.AppImage";
+      inherit (sources.${stdenvNoCC.hostPlatform.system}) hash;
+    };
+
   deskreenUnwrapped = appimageTools.wrapType2 {
-    inherit (finalAttrs) pname version;
-    src = finalAttrs.src;
+    inherit (finalAttrs) pname version src;
   };
-
-  buildInputs = [
-    finalAttrs.deskreenUnwrapped
-  ];
 
   dontUnpack = true;
   dontBuild = true;
@@ -42,6 +54,9 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [
       leo248
     ];
-    platforms = lib.platforms.linux;
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

2.0.4 was pulled (or at least, I don't see it). I wasn't able to figure out what rev the tag was on, so I tried upgrading instead (rather than pulling the package or marking it as broken). It looks like there's a bunch of different architecture builds, but I just did the aarch64-linux and x86_64-linux ones. I don't think the existing buildInputs was needed (or at least, I don't see why it's needed?)

It at least builds. I'm not able to test because I'm running my linux box headless right now and I'm not around to give it a display. 

sidenote: is appimageTools.wrapType2 still the idiomatic thing to use here? I think it depends on python 2.7, which is extra deprecated...

Partially addresses #471645

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
