### PR TITLE
crosstool-ng: init at 1.28.0

### DIFF
--- a/pkgs/by-name/cr/crosstool-ng/package.nix
+++ b/pkgs/by-name/cr/crosstool-ng/package.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  binutils,
+  bison,
+  flex,
+  help2man,
+  libtool,
+  makeWrapper,
+  ncurses,
+  automake,
+  autoconf,
+  python3,
+  texinfo,
+  unzip,
+  wget,
+  which,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "crosstool-ng";
+  version = "1.28.0";
+
+  src = fetchurl {
+    url = "https://github.com/crosstool-ng/crosstool-ng/releases/download/crosstool-ng-${finalAttrs.version}/crosstool-ng-${finalAttrs.version}.tar.xz";
+    hash = "sha256-V1DimivaXNjWeQBZJXaxZwoZh6Tc1eT2vq4JE4ofVpk=";
+  };
+
+  nativeBuildInputs = [
+    autoconf
+    automake
+    bison
+    flex
+    help2man
+    libtool
+    makeWrapper
+    texinfo
+  ];
+
+  buildInputs = [
+    binutils
+    ncurses
+    python3
+    unzip
+    wget
+    which
+  ];
+
+  preConfigure = ''
+    patchShebangs .
+    ./bootstrap
+  '';
+
+  # binutils interfere with code signing on darwin
+  dontStrip = stdenv.hostPlatform.isDarwin;
+
+  meta = {
+    homepage = "https://crosstool-ng.github.io/";
+    description = "Versatile (cross-)toolchain generator";
+    license = lib.licenses.gpl2;
+    maintainers = with lib.maintainers; [
+      jiegec
+      cilki
+    ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
Package [crosstool-ng](https://github.com/crosstool-ng/crosstool-ng). This partially supersedes https://github.com/NixOS/nixpkgs/pull/198738 which also attempted to add support for building nix packages with crosstool-ng. I'm only interested in running the tool to produce an external toolchain, so this PR merely adds the package without any cross compilation support (which can be revisited later).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
