### PR TITLE
kustomize-sops: fix typo in symlink path

### DIFF
--- a/pkgs/development/tools/kustomize/kustomize-sops.nix
+++ b/pkgs/development/tools/kustomize/kustomize-sops.nix
@@ -23,7 +23,7 @@ buildGoModule rec {
     mkdir -p $out/lib/viaduct.ai/v1/ksops-exec/
     mv $GOPATH/bin/kustomize-sops $out/bin/ksops
     ln -s $out/bin/ksops $out/lib/viaduct.ai/v1/ksops-exec/ksops-exec
-    ln -s $ous/bin/ksops $out/lib/viaduct.ai/v1/ksops/ksops
+    ln -s $out/bin/ksops $out/lib/viaduct.ai/v1/ksops/ksops
   '';
 
   # Tests are broken in a nix environment


### PR DESCRIPTION
Fixed incorrect variable name $ous -> $out in installPhase that prevented proper symlink creation.
These are necessary for the package to function correctly.

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
