### PR TITLE
patchPpdFilesHook: fix path (and use `getExe'`)

### DIFF
--- a/pkgs/by-name/pa/patchPpdFilesHook/patch-ppd-hook.sh
+++ b/pkgs/by-name/pa/patchPpdFilesHook/patch-ppd-hook.sh
@@ -5,7 +5,7 @@ fixupOutputHooks+=(_patchPpdFileCommands4fixupOutputHooks)
 # Install a hook for the `fixupPhase`:
 # If the variable `ppdFileCommands` contains a list of
 # executable names, the hook calls `patchPpdFileCommands`
-# on each output's `/share/cups/model` and `/share/ppds`
+# on each output's `/share/cups/model` and `/share/ppd`
 # directories in order to replace calls to those executables.
 
 _patchPpdFileCommands4fixupOutputHooks () {
@@ -13,8 +13,8 @@ _patchPpdFileCommands4fixupOutputHooks () {
     if [[ -d $prefix/share/cups/model ]]; then
         patchPpdFileCommands "$prefix/share/cups/model" $ppdFileCommands
     fi
-    if [[ -d $prefix/share/ppds ]]; then
-        patchPpdFileCommands "$prefix/share/ppds" $ppdFileCommands
+    if [[ -d $prefix/share/ppd ]]; then
+        patchPpdFileCommands "$prefix/share/ppd" $ppdFileCommands
     fi
 }
 

--- a/pkgs/by-name/pa/patchPpdFilesHook/test.nix
+++ b/pkgs/by-name/pa/patchPpdFilesHook/test.nix
@@ -33,10 +33,10 @@ stdenv.mkDerivation {
   ppdFileCommands = [ "cmp" ];
   preFixup = ''
     install -D "${input}" "${placeholder "out"}/share/cups/model/test.ppd"
-    install -D "${input}" "${placeholder "out"}/share/ppds/test.ppd"
+    install -D "${input}" "${placeholder "out"}/share/ppd/test.ppd"
   '';
   postFixup = ''
     diff --color --report-identical-files "${output}" "${placeholder "out"}/share/cups/model/test.ppd"
-    diff --color --report-identical-files "${output}" "${placeholder "out"}/share/ppds/test.ppd"
+    diff --color --report-identical-files "${output}" "${placeholder "out"}/share/ppd/test.ppd"
   '';
 }

--- a/pkgs/by-name/pa/patchPpdFilesHook/test.nix
+++ b/pkgs/by-name/pa/patchPpdFilesHook/test.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   replaceVars,
   diffutils,
   stdenv,
@@ -6,6 +7,8 @@
 }:
 
 let
+  inherit (lib.meta) getExe';
+
   input = replaceVars ./test.ppd {
     keep = "cmp";
     patch = "cmp";
@@ -15,9 +18,9 @@ let
 
   output = replaceVars ./test.ppd {
     keep = "cmp";
-    patch = "${diffutils}/bin/cmp";
+    patch = getExe' diffutils "cmp";
     pathkeep = "/bin/cmp";
-    pathpatch = "${diffutils}/bin/cmp";
+    pathpatch = getExe' diffutils "cmp";
   };
 in
 


### PR DESCRIPTION
*   Fix a bug in `patchPpdFilesHook`: It looks for PPD files in the wrong directory (see also commit message).  I recognized that bug [while reviewing a pull request that utilizes `patchPpdFilesHook`](https://github.com/NixOS/nixpkgs/pull/468537#discussion_r2631877909).

*   Replace `${diffutils}/bin/cmp` with `getExe' diffutils "cmp"` in the test recipe.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `39dc238759bbc151d2c9e2506552c2c779d6a911`

### `x86_64-linux`
<details>
  <summary>:white_check_mark: 9 packages built:</summary>
  <ul>
    <li>cups-drv-rastertosag-gdi</li>
    <li>cups-kyocera</li>
    <li>foomatic-db</li>
    <li>foomatic-db-ppds</li>
    <li>foomatic-db-ppds-withNonfreeDb</li>
    <li>lexmark-aex</li>
    <li>patchPpdFilesHook</li>
    <li>ptouch-driver</li>
    <li>samsung-unified-linux-driver</li>
  </ul>
</details>

## More

I have build each package that got listed by `nixpkgs-review` (see above): They all use the directory `share/cups/model`.  So none of the packages *inside* nixpkgs is affected by the change, i.e., this pull request should cause no breakage.  It *might* -- however -- affect private packages that also use the (wrong) directory `share/ppds`.  I consider that risk to be very small.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
