### PR TITLE
vintagestory: Updated hash with the new one from website

### DIFF
--- a/pkgs/by-name/vi/vintagestory/package.nix
+++ b/pkgs/by-name/vi/vintagestory/package.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://cdn.vintagestory.at/gamefiles/stable/vs_client_linux-x64_${version}.tar.gz";
-    hash = "sha256-i1IsxT+pjkKbJjHwnMcyb12nxe21mwvnoRGHMabMETY=";
+    hash = "sha256-LkiL/8W9MKpmJxtK+s5JvqhOza0BLap1SsaDvbLYR0c=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
The latest version from the website has a new hash, causing issue with rebuild. Updated it to the right one.