### PR TITLE
apfs-fuse: fix build with gcc 15

### DIFF
--- a/pkgs/by-name/ap/apfs-fuse/add_cstdint_fix_gcc15.patch
+++ b/pkgs/by-name/ap/apfs-fuse/add_cstdint_fix_gcc15.patch
@@ -1,0 +1,20 @@
+From 53cae3b21af9dca65cbe244ab72ec310a2e02164 Mon Sep 17 00:00:00 2001
+From: dkarpo <dkarpo@gmail.com>
+Date: Tue, 30 Sep 2025 10:18:03 -0600
+Subject: [PATCH] Add "<cstdint>" include to fix compilation.
+
+---
+ ApfsLib/PList.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/ApfsLib/PList.h b/ApfsLib/PList.h
+index 645df2d..a752059 100644
+--- a/ApfsLib/PList.h
++++ b/ApfsLib/PList.h
+@@ -1,5 +1,6 @@
+ #pragma once
+ 
++#include <cstdint>
+ #include <vector>
+ #include <map>
+ #include <memory>

--- a/pkgs/by-name/ap/apfs-fuse/package.nix
+++ b/pkgs/by-name/ap/apfs-fuse/package.nix
@@ -26,6 +26,10 @@ stdenv.mkDerivation {
     # fix for CMake v4
     # https://github.com/sgan81/apfs-fuse/pull/211
     ./cmake-v4.patch
+
+    # fix for GCC 15
+    # https://github.com/sgan81/apfs-fuse/pull/209
+    ./add_cstdint_fix_gcc15.patch
   ];
 
   postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
