### PR TITLE
nzportable: 0-unstable-2024-09-11 -> 0-unstable-2025-09-25

### DIFF
--- a/pkgs/by-name/nz/nzportable/assets.nix
+++ b/pkgs/by-name/nz/nzportable/assets.nix
@@ -5,12 +5,12 @@
 }:
 stdenvNoCC.mkDerivation {
   pname = "nzp-assets";
-  version = "0-unstable-2024-09-28";
+  version = "0-unstable-2025-11-25";
 
   src = fetchFromGitHub {
     owner = "nzp-team";
     repo = "assets";
-    rev = "4a7b1b787061c1c7c17ab3b59a8e0e0f44c9546f";
+    rev = "96dd29602d6d8af0cce9208910e7ab68bfc95019";
     hash = "sha256-gCTC/76r0ITIDLIph9uivq0ZJGaPUmlBGizdCUxJrng=";
   };
 

--- a/pkgs/by-name/nz/nzportable/fteqw.nix
+++ b/pkgs/by-name/nz/nzportable/fteqw.nix
@@ -41,12 +41,12 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "nzp-fteqw";
-  version = "0-unstable-2024-09-11";
+  version = "0-unstable-2025-09-25";
 
   src = fetchFromGitHub {
     owner = "nzp-team";
     repo = "fteqw";
-    rev = "593345a7f03245fc45580ac252857e5db5105033";
+    rev = "f68a2b547d2dc4bf6886b922baa1bff487cc5038";
     hash = "sha256-ANDHh4PKh8fAvbBiiW47l1XeGOCes0Sg595+65NFG6w=";
   };
 
@@ -93,6 +93,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "FTE_TOOL_IMAGE" false)
     (lib.cmakeBool "FTE_TOOL_QTV" false)
     (lib.cmakeBool "FTE_TOOL_MASTER" false)
+    (lib.cmakeFeature "CMAKE_POLICY_VERSION_MINIMUM" "3.5")
   ];
 
   postInstall = ''

--- a/pkgs/by-name/nz/nzportable/quakec.nix
+++ b/pkgs/by-name/nz/nzportable/quakec.nix
@@ -7,12 +7,12 @@
 }:
 stdenvNoCC.mkDerivation {
   pname = "nzp-quakec";
-  version = "0-unstable-2024-10-12";
+  version = "0-unstable-2025-11-26";
 
   src = fetchFromGitHub {
     owner = "nzp-team";
     repo = "quakec";
-    rev = "01e95c4dab91ce0e8b7387d2726d9ee307792ae7";
+    rev = "b1d7fec5a536b088283578866ade2c596f7928d0";
     hash = "sha256-h4llx3tzeoI1aHLokM7NqkZJWuo6rcrmWfb0pDQL+zM=";
   };
 


### PR DESCRIPTION
Hello people, this pr both updates nzportable to the latest nightly release and fixes the build process (that was stuck because of a missing cmake flag).

Hope you're all doing well, take care and merry christmas.
Best regards

<img width="731" height="576" alt="image" src="https://github.com/user-attachments/assets/7f6e0185-be82-4a8a-abf6-d6151262485d" />


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
