### PR TITLE
corretto25: init at 25.0.1.9.1

### DIFF
--- a/pkgs/development/compilers/corretto/25.nix
+++ b/pkgs/development/compilers/corretto/25.nix
@@ -1,0 +1,41 @@
+{
+  fetchFromGitHub,
+  gradle_9,
+  jdk25,
+  lib,
+  stdenv,
+  rsync,
+  pandoc,
+  runCommand,
+  testers,
+}:
+
+let
+  corretto = import ./mk-corretto.nix rec {
+    inherit
+      lib
+      stdenv
+      rsync
+      runCommand
+      testers
+      ;
+    jdk = jdk25;
+    gradle = gradle_9;
+    version = "25.0.1.9.1";
+    src = fetchFromGitHub {
+      owner = "corretto";
+      repo = "corretto-25";
+      rev = version;
+      hash = "sha256-eAjepqxp5LVQgP/HcxwwdjbXxy5jUOJC4HYntcHNX0o=";
+    };
+    extraNativeBuildInputs = [ pandoc ];
+  };
+in
+corretto.overrideAttrs (
+  final: prev: {
+    patches = (prev.patches or [ ]) ++ [
+      # See patches in openjdk/generic.nix.
+      ./remove_removal_of_wformat_during_test_compilation.patch
+    ];
+  }
+)

--- a/pkgs/development/compilers/corretto/mk-corretto.nix
+++ b/pkgs/development/compilers/corretto/mk-corretto.nix
@@ -6,6 +6,7 @@
   stdenv,
   gradle,
   extraConfig ? [ ],
+  extraNativeBuildInputs ? [ ],
   rsync,
   runCommand,
   testers,
@@ -29,11 +30,14 @@ jdk.overrideAttrs (
   finalAttrs: oldAttrs: {
     inherit pname version src;
 
-    nativeBuildInputs = oldAttrs.nativeBuildInputs ++ [
-      jdk
-      gradle
-      rsync
-    ];
+    nativeBuildInputs =
+      oldAttrs.nativeBuildInputs
+      ++ [
+        jdk
+        gradle
+        rsync
+      ]
+      ++ extraNativeBuildInputs;
 
     dontConfigure = true;
 
@@ -41,7 +45,8 @@ jdk.overrideAttrs (
       let
         extra_config = builtins.concatStringsSep " " extraConfig;
       in
-      ''
+      (oldAttrs.postPatch or "")
+      + ''
         # The rpm/deb task definitions require a Gradle plugin which we don't
         # have and so the build fails. We'll simply remove them here because
         # they are not needed anyways.

--- a/pkgs/development/compilers/corretto/remove_removal_of_wformat_during_test_compilation.patch
+++ b/pkgs/development/compilers/corretto/remove_removal_of_wformat_during_test_compilation.patch
@@ -1,0 +1,13 @@
+diff --git a/make/common/TestFilesCompilation.gmk b/make/common/TestFilesCompilation.gmk
+index fd1c54eaf..c1e240a19 100644
+--- a/make/common/TestFilesCompilation.gmk
++++ b/make/common/TestFilesCompilation.gmk
+@@ -112,7 +112,7 @@ define SetupTestFilesCompilationBody
+         CXXFLAGS := $$(TEST_CFLAGS) $$($1_CFLAGS) $$($1_CFLAGS_$$(name)), \
+         LD_SET_ORIGIN := $$($1_LD_SET_ORIGIN), \
+         LDFLAGS := $$($1_LDFLAGS) $$($1_LDFLAGS_$$(name)), \
+-        DISABLED_WARNINGS_gcc := format undef unused-but-set-variable \
++        DISABLED_WARNINGS_gcc := undef unused-but-set-variable \
+             unused-const-variable unused-function unused-value \
+             unused-variable, \
+         DISABLED_WARNINGS_clang := format-nonliteral \

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4190,6 +4190,7 @@ with pkgs;
   corretto11 = javaPackages.compiler.corretto11;
   corretto17 = javaPackages.compiler.corretto17;
   corretto21 = javaPackages.compiler.corretto21;
+  corretto25 = javaPackages.compiler.corretto25;
 
   inherit (callPackage ../development/compilers/crystal { })
     crystal_1_14

--- a/pkgs/top-level/java-packages.nix
+++ b/pkgs/top-level/java-packages.nix
@@ -47,6 +47,7 @@ in
       corretto11 = callPackage ../development/compilers/corretto/11.nix { };
       corretto17 = callPackage ../development/compilers/corretto/17.nix { };
       corretto21 = callPackage ../development/compilers/corretto/21.nix { };
+      corretto25 = callPackage ../development/compilers/corretto/25.nix { };
 
       openjdk8 = mkOpenjdk "8";
       openjdk11 = mkOpenjdk "11";


### PR DESCRIPTION
This PR adds [corretto-25](https://github.com/corretto/corretto-25) as a new package using the existing infrastructure for corretto builds. 

FYI, my previous corretto-related PR is https://github.com/NixOS/nixpkgs/pull/459071.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
