### PR TITLE
lua5_5: init at 5.5.0

### DIFF
--- a/pkgs/development/interpreters/lua-5/5.5.darwin.patch
+++ b/pkgs/development/interpreters/lua-5/5.5.darwin.patch
@@ -1,0 +1,52 @@
+diff --git a/Makefile b/Makefile
+index 388fa17..ce17b93 100644
+--- a/Makefile
++++ b/Makefile
+@@ -41,7 +41,7 @@ PLATS= guess aix bsd c89 freebsd generic ios linux macosx mingw posix solaris
+ # What to install.
+ TO_BIN= lua luac
+ TO_INC= lua.h luaconf.h lualib.h lauxlib.h lua.hpp
+-TO_LIB= liblua.a
++TO_LIB= liblua.${pkgversion}.dylib
+ TO_MAN= lua.1 luac.1
+ 
+ # Lua version and release.
+@@ -60,6 +60,9 @@ install: dummy
+ 	cd src && $(INSTALL_DATA) $(TO_INC) $(INSTALL_INC)
+ 	cd src && $(INSTALL_DATA) $(TO_LIB) $(INSTALL_LIB)
+ 	cd doc && $(INSTALL_DATA) $(TO_MAN) $(INSTALL_MAN)
++	ln -s -f liblua.${pkgversion}.dylib $(INSTALL_LIB)/liblua.${luaversion}.dylib
++	ln -s -f liblua.${luaversion}.dylib $(INSTALL_LIB)/liblua.dylib
++
+ 
+ uninstall:
+ 	cd src && cd $(INSTALL_BIN) && $(RM) $(TO_BIN)
+diff --git a/src/Makefile b/src/Makefile
+index acf33e0..42a5435 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -32,7 +32,7 @@ CMCFLAGS=
+ 
+ PLATS= guess aix bsd c89 freebsd generic ios linux macosx mingw posix solaris
+ 
+-LUA_A=	liblua.a
++LUA_A=	liblua.${pkgversion}.a
+ CORE_O=	lapi.o lcode.o lctype.o ldebug.o ldo.o ldump.o lfunc.o lgc.o llex.o lmem.o lobject.o lopcodes.o lparser.o lstate.o lstring.o ltable.o ltm.o lundump.o lvm.o lzio.o
+ LIB_O=	lauxlib.o lbaselib.o lcorolib.o ldblib.o liolib.o lmathlib.o loadlib.o loslib.o lstrlib.o ltablib.o lutf8lib.o linit.o
+ BASE_O= $(CORE_O) $(LIB_O) $(MYOBJS)
+@@ -59,9 +59,14 @@ a:	$(ALL_A)
+ $(LUA_A): $(BASE_O)
+ 	$(AR) $@ $(BASE_O)
+ 	$(RANLIB) $@
++	$(CC) -dynamiclib -install_name $(out)/lib/liblua.${pkgversion}.dylib \
++		-compatibility_version ${pkgversion} -current_version ${pkgversion} \
++		-o liblua.${pkgversion}.dylib $^
++
+ 
+ $(LUA_T): $(LUA_O) $(LUA_A)
+-	$(CC) -o $@ $(LDFLAGS) $(LUA_O) $(LUA_A) $(LIBS)
++	$(CC) -fno-common $(MYLDFLAGS) \
++		-o $@ $(LUA_O) $(LUA_A) -L. -llua.${pkgversion} $(LIBS)
+ 
+ $(LUAC_T): $(LUAC_O) $(LUA_A)
+ 	$(CC) -o $@ $(LDFLAGS) $(LUAC_O) $(LUA_A) $(LIBS)

--- a/pkgs/development/interpreters/lua-5/default.nix
+++ b/pkgs/development/interpreters/lua-5/default.nix
@@ -102,6 +102,21 @@ let
 in
 
 rec {
+  lua5_5 = callPackage ./interpreter.nix {
+    self = lua5_5;
+    version = "5.5.0";
+    hash = "sha256-V8zDK7vQBcq3W8xSREBSU1r2kXiduiuQFtXFBkDWiz0=";
+    makeWrapper = makeBinaryWrapper;
+    inherit passthruFun;
+
+    patches = lib.optional stdenv.hostPlatform.isDarwin ./5.5.darwin.patch;
+  };
+
+  lua5_5_compat = lua5_5.override {
+    self = lua5_5_compat;
+    compat = true;
+  };
+
   lua5_4 = callPackage ./interpreter.nix {
     self = lua5_4;
     version = "5.4.7";

--- a/pkgs/development/interpreters/lua-5/interpreter.nix
+++ b/pkgs/development/interpreters/lua-5/interpreter.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation (
     plat =
       if (stdenv.hostPlatform.isLinux && lib.versionOlder self.luaversion "5.4") then
         "linux"
-      else if (stdenv.hostPlatform.isLinux && lib.versionAtLeast self.luaversion "5.4") then
+      else if (stdenv.hostPlatform.isLinux && self.luaversion == "5.4") then
         "linux-readline"
       else if stdenv.hostPlatform.isDarwin then
         "macosx"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5460,6 +5460,8 @@ with pkgs;
     lua5_3_compat
     lua5_4
     lua5_4_compat
+    lua5_5
+    lua5_5_compat
     luajit_2_1
     luajit_2_0
     luajit_openresty
@@ -5472,6 +5474,7 @@ with pkgs;
   lua52Packages = recurseIntoAttrs lua5_2.pkgs;
   lua53Packages = recurseIntoAttrs lua5_3.pkgs;
   lua54Packages = recurseIntoAttrs lua5_4.pkgs;
+  lua55Packages = recurseIntoAttrs lua5_5.pkgs;
   luajitPackages = recurseIntoAttrs luajit.pkgs;
 
   luaPackages = lua52Packages;


### PR DESCRIPTION
Adds a package for Lua 5.5.

~I expect none of the `lua55Packages` to build, as luarocks doesn't yet support Lua 5.5.
Maybe we should remove the alias for now and add it later, so people can start using Lua 5.5? (cc @teto)~

- [x] To be able to build the packages, we will have to wait for https://github.com/luarocks/luarocks/issues/1848.
- [x] I've cargo culted the darwin patch from Lua 5.4. Will have to test it on a darwin builder.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
