### PR TITLE
libepoxy: include egl in cflags for pkg-config based builds

### DIFF
--- a/pkgs/by-name/li/libepoxy/package.nix
+++ b/pkgs/by-name/li/libepoxy/package.nix
@@ -75,6 +75,13 @@ stdenv.mkDerivation (finalAttrs: {
 
   doCheck = true;
 
+  # Headers depend on EGL but it is Requires.private which is not output as
+  # cflags using nixpkgs patched version of pkg-config.
+  postInstall = lib.optionalString (x11Support && !stdenv.hostPlatform.isDarwin) ''
+    substituteInPlace $out/lib/pkgconfig/epoxy.pc \
+      --replace-fail 'Requires.private:' 'Requires:'
+  '';
+
   passthru.tests = {
     pkg-config = testers.hasPkgConfigModules {
       package = finalAttrs.finalPackage;


### PR DESCRIPTION
Build systems that depend on pkg-config for cflags fail to find egl headers. The example I ran into is building qemu in a dev shell environment. This seems to be caused by nixpkgs patching the behavior of pkg-config so that it does not include private dependencies in the cflags output unless it's a static build. I also see examples of this fix in telepathy-glib, ubports-click, libgweather, and cairo.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
