### PR TITLE
[staging-next] intel-graphics-compiler: fix build with gcc 15

### DIFF
--- a/pkgs/by-name/in/intel-graphics-compiler/gcc15-allow-llvm-free-nonheap-object-warning.patch
+++ b/pkgs/by-name/in/intel-graphics-compiler/gcc15-allow-llvm-free-nonheap-object-warning.patch
@@ -1,0 +1,14 @@
+diff --git a/igc/IGC/common/LLVMWarningsPush.hpp b/igc/IGC/common/LLVMWarningsPush.hpp
+index 12874dfcc2..38acd80943 100644
+--- a/igc/IGC/common/LLVMWarningsPush.hpp
++++ b/igc/IGC/common/LLVMWarningsPush.hpp
+@@ -43,6 +43,9 @@
+ #if __GNUC__ > 8
+ #pragma GCC diagnostic ignored "-Winit-list-lifetime"
+ #endif
++#if __GNUC__ > 14
++#pragma GCC diagnostic ignored "-Wfree-nonheap-object"
++#endif
+ #endif
+ 
+ #if defined(_WIN32) || defined(_WIN64)

--- a/pkgs/by-name/in/intel-graphics-compiler/gcc15-llvm-header-fixes.patch
+++ b/pkgs/by-name/in/intel-graphics-compiler/gcc15-llvm-header-fixes.patch
@@ -1,0 +1,25 @@
+diff --git a/llvm-project/llvm/include/llvm/ADT/SmallVector.h b/llvm-project/llvm/include/llvm/ADT/SmallVector.h
+index 98dce89168..a52947e16e 100644
+--- a/llvm-project/llvm/include/llvm/ADT/SmallVector.h
++++ b/llvm-project/llvm/include/llvm/ADT/SmallVector.h
+@@ -19,6 +19,7 @@
+ #include <algorithm>
+ #include <cassert>
+ #include <cstddef>
++#include <cstdint>
+ #include <cstdlib>
+ #include <cstring>
+ #include <functional>
+diff --git a/llvm-project/llvm/include/llvm/Support/Threading.h b/llvm-project/llvm/include/llvm/Support/Threading.h
+index ba6c531ab4..78aa5e7be5 100644
+--- a/llvm-project/llvm/include/llvm/Support/Threading.h
++++ b/llvm-project/llvm/include/llvm/Support/Threading.h
+@@ -18,7 +18,7 @@
+ #include "llvm/ADT/StringRef.h"
+ #include "llvm/Config/llvm-config.h" // for LLVM_ON_UNIX
+ #include "llvm/Support/Compiler.h"
+-#include <ciso646> // So we can check the C++ standard lib macros.
++#include <version> // So we can check the C++ standard lib macros.
+ #include <optional>
+ 
+ #if defined(_MSC_VER)

--- a/pkgs/by-name/in/intel-graphics-compiler/package.nix
+++ b/pkgs/by-name/in/intel-graphics-compiler/package.nix
@@ -66,6 +66,16 @@ stdenv.mkDerivation rec {
     # https://github.com/intel/intel-graphics-compiler/commit/4f0123a7d67fb716b647f0ba5c1ab550abf2f97d
     # https://github.com/intel/intel-graphics-compiler/pull/364
     ./bump-cmake.patch
+
+    # Fix for GCC 15 by adding a previously-implicit `#include <cstdint>` and
+    # replacing `<ciso646>` with `<version>` in the the llvm directory. Based
+    # on https://github.com/intel/intel-graphics-compiler/pull/383.
+    ./gcc15-llvm-header-fixes.patch
+
+    # Fix for GCC 15 by disabling `-Werror` for `-Wfree-nonheap-object`
+    # warnings within LLVM. This is in accordance with IGC disabling warnings
+    # that originate from within LLVM (see `IGC/common/LLVMWarningsPush.hpp`).
+    ./gcc15-allow-llvm-free-nonheap-object-warning.patch
   ];
 
   sourceRoot = ".";


### PR DESCRIPTION
LLVM 16, which this release of IGC is based on, fails to build with GCC 15 due to a missing include of `<cstdint>` and an include of `<ciso646>` instead of `<version>`. We patch LLVM directly in order to fix these build failures.

Additionally, a warning under `-Wfree-nonheap-object` is emitted within LLVM, and causes compile failures due to `-Werror`. In accordance with IGC disabling warnings where they originate from within LLVM (see [`IGC/common/LLVMWarningsPush.hpp`](https://github.com/intel/intel-graphics-compiler/blob/v2.24.8/IGC/common/LLVMWarningsPush.hpp)), we patch in an ignore for this warning.

We don't know if this is the best approach to handling these issues, but `intel-graphics-compiler` and `intel-compute-runtime` do build. If there is a better approach, feel free to let us know/opt for that instead.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
