### PR TITLE
vscode: add hicolor icon

### DIFF
--- a/pkgs/applications/editors/vscode/generic.nix
+++ b/pkgs/applications/editors/vscode/generic.nix
@@ -57,6 +57,7 @@
   ripgrep,
   hasVsceSign ? false,
   patchVSCodePath ? true,
+  imagemagick,
 }:
 
 stdenv.mkDerivation (
@@ -249,6 +250,7 @@ stdenv.mkDerivation (
 
     nativeBuildInputs = [
       unzip
+      imagemagick
     ]
     ++ lib.optionals stdenv.hostPlatform.isLinux [
       autoPatchelfHook
@@ -289,7 +291,13 @@ stdenv.mkDerivation (
           # These are named vscode.png, vscode-insiders.png, etc to match the name in upstream *.deb packages.
           + ''
             mkdir -p "$out/share/pixmaps"
-            cp "$out/lib/${libraryName}/resources/app/resources/linux/code.png" "$out/share/pixmaps/${iconName}.png"
+            icon_file="$out/lib/${libraryName}/resources/app/resources/linux/code.png"
+            cp "$icon_file" "$out/share/pixmaps/${iconName}.png"
+
+            # Dynamically determine size of icon and place in appropriate directory
+            size=$(identify -format "%wx%h" "$icon_file")
+            mkdir -p "$out/share/icons/hicolor/$size/apps"
+            cp "$icon_file" "$out/share/icons/hicolor/$size/apps/${iconName}.png"
           ''
         )
         # Override the previously determined VSCODE_PATH with the one we know to be correct


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add icons to the `hicolor` folder as icons where missing on application launchers such as `Fuzzel`.

I left the `pixmaps` code to not affect any other app launchers that might still use that. (If you think this should be removed let me know)

https://github.com/NixOS/nixpkgs/issues/428824

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
