### PR TITLE
smoked-salmon: init at 0.9.7.4

### DIFF
--- a/pkgs/by-name/sm/smoked-salmon/package.nix
+++ b/pkgs/by-name/sm/smoked-salmon/package.nix
@@ -1,0 +1,94 @@
+{
+  lib,
+  fetchFromGitHub,
+  ffmpeg-headless,
+  flac,
+  lame,
+  mp3val,
+  python3Packages,
+  sox,
+}:
+let
+  runtimeDeps = [
+    ffmpeg-headless
+    flac
+    lame
+    mp3val
+    sox
+  ];
+in
+python3Packages.buildPythonApplication rec {
+  pname = "smoked-salmon";
+  version = "0.9.7.4";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "smokin-salmon";
+    repo = "smoked-salmon";
+    tag = version;
+    hash = "sha256-JOwqu/Hu7BjYLo3DdL6o+9TI/OQvlgj5Xu8WQ0cujwo=";
+  };
+
+  # Upstream tends to use very narrow version constraints
+  pythonRelaxDeps = true;
+
+  build-system = with python3Packages; [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = with python3Packages; [
+    aiohttp
+    aiohttp-jinja2
+    beautifulsoup4
+    bitstring
+    click
+    deluge-client
+    ffmpeg-python
+    filetype
+    httpx
+    humanfriendly
+    jinja2
+    msgspec
+    musicbrainzngs
+    mutagen
+    pillow
+    platformdirs
+    pycambia
+    pyoxipng
+    pyperclip
+    qbittorrent-api
+    ratelimit
+    requests
+    rich
+    send2trash
+    setuptools
+    torf
+    tqdm
+    transmission-rpc
+    unidecode
+    wheel
+  ];
+
+  makeWrapperArgs = [
+    "--suffix"
+    "PATH"
+    ":"
+    (lib.makeBinPath runtimeDeps)
+  ];
+
+  passthru = {
+    inherit runtimeDeps;
+  };
+
+  meta = {
+    description = "Toolkit for checking, editing and uploading music to Gazelle-based trackers";
+    homepage = "https://github.com/smokin-salmon/smoked-salmon";
+    license = with lib.licenses; [ asl20 ];
+    mainProgram = "salmon";
+    maintainers = with lib.maintainers; [
+      ambroisie
+      undefined-landmark
+    ];
+  };
+}

--- a/pkgs/development/python-modules/pycambia/default.nix
+++ b/pkgs/development/python-modules/pycambia/default.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  fetchpatch,
+  openssl,
+  pkg-config,
+  pytestCheckHook,
+  rustPlatform,
+}:
+let
+  cargoLockPatch = (
+    fetchpatch {
+      name = "cargo.lock.patch";
+      url = "https://github.com/KyokoMiki/pycambia/commit/00446e13c20a461c323b119e16f3f57489ba662d.patch";
+      hash = "sha256-N7F67VRxfndoN8NllmGKEePOh3mgbjlNaToUvxh+IrE=";
+    }
+  );
+in
+buildPythonPackage rec {
+  pname = "pycambia";
+  version = "0.1.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "KyokoMiki";
+    repo = "pycambia";
+    tag = version;
+    hash = "sha256-ZflLy6Qa4tBlPZkTya3ELu463qcnRcMS57a6FfHpSNE=";
+  };
+
+  patches = [ cargoLockPatch ];
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit src;
+    hash = "sha256-jmdf+Idg9PR4jgZ7bexPsAyGj86vGxLseTWXnhzP7+E=";
+    patches = [ cargoLockPatch ];
+  };
+
+  buildInputs = [ openssl ];
+
+  nativeBuildInputs = [
+    pkg-config
+    rustPlatform.cargoSetupHook
+    rustPlatform.maturinBuildHook
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "cambia" ];
+
+  meta = {
+    description = "Python wrapper for compact disc ripper log checking utility cambia";
+    homepage = "https://github.com/KyokoMiki/pycambia";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ undefined-landmark ];
+  };
+}

--- a/pkgs/development/python-modules/pyoxipng/default.nix
+++ b/pkgs/development/python-modules/pyoxipng/default.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  rustPlatform,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "pyoxipng";
+  version = "9.1.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "nfrasser";
+    repo = "pyoxipng";
+    tag = "v${version}";
+    hash = "sha256-aVya+0+X2p0VaWCZTxVlVUFFlqkqZ7A2lJjhxiXAgrE=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit src;
+    hash = "sha256-wMCx6cujqM4q96b1mg4eovKjWmsv0FcaDBCxy0OodmA=";
+  };
+
+  nativeBuildInputs = with rustPlatform; [
+    cargoSetupHook
+    maturinBuildHook
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "oxipng" ];
+
+  meta = {
+    description = "Python wrapper for multithreaded PNG optimizer oxipng";
+    homepage = "https://github.com/nfrasser/pyoxipng";
+    changelog = "https://github.com/nfrasser/pyoxipng/blob/${src.tag}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ undefined-landmark ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14110,6 +14110,8 @@ self: super: with self; {
 
   pyoxigraph = callPackage ../development/python-modules/pyoxigraph { };
 
+  pyoxipng = callPackage ../development/python-modules/pyoxipng { };
+
   pypager = callPackage ../development/python-modules/pypager { };
 
   pypalazzetti = callPackage ../development/python-modules/pypalazzetti { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13013,6 +13013,8 @@ self: super: with self; {
 
   pycairo = callPackage ../development/python-modules/pycairo { inherit (pkgs.buildPackages) meson; };
 
+  pycambia = callPackage ../development/python-modules/pycambia { };
+
   pycangjie = callPackage ../development/python-modules/pycangjie {
     inherit (pkgs.buildPackages) meson;
   };


### PR DESCRIPTION
Building on the good work done in #416926. smoked-salmon is a tool that contains a broad range of features such as:
- Generating spectrals
- Gathering metadata from multiple online sources, 
- Re-tagging/renaming files
- Uploading to gazelle based trackers

and [much more](https://github.com/smokin-salmon/smoked-salmon).

All in all a versatile tool for managing your music files. 

Manually tested briefly, the default webserver tries to copy spectrals to the nix store, which doesn't work. However with feh you can still view the spectrals, manually or by setting feh as the default in [the config](https://github.com/smokin-salmon/smoked-salmon/wiki/Configuration#upload-process-options).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
