### PR TITLE
kwin-better-blur-dx: init at 2.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8051,6 +8051,12 @@
     github = "EstebanMacanek";
     githubId = 75503218;
   };
+  eth-p = {
+    name = "Ethan P.";
+    email = "me@eth-p.dev";
+    github = "eth-p";
+    githubId = 32112321;
+  };
   ethancedwards8 = {
     email = "ethan@ethancedwards.com";
     matrix = "@ethancedwards8:matrix.org";

--- a/pkgs/kde/default.nix
+++ b/pkgs/kde/default.nix
@@ -95,6 +95,7 @@ let
         karousel = self.callPackage ./third-party/karousel { };
         koi = self.callPackage ./third-party/koi { };
         krohnkite = self.callPackage ./third-party/krohnkite { };
+        kwin-better-blur-dx = self.callPackage ./third-party/kwin-better-blur-dx { };
         kzones = self.callPackage ./third-party/kzones { };
         wallpaper-engine-plugin = self.callPackage ./third-party/wallpaper-engine-plugin { };
       }

--- a/pkgs/kde/default.nix
+++ b/pkgs/kde/default.nix
@@ -96,6 +96,9 @@ let
         koi = self.callPackage ./third-party/koi { };
         krohnkite = self.callPackage ./third-party/krohnkite { };
         kwin-better-blur-dx = self.callPackage ./third-party/kwin-better-blur-dx { };
+        kwin-better-blur-dx-x11 = self.callPackage ./third-party/kwin-better-blur-dx {
+          withKwinX11 = true;
+        };
         kzones = self.callPackage ./third-party/kzones { };
         wallpaper-engine-plugin = self.callPackage ./third-party/wallpaper-engine-plugin { };
       }

--- a/pkgs/kde/third-party/kwin-better-blur-dx/default.nix
+++ b/pkgs/kde/third-party/kwin-better-blur-dx/default.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  gitUpdater,
+  wrapQtAppsHook,
+  cmake,
+  extra-cmake-modules,
+  kwin,
+  qttools,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "kwin-better-blur-dx";
+  version = "2.0.0";
+
+  src = fetchFromGitHub {
+    owner = "xarblu";
+    repo = "kwin-effects-better-blur-dx";
+    tag = "v${version}";
+    hash = "sha256-e9Al48mFQF8Kefmw8WyhGNTKcXZs51hKJCRAjzhMvTs=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    kwin
+    qttools
+  ];
+
+  passthru.updateScript = gitUpdater { rev-prefix = "v"; };
+
+  meta = {
+    description = "Fork of the Plasma 6 blur effect with additional features and bug fixes";
+    homepage = "https://github.com/xarblu/kwin-effects-better-blur-dx";
+    license = with lib.licenses; [
+      gpl2Plus # Some files: https://github.com/search?q=repo%3Axarblu%2Fkwin-effects-better-blur-dx%20SPDX-License-Identifier&type=code
+      gpl3Only # Project: https://github.com/xarblu/kwin-effects-better-blur-dx/blob/main/LICENSE
+    ];
+    maintainers = with lib.maintainers; [ eth-p ];
+  };
+}

--- a/pkgs/kde/third-party/kwin-better-blur-dx/default.nix
+++ b/pkgs/kde/third-party/kwin-better-blur-dx/default.nix
@@ -7,11 +7,14 @@
   cmake,
   extra-cmake-modules,
   kwin,
+  kwin-x11,
   qttools,
+
+  withKwinX11 ? false,
 }:
 
 stdenv.mkDerivation rec {
-  pname = "kwin-better-blur-dx";
+  pname = "kwin-better-blur-dx" + lib.optionalString withKwinX11 "-x11";
   version = "2.0.0";
 
   src = fetchFromGitHub {
@@ -28,9 +31,12 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    kwin
     qttools
-  ];
+  ]
+  ++ lib.optional withKwinX11 kwin-x11
+  ++ lib.optional (!withKwinX11) kwin;
+
+  cmakeFlags = lib.optional withKwinX11 "-DBETTERBLUR_X11=on";
 
   passthru.updateScript = gitUpdater { rev-prefix = "v"; };
 


### PR DESCRIPTION
This pull request initializes two new packages for [kwin-better-blur-dx], which is the continuation of the now-archived [taj-ny/kwin-effects-forceblur] third-party KDE Plasma Desktop Effect. I had been using the original kwin-effects-forceblur on NixOS Unstable for a while without issues before it was archived, and now that a maintained fork exists, I felt that it would be an improvement to officially add it to nixpkgs. 

The packages are based off of kwin-better-blur-dx's [flake.nix packages](https://github.com/xarblu/kwin-effects-better-blur-dx/tree/v2.0.0/nix). I also fixed the X11 package to build it with the correct cmake options.

If any of the changes in this PR go against conventions, my apologies in advance. This is my first time adding a new package and I'm not yet familiar with the process.

**Explanation for the package license choice:**

 * The project repo has a GPLv3 [LICENSE file](https://github.com/xarblu/kwin-effects-better-blur-dx/blob/v2.0.0/LICENSE)
 * The LICENSE file does not say "or any later versions"
 * A [couple of the files](https://github.com/search?q=repo%3Axarblu%2Fkwin-effects-better-blur-dx%20SPDX-License-Identifier&type=code) in the repo have a `SPDX-License-Identifier` comment indicating `GPL-2.0-or-later`.

My interpretation is that some of the code is licensed under GPL v2.0 (or any later GPL version), while the rest of the code is licensed only under GPL v3. From my understanding, that means the project as a whole must be licensed under GPL v3.0 only. As far as nixpkgs licensing conventions go, I wasn't sure whether that meant I should omit the `gpl2Plus` or not, so I erred on the side of caution and included both.

**Explanation for using `callPackage` parameters to build both packages:**

The kwin-effects-better-blur-dx repo has separate builds for Wayland and X11. Which one is built depends on a cmake option, and most of the code is shared using `#ifdef`s. Other than that, the two builds in their dependencies (`kwin` vs `kwin_x11`) and output paths.

Since the only changes between the two packages are the build inputs and a cmake option, I felt that using a parameter to indicate which build to create made more sense than duplicating the package only to change a couple of lines.  

[kwin-better-blur-dx]: https://github.com/xarblu/kwin-effects-better-blur-dx
[taj-ny/kwin-effects-forceblur]: https://github.com/taj-ny/kwin-effects-forceblur

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
