### PR TITLE
appflowy: 0.10.6 -> 0.10.8

### DIFF
--- a/pkgs/by-name/ap/appflowy/package.nix
+++ b/pkgs/by-name/ap/appflowy/package.nix
@@ -11,6 +11,15 @@
   keybinder3,
   libnotify,
   gst_all_1,
+  libva,
+  libxv,
+  libxscrnsaver,
+  libgbm,
+  libpulseaudio,
+  alsa-lib,
+  libarchive,
+  libvdpau,
+  lcms,
 }:
 
 let
@@ -18,11 +27,11 @@ let
     rec {
       x86_64-linux = {
         urlSuffix = "linux-x86_64.tar.gz";
-        hash = "sha256-87mauW50ccOaPyK04O4I7+0bsvxVrdFxhi/Muc53wDY=";
+        hash = "sha256-UPwyLexOmuaVp611t5NR+n8OagFaZP9J/htep1Z8Rgs=";
       };
       x86_64-darwin = {
         urlSuffix = "macos-universal.zip";
-        hash = "sha256-a1WhOQ8NU3/aGAdaw8o3y7ckRdBsNgLZZ2nOrMsQdOA=";
+        hash = "sha256-5cLXQIO30n41ExhKhlRrRG5jVYFQt6Y8O4qIqpXgKDk=";
       };
       aarch64-darwin = x86_64-darwin;
     }
@@ -31,7 +40,7 @@ let
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "appflowy";
-  version = "0.10.6";
+  version = "0.10.8";
 
   src = fetchzip {
     url = "https://github.com/AppFlowy-IO/appflowy/releases/download/${finalAttrs.version}/AppFlowy-${finalAttrs.version}-${dist.urlSuffix}";
@@ -51,6 +60,15 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     libnotify
     gst_all_1.gstreamer
     gst_all_1.gst-plugins-base
+    libva
+    libxv
+    libxscrnsaver
+    libgbm
+    libpulseaudio
+    alsa-lib
+    libarchive
+    libvdpau
+    lcms
   ];
 
   dontBuild = true;

--- a/pkgs/by-name/ap/appflowy/package.nix
+++ b/pkgs/by-name/ap/appflowy/package.nix
@@ -27,11 +27,11 @@ let
     rec {
       x86_64-linux = {
         urlSuffix = "linux-x86_64.tar.gz";
-        hash = "sha256-UPwyLexOmuaVp611t5NR+n8OagFaZP9J/htep1Z8Rgs=";
+        hash = "sha256-iFbYq3S8Fw3yZhDHXZXklPXw26uttGmDFah3szwoIyw=";
       };
       x86_64-darwin = {
         urlSuffix = "macos-universal.zip";
-        hash = "sha256-5cLXQIO30n41ExhKhlRrRG5jVYFQt6Y8O4qIqpXgKDk=";
+        hash = "sha256-bLbmqLwGPPAtXHPc4Ggeqd9F1tDpakpnP3V6toS1DVI=";
       };
       aarch64-darwin = x86_64-darwin;
     }
@@ -40,7 +40,7 @@ let
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "appflowy";
-  version = "0.10.8";
+  version = "0.10.9";
 
   src = fetchzip {
     url = "https://github.com/AppFlowy-IO/appflowy/releases/download/${finalAttrs.version}/AppFlowy-${finalAttrs.version}-${dist.urlSuffix}";


### PR DESCRIPTION
Update appflowy to the [latest version](https://github.com/AppFlowy-IO/AppFlowy/releases/tag/0.10.8).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
