### PR TITLE
mop: 1.0.0 -> 0-unstable-2025-12-20

### DIFF
--- a/pkgs/by-name/mo/mop/package.nix
+++ b/pkgs/by-name/mo/mop/package.nix
@@ -4,25 +4,25 @@
   fetchFromGitHub,
 }:
 
-buildGoModule rec {
+buildGoModule {
   pname = "mop";
-  version = "1.0.0";
+  version = "0-unstable-2025-12-20";
 
   src = fetchFromGitHub {
     owner = "mop-tracker";
     repo = "mop";
-    rev = "v${version}";
-    sha256 = "sha256-oe8RG8E7xcp3ZqdDXYvpOVF3AfeSBFMherHD1YYFE/M=";
+    rev = "64f37500a195d9c4e01eb3a97199b00515e9fd7a";
+    hash = "sha256-j6+bzWfYTBMjgJbyd6JQno2eFTUGHYAv8c4x1Ocp878=";
   };
 
-  vendorHash = "sha256-kLQH7mMmBSsS9av+KnnEuBwiH6hzBOSozrn+1X+8774=";
+  vendorHash = "sha256-Jq6SMnCUvuccEP85x1EEYnafUEeBT+AmqeikFvesMYY=";
 
-  preConfigure = ''
-    for i in *.go **/*.go; do
-        substituteInPlace $i --replace michaeldv/termbox-go nsf/termbox-go
-    done
-    substituteInPlace Makefile --replace mop/cmd mop/mop
-    mv cmd mop
+  postPatch = ''
+    # unsafe.Slice requires go1.17 or later
+    substituteInPlace go.mod --replace-fail 'go 1.15' 'go 1.17'
+    # go says: github.com/rivo/uniseg@v0.2.0: is marked as explicit in vendor/modules.txt, but not explicitly required in go.mod
+    # so need to explicitly require it
+    echo 'require github.com/rivo/uniseg v0.2.0' >> go.mod
   '';
 
   meta = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Source is a 404--looks like the tag has been pulled. Not sure what rev it is so just pointed at HEAD of master. 

Looks like the patches are no longer needed. Also seemed like it needed `uniseg` explicitly. I'm new to go packaging, so let me know if there's a more idiomatic way to do this.

Partially addresses #471645 



<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
