### PR TITLE
python3 packages.unsloth 2025.9.4 -> 2025.12.5

### DIFF
--- a/pkgs/development/python-modules/cut-cross-entropy/default.nix
+++ b/pkgs/development/python-modules/cut-cross-entropy/default.nix
@@ -24,7 +24,7 @@
 
 buildPythonPackage {
   pname = "cut-cross-entropy";
-  version = "25.7.2";
+  version = "25.9.3";
   pyproject = true;
 
   # The `ml-cross-entropy` Pypi comes from a third-party.
@@ -32,8 +32,8 @@ buildPythonPackage {
   src = fetchFromGitHub {
     owner = "apple";
     repo = "ml-cross-entropy";
-    rev = "b19a424ed30a05b8261cfa84d83b2601a9454c67"; # no tags
-    hash = "sha256-AwUqKiI7XjEOZ7ofjQCOsqvxHyTFD4RZ70odPyxxntc=";
+    rev = "b7a02791b234e187b524fb1dba6a812d521b203a"; # no tags
+    hash = "sha256-CXcc/QzzFTbVU7+8hp+6RhQ0js0y7lYzI25NaHoX7wc=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/tyro/default.nix
+++ b/pkgs/development/python-modules/tyro/default.nix
@@ -23,18 +23,20 @@
   pydantic,
   pytestCheckHook,
   torch,
+  universal-pathlib,
+  bashInteractive,
 }:
 
 buildPythonPackage rec {
   pname = "tyro";
-  version = "0.9.35";
+  version = "1.0.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "brentyi";
     repo = "tyro";
     tag = "v${version}";
-    hash = "sha256-W1AtdZslaQ+lBR8vTmiq+MprDjqXc8fSWZ/63mS2obY=";
+    hash = "sha256-7Y42fq0xeuKr3+jBiFZEFEpe39sz7yMYVT8C1o9i6tE=";
   };
 
   build-system = [ hatchling ];
@@ -57,7 +59,14 @@ buildPythonPackage rec {
     pydantic
     pytestCheckHook
     torch
+    universal-pathlib
+    bashInteractive
   ];
+
+  preCheck = ''
+    export COLUMNS=200
+    export LINES=200
+  '';
 
   pythonImportsCheck = [ "tyro" ];
 

--- a/pkgs/development/python-modules/unsloth-zoo/default.nix
+++ b/pkgs/development/python-modules/unsloth-zoo/default.nix
@@ -5,36 +5,44 @@
 
   # build-system
   setuptools,
-  setuptools-scm,
 
   # dependencies
   accelerate,
   cut-cross-entropy,
   datasets,
+  filelock,
   hf-transfer,
   huggingface-hub,
   msgspec,
+  numpy,
   packaging,
   peft,
+  pillow,
+  protobuf,
   psutil,
+  regex,
   sentencepiece,
   torch,
+  torchao,
   tqdm,
   transformers,
+  triton,
   trl,
   tyro,
+  typing-extensions,
+  wheel,
 }:
 
 buildPythonPackage rec {
   pname = "unsloth-zoo";
-  version = "2025.9.5";
+  version = "2025.12.4";
   pyproject = true;
 
   # no tags on GitHub
   src = fetchPypi {
     pname = "unsloth_zoo";
     inherit version;
-    hash = "sha256-wlKlXTgEdfkz4j//LHw23CmeL7toINg5IUxcpwrPtAw=";
+    hash = "sha256-PdDQzGaZZ3PI3K/7cgDHHF+AnTsT+IPLEqUrDNgbb9M=";
   };
 
   # pyproject.toml requires an obsolete version of protobuf,
@@ -43,44 +51,56 @@ buildPythonPackage rec {
   pythonRelaxDeps = [
     "datasets"
     "protobuf"
+    "trl"
     "transformers"
     "torch"
   ];
 
   patches = [
-    # Avoid circular dependency in Nix, since `unsloth` depends on `unsloth-zoo`.
+    # Avoid circular dependency during import, `unsloth` depends on `unsloth-zoo`.
     ./dont-require-unsloth.patch
   ];
 
-  build-system = [
-    setuptools
-    setuptools-scm
-  ];
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace 'requires = ["setuptools==80.9.0", "setuptools-scm==9.2.0"]' \
+                'requires = ["setuptools"]'
+  '';
+
+  build-system = [ setuptools ];
 
   dependencies = [
     accelerate
     cut-cross-entropy
     datasets
+    filelock
     hf-transfer
     huggingface-hub
     msgspec
+    numpy
     packaging
     peft
+    pillow
+    protobuf
     psutil
+    regex
     sentencepiece
     torch
+    torchao
     tqdm
     transformers
+    triton
     trl
     tyro
+    typing-extensions
+    wheel
   ];
 
   # No tests
   doCheck = false;
 
-  pythonImportsCheck = [
-    "unsloth_zoo"
-  ];
+  # Importing tries to detect a GPU and fails in pure CPU builders.
+  dontUsePythonImportsCheck = true;
 
   meta = {
     description = "Utils for Unsloth";

--- a/pkgs/development/python-modules/unsloth-zoo/dont-require-unsloth.patch
+++ b/pkgs/development/python-modules/unsloth-zoo/dont-require-unsloth.patch
@@ -1,29 +1,20 @@
-diff --git a/unsloth_zoo/__init__.py b/unsloth_zoo/__init__.py
-index 2332907..2eed5e9 100644
 --- a/unsloth_zoo/__init__.py
 +++ b/unsloth_zoo/__init__.py
-@@ -64,8 +64,6 @@ pass
+@@ -72,8 +72,6 @@
  
  
  from importlib.util import find_spec
 -if find_spec("unsloth") is None:
 -    raise ImportError("Please install Unsloth via `pip install unsloth`!")
- pass
- del find_spec
- 
-@@ -75,12 +73,13 @@ def get_device_type():
-         return "cuda"
-     elif hasattr(torch, "xpu") and torch.xpu.is_available():
-         return "xpu"
-+    else:
-+        # Allow import during tests
-+        return None
-     raise NotImplementedError("Unsloth currently only works on NVIDIA GPUs and Intel GPUs.")
- pass
- DEVICE_TYPE : str = get_device_type()
+ if find_spec("torch") is None:
+     raise ImportError(
+         "Unsloth: Pytorch is not installed. Go to https://pytorch.org/.\n"\
+@@ -180,8 +178,6 @@
+     os.environ["UNSLOTH_ENABLE_CCE"] = "0"
+ del delete_key, major_torch, minor_torch, torch_version, importlib_version, find_spec
  
 -if not ("UNSLOTH_IS_PRESENT" in os.environ):
 -    raise ImportError("Please install Unsloth via `pip install unsloth`!")
- pass
  
  try:
+     print("🦥 Unsloth: Will patch your computer to enable 2x faster free finetuning.")

--- a/pkgs/development/python-modules/unsloth/default.nix
+++ b/pkgs/development/python-modules/unsloth/default.nix
@@ -53,15 +53,21 @@ in
 
 buildPythonPackage rec {
   pname = "unsloth";
-  version = "2025.9.4";
+  version = "2025.12.5";
   pyproject = true;
 
   # Tags on the GitHub repo don't match
   src = fetchPypi {
     pname = "unsloth";
     inherit version;
-    hash = "sha256-aT/RS48hBMZT1ab1Rx1lpSMi6yyEzJCASzDAP0d6ixA=";
+    hash = "sha256-z1BzWLgwLrsAmTD7E7SLYadfLv7+5U7s/9ach2Z2EoE=";
   };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace 'requires = ["setuptools==80.9.0", "setuptools-scm==9.2.0"]' \
+                'requires = ["setuptools", "setuptools-scm"]'
+  '';
 
   build-system = [
     setuptools
@@ -96,6 +102,7 @@ buildPythonPackage rec {
   pythonRelaxDeps = [
     "datasets"
     "protobuf"
+    "trl"
     "transformers"
     "torch"
   ];


### PR DESCRIPTION
An update of `python3Packages.unsloth` and its dependencies.

In draft because `torchao` does not build with `cudaEnabled`, see https://github.com/NixOS/nixpkgs/pull/471546 . 
Set `doCheck = false` in `torchao` to test this branch.

## Things done

Updated `unsloth` and its dependencies `unsloth-zoo`, `tyro` and `cut-cross-entropy`.

`python3Packages.viser` may be impacted as it also relies on the dependency `python3Packages.tyro`.

Tested with [Unsloth CUDA tests](https://github.com/NixOS/nixpkgs/pull/441728):

```shell
nix-build-I nixpkgs=. --arg config '{ allowUnfree = true; cudaSupport = true; openclSupport = true; rocmSupport = false;}' --option allow-import-from-derivation false -A python313Packages.unsloth.tests.qlora-train-and-merge

./result/bin/tester-cuda
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
