### PR TITLE
python3Packages.ultralytics: add missing test dependency

### DIFF
--- a/pkgs/development/python-modules/ultralytics/default.nix
+++ b/pkgs/development/python-modules/ultralytics/default.nix
@@ -26,9 +26,10 @@
   ultralytics-thop,
 
   # tests
-  pytestCheckHook,
+  aiohttp,
   onnx,
   onnxruntime,
+  pytestCheckHook,
 }:
 
 buildPythonPackage rec {
@@ -72,9 +73,10 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "ultralytics" ];
 
   nativeCheckInputs = [
-    pytestCheckHook
+    aiohttp
     onnx
     onnxruntime
+    pytestCheckHook
   ];
 
   enabledTestPaths = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

On darwin I was encountering:
```
=========================== short test summary info ============================
FAILED tests/test_python.py::test_train_ndjson - RuntimeError: Dataset 'https://github.com/ultralytics/assets/releases/download/v0.0.0/coco8-ndjson.ndjson' error ❌ No module named 'aiohttp'
=========== 1 failed, 22 passed, 2 skipped, 47 deselected in 44.57s ============
```

cc @osbm

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
