### PR TITLE
toml-test: 1.6.0 -> 2.0.0

### DIFF
--- a/pkgs/by-name/ta/taplo/package.nix
+++ b/pkgs/by-name/ta/taplo/package.nix
@@ -11,6 +11,7 @@
   # passthru dependencies
   nix-update-script,
   runCommand,
+  makeBinaryWrapper,
   toml-test,
 
   # Optional feature
@@ -68,24 +69,46 @@ rustPlatform.buildRustPackage (finalAttrs: {
           # Some of the failures are reported issues, others may not be.
           # https://github.com/tamasfe/taplo/issues/486
           skips = [
-            "valid/comment/nonascii"
-            "valid/datetime/edge"
-            "valid/key/quoted-unicode"
-            "valid/string/quoted-unicode"
-            "invalid/control/multi-cr"
-            "invalid/control/rawmulti-cr"
+            "invalid/table/append-with-dotted-keys-04"
             "invalid/table/super-twice"
+            "valid/array/array"
+            "valid/comment/everywhere"
+            "valid/comment/nonascii"
+            "valid/datetime/datetime"
+            "valid/datetime/edge"
+            "valid/datetime/leap-year"
+            "valid/datetime/local"
+            "valid/datetime/local-date"
+            "valid/datetime/local-time"
+            "valid/datetime/milliseconds"
+            "valid/datetime/timezone"
+            "valid/example"
+            "valid/key/like-date"
+            "valid/key/numeric-04"
+            "valid/key/quoted-unicode"
+            "valid/spec-1.0.0/local-date-0"
+            "valid/spec-1.0.0/local-date-time-0"
+            "valid/spec-1.0.0/local-time-0"
+            "valid/spec-1.0.0/offset-date-time-0"
+            "valid/spec-1.0.0/offset-date-time-1"
+            "valid/spec-1.0.0/table-7"
+            "valid/spec-example-1"
+            "valid/spec-example-1-compact"
+            "valid/string/quoted-unicode"
           ];
         in
         runCommand "taplo-toml-test"
           {
             nativeBuildInputs = [
-              finalAttrs.finalPackage
+              makeBinaryWrapper
               toml-test
             ];
           }
           ''
-            toml-test taplo ${lib.concatMapStringsSep " " (a: "-skip ${a}") skips} -- toml-test
+            makeWrapper ${lib.getExe finalAttrs.finalPackage} ./taplo-toml-test --add-flag toml-test
+            toml-test test -decoder=./taplo-toml-test -toml=1.0 ${
+              lib.concatMapStringsSep " " (a: "-skip ${a}") skips
+            }
             touch "$out"
           '';
     };

--- a/pkgs/by-name/to/toml-test/package.nix
+++ b/pkgs/by-name/to/toml-test/package.nix
@@ -8,16 +8,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "toml-test";
-  version = "1.6.0";
+  version = "2.0.0";
 
   src = fetchFromGitHub {
     owner = "toml-lang";
     repo = "toml-test";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-jOFkSEDNvvx8svgyYYpAbveQsclMsQRKJ2ocA6ty1Kw=";
+    hash = "sha256-QJ7rK4zdPN8c728fR9r4vXnSk4Y9T/XQJulO7kQaYFE=";
   };
 
-  vendorHash = "sha256-yt5rwpYzO38wEUhcyG4G367Byek20Uz3u+buAazq/5A=";
+  vendorHash = "sha256-aIGcv6qAQC3URQ/WIvg/+nRyrw1N2q5uBVpRH4fwgXk=";
 
   ldflags = [
     "-s"
@@ -26,7 +26,7 @@ buildGoModule (finalAttrs: {
   ];
 
   nativeInstallCheckInputs = [ versionCheckHook ];
-  versionCheckProgramArg = "--version";
+  versionCheckProgramArg = "version";
   doInstallCheck = true;
 
   passthru.updateScript = nix-update-script { };


### PR DESCRIPTION
Changelog: https://github.com/toml-lang/toml-test/releases/tag/v2.0.0
Diff: https://github.com/toml-lang/toml-test/compare/v1.6.0...v2.0.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
