### PR TITLE
seahorse: fix build with gpgme 2.0+

### DIFF
--- a/pkgs/by-name/se/seahorse/package.nix
+++ b/pkgs/by-name/se/seahorse/package.nix
@@ -2,6 +2,7 @@
   stdenv,
   lib,
   fetchurl,
+  fetchpatch,
   vala,
   meson,
   ninja,
@@ -36,6 +37,16 @@ stdenv.mkDerivation rec {
     url = "mirror://gnome/sources/seahorse/${lib.versions.major version}/seahorse-${version}.tar.xz";
     hash = "sha256-nBkX5KYff+u3h4Sc42znF/znBsNGiAuZHQVtVNrbysw=";
   };
+
+  patches = [
+    # Fix build with gpgme 2.0+
+    # https://gitlab.gnome.org/GNOME/seahorse/-/merge_requests/248
+    (fetchpatch {
+      name = "seahorse-allow-build-with-gpgme-2_0.patch";
+      url = "https://gitlab.gnome.org/GNOME/seahorse/-/commit/aa68522cc696fa491ccfdff735b77bcf113168d0.patch";
+      hash = "sha256-xd5K8xUGuMk+41JROsq7QpZ5gD2jPAbv1kQdLI3z9lc=";
+    })
+  ];
 
   nativeBuildInputs = [
     meson


### PR DESCRIPTION
- add patch from merged upstream MR:
https://gitlab.gnome.org/GNOME/seahorse/-/merge_requests/248
https://gitlab.gnome.org/GNOME/seahorse/-/commit/aa68522cc696fa491ccfdff735b77bcf113168d0

Upstream issue:
https://gitlab.gnome.org/GNOME/seahorse/-/issues/410

Fixes build failure:
```
../pgp/seahorse-gpgme.c: In function 'on_gpgme_event':
../pgp/seahorse-gpgme.c:487:14: error: 'GPGME_EVENT_NEXT_TRUSTITEM'
undeclared (first use in this function);
did you mean 'GPGME_EVENT_NEXT_KEY'?
  487 |         case GPGME_EVENT_NEXT_TRUSTITEM:
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~
      |              GPGME_EVENT_NEXT_KEY
...
ninja: build stopped: subcommand failed.
```

---

Related to `gpgme` update: https://github.com/NixOS/nixpkgs/pull/451898

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
