### PR TITLE
indilib: 2.1.6 -> 2.1.9; indi-3rdparty: 2.1.6.2 -> 2.1.9

### DIFF
--- a/pkgs/development/libraries/science/astronomy/indilib/default.nix
+++ b/pkgs/development/libraries/science/astronomy/indilib/default.nix
@@ -23,13 +23,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "indilib";
-  version = "2.1.6";
+  version = "2.1.9";
 
   src = fetchFromGitHub {
     owner = "indilib";
     repo = "indi";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-WfVC5CLzwyO40Kpv/SZaYiPGDvWLUydQaA8FvTVhHqg=";
+    hash = "sha256-L3qZ1VgL4J4TYYdgeSrWuVC2Xy+iBxIU9GBx8cllm1o=";
   };
 
   nativeBuildInputs = [
@@ -65,7 +65,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   checkInputs = [ gtest ];
 
-  doCheck = true;
+  # tests seem to be broken on darwin
+  doCheck = !stdenv.hostPlatform.isDarwin;
   doInstallCheck = true;
 
   # Socket address collisions between tests

--- a/pkgs/development/libraries/science/astronomy/indilib/indi-3rdparty.nix
+++ b/pkgs/development/libraries/science/astronomy/indilib/indi-3rdparty.nix
@@ -41,13 +41,13 @@
 }:
 
 let
-  thirdparty_version = "2.1.6.2";
+  thirdparty_version = "2.1.9";
   fxload = libusb1.override { withExamples = true; };
   src-3rdparty = fetchFromGitHub {
     owner = "indilib";
     repo = "indi-3rdparty";
     rev = "v${thirdparty_version}";
-    hash = "sha256-FMvdm7dkOkRlmbPNeQjh0jd+2bOinzW13QPP2NnOr/M=";
+    hash = "sha256-zHcJDbi+xsI1xDnZTFmUbk4GNGD8WqZUzf3hfSCmvpU=";
   };
 
   buildIndi3rdParty =

--- a/pkgs/development/libraries/science/astronomy/indilib/indi-3rdparty.nix
+++ b/pkgs/development/libraries/science/astronomy/indilib/indi-3rdparty.nix
@@ -127,6 +127,11 @@ let
 
   libaltaircam = buildIndi3rdParty {
     pname = "libaltaircam";
+
+    postPatch = ''
+      sed -i '/FIX_MACOS_LIBRARIES/d' CMakeLists.txt
+    '';
+
     meta = {
       license = lib.licenses.unfreeRedistributable;
       platforms = with lib.platforms; x86_64 ++ aarch64 ++ arm;
@@ -140,7 +145,7 @@ let
       indilib
       libusb1
     ];
-    nativeBuildInputs = [ autoPatchelfHook ];
+    nativeBuildInputs = lib.optional (!stdenv.hostPlatform.isDarwin) autoPatchelfHook;
     cmakeFlags = [ "-DCONF_DIR=etc/" ];
     meta = {
       license = lib.licenses.mpl20;
@@ -152,6 +157,7 @@ let
     pname = "libasi";
 
     postPatch = ''
+      sed -i '/FIX_MACOS_LIBRARIES/d' CMakeLists.txt
       substituteInPlace 99-asi.rules \
         --replace-fail "/bin/echo" "${lib.getBin coreutils}/bin/echo" \
         --replace-fail "/bin/sh" "${lib.getExe bash}" \
@@ -162,32 +168,55 @@ let
       libusb1
       (lib.getLib stdenv.cc.cc)
     ];
-    nativeBuildInputs = [ autoPatchelfHook ];
+    nativeBuildInputs = lib.optional (!stdenv.hostPlatform.isDarwin) autoPatchelfHook;
     meta = {
       license = lib.licenses.unfreeRedistributable;
-      platforms = with lib.platforms; x86_64 ++ aarch64 ++ i686 ++ arm;
+      platforms = [
+        "i686-linux"
+        "x86_64-linux"
+        "armv6l-linux"
+        "armv7l-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+      ];
     };
   };
 
   libastroasis = buildIndi3rdParty {
     pname = "libastroasis";
+
+    postPatch = ''
+      sed -i '/FIX_MACOS_LIBRARIES/d' CMakeLists.txt
+    '';
+
     buildInputs = [ (lib.getLib stdenv.cc.cc) ];
-    nativeBuildInputs = [ autoPatchelfHook ];
+    nativeBuildInputs = lib.optional (!stdenv.hostPlatform.isDarwin) autoPatchelfHook;
     meta = {
       license = lib.licenses.unfreeRedistributable;
-      platforms = with lib.platforms; x86_64 ++ aarch64 ++ arm;
+      platforms = [
+        "i686-linux"
+        "x86_64-linux"
+        "armv6l-linux"
+        "armv7l-linux"
+        "x86_64-darwin"
+      ];
     };
   };
 
   libatik = buildIndi3rdParty {
     pname = "libatik";
+
+    postPatch = ''
+      sed -i '/FIX_MACOS_LIBRARIES/d' CMakeLists.txt
+    '';
+
     buildInputs = [
       (lib.getLib stdenv.cc.cc)
       libusb1
       systemd
       libdc1394
     ];
-    nativeBuildInputs = [ autoPatchelfHook ];
+    nativeBuildInputs = lib.optional (!stdenv.hostPlatform.isDarwin) autoPatchelfHook;
     meta = {
       license = lib.licenses.unfreeRedistributable;
       platforms = with lib.platforms; x86_64 ++ aarch64 ++ i686 ++ arm;
@@ -196,7 +225,12 @@ let
 
   libbressercam = buildIndi3rdParty {
     pname = "libbressercam";
-    nativeBuildInputs = [ autoPatchelfHook ];
+
+    postPatch = ''
+      sed -i '/FIX_MACOS_LIBRARIES/d' CMakeLists.txt
+    '';
+
+    nativeBuildInputs = lib.optional (!stdenv.hostPlatform.isDarwin) autoPatchelfHook;
     meta = {
       license = lib.licenses.unfreeRedistributable;
       platforms = with lib.platforms; x86_64 ++ aarch64 ++ arm;
@@ -242,13 +276,24 @@ let
     nativeBuildInputs = [ autoPatchelfHook ];
     meta = {
       license = lib.licenses.unfreeRedistributable;
-      platforms = with lib.platforms; x86_64 ++ aarch64 ++ arm ++ i686;
+      platforms = [
+        "i686-linux"
+        "x86_64-linux"
+        "armv6l-linux"
+        "armv7l-linux"
+        "aarch64-linux"
+      ];
     };
   };
 
   libmallincam = buildIndi3rdParty {
     pname = "libmallincam";
-    nativeBuildInputs = [ autoPatchelfHook ];
+
+    postPatch = ''
+      sed -i '/FIX_MACOS_LIBRARIES/d' CMakeLists.txt
+    '';
+
+    nativeBuildInputs = lib.optional (!stdenv.hostPlatform.isDarwin) autoPatchelfHook;
     meta = {
       license = lib.licenses.unfreeRedistributable;
       platforms = with lib.platforms; x86_64 ++ aarch64 ++ arm;
@@ -257,6 +302,11 @@ let
 
   libmeadecam = buildIndi3rdParty {
     pname = "libmeadecam";
+
+    postPatch = ''
+      sed -i '/FIX_MACOS_LIBRARIES/d' CMakeLists.txt
+    '';
+
     buildInputs = [ libusb1 ];
     meta = {
       license = lib.licenses.lgpl21Only;
@@ -266,8 +316,13 @@ let
 
   libmicam = buildIndi3rdParty {
     pname = "libmicam";
+
+    postPatch = ''
+      sed -i '/FIX_MACOS_LIBRARIES/d' CMakeLists.txt
+    '';
+
     buildInputs = [ libusb1 ];
-    nativeBuildInputs = [ autoPatchelfHook ];
+    nativeBuildInputs = lib.optional (!stdenv.hostPlatform.isDarwin) autoPatchelfHook;
     meta = {
       license = lib.licenses.unfreeRedistributable;
       platforms = with lib.platforms; x86_64 ++ aarch64 ++ arm ++ i686;
@@ -276,7 +331,12 @@ let
 
   libnncam = buildIndi3rdParty {
     pname = "libnncam";
-    nativeBuildInputs = [ autoPatchelfHook ];
+
+    postPatch = ''
+      sed -i '/FIX_MACOS_LIBRARIES/d' CMakeLists.txt
+    '';
+
+    nativeBuildInputs = lib.optional (!stdenv.hostPlatform.isDarwin) autoPatchelfHook;
     meta = {
       license = lib.licenses.unfreeRedistributable;
       platforms = with lib.platforms; x86_64 ++ aarch64 ++ arm;
@@ -285,7 +345,12 @@ let
 
   libogmacam = buildIndi3rdParty {
     pname = "libogmacam";
-    nativeBuildInputs = [ autoPatchelfHook ];
+
+    postPatch = ''
+      sed -i '/FIX_MACOS_LIBRARIES/d' CMakeLists.txt
+    '';
+
+    nativeBuildInputs = lib.optional (!stdenv.hostPlatform.isDarwin) autoPatchelfHook;
     meta = {
       license = lib.licenses.unfreeRedistributable;
       platforms = with lib.platforms; x86_64 ++ aarch64 ++ arm;
@@ -294,7 +359,12 @@ let
 
   libomegonprocam = buildIndi3rdParty {
     pname = "libomegonprocam";
-    nativeBuildInputs = [ autoPatchelfHook ];
+
+    postPatch = ''
+      sed -i '/FIX_MACOS_LIBRARIES/d' CMakeLists.txt
+    '';
+
+    nativeBuildInputs = lib.optional (!stdenv.hostPlatform.isDarwin) autoPatchelfHook;
     meta = {
       license = lib.licenses.unfreeRedistributable;
       platforms = with lib.platforms; x86_64 ++ aarch64 ++ arm;
@@ -330,7 +400,9 @@ let
 
   libplayerone = buildIndi3rdParty {
     pname = "libplayerone";
+
     postPatch = ''
+      sed -i '/FIX_MACOS_LIBRARIES/d' CMakeLists.txt
       substituteInPlace 99-player_one_astronomy.rules \
         --replace-fail "/bin/echo" "${lib.getBin coreutils}/bin/echo" \
         --replace-fail "/bin/sh" "${lib.getExe bash}"
@@ -341,7 +413,7 @@ let
       libusb1
       systemd
     ];
-    nativeBuildInputs = [ autoPatchelfHook ];
+    nativeBuildInputs = lib.optional (!stdenv.hostPlatform.isDarwin) autoPatchelfHook;
     meta = {
       license = lib.licenses.unfreeRedistributable;
       platforms = with lib.platforms; x86_64 ++ aarch64 ++ arm;
@@ -352,6 +424,7 @@ let
     pname = "libqhy";
 
     postPatch = ''
+      sed -i '/FIX_MACOS_LIBRARIES/d' CMakeLists.txt
       substituteInPlace CMakeLists.txt \
         --replace-fail "/lib/firmware" "lib/firmware"
 
@@ -369,11 +442,17 @@ let
       (lib.getLib stdenv.cc.cc)
       libusb1
     ];
-    nativeBuildInputs = [ autoPatchelfHook ];
+    nativeBuildInputs = lib.optional (!stdenv.hostPlatform.isDarwin) autoPatchelfHook;
 
     meta = {
       license = lib.licenses.unfreeRedistributable;
-      platforms = with lib.platforms; x86_64 ++ aarch64 ++ arm;
+      platforms = [
+        "x86_64-linux"
+        "armv6l-linux"
+        "armv7l-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+      ];
     };
   };
 
@@ -383,7 +462,7 @@ let
       libftdi1
       indilib
     ];
-    nativeBuildInputs = [ autoPatchelfHook ];
+    nativeBuildInputs = lib.optional (!stdenv.hostPlatform.isDarwin) autoPatchelfHook;
     meta = {
       license = lib.licenses.unfreeRedistributable;
       platforms = lib.platforms.linux;
@@ -396,7 +475,7 @@ let
       (lib.getLib stdenv.cc.cc)
       libusb1
     ];
-    nativeBuildInputs = [ autoPatchelfHook ];
+    nativeBuildInputs = lib.optional (!stdenv.hostPlatform.isDarwin) autoPatchelfHook;
     meta = {
       license = lib.licenses.unfreeRedistributable;
       platforms = with lib.platforms; x86_64 ++ i686 ++ arm;
@@ -407,6 +486,7 @@ let
     pname = "libsbig";
 
     postPatch = ''
+      sed -i '/FIX_MACOS_LIBRARIES/d' CMakeLists.txt
       substituteInPlace CMakeLists.txt --replace-fail "/lib/firmware" "lib/firmware"
       substituteInPlace 51-sbig-debian.rules \
         --replace-fail "/sbin/fxload" "${fxload}/sbin/fxload" \
@@ -416,7 +496,7 @@ let
     '';
 
     buildInputs = [ libusb1 ];
-    nativeBuildInputs = [ autoPatchelfHook ];
+    nativeBuildInputs = lib.optional (!stdenv.hostPlatform.isDarwin) autoPatchelfHook;
 
     meta = {
       license = lib.licenses.unfreeRedistributable;
@@ -426,7 +506,12 @@ let
 
   libstarshootg = buildIndi3rdParty {
     pname = "libstarshootg";
-    nativeBuildInputs = [ autoPatchelfHook ];
+
+    postPatch = ''
+      sed -i '/FIX_MACOS_LIBRARIES/d' CMakeLists.txt
+    '';
+
+    nativeBuildInputs = lib.optional (!stdenv.hostPlatform.isDarwin) autoPatchelfHook;
     meta = {
       license = lib.licenses.unfreeRedistributable;
       platforms = with lib.platforms; x86_64 ++ aarch64 ++ arm;
@@ -435,20 +520,37 @@ let
 
   libsvbony = buildIndi3rdParty {
     pname = "libsvbony";
+
+    postPatch = ''
+      sed -i '/FIX_MACOS_LIBRARIES/d' CMakeLists.txt
+    '';
+
     buildInputs = [
       (lib.getLib stdenv.cc.cc)
       libusb1
     ];
-    nativeBuildInputs = [ autoPatchelfHook ];
+    nativeBuildInputs = lib.optional (!stdenv.hostPlatform.isDarwin) autoPatchelfHook;
     meta = {
       license = lib.licenses.unfreeRedistributable;
-      platforms = with lib.platforms; x86_64 ++ aarch64 ++ arm ++ i686;
+      platforms = [
+        "i686-linux"
+        "x86_64-linux"
+        "armv6l-linux"
+        "armv7l-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+      ];
     };
   };
 
   libsvbonycam = buildIndi3rdParty {
     pname = "libsvbonycam";
-    nativeBuildInputs = [ autoPatchelfHook ];
+
+    postPatch = ''
+      sed -i '/FIX_MACOS_LIBRARIES/d' CMakeLists.txt
+    '';
+
+    nativeBuildInputs = lib.optional (!stdenv.hostPlatform.isDarwin) autoPatchelfHook;
     meta = {
       license = lib.licenses.unfreeRedistributable;
       platforms = with lib.platforms; x86_64 ++ aarch64 ++ arm;
@@ -457,7 +559,12 @@ let
 
   libtoupcam = buildIndi3rdParty {
     pname = "libtoupcam";
-    nativeBuildInputs = [ autoPatchelfHook ];
+
+    postPatch = ''
+      sed -i '/FIX_MACOS_LIBRARIES/d' CMakeLists.txt
+    '';
+
+    nativeBuildInputs = lib.optional (!stdenv.hostPlatform.isDarwin) autoPatchelfHook;
     meta = {
       license = lib.licenses.unfreeRedistributable;
       platforms = with lib.platforms; x86_64 ++ aarch64 ++ arm;
@@ -466,7 +573,12 @@ let
 
   libtscam = buildIndi3rdParty {
     pname = "libtscam";
-    nativeBuildInputs = [ autoPatchelfHook ];
+
+    postPatch = ''
+      sed -i '/FIX_MACOS_LIBRARIES/d' CMakeLists.txt
+    '';
+
+    nativeBuildInputs = lib.optional (!stdenv.hostPlatform.isDarwin) autoPatchelfHook;
     meta = {
       license = lib.licenses.unfreeRedistributable;
       platforms = with lib.platforms; x86_64 ++ aarch64 ++ arm;


### PR DESCRIPTION
Updated indilib and the 3rdparty drivers to their latest version. They should be updated together

Corrected meta.platforms for darwin and disabled autoPatchElf for Darwin as it fails when hitting Mach-O files.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
