### PR TITLE
nixos/picom: refactor

### DIFF
--- a/nixos/modules/services/x11/picom.nix
+++ b/nixos/modules/services/x11/picom.nix
@@ -1,7 +1,6 @@
 {
   config,
   lib,
-  options,
   pkgs,
   ...
 }:
@@ -9,60 +8,16 @@
 with lib;
 
 let
-
   cfg = config.services.picom;
-  opt = options.services.picom;
 
-  pairOf =
-    x:
-    with types;
-    addCheck (listOf x) (y: length y == 2) // { description = "pair of ${x.description}"; };
-
-  mkDefaultAttrs = mapAttrs (n: v: mkDefault v);
-
-  # Basically a tinkered lib.generators.mkKeyValueDefault
-  # It either serializes a top-level definition "key: { values };"
-  # or an expression "key = { values };"
-  mkAttrsString =
-    top:
-    mapAttrsToList (
-      k: v:
-      let
-        sep = if (top && isAttrs v) then ":" else "=";
-      in
-      "${escape [ sep ] k}${sep}${mkValueString v};"
-    );
-
-  # This serializes a Nix expression to the libconfig format.
-  mkValueString =
-    v:
-    if types.bool.check v then
-      boolToString v
-    else if types.int.check v then
-      toString v
-    else if types.float.check v then
-      toString v
-    else if types.str.check v then
-      "\"${escape [ "\"" ] v}\""
-    else if builtins.isList v then
-      "[ ${concatMapStringsSep " , " mkValueString v} ]"
-    else if types.attrs.check v then
-      "{ ${concatStringsSep " " (mkAttrsString false v)} }"
-    else
-      throw ''
-        invalid expression used in option services.picom.settings:
-        ${v}
-      '';
-
-  toConf = attrs: concatStringsSep "\n" (mkAttrsString true cfg.settings);
-
-  configFile = pkgs.writeText "picom.conf" (toConf cfg.settings);
+  libconfig = pkgs.formats.libconfig { };
 
 in
 {
-
   imports = [
     (mkAliasOptionModule [ "services" "compton" ] [ "services" "picom" ])
+
+    # Removed options
     (mkRemovedOptionModule [ "services" "picom" "refreshRate" ] ''
       This option corresponds to `refresh-rate`, which has been unused
       since picom v6 and was subsequently removed by upstream.
@@ -71,307 +26,92 @@ in
     (mkRemovedOptionModule [ "services" "picom" "experimentalBackends" ] ''
       This option was removed by upstream since picom v10.
     '')
+
+    # Refactored Options
+    (mkRenamedOptionModule [ "services" "picom" "fade" ] [ "services" "picom" "settings" "fading" ])
+    (mkRenamedOptionModule
+      [ "services" "picom" "fadeDelta" ]
+      [ "services" "picom" "settings" "fade-delta" ]
+    )
+    (mkRenamedOptionModule
+      [ "services" "picom" "fadeExclude" ]
+      [ "services" "picom" "settings" "fade-exclude" ]
+    )
+    (mkRenamedOptionModule [ "services" "picom" "shadow" ] [ "services" "picom" "settings" "shadow" ])
+    (mkRenamedOptionModule
+      [ "services" "picom" "shadowOpacity" ]
+      [ "services" "picom" "settings" "shadow-opacity" ]
+    )
+    (mkRenamedOptionModule
+      [ "services" "picom" "shadowExclude" ]
+      [ "services" "picom" "settings" "shadow-exclude" ]
+    )
+    (mkRenamedOptionModule
+      [ "services" "picom" "activeOpacity" ]
+      [ "services" "picom" "settings" "active-opacity" ]
+    )
+    (mkRenamedOptionModule
+      [ "services" "picom" "inactiveOpacity" ]
+      [ "services" "picom" "settings" "inactive-opacity" ]
+    )
+    (mkRenamedOptionModule
+      [ "services" "picom" "wintypes" ]
+      [ "services" "picom" "settings" "wintypes" ]
+    )
+    (mkRenamedOptionModule
+      [ "services" "picom" "opacityRules" ]
+      [ "services" "picom" "settings" "opacity-rule" ]
+    )
+    (mkRenamedOptionModule [ "services" "picom" "backend" ] [ "services" "picom" "settings" "backend" ])
+    (mkRenamedOptionModule [ "services" "picom" "vSync" ] [ "services" "picom" "settings" "vsync" ])
+    (mkRenamedOptionModule
+      [ "services" "picom" "menuOpacity" ]
+      [ "services" "picom" "settings" "wintypes" "menu" "opacity" ]
+    )
+
+    # List/Array Migrations
+    (mkRenamedOptionModule
+      [ "services" "picom" "fadeSteps" "0" ]
+      [ "services" "picom" "settings" "fade-in-step" ]
+    )
+    (mkRenamedOptionModule
+      [ "services" "picom" "fadeSteps" "1" ]
+      [ "services" "picom" "settings" "fade-out-step" ]
+    )
+    (mkRenamedOptionModule
+      [ "services" "picom" "shadowOffsets" "0" ]
+      [ "services" "picom" "settings" "shadow-offset-x" ]
+    )
+    (mkRenamedOptionModule
+      [ "services" "picom" "shadowOffsets" "1" ]
+      [ "services" "picom" "settings" "shadow-offset-y" ]
+    )
   ];
 
   options.services.picom = {
-    enable = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        Whether or not to enable Picom as the X.org composite manager.
-      '';
-    };
+    enable = mkEnableOption "Picom as the X.org composite manager";
 
     package = mkPackageOption pkgs "picom" { };
 
-    fade = mkOption {
-      type = types.bool;
-      default = false;
+    settings = mkOption {
       description = ''
-        Fade windows in and out.
+        Define picom configuration options here, a configuration file will be generated for use by picom.
       '';
-    };
-
-    fadeDelta = mkOption {
-      type = types.ints.positive;
-      default = 10;
-      example = 5;
-      description = ''
-        Time between fade animation step (in ms).
-      '';
-    };
-
-    fadeSteps = mkOption {
-      type = pairOf (types.numbers.between 0.01 1);
-      default = [
-        0.028
-        0.03
-      ];
-      example = [
-        0.04
-        0.04
-      ];
-      description = ''
-        Opacity change between fade steps (in and out).
-      '';
-    };
-
-    fadeExclude = mkOption {
-      type = types.listOf types.str;
-      default = [ ];
-      example = [
-        "window_type *= 'menu'"
-        "name ~= 'Firefox$'"
-        "focused = 1"
-      ];
-      description = ''
-        List of conditions of windows that should not be faded.
-        See {manpage}`picom(1)` man page for more examples.
-      '';
-    };
-
-    shadow = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        Draw window shadows.
-      '';
-    };
-
-    shadowOffsets = mkOption {
-      type = pairOf types.int;
-      default = [
-        (-15)
-        (-15)
-      ];
-      example = [
-        (-10)
-        (-15)
-      ];
-      description = ''
-        Left and right offset for shadows (in pixels).
-      '';
-    };
-
-    shadowOpacity = mkOption {
-      type = types.numbers.between 0 1;
-      default = 0.75;
-      example = 0.8;
-      description = ''
-        Window shadows opacity.
-      '';
-    };
-
-    shadowExclude = mkOption {
-      type = types.listOf types.str;
-      default = [ ];
-      example = [
-        "window_type *= 'menu'"
-        "name ~= 'Firefox$'"
-        "focused = 1"
-      ];
-      description = ''
-        List of conditions of windows that should have no shadow.
-        See {manpage}`picom(1)` man page for more examples.
-      '';
-    };
-
-    activeOpacity = mkOption {
-      type = types.numbers.between 0 1;
-      default = 1.0;
-      example = 0.8;
-      description = ''
-        Opacity of active windows.
-      '';
-    };
-
-    inactiveOpacity = mkOption {
-      type = types.numbers.between 0.1 1;
-      default = 1.0;
-      example = 0.8;
-      description = ''
-        Opacity of inactive windows.
-      '';
-    };
-
-    menuOpacity = mkOption {
-      type = types.numbers.between 0 1;
-      default = 1.0;
-      example = 0.8;
-      description = ''
-        Opacity of dropdown and popup menu.
-      '';
-    };
-
-    wintypes = mkOption {
-      type = types.attrs;
+      type = libconfig.type;
       default = {
-        popup_menu = {
-          opacity = cfg.menuOpacity;
-        };
-        dropdown_menu = {
-          opacity = cfg.menuOpacity;
-        };
+        backend = "xrender";
       };
-      defaultText = literalExpression ''
-        {
-          popup_menu = { opacity = config.${opt.menuOpacity}; };
-          dropdown_menu = { opacity = config.${opt.menuOpacity}; };
-        }
-      '';
-      example = { };
-      description = ''
-        Rules for specific window types.
-      '';
     };
-
-    opacityRules = mkOption {
-      type = types.listOf types.str;
-      default = [ ];
-      example = [
-        "95:class_g = 'URxvt' && !_NET_WM_STATE@:32a"
-        "0:_NET_WM_STATE@:32a *= '_NET_WM_STATE_HIDDEN'"
-      ];
-      description = ''
-        Rules that control the opacity of windows, in format PERCENT:PATTERN.
-      '';
-    };
-
-    backend = mkOption {
-      type = types.enum [
-        "egl"
-        "glx"
-        "xrender"
-        "xr_glx_hybrid"
-      ];
-      default = "xrender";
-      description = ''
-        Backend to use: `egl`, `glx`, `xrender` or `xr_glx_hybrid`.
-      '';
-    };
-
-    vSync = mkOption {
-      type =
-        with types;
-        either bool (enum [
-          "none"
-          "drm"
-          "opengl"
-          "opengl-oml"
-          "opengl-swc"
-          "opengl-mswc"
-        ]);
-      default = false;
-      apply =
-        x:
-        let
-          res = x != "none";
-          msg =
-            "The type of services.picom.vSync has changed to bool:"
-            + " interpreting ${x} as ${boolToString res}";
-        in
-        if isBool x then x else warn msg res;
-
-      description = ''
-        Enable vertical synchronization. Chooses the best method
-        (drm, opengl, opengl-oml, opengl-swc, opengl-mswc) automatically.
-        The bool value should be used, the others are just for backwards compatibility.
-      '';
-    };
-
-    settings =
-      with types;
-      let
-        scalar =
-          oneOf [
-            bool
-            int
-            float
-            str
-          ]
-          // {
-            description = "scalar types";
-          };
-
-        libConfig =
-          oneOf [
-            scalar
-            (listOf libConfig)
-            (attrsOf libConfig)
-          ]
-          // {
-            description = "libconfig type";
-          };
-
-        topLevel = attrsOf libConfig // {
-          description = ''
-            libconfig configuration. The format consists of an attributes
-            set (called a group) of settings. Each setting can be a scalar type
-            (boolean, integer, floating point number or string), a list of
-            scalars or a group itself
-          '';
-        };
-
-      in
-      mkOption {
-        type = topLevel;
-        default = { };
-        example = literalExpression ''
-          blur =
-            { method = "gaussian";
-              size = 10;
-              deviation = 5.0;
-            };
-        '';
-        description = ''
-          Picom settings. Use this option to configure Picom settings not exposed
-          in a NixOS option or to bypass one.  For the available options see the
-          CONFIGURATION FILES section at {manpage}`picom(1)`.
-        '';
-      };
   };
 
   config = mkIf cfg.enable {
-    services.picom.settings = mkDefaultAttrs {
-      # fading
-      fading = cfg.fade;
-      fade-delta = cfg.fadeDelta;
-      fade-in-step = elemAt cfg.fadeSteps 0;
-      fade-out-step = elemAt cfg.fadeSteps 1;
-      fade-exclude = cfg.fadeExclude;
-
-      # shadows
-      shadow = cfg.shadow;
-      shadow-offset-x = elemAt cfg.shadowOffsets 0;
-      shadow-offset-y = elemAt cfg.shadowOffsets 1;
-      shadow-opacity = cfg.shadowOpacity;
-      shadow-exclude = cfg.shadowExclude;
-
-      # opacity
-      active-opacity = cfg.activeOpacity;
-      inactive-opacity = cfg.inactiveOpacity;
-
-      wintypes = cfg.wintypes;
-
-      opacity-rule = cfg.opacityRules;
-
-      # other options
-      backend = cfg.backend;
-      vsync = cfg.vSync;
-    };
-
     systemd.user.services.picom = {
       description = "Picom composite manager";
       wantedBy = [ "graphical-session.target" ];
       partOf = [ "graphical-session.target" ];
 
-      # Temporarily fixes corrupt colours with Mesa 18
-      environment = mkIf (cfg.backend == "glx") {
-        allow_rgb10_configs = "false";
-      };
-
       serviceConfig = {
-        ExecStart = "${getExe cfg.package} --config ${configFile}";
+        ExecStart = "${getExe cfg.package} --config ${libconfig.generate "picom.conf" cfg.settings}";
         RestartSec = 3;
         Restart = "always";
       };
@@ -379,7 +119,4 @@ in
 
     environment.systemPackages = [ cfg.package ];
   };
-
-  meta.maintainers = with lib.maintainers; [ rnhmjoj ];
-
 }


### PR DESCRIPTION
Initial PR #379151 - this is a third take

Working example snippet for testing (use a fork for animations and better blur):
https://gist.github.com/2hexed/fdb08830625ff415f52eb3a5ec6527f3

Edit: This PR cleans up unnecessary options. Currently, these cause no harm if you are using the default picom package; however, if a user chooses a fork, these options may break the generated picom.conf or cause undesired effects. (Example being Pijulius fork or FTlabs fork)

The existing picom module in nixos currently requires manual intervention every time the main package (or a specific fork) changes its options. This PR fixes that by allowing users to define exactly what is required, rather than providing defaults that might clutter their configuration or cause errors.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
