### PR TITLE
nexusmods-app: handle Internet Archive outages and Brotli for `games.json`

### DIFF
--- a/pkgs/by-name/ne/nexusmods-app/package.nix
+++ b/pkgs/by-name/ne/nexusmods-app/package.nix
@@ -1,5 +1,6 @@
 {
   _7zz,
+  brotli,
   buildDotnetModule,
   callPackage,
   desktop-file-utils,
@@ -39,6 +40,16 @@ buildDotnetModule (finalAttrs: {
     name = "games.json";
     url = "https://web.archive.org/web/20251221212501id_/https://data.nexusmods.com/file/nexus-data/games.json";
     hash = "sha256-OVy6b/n6n2/TdzfHCWDOTw2yai87ieki21fEp1IGamY=";
+    # The Internet Archive sometimes forces brotli compression, handle this manually for hash consistency
+    nativeBuildInputs = [ brotli ];
+    downloadToTemp = true;
+    postFetch = ''
+      if brotli --test "$downloadedFile"; then
+        brotli --decompress "$downloadedFile" --output="$out"
+      else
+        mv "$downloadedFile" "$out"
+      fi
+    '';
   };
 
   enableParallelBuilding = false;

--- a/pkgs/by-name/ne/nexusmods-app/update-games-json.sh
+++ b/pkgs/by-name/ne/nexusmods-app/update-games-json.sh
@@ -34,6 +34,13 @@ cd "$dir"/../../../../
 echo "Fetching games.json Internet Archive URL" >&2
 url=$(curl "${curl_args[@]}")
 
+# If the Internet Archive is having issues, they usually redirect to /sry
+# but return status '200 OK'. Check this to avoid a bad url+hash:
+if [[ "$url" = https://web.archive.org/sry* ]]; then
+    echo "Internet Archive temporarily unavailable (redirected to /sry)" >&2
+    exit 1
+fi
+
 # Use raw replay mode to avoid rewritten links in the JSON content
 url=$(
   sed -E 's|^https://web\.archive\.org/web/([0-9]+)/|https://web.archive.org/web/\1id_/|' \


### PR DESCRIPTION
Harden the `nexusmods-app` `games.json` update script and FOD against potential Internet Archive replay issues.

After merging #473097, transient issues with the `gamesJson` fixed-output derivation were observed, including:

1. **Temporary outages** — the Internet Archive sometimes returns a `/sry` redirect or an HTML error page.
2. **Inconsistent Brotli compression** — the Internet Archive sometimes serves `games.json` Brotli-compressed, ignoring `Accept-Encoding` headers, which causes hash mismatches if not handled.

This PR adds safeguards so that:

* The update script does not pin an invalid URL or hash if a transient outage occurs *while* running.
* The derivation handles potential Brotli compression for consistent FOD content and hash.
* The update script also handles potential Brotli compression for hash consistency.

**Note:** Only the update script is hardened against outages. Builders without a cached in-store copy of `games.json` could still fail during an Internet Archive outage. This should be uncommon but may require alternative solutions if frequent.

### Changes

* Detect replay redirects (e.g., `/sry`) and exit early in the update script.
* Prefetch `games.json` into the Nix store once (`nix store prefetch-file`).
* Validate that the fetched file is valid JSON before updating the pinned URL and hash.
* Handle potential Brotli-compressed content in both the derivation (`postFetch`) and the update script, ensuring consistent hashes.

### TODO

Consider whether other Internet Archive fetchers are affected by Brotli compression, and possibly introduce a reusable `decompressBrotliHook`. cc @theCapypara


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
- Tested, as applicable:
  - [x] [Package tests] at `passthru.tests`.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
