### PR TITLE
gtk3: fix pkg-config wayland and zlib dependencies

### DIFF
--- a/pkgs/development/libraries/gtk/3.x.nix
+++ b/pkgs/development/libraries/gtk/3.x.nix
@@ -94,6 +94,7 @@ stdenv.mkDerivation (finalAttrs: {
     # See: https://github.com/NixOS/nixpkgs/pull/449689
     # Upstream: https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/5531
     ./patches/3.0-mr5531-backport.patch
+    ./patches/3.0-fix-pkg-config-deps.patch
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # X11 module requires <gio/gdesktopappinfo.h> which is not installed on Darwin

--- a/pkgs/development/libraries/gtk/patches/3.0-fix-pkg-config-deps.patch
+++ b/pkgs/development/libraries/gtk/patches/3.0-fix-pkg-config-deps.patch
@@ -1,0 +1,57 @@
+diff --git a/meson.build b/meson.build
+index 397ea0730b..4ebe88eab3 100644
+--- a/meson.build
++++ b/meson.build
+@@ -534,6 +534,7 @@ cdata.set('HAVE_PANGOFT', pangoft_dep.found() ? 1 : false)
+ atk_pkgs = ['atk']
+ 
+ wayland_pkgs = []
++wayland_private_pkgs = []
+ if wayland_enabled
+   wlclientdep    = dependency('wayland-client', version:  wayland_req)
+   wlprotocolsdep = dependency('wayland-protocols', version: wayland_proto_req)
+@@ -546,6 +547,8 @@ if wayland_enabled
+ 
+   wayland_pkgs = [
+     'wayland-client', wayland_req,
++  ]
++  wayland_private_pkgs = [
+     'xkbcommon', xkbcommon_req,
+     'wayland-cursor', wayland_req,
+     'wayland-egl',
+@@ -890,7 +893,9 @@ pkgconf.set('host', '@0@-@1@'.format(host_machine.cpu_family(), host_machine.sys
+ pango_pkgname = win32_enabled ? 'pangowin32' : 'pango'
+ gdk_packages = ' '.join([ pango_pkgname, pango_req,
+                        'pangocairo', pango_req,
+-                       'gdk-pixbuf-2.0', gdk_pixbuf_req ])
++                       'gdk-pixbuf-2.0', gdk_pixbuf_req,
++                       wayland_pkgs,
++                       'zlib' ])
+ 
+ cairo_packages = ''
+ 
+@@ -915,7 +920,7 @@ else
+ endif
+ 
+ pkgconf.set('GDK_PRIVATE_PACKAGES',
+-            ' '.join(gio_packages + x11_pkgs + wayland_pkgs + cairo_backends +
++            ' '.join(gio_packages + x11_pkgs + wayland_private_pkgs + cairo_backends +
+                      ['epoxy', epoxy_req] + cloudproviders_packages +
+                      ['fribidi', fribidi_req]))
+ 
+@@ -924,13 +929,14 @@ gtk_packages = ' '.join([
+     cairo_packages,
+     pixbuf_dep.name(), gdk_pixbuf_req,
+     'gio-2.0', glib_req,
++    wayland_pkgs
+ ])
+ pkgconf.set('GTK_PACKAGES', gtk_packages)
+ 
+ # Requires.private
+ pc_gdk_extra_libs += cairo_libs
+ 
+-gtk_private_packages = atk_pkgs + wayland_pkgs + ['epoxy', epoxy_req, 'fribidi', fribidi_req]
++gtk_private_packages = atk_pkgs + wayland_private_pkgs + ['epoxy', epoxy_req, 'fribidi', fribidi_req]
+ if wayland_enabled or x11_enabled
+   gtk_private_packages += ['pangoft2']
+ endif


### PR DESCRIPTION
Build systems that depend on pkg-config for cflags fail to find wayland headers. The example I ran into is building qemu in a dev shell environment. This seems to be caused by nixpkgs patching the behavior of pkg-config so that it does not include private dependencies in the cflags output unless it's a static build. I also see examples of this fix in telepathy-glib, ubports-click, libgweather, and cairo.

The fix here is to move all wayland-* dependencies from "Requires.private" to "Requires" in gtk+-3.0.pc. This way they show up in cflags.

gtk3 also includes zlib in Libs in the gdk-3.0.pc file but does not explicitly list it as a dependency. This fixes that as well.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
