### PR TITLE
xfce.*: Move away from mkXfceDerivation (part 2)

### DIFF
--- a/pkgs/desktops/xfce/core/libxfce4windowing/default.nix
+++ b/pkgs/desktops/xfce/core/libxfce4windowing/default.nix
@@ -1,9 +1,12 @@
 {
   stdenv,
   lib,
-  mkXfceDerivation,
+  fetchFromGitLab,
+  gettext,
+  pkg-config,
   python3,
   wayland-scanner,
+  xfce4-dev-tools,
   glib,
   gtk3,
   libdisplay-info,
@@ -18,18 +21,32 @@
     && stdenv.hostPlatform.emulatorAvailable buildPackages,
   buildPackages,
   gobject-introspection,
+  gitUpdater,
 }:
 
-mkXfceDerivation {
-  category = "xfce";
+stdenv.mkDerivation (finalAttrs: {
   pname = "libxfce4windowing";
   version = "4.20.4";
 
-  sha256 = "sha256-8iLkljuGyJ4giVN5yuOFuTZsrdr8U3avTS/1aRSpaxc=";
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  src = fetchFromGitLab {
+    domain = "gitlab.xfce.org";
+    owner = "xfce";
+    repo = "libxfce4windowing";
+    tag = "libxfce4windowing-${finalAttrs.version}";
+    hash = "sha256-8iLkljuGyJ4giVN5yuOFuTZsrdr8U3avTS/1aRSpaxc=";
+  };
 
   nativeBuildInputs = [
+    gettext
+    pkg-config
     python3
     wayland-scanner
+    xfce4-dev-tools
   ]
   ++ lib.optionals withIntrospection [
     gobject-introspection
@@ -51,9 +68,19 @@ mkXfceDerivation {
     patchShebangs xdt-gen-visibility
   '';
 
+  configureFlags = [ "--enable-maintainer-mode" ];
+  enableParallelBuilding = true;
+
+  passthru.updateScript = gitUpdater {
+    rev-prefix = "libxfce4windowing-";
+    odd-unstable = true;
+  };
+
   meta = {
     description = "Windowing concept abstraction library for X11 and Wayland";
+    homepage = "https://gitlab.xfce.org/xfce/libxfce4windowing";
     license = lib.licenses.lgpl21Plus;
+    platforms = lib.platforms.linux;
     teams = [ lib.teams.xfce ];
   };
-}
+})

--- a/pkgs/desktops/xfce/core/thunar-volman/default.nix
+++ b/pkgs/desktops/xfce/core/thunar-volman/default.nix
@@ -1,18 +1,38 @@
 {
+  stdenv,
   lib,
-  mkXfceDerivation,
+  fetchFromGitLab,
+  gettext,
+  pkg-config,
+  xfce4-dev-tools,
+  wrapGAppsHook3,
   exo,
   gtk3,
   libgudev,
   libxfce4ui,
   libxfce4util,
   xfconf,
+  gitUpdater,
 }:
 
-mkXfceDerivation {
-  category = "xfce";
+stdenv.mkDerivation (finalAttrs: {
   pname = "thunar-volman";
   version = "4.20.0";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.xfce.org";
+    owner = "xfce";
+    repo = "thunar-volman";
+    tag = "thunar-volman-${finalAttrs.version}";
+    hash = "sha256-XIVs/vRwy3QJQW/U7eLBvGdzplWlhdxn3f1lyTQsmpE=";
+  };
+
+  nativeBuildInputs = [
+    gettext
+    pkg-config
+    xfce4-dev-tools
+    wrapGAppsHook3
+  ];
 
   buildInputs = [
     exo
@@ -23,12 +43,20 @@ mkXfceDerivation {
     xfconf
   ];
 
-  sha256 = "sha256-XIVs/vRwy3QJQW/U7eLBvGdzplWlhdxn3f1lyTQsmpE=";
+  configureFlags = [ "--enable-maintainer-mode" ];
+  enableParallelBuilding = true;
 
-  odd-unstable = false;
+  passthru.updateScript = gitUpdater {
+    rev-prefix = "thunar-volman-";
+    odd-unstable = true;
+  };
 
   meta = {
     description = "Thunar extension for automatic management of removable drives and media";
+    homepage = "https://gitlab.xfce.org/xfce/thunar-volman";
+    license = lib.licenses.gpl2Plus;
+    mainProgram = "thunar-volman";
+    platforms = lib.platforms.linux;
     teams = [ lib.teams.xfce ];
   };
-}
+})

--- a/pkgs/desktops/xfce/core/thunar/default.nix
+++ b/pkgs/desktops/xfce/core/thunar/default.nix
@@ -16,7 +16,10 @@
   pcre2,
   xfce4-panel,
   xfconf,
-  withIntrospection ? false,
+  withIntrospection ?
+    lib.meta.availableOn stdenv.hostPlatform gobject-introspection
+    && stdenv.hostPlatform.emulatorAvailable buildPackages,
+  buildPackages,
   gobject-introspection,
 }:
 

--- a/pkgs/desktops/xfce/core/tumbler/default.nix
+++ b/pkgs/desktops/xfce/core/tumbler/default.nix
@@ -1,6 +1,11 @@
 {
+  stdenv,
   lib,
-  mkXfceDerivation,
+  fetchFromGitLab,
+  gettext,
+  pkg-config,
+  xfce4-dev-tools,
+  wrapGAppsNoGuiHook,
   ffmpegthumbnailer,
   gdk-pixbuf,
   glib,
@@ -15,14 +20,27 @@
   gst_all_1,
   webp-pixbuf-loader,
   libxfce4util,
+  gitUpdater,
 }:
 
-mkXfceDerivation {
-  category = "xfce";
+stdenv.mkDerivation (finalAttrs: {
   pname = "tumbler";
   version = "4.20.1";
 
-  sha256 = "sha256-p4lAFNvCakqrsDa2FP0xbc/khx6eYqAlHwWkk8yEB7Y=";
+  src = fetchFromGitLab {
+    domain = "gitlab.xfce.org";
+    owner = "xfce";
+    repo = "tumbler";
+    tag = "tumbler-${finalAttrs.version}";
+    hash = "sha256-p4lAFNvCakqrsDa2FP0xbc/khx6eYqAlHwWkk8yEB7Y=";
+  };
+
+  nativeBuildInputs = [
+    gettext
+    pkg-config
+    xfce4-dev-tools
+    wrapGAppsNoGuiHook
+  ];
 
   buildInputs = [
     libxfce4util
@@ -58,8 +76,19 @@ mkXfceDerivation {
     wrapGApp $out/lib/tumbler-1/tumblerd
   '';
 
+  configureFlags = [ "--enable-maintainer-mode" ];
+  enableParallelBuilding = true;
+
+  passthru.updateScript = gitUpdater {
+    rev-prefix = "tumbler-";
+    odd-unstable = true;
+  };
+
   meta = {
     description = "D-Bus thumbnailer service";
+    homepage = "https://gitlab.xfce.org/xfce/tumbler";
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.linux;
     teams = [ lib.teams.xfce ];
   };
-}
+})

--- a/pkgs/desktops/xfce/core/tumbler/default.nix
+++ b/pkgs/desktops/xfce/core/tumbler/default.nix
@@ -9,14 +9,13 @@
   libgsf,
   libheif,
   libjxl,
+  libopenraw,
   librsvg,
   poppler,
   gst_all_1,
   webp-pixbuf-loader,
   libxfce4util,
 }:
-
-# TODO: add libopenraw
 
 mkXfceDerivation {
   category = "xfce";
@@ -34,6 +33,7 @@ mkXfceDerivation {
     gst_all_1.gst-plugins-base
     libgepub # optional EPUB thumbnailer support
     libgsf
+    libopenraw
     poppler # technically the glib binding
   ];
 

--- a/pkgs/desktops/xfce/core/xfce4-appfinder/default.nix
+++ b/pkgs/desktops/xfce/core/xfce4-appfinder/default.nix
@@ -1,22 +1,38 @@
 {
+  stdenv,
   lib,
-  mkXfceDerivation,
-  exo,
+  fetchFromGitLab,
+  gettext,
+  pkg-config,
+  xfce4-dev-tools,
+  wrapGAppsHook3,
   garcon,
   gtk3,
   libxfce4util,
   libxfce4ui,
   xfconf,
+  gitUpdater,
 }:
 
-mkXfceDerivation {
-  category = "xfce";
+stdenv.mkDerivation (finalAttrs: {
   pname = "xfce4-appfinder";
   version = "4.20.0";
 
-  sha256 = "sha256-HovQnkfv5BOsRPowgMkMEWQmESkivVK0Xb7I15ZaOMc=";
+  src = fetchFromGitLab {
+    domain = "gitlab.xfce.org";
+    owner = "xfce";
+    repo = "xfce4-appfinder";
+    tag = "xfce4-appfinder-${finalAttrs.version}";
+    hash = "sha256-HovQnkfv5BOsRPowgMkMEWQmESkivVK0Xb7I15ZaOMc=";
+  };
 
-  nativeBuildInputs = [ exo ];
+  nativeBuildInputs = [
+    gettext
+    pkg-config
+    xfce4-dev-tools
+    wrapGAppsHook3
+  ];
+
   buildInputs = [
     garcon
     gtk3
@@ -25,8 +41,20 @@ mkXfceDerivation {
     xfconf
   ];
 
+  configureFlags = [ "--enable-maintainer-mode" ];
+  enableParallelBuilding = true;
+
+  passthru.updateScript = gitUpdater {
+    rev-prefix = "xfce4-appfinder-";
+    odd-unstable = true;
+  };
+
   meta = {
     description = "Appfinder for the Xfce4 Desktop Environment";
+    homepage = "https://gitlab.xfce.org/xfce/xfce4-appfinder";
+    license = lib.licenses.gpl2Plus;
+    mainProgram = "xfce4-appfinder";
+    platforms = lib.platforms.linux;
     teams = [ lib.teams.xfce ];
   };
-}
+})

--- a/pkgs/desktops/xfce/core/xfce4-panel/default.nix
+++ b/pkgs/desktops/xfce/core/xfce4-panel/default.nix
@@ -1,8 +1,12 @@
 {
   stdenv,
   lib,
-  mkXfceDerivation,
+  fetchFromGitLab,
+  gettext,
+  pkg-config,
   python3,
+  xfce4-dev-tools,
+  wrapGAppsHook3,
   cairo,
   exo,
   garcon,
@@ -22,17 +26,32 @@
   buildPackages,
   gobject-introspection,
   vala,
+  gitUpdater,
 }:
 
-mkXfceDerivation {
-  category = "xfce";
+stdenv.mkDerivation (finalAttrs: {
   pname = "xfce4-panel";
   version = "4.20.5";
 
-  sha256 = "sha256-Jftj+EmmsKfK9jk8rj5uMjpteFUHFgOpoEol8JReDNI=";
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  src = fetchFromGitLab {
+    domain = "gitlab.xfce.org";
+    owner = "xfce";
+    repo = "xfce4-panel";
+    tag = "xfce4-panel-${finalAttrs.version}";
+    hash = "sha256-Jftj+EmmsKfK9jk8rj5uMjpteFUHFgOpoEol8JReDNI=";
+  };
 
   nativeBuildInputs = [
+    gettext
+    pkg-config
     python3
+    xfce4-dev-tools
+    wrapGAppsHook3
   ]
   ++ lib.optionals withIntrospection [
     gobject-introspection
@@ -65,8 +84,20 @@ mkXfceDerivation {
        --replace-fail "/usr/share/zoneinfo" "${tzdata}/share/zoneinfo"
   '';
 
+  configureFlags = [ "--enable-maintainer-mode" ];
+  enableParallelBuilding = true;
+
+  passthru.updateScript = gitUpdater {
+    rev-prefix = "xfce4-panel-";
+    odd-unstable = true;
+  };
+
   meta = {
     description = "Panel for the Xfce desktop environment";
+    homepage = "https://gitlab.xfce.org/xfce/xfce4-panel";
+    license = lib.licenses.gpl2Plus;
+    mainProgram = "xfce4-panel";
+    platforms = lib.platforms.linux;
     teams = [ lib.teams.xfce ];
   };
-}
+})


### PR DESCRIPTION
To reduce the diff when build system change comes (Xfce 4.22). `mkXfceDerivation` is generally pointless with meson.

- https://github.com/NixOS/nixpkgs/pull/472595#issuecomment-3677467001
- https://github.com/NixOS/nixpkgs/pull/472696

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

