### PR TITLE
fcp: fix build

### DIFF
--- a/pkgs/by-name/fc/fcp/0002-trailing-semicolon-in-macro.patch
+++ b/pkgs/by-name/fc/fcp/0002-trailing-semicolon-in-macro.patch
@@ -1,0 +1,13 @@
+diff --git a/src/filesystem.rs b/src/filesystem.rs
+index 28c2a01..cfc8fcb 100644
+--- a/src/filesystem.rs
++++ b/src/filesystem.rs
+@@ -44,7 +44,7 @@ wrap2!(copy, fs, u64);
+ 
+ macro_rules! make_error_message {
+     ($path:ident) => {
+-        |err| Error::new(format!("{}: {}", $path.display(), err));
++        |err| Error::new(format!("{}: {}", $path.display(), err))
+     };
+ }
+ 

--- a/pkgs/by-name/fc/fcp/package.nix
+++ b/pkgs/by-name/fc/fcp/package.nix
@@ -18,6 +18,10 @@ rustPlatform.buildRustPackage rec {
     sha256 = "0f242n8w88rikg1srimdifadhggrb2r1z0g65id60ahb4bjm8a0x";
   };
 
+  patches = [
+    ./0002-trailing-semicolon-in-macro.patch
+  ];
+
   cargoPatches = [
     (fetchpatch {
       url = "https://github.com/Svetlitski/fcp/commit/1988f88be54a507b804b037cb3887fecf11bb571.patch";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

The build failure was caused by a trailing semicolon in a macro used as expressions, which would be rejected by future Rust compilers.

Closes #471144

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
