### PR TITLE
python3Packages.beetcamp: 0.22.0 -> 0.23.0

### DIFF
--- a/pkgs/development/python-modules/beetcamp/default.nix
+++ b/pkgs/development/python-modules/beetcamp/default.nix
@@ -16,7 +16,7 @@
 }:
 
 let
-  version = "0.22.0";
+  version = "0.23.0";
 in
 buildPythonPackage {
   pname = "beetcamp";
@@ -27,7 +27,7 @@ buildPythonPackage {
     owner = "snejus";
     repo = "beetcamp";
     tag = version;
-    hash = "sha256-5tcQtvYmXT213mZnzKz2kwE5K22rro++lRF65PjC5X0=";
+    hash = "sha256-8FEDpobEGZ0Lw1+JRoFIEe3AuiuX7dwsRab+P3hC3W0=";
   };
 
   patches = [

--- a/pkgs/development/python-modules/beetcamp/remove-git-pytest-option.diff
+++ b/pkgs/development/python-modules/beetcamp/remove-git-pytest-option.diff
@@ -74,25 +74,3 @@ index 04d81f66f0..018d9e3c0c 100644
  def pytest_assertrepr_compare(op: str, left: Any, right: Any):  # noqa: ARG001
      """Pretty print the difference between dict objects."""
      actual, expected = left, right
-diff --git a/tests/test_lib.py b/tests/test_lib.py
-index 665d5aa61d..0a81e42b24 100644
---- a/tests/test_lib.py
-+++ b/tests/test_lib.py
-@@ -19,7 +19,6 @@
- 
- import pytest
- from filelock import FileLock
--from git import Repo
- from rich import box
- from rich.console import Group
- from rich.markup import escape
-@@ -273,9 +272,6 @@
-             return
- 
-         sections = [("Failed", summary["failed"], "red")]
--        with suppress(TypeError):
--            if Repo(pytestconfig.rootpath).active_branch.name == "dev":
--                sections.append(("Fixed", summary["fixed"], "green"))
- 
-         columns = []
-         for name, all_changes, color in sections:


### PR DESCRIPTION
0.22.0 isn't compatible with the current version of beets in nixpkgs


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
