### PR TITLE
python313Packages.celery: skip tests that check group

### DIFF
--- a/pkgs/development/python-modules/celery/default.nix
+++ b/pkgs/development/python-modules/celery/default.nix
@@ -123,6 +123,13 @@ buildPythonPackage rec {
     "test_stamping_headers_in_options"
     "test_stamping_with_replace"
 
+    # Celery tries to look up group ID (e.g. 30000)
+    # which does not reliably succeed in the sandbox on linux,
+    # so it throws a security error as if we were running as root.
+    # https://github.com/celery/celery/blob/0527296acb1f1790788301d4395ba6d5ce2a9704/celery/platforms.py#L807-L814
+    "test_regression_worker_startup_info"
+    "test_check_privileges"
+
     # Flaky: Unclosed temporary file handle under heavy load (as in nixpkgs-review)
     "test_check_privileges_without_c_force_root_and_no_group_entry"
   ]


### PR DESCRIPTION
Fixes builds on NixOS 25.11/unstable on aarch64-linux and x86_64-linux. Resolves #471417.

Celery attempts to prevent running as root when the pickle format is enabled, as pickles allow arbitrary code execution on load. If it cannot get information about the current user or group, it assumes that it is running as root. This is expected behavior.

https://github.com/celery/celery/blame/0527296acb1f1790788301d4395ba6d5ce2a9704/celery/platforms.py#L807-L814

On some machines, it cannot obtain this information in the build sandbox, and the build fails. The two latest 25.11 tags fail to build on two of my machines (25.11.20250627.30e2e28 aarch64-linux and 25.11.20250627.30e2e28 x86_64-linux) as well as my CI:

```
nix build nixpkgs/c8cfcd6#python313Packages.celery --rebuild
nix build nixpkgs/c6f52eb#python313Packages.celery --rebuild
```

A reasonable alternative would be to set C_FORCE_ROOT in the check environment. I choose to instead disable the failing tests based on precedent (previous tests that fail similarly are disabled) and to avoid complications if a test depends on the absence of C_FORCE_ROOT now or in the future.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

@fabaff

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
