### PR TITLE
nixpkgs-plugin-update: improve commit message generation

### DIFF
--- a/pkgs/development/python-modules/nixpkgs-plugin-update/nixpkgs-plugin-update/src/nixpkgs_plugin_update/__init__.py
+++ b/pkgs/development/python-modules/nixpkgs-plugin-update/nixpkgs-plugin-update/src/nixpkgs_plugin_update/__init__.py
@@ -20,7 +20,7 @@ import urllib.parse
 import urllib.request
 import xml.etree.ElementTree as ET
 from dataclasses import asdict, dataclass
-from datetime import UTC, datetime
+from datetime import datetime, date
 from functools import wraps
 from multiprocessing.dummy import Pool
 from pathlib import Path
@@ -749,7 +749,12 @@ class Editor:
             ]
         )
 
-        def update() -> Redirects:
+        def update() -> tuple[Redirects, list[tuple[str, str, str]]]:
+            """
+            Returns:
+                tuple of (redirects, updated_plugins)
+                where updated_plugins is [(name, old_version, new_version), ...]
+            """
             if len(plugins_to_update) == 0:
                 log.error(
                     "\n\n\n\nIt seems like you provided some arguments to `--update`:\n"
@@ -759,7 +764,7 @@ class Editor:
                     "Are you sure you provided the same URIs as in your input file?\n"
                     "(" + str(input_file) + ")\n\n"
                 )
-                return {}
+                return {}, []
 
             try:
                 pool = Pool(processes=config.proc)
@@ -773,10 +778,25 @@ class Editor:
                 results = self.merge_results(current_plugins, results)
             plugins, redirects = check_results(results)
 
+            # Track version changes for commit message generation
+            updated_plugins = []
+            current_plugin_map = {p.normalized_name: p for _, p in current_plugins}
+
+            for _, new_plugin in plugins:
+                old_plugin = current_plugin_map.get(new_plugin.normalized_name)
+                if old_plugin and old_plugin.version != new_plugin.version:
+                    updated_plugins.append(
+                        (
+                            new_plugin.normalized_name,
+                            old_plugin.version,
+                            new_plugin.version,
+                        )
+                    )
+
             plugins = sorted(plugins, key=lambda v: v[1].normalized_name)
             self.generate_nix(plugins, output_file)
 
-            return redirects
+            return redirects, updated_plugins
 
         return update
 
@@ -1192,19 +1212,25 @@ def update_plugins(editor: Editor, args):
     )
 
     start_time = time.time()
-    redirects = update()
+    redirects, updated_plugins = update()
     duration = time.time() - start_time
     print(f"The plugin update took {duration:.2f}s.")
     editor.rewrite_input(fetch_config, args.input_file, editor.deprecated, redirects)
 
     autocommit = not args.no_commit
 
-    if autocommit:
+    if autocommit and len(updated_plugins) > 0:
         try:
             repo = git.Repo(os.getcwd())
-            updated = datetime.now(tz=UTC).strftime("%Y-%m-%d")
+
+            if len(updated_plugins) == 1:
+                name, old_ver, new_ver = updated_plugins[0]
+                message = f"{editor.attr_path}.{name}: {old_ver} -> {new_ver}"
+            else:
+                message = f"{editor.attr_path}: update on {date.today()}"
+
             print(args.outfile)
-            commit(repo, f"{editor.attr_path}: update on {updated}", [args.outfile])
+            commit(repo, message, [args.outfile])
         except git.InvalidGitRepositoryError as e:
             print(f"Not in a git repository: {e}", file=sys.stderr)
             sys.exit(1)

--- a/pkgs/development/python-modules/nixpkgs-plugin-update/nixpkgs-plugin-update/src/nixpkgs_plugin_update/__init__.py
+++ b/pkgs/development/python-modules/nixpkgs-plugin-update/nixpkgs-plugin-update/src/nixpkgs_plugin_update/__init__.py
@@ -640,12 +640,21 @@ class Editor:
             autocommit = not args.no_commit
             if autocommit:
                 assert editor.nixpkgs_repo is not None
+
+                commit_message = "{drv_name}: init at {version}".format(
+                    drv_name=editor.get_drv_name(plugin.normalized_name),
+                    version=plugin.version,
+                )
+
+                if isinstance(pdesc.repo, RepoGitHub):
+                    github_url = (
+                        f"https://github.com/{pdesc.repo.owner}/{pdesc.repo.repo}"
+                    )
+                    commit_message += f"\n\n{github_url}"
+
                 commit(
                     editor.nixpkgs_repo,
-                    "{drv_name}: init at {version}".format(
-                        drv_name=editor.get_drv_name(plugin.normalized_name),
-                        version=plugin.version,
-                    ),
+                    commit_message,
                     [args.outfile, args.input_file],
                 )
 


### PR DESCRIPTION
Enhance commit messages to differentiate between single plugin updates and bulk updates. Single plugin updates now show version transitions (e.g., "vimPlugins.telescope-nvim: 1.0 -> 1.1"), while bulk updates use a date-based format.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
