### PR TITLE
unicode-paracode: 2.9 -> 3.2-unstable-2025-01-31

### DIFF
--- a/pkgs/by-name/un/unicode-paracode/package.nix
+++ b/pkgs/by-name/un/unicode-paracode/package.nix
@@ -1,7 +1,6 @@
 {
   lib,
   fetchFromGitHub,
-  fetchurl,
   python3Packages,
   installShellFiles,
   gitUpdater,
@@ -9,36 +8,40 @@
 }:
 
 python3Packages.buildPythonApplication (finalAttrs: {
-  pname = "unicode";
-  version = "2.9";
+  pname = "unicode-paracode";
+  version = "3.2-unstable-2025-01-31";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "garabik";
     repo = "unicode";
-    rev = "v${finalAttrs.version}";
-    sha256 = "sha256-FHAlZ5HID/FE9+YR7Dmc3Uh7E16QKORoD8g9jgTeQdY=";
+    rev = "7df103ee988bbfe999f457e23cbc0e954dd0e813";
+    hash = "sha256-4u/tp+KQMfgo8zS4INB8MJBOLgHqMBj3Tk2yj7Sp3YU=";
   };
-
-  patches = [
-    # Fix 3.13+ mutable locals()
-    (fetchurl {
-      url = "https://github.com/garabik/unicode/commit/412952b9b4730263f5b560924b84f8934ea4ba21.patch";
-      hash = "sha256-Rfm6Jc7V5n7ggQzA/yeDrYedGMWqRkeUX6FRCUkBWcI=";
-    })
-  ];
 
   nativeBuildInputs = [ installShellFiles ];
 
   build-system = with python3Packages; [ setuptools ];
 
   postFixup = ''
+    mkdir -p "$out/share/unicode"
+    ln -s "${unicode-character-database}/share/unicode/UnicodeData.txt" "$out/share/unicode/UnicodeData.txt"
+    # We want to keep /usr/share/unicode in the list for the Unihan files
     substituteInPlace "$out/bin/.unicode-wrapped" \
-      --replace-fail "/usr/share/unicode/UnicodeData.txt" "${unicode-character-database}/share/unicode/UnicodeData.txt"
+      --replace-fail "'/usr/share/unicode', " "'$out/share/unicode', '/usr/share/unicode', "
   '';
 
   postInstall = ''
     installManPage paracode.1 unicode.1
+  '';
+
+  checkPhase = ''
+    runHook preCheck
+
+    echo Testing: $out/bin/unicode --brief z
+    diff -u <(echo z U+007A LATIN SMALL LETTER Z) <($out/bin/unicode --brief z 2>&1) && echo Success
+
+    runHook postCheck
   '';
 
   passthru.updateScript = gitUpdater { rev-prefix = "v"; };
@@ -48,6 +51,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     homepage = "https://github.com/garabik/unicode";
     license = lib.licenses.gpl3;
     maintainers = [ lib.maintainers.woffs ];
+    mainProgram = "unicode";
     platforms = lib.platforms.all;
   };
 })


### PR DESCRIPTION
Rebase of #420887. Fixes #419447.

Upstream appears to have essentially stopped tagging releases at this point, so we go to an unstable version.

This uses a slightly more recent commit than #420887 because of https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1009314. (The upstream fix doesn't seem entirely complete to me, but it definitely looks like it helps.)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
