### PR TITLE
python3Packages.exceptiongroup: 1.3.0 -> 1.3.1 (fix build on Python 3.14)

### DIFF
--- a/pkgs/development/python-modules/exceptiongroup/default.nix
+++ b/pkgs/development/python-modules/exceptiongroup/default.nix
@@ -11,7 +11,7 @@
 
 buildPythonPackage rec {
   pname = "exceptiongroup";
-  version = "1.3.0";
+  version = "1.3.1";
   pyproject = true;
 
   disabled = pythonOlder "3.7";
@@ -20,7 +20,7 @@ buildPythonPackage rec {
     owner = "agronholm";
     repo = "exceptiongroup";
     tag = version;
-    hash = "sha256-b3Z1NsYKp0CecUq8kaC/j3xR/ZZHDIw4MhUeadizz88=";
+    hash = "sha256-3WInufN+Pp6vB/Gik6e8V1a34Dr/oiH3wDMB+2lHRMM=";
   };
 
   build-system = [ flit-scm ];


### PR DESCRIPTION
This new version includes a fix for the following build failure:

```
============================= test session starts ==============================
platform linux -- Python 3.14.0, pytest-8.4.2, pluggy-1.6.0
rootdir: /build/source
configfile: pyproject.toml
testpaths: tests
collecting ... ^Mcollected 102 items

tests/test_apport_monkeypatching.py s                                    [  0%]
tests/test_catch.py .................                                    [ 17%]
tests/test_catch_py311.py ..........                                     [ 27%]
tests/test_exceptions.py ...............................FF.............  [ 72%]
tests/test_formatting.py .......ss...ss..ss.s.s.s.s.                     [ 99%]
tests/test_suppress.py .                                                 [100%]

=================================== FAILURES ===================================
_______________ DeepRecursionInSplitAndSubgroup.test_deep_split ________________
tests/test_exceptions.py:383: in test_deep_split
    with self.assertRaises(RecursionError):
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E   AssertionError: RecursionError not raised
______________ DeepRecursionInSplitAndSubgroup.test_deep_subgroup ______________
tests/test_exceptions.py:388: in test_deep_subgroup
    with self.assertRaises(RecursionError):
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E   AssertionError: RecursionError not raised
=========================== short test summary info ============================
SKIPPED [1] tests/test_apport_monkeypatching.py:39: need Ubuntu with python3-apport installed
SKIPPED [2] tests/test_formatting.py:228: No patching is done on Python >= 3.11
SKIPPED [2] tests/test_formatting.py:355: No patching is done on Python >= 3.11
SKIPPED [2] tests/test_formatting.py:382: No patching is done on Python >= 3.11
SKIPPED [1] tests/test_formatting.py:434: No patching is done on Python >= 3.11
SKIPPED [1] tests/test_formatting.py:482: No patching is done on Python >= 3.11
SKIPPED [1] tests/test_formatting.py:506: No patching is done on Python >= 3.11
SKIPPED [1] tests/test_formatting.py:531: No patching is done on Python >= 3.11
FAILED tests/test_exceptions.py::DeepRecursionInSplitAndSubgroup::test_deep_split - AssertionError: RecursionError not raised
FAILED tests/test_exceptions.py::DeepRecursionInSplitAndSubgroup::test_deep_subgroup - AssertionError: RecursionError not raised
=================== 2 failed, 89 passed, 11 skipped in 1.35s ===================
```

See:

- https://github.com/agronholm/exceptiongroup/issues/148
- https://github.com/agronholm/exceptiongroup/releases/tag/1.3.1


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
