### PR TITLE
influxdb-cxx: 0.7.4 → 0.8.0

### DIFF
--- a/pkgs/by-name/in/influxdb-cxx/package.nix
+++ b/pkgs/by-name/in/influxdb-cxx/package.nix
@@ -5,30 +5,26 @@
   cmake,
   boost,
   catch2_3,
-  libcpr_1_10_5,
+  libcpr,
   trompeloeil,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "influxdb-cxx";
-  version = "0.7.4";
+  version = "0.8.0";
 
   src = fetchFromGitHub {
     owner = "offa";
     repo = "influxdb-cxx";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-i7YnFjAuhtMGZ26rEObbm+kPmtwzBB0fyMlJLyR+LLI=";
+    hash = "sha256-bP3Mfsv+20BfYiNdGFeNKHYdqGJSryrd7MWfqXjGnZw=";
   };
-
-  postPatch = ''
-    substituteInPlace CMakeLists.txt --replace-warn "-Werror" ""
-  '';
 
   nativeBuildInputs = [ cmake ];
 
   buildInputs = [
     boost
-    libcpr_1_10_5
+    libcpr
   ]
   ++ lib.optionals finalAttrs.finalPackage.doCheck [
     catch2_3


### PR DESCRIPTION
* https://github.com/offa/influxdb-cxx/releases/tag/v0.8.0
* fix https://hydra.nixos.org/build/314374333

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
