### PR TITLE
linphonePackages: revert to cached version

### DIFF
--- a/pkgs/applications/networking/instant-messengers/linphone/default.nix
+++ b/pkgs/applications/networking/instant-messengers/linphone/default.nix
@@ -8,8 +8,8 @@ makeScopeWithSplicing' {
   extra = self: {
     mkLinphoneDerivation = self.mk-linphone-derivation;
 
-    linphoneSdkVersion = "5.4.67";
-    linphoneSdkHash = "sha256-YG+GF6En1r8AYoIj7E5hqPcmXidMmO0ZKVx/YC5w55I=";
+    linphoneSdkVersion = "5.4.48";
+    linphoneSdkHash = "sha256-sOkq73YWbhpKJOk1dVc4tkg2+RuGyRK8/t4ckMIVVG8=";
   };
   f =
     self:

--- a/pkgs/applications/networking/instant-messengers/linphone/linphone-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/linphone/linphone-desktop/default.nix
@@ -39,7 +39,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "linphone-desktop";
-  version = "5.3.2";
+  version = "5.3.1";
 
   src = fetchFromGitLab {
     domain = "gitlab.linphone.org";
@@ -47,7 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
     group = "BC";
     repo = "linphone-desktop";
     rev = finalAttrs.version;
-    hash = "sha256-YBwN2d8Bhr876xDzzge1CutJEtWkoGJWwkybSKUDiM0=";
+    hash = "sha256-TO9JNsOnx4sTJEkai0nDKNyZWcLuGoWfuKLBM79tQvs=";
   };
 
   patches = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

BelledonneCommunications' GitLab instance has been suffering from uptime issues for a while now, leading to failures fetching the source for various packages.

While a GitHub mirror exists for most of their repos, some core components are only accessible via their GitLab.

As a temporary workaround, revert the versions of `linphone-sdk` and `linphone-desktop` to ones that are present in the binary cache.

For more context, see the discussions at https://github.com/NixOS/nixpkgs/pull/470785 and https://github.com/NixOS/nixpkgs/issues/470112

Closes #470112

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
