### PR TITLE
nixos/btrfs: use blake2b instead of blake2b_generic for kernel 6.19+

### DIFF
--- a/nixos/modules/tasks/filesystems/btrfs.nix
+++ b/nixos/modules/tasks/filesystems/btrfs.nix
@@ -89,12 +89,11 @@ in
         "crc32c"
       ]
       ++ optionals (config.boot.kernelPackages.kernel.kernelAtLeast "5.5") [
-        # Needed for mounting filesystems with new checksums
-        "xxhash_generic"
-        "blake2b_generic"
-
-        # `sha256` is always available, whereas `sha256_generic` is not available from 6.17 onwards
+        # The canonical names of these modules are not very stable, so use the algorithm names that the btrfs module expects.
+        # See: https://github.com/torvalds/linux/blob/v6.19-rc1/fs/btrfs/super.c#L2705-L2708
+        "xxhash64"
         "sha256" # Should be baked into our kernel, just to be sure
+        "blake2b-256"
       ];
 
       boot.initrd.extraUtilsCommands = mkIf (!config.boot.initrd.systemd.enable) ''


### PR DESCRIPTION
Upstream renamed the blake2b module in https://github.com/torvalds/linux/commit/fa3ca9bfe3f001ed306cb3ce9761dacffbe143f8

Quoting from upstream:

> Replace blake2b_generic.c with a new file blake2b.c which implements the
> BLAKE2b crypto_shash algorithms on top of the BLAKE2b library API.

This fixes building the system when using `linuxPackages_testing` (6.19+) with BTRFS:

```
modprobe: FATAL: Module blake2b_generic not found in directory /nix/store/.../lib/modules/6.19.0-rc1
```

Unlike the sha256 → sha256_generic change (#434430), the module names are truly different between kernel versions (`blake2b_generic.ko` vs `blake2b.ko`), so this uses version detection to select the correct module name.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests]: `systemd-initrd-btrfs-raid`, `swap-file-btrfs`, `bees`
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test