### PR TITLE
nixos/opentabletdriver: fix "Daemon is already running"

### DIFF
--- a/nixos/modules/hardware/opentabletdriver.nix
+++ b/nixos/modules/hardware/opentabletdriver.nix
@@ -8,7 +8,10 @@ let
   cfg = config.hardware.opentabletdriver;
 in
 {
-  meta.maintainers = with lib.maintainers; [ thiagokokada ];
+  meta.maintainers = with lib.maintainers; [
+    gepbird
+    thiagokokada
+  ];
 
   options = {
     hardware.opentabletdriver = {

--- a/nixos/modules/hardware/opentabletdriver.nix
+++ b/nixos/modules/hardware/opentabletdriver.nix
@@ -60,6 +60,12 @@ in
 
       serviceConfig = {
         Type = "simple";
+        # workaround for https://github.com/NixOS/nixpkgs/issues/469340
+        ExecStartPre = pkgs.writeShellScript "disable-for-gdm-greeter" ''
+          if [[ "$USER" = "gdm-greeter"* ]]; then
+            exit 1
+          fi
+        '';
         ExecStart = lib.getExe' cfg.package "otd-daemon";
         Restart = "on-failure";
       };


### PR DESCRIPTION
This issue was observed after GNOME 48 -> 49 update.
User creation for gdm was changed, now it starts systemd user
services.
This causes issues for OTD and potentially other services, as
gdm-greeter user starts an OTD process creating a named pipe in /tmp
that acts as a lock file. When a user logs in, they also start a process
which exits with "Daemon is already running" and the gdm-greeter started
process exits.
Applying upstream patches that improve cleaning up the "lock file"
doesn't fix this issue, probably because there's not enough time between
stopping the first and starting the second process.

Fixes https://github.com/NixOS/nixpkgs/issues/469340.

Tested this as described in the issue, I'm open to better ideas.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
