### PR TITLE
buildHomeAssistantComponent: reintroduce nativeCheckInputs

### DIFF
--- a/pkgs/servers/home-assistant/build-custom-component/default.nix
+++ b/pkgs/servers/home-assistant/build-custom-component/default.nix
@@ -62,7 +62,7 @@ home-assistant.python.pkgs.buildPythonPackage (
   }
   // removeAttrs args [
     "meta"
-    "nativeCheckInputs"
+    "nativeBuildInputs"
     "passthru"
   ]
 )

--- a/pkgs/servers/home-assistant/custom-components/moonraker/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/moonraker/package.nix
@@ -14,13 +14,13 @@
 buildHomeAssistantComponent rec {
   owner = "marcolivierarsenault";
   domain = "moonraker";
-  version = "1.11.1";
+  version = "1.12.0";
 
   src = fetchFromGitHub {
     owner = "marcolivierarsenault";
     repo = "moonraker-home-assistant";
     tag = version;
-    hash = "sha256-3qxTigKBZ7maUylx0NCf70tURNUWFpo2TzgxnxqjUpA=";
+    hash = "sha256-T/7A5LmDmqaThTa1TnDbXwA0qeipIk750+k1Kt7tFeY=";
   };
 
   dependencies = [

--- a/pkgs/servers/home-assistant/custom-components/mypyllant/migrate-to-new-pytest-homeassistant-custom-component.patch
+++ b/pkgs/servers/home-assistant/custom-components/mypyllant/migrate-to-new-pytest-homeassistant-custom-component.patch
@@ -1,0 +1,21 @@
+diff --git a/tests/test_services.py b/tests/test_services.py
+index 1fb07b3..f7a552c 100644
+--- a/tests/test_services.py
++++ b/tests/test_services.py
+@@ -3,6 +3,7 @@ from dataclasses import asdict
+ 
+ import pytest
+ from homeassistant.helpers.entity_registry import DATA_REGISTRY, EntityRegistry
++from homeassistant.helpers.trigger import TRIGGERS, TRIGGER_PLATFORM_SUBSCRIPTIONS
+ from homeassistant.loader import (
+     DATA_COMPONENTS,
+     DATA_INTEGRATIONS,
+@@ -31,6 +32,8 @@ def setup_hass_for_service_test(hass):
+     hass.data[DATA_PRELOAD_PLATFORMS] = {}
+     hass.data[DATA_MISSING_PLATFORMS] = {}
+     hass.data[DATA_REGISTRY] = EntityRegistry(hass)
++    hass.data[TRIGGER_PLATFORM_SUBSCRIPTIONS] = []
++    hass.data[TRIGGERS] = {}
+     return hass
+ 
+ 

--- a/pkgs/servers/home-assistant/custom-components/mypyllant/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/mypyllant/package.nix
@@ -1,6 +1,7 @@
 {
   buildHomeAssistantComponent,
   fetchFromGitHub,
+  fetchpatch2,
   lib,
 
   # dependencies
@@ -27,6 +28,11 @@ buildHomeAssistantComponent rec {
     tag = "v${version}";
     hash = "sha256-6T8SGAP2535VqZmvSeITpMIa0SBJhnWsOKM1Y66WhHE=";
   };
+
+  patches = [
+    # Migrates tests to the new version of `pytest-homeassistant-custom-component` (see https://github.com/signalkraft/mypyllant-component/pull/394).
+    ./migrate-to-new-pytest-homeassistant-custom-component.patch
+  ];
 
   dependencies = [
     mypyllant

--- a/pkgs/servers/home-assistant/custom-components/oref_alert/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/oref_alert/package.nix
@@ -13,13 +13,13 @@
 buildHomeAssistantComponent rec {
   owner = "amitfin";
   domain = "oref_alert";
-  version = "4.2.1";
+  version = "4.1.1";
 
   src = fetchFromGitHub {
     owner = "amitfin";
     repo = "oref_alert";
     tag = "v${version}";
-    hash = "sha256-mE39/f/2SmEJ5rTHhwmgGdQga4PQPGxoj/iKA1+Ou5k=";
+    hash = "sha256-nWp8cG0lFYUEO11lcZGkqx5QvOSfSVnqIqpHA8YAN30=";
   };
 
   dependencies = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

I believe tests for Home Assistant Custom Components have been disabled in #467204 ([see this comment](https://github.com/NixOS/nixpkgs/pull/467204#discussion_r2642601799)).

This PR attempts to re-enable tests.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
