### PR TITLE
dev86: 1.0.1 -> 1.0.1-unstable-2025-02-12, fix build for gcc 15

### DIFF
--- a/pkgs/by-name/de/dev86/package.nix
+++ b/pkgs/by-name/de/dev86/package.nix
@@ -6,15 +6,21 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "dev86";
-  version = "1.0.1";
+  version = "1.0.1-unstable-2025-02-12";
 
   src = fetchFromGitea {
     domain = "codeberg.org";
     owner = "jbruchon";
     repo = "dev86";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-xeOtESc0X7RZWCIpNZSHE8au9+opXwnHsAcayYLSX7w=";
+    rev = "0332db1ceb238fa7f98603cdf4223a1d839d4b31";
+    hash = "sha256-f6C7ykOmOHwxeMsF1Wm81FBBJNwTP0cF4+mFMzsc208=";
   };
+
+  patches = [
+    # Fix for GCC 15/C23 by de-K&R-ing function definitions and adding
+    # missing parameters to function declarations where necessary.
+    ./unproto-c23-compatibility.patch
+  ];
 
   makeFlags = [ "PREFIX=${placeholder "out"}" ];
 

--- a/pkgs/by-name/de/dev86/unproto-c23-compatibility.patch
+++ b/pkgs/by-name/de/dev86/unproto-c23-compatibility.patch
@@ -1,0 +1,245 @@
+diff --git a/unproto/error.c b/unproto/error.c
+index 667d978cbb..2fbccacb4d 100644
+--- a/unproto/error.c
++++ b/unproto/error.c
+@@ -53,7 +53,7 @@
+ 
+ #include <stdio.h>
+ 
+-extern void exit();
++extern void exit(int status);
+ 
+ /* Application-specific stuff */
+ 
+diff --git a/unproto/error.h b/unproto/error.h
+index dfb27e9067..cb52ae646b 100644
+--- a/unproto/error.h
++++ b/unproto/error.h
+@@ -1,6 +1,6 @@
+ /* @(#) error.h 1.2 92/01/15 21:53:14 */
+ 
+ extern int errcount;			/* error counter */
+-extern void error();			/* default context */
+-extern void error_where();		/* user-specified context */
+-extern void fatal();			/* fatal error */
++extern void error(char *text);			/* default context */
++extern void error_where(char *path, int line, char *text);		/* user-specified context */
++extern void fatal(char *text);			/* fatal error */
+diff --git a/unproto/strsave.c b/unproto/strsave.c
+index 2ee00b4172..faa4e18686 100644
+--- a/unproto/strsave.c
++++ b/unproto/strsave.c
+@@ -28,7 +28,7 @@
+ #include <string.h>
+ 
+ extern int hash(register char *s, unsigned size);
+-extern char *malloc();
++extern char *malloc(long size);
+ 
+ /* Application-specific stuff */
+ 
+diff --git a/unproto/symbol.c b/unproto/symbol.c
+index 67a4bf0bc6..a4beab5e92 100644
+--- a/unproto/symbol.c
++++ b/unproto/symbol.c
+@@ -45,7 +45,7 @@
+ #include <string.h>
+ 
+ extern int hash(register char *s, unsigned size);
+-extern char *malloc();
++extern char *malloc(long size);
+ 
+ /* Application-specific stuff */
+ 
+diff --git a/unproto/symbol.h b/unproto/symbol.h
+index 0711c1f4dc..0e2b1d88f8 100644
+--- a/unproto/symbol.h
++++ b/unproto/symbol.h
+@@ -6,6 +6,6 @@
+     struct symbol *next;
+ };
+ 
+-extern void sym_enter();		/* add symbol to table */
+-extern struct symbol *sym_find();	/* locate symbol */
++extern void sym_enter(char *name, int type);		/* add symbol to table */
++extern struct symbol *sym_find(register char *name);	/* locate symbol */
+ extern void sym_init();			/* prime the table */
+diff --git a/unproto/tok_class.c b/unproto/tok_class.c
+index 04207a07f3..9af67188ca 100644
+--- a/unproto/tok_class.c
++++ b/unproto/tok_class.c
+@@ -51,8 +51,8 @@
+ #include <stdio.h>
+ #include <string.h>
+ 
+-extern long time();
+-extern char* ctime();
++extern long time(long *tloc);
++extern char* ctime(long *clock);
+ 
+ /* Application-specific stuff */
+ 
+@@ -61,13 +61,13 @@
+ #include "token.h"
+ #include "symbol.h"
+ 
+-static struct token *tok_list();
+-static void tok_list_struct();
+-static void tok_list_append();
+-static void tok_strcat();
+-static void tok_time();
+-static void tok_date();
+-static void tok_space_append();
++static struct token *tok_list(struct token *t);
++static void tok_list_struct(register struct token *list, register struct token *t);
++static void tok_list_append(struct token *h, struct token *t);
++static void tok_strcat(register struct token *t1);
++static void tok_time(struct token *t);
++static void tok_date(struct token *t);
++static void tok_space_append(register struct token *list, register struct token *t);
+ 
+ #if defined(MAP_VOID_STAR) || defined(MAP_VOID)
+ static void tok_void();			/* rewrite void keyword */
+diff --git a/unproto/tok_io.c b/unproto/tok_io.c
+index 288950b3ac..773ca5bf4d 100644
+--- a/unproto/tok_io.c
++++ b/unproto/tok_io.c
+@@ -89,7 +89,7 @@
+ #include "vstring.h"
+ #include "error.h"
+ 
+-extern char *strsave();			/* XXX need include file */
++extern char *strsave(register char *str);			/* XXX need include file */
+ 
+ /* Stuff to keep track of original source file name and position */
+ 
+@@ -104,12 +104,12 @@
+ 
+ /* Forward declarations */
+ 
+-static int read_quoted();
+-static void read_comment();
++static int read_quoted(register struct vstring *vs, int ch);
++static void read_comment(register struct vstring *vs);
+ static int backslash_newline();
+-static char *read_hex();
+-static char *read_octal();
+-static void fix_line_control();
++static char *read_hex(struct vstring *vs, register char *cp);
++static char *read_octal(register struct vstring *vs, register char *cp, register int c);
++static void fix_line_control(register char *path, register int line);
+ 
+  /*
+   * Character input with one level of pushback. The INPUT() macro recursively
+diff --git a/unproto/tok_pool.c b/unproto/tok_pool.c
+index e2ed107ce7..bbe3d184c5 100644
+--- a/unproto/tok_pool.c
++++ b/unproto/tok_pool.c
+@@ -37,7 +37,7 @@
+ 
+ /* C library */
+ 
+-extern char *malloc();
++extern char *malloc(long size);
+ 
+ /* Application-specific stuff */
+ 
+diff --git a/unproto/token.h b/unproto/token.h
+index bb2f50a106..e3752a0eb3 100644
+--- a/unproto/token.h
++++ b/unproto/token.h
+@@ -27,11 +27,11 @@
+ /* Input/output functions and macros */
+ 
+ extern struct token *tok_get();		/* read next single token */
+-extern void tok_show();			/* display (composite) token */
++extern void tok_show(register struct token *t);			/* display (composite) token */
+ extern struct token *tok_class();	/* classify tokens */
+-extern void tok_unget();		/* stuff token back into input */
++extern void tok_unget(register struct token *t);		/* stuff token back into input */
+ extern void put_nl();			/* print newline character */
+-extern void tok_show_ch();		/* emit single-character token */
++extern void tok_show_ch(register struct token *t);		/* emit single-character token */
+ 
+ #define	tok_flush(t)	(tok_show(t), tok_free(t))
+ 
+@@ -46,7 +46,7 @@
+ /* Memory management */
+ 
+ struct token *tok_alloc();		/* allocate token storage */
+-extern void tok_free();			/* re-cycle storage */
++extern void tok_free(register struct token *t);			/* re-cycle storage */
+ 
+ /* Context */
+ 
+diff --git a/unproto/unproto.c b/unproto/unproto.c
+index 18fc2aaecf..802b91dd3e 100644
+--- a/unproto/unproto.c
++++ b/unproto/unproto.c
+@@ -140,7 +140,7 @@
+ #include <errno.h>
+ #include <string.h>
+ 
+-extern void exit();
++extern void exit(int status);
+ extern int optind;
+ extern char *optarg;
+ extern int getopt();
+@@ -159,16 +159,16 @@
+ 
+ /* Forward declarations. */
+ 
+-static struct token *dcl_flush();
+-static void block_flush();
++static struct token *dcl_flush(register struct token *t);
++static void block_flush(register struct token *t);
+ static void block_dcls();
+-static struct token *show_func_ptr_type();
+-static struct token *show_struct_type();
+-static void show_arg_name();
+-static void show_type();
+-static void pair_flush();
+-static void check_cast();
+-static void show_empty_list();
++static struct token *show_func_ptr_type(struct token *t1, struct token *t2);
++static struct token *show_struct_type(register struct token *p);
++static void show_arg_name(register struct token *s);
++static void show_type(register struct token *s);
++static void pair_flush(register struct token *t, register int start, register int stop);
++static void check_cast(struct token *t);
++static void show_empty_list(register struct token *t);
+ 
+ #define	check_cast_flush(t)	(check_cast(t), tok_free(t))
+ 
+diff --git a/unproto/vstring.c b/unproto/vstring.c
+index 220bd530fe..ef9bcffa3c 100644
+--- a/unproto/vstring.c
++++ b/unproto/vstring.c
+@@ -67,8 +67,8 @@
+ 
+ /* C library */
+ 
+-extern char *malloc();
+-extern char *realloc();
++extern char *malloc(long size);
++extern char *realloc(char *p, long size);
+ 
+ /* Application-specific stuff */
+ 
+diff --git a/unproto/vstring.h b/unproto/vstring.h
+index c2e1f88a77..16a17aa815 100644
+--- a/unproto/vstring.h
++++ b/unproto/vstring.h
+@@ -5,9 +5,9 @@
+     char   *last;			/* last position */
+ };
+ 
+-extern struct vstring *vs_alloc();	/* initial allocation */
+-extern char *vs_realloc();		/* string extension */
+-extern char *vs_strcpy();		/* copy string */
++extern struct vstring *vs_alloc(int len);	/* initial allocation */
++extern char *vs_realloc(register struct vstring *vp, char *cp);		/* string extension */
++extern char *vs_strcpy(register struct vstring *vp, register char *dst, register char *src);		/* copy string */
+ 
+ /* macro to add one character to auto-resized string */
+ 


### PR DESCRIPTION
dev86 fails to build with GCC 15 and C23 due to K&R function definitions and elided function parameters in *numerous* locations. This change fixes that in two pieces:

First, dev86 is updated to the current latest `master` release. While it would normally be odd to go from a stable release to a non-stable one, this is likely acceptable since all changes between the 1.0.1 release and master have been to fix compilation issues; see https://codeberg.org/jbruchon/dev86/compare/v1.0.1...0332db1ceb238fa7f98603cdf4223a1d839d4b31. Additionally, the according to the releases page, the v1.0 release was primarily so that this could be used in another project, and was largely untested: https://codeberg.org/jbruchon/dev86/releases/tag/v1.0. Because of this, it should be fine to move to an unstable version.

After this change, the `unproto` component is the only one which has remaining build issues. Thus, we include a patch to add previously elided function parameters.

This second patch is where we're more doubtful. I made an upstream PR at https://codeberg.org/jbruchon/dev86/pulls/15, and this patch is already a stripped down version of that (e.g. we avoid de-K&Ring definitions). However, the patch file still ends up fairly big (though trivial), which we don't love. I'm not sure if there's a better solution, or if the size of the patch is acceptable for inclusion here. I would appreciate any other judgement here.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
