### PR TITLE
vintagestory: overridability, cleanups, Wayland support

### DIFF
--- a/pkgs/by-name/vi/vintagestory/package.nix
+++ b/pkgs/by-name/vi/vintagestory/package.nix
@@ -88,12 +88,12 @@ stdenv.mkDerivation (finalAttrs: {
       runtimeLibs' = lib.strings.makeLibraryPath finalAttrs.runtimeLibs;
     in
     ''
-      makeWrapper ${dotnet-runtime_8}/bin/dotnet $out/bin/vintagestory \
+      makeWrapper ${lib.meta.getExe dotnet-runtime_8} $out/bin/vintagestory \
         --prefix LD_LIBRARY_PATH : "${runtimeLibs'}" \
         --set-default mesa_glthread true \
         --add-flags $out/share/vintagestory/Vintagestory.dll
 
-      makeWrapper ${dotnet-runtime_8}/bin/dotnet $out/bin/vintagestory-server \
+      makeWrapper ${lib.meta.getExe dotnet-runtime_8} $out/bin/vintagestory-server \
         --prefix LD_LIBRARY_PATH : "${runtimeLibs'}" \
         --set-default mesa_glthread true \
         --add-flags $out/share/vintagestory/VintagestoryServer.dll

--- a/pkgs/by-name/vi/vintagestory/package.nix
+++ b/pkgs/by-name/vi/vintagestory/package.nix
@@ -19,12 +19,12 @@
   dotnet-runtime_8,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "vintagestory";
   version = "1.21.6";
 
   src = fetchurl {
-    url = "https://cdn.vintagestory.at/gamefiles/stable/vs_client_linux-x64_${version}.tar.gz";
+    url = "https://cdn.vintagestory.at/gamefiles/stable/vs_client_linux-x64_${finalAttrs.version}.tar.gz";
     hash = "sha256-LkiL/8W9MKpmJxtK+s5JvqhOza0BLap1SsaDvbLYR0c=";
   };
 
@@ -87,12 +87,12 @@ stdenv.mkDerivation rec {
 
   preFixup = ''
     makeWrapper ${dotnet-runtime_8}/bin/dotnet $out/bin/vintagestory \
-      --prefix LD_LIBRARY_PATH : "${runtimeLibs}" \
+      --prefix LD_LIBRARY_PATH : "${finalAttrs.runtimeLibs}" \
       --set-default mesa_glthread true \
       --add-flags $out/share/vintagestory/Vintagestory.dll
 
     makeWrapper ${dotnet-runtime_8}/bin/dotnet $out/bin/vintagestory-server \
-      --prefix LD_LIBRARY_PATH : "${runtimeLibs}" \
+      --prefix LD_LIBRARY_PATH : "${finalAttrs.runtimeLibs}" \
       --set-default mesa_glthread true \
       --add-flags $out/share/vintagestory/VintagestoryServer.dll
 
@@ -116,4 +116,4 @@ stdenv.mkDerivation rec {
     ];
     mainProgram = "vintagestory";
   };
-}
+})

--- a/pkgs/by-name/vi/vintagestory/package.nix
+++ b/pkgs/by-name/vi/vintagestory/package.nix
@@ -45,11 +45,11 @@ stdenv.mkDerivation (finalAttrs: {
     pipewire
     libpulseaudio
   ]
-  ++ (with xorg; [
-    libX11
-    libXi
-    libXcursor
-  ]);
+  ++ [
+    xorg.libX11
+    xorg.libXi
+    xorg.libXcursor
+  ];
 
   desktopItems = [
     (makeDesktopItem {


### PR DESCRIPTION
This cleans up the package definition a little bit in order to make overriding runtimeLibs easier, and adds a build option to enable Wayland support.
When enabled, the game gracefully falls back to X11 when Wayland is not available. I've left it off by default until the developers decide to enable it themselves (or ship with OpenTK 4.9+). The game doesn't handle scaling so this isn't very usable for most, but it does run.

<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/df00aedd-ea7e-4dae-8ab3-a97c258917f3" />
<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/7cda2e53-0cc7-424a-9338-ca933ac60736" />

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
