### PR TITLE
cdrdao: 1.2.5 -> 1.2.6

### DIFF
--- a/pkgs/by-name/cd/cdrdao/package.nix
+++ b/pkgs/by-name/cd/cdrdao/package.nix
@@ -1,8 +1,9 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
   fetchpatch,
+  autoreconfHook,
   pkg-config,
   libiconv,
   libvorbis,
@@ -12,11 +13,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "cdrdao";
-  version = "1.2.5";
+  version = "1.2.6";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/cdrdao/cdrdao-${finalAttrs.version}.tar.bz2";
-    hash = "sha256-0ZtnyFPF26JAavqrbNeI53817r5jTKxGeVKEd8e+AbY=";
+  src = fetchFromGitHub {
+    owner = "cdrdao";
+    repo = "cdrdao";
+    tag = "rel_${lib.replaceString "." "_" finalAttrs.version}";
+    hash = "sha256-XEaJsv3c/xPO6jclJBbTopOnYamIOlumD2B+hJZraEE=";
   };
 
   makeFlags = [
@@ -26,6 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   nativeBuildInputs = [
+    autoreconfHook
     pkg-config
   ];
 
@@ -38,22 +42,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   hardeningDisable = [ "format" ];
 
-  patches = [
-    # Fix build on macOS SDK < 12
-    # https://github.com/cdrdao/cdrdao/pull/19
-    (fetchpatch {
-      url = "https://github.com/cdrdao/cdrdao/commit/105d72a61f510e3c47626476f9bbc9516f824ede.patch";
-      hash = "sha256-NVIw59CSrc/HcslhfbYQNK/qSmD4QbfuV8hWYhWelX4=";
-    })
-
-    # Fix undefined behaviour caused by uninitialized variable
-    # https://github.com/cdrdao/cdrdao/pull/21
-    (fetchpatch {
-      url = "https://github.com/cdrdao/cdrdao/commit/251a40ab42305c412674c7c2d391374d91e91c95.patch";
-      hash = "sha256-+nGlWw5rgc5Ns2l+6fQ4Hp2LbhO4R/I95h9WGIh/Ebw=";
-    })
-  ];
-
   # we have glibc/include/linux as a symlink to the kernel headers,
   # and the magic '..' points to kernelheaders, and not back to the glibc/include
   postPatch = ''
@@ -65,7 +53,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Tool for recording audio or data CD-Rs in disk-at-once (DAO) mode";
-    homepage = "https://cdrdao.sourceforge.net/";
+    homepage = "https://github.com/cdrdao/cdrdao";
     platforms = lib.platforms.unix;
     license = lib.licenses.gpl2Plus;
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Current release 404s. Things done:

- switch to new release
- switch to github (since they seem to be actively accepting PRs there?)
- couple of minor changes to get build for 1.2.6 to work
- pretty sure we can drop the patches since they are merged in

partially addresses #471645 



- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
