### PR TITLE
buildDartApplication: fix cross compilation

### DIFF
--- a/pkgs/build-support/dart/build-dart-application/default.nix
+++ b/pkgs/build-support/dart/build-dart-application/default.nix
@@ -70,7 +70,7 @@
 }@args:
 
 let
-  generators = callPackage ./generators.nix { inherit dart; } { buildDrvArgs = args; };
+  generators = callPackage ./generators.nix { } { buildDrvArgs = args; };
 
   pubspecLockFile = builtins.toJSON pubspecLock;
   pubspecLockData = pub2nix.readPubspecLock {
@@ -121,7 +121,7 @@ let
     extraSetupCommands = extraPackageConfigSetup;
   };
 
-  inherit (dartHooks.override { inherit dart; })
+  inherit (dartHooks)
     dartConfigHook
     dartBuildHook
     dartInstallHook

--- a/pkgs/build-support/dart/build-dart-application/generators.nix
+++ b/pkgs/build-support/dart/build-dart-application/generators.nix
@@ -1,11 +1,7 @@
 {
-  lib,
   stdenvNoCC,
-  dart,
-  dartHooks,
   jq,
   yq,
-  cacert,
 }:
 
 {

--- a/pkgs/build-support/dart/build-dart-application/hooks/default.nix
+++ b/pkgs/build-support/dart/build-dart-application/hooks/default.nix
@@ -1,7 +1,6 @@
 {
   lib,
   makeSetupHook,
-  dart,
   yq,
   jq,
   python3,

--- a/pkgs/development/compilers/dart/default.nix
+++ b/pkgs/development/compilers/dart/default.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchurl,
   unzip,
-  bintools,
+  buildPackages,
   versionCheckHook,
   runCommand,
   cctools,
@@ -29,7 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
     cp -R . $out
   ''
   + lib.optionalString (stdenv.hostPlatform.isLinux) ''
-    find $out/bin -executable -type f -exec patchelf --set-interpreter ${bintools.dynamicLinker} {} \;
+    find $out/bin -executable -type f -exec patchelf --set-interpreter ${buildPackages.bintools.dynamicLinker} {} \;
   ''
   + ''
     runHook postInstall


### PR DESCRIPTION
fixes cross-compilation of at least the following packages:
- `nix-build -A pkgsCross.aarch64-multiplatform.domine`
- `nix-build -A pkgsCross.aarch64-multiplatform.unused`

the first commit changes `bintools.dynamicLinker` to `buildPackages.bintools.dynamicLinker` to fix a platform offset mismatch.
the second commit removes a call to `dartHooks.override { ... }`, as overrides inside `nativeBuildInputs` don't play well with splicing & the override turned out to simply be dead code anyway.

detailed explanation (excerpted from the commit messages)
----
`bintools` is special, and `pkgs/top-level/all-packages.nix` includes
this note above the `bintools-unwrapped` definition:

> Note when > cross compiling these are used not for this stage but
> the *next* stage. That is why we choose using this stage's target
> platform / next stage's host platform.

i.e. the bintools for "this stage" is actually `buildPackages.bintools`.
that's what splicing would give if the dart derivation accessed bintools
via `nativeBuildInputs = [ bintools ]`.

further evidence for this change is that this existing code is querying
an attribute of the `targetPlatform` based on a property of the `hostPlatform`:
```
lib.optionalString (stdenv.hostPlatform.isLinux) ''
   find $out/bin -executable -type f -exec patchelf --set-interpreter ${bintools.dynamicLinker} {} \;
''
```

`bintools.dynamicLinker` is defined in
pkgs/build-support/bintools-wrapper/default.nix:
```
dynamicLinker =
  if sharedLibraryLoader == null then
    ""
  else if targetPlatform.libc == "musl" then
    "${sharedLibraryLoader}/lib/ld-musl-*"
  else if targetPlatform.libc == "uclibc" then
...
```

we're patching binaries just built for the hostPlatform, so
we can shift the `dynamicLinker` to also be for the hostPlatform
by referencing `buildPackages.bintools.dynamicLinker`.

CC: @RossComputerGuy as you seemed interested in flutter cross compilation in the past and dart is a precursor to that.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
