### PR TITLE
nixos/ly: add support for auto-login

### DIFF
--- a/nixos/modules/services/display-managers/ly.nix
+++ b/nixos/modules/services/display-managers/ly.nix
@@ -17,13 +17,14 @@ let
   iniFmt = pkgs.formats.iniWithGlobalSection { };
 
   inherit (lib)
-    concatMapStrings
     attrNames
+    concatMapStrings
     getAttr
     mkIf
     mkOption
     mkEnableOption
     mkPackageOption
+    optionalAttrs
     ;
 
   xserverWrapper = pkgs.writeShellScript "xserver-wrapper" ''
@@ -47,6 +48,11 @@ let
     setup_cmd = dmcfg.sessionData.wrapper;
     brightness_up_cmd = "${lib.getExe pkgs.brightnessctl} -q -n s +10%";
     brightness_down_cmd = "${lib.getExe pkgs.brightnessctl} -q -n s 10%-";
+  }
+  // optionalAttrs dmcfg.autoLogin.enable {
+    auto_login_service = "ly-autologin";
+    auto_login_session = dmcfg.sessionData.autologinSession;
+    auto_login_user = dmcfg.autoLogin.user;
   };
 
   finalConfig = defaultConfig // cfg.settings;
@@ -84,17 +90,32 @@ in
 
     assertions = [
       {
-        assertion = !dmcfg.autoLogin.enable;
+        assertion = dmcfg.autoLogin.enable -> dmcfg.sessionData.autologinSession != null;
         message = ''
-          ly doesn't support auto login.
+          ly auto-login requires that services.displayManager.defaultSession is set.
         '';
       }
     ];
 
-    security.pam.services.ly = {
-      startSession = true;
-      unixAuth = true;
-      enableGnomeKeyring = lib.mkDefault config.services.gnome.gnome-keyring.enable;
+    security.pam.services = {
+      ly = {
+        startSession = true;
+        unixAuth = true;
+        enableGnomeKeyring = lib.mkDefault config.services.gnome.gnome-keyring.enable;
+      };
+    }
+    // optionalAttrs dmcfg.autoLogin.enable {
+      ly-autologin.text = ''
+        auth      requisite pam_nologin.so
+        auth      required  pam_succeed_if.so uid >= 1000 quiet
+        auth      required  pam_permit.so
+
+        account   include   ly
+
+        password  include   ly
+
+        session   include   ly
+      '';
     };
 
     environment = {

--- a/nixos/tests/ly.nix
+++ b/nixos/tests/ly.nix
@@ -23,6 +23,18 @@ in
       services.displayManager.defaultSession = "none+icewm";
       services.xserver.windowManager.icewm.enable = true;
     };
+  nodes.machineAutologin =
+    { ... }:
+    lib.attrsets.recursiveUpdate machineBase {
+      services.displayManager.ly.x11Support = true;
+      services.xserver.enable = true;
+      services.displayManager.defaultSession = "none+icewm";
+      services.xserver.windowManager.icewm.enable = true;
+      services.displayManager.autoLogin = {
+        enable = true;
+        user = "alice";
+      };
+    };
   nodes.machineNoX11 =
     { ... }:
     lib.attrsets.recursiveUpdate machineBase {
@@ -82,6 +94,14 @@ in
       machine.wait_for_window("^IceWM ")
       machine.sleep(2)
       machine.screenshot("icewm")
+
+      machineAutologin.wait_until_succeeds("getfacl /dev/dri/card0 | grep video")
+      machineAutologin.send_key("ctrl-alt-f1")
+      machineAutologin.wait_for_file("/run/user/${toString user.uid}/lyxauth")
+      machineAutologin.succeed("xauth merge /run/user/${toString user.uid}/lyxauth")
+      machineAutologin.wait_for_window("^IceWM ")
+      machineAutologin.sleep(2)
+      machineAutologin.screenshot("autologin-icewm")
 
       machineNoX11.wait_until_tty_matches("1", "password")
       machineNoX11.send_key("ctrl-alt-f1")


### PR DESCRIPTION
Support for auto-login in ly was added recently, in [v1.3.0](https://codeberg.org/fairyglade/ly/releases/tag/v1.3.0) (update PR: https://github.com/NixOS/nixpkgs/pull/468869).
This PR allows configuration of ly's auto-login using options [`services.displayManager.autoLogin`](https://search.nixos.org/options?channel=unstable&show=services.displayManager.autoLogin&query=services.displaymanager.autologin) in a similar way as it's been done for GDM, LightDM and SDDM.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
