### PR TITLE
python3Packages.wgpu-py: 0.28.1 -> 0.29.0, python3Packages.rendercanvas: 2.4.2 -> 2.5.1

### DIFF
--- a/pkgs/development/python-modules/rendercanvas/default.nix
+++ b/pkgs/development/python-modules/rendercanvas/default.nix
@@ -22,14 +22,14 @@
 }:
 buildPythonPackage rec {
   pname = "rendercanvas";
-  version = "2.4.2";
+  version = "2.5.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pygfx";
     repo = "rendercanvas";
     tag = "v${version}";
-    hash = "sha256-42jnCD0jSGkz6zLokzF1lXjnVP8E2yrPu8AQ80EKEI4=";
+    hash = "sha256-FjKotBAGEtM5JYA3PGeoSl3v4m6vq1EE/r/gCsabdIo=";
   };
 
   postPatch = ''
@@ -37,8 +37,6 @@ buildPythonPackage rec {
   '';
 
   build-system = [ flit-core ];
-
-  dependencies = [ sniffio ];
 
   nativeCheckInputs = [
     pytestCheckHook
@@ -51,7 +49,10 @@ buildPythonPackage rec {
   ];
 
   # flaky timing and / or interrupt based tests
-  disabledTests = [ "test_offscreen_event_loop" ];
+  disabledTests = [
+    "test_offscreen_event_loop"
+    "test_call_later_thread"
+  ];
   disabledTestPaths = [
     "tests/test_loop.py"
     "tests/test_scheduling.py"

--- a/pkgs/development/python-modules/wgpu-py/default.nix
+++ b/pkgs/development/python-modules/wgpu-py/default.nix
@@ -39,14 +39,14 @@
 }:
 buildPythonPackage rec {
   pname = "wgpu-py";
-  version = "0.28.1";
+  version = "0.29.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pygfx";
     repo = "wgpu-py";
     tag = "v${version}";
-    hash = "sha256-91L0rXaMYtDztk9aJQhWDWa8sG+MHQ4sPyidzZmK+ZI=";
+    hash = "sha256-drXO3NHIuK34tbOZjxOCz1lnlcrfx6mADZ2WlEc9vDU=";
   };
 
   postPatch =


### PR DESCRIPTION
Supersedes #473527

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
