### PR TITLE
freecad: wrapGApps

### DIFF
--- a/pkgs/by-name/fr/freecad/package.nix
+++ b/pkgs/by-name/fr/freecad/package.nix
@@ -4,6 +4,7 @@
   cmake,
   coin3d,
   doxygen,
+  wrapGAppsHook3,
   eigen,
   fetchFromGitHub,
   fetchpatch,
@@ -71,6 +72,7 @@ freecad-utils.makeCustomizable (
       pkg-config
       swig
       doxygen
+      wrapGAppsHook3
       qt6.wrapQtAppsHook
     ];
 
@@ -131,6 +133,8 @@ freecad-utils.makeCustomizable (
       "-DBUILD_QT6=ON"
     ];
 
+    dontWrapGApps = true;
+
     qtWrapperArgs =
       let
         binPath = lib.makeBinPath [
@@ -142,6 +146,7 @@ freecad-utils.makeCustomizable (
         "--set COIN_GL_NO_CURRENT_CONTEXT_CHECK 1"
         "--prefix PATH : ${binPath}"
         "--prefix PYTHONPATH : ${python3Packages.makePythonPath pythonDeps}"
+        "\${gappsWrapperArgs[@]}"
       ];
 
     postFixup = ''


### PR DESCRIPTION
fix https://github.com/NixOS/nixpkgs/issues/467783
supersede https://github.com/NixOS/nixpkgs/pull/470594

cc @srounce
How do we know an application should be gappwrapped if we don't have thouse gtk depends in buildInputs? 

## Things done

```
> nix develop .#freecad
> gappsWrapperArgsHook 

> echo ${gappsWrapperArgs[@]}
--prefix GIO_EXTRA_MODULES : /nix/store/2rmi134a24nhc5yj79fif5imj57ij9ix-dconf-0.49.0-lib/lib/gio/modules --prefix GIO_EXTRA_MODULES : /nix/store/2rmi134a24nhc5yj79fif5imj57ij9ix-dconf-0.49.0-lib/lib/gio/modules --set GDK_PIXBUF_MODULE_FILE /nix/store/macica20pv99l5h35hjyy4fh3l8qvn62-librsvg-2.61.3/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache --prefix XDG_DATA_DIRS : /nix/store/asyx6hpiyah9kwsk03j8g1dcqgm5gmf4-gsettings-desktop-schemas-49.1/share/gsettings-schemas/gsettings-desktop-schemas-49.1:/nix/store/w9li4sk4g2ijslh3nbyl60mbb1rfjgc8-gtk+3-3.24.51/share/gsettings-schemas/gtk+3-3.24.51:/nix/store/219hncmrc1bfnf6vlr5s9m395pygxiy0-pulseaudio-17.0/share/gsettings-schemas/pulseaudio-17.0:/nix/store/dh752ravf4jlgd1p6adyc3zy2lzpapd7-pipewire-1.4.9/share/gsettings-schemas/pipewire-1.4.9
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
