### PR TITLE
fresh-editor:init at 0.1.56

### DIFF
--- a/pkgs/by-name/fr/fresh-editor/package.nix
+++ b/pkgs/by-name/fr/fresh-editor/package.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  fetchurl,
+  pkg-config,
+  openssl,
+  gzip,
+  git,
+  makeBinaryWrapper,
+  writableTmpDirAsHomeHook,
+}:
+
+let
+  # Pre-fetch the V8 binary that rusty_v8 wants to download
+  rusty_v8_archive = fetchurl {
+    url = "https://github.com/denoland/rusty_v8/releases/download/v142.2.0/librusty_v8_release_x86_64-unknown-linux-gnu.a.gz";
+    hash = "sha256-xHmofo8wTNg88/TuC2pX2OHDRYtHncoSvSBnTV65o+0=";
+  };
+in
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "fresh";
+  version = "0.1.56";
+
+  src = fetchFromGitHub {
+    owner = "sinelaw";
+    repo = "fresh";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-prgTX6nPWqVqvQkxkWrMLF5pB6vSJ+TKzM41coC5otk=";
+  };
+
+  cargoHash = "sha256-efGrh4ToPypQoPZ3sSj62UcJTFFirAfraZkKI1CH5Tw=";
+
+  nativeBuildInputs = [
+    pkg-config
+    gzip
+    writableTmpDirAsHomeHook
+  ];
+
+  nativeCheckInputs = [
+    git
+  ];
+
+  buildInputs = [
+    openssl
+  ];
+
+  # Due to issues with incorrect import paths with the actual app, I have disabled the checks below. Need to report upstream.
+  checkFlags = [
+    "--skip=e2e::"
+  ];
+  cargoTestFlags = [
+    "--lib"
+    "--bins"
+  ];
+
+  # Provide the pre-downloaded V8 binary to the build
+  preBuild = ''
+    mkdir -p $HOME/.cargo/.rusty_v8
+    mkdir -p $out/share/fresh-editor/plugins/examples
+    cp ${rusty_v8_archive} $HOME/.cargo/.rusty_v8/https___github_com_denoland_rusty_v8_releases_download_v142_2_0_librusty_v8_release_x86_64_unknown_linux_gnu_a_gz
+  '';
+
+  meta = {
+    description = "Terminal-based text editor with LSP support and TypeScript plugins";
+    homepage = "https://github.com/sinelaw/fresh";
+    changelog = "https://github.com/sinelaw/fresh/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ randoneering ];
+    mainProgram = "fresh";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fresh is a rust based terminal text editor that is open-source, built for speed, easy of use, and provides full mouse support. 

https://sinelaw.github.io/fresh/


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
