### PR TITLE
nixos/xen: work around ExecStart issue on dom0 disk backend

### DIFF
--- a/nixos/modules/virtualisation/xen-dom0.nix
+++ b/nixos/modules/virtualisation/xen-dom0.nix
@@ -907,13 +907,17 @@ in
           wantedBy = [ "multi-user.target" ];
           serviceConfig = {
             PIDFile = cfg.qemu.pidFile;
-            ExecStart = ''
-              ${cfg.qemu.package}/${cfg.qemu.package.qemu-system-i386} \
-              -xen-domid 0 -xen-attach -name dom0 -nographic -M xenpv \
-              -daemonize -monitor /dev/null -serial /dev/null -parallel \
-              /dev/null -nodefaults -no-user-config -pidfile \
-              ${cfg.qemu.pidFile}
-            '';
+            overrideStrategy = "asDropin";
+            ExecStart = [
+              ""
+              ''
+                ${cfg.qemu.package}/${cfg.qemu.package.qemu-system-i386} \
+                -xen-domid 0 -xen-attach -name dom0 -nographic -M xenpv \
+                -daemonize -monitor /dev/null -serial /dev/null -parallel \
+                /dev/null -nodefaults -no-user-config -pidfile \
+                ${cfg.qemu.pidFile}
+              ''
+            ];
           };
         };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Currently, when enabling Xen dom0 operation via the `virtualisation.xen.enable = true` NixOS configuration option, the `xen-qemu-dom0-disk-backend` systemd unit fails to start, as the resulting overridden unit does not properly clean the existing `ExecStart` entry on the systemd unit which is shipped in the Xen derivation included in nixpkgs. This leads to duplicate `ExecStart` entries, which in turn causes systemd to ignore the unit file.

This PR changes the behavior to explicitly override `ExecStart` by setting the `overrideStrategy` and using the list type input to `ExecStart` to set `ExecStart` to an empty string, followed by the actual overridden `ExecStart` entry.

I've been able to reproduce this issue on both 25.11 and unstable, so this fix will require a backport to 25.11 also.

With the changes in this PR, the service starts correctly with the override present, and I was able to confirm the started command includes the full path to the `qemu-system-i386` binary, which is the intent of the override, to ensure the QEMU disk device model is able to be started correctly without relying on `qemu-system-i386` being in the path.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
