### PR TITLE
snitch: init at 0.1.9

### DIFF
--- a/pkgs/by-name/sn/snitch/package.nix
+++ b/pkgs/by-name/sn/snitch/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  stdenv,
+  buildGoModule,
+  fetchFromGitHub,
+  apple-sdk_15,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "snitch";
+  version = "0.1.9";
+
+  src = fetchFromGitHub {
+    owner = "karol-broda";
+    repo = "snitch";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-/0MYXKBat+OumuXnS8XSiMslNHUopVDFO4RdYGECfI8=";
+  };
+
+  vendorHash = "sha256-fX3wOqeOgjH7AuWGxPQxJ+wbhp240CW8tiF4rVUUDzk=";
+
+  # these below settings (env, buildInputs, ldflags) copied from
+  # https://github.com/karol-broda/snitch/blob/master/flake.nix
+
+  env = {
+    # darwin requires cgo for libproc, linux uses pure go with /proc
+    CGO_ENABLED = if stdenv.hostPlatform.isDarwin then 1 else 0;
+  };
+
+  # darwin: use macOS 15 SDK for SecTrustCopyCertificateChain (Go 1.25 crypto/x509)
+  buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ apple-sdk_15 ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X snitch/cmd.Version=${finalAttrs.version}"
+    "-X snitch/cmd.Commit=v${finalAttrs.version}"
+    "-X snitch/cmd.Date=1970-01-01"
+  ];
+
+  meta = {
+    description = "friendlier ss / netstat for humans";
+    homepage = "https://github.com/karol-broda/snitch";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.DieracDelta ];
+    platforms = lib.platforms.unix;
+    mainProgram = "snitch";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

I mostly copied this derivation from https://github.com/karol-broda/snitch/blob/master/flake.nix, since they've already packaged the application. Would be cool to have in nixpkgs.

I know it's a relatively new package (first release last week) but on the other hand it's at nearly 700 stars and it's really pretty!

I've tested the `snitch top` on both x86_64-linux nixos and aarch64-darwin. It seems to work on both.



<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
