### PR TITLE
textlint-plugin-typst: init at 1.4.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -28727,6 +28727,12 @@
     githubId = 5121426;
     name = "Albert Safin";
   };
+  yadokani389 = {
+    email = "yadokani389@gmail.com";
+    github = "yadokani389";
+    githubId = 155296849;
+    name = "yadokani389";
+  };
   yah = {
     email = "yah@singularpoint.cc";
     github = "wangxiaoerYah";

--- a/pkgs/by-name/te/textlint-plugin-typst/package.nix
+++ b/pkgs/by-name/te/textlint-plugin-typst/package.nix
@@ -1,0 +1,118 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  bun,
+  symlinks,
+  nodejs-slim,
+  textlint,
+  textlint-plugin-typst,
+  textlint-rule-max-comma,
+}:
+
+let
+  pname = "textlint-plugin-typst";
+  version = "1.4.0";
+
+  src = fetchFromGitHub {
+    owner = "textlint";
+    repo = "textlint-plugin-typst";
+    rev = "v${version}";
+    hash = "sha256-ILS/uv+/0aePOduDBm04P/G6Y/PiouUl4zv9RI7OsdY=";
+  };
+
+  bunDeps = stdenvNoCC.mkDerivation {
+    pname = "${pname}-bun-deps";
+    inherit version src;
+
+    nativeBuildInputs = [
+      bun
+      symlinks
+    ];
+
+    dontConfigure = true;
+
+    installPhase = ''
+      runHook preInstall
+
+      export BUN_INSTALL_CACHE_DIR=$(mktemp -d)
+
+      bun install --force --frozen-lockfile --ignore-scripts --no-progress
+
+      # Converting an absolute path symbolic link to a relative path
+      symlinks -cr $BUN_INSTALL_CACHE_DIR
+
+      mkdir -p $out
+      cp -r $BUN_INSTALL_CACHE_DIR/* $out/
+
+      runHook postInstall
+    '';
+
+    # Required else we get errors that our fixed-output derivation references store paths
+    dontFixup = true;
+
+    outputHash = "sha256-L7Seb00ZDuVGlAIRvLFQ6s85vrFwvYXyAq+ZvKD3Vb0=";
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+  };
+
+in
+stdenvNoCC.mkDerivation {
+  inherit pname version src;
+
+  nativeBuildInputs = [
+    bun
+  ];
+
+  configurePhase = ''
+    runHook preConfigure
+
+    # BUN_INSTALL_CACHE_DIR must be writable
+    export BUN_INSTALL_CACHE_DIR=$(mktemp -d)
+    cp -r ${bunDeps}/* $BUN_INSTALL_CACHE_DIR
+
+    bun install --frozen-lockfile --ignore-scripts --no-progress
+
+    runHook postConfigure
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    bun run build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    local pkgdir="$out/lib/node_modules/${pname}"
+    mkdir -p $pkgdir
+
+    cp -r lib $pkgdir
+    cp package.json $pkgdir
+
+    rm -r node_modules
+    bun install --frozen-lockfile --ignore-scripts --no-progress --prod
+    cp -r node_modules $pkgdir
+
+    runHook postInstall
+  '';
+
+  passthru.tests = textlint.testPackages {
+    inherit (textlint-plugin-typst) pname;
+    rule = textlint-rule-max-comma;
+    plugin = textlint-plugin-typst;
+    testFile = ./test.typ;
+  };
+
+  meta = {
+    description = "Textlint plugin to lint Typst";
+    homepage = "https://github.com/textlint/textlint-plugin-typst";
+    changelog = "https://github.com/textlint/textlint-plugin-typst/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ yadokani389 ];
+    platforms = nodejs-slim.meta.platforms;
+  };
+}

--- a/pkgs/by-name/te/textlint-plugin-typst/test.typ
+++ b/pkgs/by-name/te/textlint-plugin-typst/test.typ
@@ -1,0 +1,2 @@
+= textlint-plugin-typst test
+Nix, is a tool, that takes a unique approach to package management and system configuration, Learn how to make reproducible, declarative, and reliable systems.


### PR DESCRIPTION
Add new package textlint-plugin-typst version 1.4.0 and maintainer entry for yadokani389.

textlint-plugin-typst is a  textlint plugin to lint Typst.

Homepage: https://github.com/textlint/textlint-plugin-typst
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
