### PR TITLE
rust-cbindgen: fix for structuredAttrs

### DIFF
--- a/pkgs/by-name/ru/rust-cbindgen/package.nix
+++ b/pkgs/by-name/ru/rust-cbindgen/package.nix
@@ -33,16 +33,16 @@ rustPlatform.buildRustPackage rec {
   checkFlags = [
     # Disable tests that require rust unstable features
     # https://github.com/eqrion/cbindgen/issues/338
-    "--skip test_expand"
-    "--skip test_bitfield"
-    "--skip lib_default_uses_debug_build"
-    "--skip lib_explicit_debug_build"
-    "--skip lib_explicit_release_build"
+    "--skip=test_expand"
+    "--skip=test_bitfield"
+    "--skip=lib_default_uses_debug_build"
+    "--skip=lib_explicit_debug_build"
+    "--skip=lib_explicit_release_build"
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # WORKAROUND: test_body fails when using clang
     # https://github.com/eqrion/cbindgen/issues/628
-    "--skip test_body"
+    "--skip=test_body"
   ];
 
   passthru.tests = {


### PR DESCRIPTION
Avoid using spaces in the check arguments.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
