### PR TITLE
asus-ec-sensors: 0.1.0-unstable-2025-01-10 -> 0.1.0-unstable-2025-12-11

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16110,6 +16110,12 @@
     github = "marijanp";
     githubId = 13599169;
   };
+  mariolopjr = {
+    name = "Mario Lopez";
+    email = "mario@techmunchies.net";
+    github = "mariolopjr";
+    githubId = 2067324;
+  };
   marius851000 = {
     email = "nix@mariusdavid.fr";
     name = "Marius David";

--- a/pkgs/os-specific/linux/asus-ec-sensors/default.nix
+++ b/pkgs/os-specific/linux/asus-ec-sensors/default.nix
@@ -35,7 +35,10 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/zeule/asus-ec-sensors";
     license = lib.licenses.gpl2Only;
     platforms = [ "x86_64-linux" ];
-    maintainers = with lib.maintainers; [ nickhu ];
+    maintainers = with lib.maintainers; [
+      nickhu
+      mariolopjr
+    ];
     broken = kernel.kernelOlder "5.11";
   };
 }

--- a/pkgs/os-specific/linux/asus-ec-sensors/default.nix
+++ b/pkgs/os-specific/linux/asus-ec-sensors/default.nix
@@ -8,13 +8,13 @@
 
 stdenv.mkDerivation rec {
   name = "asus-ec-sensors-${version}-${kernel.version}";
-  version = "0.1.0-unstable-2025-01-10";
+  version = "0.1.0-unstable-2025-12-11";
 
   src = fetchFromGitHub {
     owner = "zeule";
     repo = "asus-ec-sensors";
-    rev = "619d505b7055be618e9ba9d5e146fd641dbf3015";
-    sha256 = "sha256-vS8wNS53m495hmsI267R5Kq/j8Mo5491PJkUKRUpqPQ=";
+    rev = "0e73cd165c4d1baf8ce841604722c6981b7ba9d6";
+    sha256 = "sha256-qX+HmtBdm9bOJRnlpI/Ru0OCcUi8MQ29Y731yM9JEi0=";
   };
 
   hardeningDisable = [ "pic" ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Updates `asus-ec-sensors` to the latest git revision, which brings support for many new ASUS motherboard chipsets, now supporting the following chipsets:
```
## Supported motherboards

 * MAXIMUS VI HERO
 * PRIME X470-PRO
 * PRIME X570-PRO
 * PRIME X670E-PRO WIFI
 * PRIME Z270-A
 * Pro WS TRX50-SAGE WIFI
 * Pro WS TRX50-SAGE WIFI A
 * Pro WS X570-ACE
 * Pro WS WRX90E-SAGE SE
 * ProArt X570-CREATOR WIFI
 * ProArt X670E-CREATOR WIFI
 * ProArt X870E-CREATOR WIFI
 * ProArt B550-CREATOR
 * ROG CROSSHAIR VIII DARK HERO
 * ROG CROSSHAIR VIII HERO (WI-FI)
 * ROG CROSSHAIR VIII FORMULA
 * ROG CROSSHAIR VIII HERO
 * ROG CROSSHAIR VIII IMPACT
 * ROG CROSSHAIR X670E HERO
 * ROG CROSSHAIR X670E GENE
 * ROG MAXIMUS X HERO
 * ROG MAXIMUS XI HERO
 * ROG MAXIMUS XI HERO (WI-FI)
 * ROG MAXIMUS Z690 FORMULA
 * ROG STRIX B550-E GAMING
 * ROG STRIX B550-I GAMING
 * ROG STRIX B650E-I GAMING WIFI
 * ROG STRIX B850-I GAMING WIFI
 * ROG STRIX X470-I GAMING
 * ROG STRIX X570-E GAMING
 * ROG STRIX X570-E GAMING WIFI II
 * ROG STRIX X570-F GAMING
 * ROG STRIX X570-I GAMING
 * ROG STRIX X670E-E GAMING WIFI
 * ROG STRIX X670E-I GAMING WIFI
 * ROG STRIX X870-F GAMING WIFI
 * ROG STRIX X870-I GAMING WIFI
 * ROG STRIX X870E-E GAMING WIFI
 * ROG STRIX X870E-H GAMING WIFI7
 * ROG STRIX Z390-F GAMING
 * ROG STRIX Z490-F GAMING
 * ROG STRIX Z690-A GAMING WIFI D4
 * ROG STRIX Z690-E GAMING WIFI
 * ROG STRIX Z790-E GAMING WIFI II
 * ROG STRIX Z790-I GAMING WIFI
 * ROG ZENITH II EXTREME
 * ROG ZENITH II EXTREME ALPHA
 * TUF GAMING X670E PLUS
 * TUF GAMING X670E PLUS WIFI
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
