### PR TITLE
prometheus-dcgm-exporter: drop ld check, copy counters

### DIFF
--- a/pkgs/by-name/pr/prometheus-dcgm-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-dcgm-exporter/package.nix
@@ -42,6 +42,13 @@ buildGoModule rec {
     patchelf --add-needed libnvidia-ml.so "$out/bin/dcgm-exporter"
   '';
 
+  patches = [ ./remove-ldconfig-check.patch ];
+
+  postInstall = ''
+    mkdir -p $out/etc/dcgm-exporter
+    cp $src/etc/*.csv $out/etc/dcgm-exporter/
+  '';
+
   meta = {
     description = "NVIDIA GPU metrics exporter for Prometheus leveraging DCGM";
     homepage = "https://github.com/NVIDIA/dcgm-exporter";

--- a/pkgs/by-name/pr/prometheus-dcgm-exporter/remove-ldconfig-check.patch
+++ b/pkgs/by-name/pr/prometheus-dcgm-exporter/remove-ldconfig-check.patch
@@ -1,0 +1,56 @@
+diff --git a/internal/pkg/prerequisites/dcgmlib_rule.go b/internal/pkg/prerequisites/dcgmlib_rule.go
+--- a/internal/pkg/prerequisites/dcgmlib_rule.go
++++ b/internal/pkg/prerequisites/dcgmlib_rule.go
+@@ -20,7 +20,6 @@
+ 	debugelf "debug/elf"
+ 	"fmt"
+ 	"log/slog"
+-	"strings"
+ )
+
+ const (
+@@ -34,43 +33,7 @@
+
+ // Validate checks if libdcgm.so.4 exists and matches with the machine architecture.
+ func (c dcgmLibExistsRule) Validate() error {
+-	// On Ubuntu, ldconfig is a wrapper around ldconfig.real
+-	ldconfigPath := fmt.Sprintf("/sbin/%s.real", ldconfig)
+-	if _, err := os.Stat(ldconfigPath); err != nil {
+-		ldconfigPath = "/sbin/" + ldconfig
+-	}
+-	// Get list of shared libraries. See: man ldconfig
+-	out, err := exec.Command(ldconfigPath, ldconfigParam).Output()
+-	if err != nil {
+-		return err
+-	}
+-
+-	for _, match := range rxLDCacheEntry.FindAllSubmatch(out, -1) {
+-		libName := strings.TrimSpace(string(match[1]))
+-		if libName == libdcgmco {
+-			libPath := strings.TrimSpace(string(match[2]))
+-			selfMachine, err := c.readELF(procSelfExe)
+-			if err != nil {
+-				return err
+-			}
+-			libMachine, err := c.readELF(libPath)
+-			if err != nil {
+-				// When datacenter-gpu-manager uninstalled, the ldconfig -p may return that the libdcgm.so.4 is present,
+-				// but the library file was removed.
+-				slog.Error(err.Error())
+-				return errLibdcgmNotFound
+-			}
+-
+-			if selfMachine != libMachine {
+-				return fmt.Errorf("the %s library architecture mismatch with the system; wanted: %s, received: %s",
+-					libdcgmco, selfMachine, libMachine)
+-			}
+-
+-			return nil
+-		}
+-	}
+-
+-	return errLibdcgmNotFound
++	return nil
+ }
+
+ func (c dcgmLibExistsRule) readELF(name string) (debugelf.Machine, error) {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

I've tested this by running  nv-host-engine from pkgs.dcgm and then prometheus-dcgm-exporter: `/result/bin//dcgm-exporter -f ./result/etc/dcgm-exporter/default-counters.csv` . Prometheus is able to pick up on this (e.g. I'm able to generate a prometheus chart based on the output).

Addresses #472689 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
