### PR TITLE
[Backport staging-25.11] intel-npu-driver: init at 1.28.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -21170,6 +21170,12 @@
     matrix = "@pschmitt:one.ems.host";
     keys = [ { fingerprint = "9FBF 2ABF FB37 F7F3 F502  44E5 DC43 9C47 EACB 17F9"; } ];
   };
+  pseudocc = {
+    email = "pseudoc@163.com";
+    github = "pseudocc";
+    githubId = 85104110;
+    name = "Atlas Yu";
+  };
   pshirshov = {
     email = "pshirshov@eml.cc";
     github = "pshirshov";

--- a/nixos/modules/hardware/cpu/intel-npu.nix
+++ b/nixos/modules/hardware/cpu/intel-npu.nix
@@ -15,18 +15,17 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    assertions = [
-      {
-        assertion = config.hardware.graphics.enable;
-        message = "Intel NPU requires hardware.graphics.enable to be enabled";
-      }
-    ];
-
-    hardware.firmware = [ pkgs.intel-npu-driver.firmware ];
-    hardware.graphics.extraPackages = [ pkgs.intel-npu-driver ];
     environment.systemPackages = [
       pkgs.intel-npu-driver.validation
       pkgs.level-zero
     ];
+
+    hardware = {
+      firmware = [ pkgs.intel-npu-driver.firmware ];
+      graphics = {
+        enable = true;
+        extraPackages = [ pkgs.intel-npu-driver ];
+      };
+    };
   };
 }

--- a/nixos/modules/hardware/cpu/intel-npu.nix
+++ b/nixos/modules/hardware/cpu/intel-npu.nix
@@ -1,0 +1,32 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.hardware.cpu.intel.npu;
+in
+{
+  options = {
+    hardware.cpu.intel.npu = {
+      enable = lib.mkEnableOption "Intel NPU support";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = config.hardware.graphics.enable;
+        message = "Intel NPU requires hardware.graphics.enable to be enabled";
+      }
+    ];
+
+    hardware.firmware = [ pkgs.intel-npu-driver.firmware ];
+    hardware.graphics.extraPackages = [ pkgs.intel-npu-driver ];
+    environment.systemPackages = [
+      pkgs.intel-npu-driver.validation
+      pkgs.level-zero
+    ];
+  };
+}

--- a/nixos/modules/installer/tools/nixos-generate-config.pl
+++ b/nixos/modules/installer/tools/nixos-generate-config.pl
@@ -205,6 +205,11 @@ sub pciCheck {
         ($device eq "0x4229" || $device eq "0x4230" ||
          $device eq "0x4222" || $device eq "0x4227");
 
+    push @attrs, "hardware.cpu.intel.npu.enable = true;" if
+        $vendor eq "0x8086" &&
+        ($device eq "0x7d1d" || $device eq "0xad1d" ||
+         $device eq "0x643e" || $device eq "0xb03e");
+
     # Assume that all NVIDIA cards are supported by the NVIDIA driver.
     # There may be exceptions (e.g. old cards).
     # FIXME: do we want to enable an unfree driver here?

--- a/nixos/modules/installer/tools/nixos-generate-config.pl
+++ b/nixos/modules/installer/tools/nixos-generate-config.pl
@@ -205,10 +205,15 @@ sub pciCheck {
         ($device eq "0x4229" || $device eq "0x4230" ||
          $device eq "0x4222" || $device eq "0x4227");
 
-    push @attrs, "hardware.cpu.intel.npu.enable = true;" if
-        $vendor eq "0x8086" &&
-        ($device eq "0x7d1d" || $device eq "0xad1d" ||
-         $device eq "0x643e" || $device eq "0xb03e");
+    # Intel NPU driver
+    # list taken from linux(v6.18): drivers/accel/ivpu/ivpu_drv.h
+    if ($vendor eq "0x8086" &&
+        ($device eq "0xfd3e" || $device eq "0x7d1d" || $device eq "0xad1d" ||
+         $device eq "0x643e" || $device eq "0xb03e"))
+    {
+        push @imports, "(modulesPath + \"/hardware/cpu/intel-npu.nix\")";
+        push @attrs, "hardware.cpu.intel.npu.enable = true;";
+    }
 
     # Assume that all NVIDIA cards are supported by the NVIDIA driver.
     # There may be exceptions (e.g. old cards).

--- a/pkgs/by-name/in/intel-npu-driver/package.nix
+++ b/pkgs/by-name/in/intel-npu-driver/package.nix
@@ -12,14 +12,14 @@
 
 stdenv.mkDerivation rec {
   pname = "intel-npu-driver";
-  version = "1.22.0";
+  version = "1.23.0";
 
   src = fetchFromGitHub {
     owner = "intel";
     repo = "linux-npu-driver";
     rev = "v${version}";
     fetchSubmodules = true;
-    hash = "sha256-GxmAmbf28hn/ragkTkFBYbM6Z+uFR6X4foMOyE8UVAc=";
+    hash = "sha256-Lc+FsW0bM2cIqEXpCd9+nvFh70xCbY6aMSHZIjESxhs=";
   };
 
   buildInputs = [

--- a/pkgs/by-name/in/intel-npu-driver/package.nix
+++ b/pkgs/by-name/in/intel-npu-driver/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "intel";
     repo = "linux-npu-driver";
-    rev = "v${version}";
+    tag = "v${version}";
     fetchSubmodules = true;
     hash = "sha256-Lc+FsW0bM2cIqEXpCd9+nvFh70xCbY6aMSHZIjESxhs=";
   };

--- a/pkgs/by-name/in/intel-npu-driver/package.nix
+++ b/pkgs/by-name/in/intel-npu-driver/package.nix
@@ -12,14 +12,14 @@
 
 stdenv.mkDerivation rec {
   pname = "intel-npu-driver";
-  version = "1.26.0";
+  version = "1.28.0";
 
   src = fetchFromGitHub {
     owner = "intel";
     repo = "linux-npu-driver";
     tag = "v${version}";
     fetchSubmodules = true;
-    hash = "sha256-f3GxvYBfCCK6EGASuHrevFEVcBAyKyWXaIvSNcNcSZQ=";
+    hash = "sha256-aH7npJompKYlyq2RPXHn/lflQ1C/yYcTp2K+6kX/L0w=";
   };
 
   buildInputs = [

--- a/pkgs/by-name/in/intel-npu-driver/package.nix
+++ b/pkgs/by-name/in/intel-npu-driver/package.nix
@@ -12,14 +12,14 @@
 
 stdenv.mkDerivation rec {
   pname = "intel-npu-driver";
-  version = "1.19.0";
+  version = "1.22.0";
 
   src = fetchFromGitHub {
     owner = "intel";
     repo = "linux-npu-driver";
     rev = "v${version}";
     fetchSubmodules = true;
-    hash = "sha256-TQfqBSSHHPck0srnezqcXPHaIIC3SymvwaYU6svI13c=";
+    hash = "sha256-GxmAmbf28hn/ragkTkFBYbM6Z+uFR6X4foMOyE8UVAc=";
   };
 
   buildInputs = [

--- a/pkgs/by-name/in/intel-npu-driver/package.nix
+++ b/pkgs/by-name/in/intel-npu-driver/package.nix
@@ -12,14 +12,14 @@
 
 stdenv.mkDerivation rec {
   pname = "intel-npu-driver";
-  version = "1.23.0";
+  version = "1.24.0";
 
   src = fetchFromGitHub {
     owner = "intel";
     repo = "linux-npu-driver";
     tag = "v${version}";
     fetchSubmodules = true;
-    hash = "sha256-Lc+FsW0bM2cIqEXpCd9+nvFh70xCbY6aMSHZIjESxhs=";
+    hash = "sha256-pnQ4OV+7bKivhS5lVmdz5Zb9kqaSJK0eK0lK+68wzYU=";
   };
 
   buildInputs = [

--- a/pkgs/by-name/in/intel-npu-driver/package.nix
+++ b/pkgs/by-name/in/intel-npu-driver/package.nix
@@ -1,0 +1,75 @@
+{
+  lib,
+  stdenv,
+  udev,
+  openssl,
+  boost,
+  cmake,
+  git,
+  level-zero,
+  fetchFromGitHub,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "intel-npu-driver";
+  version = "1.19.0";
+
+  src = fetchFromGitHub {
+    owner = "intel";
+    repo = "linux-npu-driver";
+    rev = "v${version}";
+    fetchSubmodules = true;
+    hash = "sha256-TQfqBSSHHPck0srnezqcXPHaIIC3SymvwaYU6svI13c=";
+  };
+
+  buildInputs = [
+    udev
+    openssl
+    boost
+    level-zero
+  ];
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  outputs = [
+    "out"
+    "validation"
+    "firmware"
+  ];
+
+  postPatch = ''
+    rm -rf third_party/level-zero
+    rm third_party/cmake/level-zero.cmake
+    rm third_party/cmake/FindLevelZero.cmake
+    substituteInPlace third_party/CMakeLists.txt --replace-fail \
+      "include(cmake/level-zero.cmake)" \
+      ""
+    substituteInPlace third_party/level-zero-npu-extensions/ze_graph_ext.h --replace-fail \
+    "#include \"ze_api.h\"" \
+    "#include <level_zero/ze_api.h>"
+
+    substituteInPlace validation/{kmd-test,umd-test}/CMakeLists.txt --replace-fail \
+      "COMPONENT validation-npu" \
+      "DESTINATION $validation/bin COMPONENT validation-npu"
+
+    substituteInPlace firmware/CMakeLists.txt --replace-fail \
+      "DESTINATION /lib/firmware/updates/intel/vpu/" \
+      "DESTINATION $firmware/lib/firmware/intel/vpu/"
+  '';
+
+  installPhase = ''
+    cmake --install . --component level-zero-npu
+    cmake --install . --component validation-npu
+    cmake --install . --component fw-npu
+  '';
+
+  meta = {
+    homepage = "https://github.com/intel/linux-npu-driver";
+    description = "Intel NPU (Neural Processing Unit) Standalone Driver";
+    platforms = [ "x86_64-linux" ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ pseudocc ];
+  };
+}

--- a/pkgs/by-name/in/intel-npu-driver/package.nix
+++ b/pkgs/by-name/in/intel-npu-driver/package.nix
@@ -12,14 +12,14 @@
 
 stdenv.mkDerivation rec {
   pname = "intel-npu-driver";
-  version = "1.24.0";
+  version = "1.26.0";
 
   src = fetchFromGitHub {
     owner = "intel";
     repo = "linux-npu-driver";
     tag = "v${version}";
     fetchSubmodules = true;
-    hash = "sha256-pnQ4OV+7bKivhS5lVmdz5Zb9kqaSJK0eK0lK+68wzYU=";
+    hash = "sha256-f3GxvYBfCCK6EGASuHrevFEVcBAyKyWXaIvSNcNcSZQ=";
   };
 
   buildInputs = [
@@ -43,6 +43,11 @@ stdenv.mkDerivation rec {
     rm -rf third_party/level-zero
     rm third_party/cmake/level-zero.cmake
     rm third_party/cmake/FindLevelZero.cmake
+
+    substituteInPlace third_party/yaml-cpp/CMakeLists.txt --replace-fail \
+      "cmake_minimum_required" \
+      "# cmake_minimum_required"
+
     substituteInPlace third_party/CMakeLists.txt --replace-fail \
       "include(cmake/level-zero.cmake)" \
       ""


### PR DESCRIPTION
backport these 3 PRs in the same time:

1. intel-npu-driver: init at 1.26.0 [#382756](https://github.com/NixOS/nixpkgs/pull/382756)
1. nixos/nixos-generate-config: fix intel-npu imports [#472318](https://github.com/NixOS/nixpkgs/pull/472318)
1. intel-npu-driver: 1.26.0 → 1.28.0 [#472311](https://github.com/NixOS/nixpkgs/pull/472311#top)

The 1st PR introduces an installer bug, so bot-based backport #465316 was dropped.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
