### PR TITLE
nixos/thunderbird: add languagePacks config

### DIFF
--- a/nixos/modules/programs/thunderbird.nix
+++ b/nixos/modules/programs/thunderbird.nix
@@ -65,6 +65,84 @@ in
         - `"clear"`: Value has no effect. Resets to factory defaults on each startup.
       '';
     };
+
+    languagePacks = lib.mkOption {
+      # Available languages can be found in https://releases.mozilla.org/pub/thunderbird/releases/${cfg.package.version}/linux-x86_64/xpi/
+      type = lib.types.listOf (
+        lib.types.enum [
+          "af"
+          "ar"
+          "ast"
+          "be"
+          "bg"
+          "br"
+          "ca"
+          "cak"
+          "cs"
+          "cy"
+          "da"
+          "de"
+          "dsb"
+          "el"
+          "en-CA"
+          "en-GB"
+          "en-US"
+          "es-AR"
+          "es-ES"
+          "es-MX"
+          "et"
+          "eu"
+          "fi"
+          "fr"
+          "fy-NL"
+          "ga-IE"
+          "gd"
+          "gl"
+          "he"
+          "hr"
+          "hsb"
+          "hu"
+          "hy-AM"
+          "id"
+          "is"
+          "it"
+          "ja"
+          "ka"
+          "kab"
+          "kk"
+          "ko"
+          "lt"
+          "lv"
+          "ms"
+          "nb-NO"
+          "nl"
+          "nn-NO"
+          "pa-IN"
+          "pl"
+          "pt-BR"
+          "pt-PT"
+          "rm"
+          "ro"
+          "ru"
+          "sk"
+          "sl"
+          "sq"
+          "sr"
+          "sv-SE"
+          "th"
+          "tr"
+          "uk"
+          "uz"
+          "vi"
+          "zh-CN"
+          "zh-TW"
+        ]
+      );
+      default = [ ];
+      description = ''
+        The language packs to install.
+      '';
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -82,6 +160,15 @@ in
         Value = value;
         Status = cfg.preferencesStatus;
       }) cfg.preferences;
+      ExtensionSettings = builtins.listToAttrs (
+        builtins.map (
+          lang:
+          lib.attrsets.nameValuePair "langpack-${lang}@thunderbird.mozilla.org" {
+            installation_mode = "normal_installed";
+            install_url = "https://releases.mozilla.org/pub/thunderbird/releases/${cfg.package.version}/linux-x86_64/xpi/${lang}.xpi";
+          }
+        ) cfg.languagePacks
+      );
     };
   };
 


### PR DESCRIPTION
In analogy to https://github.com/NixOS/nixpkgs/pull/206698/, I added a `languagePacks` option to Thunderbird to make it easier to set it up in another language without any manual intervention.
It would look something like this:
```nix
programs.thunderbird = {
  enable = true;
  languagePacks = [ "de" ];
  preferences = {
    "intl.locale.requested" = "de";
  };
};
```

This doesn't resolve the underlying issue #46569 that `i18n.defaultLocale` is not respected, but I imagine one _could_ adopt something like the above code accessing the aforementioned `i18n.defaultLocale` into nixpkgs. I'm not sure if this is the _correct_ way, though, as I'm too unfamiliar with Firefox/Thunderbird packaging. What I can say is that [on Arch](https://archlinux.org/packages/extra/x86_64/thunderbird-i18n-de/), the language packs go into `usr/lib/thunderbird/extensions/langpack-de@thunderbird.mozilla.org.xpi`, for example. My Arch system lists this language pack as explicitly installed, by the way; no idea how that came to be.

I hope this PR is actionable enough. As this is my first contribution to nixpkgs, any feedback would be very much appreciated!
I'll try running the tests in the coming days, though it'd be nice to know beforehand if this would even be considered.

Full disclosure: This _is_ vibe-coded, but tested and cross-checked with https://github.com/NixOS/nixpkgs/pull/206698/ as well as the current [list of packs](https://releases.mozilla.org/pub/thunderbird/releases/145.0/linux-x86_64/xpi/).


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

## Maintainer pings
@booxter @lovesegfault @nbp @vcunat

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
