### PR TITLE
java-language-server: avoid using jlink

### DIFF
--- a/pkgs/by-name/ja/java-language-server/use-full-jdk.patch
+++ b/pkgs/by-name/ja/java-language-server/use-full-jdk.patch
@@ -1,0 +1,30 @@
+diff --git a/dist/launch_linux.sh b/dist/launch_linux.sh
+index 460fe5d..d38b4f7 100755
+--- a/dist/launch_linux.sh
++++ b/dist/launch_linux.sh
+@@ -10,4 +10,4 @@ JLINK_VM_OPTIONS="\
+ --add-opens jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED"
+ DIR=`dirname $0`
+ CLASSPATH_OPTIONS="-classpath $DIR/classpath/gson-2.8.9.jar:$DIR/classpath/protobuf-java-3.19.6.jar:$DIR/classpath/java-language-server.jar"
+-$DIR/linux/bin/java $JLINK_VM_OPTIONS $CLASSPATH_OPTIONS $@
++@java@ $JLINK_VM_OPTIONS $CLASSPATH_OPTIONS $@
+diff --git a/dist/launch_mac.sh b/dist/launch_mac.sh
+index d507fd2..d38b4f7 100755
+--- a/dist/launch_mac.sh
++++ b/dist/launch_mac.sh
+@@ -10,4 +10,4 @@ JLINK_VM_OPTIONS="\
+ --add-opens jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED"
+ DIR=`dirname $0`
+ CLASSPATH_OPTIONS="-classpath $DIR/classpath/gson-2.8.9.jar:$DIR/classpath/protobuf-java-3.19.6.jar:$DIR/classpath/java-language-server.jar"
+-$DIR/mac/bin/java $JLINK_VM_OPTIONS $CLASSPATH_OPTIONS $@
++@java@ $JLINK_VM_OPTIONS $CLASSPATH_OPTIONS $@
+diff --git a/dist/launch_windows.sh b/dist/launch_windows.sh
+index 612731c..070803d 100644
+--- a/dist/launch_windows.sh
++++ b/dist/launch_windows.sh
+@@ -10,4 +10,4 @@ JLINK_VM_OPTIONS="\
+ --add-opens jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED"
+ DIR=`dirname $0`
+ CLASSPATH_OPTIONS="-classpath $DIR/classpath/gson-2.8.9.jar;$DIR/classpath/protobuf-java-3.19.6.jar;$DIR/classpath/java-language-server.jar"
+-$DIR/windows/bin/java $JLINK_VM_OPTIONS $CLASSPATH_OPTIONS $@
++@java@ $JLINK_VM_OPTIONS $CLASSPATH_OPTIONS $@


### PR DESCRIPTION
Hardcode the path to the JDK's `java` executable in the launch scripts. Have the build scripts entirely skip using `jlink`.

This package uses `jlink` to bundle a Java runtime with its installed files. This runtime is not complete, and it can't compile user programs that try to use pieces of the JDK that aren't included (see e.g. georgewfraser/java-language-server#124).

Upstream, attempts have been made to use the user's JDK instead of the bundled one to avoid this problem (e.g.
georgewfraser/java-language-server#129). These have been reverted since this package mucks around with the compiler's internals and thus can crash in the face of version mismatches.

Nixpkgs has a better option: we can "statically link" this package against the full JDK used to build it. This allows user code to access a full JDK while also ensuring that this package can always find its JDK.

This is a bit of an invasive thing to do to a package's build, but I needed to write this anyway to get this package to work for me.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
