### PR TITLE
nix: add passthru.nix-cli

### DIFF
--- a/pkgs/tools/package-management/nix/modular/packaging/everything.nix
+++ b/pkgs/tools/package-management/nix/modular/packaging/everything.nix
@@ -182,6 +182,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     inherit (nix-cli) version;
+    inherit nix-cli;
     src = patchedSrc;
 
     /**


### PR DESCRIPTION
**Motivation:**

The componentized Nix packages expose `nix-everything` as their entry points: `nixVersions.nix_2_31 = nixVersions.nixComponents_2_31.nix-everything`, etc. This means, in particular, that the value of `config.nix.package` will be a `nix-everything` instance, regardless of whether the default is used or a specific version is chosen by the user.

`nix-everything` is a collection of symlinks to all of the other components. When configuring some software through Nix, a symlink is not enough and one needs a real path to the `nix` binary. For example, when configuring [`services.opensnitch.rules`](https://search.nixos.org/options?channel=25.11&show=services.opensnitch.rules) to allow Nix to access certain domains, one wants to refer to Nix using `lib.getExe config.nix.package` (in order to avoid duplicating the knowledge of which version of Nix one has configured the system to use). But this will point to a symlink, and OpenSnitch will only match on a real path, so instead the user has to write something like `lib.getExe pkgs.nixVersions.nixComponents_X_YY.nix-cli`, because there isn't currently a clean way to get from `config.nix.package` to the corresponding `nix-cli` package.

`nix-everything` already exposes most of its dependencies via `passthru.libs`; adding `passthru.nix-cli` seems like a small step that solves this problem.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
