### PR TITLE
ocamlPackages.{synchronizer,smtml},owi: update

### DIFF
--- a/pkgs/by-name/ow/owi/package.nix
+++ b/pkgs/by-name/ow/owi/package.nix
@@ -11,18 +11,18 @@
 }:
 
 let
-  ocamlPackages = ocaml-ng.ocamlPackages_5_2;
+  ocamlPackages = ocaml-ng.ocamlPackages_5_3;
 in
 ocamlPackages.buildDunePackage {
   pname = "owi";
-  version = "0.2-unstable-2025-12-13";
+  version = "0.2-unstable-2025-12-22";
 
   src = fetchFromGitHub {
     owner = "ocamlpro";
     repo = "owi";
-    rev = "0ce0a3136bfeaca01bbf9c596d79c093282cff3f";
+    rev = "014840cd9d87c912577822b171407bf7453373f0";
     fetchSubmodules = true;
-    hash = "sha256-2WrUbrwi3dSXf/eEdZCK1SnYzo52aJeTfqtN65bjW60=";
+    hash = "sha256-Mjd2XyPmAsonCcV98L8p9S0yYlJV8OEg2TPjZhzVBj8=";
   };
 
   nativeBuildInputs = with ocamlPackages; [
@@ -42,15 +42,11 @@ ocamlPackages.buildDunePackage {
     bos
     cmdliner
     digestif
-    dolmen_type
     dune-build-info
     dune-site
-    hc
-    integers
     menhirLib
     ocaml_intrinsics
     ocamlgraph
-    patricia-tree
     prelude
     processor
     scfg
@@ -61,7 +57,6 @@ ocamlPackages.buildDunePackage {
     xmlm
     yojson
     z3
-    zarith
   ];
 
   postInstall = ''
@@ -88,7 +83,10 @@ ocamlPackages.buildDunePackage {
     homepage = "https://ocamlpro.github.io/owi/";
     downloadPage = "https://github.com/OCamlPro/owi";
     license = lib.licenses.agpl3Plus;
-    maintainers = [ lib.maintainers.ethancedwards8 ];
+    maintainers = with lib.maintainers; [
+      ethancedwards8
+      redianthus
+    ];
     teams = with lib.teams; [ ngi ];
     mainProgram = "owi";
     badPlatforms = lib.platforms.darwin;

--- a/pkgs/development/ocaml-modules/smtml/default.nix
+++ b/pkgs/development/ocaml-modules/smtml/default.nix
@@ -16,7 +16,6 @@
   mtime,
   # fix eval on legacy ocaml versions
   ocaml_intrinsics ? null,
-  patricia-tree,
   prelude,
   scfg,
   yojson,
@@ -28,13 +27,13 @@
 
 buildDunePackage (finalAttrs: {
   pname = "smtml";
-  version = "0.15.0";
+  version = "0.17.0";
 
   src = fetchFromGitHub {
     owner = "formalsec";
     repo = "smtml";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-z3DDdzU39tg2F3+pAFPILiKY3pQxOpehdoxwckyhZBI=";
+    hash = "sha256-IFjaZcwBiM/xA39W+FuJ87OSEvAhvhEsZ1cF2KrxrhY=";
   };
 
   nativeBuildInputs = [
@@ -52,7 +51,6 @@ buildDunePackage (finalAttrs: {
     menhirLib
     mtime
     ocaml_intrinsics
-    patricia-tree
     prelude
     scfg
     yojson
@@ -82,6 +80,9 @@ buildDunePackage (finalAttrs: {
     downloadPage = "https://github.com/formalsec/smtml";
     changelog = "https://github.com/formalsec/smtml/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
-    maintainers = [ lib.maintainers.ethancedwards8 ];
+    maintainers = with lib.maintainers; [
+      ethancedwards8
+      redianthus
+    ];
   };
 })

--- a/pkgs/development/ocaml-modules/synchronizer/default.nix
+++ b/pkgs/development/ocaml-modules/synchronizer/default.nix
@@ -3,30 +3,35 @@
   fetchFromGitHub,
   buildDunePackage,
   prelude,
+  alcotest,
 }:
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "synchronizer";
-  version = "0.1";
+  version = "0.2";
 
   minimalOCamlVersion = "5.1";
 
   src = fetchFromGitHub {
     owner = "OCamlPro";
     repo = "synchronizer";
-    tag = version;
-    hash = "sha256-VlKqORXTXafT88GXHIYkz+A1VkEL3jP9SMqDdMyEdrw=";
+    tag = "${finalAttrs.version}";
+    hash = "sha256-0XtPHpDlyH1h8W2ZlRvJbZjCN9WP5mzk2N01WFd8eLQ=";
   };
 
   propagatedBuildInputs = [
     prelude
   ];
 
+  checkInputs = [
+    alcotest
+  ];
+
   meta = {
     homepage = "https://github.com/OCamlPro/synchronizer";
     description = "Synchronizer to make datastructures thread-safe";
-    changelog = "https://raw.githubusercontent.com/OCamlPro/synchronizer/${src.rev}/CHANGES.md";
+    changelog = "https://raw.githubusercontent.com/OCamlPro/synchronizer/${finalAttrs.src.rev}/CHANGES.md";
     license = lib.licenses.agpl3Plus;
     maintainers = with lib.maintainers; [ redianthus ];
   };
-}
+})


### PR DESCRIPTION
Latest Owi version relies on changes in both synchronizer and smtml, I updated the three of them.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
