### PR TITLE
jelu: init at 0.84.2

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1680,6 +1680,7 @@
   ./services/web-apps/invidious.nix
   ./services/web-apps/invoiceplane.nix
   ./services/web-apps/isso.nix
+  ./services/web-apps/jelu.nix
   ./services/web-apps/jirafeau.nix
   ./services/web-apps/jitsi-meet.nix
   ./services/web-apps/kanboard.nix

--- a/nixos/modules/services/web-apps/jelu.nix
+++ b/nixos/modules/services/web-apps/jelu.nix
@@ -1,0 +1,289 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.jelu;
+  settingsFormat = pkgs.formats.yaml { };
+  configFile = settingsFormat.generate "application.yml" cfg.settings;
+in
+{
+  options.services.jelu = {
+    enable = lib.mkEnableOption "Jelu book tracking service";
+
+    package = lib.mkPackageOption pkgs "jelu" { };
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "jelu";
+      description = "User account under which Jelu runs.";
+    };
+
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = "jelu";
+      description = "Group under which Jelu runs.";
+    };
+
+    dataDir = lib.mkOption {
+      type = lib.types.path;
+      default = "/var/lib/jelu";
+      description = "Directory to store Jelu database and files.";
+    };
+
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Open ports in the firewall for Jelu.";
+    };
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 11111;
+      description = "Port on which Jelu listens.";
+    };
+
+    environmentFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      description = ''
+        File containing environment variables to be passed to the Jelu service.
+        Useful for passing secrets like `SPRING_DATASOURCE_PASSWORD` or LDAP credentials.
+      '';
+    };
+
+    calibreSupport = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Enable Calibre metadata fetching support.
+        Note: This pulls in the full Calibre package which is large.
+      '';
+    };
+
+    settings = lib.mkOption {
+      description = ''
+        Configuration for Jelu, written to `application.yml`.
+        Refer to the [upstream documentation](https://bayang.github.io/jelu-web/)
+        for available options.
+      '';
+      default = { };
+      example = lib.literalExpression ''
+        {
+          jelu.cors.allowed-origins = [ "https://jelu.example.com" ];
+        }
+      '';
+      type = lib.types.submodule {
+        freeformType = settingsFormat.type;
+
+        options = {
+          server.port = lib.mkOption {
+            type = lib.types.port;
+            description = "Port Jelu listens on. Defaults to {option}`services.jelu.port`.";
+          };
+
+          jelu = {
+            database.path = lib.mkOption {
+              type = lib.types.str;
+              description = "Path to the Jelu database directory. Defaults to a subdirectory of {option}`services.jelu.dataDir`.";
+            };
+
+            files = {
+              images = lib.mkOption {
+                type = lib.types.str;
+                description = "Path to the Jelu images directory.";
+              };
+              imports = lib.mkOption {
+                type = lib.types.str;
+                description = "Path to the Jelu imports directory.";
+              };
+            };
+
+            session.duration = lib.mkOption {
+              type = lib.types.int;
+              default = 604800;
+              description = "Session duration in seconds.";
+            };
+
+            cors.allowed-origins = lib.mkOption {
+              type = lib.types.listOf lib.types.str;
+              description = "List of CORS allowed origins.";
+            };
+          };
+
+          spring = {
+            datasource = {
+              url = lib.mkOption {
+                type = lib.types.str;
+                description = "JDBC datasource URL. Defaults to an SQLite database inside {option}`services.jelu.dataDir`.";
+              };
+
+              driver-class-name = lib.mkOption {
+                type = lib.types.str;
+                default = "org.sqlite.JDBC";
+                description = "JDBC driver class name.";
+              };
+
+              username = lib.mkOption {
+                type = lib.types.str;
+                default = "jelu_user";
+                description = "Database username.";
+              };
+
+              password = lib.mkOption {
+                type = lib.types.str;
+                default = "mypass1234";
+                description = ''
+                  Database password. This is the upstream default for SQLite and
+                  is effectively unused for local SQLite databases.
+                  For production use, consider setting this via
+                  {option}`services.jelu.environmentFile` using `SPRING_DATASOURCE_PASSWORD`.
+                '';
+              };
+            };
+
+            jpa.database-platform = lib.mkOption {
+              type = lib.types.str;
+              default = "org.hibernate.community.dialect.SQLiteDialect";
+              description = "Hibernate dialect for the database platform.";
+            };
+          };
+        };
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    services.jelu.settings = {
+      server.port = lib.mkDefault cfg.port;
+      jelu = {
+        database.path = lib.mkDefault "${cfg.dataDir}/database";
+        files = {
+          images = lib.mkDefault "${cfg.dataDir}/files/images";
+          imports = lib.mkDefault "${cfg.dataDir}/files/imports";
+        };
+        cors.allowed-origins = lib.mkDefault [ "http://localhost:${toString cfg.port}" ];
+      }
+      // lib.optionalAttrs cfg.calibreSupport {
+        metadata.calibre.path = "${pkgs.calibre}/bin/fetch-ebook-metadata";
+      };
+      # Overriding jelu.database.path requires updating this URL accordingly.
+      spring.datasource.url = lib.mkDefault "jdbc:sqlite:${cfg.dataDir}/database/jelu.db";
+    };
+
+    users.users = lib.mkIf (cfg.user == "jelu") {
+      jelu = {
+        isSystemUser = true;
+        group = cfg.group;
+        home = cfg.dataDir;
+        createHome = true;
+        description = "Jelu service user";
+      };
+    };
+
+    users.groups = lib.mkIf (cfg.group == "jelu") {
+      jelu = { };
+    };
+
+    networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewall [ cfg.port ];
+
+    systemd.tmpfiles.settings."10-jelu" = {
+      "${cfg.settings.jelu.database.path}".d = {
+        user = cfg.user;
+        group = cfg.group;
+        mode = "0750";
+      };
+      "${cfg.dataDir}/files".d = {
+        user = cfg.user;
+        group = cfg.group;
+        mode = "0750";
+      };
+      "${cfg.settings.jelu.files.images}".d = {
+        user = cfg.user;
+        group = cfg.group;
+        mode = "0750";
+      };
+      "${cfg.settings.jelu.files.imports}".d = {
+        user = cfg.user;
+        group = cfg.group;
+        mode = "0750";
+      };
+    };
+
+    systemd.services.jelu = {
+      description = "Jelu book tracking service";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      environment = {
+        HOME = cfg.dataDir;
+        SSL_CERT_FILE = "/etc/ssl/certs/ca-certificates.crt";
+      }
+      // lib.optionalAttrs cfg.calibreSupport {
+        QTWEBENGINE_DISABLE_SANDBOX = "1";
+        QT_QPA_PLATFORM = "offscreen";
+        QTWEBENGINE_CHROMIUM_FLAGS = "--disable-gpu";
+        XDG_CONFIG_HOME = "${cfg.dataDir}/.config";
+        XDG_CACHE_HOME = "${cfg.dataDir}/.cache";
+      };
+
+      serviceConfig = {
+        Type = "simple";
+        User = cfg.user;
+        Group = cfg.group;
+        StateDirectory = "jelu";
+        StateDirectoryMode = "0750";
+        WorkingDirectory = cfg.dataDir;
+        EnvironmentFile = lib.mkIf (cfg.environmentFile != null) cfg.environmentFile;
+        ExecStart = "${lib.getExe cfg.package} --spring.config.additional-location=file:${configFile}";
+        Restart = "on-failure";
+        RestartSec = "10s";
+
+        # Hardening
+        NoNewPrivileges = true;
+        PrivateTmp = true;
+        PrivateDevices = true;
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        ReadWritePaths = [ cfg.dataDir ];
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectControlGroups = true;
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_UNIX"
+          "AF_NETLINK"
+        ];
+        RestrictNamespaces = true;
+        LockPersonality = true;
+        MemoryDenyWriteExecute = false; # Java requires this to be false due to JIT
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        ProtectClock = true;
+        SystemCallArchitectures = "native";
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        RemoveIPC = true;
+        UMask = "0077";
+        SystemCallFilter = [
+          "~@clock"
+          "~@cpu-emulation"
+          "~@debug"
+          "~@module"
+          "~@mount"
+          "~@obsolete"
+          "~@raw-io"
+          "~@reboot"
+          "~@swap"
+        ];
+      };
+    };
+
+    meta = {
+      maintainers = with lib.maintainers; [ m0streng0 ];
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -802,6 +802,7 @@ in
   isso = runTest ./isso.nix;
   jackett = runTest ./jackett.nix;
   jellyfin = runTest ./jellyfin.nix;
+  jelu = runTest ./jelu.nix;
   jenkins = runTest ./jenkins.nix;
   jenkins-cli = runTest ./jenkins-cli.nix;
   jibri = runTest ./jibri.nix;

--- a/nixos/tests/jelu.nix
+++ b/nixos/tests/jelu.nix
@@ -1,0 +1,20 @@
+{ lib, ... }:
+{
+  name = "jelu";
+  meta.maintainers = with lib.maintainers; [ m0streng0 ];
+
+  nodes.machine = {
+    services.jelu = {
+      enable = true;
+      openFirewall = true;
+    };
+  };
+
+  testScript = ''
+    machine.start()
+    machine.wait_for_unit("jelu.service")
+    machine.wait_for_open_port(11111)
+    machine.succeed("curl -f http://localhost:11111/")
+    machine.succeed("test -f /var/lib/jelu/database/jelu.db")
+  '';
+}

--- a/pkgs/by-name/je/jelu/package.nix
+++ b/pkgs/by-name/je/jelu/package.nix
@@ -1,0 +1,76 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  makeWrapper,
+  jre_minimal,
+  nixosTests,
+}:
+let
+  jre = jre_minimal.override {
+    modules = [
+      "java.base"
+      "java.compiler"
+      "java.desktop"
+      "java.instrument"
+      "java.logging"
+      "java.management"
+      "java.naming"
+      "java.net.http"
+      "java.prefs"
+      "java.scripting"
+      "java.security.jgss"
+      "java.sql"
+      "java.sql.rowset"
+      "java.transaction.xa"
+      "java.xml"
+      "jdk.charsets"
+      "jdk.crypto.ec"
+      "jdk.localedata"
+      "jdk.management"
+      "jdk.unsupported"
+    ];
+  };
+in
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "jelu";
+  version = "0.80.0";
+  strictDeps = true;
+  __structuredAttrs = true;
+  src = fetchurl {
+    url = "https://github.com/bayang/jelu/releases/download/v${finalAttrs.version}/jelu-${finalAttrs.version}.jar";
+    hash = "sha256-ThpnjVUsp7VQ+Eil+e0WvxoU3fRv4NP0t4eK1BUBWgQ=";
+  };
+  dontUnpack = true;
+  nativeBuildInputs = [ makeWrapper ];
+  # TODO: Build from source using buildGradleApplication once Gradle build support
+  # is more mature. Currently using pre-built JAR due to complex build process
+  # combining Java (Gradle) and Node.js (for the web UI).
+  installPhase = ''
+    runHook preInstall
+    install -Dm444 $src $out/share/jelu/jelu.jar
+    makeWrapper ${lib.getExe jre} $out/bin/jelu \
+      --add-flags "-jar $out/share/jelu/jelu.jar" \
+      --set JAVA_HOME ${jre}
+    runHook postInstall
+  '';
+  passthru.tests = {
+    inherit (nixosTests) jelu;
+  };
+  meta = {
+    description = "Self hosted read and to-read list book tracker";
+    longDescription = ''
+      Jelu is a self-hosted book tracking application that allows you to track
+      what you have read, what you are reading, and what you want to read.
+      It provides an alternative to online services like Goodreads, giving you
+      full control over your reading data.
+    '';
+    homepage = "https://github.com/bayang/jelu";
+    changelog = "https://github.com/bayang/jelu/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ m0streng0 ];
+    platforms = lib.platforms.all;
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
+    mainProgram = "jelu";
+  };
+})

--- a/pkgs/by-name/je/jelu/package.nix
+++ b/pkgs/by-name/je/jelu/package.nix
@@ -1,0 +1,76 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  makeWrapper,
+  jre_minimal,
+  nixosTests,
+}:
+let
+  jre = jre_minimal.override {
+    modules = [
+      "java.base"
+      "java.compiler"
+      "java.desktop"
+      "java.instrument"
+      "java.logging"
+      "java.management"
+      "java.naming"
+      "java.net.http"
+      "java.prefs"
+      "java.scripting"
+      "java.security.jgss"
+      "java.sql"
+      "java.sql.rowset"
+      "java.transaction.xa"
+      "java.xml"
+      "jdk.charsets"
+      "jdk.crypto.ec"
+      "jdk.localedata"
+      "jdk.management"
+      "jdk.unsupported"
+    ];
+  };
+in
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "jelu";
+  version = "0.84.2";
+  strictDeps = true;
+  __structuredAttrs = true;
+  src = fetchurl {
+    url = "https://github.com/bayang/jelu/releases/download/v${finalAttrs.version}/jelu-${finalAttrs.version}.jar";
+    hash = "sha256-0UWCNqggozVruXTpQ1/gu244RQhVCmYjPc2zb1bJZGk=";
+  };
+  dontUnpack = true;
+  nativeBuildInputs = [ makeWrapper ];
+  # TODO: Build from source using buildGradleApplication once Gradle build support
+  # is more mature. Currently using pre-built JAR due to complex build process
+  # combining Java (Gradle) and Node.js (for the web UI).
+  installPhase = ''
+    runHook preInstall
+    install -Dm444 $src $out/share/jelu/jelu.jar
+    makeWrapper ${lib.getExe jre} $out/bin/jelu \
+      --add-flags "-jar $out/share/jelu/jelu.jar" \
+      --set JAVA_HOME ${jre}
+    runHook postInstall
+  '';
+  passthru.tests = {
+    inherit (nixosTests) jelu;
+  };
+  meta = {
+    description = "Self hosted read and to-read list book tracker";
+    longDescription = ''
+      Jelu is a self-hosted book tracking application that allows you to track
+      what you have read, what you are reading, and what you want to read.
+      It provides an alternative to online services like Goodreads, giving you
+      full control over your reading data.
+    '';
+    homepage = "https://github.com/bayang/jelu";
+    changelog = "https://github.com/bayang/jelu/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ m0streng0 ];
+    platforms = lib.platforms.all;
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
+    mainProgram = "jelu";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR introduces [Jelu](https://github.com/bayang/jelu), a self-hosted read and to-read list book tracker (a "personal Goodreads").

This PR includes:
1.  **The Package**: `pkgs/by-name/je/jelu/package.nix` (version 0.75.2).
2.  **The Module**: `services.jelu`, including systemd hardening, database initialization, and fixes for Qt WebEngine/Calibre headless environments.
3.  **The Test**: A NixOS VM test (`nixosTests.jelu`) verifying service startup, port reachability, and database creation.

**Note on Source:**
I am currently packaging the upstream binary release (`.jar`). The upstream project uses a complex build process involving both Gradle and NPM (for the frontend) which is difficult to replicate in a pure offline Nix build environment at this stage. I have marked the package with `sourceProvenance = [ binaryBytecode ]`.

**Note:** I've never contributed to a module addition before, so feel free to point out any flaws and advise me on how to make it better. Thanks for the understanding. :)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
