### PR TITLE
abook: fix build with gcc 15

### DIFF
--- a/pkgs/by-name/ab/abook/0001-Fix-wcwidth-declaration.patch
+++ b/pkgs/by-name/ab/abook/0001-Fix-wcwidth-declaration.patch
@@ -1,0 +1,48 @@
+From 2e3ea5ab32ed356c45e0a7a8db37924a77a1c949 Mon Sep 17 00:00:00 2001
+From: Marcin Serwin <marcin@serwin.dev>
+Date: Sat, 20 Dec 2025 12:51:13 +0100
+Subject: [PATCH] Fix wcwidth declaration
+
+The wcwidth function is declared in `wchar.h` on POSIX systems which
+is not included in the default Autoconf includes. Because of this
+HAVE_DECL_WCWIDTH would be configured to 0.
+
+Since C23 functions with no arguments in prototypes are treated as
+taking no arguments. This results in mismatched declaration since in
+wchar.h the functions is declared as taking wchar_t.
+
+Signed-off-by: Marcin Serwin <marcin@serwin.dev>
+---
+ configure.ac | 2 +-
+ mbswidth.c   | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 7d756ee..a1ecbe2 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -61,7 +61,7 @@ AC_CHECK_HEADER(wchar.h,[
+ 	AC_DEFINE(HAVE_WCHAR_H, 1, [Define if you have the <wchar.h> header file.])],
+ 	[ac_have_wchar_h=no])
+ AC_CHECK_FUNCS(mbtowc wcwidth mbrtowc mbsinit,,ac_widec_funcs=no)
+-AC_CHECK_DECLS(wcwidth)
++AC_CHECK_DECLS(wcwidth, [], [], [#include <wchar.h>])
+ AC_CHECK_TYPE(wchar_t,,ac_widec_funcs=no)
+ 
+ if test x$ac_widec_funcs = xyes -a x$ac_have_wchar_h = xyes; then
+diff --git a/mbswidth.c b/mbswidth.c
+index 031e6b7..54a2cb5 100644
+--- a/mbswidth.c
++++ b/mbswidth.c
+@@ -63,7 +63,7 @@
+ #	warn "this configure-time declaration test was not run"
+ #endif
+ #if !HAVE_DECL_WCWIDTH
+-int wcwidth ();
++int wcwidth (wchar_t);
+ #endif
+ 
+ #ifndef wcwidth
+-- 
+2.51.2
+

--- a/pkgs/by-name/ab/abook/package.nix
+++ b/pkgs/by-name/ab/abook/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchgit,
-  fetchpatch,
   autoreconfHook,
   pkg-config,
   ncurses,
@@ -20,10 +19,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   patches = [
-    (fetchpatch {
-      url = "https://aur.archlinux.org/cgit/aur.git/plain/abook-gcc15.patch?h=abook";
-      hash = "sha256-+73+USELoby8JvuVOWZe6E+xtdhajnLnDkzD/77QoTo=";
-    })
+    ./0001-Fix-wcwidth-declaration.patch
   ];
 
   # error: implicit declaration of function 'isalnum' [-Wimplicit-function-declaration]


### PR DESCRIPTION
The AUR patch modifies configure script which is ineffective because we regenerate it with autoreconfHook.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
