### PR TITLE
python314Packages.ray: fix the eval

### DIFF
--- a/pkgs/development/python-modules/ray/default.nix
+++ b/pkgs/development/python-modules/ray/default.nix
@@ -119,7 +119,9 @@ buildPythonPackage rec {
       python = pyShortVersion;
       abi = pyShortVersion;
       platform = platforms.${stdenv.hostPlatform.system} or { };
-      sha256 = hashes.${stdenv.hostPlatform.system}.${pyShortVersion} or { };
+      sha256 =
+        hashes.${stdenv.hostPlatform.system}.${pyShortVersion}
+          or (throw "No hash specified for '${stdenv.hostPlatform.system}.${pyShortVersion}'");
     };
 
   nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [


### PR DESCRIPTION
Without the change the eval fails in an obscure way by trying to evaluate set as a string:

    $ nix build -f. python314Packages.ray.src
    error:
       … while calling a functor (an attribute set with a '__functor' attribute)
         at pkgs/development/python-modules/ray/default.nix:116:5:
          115|     in
          116|     fetchPypi {
             |     ^
          117|       inherit pname version format;

       … while evaluating a branch condition
         at lib/customisation.nix:199:7:
          198|       in
          199|       if isAttrs result then
             |       ^
          200|         result

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: cannot coerce a set to a string: { }

After the change the failure is reported via catchable `throw`:

    $ nix build -f. python314Packages.ray.src
    error:
       … while calling a functor (an attribute set with a '__functor' attribute)
         at pkgs/development/python-modules/ray/default.nix:116:5:
          115|     in
          116|     fetchPypi {
             |     ^
          117|       inherit pname version format;

       … while evaluating a branch condition
         at lib/customisation.nix:199:7:
          198|       in
          199|       if isAttrs result then
             |       ^
          200|         result

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: No hash specified for 'x86_64-linux.cp314'


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
