### PR TITLE
[staging-next] sasquatch: fix build for gcc 15

### DIFF
--- a/pkgs/by-name/sa/sasquatch/gcc15-fix-prototypes.patch
+++ b/pkgs/by-name/sa/sasquatch/gcc15-fix-prototypes.patch
@@ -1,0 +1,22 @@
+diff --git a/squashfs-tools/unsquashfs.c b/squashfs-tools/unsquashfs.c
+index ed5096b32d..adb6a91c7e 100644
+--- a/squashfs-tools/unsquashfs.c
++++ b/squashfs-tools/unsquashfs.c
+@@ -146,7 +146,7 @@
+ 
+ #define MAX_LINE 16384
+ 
+-void sigwinch_handler()
++void sigwinch_handler(int _signal)
+ {
+ 	struct winsize winsize;
+ 
+@@ -160,7 +160,7 @@
+ }
+ 
+ 
+-void sigalrm_handler()
++void sigalrm_handler(int _signal)
+ {
+ 	rotate = (rotate + 1) % 4;
+ }

--- a/pkgs/by-name/sa/sasquatch/package.nix
+++ b/pkgs/by-name/sa/sasquatch/package.nix
@@ -23,7 +23,12 @@ let
       hash = "sha256-4Mltt0yFt4oh9hsrHL8/ch5n7nZYiXIJ1UgLktPvlKQ=";
     };
 
-    patches = lib.optional stdenv.hostPlatform.isDarwin ./darwin.patch;
+    patches = [
+      # Fix build for GCC 15/C23 by adding parameters to unsquashfs signal
+      # handlers instead of relying on an empty parameter list.
+      ./gcc15-fix-prototypes.patch
+    ]
+    ++ lib.optional stdenv.hostPlatform.isDarwin ./darwin.patch;
 
     strictDeps = true;
     nativeBuildInputs = [ which ];


### PR DESCRIPTION
GCC 15 defaults to C23, so the interpretation of a function with an empty parameter list becomes that it has no parameters instead of ambiguous. Thus, we include a patch to add missing parameters to function definitions.

We also opened a PR upstream at https://github.com/onekey-sec/sasquatch/pull/32.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
