### PR TITLE
qt5.qtbase: prepare for structuredAttrs

### DIFF
--- a/pkgs/development/libraries/qt-5/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtbase.nix
@@ -136,7 +136,9 @@ stdenv.mkDerivation (
           libxcb-render-util
           libxcb-wm
         ]
-        ++ lib.optional libGLSupported libGL
+        ++ lib.optionals libGLSupported [
+          libGL
+        ]
       );
 
       buildInputs = [
@@ -146,10 +148,18 @@ stdenv.mkDerivation (
       ++ lib.optionals (!stdenv.hostPlatform.isDarwin) (
         lib.optional withLibinput libinput ++ lib.optional withGtk3 gtk3
       )
-      ++ lib.optional developerBuild gdb
-      ++ lib.optional (cups != null) cups
-      ++ lib.optional mysqlSupport libmysqlclient
-      ++ lib.optional (libpq != null) libpq;
+      ++ lib.optionals developerBuild [
+        gdb
+      ]
+      ++ lib.optionals (cups != null) [
+        cups
+      ]
+      ++ lib.optionals mysqlSupport [
+        libmysqlclient
+      ]
+      ++ lib.optionals (libpq != null) [
+        libpq
+      ];
 
       nativeBuildInputs = [
         bison
@@ -160,8 +170,12 @@ stdenv.mkDerivation (
         pkg-config
         which
       ]
-      ++ lib.optionals mysqlSupport [ libmysqlclient ]
-      ++ lib.optionals stdenv.hostPlatform.isDarwin [ xcbuild ];
+      ++ lib.optionals mysqlSupport [
+        libmysqlclient
+      ]
+      ++ lib.optionals stdenv.hostPlatform.isDarwin [
+        xcbuild
+      ];
 
     }
     // lib.optionalAttrs (stdenv.buildPlatform != stdenv.hostPlatform) {
@@ -321,13 +335,19 @@ stdenv.mkDerivation (
             ''-DLIBRESOLV_SO="${stdenv.cc.libc.out}/lib/libresolv"''
             ''-DNIXPKGS_LIBXCURSOR="${libxcursor.out}/lib/libXcursor"''
           ]
-          ++ lib.optional libGLSupported ''-DNIXPKGS_MESA_GL="${libGL.out}/lib/libGL"''
-          ++ lib.optional stdenv.hostPlatform.isLinux "-DUSE_X11"
+          ++ lib.optionals libGLSupported [
+            ''-DNIXPKGS_MESA_GL="${libGL.out}/lib/libGL"''
+          ]
+          ++ lib.optionals stdenv.hostPlatform.isLinux [
+            "-DUSE_X11"
+          ]
           ++ lib.optionals withGtk3 [
             ''-DNIXPKGS_QGTK3_XDG_DATA_DIRS="${gtk3}/share/gsettings-schemas/${gtk3.name}"''
             ''-DNIXPKGS_QGTK3_GIO_EXTRA_MODULES="${dconf.lib}/lib/gio/modules"''
           ]
-          ++ lib.optional decryptSslTraffic "-DQT_DECRYPT_SSL_TRAFFIC"
+          ++ lib.optionals decryptSslTraffic [
+            "-DQT_DECRYPT_SSL_TRAFFIC"
+          ]
         );
       }
       // lib.optionalAttrs (stdenv.buildPlatform != stdenv.hostPlatform) {
@@ -383,7 +403,9 @@ stdenv.mkDerivation (
         "-device ${qtPlatformCross stdenv.hostPlatform}"
         "-device-option CROSS_COMPILE=${stdenv.cc.targetPrefix}"
       ]
-      ++ lib.optional debugSymbols "-debug"
+      ++ lib.optionals debugSymbols [
+        "-debug"
+      ]
       ++ lib.optionals developerBuild [
         "-developer-build"
         "-no-warnings-are-errors"
@@ -474,8 +496,12 @@ stdenv.mkDerivation (
             "-dbus-linked"
             "-glib"
           ]
-          ++ lib.optional withGtk3 "-gtk"
-          ++ lib.optional withLibinput "-libinput"
+          ++ lib.optionals withGtk3 [
+            "-gtk"
+          ]
+          ++ lib.optionals withLibinput [
+            "-libinput"
+          ]
           ++ [
             "-inotify"
           ]

--- a/pkgs/development/libraries/qt-5/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtbase.nix
@@ -356,15 +356,15 @@ stdenv.mkDerivation (
           "-Wno-free-nonheap-object"
           "-w"
         ];
+      }
+      // lib.optionalAttrs (libpq != null) {
+        # PostgreSQL autodetection fails sporadically because Qt omits the "-lpq" flag
+        # if dependency paths contain the string "pq", which can occur in the hash.
+        # To prevent these failures, we need to override PostgreSQL detection.
+        PSQL_LIBS = "-L${libpq}/lib -lpq";
       };
 
       prefixKey = "-prefix ";
-
-      # PostgreSQL autodetection fails sporadically because Qt omits the "-lpq" flag
-      # if dependency paths contain the string "pq", which can occur in the hash.
-      # To prevent these failures, we need to override PostgreSQL detection.
-      PSQL_LIBS = lib.optionalString (libpq != null) "-L${libpq}/lib -lpq";
-
     }
     // lib.optionalAttrs (stdenv.buildPlatform != stdenv.hostPlatform) {
       configurePlatforms = [ ];

--- a/pkgs/development/libraries/qt-5/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtbase.nix
@@ -517,7 +517,7 @@ stdenv.mkDerivation (
             "-I"
             "${libmysqlclient}/include"
           ]
-          ++ lib.optional (qttranslations != null) [
+          ++ lib.optionals (qttranslations != null) [
             "-translationdir"
             "${qttranslations}/translations"
           ]

--- a/pkgs/development/libraries/qt-5/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtbase.nix
@@ -223,8 +223,8 @@ stdenv.mkDerivation (
                 --subst-var qtDocPrefix
         done
 
-        substituteInPlace configure --replace /bin/pwd pwd
-        substituteInPlace src/corelib/global/global.pri --replace /bin/ls ${coreutils}/bin/ls
+        substituteInPlace configure --replace-fail /bin/pwd pwd
+        substituteInPlace src/corelib/global/global.pri --replace-fail /bin/ls ${coreutils}/bin/ls
         sed -e 's@/\(usr\|opt\)/@/var/empty/@g' -i mkspecs/*/*.conf
 
         sed -i '/PATHS.*NO_DEFAULT_PATH/ d' src/corelib/Qt5Config.cmake.in

--- a/pkgs/development/libraries/qt-5/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtbase.nix
@@ -372,9 +372,12 @@ stdenv.mkDerivation (
     // {
       # TODO Remove obsolete and useless flags once the build will be totally mastered
       configureFlags = [
-        "-plugindir $(out)/$(qtPluginPrefix)"
-        "-qmldir $(out)/$(qtQmlPrefix)"
-        "-docdir $(out)/$(qtDocPrefix)"
+        "-plugindir"
+        "${placeholder "out"}/${qtPluginPrefix}"
+        "-qmldir"
+        "${placeholder "out"}/${qtQmlPrefix}"
+        "-docdir"
+        "${placeholder "out"}/${qtDocPrefix}"
 
         "-verbose"
         "-confirm-license"
@@ -391,7 +394,8 @@ stdenv.mkDerivation (
 
         "-gui"
         "-widgets"
-        "-opengl desktop"
+        "-opengl"
+        "desktop"
         "-icu"
         "-L"
         "${icu.out}/lib"
@@ -400,8 +404,10 @@ stdenv.mkDerivation (
         "-pch"
       ]
       ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
-        "-device ${qtPlatformCross stdenv.hostPlatform}"
-        "-device-option CROSS_COMPILE=${stdenv.cc.targetPrefix}"
+        "-device"
+        (qtPlatformCross stdenv.hostPlatform)
+        "-device-option"
+        "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
       ]
       ++ lib.optionals debugSymbols [
         "-debug"
@@ -460,10 +466,14 @@ stdenv.mkDerivation (
         "-${if libpq != null then "plugin" else "no"}-sql-psql"
         "-system-libpng"
 
-        "-make libs"
-        "-make tools"
-        "-${lib.optionalString (!buildExamples) "no"}make examples"
-        "-${lib.optionalString (!buildTests) "no"}make tests"
+        "-make"
+        "libs"
+        "-make"
+        "tools"
+        "-${lib.optionalString (!buildExamples) "no"}make"
+        "examples"
+        "-${lib.optionalString (!buildTests) "no"}make"
+        "tests"
       ]
       ++ (
         if stdenv.hostPlatform.isDarwin then
@@ -478,7 +488,8 @@ stdenv.mkDerivation (
           ]
           ++ [
             "-xcb"
-            "-qpa xcb"
+            "-qpa"
+            "xcb"
             "-L"
             "${libx11.out}/lib"
             "-I"

--- a/pkgs/development/libraries/qt-5/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtbase.nix
@@ -15,6 +15,8 @@
   perl,
   pkg-config,
   python3,
+  copyPathToStore,
+  makeSetupHook,
   which,
   # darwin support
   xcbuild,
@@ -84,6 +86,23 @@ let
       "linux-generic-g++"
     else
       throw "Please add a qtPlatformCross entry for ${plat.config}";
+  qtPluginPrefix = "lib/qt-${qtCompatVersion}/plugins";
+  qtQmlPrefix = "lib/qt-${qtCompatVersion}/qml";
+  qtDocPrefix = "share/doc/qt-${qtCompatVersion}";
+  fix_qt_builtin_paths = copyPathToStore ../hooks/fix-qt-builtin-paths.sh;
+  fix_qt_module_paths = copyPathToStore ../hooks/fix-qt-module-paths.sh;
+
+  devTools = [
+    "bin/fixqt4headers.pl"
+    "bin/moc"
+    "bin/qdbuscpp2xml"
+    "bin/qdbusxml2cpp"
+    "bin/qlalr"
+    "bin/qmake"
+    "bin/rcc"
+    "bin/syncqt.pl"
+    "bin/uic"
+  ];
 in
 
 stdenv.mkDerivation (
@@ -92,7 +111,6 @@ stdenv.mkDerivation (
     {
       pname = "qtbase";
       inherit qtCompatVersion src version;
-      debug = debugSymbols;
 
       propagatedBuildInputs = [
         libxml2
@@ -206,11 +224,9 @@ stdenv.mkDerivation (
 
       inherit patches;
 
-      fix_qt_builtin_paths = ../hooks/fix-qt-builtin-paths.sh;
-      fix_qt_module_paths = ../hooks/fix-qt-module-paths.sh;
       preHook = ''
-        . "$fix_qt_builtin_paths"
-        . "$fix_qt_module_paths"
+        . ${fix_qt_builtin_paths}
+        . ${fix_qt_module_paths}
         . ${../hooks/move-qt-dev-tools.sh}
         . ${../hooks/fix-qmake-libtool.sh}
       '';
@@ -218,9 +234,9 @@ stdenv.mkDerivation (
       postPatch = ''
         for prf in qml_plugin.prf qt_plugin.prf qt_docs.prf qml_module.prf create_cmake.prf; do
             substituteInPlace "mkspecs/features/$prf" \
-                --subst-var qtPluginPrefix \
-                --subst-var qtQmlPrefix \
-                --subst-var qtDocPrefix
+                --subst-var-by qtPluginPrefix ${qtPluginPrefix} \
+                --subst-var-by qtQmlPrefix ${qtQmlPrefix} \
+                --subst-var-by qtDocPrefix ${qtDocPrefix}
         done
 
         substituteInPlace configure --replace-fail /bin/pwd pwd
@@ -274,20 +290,16 @@ stdenv.mkDerivation (
           ''
       );
 
-      qtPluginPrefix = "lib/qt-${qtCompatVersion}/plugins";
-      qtQmlPrefix = "lib/qt-${qtCompatVersion}/qml";
-      qtDocPrefix = "share/doc/qt-${qtCompatVersion}";
-
       setOutputFlags = false;
       preConfigure = ''
         export LD_LIBRARY_PATH="$PWD/lib:$PWD/plugins/platforms''${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH"
 
-        NIX_CFLAGS_COMPILE+=" -DNIXPKGS_QT_PLUGIN_PREFIX=\"$qtPluginPrefix\""
+        NIX_CFLAGS_COMPILE+=" -DNIXPKGS_QT_PLUGIN_PREFIX=\"${qtPluginPrefix}\""
 
         # paralellize compilation of qtmake, which happens within ./configure
         export MAKEFLAGS+=" -j$NIX_BUILD_CORES"
 
-        ./bin/syncqt.pl -version $version
+        ./bin/syncqt.pl -version ${version}
       ''
       + lib.optionalString (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
         # QT's configure script will refuse to use pkg-config unless these two environment variables are set
@@ -309,9 +321,9 @@ stdenv.mkDerivation (
         NIX_OUTPUT_BIN = $bin
         NIX_OUTPUT_DEV = $dev
         NIX_OUTPUT_OUT = $out
-        NIX_OUTPUT_DOC = $dev/$qtDocPrefix
-        NIX_OUTPUT_QML = $bin/$qtQmlPrefix
-        NIX_OUTPUT_PLUGIN = $bin/$qtPluginPrefix
+        NIX_OUTPUT_DOC = $dev/${qtDocPrefix}
+        NIX_OUTPUT_QML = $bin/${qtQmlPrefix}
+        NIX_OUTPUT_PLUGIN = $bin/${qtPluginPrefix}
         EOF
         }
 
@@ -539,18 +551,6 @@ stdenv.mkDerivation (
         moveToOutput "mkspecs" "$dev"
       '';
 
-      devTools = [
-        "bin/fixqt4headers.pl"
-        "bin/moc"
-        "bin/qdbuscpp2xml"
-        "bin/qdbusxml2cpp"
-        "bin/qlalr"
-        "bin/qmake"
-        "bin/rcc"
-        "bin/syncqt.pl"
-        "bin/uic"
-      ];
-
       postFixup = ''
         # Don't retain build-time dependencies like gdb.
         sed '/QMAKE_DEFAULT_.*DIRS/ d' -i $dev/mkspecs/qconfig.pri
@@ -558,6 +558,7 @@ stdenv.mkDerivation (
         fixQtBuiltinPaths "''${!outputDev}" '*.pr?'
 
         # Move development tools to $dev
+        devTools="${lib.concatStringsSep " " devTools}"
         moveQtDevTools
         moveToOutput bin "$dev"
 
@@ -568,9 +569,34 @@ stdenv.mkDerivation (
 
       dontStrip = debugSymbols;
 
-      setupHook = ../hooks/qtbase-setup-hook.sh;
+      setupHook =
+        let
+          hook = makeSetupHook {
+            name = "qtbase5-setup-hook";
+            substitutions = {
+              inherit
+                qtPluginPrefix
+                qtQmlPrefix
+                qtDocPrefix
+                fix_qt_builtin_paths
+                fix_qt_module_paths
+                ;
+              debug = debugSymbols;
+            };
+          } ../hooks/qtbase-setup-hook.sh;
+        in
+        "${hook}/nix-support/setup-hook";
 
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+      passthru = {
+        inherit
+          qtPluginPrefix
+          qtQmlPrefix
+          qtDocPrefix
+          ;
+        tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+      };
+
+      __structuredAttrs = true;
 
       meta = {
         homepage = "https://www.qt.io/";


### PR DESCRIPTION
This fixes the hook for downstream users when `__structuredAttrs` are enabled.

https://github.com/NixOS/nixpkgs/issues/237216

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
