### PR TITLE
 python3Packages.causal-conv1d: 1.5.2 -> 1.5.4, add rocm support 

### DIFF
--- a/pkgs/development/python-modules/causal-conv1d/default.nix
+++ b/pkgs/development/python-modules/causal-conv1d/default.nix
@@ -14,9 +14,6 @@
   which,
 }:
 
-assert cudaSupport -> !rocmSupport;
-assert rocmSupport -> !cudaSupport;
-
 buildPythonPackage rec {
   pname = "causal-conv1d";
   version = "1.5.4";
@@ -87,7 +84,9 @@ buildPythonPackage rec {
     description = "Causal depthwise conv1d in CUDA with a PyTorch interface";
     homepage = "https://github.com/Dao-AILab/causal-conv1d";
     license = lib.licenses.bsd3;
-    # The package requires CUDA or ROCm
-    broken = !(cudaSupport || rocmSupport);
+
+    # The package requires either CUDA or ROCm.
+    # It doesn't work without either, nor with both.
+    broken = cudaSupport != rocmSupport;
   };
 }

--- a/pkgs/development/python-modules/causal-conv1d/default.nix
+++ b/pkgs/development/python-modules/causal-conv1d/default.nix
@@ -19,14 +19,14 @@ assert rocmSupport -> !cudaSupport;
 
 buildPythonPackage rec {
   pname = "causal-conv1d";
-  version = "1.5.2";
+  version = "1.5.4";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Dao-AILab";
     repo = "causal-conv1d";
     tag = "v${version}";
-    hash = "sha256-B2I5QiJl0p5d1BeQcMbJBAYUb10HzqFd88QMM8Rerm0=";
+    hash = "sha256-ELuvnKP2g1I2SuaWWiibXh/oDzp4n0vXkm4oeNPOdIw=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/causal-conv1d/default.nix
+++ b/pkgs/development/python-modules/causal-conv1d/default.nix
@@ -9,8 +9,13 @@
   rocmPackages,
   config,
   cudaSupport ? config.cudaSupport,
+  rocmSupport ? config.rocmSupport,
+  rocmGpuTargets ? rocmPackages.clr.localGpuTargets or rocmPackages.clr.gpuTargets,
   which,
 }:
+
+assert cudaSupport -> !rocmSupport;
+assert rocmSupport -> !cudaSupport;
 
 buildPythonPackage rec {
   pname = "causal-conv1d";
@@ -30,9 +35,9 @@ buildPythonPackage rec {
     torch
   ];
 
-  nativeBuildInputs = [ which ];
+  nativeBuildInputs = [ which ] ++ lib.optionals rocmSupport [ rocmPackages.clr ];
 
-  buildInputs = (
+  buildInputs =
     lib.optionals cudaSupport (
       with cudaPackages;
       [
@@ -44,26 +49,45 @@ buildPythonPackage rec {
         libcublas
       ]
     )
-  );
+    ++ lib.optionals rocmSupport (
+      with rocmPackages;
+      [
+        rocm-core
+        rocm-device-libs
+        rocm-runtime
+        rocm-comgr
+        hipblas
+        rocblas
+        hipcub
+        rocprim
+      ]
+    );
 
   dependencies = [
     torch
   ];
 
-  # pytest tests not enabled due to nvidia GPU dependency
+  # pytest tests not enabled due to GPU dependency
   pythonImportsCheck = [ "causal_conv1d" ];
 
   env = {
     CAUSAL_CONV1D_FORCE_BUILD = "TRUE";
   }
-  // lib.optionalAttrs cudaSupport { CUDA_HOME = "${lib.getDev cudaPackages.cuda_nvcc}"; };
+  // lib.optionalAttrs cudaSupport { CUDA_HOME = "${lib.getDev cudaPackages.cuda_nvcc}"; }
+  // lib.optionalAttrs rocmSupport {
+    ROCM_PATH = "${rocmPackages.clr}";
+    HIP_ARCHITECTURES = builtins.concatStringsSep "," rocmGpuTargets;
+    CPLUS_INCLUDE_PATH = lib.makeSearchPath "include" [
+      rocmPackages.hipcub
+      rocmPackages.rocprim
+    ];
+  };
 
   meta = {
     description = "Causal depthwise conv1d in CUDA with a PyTorch interface";
     homepage = "https://github.com/Dao-AILab/causal-conv1d";
     license = lib.licenses.bsd3;
-    # The package requires CUDA or ROCm, the ROCm build hasn't
-    # been completed or tested, so broken if not using cuda.
-    broken = !cudaSupport;
+    # The package requires CUDA or ROCm
+    broken = !(cudaSupport || rocmSupport);
   };
 }


### PR DESCRIPTION
Updates causal-conv1d and adds support for ROCm

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
