### PR TITLE
xorg-server: fix runtime errors

### DIFF
--- a/pkgs/by-name/xo/xorg-server/package.nix
+++ b/pkgs/by-name/xo/xorg-server/package.nix
@@ -151,6 +151,14 @@ stdenv.mkDerivation (finalAttrs: {
     mesa
   ];
 
+  hardeningDisable = [
+    # Removing this breaks GLAMOR due to failing to find libgbm symbols at runtime:
+    # Failed to load /...modesetting_drv.so: /...modesetting_drv.so: undefined symbol: gbm_bo_get_plane_count
+    # This is likely some load order weirdness, but we don't have a better solution for now.
+    # FIXME: fix this properly.
+    "bindnow"
+  ];
+
   propagatedBuildInputs = [
     dbus
     libepoxy


### PR DESCRIPTION
- add "bindnow" to `hardeningDisable`

Previously was there for 10 years:
https://github.com/NixOS/nixpkgs/commit/f519a255a56e7c42d04d1beb666d685078cc7e18

Removed during refactor:
https://github.com/NixOS/nixpkgs/commit/f7764be128f09512e80b7a911728ae52089cb959

Fixes runtime errors in nixos tests using `xorg-server`:
```
xserver-wrapper[823]: (II) LoadModule: "modesetting"
xserver-wrapper[823]: (II) Loading
/nix/store/lrbawv4ccl0x12nwrmbbzpxmzjj1z5r6-xorg-server-21.1.20/lib/xorg/modules/drivers/modesetting_drv.so
xserver-wrapper[823]: (EE) Failed to load
/nix/store/lrbawv4ccl0x12nwrmbbzpxmzjj1z5r6-xorg-server-21.1.20/lib/xorg/modules/drivers/modesetting_drv.so:
/nix/store/lrbawv4ccl0x12nwrmbbzpxmzjj1z5r6-xorg-server-21.1.20/lib/xorg/modules/drivers/modesetting_drv.so:
undefined symbol: gbm_bo_get_plane_count
xserver-wrapper[823]: (EE) Failed to load module "modesetting" (loader failed, 0)
xserver-wrapper[823]: (EE) No drivers available.
```

---

Added comment inside in case it ever comes up again as it was not easy to find.

Tested build of nixos tests that failed on `staging-next` with this error:
```text
nixosTests.plasma6
nixosTests.ly
nixosTests.sddm.default
nixosTests.keymap.azerty
```

Related to refactor PR: #446052
Noticed that it mentioned running nixosTests that now fail without this fix (`nixosTests.xterm`, `nixosTests.sx`), but I can't explain why.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
