### PR TITLE
amp: fix build with gcc15 by using in-tree oniguruma

### DIFF
--- a/pkgs/by-name/am/amp/package.nix
+++ b/pkgs/by-name/am/amp/package.nix
@@ -3,8 +3,10 @@
   fetchFromGitHub,
   rustPlatform,
   pkgsBuildBuild,
+  oniguruma,
   stdenv,
   zlib,
+  pkg-config,
   writableTmpDirAsHomeHook,
 }:
 
@@ -26,14 +28,21 @@ rustPlatform.buildRustPackage (finalAttrs: {
     (pkgsBuildBuild.writeShellScriptBin "git" "echo 0000000")
   ];
 
-  buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
+  buildInputs = [
+    oniguruma
+  ]
+  ++ (lib.optionals stdenv.hostPlatform.isDarwin [
     zlib
-  ];
+  ]);
 
   # Needing libgit2 <=1.8.0
   #env.LIBGIT2_NO_VENDOR = 1;
 
+  # bundled oniguruma failed on gcc15
+  env.RUSTONIG_SYSTEM_LIBONIG = 1;
+
   nativeCheckInputs = [
+    pkg-config
     writableTmpDirAsHomeHook
   ];
 


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
