### PR TITLE
perlPackages.X11XCB: fix runtime errors

### DIFF
--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -38248,6 +38248,15 @@ with self;
       url = "mirror://cpan/authors/id/Z/ZH/ZHMYLOVE/X11-XCB-0.24.tar.gz";
       hash = "sha256-eIUZZzpDxHUecwYaiCG2WPyV8G1cGcnx3rtgX7ILoEU=";
     };
+    patches = [
+      # Fix "undefined symbol: xcb_composite_unredirect_window"
+      (fetchpatch {
+        url = "https://github.com/zhmylove/X11-XCB/commit/b78e33f7cdf8141b085a4f8773adda6c4a4870c3.patch";
+        hash = "sha256-r1X/tGCALZOS35fNx/9udznNvLxC73o7M2U1MVqXcf0=";
+        revert = true;
+        excludes = [ "lib/X11/XCB.pm" ];
+      })
+    ];
     env.AUTOMATED_TESTING = false;
     nativeBuildInputs = [ pkgs.pkg-config ];
     buildInputs = [


### PR DESCRIPTION
- add patch reverting upstream commit that added XComposite support: https://github.com/zhmylove/X11-XCB/commit/b78e33f7cdf8141b085a4f8773adda6c4a4870c3

Fixes build failure of `i3` that uses X11XCB in tests:
```
Running phase: checkPhase
Can't load
'/nix/store/...-perl5.42.0-X11-XCB-0.24/lib/perl5/site_perl/5.42.0/x86_64-linux-thread-multi/auto/X11/XCB/XCB.so'
for module X11::XCB:
/nix/store/...-perl5.42.0-X11-XCB-0.24/lib/perl5/site_perl/5.42.0/x86_64-linux-thread-multi/auto/X11/XCB/XCB.so:
undefined symbol: xcb_composite_unredirect_window at /nix/store/...-perl-5.42.0/lib/perl5/5.42.0/XSLoader.pm line 94.
at /nix/store/...-perl5.42.0-X11-XCB-0.24/lib/perl5/site_perl/5.42.0/x86_64-linux-thread-multi/X11/XCB.pm line 16.
Compilation failed in require at /build/source/testcases/lib/i3test/Util.pm line 8.
BEGIN failed--compilation aborted at /build/source/testcases/lib/i3test/Util.pm line 8.
Compilation failed in require at ./complete-run.pl line 22.
BEGIN failed--compilation aborted at ./complete-run.pl line 22.
***** Error: complete-run.pl returned 2
===== Test log =====
cat: latest/complete-run.log: No such file or directory
```

---

Did not report upstream as I could not figure out whether it is a problem there or in nixpkgs.
`i3` is the only user in nixpkgs and seems to only use it for tests.

Fixes build failure of `i3` on current `staging-next`: https://github.com/NixOS/nixpkgs/pull/471587

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
