### PR TITLE
minder: 1.17.0 -> 2.0.2

### DIFF
--- a/pkgs/by-name/mi/minder/package.nix
+++ b/pkgs/by-name/mi/minder/package.nix
@@ -6,33 +6,30 @@
   meson,
   ninja,
   pkg-config,
-  python3,
-  shared-mime-info,
   vala,
-  wrapGAppsHook3,
+  wrapGAppsHook4,
   cairo,
   discount,
   glib,
-  gtk3,
-  gtksourceview4,
-  hicolor-icon-theme, # for setup-hook
+  gtk4,
+  gtksourceview5,
   json-glib,
   libarchive,
   libgee,
-  libhandy,
+  libwebp,
   libxml2,
   pantheon,
 }:
 
 stdenv.mkDerivation rec {
   pname = "minder";
-  version = "1.17.0";
+  version = "2.0.2";
 
   src = fetchFromGitHub {
     owner = "phase1geo";
     repo = "minder";
-    rev = version;
-    sha256 = "sha256-LZm2TLUugW/lSHp+y3Sz9IacQCEFQloVnZ9MoBjqHvI=";
+    tag = version;
+    hash = "sha256-+aAzM+OOOLwF4PJotdYSfFJu8gYp3I2E2r9fNTjJOs4=";
   };
 
   nativeBuildInputs = [
@@ -40,31 +37,23 @@ stdenv.mkDerivation rec {
     meson
     ninja
     pkg-config
-    python3
-    shared-mime-info
     vala
-    wrapGAppsHook3
+    wrapGAppsHook4
   ];
 
   buildInputs = [
     cairo
     discount
     glib
-    gtk3
-    gtksourceview4
-    hicolor-icon-theme
+    gtk4
+    gtksourceview5
     json-glib
     libarchive
     libgee
-    libhandy
+    libwebp
     libxml2
-    pantheon.granite
+    pantheon.granite7
   ];
-
-  postPatch = ''
-    chmod +x meson/post_install.py
-    patchShebangs meson/post_install.py
-  '';
 
   postFixup = ''
     for x in $out/bin/*; do


### PR DESCRIPTION
https://github.com/phase1geo/minder/compare/1.17.0...2.0.2




## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

