### PR TITLE
photoprism: fix model linking

### DIFF
--- a/pkgs/by-name/ph/photoprism/package.nix
+++ b/pkgs/by-name/ph/photoprism/package.nix
@@ -84,10 +84,14 @@ stdenv.mkDerivation (finalAttrs: {
 
     # install frontend
     ln -s ${frontend}/assets/* ${assets_path}
+    rm ${assets_path}/models
+    mkdir -p ${assets_path}/models
+    ln -s ${frontend}/assets/models/* ${assets_path}/models/
+
     # install tensorflow models
-    ln -s ${nasnet}/nasnet ${assets_path}
-    ln -s ${nsfw}/nsfw ${assets_path}
-    ln -s ${facenet}/facenet ${assets_path}
+    ln -s ${nasnet}/nasnet ${assets_path}/models/
+    ln -s ${nsfw}/nsfw ${assets_path}/models/
+    ln -s ${facenet}/facenet ${assets_path}/models/
 
     runHook postInstall
   '';


### PR DESCRIPTION
Photoprism expects models to appear under
$PHOTOPRISM_ASSETS_PATH/models/* and not just $PHOTOPRISM_ASSETS_PATH/*.

Without this change models like facenet won't actually be loaded, and the following error will show up in logs:

```
vision: Could not find SavedModel .pb or .pbtxt at supplied export directory path: /nix/store/...-photoprism-251130-b3068414c/share/photoprism/models/facenet. Check that the directory exists and that you have the right permissions for accessing it. (init )
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
