### PR TITLE
srt-xtransmit: init at 0.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -21791,6 +21791,11 @@
     github = "randomdude16671";
     githubId = 210965013;
   };
+  randomizedcoder = {
+    name = "randomizedcoder";
+    github = "randomizedcoder";
+    githubId = 64496590;
+  };
   randoneering = {
     name = "randoneering";
     email = "justin@randoneering.tech";

--- a/pkgs/by-name/sr/srt-xtransmit/package.nix
+++ b/pkgs/by-name/sr/srt-xtransmit/package.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  openssl,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "srt-xtransmit";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "maxsharabayko";
+    repo = "srt-xtransmit";
+    tag = "v${version}";
+    fetchSubmodules = true;
+    hash = "sha256-AEqVJr7TLH+MV4SntZhFFXTttnmcywda/P1EoD2px6E=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    openssl
+  ];
+
+  cmakeFlags = [
+    "-DENABLE_CXX17=OFF"
+    "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
+  ];
+
+  # Upstream CMake does not install srt-xtransmit by default.
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 bin/srt-xtransmit -t $out/bin
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "SRT xtransmit application for generating and receiving test traffic";
+    homepage = "https://github.com/maxsharabayko/srt-xtransmit";
+    license = lib.licenses.mpl20;
+    maintainers = with lib.maintainers; [ randomizedcoder ];
+    platforms = lib.platforms.unix;
+    mainProgram = "srt-xtransmit";
+  };
+}

--- a/pkgs/tools/networking/iperf/2.nix
+++ b/pkgs/tools/networking/iperf/2.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Tool to measure IP bandwidth using UDP or TCP";
     platforms = lib.platforms.unix;
     license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ randomizedcoder ];
 
     # prioritize iperf3
     priority = 10;


### PR DESCRIPTION
## Description

Add [srt-xtransmit](https://github.com/maxsharabayko/srt-xtransmit), a performance/traffic generator tool for [SRT (Secure Reliable Transport)](https://github.com/Haivision/srt).

Also adds myself as a maintainer and picks up maintenance of `iperf2`.

### Commits:
1. `maintainers: add randomizedcoder` - Add myself to maintainer list
2. `srt-xtransmit: init at 0.2.0` - New package
3. `iperf2: add maintainer` - Pick up maintenance of existing package

## Things done

- [x] Built on x86_64-linux
- [ ] Built on aarch64-linux
- [ ] Built on x86_64-darwin
- [ ] Built on aarch64-darwin
- [x] Tested `srt-xtransmit --help` works

## Links

- **srt-xtransmit homepage:** https://github.com/maxsharabayko/srt-xtransmit
- **srt-xtransmit license:** MPL-2.0