### PR TITLE
gpgmepp: propagate gpgme and libgpg-error

### DIFF
--- a/pkgs/by-name/gp/gpgmepp/package.nix
+++ b/pkgs/by-name/gp/gpgmepp/package.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
     cmake
   ];
 
-  buildInputs = [
+  propagatedBuildInputs = [
     gpgme
     libgpg-error
   ];

--- a/pkgs/development/libraries/qgpgme/default.nix
+++ b/pkgs/development/libraries/qgpgme/default.nix
@@ -1,10 +1,8 @@
 {
   cmake,
   fetchurl,
-  gpgme,
   gpgmepp,
   lib,
-  libgpg-error,
   qtbase,
   stdenv,
   which,
@@ -24,10 +22,11 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    gpgme
-    gpgmepp
-    libgpg-error
     qtbase
+  ];
+
+  propagatedBuildInputs = [
+    gpgmepp
   ];
 
   dontWrapQtApps = true;


### PR DESCRIPTION
It specifies

    find_dependency(LibGpgError "1.47")
    find_dependency(Gpgme "2.0.0")

in lib/cmake/Gpgmepp/GpgmeppConfig.cmake.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
