### PR TITLE
nixosTests.activemq: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -498,6 +498,8 @@ See <https://github.com/NixOS/nixpkgs/issues/481673>.
 
 - The [services.calibre-web](#opt-services.calibre-web.enable) systemd service has been hardened with additional sandboxing restrictions.
 
+- `services.activemq.extraJavaOptions` type was changed to a list of strings for better consistency and flexibility in specifying multiple Java options.
+
 - `services.kanidm` options for server, client and unix were moved under dedicated namespaces.
   For each component `enableComponent` and `componentSettings` are now `component.enable` and
   `component.settings`. The unix module now supports using SSH keys from Kanidm via

--- a/nixos/modules/services/amqp/activemq/default.nix
+++ b/nixos/modules/services/amqp/activemq/default.nix
@@ -95,9 +95,13 @@ in
       };
 
       extraJavaOptions = lib.mkOption {
-        type = lib.types.separatedString " ";
-        default = "";
-        example = "-Xmx2G -Xms2G -XX:MaxPermSize=512M";
+        type = lib.types.listOf lib.types.str;
+        default = [ ];
+        example = [
+          "-Xmx2G"
+          "-Xms2G"
+          "-XX:MaxPermSize=512M"
+        ];
         description = ''
           Add extra options here that you want to be sent to the
           Java runtime when the broker service is started.
@@ -142,7 +146,7 @@ in
               lib.mapAttrsToList (name: value: "-D${name}=${value}") cfg.javaProperties
             )
           } \
-          ${cfg.extraJavaOptions} ActiveMQBroker "${cfg.configurationURI}"
+          ${toString cfg.extraJavaOptions} ActiveMQBroker "${cfg.configurationURI}"
       '';
     };
 

--- a/nixos/modules/services/amqp/activemq/default.nix
+++ b/nixos/modules/services/amqp/activemq/default.nix
@@ -11,7 +11,7 @@ let
   activemqBroker =
     pkgs.runCommand "activemq-broker"
       {
-        nativeBuildInputs = [ pkgs.jdk ];
+        nativeBuildInputs = [ cfg.jdk ];
       }
       ''
         mkdir -p $out/lib
@@ -29,6 +29,10 @@ in
       enable = lib.mkEnableOption "Apache ActiveMQ message broker service";
 
       package = lib.mkPackageOption pkgs "activemq" { };
+
+      jdk = lib.mkPackageOption pkgs "JDK" {
+        default = "jdk17_headless";
+      };
 
       configurationDir = lib.mkOption {
         default = "${cfg.package}/conf";
@@ -127,7 +131,7 @@ in
       description = "Apache ActiveMQ Message Broker";
       wantedBy = [ "multi-user.target" ];
       after = [ "network.target" ];
-      path = [ pkgs.jre ];
+      path = [ cfg.jdk ];
       serviceConfig.User = "activemq";
       script = ''
         source ${cfg.package}/lib/classpath.env

--- a/nixos/modules/services/amqp/activemq/default.nix
+++ b/nixos/modules/services/amqp/activemq/default.nix
@@ -83,6 +83,7 @@ in
             "activemq.data" = "${cfg.baseDir}/data";
             "activemq.conf" = "${cfg.configurationDir}";
             "activemq.home" = "${cfg.package}";
+            "jolokia.conf" = "file:${cfg.configurationDir}/jolokia-access.xml";
           }
           // attrs;
         description = ''
@@ -97,11 +98,15 @@ in
       extraJavaOptions = lib.mkOption {
         type = lib.types.listOf lib.types.str;
         default = [ ];
-        example = [
-          "-Xmx2G"
-          "-Xms2G"
-          "-XX:MaxPermSize=512M"
-        ];
+        example = lib.literalExpression ''
+          [
+            "-Xmx2G"
+            "-Xms2G"
+            "-XX:MaxPermSize=512M"
+            "-Djava.util.logging.config.file=''${cfg.configurationDir}/logging.properties"
+            "-Djava.security.auth.login.config=''${cfg.configurationDir}/login.config"
+          ]
+        '';
         description = ''
           Add extra options here that you want to be sent to the
           Java runtime when the broker service is started.

--- a/nixos/tests/activemq.nix
+++ b/nixos/tests/activemq.nix
@@ -1,0 +1,29 @@
+{ lib, ... }:
+
+{
+  name = "activemq";
+  meta.maintainers = [ lib.maintainers.anthonyroussel ];
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      services.activemq = {
+        enable = true;
+        package = pkgs.activemq;
+      };
+    };
+
+  testScript = ''
+    machine.wait_for_unit("activemq.service")
+
+    with subtest("Check if ports are open"):
+      machine.wait_for_open_port(8161) # http api
+      machine.wait_for_open_port(1883) # mqtt
+      machine.wait_for_open_port(5672) # amqp
+      machine.wait_for_open_port(61613) # stomp
+      machine.wait_for_open_port(61616) # openwire
+
+    with subtest("Check web console"):
+      machine.succeed("curl -sS --fail -u admin:admin http://127.0.0.1:8161/admin/")
+  '';
+}

--- a/nixos/tests/activemq.nix
+++ b/nixos/tests/activemq.nix
@@ -5,11 +5,14 @@
   meta.maintainers = [ lib.maintainers.anthonyroussel ];
 
   nodes.machine =
-    { pkgs, ... }:
+    { pkgs, config, ... }:
     {
       services.activemq = {
         enable = true;
         package = pkgs.activemq;
+        extraJavaOptions = [
+          "-Djava.security.auth.login.config=${config.services.activemq.configurationDir}/login.config"
+        ];
       };
     };
 

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -197,6 +197,7 @@ in
   activation-perlless = runTest ./activation/perlless.nix;
   activation-template-dropin = runTest ./activation/template-dropin.nix;
   activation-var = runTest ./activation/var.nix;
+  activemq = runTest ./activemq.nix;
   actual = runTest ./actual.nix;
   adguardhome = runTest ./adguardhome.nix;
   aesmd = runTestOn [ "x86_64-linux" ] ./aesmd.nix;

--- a/pkgs/by-name/ac/activemq/package.nix
+++ b/pkgs/by-name/ac/activemq/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenvNoCC,
   fetchurl,
+  nixosTests,
 }:
 
 let
@@ -28,6 +29,10 @@ stdenvNoCC.mkDerivation {
 
     runHook postInstall
   '';
+
+  passthru.tests = {
+    inherit (nixosTests) activemq;
+  };
 
   meta = {
     homepage = "https://activemq.apache.org/";


### PR DESCRIPTION
* Add ActiveMQ NixOS test
* Add `services.activemq.package` option
* Add description to ActiveMQ SystemD service
* Pin ActiveMQ to JDK17 (JDK 21 not officially supported)
* Change type of `services.activemq.extraJavaOptions` to list of strings
* Fix failing ActiveMQ : add `jolokia.conf` property

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
