### PR TITLE
clash-verge-rev: 2.4.3 -> 2.4.4

### DIFF
--- a/pkgs/by-name/cl/clash-verge-rev/package.nix
+++ b/pkgs/by-name/cl/clash-verge-rev/package.nix
@@ -12,17 +12,18 @@
 }:
 let
   pname = "clash-verge-rev";
-  version = "2.4.3";
+  # Please keep service version in sync with the client
+  version = "2.4.4";
 
   src = fetchFromGitHub {
     owner = "clash-verge-rev";
     repo = "clash-verge-rev";
     tag = "v${version}";
-    hash = "sha256-GmoeOLKxdW1x6PHtslwNPVq8wDWA413NHA/VeDRb4mA=";
+    hash = "sha256-on09EX1T66aTpAd4hj6HnPwhd1S+r8zviIKg/Ijr2dg=";
   };
 
-  pnpm-hash = "sha256-qDwXPTfh1yOlugZe1UPUMKRyZOSagG4lX2eiFACgHRw=";
-  vendor-hash = "sha256-z5xVbqh+CiaTDtAx2VPQ4UjliYnV44tdp3pS8vzb1K4=";
+  pnpm-hash = "sha256-aSv8MIu1/p3p8pOG6R8SzZ1L8LI2JtbO2htgXfsWVbM=";
+  vendor-hash = "sha256-o5dGjbRiOIepaxdQrzJVyRhTVw2I8Dsa2TXdnlRcCCY=";
 
   service = callPackage ./service.nix {
     inherit

--- a/pkgs/by-name/cl/clash-verge-rev/service.nix
+++ b/pkgs/by-name/cl/clash-verge-rev/service.nix
@@ -7,25 +7,27 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "clash-verge-service-ipc";
-  version = "2.0.21";
+  # Make sure it matches the version of clash_verge_rev_ipc referenced in clash-verge-rev
+  version = "2.0.26";
 
   src = fetchFromGitHub {
     owner = "clash-verge-rev";
     repo = "clash-verge-service-ipc";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-9c9fM1l31NbY//Ri50Ql60BWWgISjMWj72ABixRaXvM=";
+    # Use revision because version tag will be removed when a new version comes out.
+    rev = "37b9964a9bce767b5b95ea2be75613b23400c9f0";
+    hash = "sha256-gc6SAjM248y3rIBDJYPAY4BCzkzZQVEws0M3CEDCdME=";
   };
 
   postPatch = ''
     # set socket path for service and test respectively
-    substituteInPlace src/lib.rs \
-      --replace-fail "/tmp/verge/clash-verge-service.sock" "/run/clash-verge-rev/service.sock" \
-      --replace-fail "/tmp/verge/clash-verge-service-test.sock" "$sourceRoot/clash-verge-service-test.sock"
-    substituteInPlace tests/test_start_permissions.rs \
-      --replace-fail "owner_perm | group_perm | other_perm" "0o0755"
+    sed -i "/not(feature = \"test\")))]/{n;s|/tmp/verge/clash-verge-service.sock|/run/clash-verge-rev/service.sock|}" src/lib.rs
+    sed -i "/feature = \"test\", unix/{n;s|/tmp/verge/clash-verge-service.sock|$PWD/clash-verge-service-test.sock|}" src/lib.rs
+    # set 755 permission on /run/clash-verge-rev/
+    substituteInPlace src/core/server.rs \
+      --replace-fail "dir_path, Permissions::from_mode(0o777)" "dir_path, Permissions::from_mode(0o755)"
   '';
 
-  cargoHash = "sha256-UbNN3uFu5anQV+3KMFPNnGrCDQTGb4uC9K83YghfQgY=";
+  cargoHash = "sha256-31TzRk6kTSZMDy+EtjDHG9hScurlm9DL+neAbD6RgpU=";
 
   buildFeatures = [
     "standalone"

--- a/pkgs/by-name/cl/clash-verge-rev/unwrapped.nix
+++ b/pkgs/by-name/cl/clash-verge-rev/unwrapped.nix
@@ -8,7 +8,6 @@
   vendor-hash,
 
   rustPlatform,
-  fetchpatch,
 
   cargo-tauri,
   jq,
@@ -31,9 +30,6 @@ rustPlatform.buildRustPackage {
   inherit version src meta;
   pname = "${pname}-unwrapped";
 
-  cargoRoot = "src-tauri";
-  buildAndTestSubdir = "src-tauri";
-
   cargoHash = vendor-hash;
 
   pnpmDeps = fetchPnpmDeps {
@@ -50,13 +46,6 @@ rustPlatform.buildRustPackage {
   env = {
     OPENSSL_NO_VENDOR = 1;
   };
-
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/clash-verge-rev/clash-verge-rev/commit/645b92bc2815fe55bbc827907bff0edbfee48674.patch";
-      hash = "sha256-BH0SvVofW6YJ3e/LOHojisenMwcxYfm3gG/dbxvYBMs=";
-    })
-  ];
 
   postPatch = ''
     # We disable the option to try to use the bleeding-edge version of mihomo


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
