### PR TITLE
sharutils: fix build for gcc 15

### DIFF
--- a/pkgs/by-name/sh/sharutils/gcc15-c23-port.patch
+++ b/pkgs/by-name/sh/sharutils/gcc15-c23-port.patch
@@ -1,0 +1,125 @@
+From: Petr Písař <ppisar@redhat.com>
+
+With GCC 15, which defaults to ISO 23, a build failed, for example like
+this:
+
+    gcc -DLOCALEDIR=\"/usr/local/share/locale\" -DHAVE_CONFIG_H -I. -I..  -I../libopts -I. -I.. -I../lib -I
+    ../lib -I../intl  -Wno-format-contains-nul -g -O2 -Wno-format-contains-nul -c -o shar.o shar.c
+    In file included from local.h:23,
+		     from shar-opts.h:354,
+		     from shar.c:46:
+    ../lib/system.h:78:7: error: conflicting types for â€˜fdopenâ€™; have â€˜FILE *(void)â€™
+       78 | FILE *fdopen ();
+	  |       ^~~~~~
+
+The cause is that ISO C23 changed a meaning of an empty argument list
+from an unspecified list to no arguments.
+
+Also K&R syntax is now deprecated and the compiler warned:
+
+    encode.c: In function â€˜write_encoded_bytesâ€™:
+    encode.c:33:1: warning: old-style function definition [-Wold-style-definition]
+       33 | write_encoded_bytes (group, file)
+	  | ^~~~~~~~~~~~~~~~~~~
+
+This patch fixes both the erros and the warnigs by specifying all the
+arguments in the modern syntax.
+
+Signed-off-by: Petr Písař <ppisar@redhat.com>
+---
+ lib/system.h   |  6 +++---
+ src/encode.c   | 13 +++----------
+ src/shar.c     |  2 +-
+ src/uudecode.c |  2 +-
+ 4 files changed, 8 insertions(+), 15 deletions(-)
+
+diff --git a/lib/system.h b/lib/system.h
+index 2b9846b..811e8cf 100644
+--- a/lib/system.h
++++ b/lib/system.h
+@@ -52,7 +52,7 @@ typedef enum {false = 0, true = 1} bool;
+ #endif
+ 
+ #if !HAVE_DECL_STRTOIMAX && !defined strtoimax
+-intmax_t strtoimax ();
++intmax_t strtoimax (const char *nptr, char **endptr, int base);
+ #endif
+ 
+ #if HAVE_STRING_H
+@@ -75,8 +75,8 @@ intmax_t strtoimax ();
+ # include <unistd.h>
+ #endif
+ 
+-FILE *fdopen ();
+-FILE *popen ();
++FILE *fdopen (int fd, const char *mode);
++FILE *popen (const char *command, const char *type);
+ 
+ /* Global functions of the shar package.  */
+ 
+diff --git a/src/encode.c b/src/encode.c
+index 09e0c69..b1de8bd 100644
+--- a/src/encode.c
++++ b/src/encode.c
+@@ -30,9 +30,7 @@
+ `------------------------------------------*/
+ 
+ static void
+-write_encoded_bytes (group, file)
+-     char *group;
+-     FILE *file;
++write_encoded_bytes (char *group, FILE *file)
+ {
+   int c1, c2, c3, c4;
+ 
+@@ -52,10 +50,7 @@ write_encoded_bytes (group, file)
+ `--------------------------------------------------------------------*/
+ 
+ static int
+-read_raw_bytes (file, buffer, buffer_size)
+-     FILE *file;
+-     char *buffer;
+-     int buffer_size;
++read_raw_bytes (FILE *file, char *buffer, int buffer_size)
+ {
+   int character;
+   int counter;
+@@ -75,9 +70,7 @@ read_raw_bytes (file, buffer, buffer_size)
+ `----------------------------------------------------*/
+ 
+ void
+-copy_file_encoded (input, output)
+-     FILE *input;
+-     FILE *output;
++copy_file_encoded (FILE *input, FILE *output)
+ {
+   char buffer[LINE_BUFFER_SIZE];
+   int counter;
+diff --git a/src/shar.c b/src/shar.c
+index 6d7ed1d..2c6e2e1 100644
+--- a/src/shar.c
++++ b/src/shar.c
+@@ -109,7 +109,7 @@ static inline unsigned char to_uchar (char ch) { return ch; }
+ #define IS_GRAPH(_c) (isprint (to_uchar (_c)) && !isspace (to_uchar (_c)))
+ #endif
+ 
+-struct tm *localtime ();
++struct tm *localtime (const time_t *timep);
+ 
+ #if MSDOS
+           /* 1 extra for CR.  */
+diff --git a/src/uudecode.c b/src/uudecode.c
+index 0621c99..b8a316e 100644
+--- a/src/uudecode.c
++++ b/src/uudecode.c
+@@ -82,7 +82,7 @@ static char const cright_years_z[] =
+ #define UU_CHMOD(_n, _fd, _m)   chmod ((_n), UU_MODE_BITS(_m))
+ #endif
+ 
+-struct passwd *getpwnam ();
++struct passwd *getpwnam (const char *name);
+ 
+ static uudecode_exit_code_t read_stduu(
+         const char *inname, const char *outname);
+-- 
+2.48.1

--- a/pkgs/by-name/sh/sharutils/gcc15-getcwdm4-port.patch
+++ b/pkgs/by-name/sh/sharutils/gcc15-getcwdm4-port.patch
@@ -1,0 +1,37 @@
+From: Petr Písař <ppisar@redhat.com>
+
+Some confgure tests failed because of function arguments missing from
+the prototypes:
+
+    configure:16105: checking whether getcwd (NULL, 0) allocates memory for result
+    configure:16162: gcc -o conftest -g -O2   conftest.c  >&5
+    conftest.c:186:16: error: conflicting types for 'getcwd'; have 'char *(void)'
+      186 |          char *getcwd ();
+	  |                ^~~~~~
+    In file included from conftest.c:181:
+    /usr/include/unistd.h:531:14: note: previous declaration of 'getcwd' with type 'char *(char *, size_t)'
+
+This patch fixes it.
+
+Maintainer is encouraged to rebase the m4 files to the latest gnulib.
+
+Signed-off-by: Petr Písař <ppisar@redhat.com>
+---
+ m4/getcwd.m4 | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/m4/getcwd.m4 b/m4/getcwd.m4
+index b9fbcec..6f24b14 100644
+--- a/m4/getcwd.m4
++++ b/m4/getcwd.m4
+@@ -21,7 +21,7 @@ AC_DEFUN([gl_FUNC_GETCWD_NULL],
+ #         include <direct.h>
+ #        endif
+ #        ifndef getcwd
+-         char *getcwd ();
++         char *getcwd (char *buf, size_t size);
+ #        endif
+ ]], [[
+ #if (defined _WIN32 || defined __WIN32__) && ! defined __CYGWIN__
+-- 
+2.48.1

--- a/pkgs/by-name/sh/sharutils/gcc15-stdboolm4-backport.patch
+++ b/pkgs/by-name/sh/sharutils/gcc15-stdboolm4-backport.patch
@@ -1,0 +1,202 @@
+From: Petr Písař <ppisar@redhat.com>
+
+The bundled gnulib check for stdbool.h did not account for ISO C23
+which provides its own false and true keywords. As a result stdbool.h
+presence was not correctly detected and libopts/compat/compat.h,
+bundled from AutoGen, failed to compile with GCC 15 which defaults to
+ISO C23:
+
+    In file included from autoopts/project.h:30,
+		     from libopts.c:2:
+    ./compat/compat.h:188:19: error: cannot use keyword â€˜falseâ€™ as enumeration constant
+      188 |    typedef enum { false = 0, true = 1 } _Bool;
+	  |                   ^~~~~
+    ./compat/compat.h:188:19: note: â€˜falseâ€™ is a keyword with â€˜-std=c23â€™ onwards
+    ./compat/compat.h:188:41: error: expected â€˜;â€™, identifier or â€˜(â€™ before â€˜_Boolâ€™
+      188 |    typedef enum { false = 0, true = 1 } _Bool;
+	  |                                         ^~~~~
+
+Signed-off-by: Petr Písař <ppisar@redhat.com>
+---
+ m4/stdbool.m4 | 129 +++++++++++++++++++++++++++++---------------------
+ 1 file changed, 74 insertions(+), 55 deletions(-)
+
+diff --git a/m4/stdbool.m4 b/m4/stdbool.m4
+index 7273b82..8e00e4a 100644
+--- a/m4/stdbool.m4
++++ b/m4/stdbool.m4
+@@ -1,27 +1,40 @@
+ # Check for stdbool.h that conforms to C99.
+ 
+-dnl Copyright (C) 2002-2006, 2009-2015 Free Software Foundation, Inc.
++dnl Copyright (C) 2002-2006, 2009-2023 Free Software Foundation, Inc.
+ dnl This file is free software; the Free Software Foundation
+ dnl gives unlimited permission to copy and/or distribute it,
+ dnl with or without modifications, as long as this notice is preserved.
+ 
+-#serial 5
++#serial 10
+ 
+ # Prepare for substituting <stdbool.h> if it is not supported.
+ 
+ AC_DEFUN([AM_STDBOOL_H],
+ [
+   AC_REQUIRE([AC_CHECK_HEADER_STDBOOL])
++  AC_REQUIRE([AC_CANONICAL_HOST])
+ 
+-  # Define two additional variables used in the Makefile substitution.
+-
++  dnl On some platforms, <stdbool.h> does not exist or does not conform to C99.
++  dnl On Solaris 10 with CC=cc CXX=CC, <stdbool.h> exists but is not usable
++  dnl in C++ mode (and no <cstdbool> exists). In this case, we use our
++  dnl replacement, also in C mode (for binary compatibility between C and C++).
+   if test "$ac_cv_header_stdbool_h" = yes; then
+-    STDBOOL_H=''
++    case "$host_os" in
++      solaris*)
++        if test -z "$GCC"; then
++          GL_GENERATE_STDBOOL_H=true
++        else
++          GL_GENERATE_STDBOOL_H=false
++        fi
++        ;;
++      *)
++        GL_GENERATE_STDBOOL_H=false
++        ;;
++    esac
+   else
+-    STDBOOL_H='stdbool.h'
++    GL_GENERATE_STDBOOL_H=true
+   fi
+-  AC_SUBST([STDBOOL_H])
+-  AM_CONDITIONAL([GL_GENERATE_STDBOOL_H], [test -n "$STDBOOL_H"])
++  AM_CONDITIONAL([GL_GENERATE_STDBOOL_H], [test "$GL_GENERATE_STDBOOL_H" = "true"])
+ 
+   if test "$ac_cv_type__Bool" = yes; then
+     HAVE__BOOL=1
+@@ -31,70 +44,76 @@ AC_DEFUN([AM_STDBOOL_H],
+   AC_SUBST([HAVE__BOOL])
+ ])
+ 
+-# AM_STDBOOL_H will be renamed to gl_STDBOOL_H in the future.
+-AC_DEFUN([gl_STDBOOL_H], [AM_STDBOOL_H])
+-
+-# This version of the macro is needed in autoconf <= 2.68.
++m4_version_prereq([2.72], [], [
+ 
+ AC_DEFUN([AC_CHECK_HEADER_STDBOOL],
+-  [AC_CACHE_CHECK([for stdbool.h that conforms to C99],
++  [AC_CHECK_TYPES([_Bool])
++   AC_CACHE_CHECK([for stdbool.h that conforms to C99 or later],
+      [ac_cv_header_stdbool_h],
+      [AC_COMPILE_IFELSE(
+         [AC_LANG_PROGRAM(
+-           [[
+-             #include <stdbool.h>
+-             #ifndef bool
+-              "error: bool is not defined"
++           [[#include <stdbool.h>
++
++             /* "true" and "false" should be usable in #if expressions and
++                integer constant expressions, and "bool" should be a valid
++                type name.
++
++                Although C99 requires bool, true, and false to be macros,
++                C23 and C++11 overrule that, so do not test for that.
++                Although C99 requires __bool_true_false_are_defined and
++                _Bool, C23 says they are obsolescent, so do not require
++                them.  */
++
++             #if !true
++               #error "'true' is not true"
+              #endif
+-             #ifndef false
+-              "error: false is not defined"
++             #if true != 1
++               #error "'true' is not equal to 1"
+              #endif
++             char b[true == 1 ? 1 : -1];
++             char c[true];
++
+              #if false
+-              "error: false is not 0"
++               #error "'false' is not false"
+              #endif
+-             #ifndef true
+-              "error: true is not defined"
+-             #endif
+-             #if true != 1
+-              "error: true is not 1"
+-             #endif
+-             #ifndef __bool_true_false_are_defined
+-              "error: __bool_true_false_are_defined is not defined"
++             #if false != 0
++               #error "'false' is not equal to 0"
+              #endif
++             char d[false == 0 ? 1 : -1];
++
++             enum { e = false, f = true, g = false * true, h = true * 256 };
++
++             char i[(bool) 0.5 == true ? 1 : -1];
++             char j[(bool) 0.0 == false ? 1 : -1];
++             char k[sizeof (bool) > 0 ? 1 : -1];
++
++             struct sb { bool s: 1; bool t; } s;
++             char l[sizeof s.t > 0 ? 1 : -1];
+ 
+-             struct s { _Bool s: 1; _Bool t; } s;
+-
+-             char a[true == 1 ? 1 : -1];
+-             char b[false == 0 ? 1 : -1];
+-             char c[__bool_true_false_are_defined == 1 ? 1 : -1];
+-             char d[(bool) 0.5 == true ? 1 : -1];
+-             /* See body of main program for 'e'.  */
+-             char f[(_Bool) 0.0 == false ? 1 : -1];
+-             char g[true];
+-             char h[sizeof (_Bool)];
+-             char i[sizeof s.t];
+-             enum { j = false, k = true, l = false * true, m = true * 256 };
+              /* The following fails for
+                 HP aC++/ANSI C B3910B A.05.55 [Dec 04 2003]. */
+-             _Bool n[m];
+-             char o[sizeof n == m * sizeof n[0] ? 1 : -1];
+-             char p[-1 - (_Bool) 0 < 0 && -1 - (bool) 0 < 0 ? 1 : -1];
++             bool m[h];
++             char n[sizeof m == h * sizeof m[0] ? 1 : -1];
++             char o[-1 - (bool) 0 < 0 ? 1 : -1];
+              /* Catch a bug in an HP-UX C compiler.  See
+-                http://gcc.gnu.org/ml/gcc-patches/2003-12/msg02303.html
+-                http://lists.gnu.org/archive/html/bug-coreutils/2005-11/msg00161.html
++                https://gcc.gnu.org/ml/gcc-patches/2003-12/msg02303.html
++                https://lists.gnu.org/r/bug-coreutils/2005-11/msg00161.html
+               */
+-             _Bool q = true;
+-             _Bool *pq = &q;
++             bool p = true;
++             bool *pp = &p;
+            ]],
+            [[
+-             bool e = &s;
+-             *pq |= q;
+-             *pq |= ! q;
+-             /* Refer to every declared value, to avoid compiler optimizations.  */
+-             return (!a + !b + !c + !d + !e + !f + !g + !h + !i + !!j + !k + !!l
+-                     + !m + !n + !o + !p + !q + !pq);
++             bool ps = &s;
++             *pp |= p;
++             *pp |= ! p;
++
++             /* Refer to every declared value, so they cannot be
++                discarded as unused.  */
++             return (!b + !c + !d + !e + !f + !g + !h + !i + !j + !k
++                     + !l + !m + !n + !o + !p + !pp + !ps);
+            ]])],
+         [ac_cv_header_stdbool_h=yes],
+         [ac_cv_header_stdbool_h=no])])
+-   AC_CHECK_TYPES([_Bool])
+-])
++])# AC_CHECK_HEADER_STDBOOL
++
++]) # m4_version_prereq 2.72
+-- 
+2.48.1

--- a/pkgs/by-name/sh/sharutils/package.nix
+++ b/pkgs/by-name/sh/sharutils/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchurl,
   fetchpatch,
+  autoreconfHook,
   gettext,
   coreutils,
   updateAutotoolsGnuConfigScriptsHook,
@@ -21,6 +22,7 @@ stdenv.mkDerivation rec {
 
   # GNU Gettext is needed on non-GNU platforms.
   buildInputs = [
+    autoreconfHook
     coreutils
     gettext
   ];
@@ -55,6 +57,12 @@ stdenv.mkDerivation rec {
       url = "https://lists.gnu.org/archive/html/bug-gnu-utils/2020-01/txt5Z_KZup0yN.txt";
       sha256 = "0an8vfy3qj6sss9w0i4j8ilf7g5mbc7y13l644jy5bcm9przcjbd";
     })
+
+    # various build fixes for >= gcc 15, sourced from
+    # https://lists.gnu.org/archive/html/bug-gnu-utils/2025-03/msg00000.html
+    ./gcc15-stdboolm4-backport.patch
+    ./gcc15-getcwdm4-port.patch
+    ./gcc15-c23-port.patch
   ];
 
   postPatch =


### PR DESCRIPTION
sharutils does not compile with GCC 15 due to C23 turning `true` and `false` into reserved keywords. We fix this by applying patches from https://lists.gnu.org/archive/html/bug-gnu-utils/2025-03/msg00000.html on the bug-gnu-utils mailing list. I couldn't quite figure out how to grab the patch as text instead of an HTML document that breaks `fetchpatch`, so I just vendored the patches instead.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
