### PR TITLE
filebrowser: 2.44.1 -> 2.55.0 [CVE-2026-23849]

### DIFF
--- a/pkgs/by-name/fi/filebrowser/package.nix
+++ b/pkgs/by-name/fi/filebrowser/package.nix
@@ -3,20 +3,22 @@
   fetchFromGitHub,
   buildGoModule,
   buildNpmPackage,
-  pnpm_9,
   fetchPnpmDeps,
   pnpmConfigHook,
+  nodejs_24,
+  pnpm_10,
   nix-update-script,
   nixosTests,
 }:
+
 let
-  version = "2.44.1";
+  version = "2.55.0";
 
   src = fetchFromGitHub {
     owner = "filebrowser";
     repo = "filebrowser";
     rev = "v${version}";
-    hash = "sha256-ln7Dst+sN99c3snPU7DrIGpwKBz/e4Lz+uOknmm6sxg=";
+    hash = "sha256-1ZzTATJEVBr76+CMk8OzxdpWGqFHPPhyC7z2MgfqN+M=";
   };
 
   frontend = buildNpmPackage rec {
@@ -25,9 +27,10 @@ let
 
     sourceRoot = "${src.name}/frontend";
 
-    nativeBuildInputs = [ pnpm_9 ];
+    nativeBuildInputs = [ pnpm_10 ];
     npmConfigHook = pnpmConfigHook;
     npmDeps = pnpmDeps;
+    nodejs = nodejs_24;
 
     pnpmDeps = fetchPnpmDeps {
       inherit
@@ -36,9 +39,9 @@ let
         src
         sourceRoot
         ;
-      pnpm = pnpm_9;
-      fetcherVersion = 2;
-      hash = "sha256-3n44BGJLdQR6uBSF09oyUzJm35/S3/ZEyZh4Wxqlfiw=";
+      fetcherVersion = 3;
+      pnpm = pnpm_10;
+      hash = "sha256-iv0LZoEyF5fASqBKNkTJhLMY0Xpa6x0i4csDoHmGU+g=";
     };
 
     installPhase = ''
@@ -50,12 +53,13 @@ let
       runHook postInstall
     '';
   };
+
 in
 buildGoModule {
   pname = "filebrowser";
   inherit version src;
 
-  vendorHash = "sha256-aVtL64Cm+nqum/qHFvplpEawgMXM2S6l8QFrJBzLVtU=";
+  vendorHash = "sha256-4WDggP5eL7IPUWTxewxV2JUZZ3kV0PwewQQothz7AC8=";
 
   excludedPackages = [ "tools" ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- filebrowser: update 2.44.0 -> 2.55.0
  - fixes [CVE-2026-23849 - File Browser vulnerable to Username Enumeration via Timing Attack in /api/login](https://github.com/NixOS/nixpkgs/issues/481892)
- Upgrade to fetcherVersion v3
- upgrade to nodejs 24
- upgrade to pnpm_10

ryantm bot was not able to update the package due to required node/pnpm version upgrade. Should be fixed now!

https://github.com/filebrowser/filebrowser/blob/master/CHANGELOG.md

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
