### PR TITLE
zxing: various fixes and improvements

### DIFF
--- a/pkgs/by-name/zx/zxing/java-zxing.sh
+++ b/pkgs/by-name/zx/zxing/java-zxing.sh
@@ -1,3 +1,3 @@
 #! /bin/sh
 
-@jre@/bin/java -cp @out@/lib/java/core-@version@.jar:@out@/lib/java/javase-@version@.jar "$@"
+@jre@/bin/java -cp @out@/lib/java/javase-@version@-jar-with-dependencies.jar "$@"

--- a/pkgs/by-name/zx/zxing/package.nix
+++ b/pkgs/by-name/zx/zxing/package.nix
@@ -39,12 +39,14 @@ maven.buildMavenPackage rec {
   '';
 
   meta = {
+    changelog = "https://github.com/zxing/zxing/releases/tag/zxing-${version}";
     description = "1D and 2D code reading library";
     sourceProvenance = with lib.sourceTypes; [
       binaryBytecode
       fromSource
     ];
     license = lib.licenses.asl20;
+    mainProgram = "zxing";
     maintainers = [ lib.maintainers.raskin ];
     platforms = lib.platforms.linux;
     homepage = "https://github.com/zxing/zxing";

--- a/pkgs/by-name/zx/zxing/package.nix
+++ b/pkgs/by-name/zx/zxing/package.nix
@@ -29,11 +29,12 @@ maven.buildMavenPackage rec {
 
     mkdir -p "$out/lib/java" "$out/bin"
     cp "target/javase-${version}-jar-with-dependencies.jar" "$out/lib/java"
-    substituteAll "${./java-zxing.sh}" "$out/bin/java-zxing"
-    substituteAll "${./zxing-cmdline-runner.sh}" "$out/bin/zxing-cmdline-runner"
-    substituteAll "${./zxing-cmdline-encoder.sh}" "$out/bin/zxing-cmdline-encoder"
-    substituteAll "${./zxing.sh}" "$out/bin/zxing"
-    chmod a+x "$out/bin"/*
+    for source in "${./java-zxing.sh}" "${./zxing-cmdline-encoder.sh}" "${./zxing-cmdline-runner.sh}" "${./zxing-gui-runner.sh}" "${./zxing.sh}"; do
+        target="''${source#*-}"
+        target="$out/bin/''${target%.sh}"
+        substituteAll "$source" "$target"
+        chmod a+x "$target"
+    done
 
     runHook postInstall
   '';

--- a/pkgs/by-name/zx/zxing/package.nix
+++ b/pkgs/by-name/zx/zxing/package.nix
@@ -1,55 +1,52 @@
 {
   lib,
-  stdenv,
-  fetchurl,
+  maven,
+  fetchFromGitHub,
   jre,
 }:
 
-let
+maven.buildMavenPackage rec {
+  pname = "zxing";
   version = "3.5.4";
 
-  # Maven builds are hard to get right
-  core_jar = fetchurl {
-    url = "https://repo1.maven.org/maven2/com/google/zxing/core/${version}/core-${version}.jar";
-    hash = "sha256-cd5diTQbX89d2J2n9E6E2CXQ4ITN8+x3yaviaw8M6xM=";
+  inherit jre;
+
+  src = fetchFromGitHub {
+    owner = "zxing";
+    repo = "zxing";
+    tag = "zxing-${version}";
+    hash = "sha256-D+ZKfDa406RIaTRhH9yXxgP8EpGe0iQU9CqkOMC4UdE=";
   };
 
-  javase_jar = fetchurl {
-    url = "https://repo1.maven.org/maven2/com/google/zxing/javase/${version}/javase-${version}.jar";
-    hash = "sha256-GWaDH0c9cv93IFeEGasRP2QXqXI0oXENK8zGUPWuDBI=";
-  };
-in
-stdenv.mkDerivation (finalAttrs: {
-  pname = "zxing";
-  inherit version jre;
+  mvnHash = "sha256-wVkWbhi5b/rZ0EF5zlQr2BMVOm5nZ1DhI6SGksZO5Vg=";
 
-  dontUnpack = true;
+  sourceRoot = "${src.name}/javase";
+
+  mvnParameters = "-Dproject.build.outputTimestamp=1980-01-01T00:00:02Z compile assembly:single";
 
   installPhase = ''
     runHook preInstall
 
     mkdir -p "$out/lib/java" "$out/bin"
-    cp "${core_jar}" "${javase_jar}" "$out/lib/java"
+    cp "target/javase-${version}-jar-with-dependencies.jar" "$out/lib/java"
     substituteAll "${./java-zxing.sh}" "$out/bin/java-zxing"
     substituteAll "${./zxing-cmdline-runner.sh}" "$out/bin/zxing-cmdline-runner"
     substituteAll "${./zxing-cmdline-encoder.sh}" "$out/bin/zxing-cmdline-encoder"
     substituteAll "${./zxing.sh}" "$out/bin/zxing"
     chmod a+x "$out/bin"/*
-    pushd "$out/lib/java"
-    for i in *.jar; do
-      mv "$i" "''${i#*-}"
-    done
-    popd
 
     runHook postInstall
   '';
 
   meta = {
     description = "1D and 2D code reading library";
-    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
+    sourceProvenance = with lib.sourceTypes; [
+      binaryBytecode
+      fromSource
+    ];
     license = lib.licenses.asl20;
     maintainers = [ lib.maintainers.raskin ];
     platforms = lib.platforms.linux;
     homepage = "https://github.com/zxing/zxing";
   };
-})
+}

--- a/pkgs/by-name/zx/zxing/zxing-cmdline-encoder.sh
+++ b/pkgs/by-name/zx/zxing/zxing-cmdline-encoder.sh
@@ -1,3 +1,3 @@
 #! /bin/sh
 
-java-zxing com.google.zxing.client.j2se.CommandLineEncoder "$@"
+@out@/bin/java-zxing com.google.zxing.client.j2se.CommandLineEncoder "$@"

--- a/pkgs/by-name/zx/zxing/zxing-cmdline-runner.sh
+++ b/pkgs/by-name/zx/zxing/zxing-cmdline-runner.sh
@@ -1,3 +1,3 @@
 #! /bin/sh
 
-java-zxing com.google.zxing.client.j2se.CommandLineRunner "$@"
+@out@/bin/java-zxing com.google.zxing.client.j2se.CommandLineRunner "$@"

--- a/pkgs/by-name/zx/zxing/zxing-gui-runner.sh
+++ b/pkgs/by-name/zx/zxing/zxing-gui-runner.sh
@@ -1,0 +1,3 @@
+#! /bin/sh
+
+@out@/bin/java-zxing com.google.zxing.client.j2se.GUIRunner "$@"

--- a/pkgs/by-name/zx/zxing/zxing.sh
+++ b/pkgs/by-name/zx/zxing/zxing.sh
@@ -1,6 +1,6 @@
 #! /bin/sh
 choice="$1";
-shift
+[ "$#" = "0" ] || shift;
 case "$choice" in
     encode | create | write | CommandLineEncoder)
         @out@/bin/zxing-cmdline-encoder "$@";

--- a/pkgs/by-name/zx/zxing/zxing.sh
+++ b/pkgs/by-name/zx/zxing/zxing.sh
@@ -9,8 +9,8 @@ case "$choice" in
         zxing-cmdline-runner "$@";
         ;;
     help | usage | --help | --usage | -h)
-        zxing read;
-        zxing write;
+        zxing read --help;
+        zxing write --help;
         ;;
     *)
         zxing read "$choice" "$@"

--- a/pkgs/by-name/zx/zxing/zxing.sh
+++ b/pkgs/by-name/zx/zxing/zxing.sh
@@ -8,6 +8,9 @@ case "$choice" in
     decode | read | run | CommandLineRunner)
         @out@/bin/zxing-cmdline-runner "$@";
         ;;
+    gui | GUIRunner)
+        @out@/bin/zxing-gui-runner "$@";
+        ;;
     help | usage | --help | --usage | -h)
         @out@/bin/zxing read --help;
         @out@/bin/zxing write --help;

--- a/pkgs/by-name/zx/zxing/zxing.sh
+++ b/pkgs/by-name/zx/zxing/zxing.sh
@@ -3,16 +3,16 @@ choice="$1";
 shift
 case "$choice" in
     encode | create | write | CommandLineEncoder)
-        zxing-cmdline-encoder "$@";
+        @out@/bin/zxing-cmdline-encoder "$@";
         ;;
     decode | read | run | CommandLineRunner)
-        zxing-cmdline-runner "$@";
+        @out@/bin/zxing-cmdline-runner "$@";
         ;;
     help | usage | --help | --usage | -h)
-        zxing read --help;
-        zxing write --help;
+        @out@/bin/zxing read --help;
+        @out@/bin/zxing write --help;
         ;;
     *)
-        zxing read "$choice" "$@"
+        @out@/bin/zxing read "$choice" "$@";
         ;;
 esac


### PR DESCRIPTION
+ Switches to `buildMavenPackage` in order to automatically pull in all necessary dependencies.  Required dependencies have been missing since 117ea0db04ec49365e76874237868fc7e8cb24d2.
+ Fixes references in the provided scripts, so that zxing does not have to be in `PATH` in order to work correctly.
+ Exposes `GUIRunner` through the main script.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc