### PR TITLE
compilers/ghc/common-hadrian: expand flags for structuredAttrs

### DIFF
--- a/pkgs/development/compilers/ghc/common-hadrian.nix
+++ b/pkgs/development/compilers/ghc/common-hadrian.nix
@@ -753,10 +753,10 @@ stdenv.mkDerivation (
       runHook preBuild
 
       # hadrianFlagsArray is created in preConfigure
-      echo "hadrianFlags: $hadrianFlags ''${hadrianFlagsArray[@]}"
+      echo "hadrianFlags: ''${hadrianFlags[@]} ''${hadrianFlagsArray[@]}"
 
       # We need to go via the bindist for installing
-      hadrian $hadrianFlags "''${hadrianFlagsArray[@]}" binary-dist-dir
+      hadrian ''${hadrianFlags[@]} "''${hadrianFlagsArray[@]}" binary-dist-dir
 
       runHook postBuild
     '';
@@ -796,7 +796,7 @@ stdenv.mkDerivation (
       export OtoolCmd=$OTOOL
     ''
     + ''
-      $configureScript $configureFlags "''${configureFlagsArray[@]}"
+      $configureScript ''${configureFlags[@]} "''${configureFlagsArray[@]}"
     '';
 
     postInstall = ''


### PR DESCRIPTION
Otherwise we lose all flags apart from the first.

This results in a `__structuredAttrs = true;` build trying to find xelatex while it is not available.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
