### PR TITLE
eventsourcingdb: init at 1.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2866,6 +2866,12 @@
     githubId = 2806307;
     keys = [ { fingerprint = "00F4 21C4 C537 7BA3 9820 E13F 6B95 E13D E469 CC5D"; } ];
   };
+  badmomber = {
+    name = "Kersten Kriegbaum";
+    email = "kersten@badmomber.com";
+    github = "BadMomber";
+    githubId = 16656033;
+  };
   badmutex = {
     email = "github@badi.sh";
     github = "badmutex";

--- a/pkgs/by-name/ev/eventsourcingdb/package.nix
+++ b/pkgs/by-name/ev/eventsourcingdb/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+}:
+
+let
+  version = "1.2.0";
+  srcs = {
+    x86_64-linux = fetchurl {
+      url = "https://eventsourcingdb.s3.fr-par.scw.cloud/${version}/eventsourcingdb-linux-amd64";
+      hash = "sha256-FDr6mn1JiRG9jZNz+z+hAAyucM5AV1rmDuEZy5jZ82U=";
+    };
+
+    aarch64-linux = fetchurl {
+      url = "https://eventsourcingdb.s3.fr-par.scw.cloud/${version}/eventsourcingdb-linux-arm64";
+      hash = "sha256-/ObI789jqkP4wnPIfq7TuRO/1DZmQdmzfH9AL8XA2C4=";
+    };
+  };
+in
+stdenv.mkDerivation {
+  pname = "eventsourcingdb";
+  inherit version;
+  src =
+    srcs.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+
+  nativeBuildInputs = [ autoPatchelfHook ];
+
+  dontBuild = true;
+  dontConfigure = true;
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -m755 -D $src $out/bin/eventsourcingdb
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Database for event sourcing";
+    homepage = "https://eventsourcingdb.io/";
+    changelog = "https://docs.eventsourcingdb.io/about-eventsourcingdb/changelog";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    # https://docs.eventsourcingdb.io/about-eventsourcingdb/licensing/
+    license = lib.licenses.unfree;
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+    maintainers = with lib.maintainers; [ badmomber ];
+    mainProgram = "eventsourcingdb";
+  };
+}


### PR DESCRIPTION
This introduces the EventSourcingDB.
Note: The license is unfree (freeware up to 25k events), so I set license = lib.licenses.unfree.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
