### PR TITLE
television: install generated completion instead

### DIFF
--- a/nixos/modules/programs/television.nix
+++ b/nixos/modules/programs/television.nix
@@ -7,7 +7,6 @@
 let
   inherit (lib.options) mkEnableOption mkPackageOption;
   inherit (lib.modules) mkIf;
-  inherit (lib.meta) getExe;
 
   cfg = config.programs.television;
 in
@@ -26,13 +25,13 @@ in
 
     programs = {
       zsh.interactiveShellInit = mkIf cfg.enableZshIntegration ''
-        eval "$(${getExe cfg.package} init zsh)"
+        source ${cfg.package}/share/television/completion.zsh
       '';
       bash.interactiveShellInit = mkIf cfg.enableBashIntegration ''
-        eval "$(${getExe cfg.package} init bash)"
+        source ${cfg.package}/share/television/completion.bash
       '';
       fish.interactiveShellInit = mkIf cfg.enableFishIntegration ''
-        ${getExe cfg.package} init fish | source
+        source ${cfg.package}/share/television/completion.fish
       '';
     };
 

--- a/pkgs/by-name/te/television/package.nix
+++ b/pkgs/by-name/te/television/package.nix
@@ -5,6 +5,7 @@
   fetchFromGitHub,
   callPackage,
   installShellFiles,
+  writableTmpDirAsHomeHook,
   nix-update-script,
   testers,
   targetPackages,
@@ -33,41 +34,25 @@ let
     strictDeps = true;
     nativeBuildInputs = [
       installShellFiles
+      writableTmpDirAsHomeHook
     ];
 
     # TODO(@getchoo): Investigate selectively disabling some tests, or fixing them
     # https://github.com/NixOS/nixpkgs/pull/423662#issuecomment-3156362941
     doCheck = false;
 
-    postPatch = ''
-      # Remove keybinding overrides from shell completion scripts
-      # Users should configure their own keybindings
-
-      # Bash: Remove bind commands
-      sed -i '/^# Bind the functions to key combinations/,$d' \
-        television/utils/shell/completion.bash
-
-      # Fish: Remove bind commands for both modes
-      sed -i '/^for mode in default insert/,$d' \
-        television/utils/shell/completion.fish
-
-      # Nushell: Remove keybinding configuration
-      sed -i '/^# Bind custom keybindings/,$d' \
-        television/utils/shell/completion.nu
-
-      # Zsh: Remove zle and bindkey commands
-      sed -i '/^zle -N tv-smart-autocomplete/,$d' \
-        television/utils/shell/completion.zsh
-    '';
-
     postInstall = ''
       installManPage target/${stdenv.hostPlatform.rust.cargoShortTarget}/assets/tv.1
 
+      # These are actually shell integrations with keybindings
+      install -Dm644 television/utils/shell/completion.* -t $out/share/television/
+    ''
+    + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
       installShellCompletion --cmd tv \
-        television/utils/shell/completion.bash \
-        television/utils/shell/completion.fish \
-        television/utils/shell/completion.nu \
-        television/utils/shell/completion.zsh
+        --bash <($out/bin/tv init bash) \
+        --fish <($out/bin/tv init fish) \
+        --zsh <($out/bin/tv init zsh) \
+        --nushell <($out/bin/tv init nu)
     '';
 
     passthru = {


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/pull/467061#issuecomment-3677187871

It turns out we have misunderstood how television completion works. The generated completion is actually complete and doesn't contain keybindings. The pre-generated completion isn't complete (doesn't contain the most important argument completion) and contains keybindings. These should be swapped and the generated completion should be picked up by default.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
