### PR TITLE
liblqr1: fix build on darwin

### DIFF
--- a/pkgs/by-name/li/liblqr1/package.nix
+++ b/pkgs/by-name/li/liblqr1/package.nix
@@ -23,7 +23,9 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   # Fix build with gcc15
-  env.NIX_CFLAGS_COMPILE = "-std=gnu17";
+  env = lib.optionalAttrs stdenv.cc.isGNU {
+    NIX_CFLAGS_COMPILE = "-std=gnu17";
+  };
 
   nativeBuildInputs = [ pkg-config ];
   propagatedBuildInputs = [ glib ];


### PR DESCRIPTION
- change `env.NIX_CFLAGS_COMPILE = "-std=gnu17"` to only apply to gcc

Fixes build failure with clangStdenv and darwin:
```
checking how to run the C++ preprocessor... /lib/cpp
configure: error: in `/build/source':
configure: error: C++ preprocessor "/lib/cpp" fails sanity check
See `config.log' for more details
...
configure:4591: clang++ -c   conftest.cpp >&5
error: invalid argument '-std=gnu17' not allowed with 'C++'
```

---

Broken by gcc15 fix in: #446163

Builds from `staging-next` hydra:
https://hydra.nixos.org/build/316607523
https://hydra.nixos.org/build/316607520

Tested build with:
```bash
nix-build --expr 'with import ./. {}; liblqr1.override { stdenv = clangStdenv; }'
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
