### PR TITLE
yosys: set `meta.mainProgram` to "yosys"

### DIFF
--- a/pkgs/by-name/gl/glasgow/package.nix
+++ b/pkgs/by-name/gl/glasgow/package.nix
@@ -99,7 +99,7 @@ python3.pkgs.buildPythonApplication rec {
   makeWrapperArgs = [
     "--set"
     "YOSYS"
-    "${yosys}/bin/yosys"
+    (lib.getExe yosys)
     "--set"
     "ICEPACK"
     "${icestorm}/bin/icepack"

--- a/pkgs/by-name/mc/mcy/package.nix
+++ b/pkgs/by-name/mc/mcy/package.nix
@@ -26,13 +26,13 @@ stdenv.mkDerivation {
     patchShebangs .
 
     substituteInPlace mcy.py \
-      --replace yosys '${yosys}/bin/yosys' \
+      --replace yosys '${lib.getExe yosys}' \
       --replace 'os.execvp("mcy-dash"' "os.execvp(\"$out/bin/mcy-dash\""
     substituteInPlace mcy-dash.py \
       --replace 'app.run(debug=True)' 'app.run(host="0.0.0.0",debug=True)' \
       --replace 'subprocess.Popen(["mcy"' "subprocess.Popen([\"$out/bin/mcy\""
     substituteInPlace scripts/create_mutated.sh \
-      --replace yosys '${yosys}/bin/yosys'
+      --replace yosys '${lib.getExe yosys}'
   '';
 
   # the build needs a bit of work...

--- a/pkgs/by-name/yo/yosys/package.nix
+++ b/pkgs/by-name/yo/yosys/package.nix
@@ -196,6 +196,7 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/YosysHQ/yosys/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.isc;
     platforms = lib.platforms.all;
+    mainProgram = "yosys";
     maintainers = with lib.maintainers; [
       shell
       thoughtpolice


### PR DESCRIPTION
Set the `meta.mainProgram` attribute on `pkgs.yosys` (9f84b1eab56e8784fd12d999c1ace191eccbf2b0), and uses it in place of `${yosys}/bin/yosys` in the `pkgs.glasgow` and `pkgs.mcy` derivations (d47b689711978eb1a29ddcf55e9bd711cf981bcb).

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
