### PR TITLE
concurrently: 8.2.2 -> 9.2.1

### DIFF
--- a/pkgs/by-name/co/concurrently/package.nix
+++ b/pkgs/by-name/co/concurrently/package.nix
@@ -7,6 +7,7 @@
   pnpm_10,
   fetchPnpmDeps,
   pnpmConfigHook,
+  versionCheckHook,
   nix-update-script,
 }:
 stdenv.mkDerivation (finalAttrs: {
@@ -58,6 +59,12 @@ stdenv.mkDerivation (finalAttrs: {
 
     runHook postInstall
   '';
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/co/concurrently/package.nix
+++ b/pkgs/by-name/co/concurrently/package.nix
@@ -8,6 +8,7 @@
   pnpm_8,
   fetchPnpmDeps,
   pnpmConfigHook,
+  nix-update-script,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "concurrently";
@@ -66,6 +67,8 @@ stdenv.mkDerivation (finalAttrs: {
 
     runHook postInstall
   '';
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     changelog = "https://github.com/open-cli-tools/concurrently/releases/tag/v${finalAttrs.version}";

--- a/pkgs/by-name/co/concurrently/package.nix
+++ b/pkgs/by-name/co/concurrently/package.nix
@@ -2,23 +2,22 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch2,
   makeWrapper,
   nodejs,
-  pnpm_8,
+  pnpm_10,
   fetchPnpmDeps,
   pnpmConfigHook,
   nix-update-script,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "concurrently";
-  version = "8.2.2";
+  version = "9.2.1";
 
   src = fetchFromGitHub {
     owner = "open-cli-tools";
     repo = "concurrently";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-VoyVYBOBMguFKnG2VItk1L5BbF72nO7bYJpb7adqICs=";
+    hash = "sha256-PKbrYgQ6D0vxMSxx+aHBo09NJZh5YYfb9Fx9L5Ue8vM=";
   };
 
   pnpmDeps = fetchPnpmDeps {
@@ -26,26 +25,17 @@ stdenv.mkDerivation (finalAttrs: {
       pname
       version
       src
-      patches
       ;
-    pnpm = pnpm_8;
-    fetcherVersion = 1;
-    hash = "sha256-F1teWIABkK0mqZcK3RdGNKmexI/C59QWSrrD1jYbHt0=";
+    pnpm = pnpm_10;
+    fetcherVersion = 3;
+    hash = "sha256-UVsmOneTICl3Ybmv7ebebkXmr1qwNh17dPhL0qlPgyg=";
   };
-
-  patches = [
-    (fetchpatch2 {
-      name = "use-pnpm-8.patch";
-      url = "https://github.com/open-cli-tools/concurrently/commit/0b67a1a5a335396340f4347886fb9d0968a57555.patch";
-      hash = "sha256-mxid2Yl9S6+mpN7OLUCrJ1vS0bQ/UwNiGJ0DL6Zn//Q=";
-    })
-  ];
 
   nativeBuildInputs = [
     makeWrapper
     nodejs
     pnpmConfigHook
-    pnpm_8
+    pnpm_10
   ];
 
   buildPhase = ''
@@ -64,6 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
     makeWrapper "${lib.getExe nodejs}" "$out/bin/concurrently" \
       --add-flags "$out/lib/concurrently/dist/bin/concurrently.js"
     ln -s "$out/bin/concurrently" "$out/bin/con"
+    cp package.json "$out/lib/concurrently/"
 
     runHook postInstall
   '';

--- a/pkgs/by-name/co/concurrently/package.nix
+++ b/pkgs/by-name/co/concurrently/package.nix
@@ -47,6 +47,17 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postBuild
   '';
 
+  preInstall = ''
+    # remove unnecessary files
+    CI=true pnpm --ignore-scripts --prod prune
+    find -type f \( -name "*.ts" -o -name "*.map" \) -exec rm -rf {} +
+    # https://github.com/pnpm/pnpm/issues/3645
+    find node_modules -xtype l -delete
+
+    # remove non-deterministic files
+    rm node_modules/{.modules.yaml,.pnpm-workspace-state-v1.json}
+  '';
+
   installPhase = ''
     runHook preInstall
 


### PR DESCRIPTION
Releases: https://github.com/open-cli-tools/concurrently/releases
Diff: https://github.com/open-cli-tools/concurrently/compare/v8.2.2...v9.2.1

The last commit reduces the closure size from 115M to 5.9M and removes files with timestamps and generated IDs to make it reproducible.
The package.json file is needed at runtime, one use case is for getting the version.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
