### PR TITLE
pam-insults: init at unstable-2025-12-19

### DIFF
--- a/pkgs/by-name/pa/pam-insults/package.nix
+++ b/pkgs/by-name/pa/pam-insults/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  asciidoctor,
+  gzip,
+  pam,
+  gettext,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "pam-insults";
+  version = "0.2.2-unstable-2025-12-19";
+
+  src = fetchFromGitHub {
+    owner = "cgoesche";
+    repo = "0.2.2-pam-insults";
+    rev = "2d13ef89640eb57b5e6a64eea080e57d9d936738";
+    hash = "sha256-VbEJCO7lvTDKvGpTXQrpgeWEpZE4CMdwaRSuv5shsbw=";
+  };
+
+  nativeBuildInputs = [
+    asciidoctor
+    gzip
+  ];
+
+  buildInputs = [
+    pam
+    gettext
+  ];
+
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace-fail "sudo " "" \
+      --replace-fail "mandb" ""
+  '';
+
+  makeFlags = [
+    "PAM_MODULES_DIR=$(out)/lib/security"
+    "MAN_DATABASE=$(out)/share/man/man8"
+  ];
+
+  preInstall = ''
+    mkdir -p $out/lib/security $out/share/man/man8
+  '';
+
+  meta = {
+    description = "PAM module that will print an insult to stderr";
+    homepage = "https://github.com/cgoesche/pam-insults";
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.linux;
+    maintainers = [ lib.maintainers.DieracDelta ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
