### PR TITLE
attemptoClex: 5133afe -> 6.5-090528

### DIFF
--- a/pkgs/applications/misc/ape/clex.nix
+++ b/pkgs/applications/misc/ape/clex.nix
@@ -6,13 +6,13 @@
 
 stdenv.mkDerivation rec {
   pname = "attempto-clex";
-  version = "5133afe";
+  version = "6.5-090528";
 
   src = fetchFromGitHub {
     owner = "Attempto";
     repo = "Clex";
     tag = version;
-    sha256 = "0p9s64g1jic213bwm6347jqckszgnni9szrrz31qjgaf32kf7nkp";
+    hash = "sha256-Oa1AMBaYpjd+U2k9lBnou4+4IgBwU8fojJ8bY9tf9ZE=";
   };
 
   installPhase = ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Old tag doesn't exist. Not sure what happened to it. Switch to this tag from 13(?) years ago? Diff of the sources shows only readme changes:

```
README.md --- Text
11 copy the large lexicon over `lexicon/clex_lexicon.pl` and recompile APE,                        11 copy the large lexicon over `lexicon/clex_lexicon.pl` and recompile APE,
12 e.g. by using these commands.                                                                   12 e.g. by using these commands.
13                                                                                                 13
14     curl -L https://raw.github.com/Attempto/Clex/master/clex_lexicon.pl > lexicon/clex_lexicon. 14     curl https://raw.github.com/Attempto/Clex/master/clex_lexicon.pl > lexicon/clex_lexicon.pl
.. pl                                                                                              ..
15     sh make_exe.sh                                                                              15     sh make_exe.sh
16
17 Instead of `curl` one can also use `wget` to download the lexicon.
18
19     wget -O - http://raw.github.com/Attempto/Clex/master/clex_lexicon.pl > lexicon/clex_lexicon
.. .pl
```

Partially addresses #471645

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
