### PR TITLE
projtlauncher: init at 0.0.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -28869,6 +28869,15 @@
       { fingerprint = "D2A8 A906 ACA7 B6D6 575E 9A2F 3A49 5054 6EA6 9E5C"; }
     ];
   };
+  yongdohyun = {
+    name = "Yong Do-Hyun";
+    email = "froster12@naver.com";
+    github = "YongDo-Hyun";
+    githubId = 97219311;
+    keys = [
+      { fingerprint = "FB56 5272 D5AE 8B57 463D A965 E49B 53C9 18C3 39A6"; }
+    ];
+  };
   yorickvp = {
     email = "yorickvanpelt@gmail.com";
     matrix = "@yorickvp:matrix.org";

--- a/pkgs/by-name/pr/projtlauncher-unwrapped/package.nix
+++ b/pkgs/by-name/pr/projtlauncher-unwrapped/package.nix
@@ -6,10 +6,10 @@
   cmark,
   extra-cmake-modules,
   fetchpatch2,
+  qt6Packages,
   gamemode,
   ghc_filesystem,
   jdk17,
-  kdePackages,
   ninja,
   nix-update-script,
   stripJavaArchivesHook,
@@ -24,29 +24,31 @@ assert lib.assertMsg (
 ) "gamemodeSupport is only available on Linux.";
 stdenv.mkDerivation (finalAttrs: {
   pname = "projtlauncher";
-  version = "0.0.3";
+  version = "0.0.3-4";
 
   src = fetchFromGitHub {
     owner = "Project-Tick";
     repo = "ProjT-Launcher";
     tag = finalAttrs.version;
-    hash = "sha256-+josMV3s6g63tLqGNbrBrbrl6Y36+uRmpiVMtbi57Ug=";
+    hash = "sha256-U7bcQOySof86EtZHa63/PNuWDDJ7kEL0NuzvJ1dGU8c=";
     fetchSubmodules = true;
   };
 
   nativeBuildInputs = [
     cmake
     ninja
-    extra-cmake-modules
     jdk17
     stripJavaArchivesHook
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    extra-cmake-modules
   ];
 
   buildInputs = [
     cmark
-    kdePackages.qtbase
-    kdePackages.qtnetworkauth
-    kdePackages.quazip
+    qt6Packages.qtbase
+    qt6Packages.qtnetworkauth
+    qt6Packages.quazip
     tomlplusplus
     zlib
   ]
@@ -71,8 +73,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   dontWrapQtApps = true;
 
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
   meta = {
-    description = "ProjT Launcher an free, open-source Minecraft launcher.";
+    description = "Free, open-source Minecraft launcher";
     longDescription = ''
       This application lets you create and manage multiple
       independent Minecraft instances, each with its own
@@ -87,7 +93,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://projtlauncher.yongdohyun.org.tr/";
     changelog = "https://github.com/Project-Tick/ProjT-Launcher/releases/tag/${finalAttrs.version}";
     license = with lib.licenses; [
-      gpl3Plus
       gpl3Only
       asl20
       cc-by-sa-40
@@ -96,6 +101,10 @@ stdenv.mkDerivation (finalAttrs: {
       yongdohyun
     ];
     mainProgram = "projtlauncher";
-    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "aarch64-darwin"
+    ];
   };
 })

--- a/pkgs/by-name/pr/projtlauncher-unwrapped/package.nix
+++ b/pkgs/by-name/pr/projtlauncher-unwrapped/package.nix
@@ -1,0 +1,101 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  cmark,
+  extra-cmake-modules,
+  fetchpatch2,
+  gamemode,
+  ghc_filesystem,
+  jdk17,
+  kdePackages,
+  ninja,
+  nix-update-script,
+  stripJavaArchivesHook,
+  tomlplusplus,
+  zlib,
+  msaClientID ? null,
+  gamemodeSupport ? stdenv.hostPlatform.isLinux,
+}:
+
+assert lib.assertMsg (
+  gamemodeSupport -> stdenv.hostPlatform.isLinux
+) "gamemodeSupport is only available on Linux.";
+stdenv.mkDerivation (finalAttrs: {
+  pname = "projtlauncher";
+  version = "0.0.3";
+
+  src = fetchFromGitHub {
+    owner = "Project-Tick";
+    repo = "ProjT-Launcher";
+    tag = finalAttrs.version;
+    hash = "sha256-+josMV3s6g63tLqGNbrBrbrl6Y36+uRmpiVMtbi57Ug=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    extra-cmake-modules
+    jdk17
+    stripJavaArchivesHook
+  ];
+
+  buildInputs = [
+    cmark
+    kdePackages.qtbase
+    kdePackages.qtnetworkauth
+    kdePackages.quazip
+    tomlplusplus
+    zlib
+  ]
+  ++ lib.optional gamemodeSupport gamemode;
+
+  cmakeFlags = [
+    # downstream branding
+    (lib.cmakeFeature "Launcher_BUILD_PLATFORM" "nixpkgs")
+  ]
+  ++ lib.optionals (msaClientID != null) [
+    (lib.cmakeFeature "Launcher_MSA_CLIENT_ID" (toString msaClientID))
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # we wrap our binary manually
+    (lib.cmakeFeature "INSTALL_BUNDLE" "nodeps")
+    # disable built-in updater
+    (lib.cmakeFeature "MACOSX_SPARKLE_UPDATE_FEED_URL" "''")
+    (lib.cmakeFeature "CMAKE_INSTALL_PREFIX" "${placeholder "out"}/Applications/")
+  ];
+
+  doCheck = true;
+
+  dontWrapQtApps = true;
+
+  meta = {
+    description = "ProjT Launcher an free, open-source Minecraft launcher.";
+    longDescription = ''
+      This application lets you create and manage multiple
+      independent Minecraft instances, each with its own
+      unique mods, texture packs, worlds, and settings.
+      Easily switch between different setups without conflicts,
+      keep all your saves and customizations organized, and
+      configure options for each instance through a simple and
+      intuitive interface. Perfect for players who want to
+      experiment with different modpacks, resource packs, or
+      gameplay styles while keeping everything neatly separated.
+    '';
+    homepage = "https://projtlauncher.yongdohyun.org.tr/";
+    changelog = "https://github.com/Project-Tick/ProjT-Launcher/releases/tag/${finalAttrs.version}";
+    license = with lib.licenses; [
+      gpl3Plus
+      gpl3Only
+      asl20
+      cc-by-sa-40
+    ];
+    maintainers = with lib.maintainers; [
+      yongdohyun
+    ];
+    mainProgram = "projtlauncher";
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+})

--- a/pkgs/by-name/pr/projtlauncher/package.nix
+++ b/pkgs/by-name/pr/projtlauncher/package.nix
@@ -1,0 +1,132 @@
+{
+  addDriverRunpath,
+  alsa-lib,
+  flite,
+  gamemode,
+  glfw3-minecraft,
+  jdk17,
+  jdk21,
+  jdk8,
+  qt6Packages,
+  lib,
+  libGL,
+  libX11,
+  libXcursor,
+  libXext,
+  libXrandr,
+  libXxf86vm,
+  libjack2,
+  libpulseaudio,
+  libusb1,
+  mesa-demos,
+  openal,
+  pciutils,
+  pipewire,
+  projtlauncher-unwrapped,
+  stdenv,
+  symlinkJoin,
+  udev,
+  vulkan-loader,
+  xrandr,
+
+  additionalLibs ? [ ],
+  additionalPrograms ? [ ],
+  controllerSupport ? stdenv.hostPlatform.isLinux,
+  gamemodeSupport ? stdenv.hostPlatform.isLinux,
+  jdks ? [
+    jdk21 # need for newest Minecraft versions
+    jdk17 # need for old and new Minecraft versions
+    jdk8 # need for legacy Minecraft versions
+  ],
+  msaClientID ? null,
+  textToSpeechSupport ? stdenv.hostPlatform.isLinux,
+}:
+
+assert lib.assertMsg (
+  controllerSupport -> stdenv.hostPlatform.isLinux
+) "controllerSupport only has an effect on Linux.";
+
+assert lib.assertMsg (
+  textToSpeechSupport -> stdenv.hostPlatform.isLinux
+) "textToSpeechSupport only has an effect on Linux.";
+
+let
+  projtlauncher' = projtlauncher-unwrapped.override { inherit msaClientID gamemodeSupport; };
+in
+
+symlinkJoin {
+  pname = "projtlauncher";
+  inherit (projtlauncher') version;
+
+  paths = [ projtlauncher' ];
+
+  nativeBuildInputs = [ qt6Packages.wrapQtAppsHook ];
+
+  buildInputs = [
+    qt6Packages.qtbase
+    qt6Packages.qtsvg
+  ]
+  ++ lib.optional stdenv.hostPlatform.isLinux qt6Packages.qtwayland;
+
+  postBuild = ''
+    wrapQtAppsHook
+  '';
+
+  qtWrapperArgs =
+    let
+      runtimeLibs = [
+        (lib.getLib stdenv.cc.cc)
+        ## native versions
+        glfw3-minecraft
+        openal
+
+        ## openal
+        alsa-lib
+        libjack2
+        libpulseaudio
+        pipewire
+
+        ## glfw
+        libGL
+        libX11
+        libXcursor
+        libXext
+        libXrandr
+        libXxf86vm
+
+        udev # oshi
+
+        vulkan-loader # VulkanMod's lwjgl
+      ]
+      ++ lib.optional textToSpeechSupport flite
+      ++ lib.optional gamemodeSupport gamemode.lib
+      ++ lib.optional controllerSupport libusb1
+      ++ additionalLibs;
+
+      runtimePrograms = [
+        mesa-demos
+        pciutils # need lspci
+        xrandr # needed for LWJGL [2.9.2, 3) https://github.com/LWJGL/lwjgl/issues/128
+      ]
+      ++ additionalPrograms;
+
+    in
+    [ "--prefix PROJTLAUNCHER_JAVA_PATHS : ${lib.makeSearchPath "bin/java" jdks}" ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      "--set LD_LIBRARY_PATH ${addDriverRunpath.driverLink}/lib:${lib.makeLibraryPath runtimeLibs}"
+      "--prefix PATH : ${lib.makeBinPath runtimePrograms}"
+    ];
+
+  meta = {
+    inherit (projtlauncher'.meta)
+      description
+      longDescription
+      homepage
+      changelog
+      license
+      maintainers
+      mainProgram
+      platforms
+      ;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This is a continuation of PR #469082

>  Is the package ready for general use? We don't want to include projects that are too immature or are going to be abandoned immediately. In case of doubt, check with upstream.

Yes my package for 0.0.3 and minimal patches are ready for general use

> Does the project have a clear license statement? Remember that software is unfree by default (all rights reserved), and merely providing access to the source code does not imply its redistribution. In case of doubt, ask upstream.

My project license is GPL 3.0 Only

> How realistic is it that it will be used by other people? It's good that nixpkgs caters to various niches, but if it's a niche of 5 people it's probably too small. A good estimate is checking upstream issues and pull requests, or other software repositories.

This question is unfortunately very vague, but yes, there will be people who use it, and there's also no specific metric.

> Is the software actively maintained upstream? Especially packages that are security-critical, rely on fast-moving dependencies, or affect data integrity should see regular maintenance.

Yes, this software is actively maintained, and 66 PRs have been successfully merged.

> Are you willing to maintain the package? You should care enough about the package to be willing to keep it up and running for at least one complete Nixpkgs' release life-cycle.

We, the Project Tick team, are absolutely ready to protect our package, our entire package.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
