### PR TITLE
kanri: 0.8.1 -> 0.8.2

### DIFF
--- a/pkgs/by-name/ka/kanri/package.nix
+++ b/pkgs/by-name/ka/kanri/package.nix
@@ -18,19 +18,19 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "kanri";
-  version = "0.8.1";
+  version = "0.8.2";
   src = fetchFromGitHub {
     owner = "kanriapp";
     repo = "kanri";
     tag = "app-v${finalAttrs.version}";
-    hash = "sha256-pP+q9AD2WATFYWHFitcrebN8y6iGCyXqmQYXCs9Ytf0=";
+    hash = "sha256-HPwCU08cOkQre7ce9IxTbhwf3vi80VTpuLCoIT6b424=";
   };
 
-  cargoHash = "sha256-JLv4YC40VcRMQVgJnunLkFIEfLKUTEDBgNMV6NmMAzA=";
+  cargoHash = "sha256-efzchVrdjcfwLtRd87S4bK6Kqrfcdwthw1F0s557u/Y=";
 
   yarnOfflineCache = fetchYarnDeps {
     yarnLock = finalAttrs.src + "/yarn.lock";
-    hash = "sha256-z0RLQ6n3hdsaBy3BiIOpuvpPBq3ST02r7lfsGfJypb8=";
+    hash = "sha256-PBhn0VTt+6rf7YTuoVf3L4a6+AoXuad4E20dWiGVOOE=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
https://github.com/kanriapp/kanri/releases/tag/app-v0.8.2

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
