### PR TITLE
suricata: 7.0.10 -> 8.0.2

### DIFF
--- a/pkgs/by-name/su/suricata/bpf_stubs_workaround.patch
+++ b/pkgs/by-name/su/suricata/bpf_stubs_workaround.patch
@@ -1,19 +1,11 @@
-*** suricata-5.0.0/ebpf/Makefile.in	2019-10-16 22:39:13.174649416 +0200
---- suricata-5.0.0/ebpf/Makefile.in.fixed	2019-10-16 22:38:41.822201802 +0200
-***************
-*** 527,533 ****
-  @BUILD_EBPF_TRUE@$(BPF_TARGETS): %.bpf: %.c
-  #      From C-code to LLVM-IR format suffix .ll (clang -S -emit-llvm)
-  @BUILD_EBPF_TRUE@	${CLANG} -Wall $(BPF_CFLAGS) -O2 \
-! @BUILD_EBPF_TRUE@		-I/usr/include/$(build_cpu)-$(build_os)/ \
-  @BUILD_EBPF_TRUE@		-D__KERNEL__ -D__ASM_SYSREG_H \
-  @BUILD_EBPF_TRUE@		-target bpf -S -emit-llvm $< -o ${@:.bpf=.ll}
-  #      From LLVM-IR to BPF-bytecode in ELF-obj file
---- 527,533 ----
-  @BUILD_EBPF_TRUE@$(BPF_TARGETS): %.bpf: %.c
-  #      From C-code to LLVM-IR format suffix .ll (clang -S -emit-llvm)
-  @BUILD_EBPF_TRUE@	${CLANG} -Wall $(BPF_CFLAGS) -O2 \
-! @BUILD_EBPF_TRUE@		-idirafter ../bpf_stubs_workaround \
-  @BUILD_EBPF_TRUE@		-D__KERNEL__ -D__ASM_SYSREG_H \
-  @BUILD_EBPF_TRUE@		-target bpf -S -emit-llvm $< -o ${@:.bpf=.ll}
-  #      From LLVM-IR to BPF-bytecode in ELF-obj file
+--- a/ebpf/Makefile.in
++++ b/ebpf/Makefile.in
+@@ -530,7 +530,7 @@
+ @BUILD_EBPF_TRUE@$(BPF_TARGETS): %.bpf: %.c
+ #      From C-code to LLVM-IR format suffix .ll (clang -S -emit-llvm)
+ @BUILD_EBPF_TRUE@	${CLANG} -Wall $(BPF_CFLAGS) -O2 -g \
+-@BUILD_EBPF_TRUE@		-I/usr/include/$(build_cpu)-$(build_os)/ \
++@BUILD_EBPF_TRUE@		-idirafter ../bpf_stubs_workaround \
+ @BUILD_EBPF_TRUE@		-D__KERNEL__ -D__ASM_SYSREG_H \
+ @BUILD_EBPF_TRUE@		-target bpf -S -emit-llvm $< -o ${@:.bpf=.ll}
+ #      From LLVM-IR to BPF-bytecode in ELF-obj file

--- a/pkgs/by-name/su/suricata/package.nix
+++ b/pkgs/by-name/su/suricata/package.nix
@@ -5,7 +5,6 @@
   clang,
   llvm,
   pkg-config,
-  makeWrapper,
   elfutils,
   file,
   jansson,
@@ -39,17 +38,21 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "suricata";
-  version = "7.0.10";
+  version = "8.0.2";
 
   src = fetchurl {
     url = "https://www.openinfosecfoundation.org/download/${pname}-${version}.tar.gz";
-    hash = "sha256-GX+SXqcBvctKFaygJLBlRrACZ0zZWLWJWPKaW7IU11k=";
+    hash = "sha256-nUUMosrb4QGZPpkDOmI0nSvanf2QpqzBvLbMbbdutVE=";
   };
+
+  patches = lib.optionals stdenv.hostPlatform.is64bit [
+    # Provide empty gnu/stubs-32.h for eBPF build
+    ./bpf_stubs_workaround.patch
+  ];
 
   nativeBuildInputs = [
     clang
     llvm
-    makeWrapper
     pkg-config
   ]
   ++ lib.optionals rustSupport [
@@ -90,14 +93,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  patches = lib.optional stdenv.hostPlatform.is64bit ./bpf_stubs_workaround.patch;
-
   postPatch = ''
-    substituteInPlace ./configure \
-      --replace "/usr/bin/file" "${file}/bin/file"
-    substituteInPlace ./libhtp/configure \
-      --replace "/usr/bin/file" "${file}/bin/file"
-
     mkdir -p bpf_stubs_workaround/gnu
     touch bpf_stubs_workaround/gnu/stubs-32.h
   '';
@@ -116,6 +112,7 @@ stdenv.mkDerivation rec {
     "--enable-python"
     "--enable-unix-socket"
     "--localstatedir=/var"
+    "--runstatedir=/run"
     "--sysconfdir=/etc"
     "--with-libhs-includes=${lib.getDev vectorscan}/include/hs"
     "--with-libhs-libraries=${lib.getLib vectorscan}/lib"
@@ -142,17 +139,8 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   installFlags = [
-    "e_datadir=\${TMPDIR}"
-    "e_localstatedir=\${TMPDIR}"
-    "e_logdir=\${TMPDIR}"
-    "e_logcertsdir=\${TMPDIR}"
-    "e_logfilesdir=\${TMPDIR}"
-    "e_rundir=\${TMPDIR}"
-    "e_sysconfdir=\${out}/etc/suricata"
-    "e_sysconfrulesdir=\${out}/etc/suricata/rules"
-    "localstatedir=\${TMPDIR}"
-    "runstatedir=\${TMPDIR}"
-    "sysconfdir=\${out}/etc"
+    "DESTDIR=\${out}"
+    "prefix=/"
   ];
 
   installTargets = [
@@ -161,10 +149,8 @@ stdenv.mkDerivation rec {
   ];
 
   postInstall = ''
-    wrapProgram "$out/bin/suricatasc" \
-      --prefix PYTHONPATH : $PYTHONPATH:$(toPythonPath "$out")
     substituteInPlace "$out/etc/suricata/suricata.yaml" \
-      --replace "/etc/suricata" "$out/etc/suricata"
+      --replace-fail "/etc/suricata" "${placeholder "out"}/etc/suricata"
   '';
 
   passthru.tests = { inherit (nixosTests) suricata; };


### PR DESCRIPTION
Fix : https://github.com/NixOS/nixpkgs/issues/438416
Diff : https://github.com/OISF/suricata/compare/suricata-7.0.10...suricata-8.0.2
Changelog : https://forum.suricata.io/t/suricata-8-0-2-and-7-0-13-released/6100

CVEs : 
CVE-2025-64344
CVE-2025-64333
CVE-2025-64332
CVE-2025-64331
CVE-2025-64330
CVE-2025-64335
CVE-2025-64334

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
