### PR TITLE
xfce.*: Move away from mkXfceDerivation (part 1)

### DIFF
--- a/pkgs/desktops/xfce/applications/orage/default.nix
+++ b/pkgs/desktops/xfce/applications/orage/default.nix
@@ -1,6 +1,11 @@
 {
+  stdenv,
   lib,
-  mkXfceDerivation,
+  fetchFromGitLab,
+  gettext,
+  pkg-config,
+  xfce4-dev-tools,
+  wrapGAppsHook3,
   glib,
   gtk3,
   libical,
@@ -8,14 +13,27 @@
   libxfce4ui,
   libxfce4util,
   tzdata,
+  gitUpdater,
 }:
 
-mkXfceDerivation {
-  category = "apps";
+stdenv.mkDerivation (finalAttrs: {
   pname = "orage";
   version = "4.20.2";
 
-  sha256 = "sha256-iV4eVYmOXfEpq5cnHeCXRvx0Ms0Dis3EIwbcSakGLXs=";
+  src = fetchFromGitLab {
+    domain = "gitlab.xfce.org";
+    owner = "apps";
+    repo = "orage";
+    tag = "orage-${finalAttrs.version}";
+    hash = "sha256-iV4eVYmOXfEpq5cnHeCXRvx0Ms0Dis3EIwbcSakGLXs=";
+  };
+
+  nativeBuildInputs = [
+    gettext
+    pkg-config
+    xfce4-dev-tools
+    wrapGAppsHook3
+  ];
 
   buildInputs = [
     glib
@@ -31,9 +49,20 @@ mkXfceDerivation {
     substituteInPlace src/tz_zoneinfo_read.c  --replace-fail "/usr/share/zoneinfo" "${tzdata}/share/zoneinfo"
   '';
 
+  configureFlags = [ "--enable-maintainer-mode" ];
+  enableParallelBuilding = true;
+
+  passthru.updateScript = gitUpdater {
+    rev-prefix = "orage-";
+    odd-unstable = true;
+  };
+
   meta = {
     description = "Simple calendar application for Xfce";
+    homepage = "https://gitlab.xfce.org/apps/orage";
+    license = lib.licenses.gpl2Plus;
     mainProgram = "orage";
+    platforms = lib.platforms.linux;
     teams = [ lib.teams.xfce ];
   };
-}
+})

--- a/pkgs/desktops/xfce/applications/xfce4-notifyd/default.nix
+++ b/pkgs/desktops/xfce/applications/xfce4-notifyd/default.nix
@@ -1,6 +1,12 @@
 {
+  stdenv,
   lib,
-  mkXfceDerivation,
+  fetchFromGitLab,
+  gettext,
+  meson,
+  ninja,
+  pkg-config,
+  wrapGAppsHook3,
   dbus,
   glib,
   gtk3,
@@ -11,17 +17,34 @@
   libxfce4ui,
   libxfce4util,
   sqlite,
+  systemd,
   xfce4-panel,
   xfconf,
+  gitUpdater,
 }:
 
-mkXfceDerivation {
-  category = "apps";
+stdenv.mkDerivation (finalAttrs: {
   pname = "xfce4-notifyd";
   version = "0.9.7";
-  odd-unstable = false;
 
-  sha256 = "sha256-pgdoy3mZOGMOBwK/cYEl8fre4fZo2lfyWzZnrSYlQ64=";
+  src = fetchFromGitLab {
+    domain = "gitlab.xfce.org";
+    owner = "apps";
+    repo = "xfce4-notifyd";
+    tag = "xfce4-notifyd-${finalAttrs.version}";
+    hash = "sha256-pgdoy3mZOGMOBwK/cYEl8fre4fZo2lfyWzZnrSYlQ64=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    gettext
+    glib # glib-genmarshal
+    meson
+    ninja
+    pkg-config
+    wrapGAppsHook3
+  ];
 
   buildInputs = [
     dbus
@@ -34,18 +57,21 @@ mkXfceDerivation {
     libxfce4ui
     libxfce4util
     sqlite
+    systemd
     xfce4-panel
     xfconf
   ];
 
-  configureFlags = [
-    "--enable-dbus-start-daemon"
-    "--enable-sound"
-  ];
+  passthru.updateScript = gitUpdater {
+    rev-prefix = "xfce4-notifyd-";
+  };
 
   meta = {
     description = "Simple notification daemon for Xfce";
+    homepage = "https://gitlab.xfce.org/apps/xfce4-notifyd";
+    license = lib.licenses.gpl2Plus;
     mainProgram = "xfce4-notifyd-config";
+    platforms = lib.platforms.linux;
     teams = [ lib.teams.xfce ];
   };
-}
+})

--- a/pkgs/desktops/xfce/core/exo/default.nix
+++ b/pkgs/desktops/xfce/core/exo/default.nix
@@ -1,26 +1,46 @@
 {
+  stdenv,
   lib,
-  mkXfceDerivation,
+  fetchFromGitLab,
   docbook_xsl,
+  gettext,
+  pkg-config,
+  xfce4-dev-tools,
+  wrapGAppsHook3,
   glib,
   libxslt,
   gtk3,
   libxfce4ui,
   libxfce4util,
   perl,
+  gitUpdater,
 }:
 
-mkXfceDerivation {
-  category = "xfce";
+stdenv.mkDerivation (finalAttrs: {
   pname = "exo";
   version = "4.20.0";
 
-  sha256 = "sha256-mlGsFaKy96eEAYgYYqtEI4naq5ZSEe3V7nsWGAEucn0=";
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  src = fetchFromGitLab {
+    domain = "gitlab.xfce.org";
+    owner = "xfce";
+    repo = "exo";
+    tag = "exo-${finalAttrs.version}";
+    hash = "sha256-mlGsFaKy96eEAYgYYqtEI4naq5ZSEe3V7nsWGAEucn0=";
+  };
 
   nativeBuildInputs = [
     libxslt
     docbook_xsl
+    gettext
     perl
+    pkg-config
+    xfce4-dev-tools
+    wrapGAppsHook3
   ];
 
   buildInputs = [
@@ -30,8 +50,19 @@ mkXfceDerivation {
     libxfce4util
   ];
 
+  configureFlags = [ "--enable-maintainer-mode" ];
+  enableParallelBuilding = true;
+
+  passthru.updateScript = gitUpdater {
+    rev-prefix = "exo-";
+    odd-unstable = true;
+  };
+
   meta = {
     description = "Application library for Xfce";
+    homepage = "https://gitlab.xfce.org/xfce/exo";
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.linux;
     teams = [ lib.teams.xfce ];
   };
-}
+})

--- a/pkgs/desktops/xfce/core/garcon/default.nix
+++ b/pkgs/desktops/xfce/core/garcon/default.nix
@@ -1,7 +1,10 @@
 {
   stdenv,
   lib,
-  mkXfceDerivation,
+  fetchFromGitLab,
+  gettext,
+  pkg-config,
+  xfce4-dev-tools,
   gtk3,
   libxfce4ui,
   libxfce4util,
@@ -10,16 +13,32 @@
     && stdenv.hostPlatform.emulatorAvailable buildPackages,
   buildPackages,
   gobject-introspection,
+  gitUpdater,
 }:
 
-mkXfceDerivation {
-  category = "xfce";
+stdenv.mkDerivation (finalAttrs: {
   pname = "garcon";
   version = "4.20.0";
 
-  sha256 = "sha256-MeZkDb2QgGMaloO6Nwlj9JmZByepd6ERqpAWqrVv1xw=";
+  outputs = [
+    "out"
+    "dev"
+  ];
 
-  nativeBuildInputs = lib.optionals withIntrospection [
+  src = fetchFromGitLab {
+    domain = "gitlab.xfce.org";
+    owner = "xfce";
+    repo = "garcon";
+    tag = "garcon-${finalAttrs.version}";
+    hash = "sha256-MeZkDb2QgGMaloO6Nwlj9JmZByepd6ERqpAWqrVv1xw=";
+  };
+
+  nativeBuildInputs = [
+    gettext
+    pkg-config
+    xfce4-dev-tools
+  ]
+  ++ lib.optionals withIntrospection [
     gobject-introspection
   ];
 
@@ -29,12 +48,22 @@ mkXfceDerivation {
     libxfce4util
   ];
 
+  configureFlags = [ "--enable-maintainer-mode" ];
+  enableParallelBuilding = true;
+
+  passthru.updateScript = gitUpdater {
+    rev-prefix = "garcon-";
+    odd-unstable = true;
+  };
+
   meta = {
     description = "Xfce menu support library";
+    homepage = "https://gitlab.xfce.org/xfce/garcon";
     license = with lib.licenses; [
       lgpl2Only
       fdl11Only
     ];
+    platforms = lib.platforms.linux;
     teams = [ lib.teams.xfce ];
   };
-}
+})

--- a/pkgs/desktops/xfce/core/libxfce4ui/default.nix
+++ b/pkgs/desktops/xfce/core/libxfce4ui/default.nix
@@ -1,8 +1,12 @@
 {
   stdenv,
-  mkXfceDerivation,
   lib,
+  fetchFromGitLab,
+  gettext,
   perl,
+  pkg-config,
+  xfce4-dev-tools,
+  wrapGAppsHook3,
   libICE,
   libSM,
   libepoxy,
@@ -18,17 +22,32 @@
   buildPackages,
   gobject-introspection,
   vala,
+  gitUpdater,
 }:
 
-mkXfceDerivation {
-  category = "xfce";
+stdenv.mkDerivation (finalAttrs: {
   pname = "libxfce4ui";
   version = "4.20.2";
 
-  sha256 = "sha256-NsTrJ2271v8vMMyiEef+4Rs0KBOkSkKPjfoJdgQU0ds=";
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  src = fetchFromGitLab {
+    domain = "gitlab.xfce.org";
+    owner = "xfce";
+    repo = "libxfce4ui";
+    tag = "libxfce4ui-${finalAttrs.version}";
+    hash = "sha256-NsTrJ2271v8vMMyiEef+4Rs0KBOkSkKPjfoJdgQU0ds=";
+  };
 
   nativeBuildInputs = [
+    gettext
     perl
+    pkg-config
+    xfce4-dev-tools
+    wrapGAppsHook3
   ]
   ++ lib.optionals withIntrospection [
     gobject-introspection
@@ -51,16 +70,26 @@ mkXfceDerivation {
   ];
 
   configureFlags = [
+    "--enable-maintainer-mode"
     "--with-vendor-info=NixOS"
   ];
 
+  enableParallelBuilding = true;
+
+  passthru.updateScript = gitUpdater {
+    rev-prefix = "libxfce4ui-";
+    odd-unstable = true;
+  };
+
   meta = {
     description = "Widgets library for Xfce";
+    homepage = "https://gitlab.xfce.org/xfce/libxfce4ui";
     mainProgram = "xfce4-about";
     license = with lib.licenses; [
       lgpl2Plus
       lgpl21Plus
     ];
+    platforms = lib.platforms.linux;
     teams = [ lib.teams.xfce ];
   };
-}
+})

--- a/pkgs/desktops/xfce/core/libxfce4util/default.nix
+++ b/pkgs/desktops/xfce/core/libxfce4util/default.nix
@@ -1,26 +1,45 @@
 {
   stdenv,
-  mkXfceDerivation,
   lib,
+  fetchFromGitLab,
+  gettext,
+  pkg-config,
   python3,
   vala,
+  xfce4-dev-tools,
+  wrapGAppsNoGuiHook,
   glib,
   withIntrospection ?
     lib.meta.availableOn stdenv.hostPlatform gobject-introspection
     && stdenv.hostPlatform.emulatorAvailable buildPackages,
   buildPackages,
   gobject-introspection,
+  gitUpdater,
 }:
 
-mkXfceDerivation {
-  category = "xfce";
+stdenv.mkDerivation (finalAttrs: {
   pname = "libxfce4util";
   version = "4.20.1";
 
-  sha256 = "sha256-QlT5ev4NhjR/apbgYQsjrweJ2IqLySozLYLzCAnmkfM=";
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  src = fetchFromGitLab {
+    domain = "gitlab.xfce.org";
+    owner = "xfce";
+    repo = "libxfce4util";
+    tag = "libxfce4util-${finalAttrs.version}";
+    hash = "sha256-QlT5ev4NhjR/apbgYQsjrweJ2IqLySozLYLzCAnmkfM=";
+  };
 
   nativeBuildInputs = [
+    gettext
+    pkg-config
     python3
+    xfce4-dev-tools
+    wrapGAppsNoGuiHook
   ]
   ++ lib.optionals withIntrospection [
     gobject-introspection
@@ -35,10 +54,20 @@ mkXfceDerivation {
     patchShebangs xdt-gen-visibility
   '';
 
+  configureFlags = [ "--enable-maintainer-mode" ];
+  enableParallelBuilding = true;
+
+  passthru.updateScript = gitUpdater {
+    rev-prefix = "libxfce4util-";
+    odd-unstable = true;
+  };
+
   meta = {
     description = "Extension library for Xfce";
+    homepage = "https://gitlab.xfce.org/xfce/libxfce4util";
     mainProgram = "xfce4-kiosk-query";
     license = lib.licenses.lgpl2Plus;
+    platforms = lib.platforms.linux;
     teams = [ lib.teams.xfce ];
   };
-}
+})


### PR DESCRIPTION
To reduce the diff when build system change comes (Xfce 4.22). `mkXfceDerivation` is generally pointless with meson.

- https://github.com/NixOS/nixpkgs/pull/472595#issuecomment-3677467001

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

