### PR TITLE
picoshare: init at 1.5.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3581,6 +3581,12 @@
     githubId = 37768199;
     name = "Christian Bergschneider";
   };
+  blokyk = {
+    email = "pro@zoeee.net";
+    github = "blokyk";
+    githubId = 32983140;
+    name = "Zoë Courvoisier";
+  };
   bloominstrong = {
     email = "github@mail.bloominstrong.net";
     github = "bloominstrong";

--- a/pkgs/by-name/pi/picoshare/package.nix
+++ b/pkgs/by-name/pi/picoshare/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+  litestream,
+  litestreamSupport ? false,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "picoshare";
+  version = "1.5.1";
+
+  src = fetchFromGitHub {
+    owner = "mtlynch";
+    repo = "picoshare";
+    tag = finalAttrs.version;
+    hash = "sha256-8mgrwnY0Y1CggAtc7BrAqC32+Wu82FQNhoK0ijM1RKw=";
+  };
+
+  vendorHash = "sha256-Wf0qKs/9XKnO2nx2KmTGPdqI0iFih30AGvOi94RPEjw=";
+
+  ldflags = [
+    # make sure build time is always set to 0 to make the build reproducible
+    "-X github.com/mtlynch/picoshare/v2/build.unixTime=0"
+    # the app displays the version in the "system > information" menu
+    "-X github.com/mtlynch/picoshare/v2/build.Version=${finalAttrs.version}"
+  ];
+
+  buildInputs = lib.optional litestreamSupport litestream;
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Minimalist, easy-to-host service for sharing images and other files";
+    homepage = "https://github.com/mtlynch/picoshare";
+    license = lib.licenses.agpl3Only;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    mainProgram = "picoshare";
+    maintainers = with lib.maintainers; [
+      blokyk
+    ];
+  };
+})


### PR DESCRIPTION
Add package for [`mtlynch/picoshare`](https://github.com/mtlynch/picoshare) (2.8k stars), a tiny self-hostable file sharing service.

I also have [a module I wrote for this software](https://github.com/blokyk/packages.nix/tree/main/modules/picoshare), though I haven't prepared it for upstreaming yet. Should it go in a different PR or can it be done in this one?

## Things done

There are no package tests added since I'm not sure how I could test the server without a `nixosTest`-like setup. If you have tests in mind that you think I should add, I'd be happy to! 

To manually test this, you can run:
```sh
$ PS_SHARED_SECRET="a_bad_passwd" PORT=1234 ./result/bin/picoshare
```

And then navigate to `http://localhost:1234` and check that the website works. Once you're done, you should delete the `data/` directory that picoshare created.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
