### PR TITLE
ltspice: 26.0.0 -> 26.0.1

### DIFF
--- a/pkgs/by-name/lt/ltspice/package.nix
+++ b/pkgs/by-name/lt/ltspice/package.nix
@@ -11,10 +11,10 @@
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "ltspice";
-  version = "26.0.0";
+  version = "26.0.1";
   src = fetchurl {
-    url = "https://web.archive.org/web/20251210201306/https://ltspice.analog.com/software/LTspice64.msi";
-    hash = "sha256-fw4z9BlkMUR/z7u+wMx6S267jn8y+HzVgDkQ9rJTQ70=";
+    url = "https://ltspice.analog.com/download/${finalAttrs.version}/LTspice64.msi";
+    hash = "sha256-7DUCZpftMtKuV7F746PIh3tjH2QrZjJkkamAjEfsAIE=";
   };
   dontUnpack = true;
   dontConfigure = true;
@@ -81,6 +81,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   meta = {
     description = "SPICE simulator, schematic capture and waveform viewer";
     homepage = "https://www.analog.com/en/resources/design-tools-and-calculators/ltspice-simulator.html";
+    changelog = "https://ltspice.analog.com/download/updates.txt";
     license = lib.licenses.unfree;
     mainProgram = "ltspice";
     maintainers = [ lib.maintainers.zimward ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Clearly the archive url is unstable, see e.g. https://github.com/NixOS/nixpkgs/pull/462612. When I build I get

```
error: hash mismatch in fixed-output derivation '/nix/store/977qn1y4vjp3nzf0k2xxkvpxqy8css5w-LTspice64.msi.drv':
         specified: sha256-fw4z9BlkMUR/z7u+wMx6S267jn8y+HzVgDkQ9rJTQ70=
            got:    sha256-r5P3kW/nDN99mbTklDrmegc3wfIoatmQC8HeAooemH8=
error: 1 dependencies of derivation '/nix/store/isyiyq1lxya07kb5g02f4s38967v5xhr-ltspice-26.0.0.drv' failed to build
```

Fixing the FOD hash results in the following error.

```
** (msiextract:20): WARNING **: 20:24:57.834: open failed for /nix/store/9ndihp2y38xzl1xr5zhdxbpp4wrdhip1-LTspice64.msi


** (msiextract:20): CRITICAL **: 20:24:57.836: libmsi_query_new: assertion 'LIBMSI_IS_DATABASE (database)' failed

** (msiextract:20): CRITICAL **: 20:24:57.836: libmsi_query_execute: assertion 'LIBMSI_IS_QUERY (query)' failed

** (msiextract:20): CRITICAL **: 20:24:57.836: libmsi_query_fetch: assertion 'LIBMSI_IS_QUERY (query)' failed

...

mv: missing destination file operand after '.'
Try 'mv --help' for more information.
```

The solution is to use a permalink I got from the [AUR](https://aur.archlinux.org/packages/ltspice#comment-1008322). There's also [https://ltspice.analog.com/download/updates.txt](https://ltspice.analog.com/download/updates.txt) which indicates the latest version, url, and hashes, which I also got from the [AUR](https://aur.archlinux.org/packages/ltspice#comment-1038084). Downloading and extracting with `msiextract`, one sees in `APPDIR:./LTspiceChangeLog.txt` the following,

```
12/1/2025 LTspice 26.0.1
       * Bug fixes
...
```

although `LTspice.json` incorrectly reports the version as `26.0.0`.

<details>
<summary>LTspice.json</summary>

```json
{
    "Downloads": {
        "Download LTspice XVII (End of Support)": {
            "Filename": "LTspice64.exe",
            "Version": ""
        },
        "Download for MacOS 10.15 and forward": {
            "Filename": "LTspice.pkg",
            "Version": "17.2.4"
        },
        "Download for Windows 10 64-bit and forward": {
            "Filename": "LTspice64.msi",
            "Version": "26.0.0"
        },
        "Download for Windows 11 ARM64 and forward": {
            "Filename": "LTspice64_arm.msi",
            "Version": "26.0.0"
        }
    },
    "Installation": "2025-12-15",
    "LTspice_Mac": "17.2.4",
    "Models": "2025-12-15"
}
```

</details>

cc @zimward

(FYI in situations where there is no stable permalink, it is easiest to mirror yourself, e.g. with github, google drive, or your own website. If archive snapshots disappear after a day, then it makes the package unusable.)

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
