### PR TITLE
waybar-lyric: 0.12.2 -> 0.14.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18159,6 +18159,12 @@
     github = "nadiaholmquist";
     githubId = 893884;
   };
+  Nadim147c = {
+    email = "theephemeral.txt@gmail.com";
+    github = "Nadim147c";
+    githubId = 90786729;
+    name = "Ephemeral";
+  };
   nadir-ishiguro = {
     github = "nadir-ishiguro";
     githubId = 23151917;

--- a/pkgs/by-name/wa/waybar-lyric/package.nix
+++ b/pkgs/by-name/wa/waybar-lyric/package.nix
@@ -34,7 +34,10 @@ buildGoModule (finalAttrs: {
     homepage = "https://github.com/Nadim147c/waybar-lyric";
     license = lib.licenses.agpl3Only;
     mainProgram = "waybar-lyric";
-    maintainers = with lib.maintainers; [ vanadium5000 ];
+    maintainers = with lib.maintainers; [
+      Nadim147c
+      vanadium5000
+    ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/wa/waybar-lyric/package.nix
+++ b/pkgs/by-name/wa/waybar-lyric/package.nix
@@ -1,22 +1,38 @@
 {
+  stdenv,
   lib,
   buildGoModule,
   fetchFromGitHub,
   versionCheckHook,
   nix-update-script,
+  installShellFiles,
 }:
 buildGoModule (finalAttrs: {
   pname = "waybar-lyric";
-  version = "0.12.2";
+  version = "0.14.3";
 
   src = fetchFromGitHub {
     owner = "Nadim147c";
     repo = "waybar-lyric";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-2iuMlcKDnhRc3PZNMjhkHElEyVdx8+p+ONHn8lC4dQ0=";
+    hash = "sha256-bpc0AF/PcdmkVr791uT2PxgV59wTAAtFMFtKHKwtkQI=";
   };
 
-  vendorHash = "sha256-JpAlpTHPxPWHBCeegnUVYsM9LjUCuvfFd0JjQpCccaM=";
+  vendorHash = "sha256-TeAZDSiww9/v3uQl8THJZdN/Ffp+FsZ3TsRStE3ndKA=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.Version=${finalAttrs.version}"
+  ];
+
+  nativeBuildInputs = [ installShellFiles ];
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd waybar-lyric \
+      --bash <($out/bin/waybar-lyric _carapace bash) \
+      --fish <($out/bin/waybar-lyric _carapace fish) \
+      --zsh <($out/bin/waybar-lyric _carapace zsh)
+  '';
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

> Maintainer ping: @Vanadium5000 
