### PR TITLE
vship: init at 4.0.2

### DIFF
--- a/pkgs/development/libraries/vship/default.nix
+++ b/pkgs/development/libraries/vship/default.nix
@@ -1,0 +1,5 @@
+{ callPackage, stdenv }:
+{
+  rocm = callPackage ./vship.nix { gpuBackend = "rocm"; };
+  cuda = callPackage ./vship.nix { gpuBackend = "cuda"; };
+}

--- a/pkgs/development/libraries/vship/vship.nix
+++ b/pkgs/development/libraries/vship/vship.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  clangStdenv,
+  fetchFromGitHub,
+  rocmPackages,
+  cudaPackages,
+  autoAddDriverRunpath,
+  pkg-config,
+  ffms,
+  ffmpeg-headless,
+  gpuBackend ? "rocm",
+}:
+# vship needs a valid GPU backend
+assert builtins.elem gpuBackend [
+  "cuda"
+  "rocm"
+];
+
+clangStdenv.mkDerivation (finalAttrs: {
+  pname = "vship";
+  version = "4.0.2";
+
+  src = fetchFromGitHub {
+    owner = "Line-fr";
+    repo = "Vship";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-enRdz0oryvERGYKpymKJLmtxThXR0NFkiinvkNAVxi0=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+  ]
+  ++ lib.optional (gpuBackend == "rocm") rocmPackages.clr
+  ++ lib.optionals (gpuBackend == "cuda") [
+    cudaPackages.cuda_nvcc
+    cudaPackages.cuda_cudart
+    autoAddDriverRunpath
+  ];
+
+  buildInputs = [
+    ffms
+    ffmpeg-headless
+  ];
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  buildFlags =
+    lib.optional (gpuBackend == "rocm") "buildall"
+    ++ lib.optional (gpuBackend == "cuda") "buildcudaall";
+
+  meta = {
+    description = "High-performance Library for GPU-accelerated visual fidelity metrics";
+    longDescription = "Easy to use high-performance Library for GPU-accelerated visual fidelity metrics with SSIMULACRA2, Butteraugli & CVVDP";
+    homepage = "https://github.com/Line-fr/Vship";
+    changelog = "https://github.com/Line-fr/Vship/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      armelclo
+    ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/tools/video/ffvship/default.nix
+++ b/pkgs/tools/video/ffvship/default.nix
@@ -1,0 +1,5 @@
+{ callPackage, stdenv }:
+{
+  rocm = callPackage ./ffvship.nix { gpuBackend = "rocm"; };
+  cuda = callPackage ./ffvship.nix { gpuBackend = "cuda"; };
+}

--- a/pkgs/tools/video/ffvship/ffvship.nix
+++ b/pkgs/tools/video/ffvship/ffvship.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  clangStdenv,
+  fetchFromGitHub,
+  pkg-config,
+  ffms,
+  ffmpeg-headless,
+  vship,
+  gpuBackend ? "rocm",
+}:
+# ffvship needs a valid GPU backend
+assert builtins.elem gpuBackend [
+  "cuda"
+  "rocm"
+];
+clangStdenv.mkDerivation (finalAttrs: {
+  pname = "ffvship";
+  version = "4.0.2";
+
+  src = fetchFromGitHub {
+    owner = "Line-fr";
+    repo = "Vship";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-enRdz0oryvERGYKpymKJLmtxThXR0NFkiinvkNAVxi0=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    ffms
+    ffmpeg-headless
+    vship.${gpuBackend}
+  ];
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  buildFlags = "buildFFVSHIP";
+
+  meta = {
+    description = "CLI for Vship";
+    homepage = "https://github.com/Line-fr/Vship";
+    changelog = "https://github.com/Line-fr/Vship/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      armelclo
+    ];
+    platforms = lib.platforms.linux;
+    mainProgram = "FFVship";
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8459,6 +8459,8 @@ with pkgs;
   # See: https://github.com/vllm-project/vllm/issues/12083
   vllm = with python312Packages; toPythonApplication vllm;
 
+  vship = recurseIntoAttrs (import ../development/libraries/vship { inherit callPackage stdenv; });
+
   vte-gtk4 = vte.override {
     gtkVersion = "4";
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6284,6 +6284,8 @@ with pkgs;
     haskellPackages.callPackage ../tools/misc/fffuu { }
   );
 
+  ffvship = recurseIntoAttrs (import ../tools/video/ffvship { inherit callPackage stdenv; });
+
   flow = callPackage ../development/tools/analysis/flow {
     ocamlPackages = ocaml-ng.ocamlPackages.overrideScope (
       self: super: {


### PR DESCRIPTION
This PR adds 2 new packages to nixpkgs:
- vship: An easy to use, high-performance Library for GPU-accelerated visual fidelity metrics with SSIMULACRA2, Butteraugli & CVVDP.
- ffvship: A CLI to use vship
 
Both of them have an Nvidia and AMD version:
- vship.amd vship.nvidia
- ffvship.amd ffvship.nvidia

I have tested them for both AMD and NVIDIA cards on my x86_64 computers.

### How to test them:
- FFVship --list-gpu
- FFVship video_path1 video_path2

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
