### PR TITLE
maintainers: drop foo-dogsquared

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8822,14 +8822,6 @@
     name = "Fausto Núñez Alberro";
     keys = [ { fingerprint = "668E 01D1 B129 3F42 0A0F  933A C880 6451 94A2 D562"; } ];
   };
-  foo-dogsquared = {
-    email = "foodogsquared@foodogsquared.one";
-    github = "foo-dogsquared";
-    githubId = 34962634;
-    matrix = "@foodogsquared:matrix.org";
-    name = "Gabriel Arazas";
-    keys = [ { fingerprint = "DDD7 D0BD 602E 564B AA04  FC35 1431 0D91 4115 2B92"; } ];
-  };
   fooker = {
     email = "fooker@lab.sh";
     github = "fooker";

--- a/nixos/modules/services/misc/guix/default.nix
+++ b/nixos/modules/services/misc/guix/default.nix
@@ -65,7 +65,7 @@ let
   '';
 in
 {
-  meta.maintainers = with lib.maintainers; [ foo-dogsquared ];
+  meta.maintainers = [ ];
 
   options.services.guix = with lib; {
     enable = mkEnableOption "Guix build daemon service";

--- a/nixos/tests/guix/basic.nix
+++ b/nixos/tests/guix/basic.nix
@@ -9,7 +9,7 @@ import ../make-test-python.nix (
   { lib, pkgs, ... }:
   {
     name = "guix-basic";
-    meta.maintainers = with lib.maintainers; [ foo-dogsquared ];
+    meta.maintainers = [ ];
 
     nodes.machine =
       { config, ... }:

--- a/nixos/tests/guix/publish.nix
+++ b/nixos/tests/guix/publish.nix
@@ -11,7 +11,7 @@ import ../make-test-python.nix (
   {
     name = "guix-publish";
 
-    meta.maintainers = with lib.maintainers; [ foo-dogsquared ];
+    meta.maintainers = [ ];
 
     nodes =
       let

--- a/pkgs/by-name/ag/ags/package.nix
+++ b/pkgs/by-name/ag/ags/package.nix
@@ -106,7 +106,6 @@ buildGoModule rec {
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [
       PerchunPak
-      foo-dogsquared
       johnrtitor
     ];
     mainProgram = "ags";

--- a/pkgs/by-name/ag/ags_1/package.nix
+++ b/pkgs/by-name/ag/ags_1/package.nix
@@ -76,7 +76,6 @@ buildNpmPackage (finalAttrs: {
     changelog = "https://github.com/Aylur/ags/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [
-      foo-dogsquared
       johnrtitor
     ];
     mainProgram = "ags";

--- a/pkgs/by-name/de/decker/package.nix
+++ b/pkgs/by-name/de/decker/package.nix
@@ -81,6 +81,6 @@ stdenv.mkDerivation rec {
     license = lib.licenses.mit;
     mainProgram = "decker";
     platforms = lib.platforms.all;
-    maintainers = with lib.maintainers; [ foo-dogsquared ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/di/disarchive/package.nix
+++ b/pkgs/by-name/di/disarchive/package.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation rec {
     homepage = "https://ngyro.com/software/disarchive.html";
     license = lib.licenses.gpl3Plus;
     mainProgram = "disarchive";
-    maintainers = with lib.maintainers; [ foo-dogsquared ];
+    maintainers = [ ];
     platforms = guile.meta.platforms;
   };
 }

--- a/pkgs/by-name/ea/eartag/package.nix
+++ b/pkgs/by-name/ea/eartag/package.nix
@@ -91,7 +91,7 @@ python3Packages.buildPythonApplication rec {
     # being incorrectly identified as unfree software.
     license = lib.licenses.mit;
     mainProgram = "eartag";
-    maintainers = with lib.maintainers; [ foo-dogsquared ];
+    maintainers = [ ];
     teams = [ lib.teams.gnome-circle ];
   };
 }

--- a/pkgs/by-name/em/emblem/package.nix
+++ b/pkgs/by-name/em/emblem/package.nix
@@ -67,9 +67,7 @@ stdenv.mkDerivation rec {
     homepage = "https://gitlab.gnome.org/World/design/emblem";
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.unix;
-    maintainers = with lib.maintainers; [
-      foo-dogsquared
-    ];
+    maintainers = [ ];
     teams = [ lib.teams.gnome-circle ];
   };
 }

--- a/pkgs/by-name/em/emulsion-palette/package.nix
+++ b/pkgs/by-name/em/emulsion-palette/package.nix
@@ -50,6 +50,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/lainsce/emulsion";
     license = lib.licenses.gpl3Only;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ foo-dogsquared ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/fl/flowtime/package.nix
+++ b/pkgs/by-name/fl/flowtime/package.nix
@@ -54,7 +54,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/Diego-Ivan/Flowtime";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [
-      foo-dogsquared
       pokon548
     ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/gh/gh-screensaver/package.nix
+++ b/pkgs/by-name/gh/gh-screensaver/package.nix
@@ -26,7 +26,7 @@ buildGoModule rec {
     description = "gh extension with animated terminal screensavers";
     homepage = "https://github.com/vilmibm/gh-screensaver";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ foo-dogsquared ];
+    maintainers = [ ];
     mainProgram = "gh-screensaver";
   };
 }

--- a/pkgs/by-name/gn/gnome-extension-manager/package.nix
+++ b/pkgs/by-name/gn/gnome-extension-manager/package.nix
@@ -68,6 +68,6 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.linux;
     mainProgram = "extension-manager";
-    maintainers = with lib.maintainers; [ foo-dogsquared ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/gn/gnome-frog/package.nix
+++ b/pkgs/by-name/gn/gnome-frog/package.nix
@@ -93,7 +93,7 @@ python3Packages.buildPythonApplication rec {
     description = "Intuitive text extraction tool (OCR) for GNOME desktop";
     license = lib.licenses.mit;
     mainProgram = "frog";
-    maintainers = with lib.maintainers; [ foo-dogsquared ];
+    maintainers = [ ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/gu/guile-avahi/package.nix
+++ b/pkgs/by-name/gu/guile-avahi/package.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
     description = "Bindings to Avahi for GNU Guile";
     homepage = "https://www.nongnu.org/guile-avahi/";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ foo-dogsquared ];
+    maintainers = [ ];
     platforms = guile.meta.platforms;
   };
 }

--- a/pkgs/by-name/gu/guile-gnutls/package.nix
+++ b/pkgs/by-name/gu/guile-gnutls/package.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
     homepage = "https://gitlab.com/gnutls/guile/";
     description = "Guile bindings for GnuTLS library";
     license = lib.licenses.lgpl21Plus;
-    maintainers = with lib.maintainers; [ foo-dogsquared ];
+    maintainers = [ ];
     platforms = guile.meta.platforms;
   };
 }

--- a/pkgs/by-name/gu/guile-lib/package.nix
+++ b/pkgs/by-name/gu/guile-lib/package.nix
@@ -60,9 +60,7 @@ stdenv.mkDerivation rec {
       for Guile".
     '';
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [
-      foo-dogsquared
-    ];
+    maintainers = [ ];
     platforms = guile.meta.platforms;
   };
 }

--- a/pkgs/by-name/gu/guile-lzlib/package.nix
+++ b/pkgs/by-name/gu/guile-lzlib/package.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
     description = "GNU Guile library providing bindings to lzlib";
     homepage = "https://notabug.org/guile-lzlib/guile-lzlib";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ foo-dogsquared ];
+    maintainers = [ ];
     platforms = guile.meta.platforms;
   };
 }

--- a/pkgs/by-name/gu/guile-lzma/package.nix
+++ b/pkgs/by-name/gu/guile-lzma/package.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     homepage = "https://ngyro.com/software/guile-lzma.html";
     description = "Guile wrapper for lzma library";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ foo-dogsquared ];
+    maintainers = [ ];
     platforms = guile.meta.platforms;
   };
 }

--- a/pkgs/by-name/gu/guile-quickcheck/package.nix
+++ b/pkgs/by-name/gu/guile-quickcheck/package.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
     homepage = "https://ngyro.com/software/guile-quickcheck.html";
     description = "Guile library providing tools for randomized, property-based testing";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ foo-dogsquared ];
+    maintainers = [ ];
     platforms = guile.meta.platforms;
   };
 }

--- a/pkgs/by-name/gu/guile-semver/package.nix
+++ b/pkgs/by-name/gu/guile-semver/package.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
     description = "GNU Guile library implementing Semantic Versioning 2.0.0";
     homepage = "https://ngyro.com/software/guile-semver.html";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ foo-dogsquared ];
+    maintainers = [ ];
     platforms = guile.meta.platforms;
   };
 }

--- a/pkgs/by-name/gu/guile-ssh/package.nix
+++ b/pkgs/by-name/gu/guile-ssh/package.nix
@@ -63,7 +63,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [
       ethancedwards8
-      foo-dogsquared
     ];
     platforms = guile.meta.platforms;
   };

--- a/pkgs/by-name/gu/guile-zlib/package.nix
+++ b/pkgs/by-name/gu/guile-zlib/package.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
     description = "GNU Guile library providing bindings to zlib";
     homepage = "https://notabug.org/guile-zlib/guile-zlib";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ foo-dogsquared ];
+    maintainers = [ ];
     platforms = guile.meta.platforms;
   };
 }

--- a/pkgs/by-name/gu/guile-zstd/package.nix
+++ b/pkgs/by-name/gu/guile-zstd/package.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
     description = "GNU Guile library providing bindings to zstd";
     homepage = "https://notabug.org/guile-zstd/guile-zstd";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ foo-dogsquared ];
+    maintainers = [ ];
     platforms = guile.meta.platforms;
   };
 }

--- a/pkgs/by-name/gu/guix/package.nix
+++ b/pkgs/by-name/gu/guix/package.nix
@@ -166,7 +166,6 @@ stdenv.mkDerivation rec {
     mainProgram = "guix";
     maintainers = with lib.maintainers; [
       cafkafk
-      foo-dogsquared
       hpfr
     ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/ha/halftone/package.nix
+++ b/pkgs/by-name/ha/halftone/package.nix
@@ -58,7 +58,7 @@ python3Packages.buildPythonApplication rec {
     description = "Simple app for giving images that pixel-art style";
     license = lib.licenses.gpl3Plus;
     mainProgram = "halftone";
-    maintainers = with lib.maintainers; [ foo-dogsquared ];
+    maintainers = [ ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/ic/ictree/package.nix
+++ b/pkgs/by-name/ic/ictree/package.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     description = "Like tree but interactive";
     homepage = "https://github.com/NikitaIvanovV/ictree";
     platforms = lib.platforms.unix;
-    maintainers = with lib.maintainers; [ foo-dogsquared ];
+    maintainers = [ ];
     mainProgram = "ictree";
   };
 }

--- a/pkgs/by-name/li/license-cli/package.nix
+++ b/pkgs/by-name/li/license-cli/package.nix
@@ -60,6 +60,6 @@ rustPlatform.buildRustPackage rec {
     description = "Command-line tool to easily add license to your project";
     license = lib.licenses.mpl20;
     mainProgram = "license";
-    maintainers = with lib.maintainers; [ foo-dogsquared ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/ma/matcha-rss-digest/package.nix
+++ b/pkgs/by-name/ma/matcha-rss-digest/package.nix
@@ -22,6 +22,6 @@ buildGoModule rec {
     description = "Daily digest generator from a list of RSS feeds";
     license = lib.licenses.mit;
     mainProgram = "matcha";
-    maintainers = with lib.maintainers; [ foo-dogsquared ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/mo/moor/package.nix
+++ b/pkgs/by-name/mo/moor/package.nix
@@ -49,7 +49,6 @@ buildGoModule (finalAttrs: {
     license = lib.licenses.bsd2WithViews;
     mainProgram = "moor";
     maintainers = with lib.maintainers; [
-      foo-dogsquared
       getchoo
       zowoq
     ];

--- a/pkgs/by-name/ni/niri/package.nix
+++ b/pkgs/by-name/ni/niri/package.nix
@@ -138,7 +138,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     changelog = "https://github.com/YaLTeR/niri/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [
-      foo-dogsquared
       sodiboo
       getchoo
     ];

--- a/pkgs/by-name/te/text-engine/package.nix
+++ b/pkgs/by-name/te/text-engine/package.nix
@@ -53,6 +53,6 @@ stdenv.mkDerivation {
       mpl20
       lgpl21Plus
     ];
-    maintainers = with lib.maintainers; [ foo-dogsquared ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/va/vale-ls/package.nix
+++ b/pkgs/by-name/va/vale-ls/package.nix
@@ -55,7 +55,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     license = lib.licenses.mit;
     mainProgram = "vale-ls";
     maintainers = with lib.maintainers; [
-      foo-dogsquared
       jansol
     ];
   };

--- a/pkgs/by-name/vi/vipsdisp/package.nix
+++ b/pkgs/by-name/vi/vipsdisp/package.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
     description = "Tiny image viewer with libvips";
     license = lib.licenses.mit;
     mainProgram = "vipsdisp";
-    maintainers = with lib.maintainers; [ foo-dogsquared ];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/by-name/wa/warp/package.nix
+++ b/pkgs/by-name/wa/warp/package.nix
@@ -89,7 +89,6 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [
       dotlambda
-      foo-dogsquared
     ];
     teams = [ lib.teams.gnome-circle ];
     platforms = lib.platforms.all;

--- a/pkgs/by-name/ym/ymuse/package.nix
+++ b/pkgs/by-name/ym/ymuse/package.nix
@@ -68,7 +68,7 @@ buildGoModule rec {
     homepage = "https://yktoo.com/en/software/ymuse/";
     description = "GTK client for Music Player Daemon (MPD)";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ foo-dogsquared ];
+    maintainers = [ ];
     mainProgram = "ymuse";
     platforms = lib.platforms.unix;
   };

--- a/pkgs/development/python-modules/material-color-utilities/default.nix
+++ b/pkgs/development/python-modules/material-color-utilities/default.nix
@@ -32,6 +32,6 @@ buildPythonPackage rec {
     homepage = "https://pypi.org/project/material_color_utilities_python";
     description = "Python port of material_color_utilities used for Material You colors";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ foo-dogsquared ];
+    maintainers = [ ];
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- Hasn't commented since [May 2024](https://github.com/NixOS/nixpkgs/issues?q=commenter:foo-dogsquared),
- hasn't opened any tickets themselves since [May 2024](https://github.com/NixOS/nixpkgs/issues?q=author:foo-dogsquared) as well,
- 217 issues and PRs [unanswered](https://github.com/NixOS/nixpkgs/issues?q=involves:foo-dogsquared+-commenter:foo-dogsquared+-author:foo-dogsquared+-reviewed-by:foo-dogsquared) since circa the same time (luckily, the majority were handled and closed by numerous co-maintainers),

all of which are longer than the 3 months, specified in the [maintainer README](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status), which makes them eligible for removal from Nixpkgs.

Gabriel, you have a week (until 20:00 UTC, Dec 27) to object and show us your intent to continue maintenance. Even if you don't make it, you're still welcome back.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
