### PR TITLE
vscode-extensions.ms-vscode.js-debug: init at 1.105.0

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -3327,6 +3327,8 @@ let
         };
       };
 
+      ms-vscode.js-debug = callPackage ./ms-vscode.js-debug { };
+
       ms-vscode.js-debug-companion = callPackage ./ms-vscode.js-debug-companion { };
 
       ms-vscode.hexeditor = buildVscodeMarketplaceExtension {

--- a/pkgs/applications/editors/vscode/extensions/ms-vscode.js-debug/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/ms-vscode.js-debug/default.nix
@@ -1,0 +1,96 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchNpmDeps,
+  nodejs,
+  npmHooks,
+  pkg-config,
+  libsecret,
+  cctools,
+  clang_20,
+  vscode-utils,
+  nix-update-script,
+}:
+
+let
+  vsix = stdenv.mkDerivation (finalAttrs: {
+    name = "vscode-js-debug-${finalAttrs.version}.vsix";
+    pname = "vscode-js-debug-vsix";
+    version = "1.105.0";
+
+    src = fetchFromGitHub {
+      owner = "microsoft";
+      repo = "vscode-js-debug";
+      tag = "v${finalAttrs.version}";
+      hash = "sha256-dYEINhJGrJFEq5422BEp3ups6vK0lpVW34GaYPMdfXk=";
+    };
+
+    npmDeps = fetchNpmDeps {
+      name = "${finalAttrs.pname}-npm-deps";
+      inherit (finalAttrs) src;
+      hash = "sha256-bBy0u6NaOAkX6vRJrRYYWUxCG6HM3h0PrzN6tZj5pVY=";
+    };
+    makeCacheWritable = true;
+
+    buildInputs = lib.optionals stdenv.isLinux [
+      libsecret
+    ];
+    nativeBuildInputs = [
+      nodejs
+      nodejs.python
+      npmHooks.npmConfigHook
+    ]
+    ++ lib.optionals stdenv.isLinux [
+      pkg-config
+    ]
+    ++ lib.optionals stdenv.isDarwin [
+      cctools.libtool
+      clang_20 # clang_21 breaks @vscode/vsce's optional dependency keytar
+    ];
+
+    strictDeps = true;
+
+    postPatch = ''
+      substituteInPlace package.json \
+        --replace-fail "playwright install chromium --with-deps --only-shell" "echo playwright install chromium --with-deps --only-shell"
+    '';
+
+    buildPhase = ''
+      runHook preBuild
+      node --run compile -- package:hoist
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      cp ./js-debug.vsix $out
+      runHook postInstall
+    '';
+  });
+in
+vscode-utils.buildVscodeExtension (finalAttrs: {
+  pname = "vscode-js-debug";
+  inherit (finalAttrs.src) version;
+
+  vscodeExtPublisher = "ms-vscode";
+  vscodeExtName = "js-debug";
+  vscodeExtUniqueId = "${finalAttrs.vscodeExtPublisher}.${finalAttrs.vscodeExtName}";
+
+  src = vsix;
+
+  passthru = {
+    vsix = finalAttrs.src;
+    updateScript = nix-update-script {
+      attrPath = "vscode-extensions.ms-vscode.js-debug.vsix";
+    };
+  };
+
+  meta = {
+    description = "An extension for debugging Node.js programs and Chrome";
+    homepage = "https://github.com/microsoft/vscode-js-debug";
+    downloadPage = "https://marketplace.visualstudio.com/items?itemName=ms-vscode.js-debug";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ xiaoxiangmoe ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
