### PR TITLE
LyX: add option to install dictionaries for the spell checker

### DIFF
--- a/pkgs/applications/misc/lyx/default.nix
+++ b/pkgs/applications/misc/lyx/default.nix
@@ -10,9 +10,13 @@
   wrapQtAppsHook,
   qtsvg,
   hunspell,
+  callPackage,
   makeWrapper, # , mythes, boost
+  lyxHunspellDicts ? (ds: [ ]),
 }:
-
+let
+  hunspellWithDicts = hunspell.withDicts lyxHunspellDicts;
+in
 stdenv.mkDerivation rec {
   version = "2.4.4";
   pname = "lyx";
@@ -20,6 +24,10 @@ stdenv.mkDerivation rec {
   src = fetchurl {
     url = "ftp://ftp.lyx.org/pub/lyx/stable/2.4.x/${pname}-${version}.tar.xz";
     hash = "sha256-/6zTdIDzIPPz+PMERf5AiX6d9EyU7oe6BBPjZAhvS5A=";
+  };
+
+  passthru = {
+    withDicts = lyxHunspellDicts: (callPackage ./default.nix { inherit lyxHunspellDicts; });
   };
 
   # LaTeX is used from $PATH, as people often want to have it with extra pkgs
@@ -36,6 +44,7 @@ stdenv.mkDerivation rec {
     file # for libmagic
     bc
     hunspell # enchant
+    hunspellWithDicts # User configured hunspell dictionaries for spell checking
   ];
 
   configureFlags = [
@@ -54,8 +63,31 @@ stdenv.mkDerivation rec {
   # python is run during runtime to do various tasks
   qtWrapperArgs = [ " --prefix PATH : ${python3}/bin" ];
 
+  installPhase = ''
+    make install
+    ln -sf ${hunspellWithDicts}/share/hunspell $out/share/lyx/dicts
+  '';
+
   meta = {
     description = "WYSIWYM frontend for LaTeX, DocBook";
+    longDescription = ''
+      WYSIWYM frontend for LaTeX, DocBook
+
+      To install dictionaries for LyX's spell checker use the Hunspell
+      syntax, e.g.
+      ```nix
+      buildInputs = with pkgs; [
+        (lyx.withDicts (ds: with ds; [en_US]))
+      ];
+      ```
+
+      To install language support for languages other than English,
+      install the LaTeX package corresponding to your language
+      `texlivePackages.collection-lang*` then follow any other instructions
+      on the LyX Wiki for your language.
+      If they don't work quite as well or don't exist, try to search
+      "<name of major university in your country> lyx manual".
+    '';
     homepage = "https://www.lyx.org";
     license = lib.licenses.gpl2Plus;
     maintainers = [ lib.maintainers.vcunat ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

* Added `withDicts` to LyX so that users can install Hunspell dictionaries for LyX without creating an overlay.
* Add `longDescription` to LyX with instructions on how to install Hunspell dictionaries as well as a note about language support because the LyX setup on Windows has a language selection page which doesn't exist here.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
