### PR TITLE
signls: init at 0.7.1

### DIFF
--- a/pkgs/by-name/si/signls/package.nix
+++ b/pkgs/by-name/si/signls/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  alsa-lib,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "signls";
+  version = "0.7.1";
+
+  src = fetchFromGitHub {
+    owner = "emprcl";
+    repo = "signls";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-fITsfMgMdv6zW4KEmteCYQdm2NfI2RLbrW44KOwtLOg=";
+  };
+
+  buildInputs = [
+    alsa-lib
+  ];
+
+  vendorHash = "sha256-reNMOb8QRJ+nMa7S2aM/f8wur0yeMDks2b6Skh6uTQQ=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.AppVersion=v${finalAttrs.version}"
+  ];
+
+  meta = {
+    description = "Non-linear, generative midi sequencer in the terminal";
+    homepage = "https://github.com/emprcl/signls";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ matthewcroughan ];
+    mainProgram = "signls";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

A really cool TUI midi sequencer

<img width="1337" height="851" alt="image" src="https://github.com/user-attachments/assets/d5a5e5ff-bad3-4dec-b6d6-5d43b858bbbb" />


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
