### PR TITLE
virtualbox: patch high cpu usage with NAT networking

### DIFF
--- a/pkgs/applications/virtualization/virtualbox/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/default.nix
@@ -231,6 +231,14 @@ stdenv.mkDerivation (finalAttrs: {
         url = "https://salsa.debian.org/pkg-virtualbox-team/virtualbox/-/raw/8028d88e6876ca5977de13c58b54e243229efe98/debian/patches/16-no-update.patch";
         hash = "sha256-AGtFsRjwd8Yw296eqX3NC2TUptAhpFTRaOMutiheQ6Y=";
       })
+      # NAT network shouldn't fully saturate one CPU
+      # https://github.com/VirtualBox/virtualbox/issues/356
+      (fetchpatch {
+        name = "vbox-nat-cpu.patch";
+        url = "https://github.com/VirtualBox/virtualbox/commit/efa378dadd192af8fbce331e9ec66fb36d65ad3d.diff";
+        hash = "sha256-7u3kSszv77leZdMs911TzAchU5mBqmNpgvuZDQaY9To=";
+        hunks = [ "2-" ];
+      })
     ]
     ++ [ ./extra_symbols.patch ]
     # When hardening is enabled, we cannot use wrapQtApp to ensure that VirtualBoxVM sees


### PR DESCRIPTION
VirtualBox 7.2.4 is saturating one CPU when a guest NIC is used in NAT mode: https://github.com/VirtualBox/virtualbox/issues/356

Upstream already committed a patch, but that is waiting for a new release.

The pull request at hand applies that patch to our `virtualbox` package.

Notifying `virtualbox` maintainers @FriedrichAltheide @blitz

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

Note: The tests `net-hostonlyif` and `simple-gui` fail, but they also fail on [current `nixos-unstable`](https://github.com/NixOS/nixpkgs/tree/c6245e83d836d0433170a16eb185cefe0572f8b8).

More, tested after cherry-picking that commit onto [current `nixos-25.11`](https://github.com/NixOS/nixpkgs/tree/c6f52ebd45e5925c188d1a20119978aa4ffd5ef6):

- [x] NAT networking still operates (can access websites from within the VM via a NAT-configured NIC)
- [x] even with active NAT networking, the host CPU remains idle as long as the VM is idle

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `17f18f4fd578c68c2feff493c873b853acaed639`

### `x86_64-linux`
<details>
  <summary>:x: 1 package failed to build:</summary>
  <ul>
    <li>linuxKernel.packages.linux_5_10.virtualbox</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 18 packages built:</summary>
  <ul>
    <li>linuxKernel.packages.linux_5_15.virtualbox</li>
    <li>linuxKernel.packages.linux_6_1.virtualbox</li>
    <li>linuxKernel.packages.linux_6_12.virtualbox</li>
    <li>linuxKernel.packages.linux_hardened.virtualbox (linuxKernel.packages.linux_6_12_hardened.virtualbox)</li>
    <li>linuxKernel.packages.linux_6_17.virtualbox</li>
    <li>linuxKernel.packages.linux_6_18.virtualbox</li>
    <li>linuxKernel.packages.linux_6_6.virtualbox</li>
    <li>linuxKernel.packages.linux_lqx.virtualbox</li>
    <li>linuxKernel.packages.linux_xanmod.virtualbox</li>
    <li>linuxKernel.packages.linux_xanmod_latest.virtualbox (linuxKernel.packages.linux_xanmod_stable.virtualbox)</li>
    <li>linuxKernel.packages.linux_zen.virtualbox</li>
    <li>virtualbox</li>
    <li>virtualbox.modsrc</li>
    <li>virtualboxHardened</li>
    <li>virtualboxHardened.modsrc</li>
    <li>virtualboxKvm</li>
    <li>virtualboxWithExtpack</li>
    <li>virtualboxWithExtpack.modsrc</li>
  </ul>
</details>

Note: The build failure of `linux_5_10` is unrelated to the pull request at hand: https://hydra.nixos.org/build/316077130

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
