### PR TITLE
Remove chuangzhu as inactive

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4830,13 +4830,6 @@
     githubId = 12386805;
     name = "Chua Hou";
   };
-  chuangzhu = {
-    name = "Chuang Zhu";
-    email = "nixos@chuang.cz";
-    github = "chuangzhu";
-    githubId = 31200881;
-    keys = [ { fingerprint = "5D03 A5E6 0754 A3E3 CA57 5037 E838 CED8 1CFF D3F9"; } ];
-  };
   chvp = {
     email = "nixpkgs@cvpetegem.be";
     matrix = "@charlotte:vanpetegem.me";

--- a/pkgs/applications/video/mpv/scripts/webtorrent-mpv-hook.nix
+++ b/pkgs/applications/video/mpv/scripts/webtorrent-mpv-hook.nix
@@ -102,7 +102,7 @@ buildNpmPackage rec {
   meta = {
     description = "Adds a hook that allows mpv to stream torrents";
     homepage = "https://github.com/mrxdst/webtorrent-mpv-hook";
-    maintainers = [ lib.maintainers.chuangzhu ];
+    maintainers = [ ];
     license = lib.licenses.isc;
   };
 }

--- a/pkgs/by-name/bl/blackbox-terminal/package.nix
+++ b/pkgs/by-name/bl/blackbox-terminal/package.nix
@@ -67,9 +67,7 @@ stdenv.mkDerivation {
     description = "Elegant and customizable terminal for GNOME";
     homepage = "https://gitlab.gnome.org/raggesilver/blackbox";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [
-      chuangzhu
-    ];
+    maintainers = [ ];
     mainProgram = "blackbox";
     platforms = lib.platforms.linux;
   };

--- a/pkgs/by-name/de/denaro/package.nix
+++ b/pkgs/by-name/de/denaro/package.nix
@@ -70,7 +70,6 @@ buildDotnetModule rec {
     license = lib.licenses.mit;
     changelog = "https://github.com/nlogozzo/NickvisionMoney/releases/tag/${version}";
     maintainers = with lib.maintainers; [
-      chuangzhu
       kashw2
     ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/ea/eaglemode/package.nix
+++ b/pkgs/by-name/ea/eaglemode/package.nix
@@ -144,9 +144,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Zoomable User Interface";
     changelog = "https://eaglemode.sourceforge.net/ChangeLog.html";
     license = lib.licenses.gpl3;
-    maintainers = with lib.maintainers; [
-      chuangzhu
-    ];
+    maintainers = [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/ej/ejabberd/package.nix
+++ b/pkgs/by-name/ej/ejabberd/package.nix
@@ -221,7 +221,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://www.ejabberd.im";
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [
-      chuangzhu
       toastal
     ];
   };

--- a/pkgs/by-name/gt/gtuber/package.nix
+++ b/pkgs/by-name/gt/gtuber/package.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation {
     description = "GStreamer plugin for streaming videos from websites";
     homepage = "https://rafostar.github.io/gtuber/";
     license = lib.licenses.lgpl21Plus;
-    maintainers = with lib.maintainers; [ chuangzhu ];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/by-name/he/headlines/package.nix
+++ b/pkgs/by-name/he/headlines/package.nix
@@ -75,7 +75,7 @@ stdenv.mkDerivation rec {
     homepage = "https://gitlab.com/caveman250/Headlines";
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ chuangzhu ];
+    maintainers = [ ];
     mainProgram = "headlines";
   };
 }

--- a/pkgs/by-name/ii/iio-oscilloscope/package.nix
+++ b/pkgs/by-name/ii/iio-oscilloscope/package.nix
@@ -74,7 +74,7 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "osc";
     license = lib.licenses.gpl2Only;
     changelog = "https://github.com/analogdevicesinc/iio-oscilloscope/releases/tag/v${finalAttrs.version}-master";
-    maintainers = with lib.maintainers; [ chuangzhu ];
+    maintainers = [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/ka/karlender/package.nix
+++ b/pkgs/by-name/ka/karlender/package.nix
@@ -73,7 +73,6 @@ rustPlatform.buildRustPackage rec {
     license = lib.licenses.gpl3Plus;
     mainProgram = "karlender";
     maintainers = with lib.maintainers; [
-      chuangzhu
       bot-wxt1221
     ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/ko/komikku/package.nix
+++ b/pkgs/by-name/ko/komikku/package.nix
@@ -108,7 +108,6 @@ python3.pkgs.buildPythonApplication rec {
     license = lib.licenses.gpl3Plus;
     changelog = "https://codeberg.org/valos/Komikku/releases/tag/v${version}";
     maintainers = with lib.maintainers; [
-      chuangzhu
       Gliczy
     ];
     teams = [ lib.teams.gnome-circle ];

--- a/pkgs/by-name/li/libspelling/package.nix
+++ b/pkgs/by-name/li/libspelling/package.nix
@@ -69,7 +69,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://gitlab.gnome.org/GNOME/libspelling";
     license = lib.licenses.lgpl21Plus;
     changelog = "https://gitlab.gnome.org/GNOME/libspelling/-/raw/${finalAttrs.version}/NEWS";
-    maintainers = with lib.maintainers; [ chuangzhu ];
+    maintainers = [ ];
     teams = [ lib.teams.gnome ];
   };
 })

--- a/pkgs/by-name/na/nanovna-qt/package.nix
+++ b/pkgs/by-name/na/nanovna-qt/package.nix
@@ -74,7 +74,7 @@ stdenv.mkDerivation rec {
     mainProgram = "vna_qt";
     license = lib.licenses.gpl2Only;
     changelog = "https://github.com/nanovna-v2/NanoVNA-QT/releases/tag/v${version}";
-    maintainers = with lib.maintainers; [ chuangzhu ];
+    maintainers = [ ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/pi/pipeline/package.nix
+++ b/pkgs/by-name/pi/pipeline/package.nix
@@ -95,7 +95,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://mobile.schmidhuberj.de/pipeline";
     mainProgram = "tubefeeder";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ chuangzhu ];
+    maintainers = [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/po/portfolio-filemanager/package.nix
+++ b/pkgs/by-name/po/portfolio-filemanager/package.nix
@@ -81,7 +81,6 @@ python3.pkgs.buildPythonApplication rec {
     mainProgram = "dev.tchx84.Portfolio";
     maintainers = with lib.maintainers; [
       dotlambda
-      chuangzhu
     ];
   };
 }

--- a/pkgs/by-name/st/standardnotes/package.nix
+++ b/pkgs/by-name/st/standardnotes/package.nix
@@ -88,7 +88,6 @@ stdenv.mkDerivation {
     license = lib.licenses.agpl3Only;
     maintainers = with lib.maintainers; [
       mgregoire
-      chuangzhu
       squalus
     ];
     sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];

--- a/pkgs/by-name/su/superd/package.nix
+++ b/pkgs/by-name/su/superd/package.nix
@@ -40,7 +40,6 @@ buildGoModule rec {
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [
-      chuangzhu
       wentam
     ];
   };

--- a/pkgs/by-name/ta/tangram/package.nix
+++ b/pkgs/by-name/ta/tangram/package.nix
@@ -95,7 +95,6 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [
       austinbutler
-      chuangzhu
     ];
     teams = [ lib.teams.gnome-circle ];
   };

--- a/pkgs/by-name/th/thumbdrives/package.nix
+++ b/pkgs/by-name/th/thumbdrives/package.nix
@@ -58,7 +58,6 @@ python3.pkgs.buildPythonApplication rec {
     homepage = "https://sr.ht/~martijnbraam/thumbdrives/";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
-      chuangzhu
       Luflosi
     ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/tu/tuba/package.nix
+++ b/pkgs/by-name/tu/tuba/package.nix
@@ -121,7 +121,6 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl3Only;
     changelog = "https://github.com/GeopJr/Tuba/releases/tag/v${version}";
     maintainers = with lib.maintainers; [
-      chuangzhu
       donovanglover
     ];
     teams = [ lib.teams.gnome-circle ];

--- a/pkgs/by-name/us/usbutils/package.nix
+++ b/pkgs/by-name/us/usbutils/package.nix
@@ -61,7 +61,6 @@ stdenv.mkDerivation rec {
     description = "Tools for working with USB devices, such as lsusb";
     maintainers = with lib.maintainers; [
       cafkafk
-      chuangzhu
     ];
     license = with lib.licenses; [
       gpl2Only # manpages, usbreset

--- a/pkgs/by-name/vi/viu/package.nix
+++ b/pkgs/by-name/vi/viu/package.nix
@@ -30,7 +30,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/atanunq/viu";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
-      chuangzhu
       sigmanificient
     ];
     mainProgram = "viu";

--- a/pkgs/by-name/wa/watchmate/package.nix
+++ b/pkgs/by-name/wa/watchmate/package.nix
@@ -54,7 +54,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/azymohliad/watchmate";
     changelog = "https://github.com/azymohliad/watchmate/raw/v${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ chuangzhu ];
+    maintainers = [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/development/gnuradio-modules/fosphor/default.nix
+++ b/pkgs/development/gnuradio-modules/fosphor/default.nix
@@ -85,7 +85,7 @@ mkDerivation {
     '';
     homepage = "https://projects.osmocom.org/projects/sdr/wiki/Fosphor";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ chuangzhu ];
+    maintainers = [ ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/development/gnuradio-modules/lora_sdr/default.nix
+++ b/pkgs/development/gnuradio-modules/lora_sdr/default.nix
@@ -54,7 +54,7 @@ mkDerivation {
     description = "Fully-functional GNU Radio software-defined radio (SDR) implementation of a LoRa transceiver";
     homepage = "https://www.epfl.ch/labs/tcl/resources-and-sw/lora-phy/";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ chuangzhu ];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/development/python-modules/curl-cffi/default.nix
+++ b/pkgs/development/python-modules/curl-cffi/default.nix
@@ -130,7 +130,6 @@ buildPythonPackage rec {
     homepage = "https://curl-cffi.readthedocs.io";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
-      chuangzhu
       sarahec
     ];
   };

--- a/pkgs/development/python-modules/pure-protobuf/default.nix
+++ b/pkgs/development/python-modules/pure-protobuf/default.nix
@@ -51,6 +51,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/eigenein/protobuf";
     changelog = "https://github.com/eigenein/protobuf/releases/tag/${src.tag}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ chuangzhu ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/py-libzfs/default.nix
+++ b/pkgs/development/python-modules/py-libzfs/default.nix
@@ -51,7 +51,7 @@ buildPythonPackage rec {
     description = "Python libzfs bindings";
     homepage = "https://github.com/truenas/py-libzfs";
     license = lib.licenses.bsd2;
-    maintainers = with lib.maintainers; [ chuangzhu ];
+    maintainers = [ ];
     # The project also supports macOS (OpenZFS on OSX, O3X), FreeBSD and OpenSolaris
     # I don't have a machine to test out, thus only packaged for Linux
     platforms = lib.platforms.linux;

--- a/pkgs/os-specific/linux/rtl8723ds/default.nix
+++ b/pkgs/os-specific/linux/rtl8723ds/default.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation {
     homepage = "https://github.com/lwfinger/rtl8723ds";
     license = lib.licenses.gpl2Only;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ chuangzhu ];
+    maintainers = [ ];
     broken = kernel.kernelAtLeast "6.17";
   };
 }


### PR DESCRIPTION
chuangzhu's:
* last PR activity was December 2, 2024 in #361174
* [last commit](https://github.com/NixOS/nixpkgs/commit/319b44d26df284ff27967f4e11adbb78747c504f) was on June 15, 2024

@chuangzhu if I don't hear from you by December 31, 2025 I will assume you are willing to be removed.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
