### PR TITLE
nix-prefetch-git: fix tag fetching and restore .git hash compatibility for `postCheckout` PR

### DIFF
--- a/pkgs/build-support/fetchgit/nix-prefetch-git
+++ b/pkgs/build-support/fetchgit/nix-prefetch-git
@@ -12,7 +12,6 @@ fetchSubmodules=
 fetchLFS=
 builder=
 fetchTags=
-fetchTagsCompat=
 branchName=$NIX_PREFETCH_GIT_BRANCH_NAME
 
 # ENV params
@@ -117,13 +116,6 @@ for arg; do
     fi
 done
 
-# `deepClone` used to effectively imply `fetchTags`.
-# We avoid such behaviour to enhance the `postCheckout` reproducibility,
-# while keeping the old behaviour for `.git` for backward compatibility purposes.
-if [[ -n "$deepClone" ]] && [[ -z "$leaveDotGit" ]]; then
-    fetchTagsCompat=true
-fi
-
 if test -z "$url"; then
     usage
 fi
@@ -188,11 +180,15 @@ checkout_hash(){
         hash=$(hash_from_ref "$ref")
     fi
 
-    local -a fetchTagsArgs
-    if [[ -n "$fetchTags" ]]; then
-        fetchTagsArgs=(--tags)
-    else
+    local -a fetchTagsArgs=()
+    # Avoid fetching all tags at clone time when not leaving .git,
+    # but keep/restore the behaviour before
+    # commit 7e085677f996 ("nix-prefetch-git: dont't fetch tags when deep clone unless leaving .git")
+    # to preserve the fragile hashes of existing .git sources.
+    if [[ -z "$leaveDotGit" ]]; then
         fetchTagsArgs=(--no-tags)
+    elif [[ -n "$deepClone" ]]; then
+        fetchTagsArgs=(--tags)
     fi
     local -a fetchTargetArgs
     if [[ -n "$deepClone" ]]; then
@@ -282,7 +278,7 @@ clone(){
 
     # Fetch all tags if requested
     # The fetched tags are potentially non-reproducible, as tags are mutable parts of the Git tree.
-    if [[ -n "$fetchTags" ]] || [[ -n "$fetchTagsCompat" ]]; then
+    if [[ -n "$fetchTags" ]]; then
         echo "fetching all tags..." >&2
         clean_git fetch origin 'refs/tags/*:refs/tags/*' || echo "warning: failed to fetch some tags" >&2
     fi

--- a/pkgs/build-support/fetchgit/nix-prefetch-git
+++ b/pkgs/build-support/fetchgit/nix-prefetch-git
@@ -287,9 +287,9 @@ clone(){
         clean_git fetch origin 'refs/tags/*:refs/tags/*' || echo "warning: failed to fetch some tags" >&2
     fi
 
-    # Name "$ref" to make `git describe` work reproducibly in `NIX_PREFETCH_GIT_CHECKOUT_HOOK`.
+    # Name tag "$ref" to make `git describe` work reproducibly in `NIX_PREFETCH_GIT_CHECKOUT_HOOK`.
     # Name only when not leaving `.git` for compatibility purposes.
-    if [[ -n "$ref" ]] && [[ -z "$leaveDotGit" ]]; then
+    if [[ "$ref" =~ ^refs/tags/ ]] && [[ -z "$leaveDotGit" ]]; then
         echo "refer to FETCH_HEAD as its original name $ref"
         clean_git update-ref "$ref" FETCH_HEAD
     fi


### PR DESCRIPTION
## Description

Fixes #473332

Restores hash compatibility for PR #465497, fixing https://github.com/NixOS/nixpkgs/pull/465497#issuecomment-3687352445

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
