### PR TITLE
python3Packages.meeko: 0.6.1 -> 0.7.1

### DIFF
--- a/pkgs/development/python-modules/meeko/default.nix
+++ b/pkgs/development/python-modules/meeko/default.nix
@@ -1,31 +1,39 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
   gemmi,
   numpy,
-  pytestCheckHook,
-  pythonOlder,
   rdkit,
   scipy,
+
+  # tests
+  pytestCheckHook,
 }:
 
 buildPythonPackage rec {
   pname = "meeko";
-  version = "0.6.1";
-  format = "setuptools";
-
-  disabled = pythonOlder "3.5";
+  version = "0.7.1";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "forlilab";
     repo = "Meeko";
     tag = "v${version}";
-    hash = "sha256-ViIBiczwxTwraYn8UnFAZFCFT28v3WEYm04W2YpU/4g=";
+    hash = "sha256-ObGUUNzfK2k37uJ/aY3DHf9BlJ1nzqTe6tHvV2rj1og=";
   };
 
-  propagatedBuildInputs = [
-    # setup.py only requires numpy but others are needed at runtime
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
     gemmi
     numpy
     rdkit
@@ -33,6 +41,41 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [ pytestCheckHook ];
+
+  disabledTests = [
+    # Require internet connection
+    "test_add_variants"
+    "test_build_noncovalent_CC"
+
+    # AssertionError: assert {'chosen_by_d...ond': [], ...} == {'chosen_by_d...ond': [], ...}
+    "test_polymer_encoding_decoding"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # AssertionError: assert 'altloc' in 'updated 1 h positions but deleted 11
+    "test_AHHY_all_static_residues"
+    "test_AHHY_flex_residues"
+    "test_AHHY_flexibilize_then_parameterize"
+    "test_AHHY_mk_prep_and_export"
+    "test_AHHY_mutate_residues"
+    "test_AHHY_padding"
+    "test_disulfide_adjacent"
+    "test_disulfides"
+    "test_export_sidechains_no_idxmap"
+    "test_insertion_code"
+    "test_just_three_padded_mol"
+    "test_monomer_encoding_decoding"
+    "test_pdbqt_writing_from_decoded_polymer"
+    "test_rdkit_molsetup_encoding_decoding"
+    "test_residue_chem_templates_encoding_decoding"
+    "test_residue_padder_encoding_decoding"
+    "test_residue_template_encoding_decoding"
+    "test_stitch_polymer"
+    "test_write_pdb_1igy"
+    "test_write_pdb_AHHY"
+
+    # RuntimeError: Updated 1 H positions but deleted 10
+    "test_altloc"
+  ];
 
   pythonImportsCheck = [ "meeko" ];
 


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/forlilab/Meeko/compare/v0.6.1...v0.7.1
Changelog: https://github.com/forlilab/Meeko/releases/tag/v0.7.1

cc @natsukium

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc