### PR TITLE
python3Packages.django-celery-beat: cleanup, skip failing test

### DIFF
--- a/pkgs/development/python-modules/django-celery-beat/default.nix
+++ b/pkgs/development/python-modules/django-celery-beat/default.nix
@@ -56,6 +56,11 @@ buildPythonPackage rec {
     "t/unit/test_schedulers.py"
   ];
 
+  disabledTests = [
+    # AssertionError: 'At 02:00, only on Monday UTC' != 'At 02:00 AM, only on Monday UTC'
+    "test_long_name"
+  ];
+
   pythonImportsCheck = [ "django_celery_beat" ];
 
   meta = {

--- a/pkgs/development/python-modules/django-celery-beat/default.nix
+++ b/pkgs/development/python-modules/django-celery-beat/default.nix
@@ -1,26 +1,29 @@
 {
   lib,
   buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
   celery,
   cron-descriptor,
   django-timezone-field,
+  python-crontab,
+  tzdata,
+
+  # tests
   ephem,
-  fetchFromGitHub,
   pytest-django,
   pytest-timeout,
   pytestCheckHook,
-  python-crontab,
-  pythonOlder,
-  setuptools,
-  tzdata,
 }:
 
 buildPythonPackage rec {
   pname = "django-celery-beat";
   version = "2.8.1";
   pyproject = true;
-
-  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "celery";
@@ -34,17 +37,17 @@ buildPythonPackage rec {
   build-system = [ setuptools ];
 
   dependencies = [
-    cron-descriptor
-    python-crontab
     celery
+    cron-descriptor
     django-timezone-field
+    python-crontab
     tzdata
   ];
 
   nativeCheckInputs = [
     ephem
-    pytest-timeout
     pytest-django
+    pytest-timeout
     pytestCheckHook
   ];
 


### PR DESCRIPTION
## Things done

- **python3Packages.django-celery-beat: cleanup**
- **python3Packages.django-celery-beat: skip failing test**

```
=================================== FAILURES ===================================
_____________________ HumanReadableTestCase.test_long_name _____________________

self = <t.unit.test_models.HumanReadableTestCase testMethod=test_long_name>

    def test_long_name(self):
        """Long day name display."""
        for day_day_of_week, expected in (
            ("1", ", only on Monday"),
            ("mon", ", only on Monday"),
            ("Monday,tue", ", only on Monday and Tuesday"),
            ("sat-sun/2", ", only on Saturday"),
            ("mon-wed", ", only on Monday, Tuesday, and Wednesday"),
            ("*", ""),
            ("0-6", ""),
            ("2-1", ""),
            ("mon-sun", ""),
            ("tue-mon", ""),
        ):
            cron = CrontabSchedule.objects.create(
                hour="2",
                minute="0",
                day_of_week=day_day_of_week,
            )

>           self.assertEqual(
                cron.human_readable,
                f"At 02:00 AM{expected} UTC",
                day_day_of_week,
            )
E           AssertionError: 'At 02:00, only on Monday UTC' != 'At 02:00 AM, only on Monday UTC'
E           - At 02:00, only on Monday UTC
E           + At 02:00 AM, only on Monday UTC
E           ?         +++
E            : 1

t/unit/test_models.py:254: AssertionError
=========================== short test summary info ============================
FAILED t/unit/test_models.py::HumanReadableTestCase::test_long_name - AssertionError: 'At 02:00, only on Monday UTC' != 'At 02:00 AM, only on Mon...
========================= 1 failed, 65 passed in 2.84s =========================
```

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
