### PR TITLE
tree-sitter.allGrammars: exclude broken grammars

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/treesit-grammars/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/treesit-grammars/package.nix
@@ -11,14 +11,14 @@ let
     path = "${drv}/parser";
   };
 
+  grammarPackage = grammars: pkgs.linkFarm "emacs-treesit-grammars" (map grammarToAttrSet grammars);
+
   # Usage:
   # treesit-grammars.with-grammars (p: [ p.tree-sitter-bash p.tree-sitter-c ... ])
-  with-grammars =
-    fn:
-    pkgs.linkFarm "emacs-treesit-grammars" (map grammarToAttrSet (fn pkgs.tree-sitter.builtGrammars));
+  with-grammars = fn: grammarPackage (fn pkgs.tree-sitter.builtGrammars);
+
+  with-all-grammars = grammarPackage pkgs.tree-sitter.allGrammars;
 in
 {
-  inherit with-grammars;
-
-  with-all-grammars = with-grammars (ps: lib.filter (p: !p.meta.broken) (lib.attrValues ps));
+  inherit with-grammars with-all-grammars;
 }

--- a/pkgs/development/tools/parsing/tree-sitter/default.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/default.nix
@@ -73,7 +73,7 @@ let
   # pkgs.tree-sitter.withPlugins (p: [ p.tree-sitter-c p.tree-sitter-java ... ])
   #
   # or for all grammars:
-  # pkgs.tree-sitter.withPlugins (_: allGrammars)
+  # pkgs.tree-sitter.withPlugins (_: pkgs.tree-sitter.allGrammars)
   # which is equivalent to
   # pkgs.tree-sitter.withPlugins (p: builtins.attrValues p)
   withPlugins =
@@ -98,7 +98,7 @@ let
       ) grammars
     );
 
-  allGrammars = builtins.attrValues builtGrammars;
+  allGrammars = lib.filter (p: !(p.meta.broken or false)) (lib.attrValues builtGrammars);
 
 in
 rustPlatform.buildRustPackage (final: {


### PR DESCRIPTION
Commit 9bfc2e203bf0b72c5c52f70c1261c36b86d73eb1 marked the tree-sitter-razor grammar as broken. That breaks building packages using tree-sitter.allGrammars (like diffsitter) as that now includes a broken package.

Excluding broken grammars from allGrammars seems more useful than forcing its users to work around this.

This is essentially the same as PR #472609 for emacsPackages.treesit-grammars.with-all-grammars, which had the same problem.

It is a possible alternative to PR #471954, which filters out derivations marked broken from builtGrammars entirely. If that PR is merged, this PR should not be (and PR #472609 should be reverted).

(Tested by building `pkgs.tree-sitter.withPlugins (_: pkgs.tree-sitter.allGrammars)` and `diffsitter`.)

(Marked as draft to get confirmation on #471954 this is the right approach)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
