### PR TITLE
onlyoffice-documentserver: build from source instead of relying on .deb

### DIFF
--- a/pkgs/by-name/x2/x2t/package.nix
+++ b/pkgs/by-name/x2/x2t/package.nix
@@ -8,12 +8,14 @@
   glibc,
   harfbuzz,
   libheif,
+  nixosTests,
   x265,
   libde265,
   icu,
   jdk,
   lib,
-  nodejs,
+  # workaround https://github.com/NixOS/nixpkgs/issues/477805
+  nodejs_22,
   # needs to be static and built with MD2 support!
   openssl,
   pkg-config,
@@ -27,7 +29,7 @@
 
 let
   qmake = qt5.qmake;
-  libv8 = nodejs.libv8;
+  libv8 = nodejs_22.libv8;
   fixIcu = writeScript "fix-icu.sh" ''
     substituteInPlace \
       $BUILDRT/Common/3dParty/icu/icu.pri \
@@ -42,19 +44,19 @@ let
     "QMAKE_LFLAGS+=-licudata"
     "QMAKE_LFLAGS+=-L${icu}/lib"
   ];
-  # see core/Common/3dParty/html/fetch.sh
-  katana-parser-src = fetchFromGitHub {
-    owner = "jasenhuang";
-    repo = "katana-parser";
-    rev = "be6df458d4540eee375c513958dcb862a391cdd1";
-    hash = "sha256-SYJFLtrg8raGyr3zQIEzZDjHDmMmt+K0po3viipZW5c=";
-  };
   # see core/Common/3dParty/html/fetch.py
   gumbo-parser-src = fetchFromGitHub {
     owner = "google";
     repo = "gumbo-parser";
     rev = "aa91b27b02c0c80c482e24348a457ed7c3c088e0";
     hash = "sha256-+607iXJxeWKoCwb490pp3mqRZ1fWzxec0tJOEFeHoCs=";
+  };
+  # see core/Common/3dParty/html/fetch.sh
+  katana-parser-src = fetchFromGitHub {
+    owner = "jasenhuang";
+    repo = "katana-parser";
+    rev = "be6df458d4540eee375c513958dcb862a391cdd1";
+    hash = "sha256-SYJFLtrg8raGyr3zQIEzZDjHDmMmt+K0po3viipZW5c=";
   };
   # see build_tools scripts/core_common/modules/googletest.py
   googletest-src = fetchFromGitHub {
@@ -117,17 +119,20 @@ let
   qmakeFlags = [ ];
   dontStrip = false;
 
-  # Revisions that correspond to onlyoffice-documentserver 9.1.0
-  core-rev = "82e281cf6bf89498e4de6018423b36576706c2b6";
+  # Revisions that correspond to onlyoffice-documentserver 9.2.1
+  core-rev = "a22f0bfb6032e91f218951ef1c0fc29f6d1ceb36";
   core = fetchFromGitHub {
     owner = "ONLYOFFICE";
     repo = "core";
     # rev that the 'core' submodule in documentserver points at
     rev = core-rev;
-    hash = "sha256-LzbO2A29WxM0XTAO2LGTtg9omL0Pvoh+6+q3ux4i7do=";
+    hash = "sha256-RSoCRcUGnavcNdZEfmBdtxJbEXhiOvbA8IwSeGBkWcs=";
   };
   web-apps = buildNpmPackage (finalAttrs: {
     name = "onlyoffice-core-webapps";
+
+    # workaround for https://github.com/NixOS/nixpkgs/issues/477803
+    nodejs = nodejs_22;
 
     #src = /home/aengelen/d/onlyoffice/documentserver/web-apps;
     #sourceRoot = "/build/web-apps/build";
@@ -135,8 +140,8 @@ let
       owner = "ONLYOFFICE";
       repo = "web-apps";
       # rev that the 'web-apps' submodule in documentserver points at
-      rev = "f63e9674a5d2d2e5a660ab726ec00a359fc3c750";
-      hash = "sha256-kKm6+phd6a7kP/kv6/v/FFgh96Kbs6h6jIjpFtRJgps=";
+      rev = "c2074bbff69902490d49fa7fb511801a11c581f4";
+      hash = "sha256-i+m8a1b8RaVmyUAC+FiEdSyXmPWse9XaJaaLL7iq73o=";
     };
     sourceRoot = "${finalAttrs.src.name}/build";
 
@@ -175,8 +180,8 @@ let
       owner = "ONLYOFFICE";
       repo = "sdkjs";
       # rev that the 'sdkjs' submodule in documentserver points at
-      rev = "d169f841a7e9e46368c36236dd5820e3e10d4a98";
-      hash = "sha256-GQwzz3P49sWjCxh41zyuUs5MyMjBQXaMKzxUUTHq0UE=";
+      rev = "1e81e7e844fcc602c639067cce7d7726749dc11b";
+      hash = "sha256-9vDGU8paLUAk3GtLbawhog2EDtCVHzNPBjkryxyg6Gs=";
     };
     sourceRoot = "${finalAttrs.src.name}/build";
 
@@ -738,7 +743,7 @@ buildCoreComponent "X2tConverter/build/Qt" {
   pname = "x2t";
   # x2t is not 'directly' versioned, so we version it after the version
   # of documentserver it's pulled into as a submodule
-  version = "9.1.0";
+  version = "9.2.1";
 
   buildInputs = [
     unicodeConverter
@@ -814,6 +819,7 @@ buildCoreComponent "X2tConverter/build/Qt" {
     x2t = runCommand "x2t-test" { } ''
       (${x2t}/bin/x2t || true) | grep "OOX/binary file converter." && mkdir -p $out
     '';
+    nixos-module = nixosTests.onlyoffice;
   };
   passthru.components = {
     inherit


### PR DESCRIPTION
This packages onlyoffice-documentserver from sources instead of relying on the binary deb's.

The setup of the module is fairly complicated. I some of the complication comes from the fact that we tried to also support loading 'system' fonts beyond the ones packaged with documentserver, without needing to rebuild the package - sadly, AFAICT this is not currently working even on the main branch.

This PR keeps most of the original structure intact. We can do further cleanups/restructures and adding support for loading additional fonts for next steps.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
