### PR TITLE
aws-cdk-cli: init at 2.1100.1

### DIFF
--- a/pkgs/by-name/aw/aws-cdk-cli/package.nix
+++ b/pkgs/by-name/aw/aws-cdk-cli/package.nix
@@ -1,0 +1,121 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchYarnDeps,
+  nodejs,
+  yarnBuildHook,
+  yarnConfigHook,
+  yarnInstallHook,
+  diffutils,
+  zip,
+  jq,
+  unzip,
+  testers,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "aws-cdk-cli";
+  version = "2.1100.1";
+
+  src = fetchFromGitHub {
+    owner = "aws";
+    repo = "aws-cdk-cli";
+    tag = "cdk@v${finalAttrs.version}";
+    hash = "sha256-GIW6y2njqZExAiegDXNWUQB0HzNvXlg02L9DBo4oQnI=";
+  };
+
+  yarnOfflineCache = fetchYarnDeps {
+    yarnLock = "${finalAttrs.src}/yarn.lock";
+    hash = "sha256-oUsH7ccuHFgZw9cnwhIq/mbEgNdJJv9GzBh6HsJT+kU=";
+  };
+
+  nativeBuildInputs = [
+    yarnConfigHook
+    yarnBuildHook
+    yarnInstallHook
+    nodejs
+    zip
+    jq
+    # tests
+    diffutils
+    unzip
+  ];
+
+  env = {
+    NX_DISABLE_REMOTE_CACHE = "true";
+    NX_TASKS_RUNNER_DYNAMIC_OUTPUT = "false";
+    NX_VERBOSE_LOGGING = "true";
+    # Needed to properly embed version info
+    CODEBUILD_RESOLVED_SOURCE_VERSION = finalAttrs.version;
+  };
+
+  # Regular "build" is very heavy and does things we don't need.
+  yarnBuildScript = "compile";
+
+  postPatch =
+    let
+      cliVersionJson = builtins.toJSON {
+        inherit (finalAttrs) version;
+      };
+    in
+    ''
+      echo '${cliVersionJson}' > packages/@aws-cdk/cloud-assembly-schema/cli-version.json
+    '';
+
+  preBuild = ''
+    export NX_PARALLEL="$NIX_BUILD_CORES"
+    pushd packages/@aws-cdk/integ-runner
+    patchShebangs build-tools/generate.sh
+    build-tools/generate.sh
+    popd
+    pushd packages/aws-cdk
+    patchShebangs generate.sh
+    ./generate.sh
+    popd
+  '';
+
+  postInstall = ''
+    # Manually bundle non-bundled dependencies
+    cp -r packages/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema $out/lib/node_modules/aws-cdk-cli/node_modules/jsonschema
+    cp -r packages/aws-cdk/node_modules/decamelize $out/lib/node_modules/aws-cdk-cli/node_modules/decamelize
+
+    patchShebangs "$out/lib/node_modules/aws-cdk-cli/node_modules/aws-cdk/bin"
+    ln -s "$out/lib/node_modules/aws-cdk-cli/node_modules/aws-cdk/bin" "$out/bin"
+    # Delete broken symlinks
+    find "$out/lib/node_modules" -xtype l -delete
+
+    # Fix version
+    pushd $out/lib/node_modules/aws-cdk-cli/packages/aws-cdk
+    mv package.json package.json.bak
+    jq '.version = "${finalAttrs.version}"' < package.json.bak > package.json
+    rm package.json.bak
+    mv build-info.json bi.json
+    jq '.commit = "nixpkgs"' < bi.json > build-info.json
+    rm bi.json
+    popd
+  '';
+
+  # Fixup takes an absurdly long time, so disable it
+  dontFixup = true;
+
+  passthru = {
+    tests.version = testers.testVersion { package = finalAttrs.package; };
+    updateScript = nix-update-script {
+      extraArgs = [
+        "--version-regex"
+        "cdk@v(.*)"
+      ];
+    };
+  };
+
+  meta = {
+    description = "AWS CDK Toolkit";
+    homepage = "https://docs.aws.amazon.com/cdk/v2/guide/cli.html";
+    license = lib.licenses.asl20;
+    maintainers = [ ];
+    mainProgram = "cdk";
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/development/node-packages/aliases.nix
+++ b/pkgs/development/node-packages/aliases.nix
@@ -73,6 +73,7 @@ mapAliases {
   inherit (pkgs) asar; # added 2023-08-26
   inherit (pkgs) auto-changelog; # added 2024-06-25
   inherit (pkgs) aws-azure-login; # added 2023-09-30
+  aws-cdk = pkgs.aws-cdk-cli; # Added 2025-12-23
   awesome-lint = throw "'awesome-lint' has been removed because it was unmaintainable in nixpkgs"; # Added 2025-11-17
   balanceofsatoshis = pkgs.balanceofsatoshis; # added 2023-07-31
   inherit (pkgs) bash-language-server; # added 2024-06-07

--- a/pkgs/development/node-packages/main-programs.nix
+++ b/pkgs/development/node-packages/main-programs.nix
@@ -5,7 +5,6 @@
 
   # Packages that provide a single executable.
   "@angular/cli" = "ng";
-  aws-cdk = "cdk";
   grunt-cli = "grunt";
   gulp-cli = "gulp";
 }

--- a/pkgs/development/node-packages/node-packages.json
+++ b/pkgs/development/node-packages/node-packages.json
@@ -6,7 +6,6 @@
 , "@tailwindcss/line-clamp"
 , "@tailwindcss/typography"
 , "alex"
-, "aws-cdk"
 , "browserify"
 , "browser-sync"
 , "coc-go"

--- a/pkgs/development/node-packages/node-packages.nix
+++ b/pkgs/development/node-packages/node-packages.nix
@@ -19471,24 +19471,6 @@ in
     bypassCache = true;
     reconstructLock = true;
   };
-  aws-cdk = nodeEnv.buildNodePackage {
-    name = "aws-cdk";
-    packageName = "aws-cdk";
-    version = "2.1004.0";
-    src = fetchurl {
-      url = "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1004.0.tgz";
-      sha512 = "3E5ICmSc7ZCZCwLX7NY+HFmmdUYgRaL+67h/BDoDQmkhx9StC8wG4xgzHFY9k8WQS0+ib/MP28f2d9yzHtQLlQ==";
-    };
-    buildInputs = globalBuildInputs;
-    meta = {
-      description = "AWS CDK CLI, the command line tool for CDK apps";
-      homepage = "https://github.com/aws/aws-cdk";
-      license = "Apache-2.0";
-    };
-    production = true;
-    bypassCache = true;
-    reconstructLock = true;
-  };
   browserify = nodeEnv.buildNodePackage {
     name = "browserify";
     packageName = "browserify";


### PR DESCRIPTION
Initial code taken from https://gist.github.com/tomodachi94/e438b23c232e53fb684d8177ca6f7412 which is why I added the co-authored-by trailer. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
