### PR TITLE
pkgsCross.x86_64-freebsd.pkgsStatic.ghc: fix build

### DIFF
--- a/pkgs/development/compilers/ghc/common-hadrian.nix
+++ b/pkgs/development/compilers/ghc/common-hadrian.nix
@@ -606,6 +606,16 @@ stdenv.mkDerivation (
         "-j$NIX_BUILD_CORES"
         ${lib.escapeShellArgs hadrianSettings}
       )
+    ''
+    # Configure tests the C compiler by building and linking. This works mostly fine,
+    # even in pkgsStatic, even though the makeStatic adapater doesn't actually take
+    # effect for the target platform here. This only works, because stdenv provides
+    # some core libraries as shared objects in pkgsStatic as well.
+    # FreeBSD has disabled this entirely, and thus configure would fail this step.
+    # Only provide -static for non-darwin, because on darwin we only build mostly-static
+    # binaries anyway, which don't use -static.
+    + lib.optionalString (targetPlatform.isStatic && !targetPlatform.isDarwin) ''
+      export NIX_CFLAGS_LINK_FOR_TARGET+=" -static"
     '';
 
     ${if targetPlatform.isGhcjs then "configureScript" else null} = "emconfigure ./configure";

--- a/pkgs/development/compilers/llvm/common/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/common/compiler-rt/default.nix
@@ -94,9 +94,13 @@ stdenv.mkDerivation (finalAttrs: {
     ninja
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [ jq ];
-  buildInputs =
-    lib.optional (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isRiscV) linuxHeaders
-    ++ lib.optional (stdenv.hostPlatform.isFreeBSD) freebsd.include;
+  buildInputs = lib.optional (
+    stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isRiscV
+  ) linuxHeaders;
+
+  # Not adding this to buildInputs to avoid propagation when isStatic. Propagation would break
+  # the correct order of header lookup paths in NIX_CFLAGS_COMPILE for libcxx.
+  depsHostHost = lib.optional (stdenv.hostPlatform.isFreeBSD) freebsd.include;
 
   env = {
     NIX_CFLAGS_COMPILE = toString (


### PR DESCRIPTION
I'd like to cross compile static haskell binaries for FreeBSD - but right now the compiler doesn't even build.

Still work in progress, it doesn't build, yet. I did make it past the first configure error though.

Now, I am facing this:

```
checking C++ standard library flavour... In file included from actest.cpp:1:
In file included from /nix/store/z1d5f8v9qv1anhmczx0zrh4fx4qgz7zz-libcxx-static-x86_64-unknown-freebsd-21.1.2-dev/include/c++/v1/iostream:45:
In file included from /nix/store/z1d5f8v9qv1anhmczx0zrh4fx4qgz7zz-libcxx-static-x86_64-unknown-freebsd-21.1.2-dev/include/c++/v1/ios:228:
In file included from /nix/store/z1d5f8v9qv1anhmczx0zrh4fx4qgz7zz-libcxx-static-x86_64-unknown-freebsd-21.1.2-dev/include/c++/v1/__locale:19:
In file included from /nix/store/z1d5f8v9qv1anhmczx0zrh4fx4qgz7zz-libcxx-static-x86_64-unknown-freebsd-21.1.2-dev/include/c++/v1/__memory/shared_count.h:14:
In file included from /nix/store/z1d5f8v9qv1anhmczx0zrh4fx4qgz7zz-libcxx-static-x86_64-unknown-freebsd-21.1.2-dev/include/c++/v1/typeinfo:390:
/nix/store/z1d5f8v9qv1anhmczx0zrh4fx4qgz7zz-libcxx-static-x86_64-unknown-freebsd-21.1.2-dev/include/c++/v1/cstddef:45:5: error: <cstddef> tried including <stddef.h> but didn't find libc++'s <stddef.h> header.           This usually means that your header search paths are not configured properly.           The header search paths should contain the C++ Standard Library headers before           any C Standard Library, and you are probably using compiler flags that make that           not be the case.
   45 | #   error <cstddef> tried including <stddef.h> but didn't find libc++'s <stddef.h> header. \
      |     ^
```

I believe this is because `NIX_CFLAGS_COMPILE_FOR_TARGET` contains a one too many dependencies (reformatted for readability):

```
declare -x NIX_CFLAGS_COMPILE_FOR_TARGET="
  -isystem /nix/store/z1d5f8v9qv1anhmczx0zrh4fx4qgz7zz-libcxx-static-x86_64-unknown-freebsd-21.1.2-dev/include
  -fmacro-prefix-map=/nix/store/z1d5f8v9qv1anhmczx0zrh4fx4qgz7zz-libcxx-static-x86_64-unknown-freebsd-21.1.2-dev=/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-libcxx-static-x86_64-unknown-freebsd-21.1.2-dev
  -isystem /nix/store/9n75d9x41yp4wbfbax3y7h7ibwmwjynv-libcxxrt-static-x86_64-unknown-freebsd-15.0.0-dev/include
  -fmacro-prefix-map=/nix/store/9n75d9x41yp4wbfbax3y7h7ibwmwjynv-libcxxrt-static-x86_64-unknown-freebsd-15.0.0-dev=/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-libcxxrt-static-x86_64-unknown-freebsd-15.0.0-dev
  -isystem /nix/store/r2f5k4qbpi7jhc9x10fns9nii62vqy4s-include-static-x86_64-unknown-freebsd-15.0.0/include
  -fmacro-prefix-map=/nix/store/r2f5k4qbpi7jhc9x10fns9nii62vqy4s-include-static-x86_64-unknown-freebsd-15.0.0=/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-include-static-x86_64-unknown-freebsd-15.0.0
  -isystem /nix/store/8mqmvzaq7rhd61a5gpxkf4ynjcjlpsv6-libffi-static-x86_64-unknown-freebsd-3.5.2-dev/include
  -fmacro-prefix-map=/nix/store/8mqmvzaq7rhd61a5gpxkf4ynjcjlpsv6-libffi-static-x86_64-unknown-freebsd-3.5.2-dev=/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-libffi-static-x86_64-unknown-freebsd-3.5.2-dev
  -isystem /nix/store/yjkv8lb2l3gb6p6wnrzddg466rljl86k-libc-iconv-15.0.0/include -fmacro-prefix-map=/nix/store/yjkv8lb2l3gb6p6wnrzddg466rljl86k-libc-iconv-15.0.0=/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-libc-iconv-15.0.0
"
```

The libcxx-static (and probably libcxxrt-static) are expected, I believe. I see similar things when I try `pkgsCross.gnu64.pkgsStatic.pkgsLLVM.haskell.packages.native-bignum.ghc912.hello` on aarch64-linux (which actually works!), so I think these come from the LLVM part.

The last two, i.e. libffi-static and libc-iconv are fine, too - they are just regular dependencies of GHC.

But the middle one, i.e. include-static seems to be the problem. It provides those headers mentioned in the error message - but it should not, because they are supposed to be added later via `nix-support/libcxx-cxxflags`, which provides the proper paths to `...libcxx-static-x86_64-unknown-freebsd-21.1.2-dev/include/c++/v1`.

I have no idea why the `include` thing is suddenly added here. It is FreeBSD specific, but it only seems to appear in the static case.

(my CC wrapper knowledge is close to zero, so this was already quite confusing to dig up for me)

cc @alyssais for static, @rhelmot for FreeBSD and @sternenseemann for GHC - any ideas?

## Things done

- Built on platform:
  - [ ] x86_64-freebsd
- Tested, as applicable:
  - [ ] pkgsCross.x86_64-freebsd.pkgsStatic.haskell.packages.native-bignum.ghc910.hello
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
