### PR TITLE
github/labeler: auto-tag backports for labeler

### DIFF
--- a/.github/labeler-no-sync.yml
+++ b/.github/labeler-no-sync.yml
@@ -28,6 +28,7 @@
           - any-glob-to-any-file:
               - .github/actions/*
               - .github/workflows/*
+              - .github/labeler*.yml
               - ci/**/*.*
               - maintainers/github-teams.json
       - base-branch: ['master']
@@ -38,6 +39,7 @@
           - any-glob-to-any-file:
               - .github/actions/*
               - .github/workflows/*
+              - .github/labeler*.yml
               - ci/**/*.*
               - maintainers/github-teams.json
       - base-branch: ['master']


### PR DESCRIPTION
The labeler reads its config from the PR's base branch. Therefore, its config files need to be kept in sync across development branches, like other CI files.

See discussion: https://github.com/NixOS/nixpkgs/pull/472196#issuecomment-3675933613

After this PR, we will need to manually backport `master`'s copy of the labeler config files to the release branches.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
