### PR TITLE
perplexity-mcp: init at 0-unstable-2025-12-19

### DIFF
--- a/pkgs/by-name/pe/perplexity-mcp/package.nix
+++ b/pkgs/by-name/pe/perplexity-mcp/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "perplexity-mcp";
+  version = "0-unstable-2025-12-19";
+
+  src = fetchFromGitHub {
+    owner = "perplexityai";
+    repo = "modelcontextprotocol";
+    rev = "29dddc491b5853d8be66aac9e0ffdce105aa7f07";
+    hash = "sha256-GBA4NPGf6fbj8DJ6Cke4DD03jMe3Ts6uGu2PoLhOaUg=";
+  };
+
+  npmDepsHash = "sha256-aAIH/z/5BSbLYmAc7ZyPEIoblLdHlncp8uFGFDebots=";
+
+  passthru = {
+    updateScript = nix-update-script {
+      extraArgs = [
+        "--version=branch"
+      ];
+    };
+  };
+
+  meta = {
+    description = "The official MCP server implementation for the Perplexity API Platform";
+    homepage = "https://github.com/perplexityai/modelcontextprotocol";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ malik ];
+    mainProgram = "perplexity-mcp";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
## About
The official MCP server implementation for the Perplexity API Platform. (https://github.com/perplexityai/modelcontextprotocol)
I already am using it successfully in my configuration of [crush](https://github.com/charmbracelet/crush).
```nix
programs.crush.settings.mcp = {
  perplexity = {
    type = "stdio";
    command = "${pkgs.perplexity-mcp}/bin/perplexity-mcp";
    args = [ ];
    env = {
      PERPLEXITY_API_KEY = "$(cat ${config.sops.secrets.perplexity-api-key.path})";
    };
    disabled = false;
  };
};
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
