### PR TITLE
r2mod_cli: 1.3.3.1 -> 1.3.3

### DIFF
--- a/pkgs/by-name/r2/r2mod_cli/package.nix
+++ b/pkgs/by-name/r2/r2mod_cli/package.nix
@@ -1,22 +1,22 @@
 {
-  fetchFromGitHub,
   bashInteractive,
   jq,
   makeWrapper,
   p7zip,
   lib,
   stdenv,
+  fetchzip,
 }:
 
 stdenv.mkDerivation rec {
   pname = "r2mod_cli";
-  version = "1.3.3.1";
+  version = "1.3.3";
 
-  src = fetchFromGitHub {
-    owner = "Foldex";
-    repo = "r2mod_cli";
-    rev = "v${version}";
-    sha256 = "sha256-Y9ZffztxfGYiUSphqwhe3rTbnJ/vmGGi1pLml+1tLP8=";
+  src = fetchzip {
+    url = "https://thunderstore.io/package/download/Foldex/r2mod_cli/${version}/";
+    hash = "sha256-J7ybNZa44/H+AjQ7L949I3iClXoDwinl/ITMK/QsTR0=";
+    extension = "zip";
+    stripRoot = false;
   };
 
   buildInputs = [ bashInteractive ];
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Risk of Rain 2 Mod Manager in Bash";
-    homepage = "https://github.com/foldex/r2mod_cli";
+    homepage = "https://thunderstore.io/package/Foldex/r2mod_cli";
     license = lib.licenses.gpl3Only;
     maintainers = [ lib.maintainers.reedrw ];
     mainProgram = "r2mod";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Source is a 404. I found a mirror which has the src but the version is slightly different. No idea why I needed to force extension=zip. 

Wasn't able to test because I don't own risk of rain 2.

Partially addresses #471645 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
