### PR TITLE
jool: Unbreak with linux kernel >= 6.18

### DIFF
--- a/pkgs/os-specific/linux/jool/default.nix
+++ b/pkgs/os-specific/linux/jool/default.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   kernel,
   kernelModuleMakeFlags,
   nixosTests,
@@ -15,6 +16,13 @@ stdenv.mkDerivation {
   name = "jool-${sourceAttrs.version}-${kernel.version}";
 
   src = sourceAttrs.src;
+
+  patches = lib.optionals (lib.versionAtLeast kernel.version "6.18.0") [
+    (fetchpatch {
+      url = "https://gitlab.alpinelinux.org/alpine/aports/-/raw/3.23-stable/community/jool-modules-lts/kernel-6.18.patch";
+      hash = "sha256-EtV95YaOzPU3e/8NQvUtAH/RWiV16djeKrnvSgYybCQ=";
+    })
+  ];
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
   hardeningDisable = [ "pic" ];


### PR DESCRIPTION
Current version of `jool` is broken with linux >= 6.18, courtesy: some refactoring.

```
       > make -C common                                                                                                                                                                                          
       > make[1]: Entering directory '/build/source/src/mod/common'                                                                                                                                              
       > make -C /nix/store/vai15p6c78y8bvb29napkcwch1j8m7rx-linux-6.18.1-dev/lib/modules/6.18.1/build M=$PWD                                                                                                    
       > make[2]: Entering directory '/nix/store/vai15p6c78y8bvb29napkcwch1j8m7rx-linux-6.18.1-dev/lib/modules/6.18.1/build'
       > make[3]: Entering directory '/build/source/src/mod/common'
       >   CC [M]  rfc7915/4to6.o
       >   CC [M]  rfc7915/6to4.o
       > rfc7915/6to4.c: In function 'compute_flowix64':
       > rfc7915/6to4.c:206:14: error: 'struct flowi4' has no member named 'flowi4_tos'
       >   206 |         flow4->flowi4_tos = xlat_tos(&state->jool.globals, hdr6);
       >       |              ^~
       > rfc7915/6to4.c: In function 'ttp64_ipv4_external':
       > rfc7915/6to4.c:648:26: error: 'struct flowi4' has no member named 'flowi4_tos'
       >   648 |         hdr4->tos = flow4->flowi4_tos;
       >       |                          ^~
       > make[5]: *** [/nix/store/vai15p6c78y8bvb29napkcwch1j8m7rx-linux-6.18.1-dev/lib/modules/6.18.1/source/scripts/Makefile.build:287: rfc7915/6to4.o] Error 1
       > make[4]: *** [/nix/store/vai15p6c78y8bvb29napkcwch1j8m7rx-linux-6.18.1-dev/lib/modules/6.18.1/source/Makefile:2010: .] Error 2
       > make[3]: *** [/nix/store/vai15p6c78y8bvb29napkcwch1j8m7rx-linux-6.18.1-dev/lib/modules/6.18.1/source/Makefile:248: __sub-make] Error 2
       > make[3]: Leaving directory '/build/source/src/mod/common'
       > make[2]: *** [/nix/store/vai15p6c78y8bvb29napkcwch1j8m7rx-linux-6.18.1-dev/lib/modules/6.18.1/source/Makefile:248: __sub-make] Error 2
       > make[2]: Leaving directory '/nix/store/vai15p6c78y8bvb29napkcwch1j8m7rx-linux-6.18.1-dev/lib/modules/6.18.1/build'
       > make[1]: *** [Makefile:5: all] Error 2
       > make[1]: Leaving directory '/build/source/src/mod/common'
       > make: *** [Makefile:8: common] Error 2
       > make: Leaving directory '/build/source/src/mod'
```

The [patch](https://gitlab.alpinelinux.org/alpine/aports/-/commit/039d64c4c48ab3533c46e012a7e218ce40a5aa9d) borrowed from AlpineLinux unbreaks it.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
