### PR TITLE
cantus: init at 0.4.0

### DIFF
--- a/pkgs/by-name/ca/cantus/package.nix
+++ b/pkgs/by-name/ca/cantus/package.nix
@@ -1,0 +1,51 @@
+{
+  fetchFromGitHub,
+  lib,
+  rustPlatform,
+  pkg-config,
+  autoPatchelfHook,
+  stdenv,
+  wayland,
+  vulkan-loader,
+  libxkbcommon,
+  nix-update-script,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "cantus";
+  version = "0.4.0";
+
+  src = fetchFromGitHub {
+    owner = "CodedNil";
+    repo = "cantus";
+    tag = version;
+    hash = "sha256-Mox8OGJFbQd3dy/I1O6OjqDa4FAFcZWiS+zOuTwV6js=";
+  };
+
+  cargoHash = "sha256-9+2+PkUA+s6v/Mrpo8M1lLemxClVONbbeHtric2z/Jw=";
+
+  nativeBuildInputs = [
+    pkg-config
+    autoPatchelfHook
+  ];
+
+  runtimeDependencies = [
+    libxkbcommon
+    vulkan-loader
+  ];
+
+  buildInputs = [
+    stdenv.cc.cc.lib
+    wayland
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Beautiful interactive music widget for Wayland";
+    homepage = "https://github.com/CodedNil/cantus";
+    license = lib.licenses.mit;
+    mainProgram = "cantus";
+    maintainers = with lib.maintainers; [ CodedNil ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
Adds cantus, a beautiful interactive music widget for wayland.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
