### PR TITLE
mtree: init at 1.0.0-unstable-2022-05-19

### DIFF
--- a/pkgs/by-name/mt/mtree/0001-Port-to-Linux-with-libbsd-and-libmd.patch
+++ b/pkgs/by-name/mt/mtree/0001-Port-to-Linux-with-libbsd-and-libmd.patch
@@ -1,0 +1,364 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Philip Taron <philip.taron@gmail.com>
+Date: Fri, 19 Dec 2025 16:12:14 -0800
+Subject: [PATCH] Port to Linux with libbsd and libmd.
+
+ - Add libbsd and libmd as build dependencies
+ - Add BSD header includes (bsd/pwd.h, bsd/grp.h, bsd/libutil.h, bsd/stdlib.h, bsd/unistd.h, bsd/vis.h, sys/time.h)
+ - Add S_ISTXT -> S_ISVTX compatibility define for sticky bit
+ - Fix __RCSID guards in pack_dev.c and stat_flags.c
+ - Fix string.h typo in getid.c (was stringh.h)
+ - Add UID_MAX/GID_MAX fallback defines
+ - Guard pwcache_groupdb/pwcache_userdb calls (not available on Linux)
+ - Fix invalid free() of static buffer from flags_to_string()
+
+Signed-off-by: Philip Taron <philip.taron@gmail.com>
+---
+ compare.c    | 27 +++++++++++++--------------
+ configure.ac |  9 +++++++++
+ create.c     | 17 +++++++++++------
+ excludes.c   |  3 +++
+ getid.c      | 18 ++++++++++++++++--
+ mtree.c      |  3 +++
+ mtree.h      |  5 +++++
+ only.c       |  3 +++
+ pack_dev.c   |  2 +-
+ spec.c       | 24 +++++++++++++++++++++---
+ stat_flags.c |  2 +-
+ 11 files changed, 86 insertions(+), 27 deletions(-)
+
+diff --git a/compare.c b/compare.c
+index 11462b2e10264b533c2c428756da884c424e73a8..356d067abbd86839961ec0581ee7c49ceab78f0a 100644
+--- a/compare.c
++++ b/compare.c
+@@ -57,6 +57,9 @@ __RCSID("$NetBSD: compare.c,v 1.60 2021/04/03 13:37:18 simonb Exp $");
+ #if HAVE_STRING_H
+ #include <string.h>
+ #endif
++#if HAVE_SYS_TIME_H
++#include <sys/time.h>
++#endif
+ #if HAVE_TIME_H
+ #include <time.h>
+ #endif
+@@ -126,21 +129,19 @@ do {									\
+ 
+ #define CHANGEFLAGS							\
+ 	if (flags != p->fts_statp->st_flags) {				\
+-		char *sf;						\
++		/* flags_to_string returns a static buffer - do not free */ \
+ 		if (!label) {						\
+ 			MARK;						\
+-			sf = flags_to_string(p->fts_statp->st_flags, "none"); \
+-			printf("%sflags (\"%s\"", tab, sf);		\
+-			free(sf);					\
++			printf("%sflags (\"%s\"", tab,			\
++			    flags_to_string(p->fts_statp->st_flags, "none")); \
+ 		}							\
+ 		if (lchflags(p->fts_accpath, flags)) {			\
+ 			label++;					\
+ 			printf(", not modified: %s)\n",			\
+ 			    strerror(errno));				\
+ 		} else {						\
+-			sf = flags_to_string(flags, "none");		\
+-			printf(", modified to \"%s\")\n", sf);		\
+-			free(sf);					\
++			printf(", modified to \"%s\")\n",		\
++			    flags_to_string(flags, "none"));		\
+ 		}							\
+ 	}
+ 
+@@ -416,16 +417,14 @@ typeerr:		LABEL;
+         if ((s->flags & F_FLAGS) && ((s->st_flags != p->fts_statp->st_flags)
+ 	    || mflag || iflag)) {
+ 		if (s->st_flags != p->fts_statp->st_flags) {
+-			char *f_s;
++			/* flags_to_string returns a static buffer - do not free */
+ 			LABEL;
+-			f_s = flags_to_string(s->st_flags, "none");
+ 			printf(flavor == F_FREEBSD9 ?
+ 			    "%sflags expected \"%s\" found " :
+-			    "%sflags (\"%s\" is not ", tab, f_s);
+-			free(f_s);
+-			f_s = flags_to_string(p->fts_statp->st_flags, "none");
+-			printf("\"%s\"", f_s);
+-			free(f_s);
++			    "%sflags (\"%s\" is not ", tab,
++			    flags_to_string(s->st_flags, "none"));
++			printf("\"%s\"",
++			    flags_to_string(p->fts_statp->st_flags, "none"));
+ 		}
+ 		if (uflag) {
+ 			if (iflag)
+diff --git a/configure.ac b/configure.ac
+index ed44b7e5c122744b9bf1719d6f5177fa91787421..4ade3837d7370182f97f926c396bd68d9d029d11 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -29,9 +29,16 @@ AC_CHECK_HEADERS([ \
+ 	sys/queue.h \
+ 	sys/stat.h \
+ 	sys/sysmacros.h \
++	sys/time.h \
+ 	sys/types.h \
+ 	assert.h \
++	bsd/grp.h \
++	bsd/libutil.h \
++	bsd/pwd.h \
++	bsd/stdlib.h \
+ 	bsd/sys/cdefs.h \
++	bsd/unistd.h \
++	bsd/vis.h \
+ 	ctype.h \
+ 	dirent.h \
+ 	err.h \
+@@ -86,6 +93,8 @@ AH_BOTTOM([/* Define to 1 if the user- and root-changeable masks were detected *
+ # Checks for library functions.
+ AC_REPLACE_FNMATCH
+ AC_CHECK_FUNCS([ \
++	pwcache_groupdb \
++	pwcache_userdb \
+ 	endgrent \
+ 	endpwent \
+ 	getcwd \
+diff --git a/create.c b/create.c
+index f32d6f3522a9c1176144f60c502ec18a03677b40..0a6f85fbe879eb5f70562c8da74f200441544b3b 100644
+--- a/create.c
++++ b/create.c
+@@ -48,9 +48,15 @@ __RCSID("$NetBSD: create.c,v 1.76 2018/11/18 23:03:36 sevan Exp $");
+ #if HAVE_GRP_H
+ #include <grp.h>
+ #endif
++#if HAVE_BSD_GRP_H
++#include <bsd/grp.h>
++#endif
+ #if HAVE_PWD_H
+ #include <pwd.h>
+ #endif
++#if HAVE_BSD_PWD_H
++#include <bsd/pwd.h>
++#endif
+ #if HAVE_STDARG_H
+ #include <stdarg.h>
+ #endif
+@@ -376,9 +382,9 @@ statf(FILE *fp, int indent, FTSENT *p)
+ 		    vispath(rlink(p->fts_accpath)));
+ #if HAVE_STRUCT_STAT_ST_FLAGS
+ 	if (keys & F_FLAGS && p->fts_statp->st_flags != flags) {
+-		char *str = flags_to_string(p->fts_statp->st_flags, "none");
+-		output(fp, indent, &offset, "flags=%s", str);
+-		free(str);
++		/* flags_to_string returns a static buffer - do not free */
++		output(fp, indent, &offset, "flags=%s",
++		    flags_to_string(p->fts_statp->st_flags, "none"));
+ 	}
+ #endif
+ 	putchar('\n');
+@@ -497,9 +503,8 @@ statd(FILE *fp, FTS *t, FTSENT *parent, uid_t *puid, gid_t *pgid, mode_t *pmode,
+ 		if (keys & F_NLINK)
+ 			fprintf(fp, " nlink=1");
+ 		if (keys & F_FLAGS) {
+-			char *str = flags_to_string(saveflags, "none");
+-			fprintf(fp, " flags=%s", str);
+-			free(str);
++			/* flags_to_string returns a static buffer - do not free */
++			fprintf(fp, " flags=%s", flags_to_string(saveflags, "none"));
+ 		}
+ 		fprintf(fp, "\n");
+ 		*puid = saveuid;
+diff --git a/excludes.c b/excludes.c
+index abdff4d54afa989b83861763e908e4ce7c1341c8..dcd5b61bb523701aeb9485ed285a03056e860793 100644
+--- a/excludes.c
++++ b/excludes.c
+@@ -49,6 +49,9 @@ __RCSID("$NetBSD: excludes.c,v 1.13 2004/06/20 22:20:18 jmc Exp $");
+ #if HAVE_LIBUTIL_H
+ #include <libutil.h>
+ #endif
++#if HAVE_BSD_LIBUTIL_H
++#include <bsd/libutil.h>
++#endif
+ #if HAVE_UTIL_H
+ #include <util.h>
+ #endif
+diff --git a/getid.c b/getid.c
+index 522d4a379a1d7d84d75445e8b6b6459b7a270c32..854710b21bd55c676cf2f4e47ada49236863db7a 100644
+--- a/getid.c
++++ b/getid.c
+@@ -49,8 +49,8 @@ __RCSID("$NetBSD: getid.c,v 1.10 2014/10/27 21:46:45 christos Exp $");
+ #if HAVE_STDLIB_H
+ #include <stdlib.h>
+ #endif
+-#if HAVE_STRINGH_H
+-#include <stringh.h>
++#if HAVE_STRING_H
++#include <string.h>
+ #endif
+ #if HAVE_TIME_H
+ #include <time.h>
+@@ -61,6 +61,14 @@ __RCSID("$NetBSD: getid.c,v 1.10 2014/10/27 21:46:45 christos Exp $");
+ 
+ #include "extern.h"
+ 
++/* BSD UID_MAX/GID_MAX - fall back to UINT_MAX if not defined */
++#ifndef UID_MAX
++#define UID_MAX UINT_MAX
++#endif
++#ifndef GID_MAX
++#define GID_MAX UINT_MAX
++#endif
++
+ static	struct group *	gi_getgrnam(const char *);
+ static	struct group *	gi_getgrgid(gid_t);
+ static	int		gi_setgroupent(int);
+@@ -115,11 +123,17 @@ setup_getid(const char *dir)
+ 		return (0);
+ 
+ 				/* switch pwcache(3) lookup functions */
++#if HAVE_PWCACHE_GROUPDB && HAVE_PWCACHE_USERDB
+ 	if (pwcache_groupdb(gi_setgroupent, gi_endgrent,
+ 			    gi_getgrnam, gi_getgrgid) == -1
+ 	    || pwcache_userdb(gi_setpassent, gi_endpwent,
+ 			    gi_getpwnam, gi_getpwuid) == -1)
+ 		return (0);
++#else
++	/* pwcache functions not available - custom database not supported */
++	warnx("custom password/group database not supported on this platform");
++	return (0);
++#endif
+ 
+ 	return (1);
+ }
+diff --git a/mtree.c b/mtree.c
+index 4b5f695b9c13593543dc59c5cb8cbe126a54e6d4..bedcc8ddd01051a85e1cc8989e72d9232d891dfe 100644
+--- a/mtree.c
++++ b/mtree.c
+@@ -50,6 +50,9 @@ __RCSID("$NetBSD: mtree.c,v 1.50 2015/01/23 02:27:01 christos Exp $");
+ #if HAVE_STDLIB_H
+ #include <stdlib.h>
+ #endif
++#if HAVE_BSD_STDLIB_H
++#include <bsd/stdlib.h>
++#endif
+ #if HAVE_STRING_H
+ #include <string.h>
+ #endif
+diff --git a/mtree.h b/mtree.h
+index e9df5fa8e61f5743d8df49c66fcb680c67cb1967..e54ad13374db630000c2fe29e5993c175c1b7656 100644
+--- a/mtree.h
++++ b/mtree.h
+@@ -11,6 +11,11 @@
+ #ifndef _MTREE_H_
+ #define	_MTREE_H_
+ 
++/* BSD uses S_ISTXT for the sticky bit, Linux uses S_ISVTX */
++#ifndef S_ISTXT
++#define	S_ISTXT	S_ISVTX
++#endif
++
+ #define	KEYDEFAULT	(F_GID | F_MODE | F_NLINK | F_SIZE | F_SLINK | \
+ 			F_TIME | F_TYPE | F_UID | F_FLAGS)
+ 
+diff --git a/only.c b/only.c
+index bf721dd17309eca0ed4012ba337df0c62693d366..ad73cce9201e753b763f095af48758ea5d74012e 100644
+--- a/only.c
++++ b/only.c
+@@ -51,6 +51,9 @@ __RCSID("$NetBSD: only.c,v 1.3 2017/09/07 04:04:13 nakayama Exp $");
+ #if HAVE_LIBUTIL_H
+ #include <libutil.h>
+ #endif
++#if HAVE_BSD_LIBUTIL_H
++#include <bsd/libutil.h>
++#endif
+ #if HAVE_UTIL_H
+ #include <util.h>
+ #endif
+diff --git a/pack_dev.c b/pack_dev.c
+index 0e881185c89fba6a0fbee270738a318011509885..2b8fb5de61ac5ee4b3b78368b0c34863755a2520 100644
+--- a/pack_dev.c
++++ b/pack_dev.c
+@@ -22,7 +22,7 @@
+ #if HAVE_SYS_CDEFS_H
+ #include <sys/cdefs.h>
+ #endif
+-#if !defined(lint)
++#if defined(__RCSID) && !defined(lint)
+ __RCSID("$NetBSD: pack_dev.c,v 1.12 2013/06/14 16:28:20 tsutsui Exp $");
+ #endif /* not lint */
+ 
+diff --git a/spec.c b/spec.c
+index 0f82a91de905384b0b7eea95b04537c1b6548b89..67cdc7b328935990b9e2428fff384990e5c17669 100644
+--- a/spec.c
++++ b/spec.c
+@@ -52,9 +52,15 @@ __RCSID("$NetBSD: spec.c,v 1.90 2017/12/14 18:34:41 christos Exp $");
+ #if HAVE_GRP_H
+ #include <grp.h>
+ #endif
++#if HAVE_BSD_GRP_H
++#include <bsd/grp.h>
++#endif
+ #if HAVE_PWD_H
+ #include <pwd.h>
+ #endif
++#if HAVE_BSD_PWD_H
++#include <bsd/pwd.h>
++#endif
+ #if HAVE_STDARG_H
+ #include <stdarg.h>
+ #endif
+@@ -64,19 +70,31 @@ __RCSID("$NetBSD: spec.c,v 1.90 2017/12/14 18:34:41 christos Exp $");
+ #if HAVE_STDIO_H
+ #include <stdio.h>
+ #endif
++#if HAVE_STDLIB_H
++#include <stdlib.h>
++#endif
+ #if HAVE_STRING_H
+ #include <string.h>
+ #endif
+ #if HAVE_UNISTD_H
+ #include <unistd.h>
+ #endif
++#if HAVE_BSD_UNISTD_H
++#include <bsd/unistd.h>
++#endif
+ #if HAVE_VIS_H
+ #include <vis.h>
+ #endif
++#if HAVE_BSD_VIS_H
++#include <bsd/vis.h>
++#endif
+ 
+ #if HAVE_LIBUTIL_H
+ #include <libutil.h>
+ #endif
++#if HAVE_BSD_LIBUTIL_H
++#include <bsd/libutil.h>
++#endif
+ #if HAVE_UTIL_H
+ #include <util.h>
+ #endif
+@@ -390,9 +408,9 @@ dump_nodes(FILE *fp, const char *dir, NODE *root, int pathlast)
+ 			appendfield(fp, pathlast, "%s=%s", SHA512KEY,
+ 			    cur->sha512digest);
+ 		if (MATCHFLAG(F_FLAGS)) {
+-			str = flags_to_string(cur->st_flags, "none");
+-			appendfield(fp, pathlast, "flags=%s", str);
+-			free(str);
++			/* flags_to_string returns a static buffer - do not free */
++			appendfield(fp, pathlast, "flags=%s",
++			    flags_to_string(cur->st_flags, "none"));
+ 		}
+ 		if (MATCHFLAG(F_IGN))
+ 			appendfield(fp, pathlast, "ignore");
+diff --git a/stat_flags.c b/stat_flags.c
+index 91f0d1aaca04350573c6b82066ff0918285d1dae..44b081c710984347a167763d116767627e33254d 100644
+--- a/stat_flags.c
++++ b/stat_flags.c
+@@ -25,7 +25,7 @@
+ #if HAVE_SYS_CDEFS_H
+ #include <sys/cdefs.h>
+ #endif
+-#if !defined(lint)
++#if defined(__RCSID) && !defined(lint)
+ #if 0
+ static char sccsid[] = "@(#)stat_flags.c	8.2 (Berkeley) 7/28/94";
+ #else

--- a/pkgs/by-name/mt/mtree/package.nix
+++ b/pkgs/by-name/mt/mtree/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  autoreconfHook,
+  libbsd,
+  libmd,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "mtree";
+  version = "1.0.0-unstable-2022-05-19";
+
+  src = fetchFromGitHub {
+    owner = "jashank";
+    repo = "mtree-portable";
+    rev = "fea79f387c592cede1217b8d019549d8d6b42235";
+    hash = "sha256-VBm5oDquYvR2TeOlSRAzOGSQ3L8K3Ci8aZxJ8sg1PEU=";
+  };
+
+  nativeBuildInputs = [ autoreconfHook ];
+
+  buildInputs = [
+    libbsd
+    libmd
+  ];
+
+  patches = [
+    ./0001-Port-to-Linux-with-libbsd-and-libmd.patch
+  ];
+
+  meta = {
+    description = "Utility for mapping and checking directory hierarchies";
+    homepage = "https://github.com/jashank/mtree-portable";
+    changelog = "https://github.com/jashank/mtree-portable/blob/${finalAttrs.src.rev}/CHANGES";
+    license = lib.licenses.bsd2;
+    maintainers = [ lib.maintainers.philiptaron ];
+    mainProgram = "mtree";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
There's an old chestnut of an application called `mtree` that's used in the *BSD world. 

- https://man.freebsd.org/cgi/man.cgi?mtree(8)
- https://man.freebsd.org/cgi/man.cgi?mtree(5)
- https://jashankj.space/blog/2022-05-18-adventures-with-mtree/

So I did the little bit of work needed to make it compile and run on Linux.

## About `mtree`

The `mtree` utility is a file hierarchy specification and verification tool originally from BSD systems. It creates a specification (or "manifest") of a directory tree that records file metadata such as permissions, ownership, timestamps, sizes, and cryptographic checksums. This specification can later be used to verify that a directory structure remains unchanged—making mtree valuable for system integrity checking, package verification, and detecting unauthorized modifications to critical files. The tool is commonly used in FreeBSD and NetBSD for verifying base system installations and in security auditing workflows where filesystem integrity matters.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
