### PR TITLE
zotero-beta: 7.0.0-beta.111+b4f6c050e -> 8.0-beta.20+1233fd5a7

### DIFF
--- a/pkgs/by-name/zo/zotero-beta/package.nix
+++ b/pkgs/by-name/zo/zotero-beta/package.nix
@@ -16,19 +16,28 @@
   libgbm,
   pango,
   pciutils,
+  firefox-esr,
+  nspr,
+  nss,
 }:
 
 stdenv.mkDerivation rec {
   pname = "zotero";
-  version = "7.0.0-beta.111+b4f6c050e";
+  version = "8.0-beta.20+1233fd5a7";
 
   src =
     let
-      escapedVersion = lib.replaceStrings [ "+" ] [ "%2B" ] version;
+      inherit (stdenv.hostPlatform) system linuxArch;
+      escapedVersion = lib.escapeURL version;
+      platformHash = {
+        x86_64-linux = "sha256-IV8pukYHlGOL4bInbdh1SqKjlItum4LY7SRE+v73Spk=";
+        aarch64-linux = "sha256-+V1XtmpI7ye37oba9nNTBOC+D9+V3ag1y+SYabXfxpQ=";
+      };
+      throwSystem = throw "Unsupported system: ${system}";
     in
     fetchurl {
-      url = "https://download.zotero.org/client/beta/${escapedVersion}/Zotero-${escapedVersion}_linux-x86_64.tar.bz2";
-      hash = "sha256-pZsmS4gKCT8UAjz9IJg5C7n4kk7bWT/7H5ONF20CzPM=";
+      url = "https://download.zotero.org/client/beta/${escapedVersion}/Zotero-${escapedVersion}_linux-${linuxArch}.tar.xz";
+      hash = platformHash.${system} or throwSystem;
     };
 
   dontPatchELF = true;
@@ -88,6 +97,16 @@ stdenv.mkDerivation rec {
     mkdir -p "$out/bin"
     ln -s "$prefix/usr/lib/zotero-bin-${version}/zotero" "$out/bin/"
 
+    # Replace bundled shared libraries with system-provided ones
+    for path in ${firefox-esr}/lib/firefox ${nspr}/lib ${nss}/lib; do
+      for lib in "$path"/*.so; do
+        name="$(basename "$lib")"
+        if [ -f $lib ] && [ -f "$prefix/usr/lib/zotero-bin-${version}/$name" ]; then
+          ln -sf "$lib" "$prefix/usr/lib/zotero-bin-${version}/$name"
+        fi
+      done
+    done
+
     # Install desktop file and icons
     mkdir -p $out/share/applications
     cp ${desktopItem}/share/applications/* $out/share/applications/
@@ -114,6 +133,9 @@ stdenv.mkDerivation rec {
     find . -executable -type f -exec \
       patchelf --set-rpath "$libPath" \
         "$out/usr/lib/zotero-bin-${version}/{}" \;
+
+    patchelf --add-needed libGL.so.1 --add-needed libEGL.so.1 \
+      "$out/usr/lib/zotero-bin-${version}/zotero-bin"
   '';
 
   meta = {
@@ -122,7 +144,10 @@ stdenv.mkDerivation rec {
     mainProgram = "zotero";
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.agpl3Only;
-    platforms = [ "x86_64-linux" ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
     maintainers = with lib.maintainers; [
       atila
       justanotherariel


### PR DESCRIPTION
inspired by https://github.com/NixOS/nixpkgs/pull/409474
build/tested on aarch64-linux platform

i tried to replace glxtest/v4l2test/vaapitest with the provided one from firefox-esr, however glxtest form firefox-esr does not work, maybe we should also patchelf --add-needed libGL.so.1 --add-needed libEGL.so.1 for glxtest in firefox-esr

cc @mweinelt maybe a bug in ${firefox-esr}/lib/firefox/glxtest

```
$ ${firefox}/lib/firefox/glxtest 
WARNING
libpci missing
WARNING
libEGL missing
ERROR
libGL.so.1 missing  
$ ${zotero-beta}/usr/lib/zotero-bin-8.0-beta.20+1233fd5a7/glxtest 
DRI_DRIVER
panthor
VENDOR
Mesa
RENDERER
Mali-G610 (Panfrost)
VERSION
OpenGL ES 3.1 Mesa 25.3.1
TFP
TRUE
DRM_RENDERDEVICE
/dev/dri/renderD128
MESA_VENDOR_ID
0x7c90
MESA_DEVICE_ID
0xc99b
TEST_TYPE
EGL
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
