### PR TITLE
matrix-continuwuity: fix exploit in create_invite_route function

### DIFF
--- a/pkgs/by-name/ma/matrix-continuwuity/continuwuity-exploit-fix.diff
+++ b/pkgs/by-name/ma/matrix-continuwuity/continuwuity-exploit-fix.diff
@@ -1,0 +1,51 @@
+diff --git a/src/api/server/invite.rs b/src/api/server/invite.rs
+index 78a65fe8..d284fedd 100644
+--- a/src/api/server/invite.rs
++++ b/src/api/server/invite.rs
+@@ -61,6 +61,46 @@ pub(crate) async fn create_invite_route(
+ 	let mut signed_event = utils::to_canonical_object(&body.event)
+ 		.map_err(|_| err!(Request(InvalidParam("Invite event is invalid."))))?;
+ 
++	// Ensure this is a membership event
++	if signed_event
++		.get("type")
++		.expect("event must have a type")
++		.as_str()
++		.expect("type must be a string")
++		!= "m.room.member"
++	{
++		return Err!(Request(BadJson(
++			"Not allowed to send non-membership event to invite endpoint."
++		)));
++	}
++
++	let content: RoomMemberEventContent = serde_json::from_value(
++		signed_event
++			.get("content")
++			.ok_or_else(|| err!(Request(BadJson("Event missing content property"))))?
++			.clone()
++			.into(),
++	)
++	.map_err(|e| err!(Request(BadJson(warn!("Event content is empty or invalid: {e}")))))?;
++
++	// Ensure this is an invite membership event
++	if content.membership != MembershipState::Invite {
++		return Err!(Request(BadJson(
++			"Not allowed to send a non-invite membership event to invite endpoint."
++		)));
++	}
++
++	// Ensure the sending user isn't a lying bozo
++	let sender_server = signed_event
++		.get("sender")
++		.try_into()
++		.map(UserId::server_name)
++		.map_err(|e| err!(Request(InvalidParam("Invalid sender property: {e}"))))?;
++	if sender_server != body.origin() {
++		return Err!(Request(Forbidden("Sender's server does not match the origin server.",)));
++	}
++
++	// Ensure the target user belongs to this server
+ 	let recipient_user: OwnedUserId = signed_event
+ 		.get("state_key")
+ 		.try_into()

--- a/pkgs/by-name/ma/matrix-continuwuity/package.nix
+++ b/pkgs/by-name/ma/matrix-continuwuity/package.nix
@@ -87,6 +87,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
     hash = "sha256-UHlKAYgIkVtZJV+H2Xl7HssV03Q3XNxluMfLRY2e+Do=";
   };
 
+  # https://forgejo.ellis.link/continuwuation/continuwuity/commit/b2bead67ac8bc45de9a612578f295e5b7fc6c2b5
+  # https://forgejo.ellis.link/continuwuation/continuwuity/commit/7fa4fa98628593c1a963f5aa8dbc3657d604b047
+  # this patch is probably unneeded with the next release
+  patches = [ ./continuwuity-exploit-fix.diff ];
+
   cargoHash = "sha256-imfpl+72zlqeEREdTGFG3bsMdPTXe/sb1uGvMC6BGT0=";
 
   nativeBuildInputs = [


### PR DESCRIPTION
this fixes and exploit being used in the wild against continuwuity

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

### note: i have not yet been able to test this fix since im away from my PC and my laptop crashed trying to compile this