### PR TITLE
nixos/scion: remove activation script

### DIFF
--- a/nixos/modules/services/networking/scion/scion-dispatcher.nix
+++ b/nixos/modules/services/networking/scion/scion-dispatcher.nix
@@ -54,9 +54,16 @@ in
     # scion programs hardcode path to dispatcher in /run/shm, and is not
     # configurable at runtime upstream plans to obsolete the dispatcher in
     # favor of an SCMP daemon, at which point this can be removed.
-    system.activationScripts.scion-dispatcher = ''
-      ln -sf /dev/shm /run/shm
-    '';
+    systemd.services.scion-dispatcher-prepare = {
+      serviceConfig = {
+        Type = "oneshot";
+      };
+      script = ''
+        ln -sf /dev/shm /run/shm
+      '';
+      wantedBy = [ config.systemd.services.scion-dispatcher.name ];
+      before = [ config.systemd.services.scion-dispatcher.name ];
+    };
 
     systemd.services.scion-dispatcher = {
       description = "SCION Dispatcher";

--- a/nixos/tests/scion/freestanding-deployment/default.nix
+++ b/nixos/tests/scion/freestanding-deployment/default.nix
@@ -138,6 +138,7 @@ in
         exit 1
       '';
     in
+    # python
     ''
       # List of AS instances
       machines = [scion01, scion02, scion03, scion04, scion05]
@@ -168,6 +169,10 @@ in
 
       # Wait for scion-control.service on all instances
       wait_for_unit("scion-control.service")
+
+      wait_for_unit("scion-dispatcher.service")
+      succeed("test -L /run/shm")
+      succeed('test "$(readlink --no-newline /run/shm)" = /dev/shm')
 
       # Ensure cert is valid against TRC
       succeed("scion-pki certificate verify --trc /etc/scion/certs/*.trc /etc/scion/crypto/as/*.pem >&2")


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

See https://github.com/NixOS/nixpkgs/issues/475305

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
