### PR TITLE
fetchurl: builder.sh: use --fail-with-body to avoid misleading error messages

### DIFF
--- a/pkgs/build-support/fetchurl/builder.sh
+++ b/pkgs/build-support/fetchurl/builder.sh
@@ -62,7 +62,7 @@ tryDownload() {
     # if we get error code 18, resume partial download
     while [ $curlexit -eq 18 ]; do
        # keep this inside an if statement, since on failure it doesn't abort the script
-       if "${curl[@]}" -C - --fail "$url" --output "$target"; then
+       if "${curl[@]}" -C - --fail-with-body "$url" --output "$target"; then
           success=1
           break
        else


### PR DESCRIPTION
EDIT: maybe this is not such a good idea because it also prints the received html if it is returned? I'm not sure how else to make the error message less confusing besides adding in some special grepping to filter out the SSL errors if there's an error code.

Example of the printing HTML:

```
curl --fail-with-body https://example.com/this/does/not/exist.zip
<!doctype html><html lang="en"><head><title>Example Domain</title><meta name="viewport" content="width=device-width, initial-scale=1"><style>body{background:#eee;width:60vw;margin:15vh auto;font-family:system-ui,sans-serif}h1{font-size:1.5em}div{opacity:0.8}a:link,a:visited{color:#348}</style><body><div><h1>Example Domain</h1><p>This domain is for use in documentation examples without needing permission. Avoid use in operations.<p><a href="https://iana.org/domains/example">Learn more</a></div></body></html>
curl: (22) The requested URL returned error: 404
```

Maybe this is a good thing because extra information?

----

Besides the additional html, I *think* the functionality should be the same as --fail, but with less misleading errors. https://curl.se/mail/archive-2024-04/0009.html this wasn't very definitive, but I don't think builder.sh is doing auth anywhere so the behavior should match. I'm not super familiar with the builder.sh code so I'm not 100% that this won't break something.

Some of the failure cases are nicer:

```
❯ nix-build --expr 'with import /home/jrestivo/dev/nixpkgs {config.allowUnfree = true;}; skeu.src' --substituters ""
this derivation will be built:
  /nix/store/h6vk8c8k2raw9lzdx3i6hb7jan0yn2cm-source.drv
building '/nix/store/h6vk8c8k2raw9lzdx3i6hb7jan0yn2cm-source.drv'...
structuredAttrs is enabled

trying https://github.com/darkomarko42/skeu/archive/0.5.1.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100     9 100     9   0     0    44     0  --:--:-- --:--:-- --:--:--    44
curl: (22) The requested URL returned error: 404
Warning: Problem (retrying all errors). Will retry in 1 second. 3 retries left.
100     9 100     9   0     0   310     0  --:--:-- --:--:-- --:--:--   321
curl: (22) The requested URL returned error: 404
Warning: Problem (retrying all errors). Will retry in 2 seconds. 2 retries
Warning: left.
100     9 100     9   0     0   298     0  --:--:-- --:--:-- --:--:--   300
curl: (22) The requested URL returned error: 404
Warning: Problem (retrying all errors). Will retry in 4 seconds. 1 retry left.
100     9 100     9   0     0   297     0  --:--:-- --:--:-- --:--:--   300
curl: (22) The requested URL returned error: 404
error: cannot download source from any mirror
```

I'm not sure if I should PR against master or some other branch, so I'm leaving this as a draft to prevent CI from running.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
