### PR TITLE
silice: 0-unstable-2025-07-03 -> 0-unstable-2025-10-02

### DIFF
--- a/pkgs/by-name/si/silice/package.nix
+++ b/pkgs/by-name/si/silice/package.nix
@@ -19,13 +19,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "silice";
-  version = "0-unstable-2025-07-03";
+  version = "0-unstable-2025-10-02";
 
   src = fetchFromGitHub {
     owner = "sylefeb";
     repo = "silice";
-    rev = "656632ec300f8be3636cfd9bca5be954fc9c9120";
-    hash = "sha256-0awHQrGm4ggWE9+69ova1cXAaesaMNihbzpgAytRTks=";
+    rev = "73bebc454ef36cf447a99b5c50409af171675279";
+    hash = "sha256-GsIOs41wUjq1IYZcrASMEHAvS2/vJeJRK7I/cqSgzYY=";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION

- Built on platform:
  - [x] x86_64-linux
- Tested, as applicable:

Please update @astro @pbsds 