### PR TITLE
mpv: 0.40.0 -> 0.41.0

### DIFF
--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -98,7 +98,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "mpv";
-  version = "0.40.0";
+  version = "0.41.0";
 
   outputs = [
     "out"
@@ -111,32 +111,8 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "mpv-player";
     repo = "mpv";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-x8cDczKIX4+KrvRxZ+72TGlEQHd4Kx7naq0CSoOZGHA=";
+    hash = "sha256-gJWqfvPE6xOKlgj2MzZgXiyOKxksJlY/tL6T/BeG19c=";
   };
-
-  patches = [
-    # ffmpeg-8 compat:
-    #   https://github.com/mpv-player/mpv/pull/16145
-    (fetchpatch {
-      name = "ffmpeg-8.patch";
-      url = "https://github.com/mpv-player/mpv/commit/26b29fba02a2782f68e2906f837d21201fc6f1b9.patch";
-      hash = "sha256-ANNoTtIJBARHbm5IgrE0eEZyzmNhOnbVgve7iqCBzQg=";
-    })
-    # clipboard-wayland: prevent reading from hung up fd:
-    #   https://github.com/mpv-player/mpv/pull/16140
-    (fetchpatch {
-      name = "clipboard-wayland-prevent-hung-up-fd.patch";
-      url = "https://github.com/mpv-player/mpv/commit/d20ded876d27497d3fe6a9494add8106b507a45c.patch";
-      hash = "sha256-sll4BpeVW6OA+/vbH7ZfIh0/vePfPEX87vzUu/GCj44=";
-    })
-    # clipboard-wayland: read already sent data when the fd is hung up:
-    #   https://github.com/mpv-player/mpv/pull/16236
-    (fetchpatch {
-      name = "clipboard-wayland-read-sent-data-on-hangup.patch";
-      url = "https://github.com/mpv-player/mpv/commit/896b3400f3cad286533dbb9cc3658ce18ed9966c.patch";
-      hash = "sha256-GU0VdYC/Q0RCS/I2h4gBVNhScDLSAB2KxN3Ca6CGBMM=";
-    })
-  ];
 
   postPatch = lib.concatStringsSep "\n" [
     # Don't reference compile time dependencies or create a build outputs cycle
@@ -170,7 +146,9 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.mesonEnable "dvbin" dvbinSupport)
     (lib.mesonEnable "dvdnav" dvdnavSupport)
     (lib.mesonEnable "openal" openalSupport)
-    (lib.mesonEnable "sdl2" sdl2Support)
+    (lib.mesonEnable "sdl2-audio" sdl2Support)
+    (lib.mesonEnable "sdl2-gamepad" sdl2Support)
+    (lib.mesonEnable "sdl2-video" sdl2Support)
   ];
 
   mesonAutoFeatures = "auto";


### PR DESCRIPTION
Tested a little bit on Linux, seems to work fine, including some scripts. Not tested at all on Darwin.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
