### PR TITLE
beads: 0.27.2 -> 0.35.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13435,8 +13435,8 @@
   };
   kedry = {
     name = "Kevin Edry";
-    github = "kedry";
-    githubId = 12020122;
+    github = "KevinEdry";
+    githubId = 42734162;
   };
   keegancsmith = {
     email = "keegan.csmith@gmail.com";

--- a/pkgs/by-name/be/beads/package.nix
+++ b/pkgs/by-name/be/beads/package.nix
@@ -11,16 +11,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "beads";
-  version = "0.27.2";
+  version = "0.35.0";
 
   src = fetchFromGitHub {
     owner = "steveyegge";
     repo = "beads";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-PpuyQCQocmOqt4EYDsjx1nh0dRxt2e7Vu1/KQ74B88Q=";
+    hash = "sha256-qsT6MYquDXB+nZSlHwgZ3KiFN5NYp4F7hwk0aHda6CM=";
   };
 
-  vendorHash = "sha256-5p4bHTBB6X30FosIn6rkMDJoap8tOvB7bLmVKsy09D8=";
+  vendorHash = "sha256-Brzb6HZHYtF8LTkP3uQ21GG72c5ekzSkQ2EdrqkdeO0=";
 
   subPackages = [ "cmd/bd" ];
 


### PR DESCRIPTION
## Description

Update beads to 0.35.0 and fix maintainer GitHub info.

## Things done

- [x] Built on platform(s)
  - [x] x86_64-darwin
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside nixos/tests)
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)