### PR TITLE
subconverter: init at 0.9.0-unstable-2025-11-08

### DIFF
--- a/pkgs/by-name/li/libcron/0001-build-find-date-from-system-libaries.patch
+++ b/pkgs/by-name/li/libcron/0001-build-find-date-from-system-libaries.patch
@@ -1,0 +1,112 @@
+From 66199d9383e32e3cfcb04ab23d830a222478adb1 Mon Sep 17 00:00:00 2001
+From: Moraxyc <i@qaq.li>
+Date: Sun, 21 Dec 2025 12:45:57 +0800
+Subject: [PATCH] build: find date from system libaries
+
+---
+ CMakeLists.txt         |  2 --
+ libcron/CMakeLists.txt |  5 ++++-
+ test/CMakeLists.txt    | 15 ++++++++++-----
+ test/CronTest.cpp      |  2 +-
+ 4 files changed, 15 insertions(+), 9 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9a994d5..4a232b0 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -8,5 +8,3 @@ add_dependencies(cron_test libcron)
+ 
+ install(TARGETS libcron DESTINATION lib)
+ install(DIRECTORY libcron/include/libcron DESTINATION include)
+-install(DIRECTORY libcron/externals/date/include/date DESTINATION include)
+-
+diff --git a/libcron/CMakeLists.txt b/libcron/CMakeLists.txt
+index 6511821..d47becb 100644
+--- a/libcron/CMakeLists.txt
++++ b/libcron/CMakeLists.txt
+@@ -1,6 +1,8 @@
+ cmake_minimum_required(VERSION 3.6)
+ project(libcron)
+ 
++find_package(date REQUIRED)
++
+ set(CMAKE_CXX_STANDARD 17)
+ 
+ # Deactivate Iterator-Debugging on Windows
+@@ -31,8 +33,9 @@ add_library(${PROJECT_NAME}
+ 		src/CronSchedule.cpp
+ 		src/Task.cpp)
+ 
++target_link_libraries(${PROJECT_NAME} PUBLIC date::date)
++
+ target_include_directories(${PROJECT_NAME}
+-		PUBLIC ${CMAKE_CURRENT_LIST_DIR}/externals/date/include
+ 		PUBLIC include)
+ 
+ if(NOT MSVC)
+diff --git a/test/CMakeLists.txt b/test/CMakeLists.txt
+index 5755431..499ba86 100644
+--- a/test/CMakeLists.txt
++++ b/test/CMakeLists.txt
+@@ -1,6 +1,8 @@
+ cmake_minimum_required(VERSION 3.6)
+ project(cron_test)
+ 
++find_package(Catch2 REQUIRED)
++
+ set(CMAKE_CXX_STANDARD 17)
+ 
+ # Deactivate Iterator-Debugging on Windows
+@@ -8,7 +10,7 @@ option(LIBCRON_DEACTIVATE_ITERATOR_DEBUGGING "Build with iterator-debugging (MSV
+ 
+ if( MSVC )
+         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4")
+-        
++
+ 	if (LIBCRON_DEACTIVATE_ITERATOR_DEBUGGING)
+ 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_HAS_ITERATOR_DEBUGGING=0")
+ 	endif()
+@@ -17,8 +19,6 @@ else()
+ endif()
+ 
+ include_directories(
+-        ${CMAKE_CURRENT_LIST_DIR}/externals/Catch2/single_include/catch2
+-        ${CMAKE_CURRENT_LIST_DIR}/../libcron/externals/date/include
+         ${CMAKE_CURRENT_LIST_DIR}/..
+ )
+ 
+@@ -30,12 +30,17 @@ add_executable(
+ 	CronTest.cpp)
+ 
+ if(NOT MSVC)
+-	target_link_libraries(${PROJECT_NAME} libcron pthread)
++	target_link_libraries(${PROJECT_NAME} libcron Catch2::Catch2 pthread)
+ 
+ 	# Assume a modern compiler supporting uncaught_exceptions()
+ 	target_compile_definitions (${PROJECT_NAME} PRIVATE -DHAS_UNCAUGHT_EXCEPTIONS)
+ else()
+-	target_link_libraries(${PROJECT_NAME} libcron)
++	target_link_libraries(${PROJECT_NAME} libcron Catch2::Catch2)
++endif()
++
++if(TARGET Catch2::Catch2)
++    get_target_property(CATCH2_INC_DIR Catch2::Catch2 INTERFACE_INCLUDE_DIRECTORIES)
++    target_include_directories(${PROJECT_NAME} PRIVATE "${CATCH2_INC_DIR}/catch2")
+ endif()
+ 
+ set_target_properties(${PROJECT_NAME} PROPERTIES
+diff --git a/test/CronTest.cpp b/test/CronTest.cpp
+index 253206f..a309409 100644
+--- a/test/CronTest.cpp
++++ b/test/CronTest.cpp
+@@ -1,6 +1,6 @@
+ #include <catch.hpp>
+ #include <libcron/include/libcron/Cron.h>
+-#include <libcron/externals/date/include/date/date.h>
++#include <date/date.h>
+ #include <thread>
+ #include <iostream>
+ 
+-- 
+2.51.2
+

--- a/pkgs/by-name/li/libcron/package.nix
+++ b/pkgs/by-name/li/libcron/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  nix-update-script,
+  catch2,
+
+  howard-hinnant-date,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libcron";
+  version = "1.3.3";
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "PerMalmberg";
+    repo = "libcron";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-DENyjZHG0xBJU/+e/K4xhhoMLSqHIV1VoYcAHX/mQqw=";
+  };
+
+  patches = [
+    # To avoid using the vendored dependencies
+    ./0001-build-find-date-from-system-libaries.patch
+  ];
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    catch2
+    howard-hinnant-date
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "C++ scheduling library using cron formatting";
+    homepage = "https://github.com/PerMalmberg/libcron";
+    changelog = "https://github.com/PerMalmberg/libcron/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ moraxyc ];
+  };
+})

--- a/pkgs/by-name/qu/quickjspp/package.nix
+++ b/pkgs/by-name/qu/quickjspp/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+
+  cmake,
+  ninja,
+  unstableGitUpdater,
+
+  quickjs,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "quickjspp";
+  version = "0-unstable-2025-07-04";
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "ftk";
+    repo = "quickjspp";
+    rev = "01cdd3047ced48265b127790848a0ca88204f2c7";
+    hash = "sha256-mjnkbx/6DT0MXdeqA/2/CaMQy/iAUjIaGJT1Oi+JEqg=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+  ];
+
+  propagatedBuildInputs = [ quickjs ];
+
+  passthru.updateScript = unstableGitUpdater { hardcodeZeroVersion = true; };
+
+  meta = {
+    description = "QuickJS C++ wrapper";
+    homepage = "https://github.com/ftk/quickjspp";
+    license = lib.licenses.cc0;
+    maintainers = with lib.maintainers; [ moraxyc ];
+  };
+})

--- a/pkgs/by-name/su/subconverter/package.nix
+++ b/pkgs/by-name/su/subconverter/package.nix
@@ -1,0 +1,110 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+
+  cmake,
+  pkg-config,
+  nix-update-script,
+
+  curl,
+  libcron,
+  pcre2,
+  quickjs,
+  quickjspp,
+  rapidjson,
+  toml11,
+  yaml-cpp,
+  howard-hinnant-date,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "subconverter";
+  version = "0.9.0-unstable-2026-02-27";
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "tindy2013";
+    repo = "subconverter";
+    rev = "5b8d3af0d7b659e3ff6029560e4a6811538a9c21";
+    hash = "sha256-gfzjH/KtgcfESv3SjJSRsx6GmoDbhjfPI7B9NdfyV9o=";
+  };
+
+  postPatch = ''
+    substituteInPlace src/main.cpp \
+      --replace-fail 'setcd(prgpath);' '// setcd(prgpath); read-only nix store'
+  '';
+
+  outputs = [
+    "out"
+    "data"
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    curl
+    toml11
+    yaml-cpp
+    pcre2
+    quickjs
+    quickjspp
+    libcron
+    rapidjson
+    howard-hinnant-date
+  ];
+
+  # Fix link error by aliasing the unhandled promise API to the legacy symbol.
+  #   undefined reference to `JS_SetHostUnhandledPromiseRejectionTracker'
+  cmakeFlags = [
+    (lib.cmakeFeature "CMAKE_CXX_FLAGS" "-DJS_SetHostUnhandledPromiseRejectionTracker=JS_SetHostPromiseRejectionTracker")
+  ];
+
+  # to fix `realpath` buffer overflow detection crash
+  hardeningDisable = [ "fortify" ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 subconverter $out/bin/subconverter
+    cp -r $src/base $data
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Utility to convert between various subscription format";
+    longDescription = ''
+      Subconverter is a tool to convert between various subscription formats.
+
+      Note:
+      Unlike the upstream releases, this package does not include
+      configuration files alongside the binary in the read-only Nix store.
+      It runs in your current working directory.
+
+      To run subconverter properly, prepare a working directory with
+      the configuration files.
+
+      ```bash
+      mkdir -p ~/subconverter && cd ~/subconverter
+
+      # Copy default assets
+      cp -r $(nix-build '<nixpkgs>' -A subconverter.data --no-out-link)/* .
+      chmod -R +w .
+
+      subconverter
+      ```
+    '';
+    homepage = "https://github.com/tindy2013/subconverter";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ moraxyc ];
+    mainProgram = "subconverter";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
- [libcron](https://github.com/PerMalmberg/libcron): init at 1.3.3
- [quickjspp](https://github.com/ftk/quickjspp): init at 0-unstable-2025-07-04
- [subconverter](https://github.com/tindy2013/subconverter): init at 0.9.0-unstable-2026-02-27

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
