### PR TITLE
xfce.*: Move away from mkXfceDerivation (part 3)

### DIFF
--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -9,6 +9,11 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
+- `xfce.mkXfceDerivation` has been deprecated, please use `stdenv.mkDerivation`
+  directly. You can migrate by adding `pkg-config`, `xfce4-dev-tools`, and
+  `wrapGAppsHook3` to your `nativeBuildInputs` and `--enable-maintainer-mode`
+  to your `configureFlags`.
+
 - `corepack_latest` has been removed, as Corepack is no longer distributed with Node.js.
 
 - `spoof` has been removed, as there are many issues upstream with it working on modern OS versions, and it appears to be unmaintained.

--- a/pkgs/desktops/xfce/core/xfce4-power-manager/default.nix
+++ b/pkgs/desktops/xfce/core/xfce4-power-manager/default.nix
@@ -1,7 +1,12 @@
 {
+  stdenv,
   lib,
-  mkXfceDerivation,
+  fetchFromGitLab,
+  gettext,
+  pkg-config,
   wayland-scanner,
+  xfce4-dev-tools,
+  wrapGAppsHook3,
   gtk3,
   libnotify,
   libxfce4ui,
@@ -12,17 +17,27 @@
   wlr-protocols,
   xfconf,
   xfce4-panel,
+  gitUpdater,
 }:
 
-mkXfceDerivation {
-  category = "xfce";
+stdenv.mkDerivation (finalAttrs: {
   pname = "xfce4-power-manager";
   version = "4.20.0";
 
-  sha256 = "sha256-qKUdrr+giLzNemhT3EQsOKTSiIx50NakmK14Ak7ZOCE=";
+  src = fetchFromGitLab {
+    domain = "gitlab.xfce.org";
+    owner = "xfce";
+    repo = "xfce4-power-manager";
+    tag = "xfce4-power-manager-${finalAttrs.version}";
+    hash = "sha256-qKUdrr+giLzNemhT3EQsOKTSiIx50NakmK14Ak7ZOCE=";
+  };
 
   nativeBuildInputs = [
+    gettext
+    pkg-config
     wayland-scanner
+    xfce4-dev-tools
+    wrapGAppsHook3
   ];
 
   buildInputs = [
@@ -46,8 +61,20 @@ mkXfceDerivation {
     substituteInPlace src/xfpm-suspend.c --replace-fail "SBINDIR" "\"/run/current-system/sw/bin\""
   '';
 
+  configureFlags = [ "--enable-maintainer-mode" ];
+  enableParallelBuilding = true;
+
+  passthru.updateScript = gitUpdater {
+    rev-prefix = "xfce4-power-manager-";
+    odd-unstable = true;
+  };
+
   meta = {
     description = "Power manager for the Xfce Desktop Environment";
+    homepage = "https://gitlab.xfce.org/xfce/xfce4-power-manager";
+    license = lib.licenses.gpl2Plus;
+    mainProgram = "xfce4-power-manager";
+    platforms = lib.platforms.linux;
     teams = [ lib.teams.xfce ];
   };
-}
+})

--- a/pkgs/desktops/xfce/core/xfce4-session/default.nix
+++ b/pkgs/desktops/xfce/core/xfce4-session/default.nix
@@ -1,6 +1,11 @@
 {
+  stdenv,
   lib,
-  mkXfceDerivation,
+  fetchFromGitLab,
+  gettext,
+  pkg-config,
+  xfce4-dev-tools,
+  wrapGAppsHook3,
   polkit,
   exo,
   libxfce4util,
@@ -12,15 +17,27 @@
   gtk-layer-shell,
   glib,
   libwnck,
-  xfce4-session,
+  gitUpdater,
 }:
 
-mkXfceDerivation {
-  category = "xfce";
+stdenv.mkDerivation (finalAttrs: {
   pname = "xfce4-session";
   version = "4.20.3";
 
-  sha256 = "sha256-HfVspmAkjuGgoI87VHNHFGZP17ZA0b31llY93gUtWxs=";
+  src = fetchFromGitLab {
+    domain = "gitlab.xfce.org";
+    owner = "xfce";
+    repo = "xfce4-session";
+    tag = "xfce4-session-${finalAttrs.version}";
+    hash = "sha256-HfVspmAkjuGgoI87VHNHFGZP17ZA0b31llY93gUtWxs=";
+  };
+
+  nativeBuildInputs = [
+    gettext
+    pkg-config
+    xfce4-dev-tools
+    wrapGAppsHook3
+  ];
 
   buildInputs = [
     exo
@@ -37,14 +54,27 @@ mkXfceDerivation {
   ];
 
   configureFlags = [
+    "--enable-maintainer-mode"
     "--with-xsession-prefix=${placeholder "out"}"
     "--with-wayland-session-prefix=${placeholder "out"}"
   ];
 
-  passthru.xinitrc = "${xfce4-session}/etc/xdg/xfce4/xinitrc";
+  enableParallelBuilding = true;
+
+  passthru = {
+    xinitrc = "${finalAttrs.finalPackage}/etc/xdg/xfce4/xinitrc";
+    updateScript = gitUpdater {
+      rev-prefix = "xfce4-session-";
+      odd-unstable = true;
+    };
+  };
 
   meta = {
     description = "Session manager for Xfce";
+    homepage = "https://gitlab.xfce.org/xfce/xfce4-session";
+    license = lib.licenses.gpl2Plus;
+    mainProgram = "xfce4-session";
+    platforms = lib.platforms.linux;
     teams = [ lib.teams.xfce ];
   };
-}
+})

--- a/pkgs/desktops/xfce/core/xfconf/default.nix
+++ b/pkgs/desktops/xfce/core/xfconf/default.nix
@@ -1,27 +1,46 @@
 {
   stdenv,
   lib,
-  mkXfceDerivation,
+  fetchFromGitLab,
+  gettext,
   gobject-introspection,
   perl,
+  pkg-config,
   vala,
+  xfce4-dev-tools,
+  wrapGAppsNoGuiHook,
   libxfce4util,
   glib,
   withIntrospection ?
     lib.meta.availableOn stdenv.hostPlatform gobject-introspection
     && stdenv.hostPlatform.emulatorAvailable buildPackages,
   buildPackages,
+  gitUpdater,
 }:
 
-mkXfceDerivation {
-  category = "xfce";
+stdenv.mkDerivation (finalAttrs: {
   pname = "xfconf";
   version = "4.20.0";
 
-  sha256 = "sha256-U+Sk7ubBr1ZD1GLQXlxrx0NQdhV/WpVBbnLcc94Tjcw=";
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  src = fetchFromGitLab {
+    domain = "gitlab.xfce.org";
+    owner = "xfce";
+    repo = "xfconf";
+    tag = "xfconf-${finalAttrs.version}";
+    hash = "sha256-U+Sk7ubBr1ZD1GLQXlxrx0NQdhV/WpVBbnLcc94Tjcw=";
+  };
 
   nativeBuildInputs = [
+    gettext
     perl
+    pkg-config
+    xfce4-dev-tools
+    wrapGAppsNoGuiHook
   ]
   ++ lib.optionals withIntrospection [
     gobject-introspection
@@ -32,9 +51,20 @@ mkXfceDerivation {
 
   propagatedBuildInputs = [ glib ];
 
+  configureFlags = [ "--enable-maintainer-mode" ];
+  enableParallelBuilding = true;
+
+  passthru.updateScript = gitUpdater {
+    rev-prefix = "xfconf-";
+    odd-unstable = true;
+  };
+
   meta = {
     description = "Simple client-server configuration storage and query system for Xfce";
+    homepage = "https://gitlab.xfce.org/xfce/xfconf";
     mainProgram = "xfconf-query";
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.linux;
     teams = [ lib.teams.xfce ];
   };
-}
+})

--- a/pkgs/desktops/xfce/core/xfdesktop/default.nix
+++ b/pkgs/desktops/xfce/core/xfdesktop/default.nix
@@ -1,6 +1,11 @@
 {
+  stdenv,
   lib,
-  mkXfceDerivation,
+  fetchFromGitLab,
+  gettext,
+  pkg-config,
+  xfce4-dev-tools,
+  wrapGAppsHook3,
   exo,
   gtk3,
   libxfce4ui,
@@ -12,14 +17,27 @@
   garcon,
   gtk-layer-shell,
   thunar,
+  gitUpdater,
 }:
 
-mkXfceDerivation {
-  category = "xfce";
+stdenv.mkDerivation (finalAttrs: {
   pname = "xfdesktop";
   version = "4.20.1";
 
-  sha256 = "sha256-QBzsHXEdTGj8PlgB+L/TJjxAVksKqf+9KrRN3YaBf44=";
+  src = fetchFromGitLab {
+    domain = "gitlab.xfce.org";
+    owner = "xfce";
+    repo = "xfdesktop";
+    tag = "xfdesktop-${finalAttrs.version}";
+    hash = "sha256-QBzsHXEdTGj8PlgB+L/TJjxAVksKqf+9KrRN3YaBf44=";
+  };
+
+  nativeBuildInputs = [
+    gettext
+    pkg-config
+    xfce4-dev-tools
+    wrapGAppsHook3
+  ];
 
   buildInputs = [
     exo
@@ -35,8 +53,20 @@ mkXfceDerivation {
     thunar
   ];
 
+  configureFlags = [ "--enable-maintainer-mode" ];
+  enableParallelBuilding = true;
+
+  passthru.updateScript = gitUpdater {
+    rev-prefix = "xfdesktop-";
+    odd-unstable = true;
+  };
+
   meta = {
     description = "Xfce's desktop manager";
+    homepage = "https://gitlab.xfce.org/xfce/xfdesktop";
+    mainProgram = "xfdesktop";
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.linux;
     teams = [ lib.teams.xfce ];
   };
-}
+})

--- a/pkgs/desktops/xfce/core/xfwm4/default.nix
+++ b/pkgs/desktops/xfce/core/xfwm4/default.nix
@@ -1,8 +1,12 @@
 {
+  stdenv,
   lib,
-  mkXfceDerivation,
-  exo,
+  fetchFromGitLab,
+  gettext,
   librsvg,
+  pkg-config,
+  xfce4-dev-tools,
+  wrapGAppsHook3,
   dbus-glib,
   libepoxy,
   gtk3,
@@ -13,18 +17,27 @@
   libwnck,
   libXpresent,
   xfconf,
+  gitUpdater,
 }:
 
-mkXfceDerivation {
-  category = "xfce";
+stdenv.mkDerivation (finalAttrs: {
   pname = "xfwm4";
   version = "4.20.0";
 
-  sha256 = "sha256-5UZQrAH0oz+G+7cvXCLDJ4GSXNJcyl4Ap9umb7h0f5Q=";
+  src = fetchFromGitLab {
+    domain = "gitlab.xfce.org";
+    owner = "xfce";
+    repo = "xfwm4";
+    tag = "xfwm4-${finalAttrs.version}";
+    hash = "sha256-5UZQrAH0oz+G+7cvXCLDJ4GSXNJcyl4Ap9umb7h0f5Q=";
+  };
 
   nativeBuildInputs = [
-    exo
-    librsvg
+    gettext
+    librsvg # rsvg-convert
+    pkg-config
+    xfce4-dev-tools
+    wrapGAppsHook3
   ];
 
   buildInputs = [
@@ -40,8 +53,20 @@ mkXfceDerivation {
     xfconf
   ];
 
+  configureFlags = [ "--enable-maintainer-mode" ];
+  enableParallelBuilding = true;
+
+  passthru.updateScript = gitUpdater {
+    rev-prefix = "xfwm4-";
+    odd-unstable = true;
+  };
+
   meta = {
     description = "Window manager for Xfce";
+    homepage = "https://gitlab.xfce.org/xfce/xfwm4";
+    mainProgram = "xfwm4";
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.linux;
     teams = [ lib.teams.xfce ];
   };
-}
+})

--- a/pkgs/desktops/xfce/default.nix
+++ b/pkgs/desktops/xfce/default.nix
@@ -19,8 +19,6 @@ makeScopeWithSplicing' {
 
       genericUpdater = pkgs.genericUpdater;
 
-      mkXfceDerivation = callPackage ./mkXfceDerivation.nix { };
-
       #### CORE
 
       exo = callPackage ./core/exo { };
@@ -168,6 +166,13 @@ makeScopeWithSplicing' {
       #### ALIASES
 
       automakeAddFlags = throw "xfce.automakeAddFlags has been removed: this setup-hook is no longer used in Nixpkgs"; # added 2024-03-24
+
+      mkXfceDerivation = lib.warnOnInstantiate ''
+        xfce.mkXfceDerivation has been deprecated, please use stdenv.mkDerivation
+        directly. You can migrate by adding `pkg-config`, `xfce4-dev-tools`, and
+        `wrapGAppsHook3` to your nativeBuildInputs and `--enable-maintainer-mode`
+        to your configureFlags.
+      '' (callPackage ./mkXfceDerivation.nix { }); # added 2025-12-22
 
       xinitrc = self.xfce4-session.xinitrc; # added 2019-11-04
 

--- a/pkgs/desktops/xfce/default.nix
+++ b/pkgs/desktops/xfce/default.nix
@@ -15,10 +15,6 @@ makeScopeWithSplicing' {
       inherit (self) callPackage;
     in
     {
-      #### NixOS support
-
-      genericUpdater = pkgs.genericUpdater;
-
       #### CORE
 
       exo = callPackage ./core/exo { };
@@ -166,6 +162,8 @@ makeScopeWithSplicing' {
       #### ALIASES
 
       automakeAddFlags = throw "xfce.automakeAddFlags has been removed: this setup-hook is no longer used in Nixpkgs"; # added 2024-03-24
+
+      genericUpdater = throw "xfce.genericUpdater has been removed: use pkgs.genericUpdater directly"; # added 2025-12-22
 
       mkXfceDerivation = lib.warnOnInstantiate ''
         xfce.mkXfceDerivation has been deprecated, please use stdenv.mkDerivation


### PR DESCRIPTION
To reduce the diff when build system change comes (Xfce 4.22). `mkXfceDerivation` is generally pointless with meson.

- https://github.com/NixOS/nixpkgs/pull/472595#issuecomment-3677467001
- https://github.com/NixOS/nixpkgs/pull/472972

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

