### PR TITLE
censor: init at 0.3.0

### DIFF
--- a/pkgs/by-name/ce/censor/package.nix
+++ b/pkgs/by-name/ce/censor/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  fetchFromGitea,
+  python3Packages,
+  wrapGAppsHook4,
+  gobject-introspection,
+  libadwaita,
+  meson,
+  ninja,
+  pkg-config,
+  desktop-file-utils,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "censor";
+  version = "0.3.0";
+  pyproject = false;
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "censor";
+    repo = "Censor";
+    tag = "v${version}";
+    hash = "sha256-16Cy9yNOLvdVZ234kTB8fa585eI4f7yVnbMoPcHtGHk=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    gobject-introspection
+    wrapGAppsHook4
+    desktop-file-utils
+  ];
+
+  buildInputs = [
+    libadwaita
+  ];
+
+  dependencies = with python3Packages; [
+    pygobject3
+    pymupdf
+  ];
+
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
+  meta = {
+    description = "PDF document redaction for the GNOME desktop";
+    homepage = "https://codeberg.org/censor/Censor";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ onny ];
+    mainProgram = "censor";
+  };
+}


### PR DESCRIPTION
Adding censor, PDF Document Redaction for the GNOME Desktop https://codeberg.org/censor/Censor

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
