### PR TITLE
gdb: rename host to target

### DIFF
--- a/pkgs/by-name/gd/gdb/package.nix
+++ b/pkgs/by-name/gd/gdb/package.nix
@@ -212,7 +212,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "GNU Project debugger";
-    mainProgram = "gdb";
+    mainProgram = targetPrefix + "gdb";
     longDescription = ''
       GDB, the GNU Project debugger, allows you to see what is going
       on `inside' another program while it executes -- or what another

--- a/pkgs/by-name/gd/gdb/package.nix
+++ b/pkgs/by-name/gd/gdb/package.nix
@@ -35,7 +35,7 @@
   python3,
   enableDebuginfod ? lib.meta.availableOn stdenv.hostPlatform elfutils,
   elfutils,
-  hostCpuOnly ? false,
+  targetCpuOnly ? false,
   enableSim ? false,
   enableUbsan ? false,
   safePaths ? [
@@ -60,7 +60,7 @@ let
   targetPrefix = optionalString (
     stdenv.targetPlatform != stdenv.hostPlatform
   ) "${stdenv.targetPlatform.config}-";
-  pname = targetPrefix + "gdb" + optionalString hostCpuOnly "-host-cpu-only";
+  pname = targetPrefix + "gdb" + optionalString targetCpuOnly "-target-cpu-only";
 in
 
 stdenv.mkDerivation (finalAttrs: {
@@ -87,9 +87,7 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     ./debug-info-from-env.patch
   ]
-  ++ optionals stdenv.hostPlatform.isDarwin [
-    ./darwin-target-match.patch
-  ];
+  ++ optionals stdenv.hostPlatform.isDarwin [ ./darwin-target-match.patch ];
 
   nativeBuildInputs = [
     pkg-config
@@ -185,7 +183,7 @@ stdenv.mkDerivation (finalAttrs: {
       !stdenv.hostPlatform.isStatic && !stdenv.hostPlatform.isLoongArch64
     ) "inprocess-agent")
   ]
-  ++ optional (!hostCpuOnly) "--enable-targets=all"
+  ++ optional (!targetCpuOnly) "--enable-targets=all"
   # Workaround for Apple Silicon, "--target" must be "faked", see eg: https://github.com/Homebrew/homebrew-core/pull/209753
   ++ optional (
     stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64

--- a/pkgs/kde/plasma/drkonqi/default.nix
+++ b/pkgs/kde/plasma/drkonqi/default.nix
@@ -9,7 +9,7 @@
 }:
 let
   gdb' = gdb.override {
-    hostCpuOnly = true;
+    targetCpuOnly = true;
     python3 = python3.withPackages (ps: [
       ps.psutil
       ps.pygdbmi

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -798,6 +798,7 @@ mapAliases {
   gcc12 = throw "gcc12 has been removed from Nixpkgs, as it is unmaintained and obsolete"; # Added 2025-08-08
   gcc12Stdenv = throw "gcc12Stdenv has been removed from Nixpkgs, as it is unmaintained and obsolete"; # Added 2025-08-08
   gccgo12 = throw "gccgo12 has been removed from Nixpkgs, as it is unmaintained and obsolete"; # Added 2025-08-08
+  gdbHostCpuOnly = warnAlias "'gdbHostCpuOnly' has been renamed to/replaced by 'gdbTargetCpuOnly'" gdbTargetCpuOnly; # Added 2026-04-04
   gdc11 = throw "gdc11 has been removed from Nixpkgs, as it is unmaintained and obsolete"; # Added 2025-08-08
   gdc = throw "gdc has been removed from Nixpkgs, as recent versions require complex bootstrapping"; # Added 2025-08-08
   gdmd = throw "gdmd has been removed from Nixpkgs, as it depends on GDC which was removed"; # Added 2025-08-08

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6103,7 +6103,7 @@ with pkgs;
     enablePythonApi = false;
   };
 
-  gdbHostCpuOnly = gdb.override { hostCpuOnly = true; };
+  gdbTargetCpuOnly = gdb.override { targetCpuOnly = true; };
 
   valgrind-light = (valgrind.override { gdb = null; }).overrideAttrs (oldAttrs: {
     meta = oldAttrs.meta // {


### PR DESCRIPTION
Cross-compiled GDB with `hostCpuOnly` set to true can debug the target architecture, not the host architecture. For example, on my machine, `pkgsCross.arm-embedded.buildPackages.gdbHostCpuOnly` is compiled with `--host=x86_64-unknown-linux-gnu --target=arm-none-eabi`, and is meant to debug ARM, even if its name would make you think it's for x86-64.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
  - [x] Most probably.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
