### PR TITLE
rPackages.RBioFormats: fix build and revdeps properly

### DIFF
--- a/pkgs/by-name/bf/bftools/package.nix
+++ b/pkgs/by-name/bf/bftools/package.nix
@@ -8,11 +8,11 @@
 
 stdenv.mkDerivation rec {
   pname = "bftools";
-  version = "6.3.0";
+  version = "7.3.0";
 
   src = fetchzip {
     url = "http://downloads.openmicroscopy.org/bio-formats/${version}/artifacts/bftools.zip";
-    sha256 = "02nvvmpfglpah1ihd08aw65g1794w588c988cdar1hfl4s80qwhb";
+    hash = "sha256-EQ7P07d53e6Q/9Wt2Pa1h0TfuYblOZeByGW30oE3i6M=";
   };
 
   installPhase = ''
@@ -39,6 +39,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Bundle of scripts for using Bio-Formats on the command line with bioformats_package.jar already included";
+    mainProgram = "showinf";
     sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     license = lib.licenses.gpl2;
     platforms = lib.platforms.all;

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -1758,7 +1758,6 @@ let
     "Rmpi" # tries to run MPI processes
     "ReactomeContentService4R" # tries to connect to Reactome
     "PhIPData" # tries to download something from a DB
-    "RBioFormats" # tries to download jar during load test
     "pbdMPI" # tries to run MPI processes
     "CTdata" # tries to connect to ExperimentHub
     "rfaRm" # tries to connect to Ebi
@@ -2018,6 +2017,34 @@ let
         substituteInPlace "src/xCNV.c" \
         --replace-fail "Calloc" "R_Calloc" \
         --replace-fail "Free" "R_Free"
+      '';
+    });
+
+    RBioFormats = old.RBioFormats.overrideAttrs (attrs: {
+      # 1. Never download the jar file
+      # 2. Use jar from pkgs.bftools instead
+      # 3. Break the build if versions don't match
+      propagatedBuildInputs = (attrs.propagatedBuildInputs or [ ]) ++ [ pkgs.bftools ];
+
+      postPatch = ''
+        substituteInPlace "R/zzz.R" \
+          --replace-fail '!file.exists(bf_jar)' 'FALSE' \
+          --replace-fail \
+          '.jpackage(pkg, lib.loc = lib, morePaths = c(jars, bf_jar))' \
+          '.jpackage(pkg, lib.loc = lib, morePaths = union(jars, "${lib.getBin pkgs.bftools}/share/java/bioformats_package.jar"))' \
+          --replace-fail 'bf_jar <-' 'stopifnot(bf_ver == "${pkgs.bftools.version}");bf_jar <-'
+      '';
+
+      # Ensure that bftools version matches that in the package DESCRIPTION
+      preInstall = ''
+        rbf_version="$(sed  -n 's/^BioFormats: //p' DESCRIPTION)"
+        bf_version="${pkgs.bftools.version}"
+        if [ "$rbf_version" != "$bf_version" ]; then
+           echo "BioFormats version mismatch detected!"
+           echo "RBioformats needs: $rbf_version"
+           echo "bftools provides: $bf_version"
+           exit 1
+        fi
       '';
     });
 


### PR DESCRIPTION
- bftools: Upgrade BioFormats to the version *required by the R package* (currently 7.3.0, while the latest is 8.3.0). Also add mainProgram
- RBioFormats: Vendor the jar file from BioFormats instead of downloading it. Check required bftools version vs pkgs.bftools.version.

@jbedo @tbenst 

Context: https://github.com/NixOS/nixpkgs/pull/461049 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.


-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
