### PR TITLE
love: fix segfault on Darwin by using CMake build

### DIFF
--- a/pkgs/development/interpreters/love/11.nix
+++ b/pkgs/development/interpreters/love/11.nix
@@ -21,6 +21,7 @@
   automake,
   libtool,
   xorg,
+  cmake,
 }:
 
 stdenv.mkDerivation rec {
@@ -34,53 +35,63 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-wZktNh4UB3QH2wAIIlnYUlNoXbjEDwUmPnT4vesZNm0=";
   };
 
-  nativeBuildInputs = [
-    pkg-config
-    autoconf
-    automake
-  ];
-  buildInputs = [
-    SDL2
-    openal
-    (if stdenv.isDarwin then lua5_1 else luajit)
-    freetype
-    physfs
-    libmodplug
-    mpg123
-    libvorbis
-    libogg
-    libtheora
-    which
-    libtool
-  ]
-  ++ lib.optionals stdenv.isLinux [
-    xorg.libX11 # SDL2 optional depend, for SDL_syswm.h
-    libGLU
-    libGL
-  ];
+  nativeBuildInputs =
+    [ pkg-config ]
+    ++ lib.optionals stdenv.isDarwin [ cmake ]
+    ++ lib.optionals (!stdenv.isDarwin) [
+      autoconf
+      automake
+    ];
+  buildInputs =
+    [
+      SDL2
+      openal
+      (if stdenv.isDarwin then lua5_1 else luajit)
+      freetype
+      physfs
+      libmodplug
+      mpg123
+      libvorbis
+      libogg
+      libtheora
+      which
+      libtool
+    ]
+    ++ lib.optionals stdenv.isLinux [
+      xorg.libX11 # SDL2 optional depend, for SDL_syswm.h
+      libGLU
+      libGL
+    ];
 
-  preConfigure = "$shell ./platform/unix/automagic";
+  preConfigure = lib.optionalString (!stdenv.isDarwin) "$shell ./platform/unix/automagic";
 
   configureFlags = [
     (if stdenv.isDarwin then "--with-lua=lua" else "--with-lua=luajit")
   ];
 
+  # Use CMake on Darwin to build macOS-specific module (src/common/macosx.mm)
+  # Autotools build doesn't compile this file, leading to stubbed functions and segfaults
+  configurePhase = lib.optionalString stdenv.isDarwin ''
+    mkdir -p build
+    cd build
+    cmake .. \
+      -DCMAKE_INSTALL_PREFIX=$out \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+  '';
+
   env.NIX_CFLAGS_COMPILE = "-DluaL_reg=luaL_Reg"; # needed since luajit-2.1.0-beta3
 
-  # Fix Darwin bundle/dylib linking and macOS function calls
-  preBuild = lib.optionalString stdenv.isDarwin ''
-    # Fix libtool to use dynamiclib instead of bundle for Darwin
-    substituteInPlace libtool \
-      --replace "-bundle" "-dynamiclib" \
-      --replace "-Wl,-bundle" "-Wl,-dynamiclib"
-
-    substituteInPlace src/love.cpp \
-      --replace "love::macosx::checkDropEvents()" "std::string(\"\")" \
-      --replace "love::macosx::getLoveInResources()" "std::string(\"\")"
+  # CMake doesn't define install target for LÖVE, so install manually on Darwin
+  installPhase = lib.optionalString stdenv.isDarwin ''
+    mkdir -p $out/bin $out/lib
+    cp love $out/bin/
+    cp libliblove.dylib $out/lib/
   '';
 
   postFixup = lib.optionalString stdenv.isDarwin ''
-    install_name_tool -change ".libs/liblove-11.5.so" "$out/lib/liblove-11.5.so" "$out/bin/love"
+    # Fix rpath so love binary can find libliblove.dylib
+    install_name_tool -change "@rpath/libliblove.dylib" "$out/lib/libliblove.dylib" "$out/bin/love"
   '';
 
   meta = {


### PR DESCRIPTION
## Description

Fixes segmentation fault in LÖVE (Lua game engine) on Darwin platforms by switching from autotools to CMake build system.

## Problem

The current autotools build doesn't compile `src/common/macosx.mm` (macOS-specific module), leading to stubbed macOS functions that cause segmentation faults on Darwin.

## Solution

This PR switches to CMake for Darwin builds, which properly compiles the macOS module:

- Add `cmake` to `nativeBuildInputs` on Darwin
- Use CMake `configurePhase` instead of autotools on Darwin  
- Add custom `installPhase` (CMake doesn't define install target for LÖVE)
- Fix rpath to point to `libliblove.dylib`

## Impact

This enables LÖVE to work properly on aarch64-darwin (Apple Silicon) and should also work on x86_64-darwin.

## Testing

- **Platform**: M1 Max / macOS 15.7.3
- **Test**: `nix develop` then `love .` with a test LÖVE project
- **Before**: Segmentation fault: 11
- **After**: Application runs successfully