### PR TITLE
gophie: init at 1.1

### DIFF
--- a/pkgs/by-name/go/gophie/package.nix
+++ b/pkgs/by-name/go/gophie/package.nix
@@ -1,0 +1,84 @@
+{
+  lib,
+  stdenv,
+  jre,
+  makeWrapper,
+  jdk,
+  makeDesktopItem,
+  copyDesktopItems,
+  fetchFromGitHub,
+  stripJavaArchivesHook,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "gophie";
+  version = "1.1";
+
+  src = fetchFromGitHub {
+    owner = "jankammerath";
+    repo = "gophie";
+    tag = finalAttrs.version;
+    hash = "sha256-k+Q5+h18LBMxZLhv39+Ky3vq75zDVuxj4TJt9xwixjY=";
+  };
+
+  nativeBuildInputs = [
+    jdk
+    stripJavaArchivesHook
+    copyDesktopItems
+    makeWrapper
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    # See https://github.com/jankammerath/gophie/blob/master/make.sh
+    javac -d class/ -sourcepath src/ -classpath ".:res/*.ttf:res/*.gif:res/*.png" src/org/gophie/Gophie.java
+    cd class
+    jar cvfe ../build/Gophie.jar org.gophie.Gophie org/gophie/*.class org/gophie/*/*.class org/gophie/*/*/*.class ../res/*.ttf ../res/*.gif ../res/*.png
+    cd ..
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 build/Gophie.jar $out/share/gophie/Gophie.jar
+
+    makeWrapper ${jre}/bin/java $out/bin/Gophie \
+      --add-flags "-jar $out/share/gophie/Gophie.jar"
+
+    for size in 16 32 48 128 256 512; do
+      install -Dm644 build/icon/gophie-"$size"x"$size".png $out/share/icons/hicolor/"$size"x"$size"/apps/gophie.png
+    done
+
+    runHook postInstall
+  '';
+
+  # There are no tests.
+  doCheck = false;
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "gophie";
+      exec = finalAttrs.meta.mainProgram;
+      icon = "gophie";
+      comment = finalAttrs.meta.description;
+      desktopName = "Gophie";
+      categories = [
+        "Network"
+        "WebBrowser"
+        "Java"
+      ];
+    })
+  ];
+
+  meta = {
+    description = "Gophie is a modern, graphical and cross-platform client for the Gopher protocol";
+    homepage = "https://github.com/jankammerath/gophie";
+    changelog = "https://github.com/jankammerath/gophie/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ theobori ];
+    mainProgram = "Gophie";
+    platforms = jdk.meta.platforms;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

In this PR, I add [Gophie](https://github.com/jankammerath/gophie), a modern, graphical and cross-platform client for the Gopher protocol.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
