### PR TITLE
treewide: prepare Rust packages for structuredAttrs by putting OPENSSL_NO_VENDOR in env

### DIFF
--- a/pkgs/build-support/teleport/default.nix
+++ b/pkgs/build-support/teleport/default.nix
@@ -58,7 +58,7 @@ let
     # buildRustPackage sets strictDeps = true;
     nativeCheckInputs = finalAttrs.buildInputs;
 
-    OPENSSL_NO_VENDOR = "1";
+    env.OPENSSL_NO_VENDOR = "1";
 
     postInstall = ''
       mkdir -p $out/include

--- a/pkgs/by-name/cl/cloud-hypervisor/package.nix
+++ b/pkgs/by-name/cl/cloud-hypervisor/package.nix
@@ -28,7 +28,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   buildInputs = lib.optional stdenv.hostPlatform.isAarch64 dtc;
   checkInputs = [ openssl ];
 
-  OPENSSL_NO_VENDOR = true;
+  env.OPENSSL_NO_VENDOR = true;
 
   cargoTestFlags = [
     "--workspace"

--- a/pkgs/by-name/co/cook-cli/package.nix
+++ b/pkgs/by-name/co/cook-cli/package.nix
@@ -35,7 +35,7 @@ rustPlatform.buildRustPackage rec {
     openssl
   ];
 
-  OPENSSL_NO_VENDOR = 1;
+  env.OPENSSL_NO_VENDOR = 1;
 
   npmDeps = fetchNpmDeps {
     inherit src;

--- a/pkgs/by-name/dy/dynein/package.nix
+++ b/pkgs/by-name/dy/dynein/package.nix
@@ -19,7 +19,7 @@ rustPlatform.buildRustPackage rec {
   };
 
   # Use system openssl.
-  OPENSSL_NO_VENDOR = 1;
+  env.OPENSSL_NO_VENDOR = 1;
 
   cargoHash = "sha256-PA7Hvn+vYBD80thkIamwOhw4lJWAmU/TQBnwJro4r7c=";
 

--- a/pkgs/by-name/el/elan/package.nix
+++ b/pkgs/by-name/el/elan/package.nix
@@ -32,7 +32,7 @@ rustPlatform.buildRustPackage rec {
     makeWrapper
   ];
 
-  OPENSSL_NO_VENDOR = 1;
+  env.OPENSSL_NO_VENDOR = 1;
   buildInputs = [
     curl
     zlib

--- a/pkgs/by-name/fe/feroxbuster/package.nix
+++ b/pkgs/by-name/fe/feroxbuster/package.nix
@@ -22,7 +22,7 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-kWRODW1BsnifEqGZj8jK5tUK/5zK1AIRSq3JSo6YmkI=";
 
-  OPENSSL_NO_VENDOR = true;
+  env.OPENSSL_NO_VENDOR = true;
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/by-name/fi/fishy/package.nix
+++ b/pkgs/by-name/fi/fishy/package.nix
@@ -21,7 +21,7 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-F4zbalop1PEb381DctUIzdm3v71b6M/hnuw9BuIEkBU=";
 
-  OPENSSL_NO_VENDOR = 1;
+  env.OPENSSL_NO_VENDOR = 1;
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ openssl ];

--- a/pkgs/by-name/gi/git-gr/package.nix
+++ b/pkgs/by-name/gi/git-gr/package.nix
@@ -30,7 +30,7 @@ rustPlatform.buildRustPackage {
 
   cargoHash = "sha256-5YHE1NVUcZ5NeOl3Z87l3PVsmlkswhnT83Oi9loJjdM=";
 
-  OPENSSL_NO_VENDOR = true;
+  env.OPENSSL_NO_VENDOR = true;
 
   nativeBuildInputs = [ installShellFiles ] ++ lib.optional stdenv.hostPlatform.isLinux pkg-config;
 

--- a/pkgs/by-name/gi/git-together/package.nix
+++ b/pkgs/by-name/gi/git-together/package.nix
@@ -20,7 +20,7 @@ rustPlatform.buildRustPackage rec {
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ openssl ];
 
-  OPENSSL_NO_VENDOR = true;
+  env.OPENSSL_NO_VENDOR = true;
 
   cargoHash = "sha256-5LKKjHzIlXw0bUmF7GDCVW0cptCxohq6CNPIrMZKorM=";
 

--- a/pkgs/by-name/gi/git-trim/package.nix
+++ b/pkgs/by-name/gi/git-trim/package.nix
@@ -30,7 +30,7 @@ rustPlatform.buildRustPackage rec {
     })
   ];
 
-  OPENSSL_NO_VENDOR = 1;
+  env.OPENSSL_NO_VENDOR = 1;
 
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/by-name/gi/gitui/package.nix
+++ b/pkgs/by-name/gi/gitui/package.nix
@@ -51,9 +51,11 @@ rustPlatform.buildRustPackage {
     substituteInPlace Cargo.toml --replace-fail 'build = "build.rs"' ""
   '';
 
-  GITUI_BUILD_NAME = version;
-  # Needed to get openssl-sys to use pkg-config.
-  OPENSSL_NO_VENDOR = 1;
+  env = {
+    GITUI_BUILD_NAME = version;
+    # Needed to get openssl-sys to use pkg-config.
+    OPENSSL_NO_VENDOR = 1;
+  };
 
   # Getting app_config_path fails with a permission denied
   checkFlags = [

--- a/pkgs/by-name/gu/gurk-rs/package.nix
+++ b/pkgs/by-name/gu/gurk-rs/package.nix
@@ -37,14 +37,15 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = [ openssl ];
 
-  NIX_LDFLAGS = lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) [
-    "-framework"
-    "AppKit"
-  ];
+  env = {
+    NIX_LDFLAGS = lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) [
+      "-framework"
+      "AppKit"
+    ];
+    OPENSSL_NO_VENDOR = true;
+  };
 
   PROTOC = "${pkgsBuildHost.protobuf}/bin/protoc";
-
-  OPENSSL_NO_VENDOR = true;
 
   useNextest = true;
 

--- a/pkgs/by-name/he/heygpt/package.nix
+++ b/pkgs/by-name/he/heygpt/package.nix
@@ -19,10 +19,12 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [ openssl ];
 
-  # Needed to get openssl-sys to use pkg-config.
-  OPENSSL_NO_VENDOR = 1;
-  OPENSSL_LIB_DIR = "${lib.getLib openssl}/lib";
-  OPENSSL_DIR = "${lib.getDev openssl}";
+  env = {
+    # Needed to get openssl-sys to use pkg-config.
+    OPENSSL_NO_VENDOR = 1;
+    OPENSSL_LIB_DIR = "${lib.getLib openssl}/lib";
+    OPENSSL_DIR = "${lib.getDev openssl}";
+  };
 
   meta = {
     description = "Simple command-line interface for ChatGPT API";

--- a/pkgs/by-name/ko/koji/package.nix
+++ b/pkgs/by-name/ko/koji/package.nix
@@ -26,7 +26,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-dnidKrH/HSUpm8sU51G4e74NgyyO3v2sTK4eDKSJujA=";
 
-  OPENSSL_NO_VENDOR = 1;
+  env.OPENSSL_NO_VENDOR = 1;
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/by-name/kr/krill/package.nix
+++ b/pkgs/by-name/kr/krill/package.nix
@@ -24,7 +24,7 @@ rustPlatform.buildRustPackage rec {
   nativeBuildInputs = [ pkg-config ];
 
   # Needed to get openssl-sys to use pkgconfig.
-  OPENSSL_NO_VENDOR = 1;
+  env.OPENSSL_NO_VENDOR = 1;
 
   # disable failing tests on darwin
   doCheck = !stdenv.hostPlatform.isDarwin;

--- a/pkgs/by-name/ma/materialize/package.nix
+++ b/pkgs/by-name/ma/materialize/package.nix
@@ -118,6 +118,8 @@ rustPlatform.buildRustPackage rec {
 
     # needed to dynamically link rdkafka
     CARGO_FEATURE_DYNAMIC_LINKING = 1;
+    # Needed to get openssl-sys to use pkg-config.
+    OPENSSL_NO_VENDOR = 1;
   };
 
   cargoHash = "sha256-+OREisZ/vw3Oi5MNCYn7u06pZKtf+2trlGyn//uAGws=";
@@ -130,9 +132,6 @@ rustPlatform.buildRustPackage rec {
   ]
   # Provides the mig command used by the krb5-src build script
   ++ lib.optional stdenv.hostPlatform.isDarwin darwin.bootstrap_cmds;
-
-  # Needed to get openssl-sys to use pkg-config.
-  OPENSSL_NO_VENDOR = 1;
 
   buildInputs = [
     openssl

--- a/pkgs/by-name/md/mdbook-linkcheck/package.nix
+++ b/pkgs/by-name/md/mdbook-linkcheck/package.nix
@@ -26,7 +26,7 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = lib.optionals (!stdenv.hostPlatform.isDarwin) [ pkg-config ];
 
-  OPENSSL_NO_VENDOR = 1;
+  env.OPENSSL_NO_VENDOR = 1;
 
   doCheck = false; # tries to access network to test broken web link functionality
 

--- a/pkgs/by-name/me/meli/package.nix
+++ b/pkgs/by-name/me/meli/package.nix
@@ -42,7 +42,7 @@ rustPlatform.buildRustPackage rec {
   cargoHash = "sha256-DJtk8xLppXdl9sSt6GcaXwZ5MEIY/s/z/bdcdr8YdLw=";
 
   # Needed to get openssl-sys to use pkg-config
-  OPENSSL_NO_VENDOR = 1;
+  env.OPENSSL_NO_VENDOR = 1;
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/by-name/mo/monolith/package.nix
+++ b/pkgs/by-name/mo/monolith/package.nix
@@ -22,7 +22,7 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-rIwlNXe7me3Ehj1EIYiOYo12FQqovmZT0ui58gFRWWw=";
 
-  OPENSSL_NO_VENDOR = true;
+  env.OPENSSL_NO_VENDOR = true;
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [

--- a/pkgs/by-name/ne/nearcore/package.nix
+++ b/pkgs/by-name/ne/nearcore/package.nix
@@ -29,11 +29,13 @@ rustPlatform.buildRustPackage rec {
       --replace 'get_git_version()?' '"nix:${version}"'
   '';
 
-  CARGO_PROFILE_RELEASE_CODEGEN_UNITS = "1";
-  CARGO_PROFILE_RELEASE_LTO = "fat";
-  NEAR_RELEASE_BUILD = "release";
+  env = {
+    CARGO_PROFILE_RELEASE_CODEGEN_UNITS = "1";
+    CARGO_PROFILE_RELEASE_LTO = "fat";
+    NEAR_RELEASE_BUILD = "release";
 
-  OPENSSL_NO_VENDOR = 1; # we want to link to OpenSSL provided by Nix
+    OPENSSL_NO_VENDOR = 1; # we want to link to OpenSSL provided by Nix
+  };
 
   # don't build SDK samples that require wasm-enabled rust
   buildAndTestSubdir = "neard";

--- a/pkgs/by-name/op/openapi-tui/package.nix
+++ b/pkgs/by-name/op/openapi-tui/package.nix
@@ -19,7 +19,7 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-911ARjYvTNqLVVUWxATbtiKXOC9AqalFvDvp/qAef1Q=";
 
-  OPENSSL_NO_VENDOR = true;
+  env.OPENSSL_NO_VENDOR = true;
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ openssl ];

--- a/pkgs/by-name/pi/pixi-pack/package.nix
+++ b/pkgs/by-name/pi/pixi-pack/package.nix
@@ -26,7 +26,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   nativeBuildInputs = [ pkg-config ];
 
   # Needed to get openssl-sys to use pkgconfig.
-  OPENSSL_NO_VENDOR = 1;
+  env.OPENSSL_NO_VENDOR = 1;
 
   # Tests require downloading artifacts from conda.
   doCheck = false;

--- a/pkgs/by-name/po/polkadot/package.nix
+++ b/pkgs/by-name/po/polkadot/package.nix
@@ -68,9 +68,11 @@ rustPlatform.buildRustPackage rec {
 
   doCheck = false;
 
-  OPENSSL_NO_VENDOR = 1;
-  PROTOC = "${protobuf}/bin/protoc";
-  ROCKSDB_LIB_DIR = "${rocksdb}/lib";
+  env = {
+    OPENSSL_NO_VENDOR = 1;
+    PROTOC = "${protobuf}/bin/protoc";
+    ROCKSDB_LIB_DIR = "${rocksdb}/lib";
+  };
 
   meta = {
     description = "Implementation of a https://polkadot.network node in Rust based on the Substrate framework";

--- a/pkgs/by-name/pr/prisma-engines_6/package.nix
+++ b/pkgs/by-name/pr/prisma-engines_6/package.nix
@@ -24,7 +24,7 @@ rustPlatform.buildRustPackage rec {
   cargoHash = "sha256-PgCfBcmK9RCA5BMacJ5oYEpo2DnBKx2xPbdLb79yCCY=";
 
   # Use system openssl.
-  OPENSSL_NO_VENDOR = 1;
+  env.OPENSSL_NO_VENDOR = 1;
 
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/by-name/ra/railway/package.nix
+++ b/pkgs/by-name/ra/railway/package.nix
@@ -22,7 +22,7 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = [ openssl ];
 
-  OPENSSL_NO_VENDOR = 1;
+  env.OPENSSL_NO_VENDOR = 1;
 
   meta = {
     mainProgram = "railway";

--- a/pkgs/by-name/ru/rust-motd/package.nix
+++ b/pkgs/by-name/ru/rust-motd/package.nix
@@ -27,7 +27,7 @@ rustPlatform.buildRustPackage rec {
     openssl
   ];
 
-  OPENSSL_NO_VENDOR = 1;
+  env.OPENSSL_NO_VENDOR = 1;
 
   meta = {
     description = "Beautiful, useful MOTD generation with zero runtime dependencies";

--- a/pkgs/by-name/ru/rustfinity/package.nix
+++ b/pkgs/by-name/ru/rustfinity/package.nix
@@ -20,7 +20,7 @@ rustPlatform.buildRustPackage rec {
   nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ pkg-config ];
   buildInputs = lib.optionals stdenv.hostPlatform.isLinux [ openssl ];
 
-  OPENSSL_NO_VENDOR = 1;
+  env.OPENSSL_NO_VENDOR = 1;
 
   # Requires network and fs access
   checkFlags = [

--- a/pkgs/by-name/ru/rustus/package.nix
+++ b/pkgs/by-name/ru/rustus/package.nix
@@ -24,10 +24,12 @@ rustPlatform.buildRustPackage {
 
   cargoHash = "sha256-df92+gp/DtdHwPxJF89zKHjmVWzfrjnD8wAlrPRyyxk=";
 
-  env.OPENSSL_NO_VENDOR = 1;
+  env = {
+    OPENSSL_NO_VENDOR = 1;
 
-  # needed to dynamically link rdkafka
-  CARGO_FEATURE_DYNAMIC_LINKING = 1;
+    # needed to dynamically link rdkafka
+    CARGO_FEATURE_DYNAMIC_LINKING = 1;
+  };
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/by-name/sn/snarkos/package.nix
+++ b/pkgs/by-name/sn/snarkos/package.nix
@@ -27,16 +27,18 @@ rustPlatform.buildRustPackage rec {
     rustPlatform.bindgenHook
   ];
 
-  # Needed to get openssl-sys to use pkg-config.
-  OPENSSL_NO_VENDOR = 1;
-  OPENSSL_LIB_DIR = "${lib.getLib openssl}/lib";
-  OPENSSL_DIR = "${lib.getDev openssl}";
+  env = {
+    # Needed to get openssl-sys to use pkg-config.
+    OPENSSL_NO_VENDOR = 1;
+    OPENSSL_LIB_DIR = "${lib.getLib openssl}/lib";
+    OPENSSL_DIR = "${lib.getDev openssl}";
 
-  # TODO check why rust compilation fails by including the rocksdb from nixpkgs
-  # Used by build.rs in the rocksdb-sys crate. If we don't set these, it would
-  # try to build RocksDB from source.
-  # ROCKSDB_INCLUDE_DIR="${rocksdb}/include";
-  # ROCKSDB_LIB_DIR="${rocksdb}/lib";
+    # TODO check why rust compilation fails by including the rocksdb from nixpkgs
+    # Used by build.rs in the rocksdb-sys crate. If we don't set these, it would
+    # try to build RocksDB from source.
+    # ROCKSDB_INCLUDE_DIR="${rocksdb}/include";
+    # ROCKSDB_LIB_DIR="${rocksdb}/lib";
+  };
 
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
     curl

--- a/pkgs/by-name/so/solana-cli/package.nix
+++ b/pkgs/by-name/so/solana-cli/package.nix
@@ -55,8 +55,11 @@ rustPlatform.buildRustPackage rec {
 
   strictDeps = true;
   cargoBuildFlags = map (n: "--bin=${n}") solanaPkgs;
-  RUSTFLAGS = "-Amismatched_lifetime_syntaxes -Adead_code -Aunused_parens";
-  LIBCLANG_PATH = "${libclang.lib}/lib";
+
+  env = {
+    RUSTFLAGS = "-Amismatched_lifetime_syntaxes -Adead_code -Aunused_parens";
+    LIBCLANG_PATH = "${libclang.lib}/lib";
+  };
 
   # Even tho the tests work, a shit ton of them try to connect to a local RPC
   # or access internet in other ways, eventually failing due to Nix sandbox.
@@ -96,17 +99,19 @@ rustPlatform.buildRustPackage rec {
     find . -name libsolana_program.rlib -exec cp {} $out/bin/deps \;
   '';
 
-  # Used by build.rs in the rocksdb-sys crate. If we don't set these, it would
-  # try to build RocksDB from source.
-  ROCKSDB_LIB_DIR = "${rocksdb}/lib";
+  env = {
+    # Used by build.rs in the rocksdb-sys crate. If we don't set these, it would
+    # try to build RocksDB from source.
+    ROCKSDB_LIB_DIR = "${rocksdb}/lib";
 
-  # Require this on darwin otherwise the compiler starts rambling about missing
-  # cmath functions
-  CPPFLAGS = lib.optionals stdenv.hostPlatform.isDarwin "-isystem ${lib.getInclude stdenv.cc.libcxx}/include/c++/v1";
-  LDFLAGS = lib.optionals stdenv.hostPlatform.isDarwin "-L${lib.getLib stdenv.cc.libcxx}/lib";
+    # Require this on darwin otherwise the compiler starts rambling about missing
+    # cmath functions
+    CPPFLAGS = lib.optionals stdenv.hostPlatform.isDarwin "-isystem ${lib.getInclude stdenv.cc.libcxx}/include/c++/v1";
+    LDFLAGS = lib.optionals stdenv.hostPlatform.isDarwin "-L${lib.getLib stdenv.cc.libcxx}/lib";
 
-  # If set, always finds OpenSSL in the system, even if the vendored feature is enabled.
-  OPENSSL_NO_VENDOR = 1;
+    # If set, always finds OpenSSL in the system, even if the vendored feature is enabled.
+    OPENSSL_NO_VENDOR = 1;
+  };
 
   meta = {
     description = "Web-Scale Blockchain for fast, secure, scalable, decentralized apps and marketplaces";

--- a/pkgs/by-name/sq/squawk/package.nix
+++ b/pkgs/by-name/sq/squawk/package.nix
@@ -31,9 +31,11 @@ rustPlatform.buildRustPackage rec {
     openssl
   ];
 
-  OPENSSL_NO_VENDOR = 1;
+  env = {
+    OPENSSL_NO_VENDOR = 1;
 
-  LIBPG_QUERY_PATH = libpg_query;
+    LIBPG_QUERY_PATH = libpg_query;
+  };
 
   checkFlags = [
     # depends on the PostgreSQL version

--- a/pkgs/by-name/sv/svix-server/package.nix
+++ b/pkgs/by-name/sv/svix-server/package.nix
@@ -30,11 +30,13 @@ rustPlatform.buildRustPackage rec {
     protobuf
   ];
 
-  # needed for internal protobuf c wrapper library
-  PROTOC = "${protobuf}/bin/protoc";
-  PROTOC_INCLUDE = "${protobuf}/include";
+  env = {
+    # needed for internal protobuf c wrapper library
+    PROTOC = "${protobuf}/bin/protoc";
+    PROTOC_INCLUDE = "${protobuf}/include";
 
-  OPENSSL_NO_VENDOR = 1;
+    OPENSSL_NO_VENDOR = 1;
+  };
 
   # disable tests because they require postgres and redis to be running
   doCheck = false;

--- a/pkgs/by-name/te/termscp/package.nix
+++ b/pkgs/by-name/te/termscp/package.nix
@@ -35,7 +35,7 @@ rustPlatform.buildRustPackage rec {
   ];
 
   # Needed to get openssl-sys to use pkg-config.
-  OPENSSL_NO_VENDOR = 1;
+  env.OPENSSL_NO_VENDOR = 1;
 
   nativeInstallCheckInputs = [
     versionCheckHook

--- a/pkgs/by-name/tr/transmission-rss/package.nix
+++ b/pkgs/by-name/tr/transmission-rss/package.nix
@@ -24,7 +24,7 @@ rustPlatform.buildRustPackage {
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ openssl ];
 
-  OPENSSL_NO_VENDOR = 1;
+  env.OPENSSL_NO_VENDOR = 1;
 
   meta = {
     description = "Add torrents to transmission based on RSS list";

--- a/pkgs/by-name/we/websocat/package.nix
+++ b/pkgs/by-name/we/websocat/package.nix
@@ -51,7 +51,7 @@ rustPlatform.buildRustPackage rec {
   buildFeatures = [ "ssl" ];
 
   # Needed to get openssl-sys to use pkg-config.
-  OPENSSL_NO_VENDOR = 1;
+  env.OPENSSL_NO_VENDOR = 1;
 
   # The wrapping is required so that the "sh-c" option of websocat works even
   # if sh is not in the PATH (as can happen, for instance, when websocat is

--- a/pkgs/by-name/wr/wrangler_1/package.nix
+++ b/pkgs/by-name/wr/wrangler_1/package.nix
@@ -32,7 +32,7 @@ rustPlatform.buildRustPackage rec {
     libiconv
   ];
 
-  OPENSSL_NO_VENDOR = 1;
+  env.OPENSSL_NO_VENDOR = 1;
 
   # tries to use "/homeless-shelter" and fails
   doCheck = false;

--- a/pkgs/by-name/xi/xiu/package.nix
+++ b/pkgs/by-name/xi/xiu/package.nix
@@ -34,7 +34,7 @@ rustPlatform.buildRustPackage rec {
     openssl
   ];
 
-  OPENSSL_NO_VENDOR = 1;
+  env.OPENSSL_NO_VENDOR = 1;
 
   meta = {
     description = "Simple, high performance and secure live media server in pure Rust (RTMP[cluster]/RTSP/WebRTC[whip/whep]/HTTP-FLV/HLS";

--- a/pkgs/servers/web-apps/lemmy/server.nix
+++ b/pkgs/servers/web-apps/lemmy/server.nix
@@ -39,15 +39,17 @@ rustPlatform.buildRustPackage rec {
     libiconv
   ];
 
-  # Using OPENSSL_NO_VENDOR is not an option on darwin
-  # As of version 0.10.35 rust-openssl looks for openssl on darwin
-  # with a hardcoded path to /usr/lib/libssl.x.x.x.dylib
-  # https://github.com/sfackler/rust-openssl/blob/master/openssl-sys/build/find_normal.rs#L115
-  OPENSSL_LIB_DIR = "${lib.getLib openssl}/lib";
-  OPENSSL_INCLUDE_DIR = "${openssl.dev}/include";
+  env = {
+    # Using OPENSSL_NO_VENDOR is not an option on darwin
+    # As of version 0.10.35 rust-openssl looks for openssl on darwin
+    # with a hardcoded path to /usr/lib/libssl.x.x.x.dylib
+    # https://github.com/sfackler/rust-openssl/blob/master/openssl-sys/build/find_normal.rs#L115
+    OPENSSL_LIB_DIR = "${lib.getLib openssl}/lib";
+    OPENSSL_INCLUDE_DIR = "${openssl.dev}/include";
 
-  PROTOC = "${protobuf}/bin/protoc";
-  PROTOC_INCLUDE = "${protobuf}/include";
+    PROTOC = "${protobuf}/bin/protoc";
+    PROTOC_INCLUDE = "${protobuf}/include";
+  };
   nativeBuildInputs = [
     protobuf
     rustfmt

--- a/pkgs/tools/filesystems/garage/default.nix
+++ b/pkgs/tools/filesystems/garage/default.nix
@@ -45,7 +45,7 @@ let
         cacert
       ];
 
-      OPENSSL_NO_VENDOR = true;
+      env.OPENSSL_NO_VENDOR = true;
 
       # See https://git.deuxfleurs.fr/Deuxfleurs/garage/src/tag/v2.1.0/nix/compile.nix#L71-L78
       # on version changes for checking if changes are required here


### PR DESCRIPTION
Also a bunch of other environment variables found along the way.

Should be zero rebuilds.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
