### PR TITLE
linux/common-config: enable ARM64_PMEM

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -1351,6 +1351,8 @@ let
         X86_PLATFORM_DRIVERS_DELL = lib.mkIf stdenv.hostPlatform.isx86 (whenAtLeast "5.12" yes);
         X86_PLATFORM_DRIVERS_HP = lib.mkIf stdenv.hostPlatform.isx86 (whenAtLeast "6.1" yes);
 
+        ARM64_PMEM = lib.mkIf stdenv.hostPlatform.isAarch64 yes;
+
         LIRC = yes;
 
         SCHED_CORE = whenAtLeast "5.14" yes;


### PR DESCRIPTION
This feature, while not enabled by default by the Linux defconfig, is required for usage of mainline kernels in the NVidia Jetson boards.

It appears to have no adverse effects, since its availability is detected at runtime, so it's fine to have enabled on all aarch64 platforms.

Other distros have this enabled by default as well:
- Debian: https://salsa.debian.org/kernel-team/linux/-/blob/debian/latest/debian/config/arm64/config#L36
- Ubuntu: https://git.launchpad.net/~ubuntu-kernel/ubuntu/+source/linux/+git/noble/tree/debian.master/config/annotations#n1657
- Fedora: https://src.fedoraproject.org/rpms/kernel/blob/rawhide/f/kernel-aarch64-fedora.config#_497

This is also, from what I can tell, the only blocker to being able to use NixOS on an NVidia Jetson, since they support UEFI just fine, and the out-of-tree modules can easily be packaged in nixos-hardware. While the kernel patch could go there, this does save a significant amount of pain by not requiring a full kernel recompilation.

As for enabling this for all kernel versions, it's been around since 4.14, much older than any supported kernel: https://cateee.net/lkddb/web-lkddb/ARM64_PMEM.html

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
