### PR TITLE
treewide: prepare packages for structuredAttrs by fixing makeFlags

### DIFF
--- a/pkgs/by-name/cu/cups-brother-hl3170cdw/package.nix
+++ b/pkgs/by-name/cu/cups-brother-hl3170cdw/package.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
       --replace-fail "exec[300]" "exec[400]"
   '';
 
-  makeFlags = [ "-C brcupsconfig" ];
+  makeFlags = [ "--directory=brcupsconfig" ];
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/by-name/ed/edk2/package.nix
+++ b/pkgs/by-name/ed/edk2/package.nix
@@ -77,10 +77,7 @@ stdenv.mkDerivation (finalAttrs: {
   depsHostHost = [ libuuid ];
   strictDeps = true;
 
-  # trick taken from https://src.fedoraproject.org/rpms/edk2/blob/08f2354cd280b4ce5a7888aa85cf520e042955c3/f/edk2.spec#_319
-  ${"GCC5_${targetArch}_PREFIX"} = stdenv.cc.targetPrefix;
-
-  makeFlags = [ "-C BaseTools" ];
+  makeFlags = [ "--directory=BaseTools" ];
 
   env = {
     NIX_CFLAGS_COMPILE =
@@ -88,6 +85,9 @@ stdenv.mkDerivation (finalAttrs: {
       + lib.optionalString (stdenv.cc.isGNU) " -Wno-error=stringop-truncation"
       + lib.optionalString (stdenv.hostPlatform.isDarwin) " -Wno-error=macro-redefined";
     PYTHON_COMMAND = lib.getExe pythonEnv;
+    # trick taken from https://src.fedoraproject.org/rpms/edk2/blob/08f2354cd280b4ce5a7888aa85cf520e042955c3/f/edk2.spec#_319
+    ${"GCC5_${targetArch}_PREFIX"} = stdenv.cc.targetPrefix;
+
   };
 
   hardeningDisable = [

--- a/pkgs/by-name/gr/grafx2/package.nix
+++ b/pkgs/by-name/gr/grafx2/package.nix
@@ -52,9 +52,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   strictDeps = false; # Why??
 
-  makeFlags = [ "-C src" ];
+  makeFlags = [ "--directory=src" ];
   installFlags = [
-    "-C src"
+    "--directory=src"
     "PREFIX=$(out)"
   ];
 

--- a/pkgs/by-name/op/openseachest/package.nix
+++ b/pkgs/by-name/op/openseachest/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
-  makeFlags = [ "-C Make/gcc" ];
+  makeFlags = [ "--directory=Make/gcc" ];
   buildFlags = [ "release" ];
 
   installPhase = ''

--- a/pkgs/by-name/pr/proot/package.nix
+++ b/pkgs/by-name/pr/proot/package.nix
@@ -43,10 +43,10 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  makeFlags = [ "-C src" ];
+  makeFlags = [ "--directory=src" ];
 
   postBuild = ''
-    make -C doc proot/man.1
+    make --directory=doc proot/man.1
   '';
 
   installFlags = [ "PREFIX=${placeholder "out"}" ];


### PR DESCRIPTION
Avoid using spaces in `makeFlags`.

`edk2` also has an environment variable moved into `env`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
