### PR TITLE
nixos/activation: deprecate reloading or restarting units from the activation script

### DIFF
--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -16,6 +16,8 @@
 - `kanata` now requires `karabiner-dk` version 6.0+ or later.
   The package has been updated to use the new `karabiner-dk` package and the `darwinDriver` output stays at the version defined in the package.
 
+- Reloading or restarting systemd units from the NixOS activation script is deprecated, and will be removed in NixOS 26.11. This deprecation is part of a bigger effort to deprecate activation scripts altogether, which will take place over several releases. There are no in-tree usages of the now-deprecated reload/restart functionality.
+
 - `elegant-sddm` has been updated to be Qt6 compatible. Themes for SDDM are slightly different so read the [wiki](https://wiki.nixos.org/wiki/SDDM_Themes) for more.
 
 - `iroh` has been removed and split up into `iroh-dns-server` and `iroh-relay`.

--- a/nixos/doc/manual/development/activation-script.section.md
+++ b/nixos/doc/manual/development/activation-script.section.md
@@ -34,25 +34,6 @@ is also run when `nixos-rebuild dry-activate` is run. To differentiate between
 real and dry activation, the `$NIXOS_ACTION` environment variable can be
 read which is set to `dry-activate` when a dry activation is done.
 
-An activation script can write to special files instructing
-`switch-to-configuration` to restart/reload units. The script will take these
-requests into account and will incorporate the unit configuration as described
-above. This means that the activation script will "fake" a modified unit file
-and `switch-to-configuration` will act accordingly. By doing so, configuration
-like [systemd.services.\<name\>.restartIfChanged](#opt-systemd.services) is
-respected. Since the activation script is run **after** services are already
-stopped, [systemd.services.\<name\>.stopIfChanged](#opt-systemd.services)
-cannot be taken into account anymore and the unit is always restarted instead
-of being stopped and started afterwards.
-
-The files that can be written to are `/run/nixos/activation-restart-list` and
-`/run/nixos/activation-reload-list` with their respective counterparts for
-dry activation being `/run/nixos/dry-activation-restart-list` and
-`/run/nixos/dry-activation-reload-list`. Those files can contain
-newline-separated lists of unit names where duplicates are being ignored. These
-files are not create automatically and activation scripts must take the
-possibility into account that they have to create them first.
-
 ## NixOS snippets {#sec-activation-script-nixos-snippets}
 
 There are some snippets NixOS enables by default because disabling them would
@@ -63,12 +44,8 @@ do:
 - `etc` sets up the contents of `/etc`, this includes systemd units and
   excludes `/etc/passwd`, `/etc/group`, and `/etc/shadow` (which are managed by
   the `users` snippet)
-- `hostname` sets the system's hostname in the kernel (not in `/etc`)
 - `modprobe` sets the path to the `modprobe` binary for module auto-loading
-- `nix` prepares the nix store and adds a default initial channel
 - `specialfs` is responsible for mounting filesystems like `/proc` and `sys`
 - `users` creates and removes users and groups by managing `/etc/passwd`,
   `/etc/group` and `/etc/shadow`. This also creates home directories
 - `usrbinenv` creates `/usr/bin/env`
-- `var` creates some directories in `/var` that are not service-specific
-- `wrappers` creates setuid wrappers like `sudo`

--- a/pkgs/by-name/sw/switch-to-configuration-ng/src/src/main.rs
+++ b/pkgs/by-name/sw/switch-to-configuration-ng/src/src/main.rs
@@ -1443,6 +1443,13 @@ won't take effect until you reboot the system.
             .map(|mut child| child.wait());
 
         // Handle the activation script requesting the restart or reload of a unit.
+
+        if std::fs::exists(DRY_RESTART_BY_ACTIVATION_LIST_FILE)?
+            || std::fs::exists(DRY_RELOAD_BY_ACTIVATION_LIST_FILE)?
+        {
+            eprintln!("WARN: restarting or reloading systemd units from the activation script is deprecated and will be removed in NixOS 26.11.");
+        }
+
         for unit in std::fs::read_to_string(DRY_RESTART_BY_ACTIVATION_LIST_FILE)
             .unwrap_or_default()
             .lines()
@@ -1605,6 +1612,12 @@ won't take effect until you reboot the system.
             eprintln!("Failed to run activate script");
             exit_code = 2;
         }
+    }
+
+    if std::fs::exists(RESTART_BY_ACTIVATION_LIST_FILE)?
+        || std::fs::exists(RELOAD_BY_ACTIVATION_LIST_FILE)?
+    {
+        eprintln!("WARN: restarting or reloading systemd units from the activation script is deprecated and will be removed in NixOS 26.11.");
     }
 
     // Handle the activation script requesting the restart or reload of a unit.


### PR DESCRIPTION
This deprecation is part of a bigger effort to deprecate activation scripts altogether, which will take place over several releases.
There are no in-tree usages of the now-deprecated reload/restart functionality.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
