### PR TITLE
python3Packages.setuptools-rust: fix python version inconsistency

### DIFF
--- a/pkgs/development/interpreters/python/passthrufun.nix
+++ b/pkgs/development/interpreters/python/passthrufun.nix
@@ -141,7 +141,13 @@ rec {
   pythonAtLeast = lib.versionAtLeast pythonVersion;
   pythonOlder = lib.versionOlder pythonVersion;
   inherit hasDistutilsCxxPatch;
-  inherit pythonOnBuildForHost;
+  inherit
+    pythonOnBuildForBuild
+    pythonOnBuildForHost
+    pythonOnBuildForTarget
+    pythonOnHostForHost
+    pythonOnTargetForTarget
+    ;
   inherit pythonABITags;
 
   tests = callPackage ./tests.nix {

--- a/pkgs/development/python-modules/setuptools-rust/default.nix
+++ b/pkgs/development/python-modules/setuptools-rust/default.nix
@@ -13,6 +13,7 @@
   setuptools-rust,
   setuptools-scm,
   replaceVars,
+  python,
   targetPackages,
 }:
 buildPythonPackage rec {
@@ -44,20 +45,12 @@ buildPythonPackage rec {
 
   # integrate the setup hook to set up the build environment for cross compilation
   # this hook is automatically propagated to consumers using setuptools-rust as build-system
-  #
-  # Only include the setup hook if targetPackages.python3 is defined.
-  # targetPackages.python3 is not always available, for example when including
-  # setuptools-rust via buildInputs instead of nativeBuildInputs or building it directly.
-  setupHook =
-    if !(targetPackages ? python3) then
-      null
-    else
-      replaceVars ./setuptools-rust-hook.sh {
-        pyLibDir = "${targetPackages.python3}/lib/${targetPackages.python3.libPrefix}";
-        cargoBuildTarget = stdenv.targetPlatform.rust.rustcTargetSpec;
-        cargoLinkerVar = stdenv.targetPlatform.rust.cargoEnvVarTarget;
-        targetLinker = "${targetPackages.stdenv.cc}/bin/${targetPackages.stdenv.cc.targetPrefix}cc";
-      };
+  setupHook = replaceVars ./setuptools-rust-hook.sh {
+    pyLibDir = "${python.pythonOnTargetForTarget}/lib/${python.pythonOnTargetForTarget.libPrefix}";
+    cargoBuildTarget = stdenv.targetPlatform.rust.rustcTargetSpec;
+    cargoLinkerVar = stdenv.targetPlatform.rust.cargoEnvVarTarget;
+    targetLinker = "${targetPackages.stdenv.cc}/bin/${targetPackages.stdenv.cc.targetPrefix}cc";
+  };
 
   passthru.tests = {
     pyo3 = maturin.tests.pyo3.override {


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/pull/467817#discussion_r2639897654

> The default version of python is incorrectly introduced here, instead of the correct one corresponding to `python3Packages`.
> This is causing `python312Packages.bcrypt` to fail in staging-next, and potentially other packages, because pyo3 tries to use a higher version than current system, resulting in incompatible symbols.

staging-next: #471587

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
