### PR TITLE
nixos/facter: enable grub uefi support based on facter report

### DIFF
--- a/nixos/modules/hardware/facter/boot.nix
+++ b/nixos/modules/hardware/facter/boot.nix
@@ -1,0 +1,16 @@
+{
+  config,
+  lib,
+  ...
+}:
+
+{
+  options.hardware.facter.detected.uefi.supported = lib.mkEnableOption "the facter uefi module" // {
+    default = config.hardware.facter.report.uefi.supported or false;
+    defaultText = "hardware dependent";
+  };
+
+  config.boot.loader.grub.efiSupport = lib.mkIf config.hardware.facter.detected.uefi.supported (
+    lib.mkDefault true
+  );
+}

--- a/nixos/modules/hardware/facter/default.nix
+++ b/nixos/modules/hardware/facter/default.nix
@@ -5,6 +5,7 @@
 }:
 {
   imports = [
+    ./boot.nix
     ./bluetooth.nix
     ./camera
     ./debug.nix


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

See https://github.com/nix-community/nixos-facter-modules/commit/fb9eea6bb0ac1ce07bcf7498fcff6e5f653b6091

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
