### PR TITLE
nixos/tests/postgresql: switch to unittest-style assertions

### DIFF
--- a/nixos/tests/postgresql/anonymizer.nix
+++ b/nixos/tests/postgresql/anonymizer.nix
@@ -50,9 +50,9 @@ let
             ]
 
         def check_anonymized_row(row, id, original_name):
-            assert row[0] == id, f"Expected first row to have ID {id}, but got {row[0]}"
-            assert row[1] != original_name, f"Expected first row to have a name other than {original_name}"
-            assert not bool(row[2]), "Expected points to be NULL in first row"
+            t.assertEqual(row[0], id)
+            t.assertNotEqual(row[1], original_name)
+            t.assertFalse(bool(row[2]))
 
         def find_xsv_in_dump(dump, sep=','):
             """
@@ -81,8 +81,8 @@ let
                 raise
 
         def check_original_data(output):
-            assert output[0] == ['1','Foo','23'], f"Expected first row from player table to be 1,Foo,23; got {output[0]}"
-            assert output[1] == ['2','Bar','42'], f"Expected first row from player table to be 2,Bar,42; got {output[1]}"
+            t.assertEqual(output[0], ["1", "Foo", "23"])
+            t.assertEqual(output[1], ["2", "Bar", "42"])
 
         def check_anonymized_rows(output):
             check_anonymized_row(output[0], '1', 'Foo')

--- a/nixos/tests/postgresql/postgresql-jit.nix
+++ b/nixos/tests/postgresql/postgresql-jit.nix
@@ -42,8 +42,8 @@ let
                   SELECT CONCAT('jit result = ', SUM(id)) from demo;
                 ''} | sudo -u postgres psql"
             )
-            assert "JIT:" in output
-            assert "jit result = 15" in output
+            t.assertIn("JIT:", output)
+            t.assertIn("jit result = 15", output)
 
         machine.shutdown()
       '';

--- a/nixos/tests/postgresql/postgresql.nix
+++ b/nixos/tests/postgresql/postgresql.nix
@@ -236,13 +236,13 @@ let
                 )
               )
               print(clauses)
-              assert clauses['rolsuper'], 'expected user with clauses to have superuser clause'
-              assert clauses['rolinherit'], 'expected user with clauses to have inherit clause'
-              assert clauses['rolcreaterole'], 'expected user with clauses to have create role clause'
-              assert clauses['rolcreatedb'], 'expected user with clauses to have create db clause'
-              assert clauses['rolcanlogin'], 'expected user with clauses to have login clause'
-              assert clauses['rolreplication'], 'expected user with clauses to have replication clause'
-              assert clauses['rolbypassrls'], 'expected user with clauses to have bypassrls clause'
+              t.assertTrue(clauses["rolsuper"])
+              t.assertTrue(clauses["rolinherit"])
+              t.assertTrue(clauses["rolcreaterole"])
+              t.assertTrue(clauses["rolcreatedb"])
+              t.assertTrue(clauses["rolcanlogin"])
+              t.assertTrue(clauses["rolreplication"])
+              t.assertTrue(clauses["rolbypassrls"])
 
           with subtest("All user permissions default when ensureClauses is not provided"):
               clauses = json.loads(
@@ -250,13 +250,13 @@ let
                     "sudo -u postgres psql -tc \"${getClausesQuery "default-clauses"}\""
                 )
               )
-              assert not clauses['rolsuper'], 'expected user with no clauses set to have default superuser clause'
-              assert clauses['rolinherit'], 'expected user with no clauses set to have default inherit clause'
-              assert not clauses['rolcreaterole'], 'expected user with no clauses set to have default create role clause'
-              assert not clauses['rolcreatedb'], 'expected user with no clauses set to have default create db clause'
-              assert clauses['rolcanlogin'], 'expected user with no clauses set to have default login clause'
-              assert not clauses['rolreplication'], 'expected user with no clauses set to have default replication clause'
-              assert not clauses['rolbypassrls'], 'expected user with no clauses set to have default bypassrls clause'
+              t.assertFalse(clauses["rolsuper"])
+              t.assertTrue(clauses["rolinherit"])
+              t.assertFalse(clauses["rolcreaterole"])
+              t.assertFalse(clauses["rolcreatedb"])
+              t.assertTrue(clauses["rolcanlogin"])
+              t.assertFalse(clauses["rolreplication"])
+              t.assertFalse(clauses["rolbypassrls"])
 
           machine.shutdown()
         '';


### PR DESCRIPTION
This has the benefit that we don't have to write ad-hoc code anymore for showing the different, `unittest` takes care of that for us already.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
