### PR TITLE
beetcamp: move beets dependency to `nativeBuildInputs`

### DIFF
--- a/pkgs/development/python-modules/beetcamp/default.nix
+++ b/pkgs/development/python-modules/beetcamp/default.nix
@@ -40,10 +40,13 @@ buildPythonPackage {
   ];
 
   dependencies = [
-    beets
     httpx
     packaging
     pycountry
+  ];
+
+  nativeBuildInputs = [
+    beets
   ];
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/beetcamp/default.nix
+++ b/pkgs/development/python-modules/beetcamp/default.nix
@@ -13,6 +13,7 @@
   filelock,
   writableTmpDirAsHomeHook,
   nix-update-script,
+  beetcamp ? null, # For `passthru.tests`.
 }:
 
 let
@@ -58,7 +59,19 @@ buildPythonPackage {
     "test_get_html"
   ];
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    updateScript = nix-update-script { };
+    tests = {
+      beets-with-beetcamp = beets.override {
+        pluginOverrides = {
+          beetcamp = {
+            enable = true;
+            propagatedBuildInputs = [ beetcamp ];
+          };
+        };
+      };
+    };
+  };
 
   meta = {
     description = "Bandcamp autotagger source for beets (http://beets.io)";


### PR DESCRIPTION
This will make it possible to use `beetcamp` without setting `dontUsePythonCatchConflicts = true` in an override.

This adds a disabled-by-default `beetcamp` plugin for a nicer UX.

See: https://github.com/NixOS/nixpkgs/pull/471166#discussion_r2642534939


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
