### PR TITLE
lib.generators.toINI: allow duplicate sections

### DIFF
--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -2577,6 +2577,27 @@ runTests {
     '';
   };
 
+  testToINIDuplicateSections = {
+    expr = generators.toINI { listsAsDuplicateSections = true; } {
+      foo = [
+        { bar = "baz"; }
+        { bar = "qux"; }
+      ];
+      quux = {
+        corge = true;
+      };
+    };
+    expected = ''
+      [foo]
+      bar=baz
+      [foo]
+      bar=qux
+
+      [quux]
+      corge=true
+    '';
+  };
+
   testToINIDefaultEscapes = {
     expr = generators.toINI { } {
       "no [ and ] allowed unescaped" = {

--- a/pkgs/pkgs-lib/tests/formats.nix
+++ b/pkgs/pkgs-lib/tests/formats.nix
@@ -282,6 +282,41 @@ runBuildTests {
     '';
   };
 
+  iniDuplicateSectionsWithoutList = shouldFail {
+    format = formats.ini { };
+    input = {
+      foo = [
+        { bar = "baz"; }
+        { qux = "quux"; }
+      ];
+      corge = {
+        grault = "garply";
+      };
+    };
+  };
+
+  iniDuplicateSections = shouldPass {
+    format = formats.ini { listsAsDuplicateSections = true; };
+    input = {
+      foo = [
+        { bar = "baz"; }
+        { qux = "quux"; }
+      ];
+      corge = {
+        grault = "garply";
+      };
+    };
+    expected = ''
+      [corge]
+      grault=garply
+
+      [foo]
+      bar=baz
+      [foo]
+      qux=quux
+    '';
+  };
+
   iniListToValue = shouldPass {
     format = formats.ini {
       listToValue = lib.concatMapStringsSep ", " (lib.generators.mkValueStringDefault { });


### PR DESCRIPTION
With these changes we can generate an INI string with sections that have
duplicate names by putting the attributes for a section in a list:
```
lib.generators.toINI { listsAsDuplicateSections = true; } {
  foo = [
    { bar = "baz"; }
    { bar = "qux"; }
  ];
}

> [foo]
> bar=baz
> [foo]
> bar=qux
```

This is quite useful for Weston, which requires every launcher to be in
their own section in the `weston.ini` file:
https://man.archlinux.org/man/weston.ini.5.html#LAUNCHER_SECTION

Signed-off-by: David Wronek <david.wronek@mainlining.org>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
