### PR TITLE
yosys-slang: init at 0-unstable-2025-12-15

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15454,6 +15454,12 @@
     githubId = 1104419;
     name = "Lucas Hoffmann";
   };
+  lucgaitskell = {
+    email = "me@lucg.xyz";
+    github = "luciengaitskell";
+    githubId = 9143221;
+    name = "Luc Gaitskell";
+  };
   luckshiba = {
     email = "luckshiba@protonmail.com";
     github = "luckshiba";

--- a/pkgs/by-name/yo/yosys-slang/package.nix
+++ b/pkgs/by-name/yo/yosys-slang/package.nix
@@ -1,0 +1,53 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  cmake,
+  yosys,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "yosys-slang";
+  version = "0-unstable-2026-01-31";
+  plugin = "slang";
+
+  src = fetchFromGitHub {
+    owner = "povik";
+    repo = "yosys-slang";
+    rev = "4e1ad7c11e23cffe131aa5c478083f1d99f0c0be";
+    hash = "sha256-4uKvtBUdDYm7ZERLcjWObvkbIARANUWiz4HmZsN2AA4=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    yosys
+  ];
+
+  cmakeFlags = [
+    "-DCMAKE_BUILD_TYPE=Release"
+    "-DYOSYS_CONFIG=${yosys}/bin/yosys-config"
+    "-DYOSYS_SLANG_REVISION=${finalAttrs.src.rev}"
+    "-DSLANG_REVISION=UNKNOWN"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/yosys/plugins
+    cp slang.so $out/share/yosys/plugins/slang.so
+    runHook postInstall
+  '';
+
+  doCheck = false; # No tests defined in the plugin itself
+
+  meta = with lib; {
+    description = "SystemVerilog frontend plugin for Yosys using the slang library";
+    homepage = "https://github.com/povik/yosys-slang";
+    license = licenses.isc;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ lucgaitskell ];
+  };
+})

--- a/pkgs/by-name/yo/yosys/package.nix
+++ b/pkgs/by-name/yo/yosys/package.nix
@@ -25,6 +25,7 @@
   makeWrapper,
   yosys-bluespec,
   yosys-ghdl,
+  yosys-slang,
   yosys-symbiflow,
   nix-update-script,
   enablePython ? true, # enable python binding
@@ -58,6 +59,7 @@ let
   allPlugins = {
     bluespec = yosys-bluespec;
     ghdl = yosys-ghdl;
+    slang = yosys-slang;
   }
   // yosys-symbiflow;
 


### PR DESCRIPTION
Add `yosys-slang` yosys plugin: https://github.com/povik/yosys-slang
This plugin is provided in the [OSS CAD Suite](https://github.com/YosysHQ/oss-cad-suite-build) and therefore would be nice to have as a nixpkg.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Can show the plugin loaded with:
```
yosys -m result/share/yosys/plugins/slang.so -p "help read_slang"
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
  - [x] Ran manual tests with Yosys to confirm the extension-provided `read_slang` ran.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
