### PR TITLE
extra-container: 0.13 -> 0.14

### DIFF
--- a/pkgs/by-name/ex/extra-container/package.nix
+++ b/pkgs/by-name/ex/extra-container/package.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation rec {
   pname = "extra-container";
-  version = "0.13";
+  version = "0.14";
 
   src = fetchFromGitHub {
     owner = "erikarvstedt";
     repo = "extra-container";
     rev = version;
-    hash = "sha256-vgh3TqfkFdnPxREBedw4MQehIDc3N8YyxBOB45n+AvU=";
+    hash = "sha256-XGp4HHH6D6ZKiO5RnMzqYJYnZB538EnEflvlTsOKpvo=";
   };
 
   buildCommand = ''


### PR DESCRIPTION
[Release notes](https://github.com/erikarvstedt/extra-container/blob/master/CHANGELOG.md#014-2025-12-19).

- [x] Tested on x86_64-linux

cc @ck3d @Lassulus