### PR TITLE
androidenv: support nonstandard SDK versions

### DIFF
--- a/pkgs/development/mobile/androidenv/examples/shell-without-emulator.nix
+++ b/pkgs/development/mobile/androidenv/examples/shell-without-emulator.nix
@@ -38,6 +38,8 @@ let
     };
   */
 
+  inherit (pkgs) lib;
+
   # Otherwise, just use the in-tree androidenv:
   androidEnv = pkgs.callPackage ./.. {
     inherit pkgs licenseAccepted;
@@ -48,7 +50,13 @@ let
     includeSystemImages = false;
     includeEmulator = false;
 
-    platformVersions = [ "latest" ];
+    platformVersions = [
+      "UpsideDownCake"
+      "36"
+      "36x"
+      "latest"
+      "CANARY"
+    ];
 
     # Accepting more licenses declaratively:
     extraLicenses = [
@@ -70,7 +78,9 @@ let
   androidComposition = androidEnv.composeAndroidPackages sdkArgs;
   androidSdk = androidComposition.androidsdk;
   platformTools = androidComposition.platform-tools;
-  latestSdk = pkgs.lib.foldl' pkgs.lib.max 0 androidComposition.platformVersions;
+  latestSdkVersion = lib.foldl' (
+    s: x: if lib.strings.compareVersions (toString x) s > 0 then toString x else s
+  ) "0" androidComposition.platformVersions;
   jdk = pkgs.jdk;
 in
 pkgs.mkShell {
@@ -97,7 +107,6 @@ pkgs.mkShell {
   '';
 
   passthru.tests = {
-
     shell-without-emulator-sdkmanager-packages-test =
       pkgs.runCommand "shell-without-emulator-sdkmanager-packages-test"
         {
@@ -113,7 +122,7 @@ pkgs.mkShell {
 
           packages=(
             "build-tools" "cmdline-tools" \
-            "platform-tools" "platforms;android-${toString latestSdk}"
+            "platform-tools" "platforms;android-${toString latestSdkVersion}"
           )
 
           for package in "''${packages[@]}"; do


### PR DESCRIPTION
Google have been releasing 'nonstandard' SDK versions for a while. Named things like CANARY, UpsideDownCake, 36x, and so on, androidenv has been generally unable to use them, instead preferring Google's officially supported Android SDKs corresponding to the [API levels](https://apilevels.com/) (e.g. "35" or "36").

Updates to those SDK versions have generally come in the form of updates to Google's repositories that repo.json picks up. These are mostly noneventful for end users, unless a user experienced a bug in an API definition, then it tended to be picked up with an androidenv repo update.

API 36.1 changes this. It's not just a number (so it doesn't correspond to a unique API level). The previous attempt in #470569 simply preferred the newer version to attempt to emulate the old behavior.

Unfortunately, this now requires a Gradle change (see #472561). So this means we should just support all the strange SDK versions now and have a test for it.

Note that only depending on "latest" (the default) will properly pick these up as the latest, but using a min and max SDK version or numLatestPlatformVersions > 1 will create a range of SDK versions as before, which means you may miss (e.g.) 36.1 but will still have 36. Considering that this requires `compileSdk "android-36.1"` instead of a simple `compileSdk 36` in Gradle, it's recommended to explicitly specify platformVersions if you depend on this change, or use the defaults, where it will only install the latest.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
