### PR TITLE
gnucobol: add meta.mainProgram

### DIFF
--- a/pkgs/by-name/gn/gnucobol/package.nix
+++ b/pkgs/by-name/gn/gnucobol/package.nix
@@ -143,6 +143,7 @@ stdenv.mkDerivation (finalAttrs: {
       gpl3Only
       lgpl3Only
     ];
+    mainProgram = "cobc";
     maintainers = with lib.maintainers; [
       lovesegfault
       techknowlogick


### PR DESCRIPTION
## Summary

  - Add `meta.mainProgram = "cobc"` to the gnucobol package

  The COBOL compiler `cobc` is the primary executable provided by gnucobol,
  making it the appropriate value for `mainProgram` per nixpkgs guidelines.

  ## Checklist

  - [x] Tested using sandboxing (nix-instantiate evaluates successfully)
  - Built on platform:
       - [x] aarch64-darwin
  - [x] Tested compilation of all pkgs that depend on this change using `nixpkgs-review`
    ```
    --------- Report for 'aarch64-darwin' ---------
    4 packages built:
    gnucobol gnucobol.bin gnucobol.dev gnucobol.lib
    ```
  - [x] Tested execution of all binary files (N/A - meta-only change)
