### PR TITLE
turntable: 0.3.3 -> 0.4.0

### DIFF
--- a/pkgs/by-name/tu/turntable/package.nix
+++ b/pkgs/by-name/tu/turntable/package.nix
@@ -12,7 +12,9 @@
   libsoup_3,
   json-glib,
   libsecret,
+  libglycin,
   glib-networking,
+  glycin-loaders,
 
   # Per the upstream request. Key owned by Aleksana
   lastfmKey ? "b5027c5178ca2abfcc31bd04397c3c0e",
@@ -21,14 +23,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "turntable";
-  version = "0.3.3";
+  version = "0.4.0";
 
   src = fetchFromGitea {
     domain = "codeberg.org";
     owner = "GeopJr";
     repo = "Turntable";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-fBduW49eNOEzRVBb72zcB5arTjTiRUy8jE3sSMjPITE=";
+    hash = "sha256-Rvkzh2Cila6ZhQZyX5zzUrWane6nLAjrwnKk0LPWKuE=";
   };
 
   nativeBuildInputs = [
@@ -45,6 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
     libsoup_3
     json-glib
     libsecret
+    libglycin
     glib-networking
   ];
 
@@ -54,6 +57,12 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   strictDeps = true;
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix XDG_DATA_DIRS : "${glycin-loaders}/share"
+    )
+  '';
 
   meta = {
     description = "Scrobbles your music to multiple services with playback controls for MPRIS players";


### PR DESCRIPTION
Still doesn't get last.fm to work, it's quite strange as I don't use a proxy now. Not sure what went wrong, but no regressions at least

Fixes https://github.com/NixOS/nixpkgs/pull/414463#issuecomment-3677242222

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
