### PR TITLE
ifm: 2015-11-08 -> 5.5

### DIFF
--- a/pkgs/by-name/if/ifm/package.nix
+++ b/pkgs/by-name/if/ifm/package.nix
@@ -1,22 +1,25 @@
 {
   lib,
   stdenv,
-  fetchzip,
+  fetchFromSourcehut,
   autoreconfHook,
   bison,
   flex,
   help2man,
   perl,
   tk,
+  python3,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "ifm";
-  version = "2015-11-08";
+  version = "5.5";
 
-  src = fetchzip {
-    url = "https://bitbucket.org/zondo/ifm/get/dca0774e4d3a.zip";
-    sha256 = "14af21qjd5jvsscm6vxpsdrnipdr33g6niagzmykrhyfhwcbjahi";
+  src = fetchFromSourcehut {
+    owner = "~zondo";
+    repo = "ifm";
+    tag = finalAttrs.version;
+    hash = "sha256-RA0F8hccVJTq/F4l27CwhxynTqVuLJaYBiUfd/UfvPc=";
   };
 
   nativeBuildInputs = [
@@ -24,6 +27,7 @@ stdenv.mkDerivation {
     bison
     flex
     help2man
+    python3
   ];
 
   buildInputs = [
@@ -45,4 +49,4 @@ stdenv.mkDerivation {
     platforms = lib.platforms.linux;
     maintainers = [ ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Source dead (moved to sourcehut). I'm also not really sure what release 2015-11-08 was, so I bumped it to the latest release. Seems to build, and the ifm executable runs. But, I'm not familiar enough with the project to rigorously test it.

Partially addresses #471645

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
