### PR TITLE
nixos/{autoUpgrade,switchable-system}: introduce the concepts of switch inhibitors and reboot triggers

### DIFF
--- a/nixos/modules/services/system/dbus.nix
+++ b/nixos/modules/services/system/dbus.nix
@@ -174,6 +174,10 @@ in
         permissions = "u+rx,g+rx,o-rx";
       };
 
+      system.switch.inhibitors = [
+        cfg.dbusPackage
+      ];
+
       systemd.services.dbus = {
         aliases = [
           # hack aiding to prevent dbus from restarting when switching from dbus-broker back to dbus
@@ -209,6 +213,10 @@ in
       ];
 
       systemd.packages = [
+        cfg.brokerPackage
+      ];
+
+      system.switch.inhibitors = [
         cfg.brokerPackage
       ];
 

--- a/nixos/modules/system/activation/switchable-system.nix
+++ b/nixos/modules/system/activation/switchable-system.nix
@@ -16,38 +16,129 @@
     '')
   ];
 
-  options.system.switch.enable = lib.mkOption {
-    type = lib.types.bool;
-    default = true;
-    description = ''
-      Whether to include the capability to switch configurations.
+  options.system.switch = {
+    enable = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Whether to include the capability to switch configurations.
 
-      Disabling this makes the system unable to be reconfigured via `nixos-rebuild`.
+        Disabling this makes the system unable to be reconfigured via `nixos-rebuild`.
 
-      This is good for image based appliances where updates are handled
-      outside the image. Reducing features makes the image lighter and
-      slightly more secure.
-    '';
+        This is good for image based appliances where updates are handled
+        outside the image. Reducing features makes the image lighter and
+        slightly more secure.
+      '';
+    };
+
+    inhibitors = lib.mkOption {
+      type = lib.types.listOf lib.types.pathInStore;
+      default = [ ];
+      description = ''
+        List of derivations that will prevent switching into a configuration when
+        they change.
+        This can be manually overridden on the command line if required.
+      '';
+    };
   };
 
   config = lib.mkIf config.system.switch.enable {
     # Use a subshell so we can source makeWrapper's setup hook without
     # affecting the rest of activatableSystemBuilderCommands.
-    system.activatableSystemBuilderCommands = ''
-      (
-        source ${pkgs.buildPackages.makeWrapper}/nix-support/setup-hook
+    system = {
+      activatableSystemBuilderCommands = ''
+        (
+          source ${pkgs.buildPackages.makeWrapper}/nix-support/setup-hook
 
-        mkdir $out/bin
-        ln -sf ${lib.getExe pkgs.switch-to-configuration-ng} $out/bin/switch-to-configuration
-        wrapProgram $out/bin/switch-to-configuration \
-          --set OUT $out \
-          --set TOPLEVEL ''${!toplevelVar} \
-          --set DISTRO_ID ${lib.escapeShellArg config.system.nixos.distroId} \
-          --set INSTALL_BOOTLOADER ${lib.escapeShellArg config.system.build.installBootLoader} \
-          --set PRE_SWITCH_CHECK ${lib.escapeShellArg config.system.preSwitchChecksScript} \
-          --set LOCALE_ARCHIVE ${config.i18n.glibcLocales}/lib/locale/locale-archive \
-          --set SYSTEMD ${config.systemd.package}
-      )
-    '';
+          mkdir $out/bin
+          ln -sf ${lib.getExe pkgs.switch-to-configuration-ng} $out/bin/switch-to-configuration
+          wrapProgram $out/bin/switch-to-configuration \
+            --set OUT $out \
+            --set TOPLEVEL ''${!toplevelVar} \
+            --set DISTRO_ID ${lib.escapeShellArg config.system.nixos.distroId} \
+            --set INSTALL_BOOTLOADER ${lib.escapeShellArg config.system.build.installBootLoader} \
+            --set PRE_SWITCH_CHECK ${lib.escapeShellArg config.system.preSwitchChecksScript} \
+            --set LOCALE_ARCHIVE ${config.i18n.glibcLocales}/lib/locale/locale-archive \
+            --set SYSTEMD ${config.systemd.package}
+        )
+      '';
+
+      systemBuilderCommands = ''
+        ln -s ${config.system.build.inhibitSwitch} $out/switch-inhibitors
+      '';
+
+      build.inhibitSwitch = pkgs.writeTextFile {
+        name = "switch-inhibitors";
+        text = lib.concatMapStringsSep "\n" (drv: drv.outPath) config.system.switch.inhibitors;
+      };
+
+      preSwitchChecks.switchInhibitors =
+        let
+          realpath = lib.getExe' pkgs.coreutils "realpath";
+          sha256sum = lib.getExe' pkgs.coreutils "sha256sum";
+          diff = lib.getExe' pkgs.diffutils "diff";
+        in
+        # bash
+        ''
+          incoming="''${1-}"
+          action="''${2-}"
+
+          if [ "$action" == "boot" ]; then
+            echo "Not checking switch inhibitors (action = $action)"
+            exit
+          fi
+
+          echo -n "Checking switch inhibitors..."
+
+          booted_inhibitors="$(${realpath} /run/booted-system)/switch-inhibitors"
+          booted_inhibitors_sha="$(
+            if [ -f "$booted_inhibitors" ]; then
+              ${sha256sum} - < "$booted_inhibitors"
+            else
+              echo 'none'
+            fi
+          )"
+
+          if [ "$booted_inhibitors_sha" == "none" ]; then
+            echo
+            echo "The previous configuration did not specify switch inhibitors, nothing to check."
+            exit
+          fi
+
+          new_inhibitors="$(${realpath} "$incoming")/switch-inhibitors"
+          new_inhibitors_sha="$(
+            if [ -f "$new_inhibitors" ]; then
+              ${sha256sum} - < "$new_inhibitors"
+            else
+              echo 'none'
+            fi
+          )"
+
+          if [ "$new_inhibitors_sha" == "none" ]; then
+            echo
+            echo "The new configuration does not specify switch inhibitors, nothing to check."
+            exit
+          fi
+
+          if [ "$new_inhibitors_sha" != "$booted_inhibitors_sha" ]; then
+            echo
+            echo "Found diff in switch inhibitors:"
+            echo
+            ${diff} --color "$booted_inhibitors" "$new_inhibitors"
+            echo
+            echo "The new configuration contains changes to packages that were"
+            echo "listed as switch inhibitors."
+            echo
+            echo "If you really want to switch into this configuration directly, then"
+            echo "you can set NIXOS_NO_CHECK=1 to ignore these pre-switch checks."
+            echo
+            echo "WARNING: doing so might cause the switch to fail or your system to become unstable."
+            echo
+            exit 1
+          else
+            echo " done"
+          fi
+        '';
+    };
   };
 }

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -567,6 +567,10 @@ in
       );
     };
 
+    system.switch.inhibitors = [
+      cfg.package
+    ];
+
     environment.systemPackages = [ cfg.package ];
 
     environment.etc =

--- a/nixos/modules/tasks/auto-upgrade.nix
+++ b/nixos/modules/tasks/auto-upgrade.nix
@@ -114,6 +114,27 @@ in
         '';
       };
 
+      rebootTriggers = lib.mkOption {
+        type = lib.types.listOf lib.types.pathInStore;
+        default = [ ];
+        description = ''
+          List of derivations that will cause an auto-reboot when changed when
+          {option}`system.autoUpgrade.allowReboot` is set to true.
+        '';
+        defaultText = lib.literalExpression ''
+          [
+            config.system.build.initialRamdisk
+            config.system.build.kernel
+            config.hardware.firmware
+            (pkgs.writeTextFile {
+              name = "kernel-params";
+              text = lib.concatStringsSep " " config.boot.kernelParams;
+            })
+          ]
+          ++ config.system.switch.inhibitors
+        '';
+      };
+
       randomizedDelaySec = lib.mkOption {
         default = "0";
         type = lib.types.str;
@@ -197,133 +218,205 @@ in
 
   };
 
-  config = lib.mkIf cfg.enable {
+  config = lib.mkMerge [
 
-    assertions = [
-      {
-        assertion = !((cfg.channel != null) && (cfg.flake != null));
-        message = ''
-          The options 'system.autoUpgrade.channel' and 'system.autoUpgrade.flake' cannot both be set.
-        '';
-      }
-      {
-        assertion = (cfg.runGarbageCollection -> config.nix.enable);
-        message = ''
-          The option 'system.autoUpgrade.runGarbageCollection = true' requires 'nix.enable = true'.
-        '';
-      }
-    ];
-
-    system.autoUpgrade.flags = (
-      if cfg.flake == null then
-        [ "--no-build-output" ]
-        ++ lib.optionals (cfg.channel != null) [
-          "-I"
-          "nixpkgs=${cfg.channel}/nixexprs.tar.xz"
+    {
+      system = {
+        autoUpgrade.rebootTriggers = [
+          config.system.build.initialRamdisk
+          config.system.build.kernel
+          config.hardware.firmware
+          (pkgs.writeTextFile {
+            name = "kernel-params";
+            text = lib.concatStringsSep " " config.boot.kernelParams;
+          })
         ]
-      else
-        [
-          "--refresh"
-          "--flake ${cfg.flake}"
-        ]
-    );
+        ++ config.system.switch.inhibitors;
 
-    systemd.services.nixos-upgrade = {
-      description = "NixOS Upgrade";
+        systemBuilderCommands = ''
+          ln -s ${config.system.build.rebootTriggers} $out/reboot-triggers
+        '';
 
-      restartIfChanged = false;
-      unitConfig.X-StopOnRemoval = false;
-      unitConfig.OnSuccess = lib.optional (
-        cfg.runGarbageCollection && config.nix.enable
-      ) "nix-gc.service";
+        build.rebootTriggers = pkgs.writeTextFile {
+          name = "reboot-triggers";
+          text = lib.concatMapStringsSep "\n" (drv: drv.outPath) config.system.autoUpgrade.rebootTriggers;
+        };
+      };
+    }
 
-      serviceConfig.Type = "oneshot";
-
-      environment =
-        config.nix.envVars
-        // {
-          inherit (config.environment.sessionVariables) NIX_PATH;
-          HOME = "/root";
+    (lib.mkIf cfg.enable {
+      assertions = [
+        {
+          assertion = !((cfg.channel != null) && (cfg.flake != null));
+          message = ''
+            The options 'system.autoUpgrade.channel' and 'system.autoUpgrade.flake' cannot both be set.
+          '';
         }
-        // config.networking.proxy.envVars;
-
-      path = with pkgs; [
-        coreutils
-        gnutar
-        xz.bin
-        gzip
-        gitMinimal
-        config.nix.package.out
-        config.programs.ssh.package
+        {
+          assertion = (cfg.runGarbageCollection -> config.nix.enable);
+          message = ''
+            The option 'system.autoUpgrade.runGarbageCollection = true' requires 'nix.enable = true'.
+          '';
+        }
       ];
 
-      script =
-        let
-          nixos-rebuild = "${config.system.build.nixos-rebuild}/bin/nixos-rebuild";
-          date = "${pkgs.coreutils}/bin/date";
-          readlink = "${pkgs.coreutils}/bin/readlink";
-          shutdown = "${config.systemd.package}/bin/shutdown";
-          upgradeFlag = lib.optional (cfg.channel == null && cfg.upgrade) "--upgrade";
-        in
-        if cfg.allowReboot then
-          ''
-            ${nixos-rebuild} boot ${toString (cfg.flags ++ upgradeFlag)}
-            booted="$(${readlink} /run/booted-system/{initrd,kernel,kernel-modules})"
-            built="$(${readlink} /nix/var/nix/profiles/system/{initrd,kernel,kernel-modules})"
-
-            ${lib.optionalString (cfg.rebootWindow != null) ''
-              current_time="$(${date} +%H:%M)"
-
-              lower="${cfg.rebootWindow.lower}"
-              upper="${cfg.rebootWindow.upper}"
-
-              if [[ "''${lower}" < "''${upper}" ]]; then
-                if [[ "''${current_time}" > "''${lower}" ]] && \
-                   [[ "''${current_time}" < "''${upper}" ]]; then
-                  do_reboot="true"
-                else
-                  do_reboot="false"
-                fi
-              else
-                # lower > upper, so we are crossing midnight (e.g. lower=23h, upper=6h)
-                # we want to reboot if cur > 23h or cur < 6h
-                if [[ "''${current_time}" < "''${upper}" ]] || \
-                   [[ "''${current_time}" > "''${lower}" ]]; then
-                  do_reboot="true"
-                else
-                  do_reboot="false"
-                fi
-              fi
-            ''}
-
-            if [ "''${booted}" = "''${built}" ]; then
-              ${nixos-rebuild} ${cfg.operation} ${toString cfg.flags}
-            ${lib.optionalString (cfg.rebootWindow != null) ''
-              elif [ "''${do_reboot}" != true ]; then
-                echo "Outside of configured reboot window, skipping."
-            ''}
-            else
-              ${shutdown} -r +1
-            fi
-          ''
+      system.autoUpgrade.flags = (
+        if cfg.flake == null then
+          [ "--no-build-output" ]
+          ++ lib.optionals (cfg.channel != null) [
+            "-I"
+            "nixpkgs=${cfg.channel}/nixexprs.tar.xz"
+          ]
         else
-          ''
-            ${nixos-rebuild} ${cfg.operation} ${toString (cfg.flags ++ upgradeFlag)}
-          '';
+          [
+            "--refresh"
+            "--flake ${cfg.flake}"
+          ]
+      );
 
-      startAt = cfg.dates;
+      systemd.services.nixos-upgrade = {
+        description = "NixOS Upgrade";
 
-      after = [ "network-online.target" ];
-      wants = [ "network-online.target" ];
-    };
+        restartIfChanged = false;
+        unitConfig.X-StopOnRemoval = false;
+        unitConfig.OnSuccess = lib.optional (
+          cfg.runGarbageCollection && config.nix.enable
+        ) "nix-gc.service";
 
-    systemd.timers.nixos-upgrade = {
-      timerConfig = {
-        RandomizedDelaySec = cfg.randomizedDelaySec;
-        FixedRandomDelay = cfg.fixedRandomDelay;
-        Persistent = cfg.persistent;
+        serviceConfig.Type = "oneshot";
+
+        environment =
+          config.nix.envVars
+          // {
+            inherit (config.environment.sessionVariables) NIX_PATH;
+            HOME = "/root";
+          }
+          // config.networking.proxy.envVars;
+
+        path = with pkgs; [
+          coreutils
+          gnutar
+          xz.bin
+          gzip
+          gitMinimal
+          config.nix.package.out
+          config.programs.ssh.package
+          config.system.build.nixos-rebuild
+          config.systemd.package
+        ];
+
+        script =
+          let
+            upgradeFlag = lib.optional (cfg.channel == null && cfg.flake == null) "--upgrade";
+          in
+          if cfg.allowReboot then
+            # bash
+            ''
+              echo "Running nixos-rebuild boot..."
+              new_configuration="$(
+                # For some reason we still get a newline here in the journal between the
+                # nixos-rebuild stderr output and us echoing the store path that was
+                # printed on stdout.
+                # This might have to do with the particular way in which systemd handles
+                # stdout/stderr, they are unix sockets and not normal streams.
+                store_path="$(nixos-rebuild boot ${toString (cfg.flags ++ upgradeFlag)})"
+                echo "$store_path" >&2
+                echo "$store_path"
+              )"
+              if [ -z "$new_configuration" ]; then
+                echo "Looks like nixos-rebuild failed... Aborting"
+                exit 1
+              fi
+              echo "New configuration is $new_configuration"
+              switch_to_new_configuration="$new_configuration"/bin/switch-to-configuration
+
+              ${lib.optionalString (cfg.rebootWindow != null) # bash
+                ''
+                  current_time="$(date +%H:%M)"
+
+                  lower="${cfg.rebootWindow.lower}"
+                  upper="${cfg.rebootWindow.upper}"
+
+                  if [[ "''${lower}" < "''${upper}" ]]; then
+                    if [[ "''${current_time}" > "''${lower}" ]] && [[ "''${current_time}" < "''${upper}" ]]; then
+                      do_reboot="true"
+                    else
+                      do_reboot="false"
+                    fi
+                  else
+                    # lower > upper, so we are crossing midnight (e.g. lower=23h, upper=6h)
+                    # we want to reboot if cur > 23h or cur < 6h
+                    if [[ "''${current_time}" < "''${upper}" ]] || [[ "''${current_time}" > "''${lower}" ]]; then
+                      do_reboot="true"
+                    else
+                      do_reboot="false"
+                    fi
+                  fi
+                ''
+              }
+
+              booted_triggers="$(realpath /run/booted-system)/reboot-triggers"
+              booted_triggers_sha="$(
+                if [ -f "$booted_triggers" ]; then
+                  sha256sum - < "$booted_triggers"
+                else
+                  echo 'none'
+                fi
+              )"
+
+              new_triggers="$(realpath "$new_configuration")/reboot-triggers"
+              new_triggers_sha="$(
+                if [ -f "$new_triggers" ]; then
+                  sha256sum - < "$new_triggers"
+                else
+                  echo 'none'
+                fi
+              )"
+
+              ${lib.optionalString (cfg.operation == "switch") # bash
+                ''
+                  echo "Running switch-to-configuration check..."
+                  if "$switch_to_new_configuration" check; then
+                    echo "Checking reboot triggers..."
+                    if [ "$new_triggers_sha" == "$booted_triggers_sha" ]; then
+                      echo "Switching into the new generation..."
+                      "$switch_to_new_configuration" ${cfg.operation}
+                      exit 0
+                    fi
+                  fi
+                ''
+              }
+              ${lib.optionalString (cfg.rebootWindow != null) # bash
+                ''
+                  if [ "''${do_reboot}" != true ]; then
+                    echo "Outside of configured reboot window, skipping."
+                    exit 0
+                  fi
+                ''
+              }
+              echo "Scheduling a reboot to activate the new generation"
+              systemctl reboot --when="+2min"
+            ''
+          else
+            # bash
+            ''
+              nixos-rebuild ${cfg.operation} ${toString (cfg.flags ++ upgradeFlag)}
+            '';
+
+        startAt = cfg.dates;
+
+        after = [ "network-online.target" ];
+        wants = [ "network-online.target" ];
       };
-    };
-  };
 
+      systemd.timers.nixos-upgrade = {
+        timerConfig = {
+          RandomizedDelaySec = cfg.randomizedDelaySec;
+          FixedRandomDelay = cfg.fixedRandomDelay;
+          Persistent = cfg.persistent;
+        };
+      };
+    })
+
+  ];
 }


### PR DESCRIPTION
- **nixos/switchable-system: introduce a standard pre-switch check to prevent switching under certain conditions**
- **nixos/autoUpgrade: introduce reboot triggers to customise the auto-reboot behaviour**

This PR introduces two new concepts to make switching systems safer:

1. switch inhibitors

This first commit introduces "switch inhibitors" which are derivations that prevent a switch of a system to a new configuration if those derivations don't have the same hash in both configurations.
This means that we can for instance add the systemd and dbus derivations such that users will be instructed to reboot their system when those derivations have changed instead of switching.

This feature should be used sparingly, but it can make NixOS more robust by avoiding users switching to a configuration that can make their system unstable (like major updates of systemd, or new versions of dbus since the dbus and dbus-broker daemons cannot be restarted).

The user can still force the switch by setting an env var.

2. reboot triggers

The auto-upgrade service can reboot the system automatically, but the user cannot control what exactly triggers a reboot.
This commit makes these "reboot triggers" configurable, so that users can control which derivations cause their systems to reboot automatically.
This feature works very well in combination with switch inhibitors, which are automatically added as reboot triggers as well.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
