### PR TITLE
monado: Allow multiarch builds to work

### DIFF
--- a/pkgs/by-name/mo/monado/package.nix
+++ b/pkgs/by-name/mo/monado/package.nix
@@ -60,6 +60,8 @@
   # https://gitlab.freedesktop.org/monado/monado/-/blob/master/doc/targets.md#xrt_feature_service-disabled
   serviceSupport ? true,
   tracingSupport ? false,
+  # Only build client libraries to allow applications/games to connect to the monado IPC socket for VR eg, for 32 bit applications/games on a 64 bit host
+  clientLibOnly ? false,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -124,8 +126,6 @@ stdenv.mkDerivation (finalAttrs: {
     libxdmcp
     libxext
     libxrandr
-    onnxruntime
-    opencv4
     openvr
     orc
     pcre2
@@ -140,6 +140,10 @@ stdenv.mkDerivation (finalAttrs: {
     zlib
     zstd
   ]
+  ++ lib.optionals (!clientLibOnly) [
+    onnxruntime
+    opencv4
+  ]
   ++ lib.optionals tracingSupport [
     tracy
   ]
@@ -149,16 +153,39 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeFlags = [
-    (lib.cmakeBool "XRT_FEATURE_SERVICE" serviceSupport)
+    (lib.cmakeBool "XRT_FEATURE_SERVICE" (serviceSupport && !clientLibOnly))
     (lib.cmakeBool "XRT_HAVE_TRACY" tracingSupport)
     (lib.cmakeBool "XRT_FEATURE_TRACING" tracingSupport)
     (lib.cmakeBool "XRT_OPENXR_INSTALL_ABSOLUTE_RUNTIME_PATH" true)
+  ]
+  ++ lib.optionals clientLibOnly [
+    (lib.cmakeBool "XRT_FEATURE_CLIENT_WITHOUT_SERVICE" true)
+    (lib.cmakeBool "XRT_FEATURE_STEAMVR_PLUGIN" false)
+    (lib.cmakeBool "XRT_HAVE_LIBUVC" false)
+    (lib.cmakeBool "XRT_HAVE_LIBUSB" false)
+    (lib.cmakeBool "XRT_HAVE_JPEG" false)
+    (lib.cmakeBool "XRT_HAVE_HIDAPI" false)
+    (lib.cmakeBool "XRT_HAVE_GST" false)
+    (lib.cmakeBool "XRT_HAVE_BLUETOOTH" false)
+    (lib.cmakeBool "XRT_FEATURE_DEBUG_GUI" false)
+    (lib.cmakeBool "XRT_FEATURE_WINDOW_PEEK" false)
+    (lib.cmakeBool "XRT_FEATURE_SLAM" false)
+    (lib.cmakeBool "XRT_MODULE_MONADO_CLI" false)
+    (lib.cmakeBool "XRT_MODULE_MONADO_GUI" false)
+    (lib.cmakeBool "XRT_MODULE_MERCURY_HANDTRACKING" false)
+    (lib.cmakeBool "XRT_BUILD_SAMPLES" false)
   ];
 
   # Help openxr-loader find this runtime
   setupHook = writeText "setup-hook" ''
     export XDG_CONFIG_DIRS=@out@/etc/xdg''${XDG_CONFIG_DIRS:+:''${XDG_CONFIG_DIRS}}
   '';
+
+  # While it seems like you could use stdenv.hostPlatform.parsed.cpu.arch for the next variable, you can't, as this always sets the correct host CPU, even if you're using i686 packages on x86_64
+  # This may not be correct on every CPU architecture as per, https://registry.khronos.org/OpenXR/specs/1.1/loader.html#architecture-identifiers
+  postInstall = ''
+    cp "$out/share/openxr/1/openxr_monado.json" "$out/share/openxr/1/openxr_monado.${stdenv.hostPlatform.parsed.cpu.name}.json"
+  ''; # Do not change this from using `cp` as this will break the multiarch build because it will be pointing to openxr_monado.json for both the 32 bit json and the 64 bit json.
 
   passthru = {
     updateScript = nix-update-script { };
@@ -170,7 +197,25 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://monado.freedesktop.org/";
     license = lib.licenses.boost;
     maintainers = with lib.maintainers; [ Scrumplex ];
-    platforms = lib.platforms.linux;
     mainProgram = "monado-cli";
+    platforms = [
+      "x86_64-linux"
+      "i686-linux"
+      "aarch64-linux"
+      "armv7a-vfp-linux"
+      "armv5te-linux"
+      "mips64-linux"
+      "mips-linux"
+      "ppc64-linux"
+      "ppc64el-linux"
+      "s390x-linux"
+      "hppa-linux"
+      "alpha-linux"
+      "ia64-linux"
+      "m68k-linux"
+      "riscv64-linux"
+      "sparc64-linux"
+      "loongarch64-linux"
+    ];
   };
 })


### PR DESCRIPTION
This allows for multiple CPU architecture builds of monado on the same machine, as the current build does not work easily as an input for a `symlinkJoin` based build. I've also made the client library only option strip out unnecessary files from the output and turn off features that shouldn't be required for such of a build.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
