### PR TITLE
gitbutler: 0.15.10 -> 0.18.8

### DIFF
--- a/pkgs/by-name/gi/gitbutler/gix-from-crates-io.patch
+++ b/pkgs/by-name/gi/gitbutler/gix-from-crates-io.patch
@@ -1,1415 +1,1020 @@
 diff --git a/Cargo.lock b/Cargo.lock
-index 60b520f8d..8406c39d0 100644
+index 6ee5075ea..291e43241 100644
 --- a/Cargo.lock
 +++ b/Cargo.lock
-@@ -13,9 +13,9 @@ dependencies = [
+@@ -157,9 +157,9 @@ dependencies = [
  
  [[package]]
- name = "adler2"
--version = "2.0.0"
-+version = "2.0.1"
+ name = "anstyle-svg"
+-version = "0.1.11"
++version = "0.1.12"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
-+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
- 
- [[package]]
- name = "aes"
-@@ -95,9 +95,9 @@ checksum = "84521a3cf562bc62942e294181d9eef17eb38ceb8c68677bc49f144e4c3d4f8d"
- 
- [[package]]
- name = "android_logger"
--version = "0.15.0"
-+version = "0.15.1"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "f6f39be698127218cca460cb624878c9aa4e2b47dba3b277963d2bf00bad263b"
-+checksum = "dbb4e440d04be07da1f1bf44fb4495ebd58669372fe0cffa6e48595ac5bd88a3"
- dependencies = [
-  "android_log-sys",
-  "env_filter",
-@@ -115,9 +115,9 @@ dependencies = [
- 
- [[package]]
- name = "anstream"
--version = "0.6.18"
-+version = "0.6.20"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
-+checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
+-checksum = "26b9ec8c976eada1b0f9747a3d7cc4eae3bef10613e443746e7487f26c872fde"
++checksum = "e22d9f3dea8bbda97c75bd0f0203e23f1e190d6d6f27a40e10063946dc4d4362"
  dependencies = [
   "anstyle",
-  "anstyle-parse",
-@@ -130,37 +130,37 @@ dependencies = [
- 
- [[package]]
- name = "anstyle"
--version = "1.0.10"
-+version = "1.0.11"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
-+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
- 
- [[package]]
- name = "anstyle-parse"
--version = "0.2.6"
-+version = "0.2.7"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
-+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
- dependencies = [
-  "utf8parse",
- ]
- 
- [[package]]
- name = "anstyle-query"
--version = "1.1.2"
-+version = "1.1.4"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
-+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
- dependencies = [
-- "windows-sys 0.59.0",
-+ "windows-sys 0.60.2",
- ]
- 
- [[package]]
- name = "anstyle-wincon"
--version = "3.0.7"
-+version = "3.0.10"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
-+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
- dependencies = [
-  "anstyle",
-- "once_cell",
-- "windows-sys 0.59.0",
-+ "once_cell_polyfill",
-+ "windows-sys 0.60.2",
- ]
- 
- [[package]]
-@@ -180,15 +180,15 @@ dependencies = [
- 
- [[package]]
- name = "arboard"
--version = "3.5.0"
-+version = "3.6.0"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "c1df21f715862ede32a0c525ce2ca4d52626bb0007f8c18b87a384503ac33e70"
-+checksum = "55f533f8e0af236ffe5eb979b99381df3258853f00ba2e44b6e1955292c75227"
- dependencies = [
+  "anstyle-lossy",
+@@ -203,11 +203,11 @@ dependencies = [
   "clipboard-win",
   "image",
   "log",
-  "objc2 0.6.1",
-- "objc2-app-kit 0.3.1",
-+ "objc2-app-kit",
+- "objc2 0.6.3",
++ "objc2",
+  "objc2-app-kit",
   "objc2-core-foundation",
   "objc2-core-graphics",
-  "objc2-foundation 0.3.1",
-@@ -213,14 +213,14 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
- 
- [[package]]
- name = "ashpd"
--version = "0.9.2"
-+version = "0.11.0"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "4d43c03d9e36dd40cab48435be0b09646da362c278223ca535493877b2c1dee9"
-+checksum = "6cbdf310d77fd3aaee6ea2093db7011dc2d35d2eb3481e5607f1f8d942ed99df"
- dependencies = [
-  "enumflags2",
-  "futures-channel",
-  "futures-util",
-- "rand 0.8.5",
-+ "rand 0.9.2",
-  "raw-window-handle",
-  "serde",
-  "serde_repr",
-@@ -229,7 +229,7 @@ dependencies = [
-  "wayland-backend",
-  "wayland-client",
-  "wayland-protocols",
-- "zbus 4.4.0",
-+ "zbus 5.9.0",
- ]
- 
- [[package]]
-@@ -262,9 +262,9 @@ dependencies = [
- 
- [[package]]
- name = "async-channel"
--version = "2.3.1"
-+version = "2.5.0"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
-+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
- dependencies = [
-  "concurrent-queue",
-  "event-listener-strategy",
-@@ -288,9 +288,9 @@ dependencies = [
- 
- [[package]]
- name = "async-io"
--version = "2.4.0"
-+version = "2.5.0"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "43a2b323ccce0a1d90b449fd71f2a06ca7faa7c54c2751f06c9bd851fc061059"
-+checksum = "19634d6336019ef220f09fd31168ce5c184b295cbf80345437cc36094ef223ca"
- dependencies = [
-  "async-lock",
-  "cfg-if",
-@@ -299,17 +299,16 @@ dependencies = [
+- "objc2-foundation 0.3.2",
++ "objc2-foundation",
+  "parking_lot",
+  "percent-encoding",
+  "windows-sys 0.60.2",
+@@ -299,16 +299,16 @@ dependencies = [
   "futures-lite",
   "parking",
   "polling",
-- "rustix 0.38.44",
-+ "rustix 1.0.8",
+- "rustix 1.1.2",
++ "rustix",
   "slab",
-- "tracing",
-- "windows-sys 0.59.0",
-+ "windows-sys 0.60.2",
+  "windows-sys 0.61.2",
  ]
  
  [[package]]
  name = "async-lock"
--version = "3.4.0"
-+version = "3.4.1"
+-version = "3.4.1"
++version = "3.4.2"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
-+checksum = "5fd03604047cee9b6ce9de9f70c6cd540a0520c813cbd49bae61f33ab80ed1dc"
+-checksum = "5fd03604047cee9b6ce9de9f70c6cd540a0520c813cbd49bae61f33ab80ed1dc"
++checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
  dependencies = [
   "event-listener",
   "event-listener-strategy",
-@@ -350,14 +349,14 @@ checksum = "0289cba6d5143bfe8251d57b4a8cac036adf158525a76533a7082ba65ec76398"
+@@ -329,7 +329,7 @@ dependencies = [
+  "eventsource-stream",
+  "futures",
+  "rand 0.9.2",
+- "reqwest 0.12.24",
++ "reqwest 0.12.27",
+  "reqwest-eventsource",
+  "secrecy",
+  "serde",
+@@ -345,9 +345,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "async-openai-macros"
+-version = "0.1.0"
++version = "0.1.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "0289cba6d5143bfe8251d57b4a8cac036adf158525a76533a7082ba65ec76398"
++checksum = "81872a8e595e8ceceab71c6ba1f9078e313b452a1e31934e6763ef5d308705e4"
  dependencies = [
   "proc-macro2",
   "quote",
-- "syn 2.0.101",
-+ "syn 2.0.104",
- ]
- 
- [[package]]
- name = "async-process"
--version = "2.3.0"
-+version = "2.4.0"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "63255f1dc2381611000436537bbedfe83183faa303a5a0edaf191edef06526bb"
-+checksum = "65daa13722ad51e6ab1a1b9c01299142bc75135b337923cfa10e79bbbd669f00"
- dependencies = [
-  "async-channel",
-  "async-io",
-@@ -368,8 +367,7 @@ dependencies = [
+@@ -369,7 +369,7 @@ dependencies = [
   "cfg-if",
   "event-listener",
   "futures-lite",
-- "rustix 0.38.44",
-- "tracing",
-+ "rustix 1.0.8",
+- "rustix 1.1.2",
++ "rustix",
  ]
  
  [[package]]
-@@ -380,14 +378,14 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
- dependencies = [
-  "proc-macro2",
-  "quote",
-- "syn 2.0.101",
-+ "syn 2.0.104",
- ]
- 
- [[package]]
- name = "async-signal"
--version = "0.2.10"
-+version = "0.2.12"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "637e00349800c0bdf8bfc21ebbc0b6524abea702b0da4168ac00d070d0c0b9f3"
-+checksum = "f567af260ef69e1d52c2b560ce0ea230763e6fbb9214a85d768760a920e3e3c1"
- dependencies = [
-  "async-io",
-  "async-lock",
-@@ -395,10 +393,10 @@ dependencies = [
+@@ -395,7 +395,7 @@ dependencies = [
   "cfg-if",
   "futures-core",
   "futures-io",
-- "rustix 0.38.44",
-+ "rustix 1.0.8",
+- "rustix 1.1.2",
++ "rustix",
   "signal-hook-registry",
   "slab",
-- "windows-sys 0.59.0",
-+ "windows-sys 0.60.2",
- ]
- 
- [[package]]
-@@ -420,7 +418,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
- dependencies = [
-  "proc-macro2",
-  "quote",
-- "syn 2.0.101",
-+ "syn 2.0.104",
- ]
- 
- [[package]]
-@@ -437,7 +435,7 @@ checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
- dependencies = [
-  "proc-macro2",
-  "quote",
-- "syn 2.0.101",
-+ "syn 2.0.104",
- ]
- 
- [[package]]
-@@ -471,9 +469,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
- 
- [[package]]
- name = "autocfg"
--version = "1.4.0"
-+version = "1.5.0"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
-+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+  "windows-sys 0.61.2",
+@@ -455,9 +455,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
  
  [[package]]
  name = "axum"
-@@ -691,9 +689,9 @@ dependencies = [
- 
- [[package]]
- name = "blocking"
--version = "1.6.1"
-+version = "1.6.2"
+-version = "0.8.7"
++version = "0.8.8"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
-+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+-checksum = "5b098575ebe77cb6d14fc7f32749631a6e44edbef6b796f89b020e99ba20d425"
++checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
  dependencies = [
-  "async-channel",
-  "async-task",
-@@ -722,7 +720,7 @@ dependencies = [
-  "proc-macro-crate 3.3.0",
-  "proc-macro2",
-  "quote",
-- "syn 2.0.101",
-+ "syn 2.0.104",
+  "axum-core",
+  "base64 0.22.1",
+@@ -600,22 +600,13 @@ dependencies = [
+  "generic-array",
+ ]
+ 
+-[[package]]
+-name = "block2"
+-version = "0.5.1"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
+-dependencies = [
+- "objc2 0.5.2",
+-]
+-
+ [[package]]
+ name = "block2"
+ version = "0.6.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+ dependencies = [
+- "objc2 0.6.3",
++ "objc2",
  ]
  
  [[package]]
-@@ -759,9 +757,9 @@ dependencies = [
+@@ -697,9 +688,9 @@ dependencies = [
  
  [[package]]
  name = "bumpalo"
--version = "3.17.0"
-+version = "3.19.0"
+-version = "3.19.0"
++version = "3.19.1"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
-+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
++checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
  
  [[package]]
  name = "but"
-@@ -941,7 +939,7 @@ dependencies = [
-  "insta",
+@@ -795,7 +786,7 @@ dependencies = [
+  "gitbutler-stack",
+  "gix",
+  "itertools",
+- "reqwest 0.12.24",
++ "reqwest 0.12.27",
+  "rmcp",
+  "schemars 1.1.0",
+  "serde",
+@@ -975,7 +966,7 @@ dependencies = [
+  "parking_lot",
   "serde",
   "serde_json",
-- "toml",
-+ "toml 0.8.23",
+- "toml 0.9.8",
++ "toml 0.9.10+spec-1.1.0",
   "tracing",
+  "ts-rs",
   "uuid",
- ]
-@@ -986,7 +984,7 @@ dependencies = [
-  "petgraph 0.8.2",
-  "serde",
-  "termtree",
-- "toml",
-+ "toml 0.8.23",
-  "tracing",
- ]
- 
-@@ -1008,7 +1006,7 @@ dependencies = [
-  "serde",
-  "serde-error",
-  "serde_json",
-- "toml",
-+ "toml 0.8.23",
-  "tracing",
-  "uuid",
- ]
-@@ -1057,7 +1055,7 @@ dependencies = [
-  "insta",
-  "serde",
-  "tempfile",
-- "toml",
-+ "toml 0.8.23",
-  "tracing",
- ]
- 
-@@ -1275,9 +1273,9 @@ dependencies = [
- 
- [[package]]
- name = "bytemuck"
--version = "1.23.0"
-+version = "1.23.2"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "9134a6ef01ce4b366b50689c94f82c14bc72bc5d0386829828a2e2752ef7958c"
-+checksum = "3995eaeebcdf32f91f980d360f78732ddc061097ab4e39991ae7a6ace9194677"
- 
- [[package]]
- name = "byteorder"
-@@ -1346,9 +1344,9 @@ dependencies = [
- 
- [[package]]
- name = "camino"
--version = "1.1.9"
-+version = "1.1.11"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
-+checksum = "5d07aa9a93b00c76f71bc35d598bed923f6d4f3a9ca5c24b7737ae1a292841c0"
- dependencies = [
-  "serde",
- ]
-@@ -1378,12 +1376,12 @@ dependencies = [
- 
- [[package]]
- name = "cargo_toml"
--version = "0.22.1"
-+version = "0.22.3"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "02260d489095346e5cafd04dea8e8cb54d1d74fcd759022a9b72986ebe9a1257"
-+checksum = "374b7c592d9c00c1f4972ea58390ac6b18cbb6ab79011f3bdc90a0b82ca06b77"
- dependencies = [
-  "serde",
-- "toml",
-+ "toml 0.9.5",
- ]
- 
- [[package]]
-@@ -1397,9 +1395,9 @@ dependencies = [
- 
- [[package]]
- name = "cc"
--version = "1.2.23"
-+version = "1.2.31"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "5f4ac86a9e5bc1e2b3449ab9d7d3a6a405e3d1bb28d7b9be8614f55846ae3766"
-+checksum = "c3a42d84bb6b69d3a8b3eaacf0d88f179e1929695e1ad012b6cf64d9caaa5fd2"
- dependencies = [
-  "jobserver",
-  "libc",
-@@ -1435,9 +1433,9 @@ dependencies = [
- 
- [[package]]
- name = "cfg-if"
--version = "1.0.0"
-+version = "1.0.1"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
- 
- [[package]]
- name = "cfg_aliases"
-@@ -1472,9 +1470,9 @@ dependencies = [
- 
- [[package]]
- name = "clap"
--version = "4.5.42"
-+version = "4.5.43"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "ed87a9d530bb41a67537289bafcac159cb3ee28460e0a4571123d2a778a6a882"
-+checksum = "50fd97c9dc2399518aa331917ac6f274280ec5eb34e555dd291899745c48ec6f"
- dependencies = [
-  "clap_builder",
-  "clap_derive",
-@@ -1482,9 +1480,9 @@ dependencies = [
- 
- [[package]]
- name = "clap_builder"
--version = "4.5.42"
-+version = "4.5.43"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "64f4f3f3c77c94aff3c7e9aac9a2ca1974a5adf392a8bb751e827d6d127ab966"
-+checksum = "c35b5830294e1fa0462034af85cc95225a4cb07092c088c55bda3147cfcd8f65"
- dependencies = [
-  "anstream",
-  "anstyle",
-@@ -1501,20 +1499,20 @@ dependencies = [
-  "heck 0.5.0",
-  "proc-macro2",
-  "quote",
-- "syn 2.0.101",
-+ "syn 2.0.104",
- ]
- 
- [[package]]
- name = "clap_lex"
--version = "0.7.4"
-+version = "0.7.5"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
-+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
- 
- [[package]]
- name = "clipboard-win"
--version = "5.4.0"
-+version = "5.4.1"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "15efe7a882b08f34e38556b14f2fb3daa98769d06c7f0c1b076dfd0d983bc892"
-+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
- dependencies = [
-  "error-code",
- ]
-@@ -1527,14 +1525,14 @@ checksum = "cbd0f76e066e64fdc5631e3bb46381254deab9ef1158292f27c8c57e3bf3fe59"
- 
- [[package]]
- name = "cocoa"
--version = "0.26.0"
-+version = "0.26.1"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "f79398230a6e2c08f5c9760610eb6924b52aa9e7950a619602baba59dcbbdbb2"
-+checksum = "ad36507aeb7e16159dfe68db81ccc27571c3ccd4b76fb2fb72fc59e7a4b1b64c"
- dependencies = [
-  "bitflags 2.9.1",
-  "block",
-  "cocoa-foundation",
-- "core-foundation 0.10.0",
-+ "core-foundation 0.10.1",
-  "core-graphics",
-  "foreign-types 0.5.0",
-  "libc",
-@@ -1543,23 +1541,22 @@ dependencies = [
- 
- [[package]]
- name = "cocoa-foundation"
--version = "0.2.0"
-+version = "0.2.1"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "e14045fb83be07b5acf1c0884b2180461635b433455fa35d1cd6f17f1450679d"
-+checksum = "81411967c50ee9a1fc11365f8c585f863a22a9697c89239c452292c40ba79b0d"
- dependencies = [
-  "bitflags 2.9.1",
-  "block",
-- "core-foundation 0.10.0",
-+ "core-foundation 0.10.1",
-  "core-graphics-types",
-- "libc",
-  "objc",
- ]
- 
- [[package]]
- name = "colorchoice"
--version = "1.0.3"
-+version = "1.0.4"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
-+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
- 
- [[package]]
- name = "colored"
-@@ -1705,9 +1702,9 @@ dependencies = [
- 
- [[package]]
- name = "core-foundation"
--version = "0.10.0"
-+version = "0.10.1"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
-+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
- dependencies = [
-  "core-foundation-sys",
-  "libc",
-@@ -1726,7 +1723,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
- dependencies = [
-  "bitflags 2.9.1",
-- "core-foundation 0.10.0",
-+ "core-foundation 0.10.1",
-  "core-graphics-types",
-  "foreign-types 0.5.0",
-  "libc",
-@@ -1739,7 +1736,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
- dependencies = [
-  "bitflags 2.9.1",
-- "core-foundation 0.10.0",
-+ "core-foundation 0.10.1",
-  "libc",
- ]
- 
-@@ -1825,7 +1822,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
- dependencies = [
-  "quote",
-- "syn 2.0.101",
-+ "syn 2.0.104",
- ]
- 
- [[package]]
-@@ -1835,29 +1832,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
- dependencies = [
-  "quote",
-- "syn 2.0.101",
-+ "syn 2.0.104",
- ]
- 
- [[package]]
- name = "curl"
--version = "0.4.47"
-+version = "0.4.48"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "d9fb4d13a1be2b58f14d60adba57c9834b78c62fd86c3e76a148f732686e9265"
-+checksum = "9e2d5c8f48d9c0c23250e52b55e82a6ab4fdba6650c931f5a0a57a43abda812b"
- dependencies = [
-  "curl-sys",
-  "libc",
-  "openssl-probe",
-  "openssl-sys",
-  "schannel",
-- "socket2 0.5.9",
-- "windows-sys 0.52.0",
-+ "socket2 0.5.10",
-+ "windows-sys 0.59.0",
- ]
- 
- [[package]]
- name = "curl-sys"
--version = "0.4.80+curl-8.12.1"
-+version = "0.4.82+curl-8.14.1"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "55f7df2eac63200c3ab25bde3b2268ef2ee56af3d238e76d61f01c3c49bff734"
-+checksum = "c4d63638b5ec65f1a4ae945287b3fd035be4554bbaf211901159c9a2a74fb5be"
- dependencies = [
-  "cc",
-  "libc",
-@@ -1865,7 +1862,7 @@ dependencies = [
-  "openssl-sys",
-  "pkg-config",
-  "vcpkg",
-- "windows-sys 0.52.0",
-+ "windows-sys 0.59.0",
- ]
- 
- [[package]]
-@@ -1889,7 +1886,7 @@ dependencies = [
-  "proc-macro2",
-  "quote",
-  "strsim",
-- "syn 2.0.101",
-+ "syn 2.0.104",
- ]
- 
- [[package]]
-@@ -1900,7 +1897,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
- dependencies = [
-  "darling_core",
-  "quote",
-- "syn 2.0.101",
-+ "syn 2.0.104",
- ]
- 
- [[package]]
-@@ -1982,7 +1979,7 @@ checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
- dependencies = [
-  "proc-macro2",
-  "quote",
-- "syn 2.0.101",
-+ "syn 2.0.104",
- ]
- 
- [[package]]
-@@ -2003,7 +2000,7 @@ dependencies = [
-  "darling",
-  "proc-macro2",
-  "quote",
-- "syn 2.0.101",
-+ "syn 2.0.104",
- ]
- 
- [[package]]
-@@ -2013,7 +2010,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
- dependencies = [
-  "derive_builder_core",
-- "syn 2.0.101",
-+ "syn 2.0.104",
- ]
- 
- [[package]]
-@@ -2026,7 +2023,7 @@ dependencies = [
-  "proc-macro2",
-  "quote",
-  "rustc_version",
-- "syn 2.0.101",
-+ "syn 2.0.104",
- ]
- 
- [[package]]
-@@ -2052,15 +2049,15 @@ dependencies = [
- 
- [[package]]
- name = "diesel_derives"
--version = "2.2.5"
-+version = "2.2.7"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "68d4216021b3ea446fd2047f5c8f8fe6e98af34508a254a01e4d6bc1e844f84d"
-+checksum = "1b96984c469425cb577bf6f17121ecb3e4fe1e81de5d8f780dd372802858d756"
- dependencies = [
-  "diesel_table_macro_syntax",
-  "dsl_auto_type",
-  "proc-macro2",
-  "quote",
-- "syn 2.0.101",
-+ "syn 2.0.104",
- ]
- 
- [[package]]
-@@ -2080,7 +2077,7 @@ version = "0.2.0"
- source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "209c735641a413bc68c4923a9d6ad4bcb3ca306b794edaa7eb0b3228a99ffb25"
- dependencies = [
-- "syn 2.0.101",
-+ "syn 2.0.104",
- ]
- 
- [[package]]
-@@ -2162,7 +2159,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
- dependencies = [
-  "libc",
-  "option-ext",
-- "redox_users 0.5.0",
-+ "redox_users 0.5.2",
-  "windows-sys 0.60.2",
- ]
- 
-@@ -2190,6 +2187,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
- dependencies = [
-  "bitflags 2.9.1",
-+ "block2 0.6.1",
-+ "libc",
-  "objc2 0.6.1",
- ]
- 
-@@ -2201,7 +2200,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
- dependencies = [
-  "proc-macro2",
-  "quote",
-- "syn 2.0.101",
-+ "syn 2.0.104",
- ]
- 
- [[package]]
-@@ -2210,7 +2209,7 @@ version = "0.5.2"
- source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
- dependencies = [
-- "libloading",
-+ "libloading 0.8.8",
- ]
- 
- [[package]]
-@@ -2227,13 +2226,13 @@ dependencies = [
- 
- [[package]]
- name = "dlopen2_derive"
--version = "0.4.0"
-+version = "0.4.1"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "f2b99bf03862d7f545ebc28ddd33a665b50865f4dfd84031a393823879bd4c54"
-+checksum = "788160fb30de9cdd857af31c6a2675904b16ece8fc2737b2c7127ba368c9d0f4"
- dependencies = [
-  "proc-macro2",
-  "quote",
-- "syn 2.0.101",
-+ "syn 2.0.104",
- ]
- 
- [[package]]
-@@ -2277,7 +2276,7 @@ dependencies = [
-  "heck 0.5.0",
-  "proc-macro2",
-  "quote",
-- "syn 2.0.101",
-+ "syn 2.0.104",
- ]
- 
- [[package]]
-@@ -2303,9 +2302,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
- 
- [[package]]
- name = "dyn-clone"
--version = "1.0.19"
-+version = "1.0.20"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
-+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
- 
- [[package]]
- name = "either"
-@@ -2315,16 +2314,16 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
- 
- [[package]]
- name = "embed-resource"
--version = "3.0.2"
-+version = "3.0.5"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "7fbc6e0d8e0c03a655b53ca813f0463d2c956bc4db8138dbc89f120b066551e3"
-+checksum = "4c6d81016d6c977deefb2ef8d8290da019e27cc26167e102185da528e6c0ab38"
- dependencies = [
-  "cc",
-  "memchr",
-  "rustc_version",
-- "toml",
-+ "toml 0.9.5",
-  "vswhom",
-- "winreg 0.52.0",
-+ "winreg 0.55.0",
- ]
- 
- [[package]]
-@@ -2356,9 +2355,9 @@ checksum = "a3d8a32ae18130a3c84dd492d4215c3d913c3b07c6b63c2eb3eb7ff1101ab7bf"
- 
- [[package]]
- name = "enumflags2"
--version = "0.7.11"
-+version = "0.7.12"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "ba2f4b465f5318854c6f8dd686ede6c0a9dc67d4b1ac241cf0eb51521a309147"
-+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
- dependencies = [
-  "enumflags2_derive",
-  "serde",
-@@ -2366,13 +2365,13 @@ dependencies = [
- 
- [[package]]
- name = "enumflags2_derive"
--version = "0.7.11"
-+version = "0.7.12"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "fc4caf64a58d7a6d65ab00639b046ff54399a39f5f2554728895ace4b297cd79"
-+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
- dependencies = [
-  "proc-macro2",
-  "quote",
-- "syn 2.0.101",
-+ "syn 2.0.104",
- ]
- 
- [[package]]
-@@ -2403,12 +2402,12 @@ dependencies = [
- 
- [[package]]
- name = "errno"
--version = "0.3.12"
-+version = "0.3.13"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
-+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
- dependencies = [
-  "libc",
-- "windows-sys 0.59.0",
-+ "windows-sys 0.60.2",
- ]
- 
- [[package]]
-@@ -2419,9 +2418,9 @@ checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
- 
- [[package]]
- name = "event-listener"
--version = "5.4.0"
-+version = "5.4.1"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
-+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
- dependencies = [
-  "concurrent-queue",
-  "parking",
-@@ -2495,11 +2494,11 @@ dependencies = [
- 
- [[package]]
- name = "file-id"
--version = "0.2.2"
-+version = "0.2.3"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "6bc904b9bbefcadbd8e3a9fb0d464a9b979de6324c03b3c663e8994f46a5be36"
-+checksum = "e1fc6a637b6dc58414714eddd9170ff187ecb0933d4c7024d1abbd23a3cc26e9"
- dependencies = [
-- "windows-sys 0.52.0",
-+ "windows-sys 0.60.2",
- ]
- 
- [[package]]
-@@ -2528,9 +2527,9 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
- 
- [[package]]
- name = "flate2"
--version = "1.1.1"
-+version = "1.1.2"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
-+checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
- dependencies = [
-  "crc32fast",
-  "libz-rs-sys",
-@@ -2588,7 +2587,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
- dependencies = [
-  "proc-macro2",
-  "quote",
-- "syn 2.0.101",
-+ "syn 2.0.104",
- ]
- 
- [[package]]
-@@ -2703,9 +2702,9 @@ checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
- 
- [[package]]
- name = "futures-lite"
--version = "2.6.0"
-+version = "2.6.1"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "f5edaec856126859abb19ed65f39e90fea3a9574b9707f13539acf4abf7eb532"
-+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
- dependencies = [
-  "fastrand",
-  "futures-core",
-@@ -2722,7 +2721,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
- dependencies = [
-  "proc-macro2",
-  "quote",
-- "syn 2.0.101",
-+ "syn 2.0.104",
- ]
- 
- [[package]]
-@@ -2919,7 +2918,7 @@ dependencies = [
-  "cfg-if",
-  "js-sys",
-  "libc",
-- "wasi 0.11.0+wasi-snapshot-preview1",
-+ "wasi 0.11.1+wasi-snapshot-preview1",
-  "wasm-bindgen",
- ]
- 
-@@ -2997,7 +2996,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "587d0dd757ea38f8a7b4761026162f6b9ab39e2cc7eba386852371841f5fe69b"
- dependencies = [
-  "git2",
-- "gix-path 0.10.19",
-+ "gix-path",
-  "log",
-  "shellexpand",
-  "thiserror 2.0.12",
-@@ -3066,7 +3065,7 @@ dependencies = [
-  "serde-error",
-  "tempfile",
-  "tokio",
-- "toml",
-+ "toml 0.8.23",
-  "tracing",
-  "url",
- ]
-@@ -3235,7 +3234,7 @@ dependencies = [
-  "bstr",
+@@ -1089,7 +1080,7 @@ dependencies = [
+  "anyhow",
   "gix",
   "serde",
-- "toml",
-+ "toml 0.8.23",
+- "toml 0.9.8",
++ "toml 0.9.10+spec-1.1.0",
   "walkdir",
  ]
  
-@@ -3318,7 +3317,7 @@ dependencies = [
-  "gitbutler-testsupport",
-  "gix",
+@@ -1122,7 +1113,7 @@ dependencies = [
+  "gitbutler-user",
+  "http 1.4.0",
+  "octorust",
+- "reqwest 0.12.24",
++ "reqwest 0.12.27",
   "serde",
-- "toml",
-+ "toml 0.8.23",
-  "tracing",
- ]
- 
-@@ -3346,7 +3345,7 @@ dependencies = [
-  "serde",
-  "strum",
-  "tempfile",
-- "toml",
-+ "toml 0.8.23",
-  "tracing",
- ]
- 
-@@ -3429,7 +3428,7 @@ dependencies = [
   "serde_json",
+ ]
+@@ -1205,7 +1196,7 @@ dependencies = [
+  "itertools",
+  "md5",
+  "serde",
+- "toml 0.9.8",
++ "toml 0.9.10+spec-1.1.0",
+  "tracing",
+ ]
+ 
+@@ -1256,7 +1247,7 @@ dependencies = [
+  "petgraph",
+  "serde",
   "tempfile",
-  "thiserror 2.0.12",
-- "toml",
-+ "toml 0.8.23",
+- "toml 0.9.8",
++ "toml 0.9.10+spec-1.1.0",
+  "tracing",
+ ]
+ 
+@@ -1598,9 +1589,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "camino"
+-version = "1.2.1"
++version = "1.2.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "276a59bf2b2c967788139340c9f0c5b12d7fd6630315c15c217e559de85d2609"
++checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+ dependencies = [
+  "serde_core",
+ ]
+@@ -1635,7 +1626,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "374b7c592d9c00c1f4972ea58390ac6b18cbb6ab79011f3bdc90a0b82ca06b77"
+ dependencies = [
+  "serde",
+- "toml 0.9.8",
++ "toml 0.9.10+spec-1.1.0",
+ ]
+ 
+ [[package]]
+@@ -1649,9 +1640,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "cc"
+-version = "1.2.48"
++version = "1.2.50"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c481bdbf0ed3b892f6f806287d72acd515b352a4ec27a208489b8c1bc839633a"
++checksum = "9f50d563227a1c37cc0a263f64eca3334388c01c5e4c4861a9def205c614383c"
+ dependencies = [
+  "find-msvc-tools",
+  "jobserver",
+@@ -1758,9 +1749,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "clap_complete"
+-version = "4.5.61"
++version = "4.5.62"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "39615915e2ece2550c0149addac32fb5bd312c657f43845bb9088cb9c8a7c992"
++checksum = "004eef6b14ce34759aa7de4aea3217e368f463f46a3ed3764ca4b5a4404003b4"
+ dependencies = [
+  "clap",
+ ]
+@@ -2000,6 +1991,24 @@ dependencies = [
+  "url",
+ ]
+ 
++[[package]]
++name = "cookie_store"
++version = "0.22.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "3fc4bff745c9b4c7fb1e97b25d13153da2bc7796260141df62378998d070207f"
++dependencies = [
++ "cookie",
++ "document-features",
++ "idna",
++ "log",
++ "publicsuffix",
++ "serde",
++ "serde_derive",
++ "serde_json",
++ "time",
++ "url",
++]
++
+ [[package]]
+ name = "core-foundation"
+ version = "0.9.4"
+@@ -2309,9 +2318,9 @@ checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
+ 
+ [[package]]
+ name = "dbus"
+-version = "0.9.9"
++version = "0.9.10"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "190b6255e8ab55a7b568df5a883e9497edc3e4821c06396612048b430e5ad1e9"
++checksum = "21b3aa68d7e7abee336255bd7248ea965cc393f3e70411135a6f6a4b651345d4"
+ dependencies = [
+  "libc",
+  "libdbus-sys",
+@@ -2403,18 +2412,18 @@ dependencies = [
+ 
+ [[package]]
+ name = "deser-hjson"
+-version = "2.2.4"
++version = "2.2.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7d94aac4095c08ded7e4b9ba7fc2b2929f11b94bb96897ca188b0f64e01688e1"
++checksum = "1fbc1498156ddf9adc2eb251c1697b3a0dea599c94fb8cf1313f986adcc70f6e"
+ dependencies = [
+  "serde",
+ ]
+ 
+ [[package]]
+ name = "diesel"
+-version = "2.3.4"
++version = "2.3.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "0c415189028b232660655e4893e8bc25ca7aee8e96888db66d9edb400535456a"
++checksum = "e130c806dccc85428c564f2dc5a96e05b6615a27c9a28776bd7761a9af4bb552"
+ dependencies = [
+  "chrono",
+  "diesel_derives",
+@@ -2426,9 +2435,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "diesel_derives"
+-version = "2.3.5"
++version = "2.3.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "8587cbca3c929fb198e7950d761d31ca72b80aa6e07c1b7bec5879d187720436"
++checksum = "c30b2969f923fa1f73744b92bb7df60b858df8832742d9a3aceb79236c0be1d2"
+ dependencies = [
+  "diesel_table_macro_syntax",
+  "dsl_auto_type",
+@@ -2558,9 +2567,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
+ dependencies = [
+  "bitflags 2.10.0",
+- "block2 0.6.2",
++ "block2",
+  "libc",
+- "objc2 0.6.3",
++ "objc2",
+ ]
+ 
+ [[package]]
+@@ -2585,9 +2594,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "dlopen2"
+-version = "0.8.0"
++version = "0.8.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b54f373ccf864bf587a89e880fb7610f8d73f3045f13580948ccbcaff26febff"
++checksum = "5e2c5bd4158e66d1e215c49b837e11d62f3267b30c92f1d171c4d3105e3dc4d4"
+ dependencies = [
+  "dlopen2_derive",
+  "libc",
+@@ -2597,9 +2606,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "dlopen2_derive"
+-version = "0.4.1"
++version = "0.4.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "788160fb30de9cdd857af31c6a2675904b16ece8fc2737b2c7127ba368c9d0f4"
++checksum = "0fbbb781877580993a8707ec48672673ec7b81eeba04cfd2310bd28c08e47c8f"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+@@ -2701,7 +2710,7 @@ dependencies = [
+  "cc",
+  "memchr",
+  "rustc_version",
+- "toml 0.9.8",
++ "toml 0.9.10+spec-1.1.0",
+  "vswhom",
+  "winreg 0.55.0",
+ ]
+@@ -2729,9 +2738,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "endi"
+-version = "1.1.0"
++version = "1.1.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a3d8a32ae18130a3c84dd492d4215c3d913c3b07c6b63c2eb3eb7ff1101ab7bf"
++checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+ 
+ [[package]]
+ name = "enumflags2"
+@@ -2902,14 +2911,6 @@ dependencies = [
+  "windows-sys 0.60.2",
+ ]
+ 
+-[[package]]
+-name = "file-id"
+-version = "0.2.3"
+-source = "git+https://github.com/notify-rs/notify?rev=978fe719b066a8ce76b9a9d346546b1569eecfb6#978fe719b066a8ce76b9a9d346546b1569eecfb6"
+-dependencies = [
+- "windows-sys 0.60.2",
+-]
+-
+ [[package]]
+ name = "filetime"
+ version = "0.2.26"
+@@ -3292,7 +3293,7 @@ version = "1.1.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+ dependencies = [
+- "rustix 1.1.2",
++ "rustix",
+  "windows-link 0.2.1",
+ ]
+ 
+@@ -3398,9 +3399,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "git2"
+-version = "0.20.2"
++version = "0.20.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2deb07a133b1520dc1a5690e9bd08950108873d7ed5de38dcc74d3b5ebffa110"
++checksum = "3e2b37e2f62729cdada11f0e6b3b6fe383c69c29fc619e391223e12856af308c"
+ dependencies = [
+  "bitflags 2.10.0",
+  "libc",
+@@ -3418,7 +3419,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "587d0dd757ea38f8a7b4761026162f6b9ab39e2cc7eba386852371841f5fe69b"
+ dependencies = [
+  "git2",
+- "gix-path 0.10.22 (registry+https://github.com/rust-lang/crates.io-index)",
++ "gix-path",
+  "log",
+  "shellexpand",
+  "thiserror 2.0.17",
+@@ -3601,7 +3602,7 @@ name = "gitbutler-git"
+ version = "0.0.0"
+ dependencies = [
+  "anyhow",
+- "file-id 0.2.3 (git+https://github.com/notify-rs/notify?rev=978fe719b066a8ce76b9a9d346546b1569eecfb6)",
++ "file-id",
+  "futures",
+  "gix",
+  "nix 0.30.1",
+@@ -3634,7 +3635,7 @@ name = "gitbutler-notify-debouncer"
+ version = "0.0.0"
+ dependencies = [
+  "deser-hjson",
+- "file-id 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
++ "file-id",
+  "gitbutler-notify-debouncer",
+  "mock_instant",
+  "notify",
+@@ -3661,7 +3662,7 @@ dependencies = [
+  "gitbutler-stack",
+  "gitbutler-testsupport",
+  "serde",
+- "toml 0.9.8",
++ "toml 0.9.10+spec-1.1.0",
   "tracing",
   "uuid",
  ]
-@@ -3506,7 +3505,7 @@ dependencies = [
+@@ -3689,7 +3690,7 @@ dependencies = [
+  "serde",
+  "strum",
+  "tempfile",
+- "toml 0.9.8",
++ "toml 0.9.10+spec-1.1.0",
+  "tracing",
+ ]
+ 
+@@ -3764,7 +3765,7 @@ dependencies = [
+  "serde_json",
+  "tempfile",
+  "thiserror 2.0.17",
+- "toml 0.9.8",
++ "toml 0.9.10+spec-1.1.0",
+  "tracing",
+  "uuid",
+ ]
+@@ -3817,7 +3818,7 @@ dependencies = [
   "itertools",
   "serde",
   "tempfile",
-- "toml",
-+ "toml 0.8.23",
+- "toml 0.9.8",
++ "toml 0.9.10+spec-1.1.0",
  ]
  
  [[package]]
-@@ -3729,15 +3728,16 @@ dependencies = [
+@@ -3996,54 +3997,55 @@ dependencies = [
+ 
  [[package]]
  name = "gix"
- version = "0.73.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#202bc6da79854d1fb6bb32b9c6bb2a6f882c77f5"
+-version = "0.75.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
++version = "0.76.0"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "514c29cc879bdc0286b0cbc205585a49b252809eb86c69df4ce4f855ee75f635"
++checksum = "0da205378175c7e08c1d9357be8e6056c541d5907c29842d025b2a732ce06d52"
  dependencies = [
-- "gix-actor 0.35.3",
-+ "gix-actor",
-  "gix-attributes 0.27.0",
+- "gix-actor 0.36.0",
+- "gix-attributes 0.28.1",
++ "gix-actor 0.36.1",
++ "gix-attributes 0.29.0",
   "gix-command",
-  "gix-commitgraph 0.29.0",
+- "gix-commitgraph 0.30.1",
++ "gix-commitgraph 0.31.0",
   "gix-config",
   "gix-credentials",
-- "gix-date 0.10.4",
-+ "gix-date",
+- "gix-date 0.11.0",
++ "gix-date 0.11.1",
   "gix-diff",
   "gix-dir",
-  "gix-discover 0.41.0",
-@@ -3756,7 +3756,7 @@ dependencies = [
-  "gix-object 0.50.1",
+- "gix-discover 0.43.0",
+- "gix-features 0.44.1",
++ "gix-discover 0.44.0",
++ "gix-features 0.45.0",
+  "gix-filter",
+- "gix-fs 0.17.0",
+- "gix-glob 0.22.1",
+- "gix-hash 0.20.1",
+- "gix-hashtable 0.10.0",
+- "gix-ignore 0.17.1",
+- "gix-index 0.43.0",
+- "gix-lock 19.0.0",
++ "gix-fs 0.18.0",
++ "gix-glob 0.23.0",
++ "gix-hash 0.21.0",
++ "gix-hashtable 0.11.0",
++ "gix-ignore 0.18.0",
++ "gix-index 0.44.0",
++ "gix-lock 20.0.0",
+  "gix-mailmap",
+  "gix-merge",
+  "gix-negotiate",
+- "gix-object 0.52.0",
++ "gix-object 0.53.0",
   "gix-odb",
   "gix-pack",
-- "gix-path 0.10.20",
+- "gix-path 0.10.22 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
 + "gix-path",
   "gix-pathspec",
   "gix-prompt",
   "gix-protocol",
-@@ -3769,12 +3769,12 @@ dependencies = [
+- "gix-ref 0.55.0",
++ "gix-ref 0.56.0",
+  "gix-refspec",
+  "gix-revision",
+- "gix-revwalk 0.23.0",
++ "gix-revwalk 0.24.0",
+  "gix-sec 0.12.2",
+  "gix-shallow",
   "gix-status",
   "gix-submodule",
-  "gix-tempfile 18.0.0",
-- "gix-trace 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-tempfile 19.0.1",
+- "gix-trace 0.1.15 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-tempfile 20.0.0",
 + "gix-trace",
   "gix-transport",
-  "gix-traverse 0.47.0",
+- "gix-traverse 0.49.0",
++ "gix-traverse 0.50.0",
   "gix-url",
-- "gix-utils 0.3.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-- "gix-validate 0.10.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-utils 0.3.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-validate 0.10.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-worktree 0.44.0",
 + "gix-utils",
 + "gix-validate",
-  "gix-worktree 0.42.0",
++ "gix-worktree 0.45.0",
   "gix-worktree-state",
-  "once_cell",
-@@ -3783,28 +3783,15 @@ dependencies = [
-  "thiserror 2.0.12",
- ]
- 
--[[package]]
--name = "gix-actor"
--version = "0.35.2"
--source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "58ebbb8f41071c7cf318a0b1db667c34e1df49db7bf387d282a4e61a3b97882c"
--dependencies = [
-- "bstr",
-- "gix-date 0.10.3",
-- "gix-utils 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
-- "itoa",
-- "thiserror 2.0.12",
-- "winnow 0.7.12",
--]
--
- [[package]]
- name = "gix-actor"
- version = "0.35.3"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#202bc6da79854d1fb6bb32b9c6bb2a6f882c77f5"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "d1b1ec302f8dc059df125ed46dfdc7e9d33fe7724df19843aea53b5ffd32d5bb"
+  "serde",
+  "smallvec",
+@@ -4058,7 +4060,7 @@ checksum = "987a51a7e66db6ef4dc030418eb2a42af6b913a79edd8670766122d8af3ba59e"
  dependencies = [
   "bstr",
-- "gix-date 0.10.4",
-- "gix-utils 0.3.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-+ "gix-date",
+  "gix-date 0.10.7",
+- "gix-utils 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "gix-utils",
+  "itoa",
+  "thiserror 2.0.17",
+  "winnow 0.7.14",
+@@ -4066,12 +4068,13 @@ dependencies = [
+ 
+ [[package]]
+ name = "gix-actor"
+-version = "0.36.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
++version = "0.36.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "636ca0d7bf8f7ad8ba84a5dda8312c8944b275be09d88b072e08f57d3e47c1e8"
+ dependencies = [
+  "bstr",
+- "gix-date 0.11.0",
+- "gix-utils 0.3.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-date 0.11.1",
 + "gix-utils",
   "itoa",
   "serde",
-  "thiserror 2.0.12",
-@@ -3819,9 +3806,9 @@ checksum = "6f50d813d5c2ce9463ba0c29eea90060df08e38ad8f34b8a192259f8bce5c078"
+  "thiserror 2.0.17",
+@@ -4086,9 +4089,9 @@ checksum = "6f50d813d5c2ce9463ba0c29eea90060df08e38ad8f34b8a192259f8bce5c078"
  dependencies = [
   "bstr",
   "gix-glob 0.20.1",
-- "gix-path 0.10.19",
-- "gix-quote 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
-- "gix-trace 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-path 0.10.22 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-quote 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-trace 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
 + "gix-path",
 + "gix-quote",
 + "gix-trace",
   "kstring",
   "smallvec",
-  "thiserror 2.0.12",
-@@ -3831,13 +3818,14 @@ dependencies = [
+  "thiserror 2.0.17",
+@@ -4097,14 +4100,15 @@ dependencies = [
+ 
  [[package]]
  name = "gix-attributes"
- version = "0.27.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#202bc6da79854d1fb6bb32b9c6bb2a6f882c77f5"
+-version = "0.28.1"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
++version = "0.29.0"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "45442188216d08a5959af195f659cb1f244a50d7d2d0c3873633b1cd7135f638"
++checksum = "f47dabf8a50f1558c3a55d978440c7c4f22f87ac897bef03b4edbc96f6115966"
  dependencies = [
   "bstr",
-  "gix-glob 0.21.0",
-- "gix-path 0.10.20",
-- "gix-quote 0.6.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-- "gix-trace 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-glob 0.22.1",
+- "gix-path 0.10.22 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-quote 0.6.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-trace 0.1.15 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-glob 0.23.0",
 + "gix-path",
 + "gix-quote",
 + "gix-trace",
   "kstring",
   "serde",
   "smallvec",
-@@ -3854,14 +3842,6 @@ dependencies = [
-  "thiserror 2.0.12",
+@@ -4121,14 +4125,6 @@ dependencies = [
+  "thiserror 2.0.17",
  ]
  
 -[[package]]
 -name = "gix-bitmap"
--version = "0.2.14"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#202bc6da79854d1fb6bb32b9c6bb2a6f882c77f5"
+-version = "0.2.15"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
 -dependencies = [
-- "thiserror 2.0.12",
+- "thiserror 2.0.17",
 -]
 -
  [[package]]
  name = "gix-chunk"
- version = "0.4.11"
-@@ -3871,23 +3851,16 @@ dependencies = [
-  "thiserror 2.0.12",
+ version = "0.4.12"
+@@ -4138,23 +4134,16 @@ dependencies = [
+  "thiserror 2.0.17",
  ]
  
 -[[package]]
 -name = "gix-chunk"
--version = "0.4.11"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#202bc6da79854d1fb6bb32b9c6bb2a6f882c77f5"
+-version = "0.4.12"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
 -dependencies = [
-- "thiserror 2.0.12",
+- "thiserror 2.0.17",
 -]
 -
  [[package]]
  name = "gix-command"
- version = "0.6.2"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#202bc6da79854d1fb6bb32b9c6bb2a6f882c77f5"
+ version = "0.6.3"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "6b31b65ca48a352ae86312b27a514a0c661935f96b481ac8b4371f65815eb196"
++checksum = "095c8367c9dc4872a7706fbc39c7f34271b88b541120a4365ff0e36366f66e62"
  dependencies = [
   "bstr",
-- "gix-path 0.10.20",
-- "gix-quote 0.6.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-- "gix-trace 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-path 0.10.22 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-quote 0.6.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-trace 0.1.15 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
 + "gix-path",
 + "gix-quote",
 + "gix-trace",
   "shell-words",
  ]
  
-@@ -3898,7 +3871,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+@@ -4165,7 +4154,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "e05050fd6caa6c731fe3bd7f9485b3b520be062d3d139cb2626e052d6c127951"
  dependencies = [
   "bstr",
-- "gix-chunk 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-chunk 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
 + "gix-chunk",
   "gix-hash 0.18.0",
   "memmap2",
-  "thiserror 2.0.12",
-@@ -3907,10 +3880,11 @@ dependencies = [
+  "thiserror 2.0.17",
+@@ -4173,12 +4162,13 @@ dependencies = [
+ 
  [[package]]
  name = "gix-commitgraph"
- version = "0.29.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#202bc6da79854d1fb6bb32b9c6bb2a6f882c77f5"
+-version = "0.30.1"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
++version = "0.31.0"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "6bb23121e952f43a5b07e3e80890336cb847297467a410475036242732980d06"
++checksum = "efdcba8048045baf15225daf949d597c3e6183d130245e22a7fbd27084abe63a"
  dependencies = [
   "bstr",
-- "gix-chunk 0.4.11 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-chunk 0.4.12 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-hash 0.20.1",
 + "gix-chunk",
-  "gix-hash 0.19.0",
++ "gix-hash 0.21.0",
   "memmap2",
   "serde",
-@@ -3920,13 +3894,14 @@ dependencies = [
+  "thiserror 2.0.17",
+@@ -4186,15 +4176,16 @@ dependencies = [
+ 
  [[package]]
  name = "gix-config"
- version = "0.46.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#202bc6da79854d1fb6bb32b9c6bb2a6f882c77f5"
+-version = "0.48.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
++version = "0.49.0"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "5dfb898c5b695fd4acfc3c0ab638525a65545d47706064dcf7b5ead6cdb136c0"
++checksum = "7f15f96a354d296b505575870c4ebe279552a67132b61223869181d11894859d"
  dependencies = [
   "bstr",
   "gix-config-value",
-  "gix-features 0.43.1",
-  "gix-glob 0.21.0",
-- "gix-path 0.10.20",
+- "gix-features 0.44.1",
+- "gix-glob 0.22.1",
+- "gix-path 0.10.22 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-ref 0.55.0",
++ "gix-features 0.45.0",
++ "gix-glob 0.23.0",
 + "gix-path",
-  "gix-ref 0.53.0",
-  "gix-sec 0.12.0",
++ "gix-ref 0.56.0",
+  "gix-sec 0.12.2",
   "memchr",
-@@ -3940,11 +3915,12 @@ dependencies = [
+  "smallvec",
+@@ -4205,29 +4196,31 @@ dependencies = [
+ 
  [[package]]
  name = "gix-config-value"
- version = "0.15.1"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#202bc6da79854d1fb6bb32b9c6bb2a6f882c77f5"
+-version = "0.15.3"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
++version = "0.16.0"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "9f012703eb67e263c6c1fc96649fec47694dd3e5d2a91abfc65e4a6a6dc85309"
++checksum = "2409cffa4fe8b303847d5b6ba8df9da9ba65d302fc5ee474ea0cac5afde79840"
  dependencies = [
-  "bitflags 2.9.1",
+  "bitflags 2.10.0",
   "bstr",
-- "gix-path 0.10.20",
+- "gix-path 0.10.22 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
 + "gix-path",
   "libc",
-  "thiserror 2.0.12",
+  "thiserror 2.0.17",
  ]
-@@ -3952,38 +3928,27 @@ dependencies = [
+ 
  [[package]]
  name = "gix-credentials"
- version = "0.30.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#202bc6da79854d1fb6bb32b9c6bb2a6f882c77f5"
+-version = "0.32.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
++version = "0.33.0"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "0039dd3ac606dd80b16353a41b61fc237ca5cb8b612f67a9f880adfad4be4e05"
++checksum = "752cc9d771a65c0a6e7ac601848a08513e9e2b9e25804a354108305e2ef18c5a"
  dependencies = [
   "bstr",
   "gix-command",
   "gix-config-value",
-- "gix-date 0.10.4",
-- "gix-path 0.10.20",
-+ "gix-date",
+- "gix-date 0.11.0",
+- "gix-path 0.10.22 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-date 0.11.1",
 + "gix-path",
   "gix-prompt",
-  "gix-sec 0.12.0",
-- "gix-trace 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+  "gix-sec 0.12.2",
+- "gix-trace 0.1.15 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
 + "gix-trace",
   "gix-url",
   "serde",
-  "thiserror 2.0.12",
- ]
+  "thiserror 2.0.17",
+@@ -4248,8 +4241,9 @@ dependencies = [
  
--[[package]]
--name = "gix-date"
--version = "0.10.3"
--source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "d7235bdf4d9d54a6901928e3a37f91c16f419e6957f520ed929c3d292b84226e"
--dependencies = [
-- "bstr",
-- "itoa",
-- "jiff",
-- "smallvec",
-- "thiserror 2.0.12",
--]
--
  [[package]]
  name = "gix-date"
- version = "0.10.4"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#202bc6da79854d1fb6bb32b9c6bb2a6f882c77f5"
+-version = "0.11.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
++version = "0.11.1"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "467254054f8df1e85b5f73cb910602767b0122391d994302a091841ba43edfaa"
++checksum = "c0a1259955c76335c9d1a8c511811b10dbc800ffeeca3daea1e0aadd0c98f6b7"
  dependencies = [
   "bstr",
   "itoa",
-@@ -3996,7 +3961,8 @@ dependencies = [
+@@ -4261,43 +4255,45 @@ dependencies = [
+ 
  [[package]]
  name = "gix-diff"
- version = "0.53.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#202bc6da79854d1fb6bb32b9c6bb2a6f882c77f5"
+-version = "0.55.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
++version = "0.56.0"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "de854852010d44a317f30c92d67a983e691c9478c8a3fb4117c1f48626bcdea8"
++checksum = "3ebc8f56f3300d3c5f98d927b11762ef98e35ddbf9ebf3bdbdb53dbc6d9cbb7e"
  dependencies = [
   "bstr",
-  "gix-attributes 0.27.0",
-@@ -4006,10 +3972,10 @@ dependencies = [
-  "gix-hash 0.19.0",
-  "gix-index 0.41.0",
-  "gix-object 0.50.1",
-- "gix-path 0.10.20",
+- "gix-attributes 0.28.1",
++ "gix-attributes 0.29.0",
+  "gix-command",
+  "gix-filter",
+- "gix-fs 0.17.0",
+- "gix-hash 0.20.1",
+- "gix-index 0.43.0",
+- "gix-object 0.52.0",
+- "gix-path 0.10.22 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-fs 0.18.0",
++ "gix-hash 0.21.0",
++ "gix-index 0.44.0",
++ "gix-object 0.53.0",
 + "gix-path",
   "gix-pathspec",
-  "gix-tempfile 18.0.0",
-- "gix-trace 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-tempfile 19.0.1",
+- "gix-trace 0.1.15 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-traverse 0.49.0",
+- "gix-worktree 0.44.0",
++ "gix-tempfile 20.0.0",
 + "gix-trace",
-  "gix-traverse 0.47.0",
-  "gix-worktree 0.42.0",
++ "gix-traverse 0.50.0",
++ "gix-worktree 0.45.0",
   "imara-diff",
-@@ -4019,7 +3985,8 @@ dependencies = [
+  "thiserror 2.0.17",
+ ]
+ 
  [[package]]
  name = "gix-dir"
- version = "0.15.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#202bc6da79854d1fb6bb32b9c6bb2a6f882c77f5"
+-version = "0.17.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
++version = "0.18.0"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "dad34e4f373f94902df1ba1d2a1df3a1b29eacd15e316ac5972d842e31422dd7"
++checksum = "40d285a847a95b3c76c0f7b17143bdc68c917d3f9f772bfd4c83fbadb7497067"
  dependencies = [
   "bstr",
-  "gix-discover 0.41.0",
-@@ -4027,10 +3994,10 @@ dependencies = [
-  "gix-ignore 0.16.0",
-  "gix-index 0.41.0",
-  "gix-object 0.50.1",
-- "gix-path 0.10.20",
+- "gix-discover 0.43.0",
+- "gix-fs 0.17.0",
+- "gix-ignore 0.17.1",
+- "gix-index 0.43.0",
+- "gix-object 0.52.0",
+- "gix-path 0.10.22 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-discover 0.44.0",
++ "gix-fs 0.18.0",
++ "gix-ignore 0.18.0",
++ "gix-index 0.44.0",
++ "gix-object 0.53.0",
 + "gix-path",
   "gix-pathspec",
-- "gix-trace 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-- "gix-utils 0.3.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-trace 0.1.15 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-utils 0.3.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-worktree 0.44.0",
 + "gix-trace",
 + "gix-utils",
-  "gix-worktree 0.42.0",
-  "thiserror 2.0.12",
++ "gix-worktree 0.45.0",
+  "thiserror 2.0.17",
  ]
-@@ -4045,7 +4012,7 @@ dependencies = [
+ 
+@@ -4311,7 +4307,7 @@ dependencies = [
   "dunce",
   "gix-fs 0.15.0",
   "gix-hash 0.18.0",
-- "gix-path 0.10.19",
+- "gix-path 0.10.22 (registry+https://github.com/rust-lang/crates.io-index)",
 + "gix-path",
   "gix-ref 0.52.1",
   "gix-sec 0.11.0",
-  "thiserror 2.0.12",
-@@ -4054,13 +4021,14 @@ dependencies = [
+  "thiserror 2.0.17",
+@@ -4319,15 +4315,16 @@ dependencies = [
+ 
  [[package]]
  name = "gix-discover"
- version = "0.41.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#202bc6da79854d1fb6bb32b9c6bb2a6f882c77f5"
+-version = "0.43.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
++version = "0.44.0"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "ffb180c91ca1a2cf53e828bb63d8d8f8fa7526f49b83b33d7f46cbeb5d79d30a"
++checksum = "3f2fe2922c3358a93f5e5b62c1c6d856f59ed863f5fd2da1929f66567d3b0e12"
  dependencies = [
   "bstr",
   "dunce",
-  "gix-fs 0.16.0",
-  "gix-hash 0.19.0",
-- "gix-path 0.10.20",
+- "gix-fs 0.17.0",
+- "gix-hash 0.20.1",
+- "gix-path 0.10.22 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-ref 0.55.0",
++ "gix-fs 0.18.0",
++ "gix-hash 0.21.0",
 + "gix-path",
-  "gix-ref 0.53.0",
-  "gix-sec 0.12.0",
-  "thiserror 2.0.12",
-@@ -4072,9 +4040,9 @@ version = "0.42.1"
++ "gix-ref 0.56.0",
+  "gix-sec 0.12.2",
+  "thiserror 2.0.17",
+ ]
+@@ -4338,9 +4335,9 @@ version = "0.42.1"
  source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "56f4399af6ec4fd9db84dd4cf9656c5c785ab492ab40a7c27ea92b4241923fed"
  dependencies = [
-- "gix-path 0.10.19",
-- "gix-trace 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
-- "gix-utils 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-path 0.10.22 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-trace 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-utils 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 + "gix-path",
 + "gix-trace",
 + "gix-utils",
   "libc",
   "prodash 29.0.2",
   "walkdir",
-@@ -4083,15 +4051,16 @@ dependencies = [
+@@ -4348,40 +4345,42 @@ dependencies = [
+ 
  [[package]]
  name = "gix-features"
- version = "0.43.1"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#202bc6da79854d1fb6bb32b9c6bb2a6f882c77f5"
+-version = "0.44.1"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
++version = "0.45.0"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "cd1543cd9b8abcbcebaa1a666a5c168ee2cda4dea50d3961ee0e6d1c42f81e5b"
++checksum = "ba0ba40b1ca17f2cb3987c8d54e596aba924201cd8e5947098b441067e6686a0"
  dependencies = [
   "bytes",
   "crc32fast",
   "crossbeam-channel",
-  "flate2",
-- "gix-path 0.10.20",
-- "gix-trace 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-- "gix-utils 0.3.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-path 0.10.22 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-trace 0.1.15 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-utils 0.3.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
 + "gix-path",
 + "gix-trace",
 + "gix-utils",
   "libc",
+- "libz-rs-sys",
   "once_cell",
   "parking_lot",
-@@ -4103,7 +4072,8 @@ dependencies = [
+  "prodash 30.0.1",
+  "thiserror 2.0.17",
+  "walkdir",
++ "zlib-rs",
+ ]
+ 
  [[package]]
  name = "gix-filter"
- version = "0.20.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#202bc6da79854d1fb6bb32b9c6bb2a6f882c77f5"
+-version = "0.22.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
++version = "0.23.0"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "aa6571a3927e7ab10f64279a088e0dae08e8da05547771796d7389bbe28ad9ff"
++checksum = "22c005832d42de07bacdef53d3b87f6067e765b9753f85788655a1b4a20fc2b6"
  dependencies = [
   "bstr",
   "encoding_rs",
-@@ -4112,10 +4082,10 @@ dependencies = [
-  "gix-hash 0.19.0",
-  "gix-object 0.50.1",
-  "gix-packetline-blocking",
-- "gix-path 0.10.20",
-- "gix-quote 0.6.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-- "gix-trace 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-- "gix-utils 0.3.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-attributes 0.28.1",
++ "gix-attributes 0.29.0",
+  "gix-command",
+- "gix-hash 0.20.1",
+- "gix-object 0.52.0",
++ "gix-hash 0.21.0",
++ "gix-object 0.53.0",
+  "gix-packetline",
+- "gix-path 0.10.22 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-quote 0.6.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-trace 0.1.15 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-utils 0.3.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
 + "gix-path",
 + "gix-quote",
 + "gix-trace",
 + "gix-utils",
   "smallvec",
-  "thiserror 2.0.12",
+  "thiserror 2.0.17",
  ]
-@@ -4129,21 +4099,22 @@ dependencies = [
+@@ -4395,21 +4394,22 @@ dependencies = [
   "bstr",
   "fastrand",
   "gix-features 0.42.1",
-- "gix-path 0.10.19",
-- "gix-utils 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-path 0.10.22 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-utils 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 + "gix-path",
 + "gix-utils",
-  "thiserror 2.0.12",
+  "thiserror 2.0.17",
  ]
  
  [[package]]
  name = "gix-fs"
- version = "0.16.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#202bc6da79854d1fb6bb32b9c6bb2a6f882c77f5"
+-version = "0.17.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
++version = "0.18.0"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "d793f71e955d18f228d20ec433dcce6d0e8577efcdfd11d72d09d7cc2758dfd1"
++checksum = "95b160a13547a64d67a02d894e4f5502a2a5f98635c89931f6bb9c7a4c80c7db"
  dependencies = [
   "bstr",
   "fastrand",
-  "gix-features 0.43.1",
-- "gix-path 0.10.20",
-- "gix-utils 0.3.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-features 0.44.1",
+- "gix-path 0.10.22 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-utils 0.3.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-features 0.45.0",
 + "gix-path",
 + "gix-utils",
-  "thiserror 2.0.12",
+  "thiserror 2.0.17",
  ]
  
-@@ -4156,18 +4127,19 @@ dependencies = [
-  "bitflags 2.9.1",
+@@ -4422,18 +4422,19 @@ dependencies = [
+  "bitflags 2.10.0",
   "bstr",
   "gix-features 0.42.1",
-- "gix-path 0.10.19",
+- "gix-path 0.10.22 (registry+https://github.com/rust-lang/crates.io-index)",
 + "gix-path",
  ]
  
  [[package]]
  name = "gix-glob"
- version = "0.21.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#202bc6da79854d1fb6bb32b9c6bb2a6f882c77f5"
+-version = "0.22.1"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
++version = "0.23.0"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "b947db8366823e7a750c254f6bb29e27e17f27e457bf336ba79b32423db62cd5"
++checksum = "e8546300aee4c65c5862c22a3e321124a69b654a61a8b60de546a9284812b7e2"
  dependencies = [
-  "bitflags 2.9.1",
+  "bitflags 2.10.0",
   "bstr",
-  "gix-features 0.43.1",
-- "gix-path 0.10.20",
+- "gix-features 0.44.1",
+- "gix-path 0.10.22 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-features 0.45.0",
 + "gix-path",
   "serde",
  ]
  
-@@ -4186,7 +4158,8 @@ dependencies = [
+@@ -4451,11 +4452,12 @@ dependencies = [
+ 
  [[package]]
  name = "gix-hash"
- version = "0.19.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#202bc6da79854d1fb6bb32b9c6bb2a6f882c77f5"
+-version = "0.20.1"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
++version = "0.21.0"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "251fad79796a731a2a7664d9ea95ee29a9e99474de2769e152238d4fdb69d50e"
++checksum = "0799db4b114b97da340a3acd6b65f4ef4d325a590acef867ab0e51729b8b761c"
  dependencies = [
   "faster-hex",
-  "gix-features 0.43.1",
-@@ -4209,7 +4182,8 @@ dependencies = [
+- "gix-features 0.44.1",
++ "gix-features 0.45.0",
+  "serde",
+  "sha1-checked",
+  "thiserror 2.0.17",
+@@ -4474,10 +4476,11 @@ dependencies = [
+ 
  [[package]]
  name = "gix-hashtable"
- version = "0.9.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#202bc6da79854d1fb6bb32b9c6bb2a6f882c77f5"
+-version = "0.10.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
++version = "0.11.0"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "c35300b54896153e55d53f4180460931ccd69b7e8d2f6b9d6401122cdedc4f07"
++checksum = "222f7428636020bef272a87ed833ea48bf5fb3193f99852ae16fbb5a602bd2f0"
  dependencies = [
-  "gix-hash 0.19.0",
-  "hashbrown 0.15.4",
-@@ -4224,20 +4198,21 @@ checksum = "ae358c3c96660b10abc7da63c06788dfded603e717edbd19e38c6477911b71c8"
+- "gix-hash 0.20.1",
++ "gix-hash 0.21.0",
+  "hashbrown 0.16.1",
+  "parking_lot",
+ ]
+@@ -4490,20 +4493,21 @@ checksum = "ae358c3c96660b10abc7da63c06788dfded603e717edbd19e38c6477911b71c8"
  dependencies = [
   "bstr",
   "gix-glob 0.20.1",
-- "gix-path 0.10.19",
-- "gix-trace 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-path 0.10.22 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-trace 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
 + "gix-path",
 + "gix-trace",
   "unicode-bom",
@@ -1417,25 +1022,27 @@ index 60b520f8d..8406c39d0 100644
  
  [[package]]
  name = "gix-ignore"
- version = "0.16.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#202bc6da79854d1fb6bb32b9c6bb2a6f882c77f5"
+-version = "0.17.1"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
++version = "0.18.0"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "564d6fddf46e2c981f571b23d6ad40cb08bddcaf6fc7458b1d49727ad23c2870"
++checksum = "dfa727fdf54fd9fb53fa3fbb1a5c17172d3073e8e336bf155f3cac3e25b81b21"
  dependencies = [
   "bstr",
-  "gix-glob 0.21.0",
-- "gix-path 0.10.20",
-- "gix-trace 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-glob 0.22.1",
+- "gix-path 0.10.22 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-trace 0.1.15 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-glob 0.23.0",
 + "gix-path",
 + "gix-trace",
   "serde",
   "unicode-bom",
  ]
-@@ -4252,15 +4227,15 @@ dependencies = [
+@@ -4518,47 +4522,48 @@ dependencies = [
   "bstr",
   "filetime",
   "fnv",
-- "gix-bitmap 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-bitmap 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
 + "gix-bitmap",
   "gix-features 0.42.1",
   "gix-fs 0.15.0",
@@ -1443,598 +1050,702 @@ index 60b520f8d..8406c39d0 100644
   "gix-lock 17.1.0",
   "gix-object 0.49.1",
   "gix-traverse 0.46.2",
-- "gix-utils 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
-- "gix-validate 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-utils 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-validate 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
 + "gix-utils",
 + "gix-validate",
   "hashbrown 0.14.5",
   "itoa",
   "libc",
-@@ -4273,21 +4248,22 @@ dependencies = [
+  "memmap2",
+- "rustix 1.1.2",
++ "rustix",
+  "smallvec",
+  "thiserror 2.0.17",
+ ]
+ 
  [[package]]
  name = "gix-index"
- version = "0.41.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#202bc6da79854d1fb6bb32b9c6bb2a6f882c77f5"
+-version = "0.43.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
++version = "0.44.0"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "2af39fde3ce4ce11371d9ce826f2936ec347318f2d1972fe98c2e7134e267e25"
++checksum = "015374c00aff762bb21dafbb73a2267583392b320cb4aef156805838752a4152"
  dependencies = [
-  "bitflags 2.9.1",
+  "bitflags 2.10.0",
   "bstr",
   "filetime",
   "fnv",
-- "gix-bitmap 0.2.14 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-bitmap 0.2.15 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-features 0.44.1",
+- "gix-fs 0.17.0",
+- "gix-hash 0.20.1",
+- "gix-lock 19.0.0",
+- "gix-object 0.52.0",
+- "gix-traverse 0.49.0",
+- "gix-utils 0.3.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-validate 0.10.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
 + "gix-bitmap",
-  "gix-features 0.43.1",
-  "gix-fs 0.16.0",
-  "gix-hash 0.19.0",
-  "gix-lock 18.0.0",
-  "gix-object 0.50.1",
-  "gix-traverse 0.47.0",
-- "gix-utils 0.3.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-- "gix-validate 0.10.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-features 0.45.0",
++ "gix-fs 0.18.0",
++ "gix-hash 0.21.0",
++ "gix-lock 20.0.0",
++ "gix-object 0.53.0",
++ "gix-traverse 0.50.0",
 + "gix-utils",
 + "gix-validate",
-  "hashbrown 0.15.4",
+  "hashbrown 0.16.1",
   "itoa",
   "libc",
-@@ -4305,28 +4281,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+  "memmap2",
+- "rustix 1.1.2",
++ "rustix",
+  "serde",
+  "smallvec",
+  "thiserror 2.0.17",
+@@ -4571,67 +4576,71 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "570f8b034659f256366dc90f1a24924902f20acccd6a15be96d44d1269e7a796"
  dependencies = [
   "gix-tempfile 17.1.0",
-- "gix-utils 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-utils 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 + "gix-utils",
-  "thiserror 2.0.12",
+  "thiserror 2.0.17",
  ]
  
  [[package]]
  name = "gix-lock"
- version = "18.0.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#202bc6da79854d1fb6bb32b9c6bb2a6f882c77f5"
+-version = "19.0.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
++version = "20.0.0"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "b9fa71da90365668a621e184eb5b979904471af1b3b09b943a84bc50e8ad42ed"
++checksum = "beefa8f90ef048ab98375217777c6e74c53c9639b0c2978ea1886c41e7005322"
  dependencies = [
-  "gix-tempfile 18.0.0",
-- "gix-utils 0.3.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-tempfile 19.0.1",
+- "gix-utils 0.3.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-tempfile 20.0.0",
 + "gix-utils",
-  "thiserror 2.0.12",
+  "thiserror 2.0.17",
  ]
  
  [[package]]
  name = "gix-mailmap"
- version = "0.27.2"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#202bc6da79854d1fb6bb32b9c6bb2a6f882c77f5"
+-version = "0.28.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
++version = "0.28.1"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "9a8982e1874a2034d7dd481bcdd6a05579ba444bcda748511eb0f8e50eb10487"
++checksum = "b3b7272fbfa52a197c0c4ec857a2ffb5710c6265f258ba43a4860695d4bcea00"
  dependencies = [
   "bstr",
-- "gix-actor 0.35.3",
-- "gix-date 0.10.4",
-+ "gix-actor",
-+ "gix-date",
+- "gix-actor 0.36.0",
+- "gix-date 0.11.0",
++ "gix-actor 0.36.1",
++ "gix-date 0.11.1",
   "serde",
-  "thiserror 2.0.12",
+  "thiserror 2.0.17",
  ]
-@@ -4334,7 +4312,8 @@ dependencies = [
+ 
  [[package]]
  name = "gix-merge"
- version = "0.6.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#202bc6da79854d1fb6bb32b9c6bb2a6f882c77f5"
+-version = "0.8.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
++version = "0.9.0"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "88c2580b4122a0c40de25f8f20a1817704b5f4e4798c78d29d4a89500af2da89"
++checksum = "4d27d44aac025200b77c00329c5a4c98b91254912c480cdf561bd772dd1d58c4"
  dependencies = [
   "bstr",
   "gix-command",
-@@ -4344,12 +4323,12 @@ dependencies = [
-  "gix-hash 0.19.0",
-  "gix-index 0.41.0",
-  "gix-object 0.50.1",
-- "gix-path 0.10.20",
-- "gix-quote 0.6.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+  "gix-diff",
+  "gix-filter",
+- "gix-fs 0.17.0",
+- "gix-hash 0.20.1",
+- "gix-index 0.43.0",
+- "gix-object 0.52.0",
+- "gix-path 0.10.22 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-quote 0.6.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-fs 0.18.0",
++ "gix-hash 0.21.0",
++ "gix-index 0.44.0",
++ "gix-object 0.53.0",
 + "gix-path",
 + "gix-quote",
   "gix-revision",
-  "gix-revwalk 0.21.0",
-  "gix-tempfile 18.0.0",
-- "gix-trace 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-revwalk 0.23.0",
+- "gix-tempfile 19.0.1",
+- "gix-trace 0.1.15 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-worktree 0.44.0",
++ "gix-revwalk 0.24.0",
++ "gix-tempfile 20.0.0",
 + "gix-trace",
-  "gix-worktree 0.42.0",
++ "gix-worktree 0.45.0",
   "imara-diff",
-  "thiserror 2.0.12",
-@@ -4358,11 +4337,12 @@ dependencies = [
+  "thiserror 2.0.17",
+ ]
+ 
  [[package]]
  name = "gix-negotiate"
- version = "0.21.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#202bc6da79854d1fb6bb32b9c6bb2a6f882c77f5"
+-version = "0.23.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
++version = "0.24.0"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "1d58d4c9118885233be971e0d7a589f5cfb1a8bd6cb6e2ecfb0fc6b1b293c83b"
++checksum = "0873ebf26bd54c5c8c83635dc1963ebf644d351601d6a0d3e5c712dffdace135"
  dependencies = [
-  "bitflags 2.9.1",
-  "gix-commitgraph 0.29.0",
-- "gix-date 0.10.4",
-+ "gix-date",
-  "gix-hash 0.19.0",
-  "gix-object 0.50.1",
-  "gix-revwalk 0.21.0",
-@@ -4377,14 +4357,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "d957ca3640c555d48bb27f8278c67169fa1380ed94f6452c5590742524c40fbb"
- dependencies = [
-  "bstr",
-- "gix-actor 0.35.2",
-- "gix-date 0.10.3",
-+ "gix-actor",
-+ "gix-date",
+  "bitflags 2.10.0",
+- "gix-commitgraph 0.30.1",
+- "gix-date 0.11.0",
+- "gix-hash 0.20.1",
+- "gix-object 0.52.0",
+- "gix-revwalk 0.23.0",
++ "gix-commitgraph 0.31.0",
++ "gix-date 0.11.1",
++ "gix-hash 0.21.0",
++ "gix-object 0.53.0",
++ "gix-revwalk 0.24.0",
+  "smallvec",
+  "thiserror 2.0.17",
+ ]
+@@ -4648,9 +4657,9 @@ dependencies = [
   "gix-features 0.42.1",
   "gix-hash 0.18.0",
   "gix-hashtable 0.8.1",
-- "gix-path 0.10.19",
-- "gix-utils 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
-- "gix-validate 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-path 0.10.22 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-utils 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-validate 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
 + "gix-path",
 + "gix-utils",
 + "gix-validate",
   "itoa",
   "smallvec",
-  "thiserror 2.0.12",
-@@ -4394,17 +4374,18 @@ dependencies = [
+  "thiserror 2.0.17",
+@@ -4659,18 +4668,19 @@ dependencies = [
+ 
  [[package]]
  name = "gix-object"
- version = "0.50.1"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#202bc6da79854d1fb6bb32b9c6bb2a6f882c77f5"
+-version = "0.52.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
++version = "0.53.0"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "aff2047f96d57bcc721426e11ec0f9efeb432d5e6ef5f1aa84cfc55198971dca"
++checksum = "7ec9557a30ab9abfec4d67975413e3099509ed5da599c901ea40f7da52755128"
  dependencies = [
   "bstr",
-- "gix-actor 0.35.3",
-- "gix-date 0.10.4",
-+ "gix-actor",
-+ "gix-date",
-  "gix-features 0.43.1",
-  "gix-hash 0.19.0",
-  "gix-hashtable 0.9.0",
-- "gix-path 0.10.20",
-- "gix-utils 0.3.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-- "gix-validate 0.10.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-actor 0.36.0",
+- "gix-date 0.11.0",
+- "gix-features 0.44.1",
+- "gix-hash 0.20.1",
+- "gix-hashtable 0.10.0",
+- "gix-path 0.10.22 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-utils 0.3.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-validate 0.10.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-actor 0.36.1",
++ "gix-date 0.11.1",
++ "gix-features 0.45.0",
++ "gix-hash 0.21.0",
++ "gix-hashtable 0.11.0",
 + "gix-path",
 + "gix-utils",
 + "gix-validate",
   "itoa",
   "serde",
   "smallvec",
-@@ -4415,18 +4396,19 @@ dependencies = [
+@@ -4680,19 +4690,20 @@ dependencies = [
+ 
  [[package]]
  name = "gix-odb"
- version = "0.70.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#202bc6da79854d1fb6bb32b9c6bb2a6f882c77f5"
+-version = "0.72.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
++version = "0.73.0"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "9c9d7af10fda9df0bb4f7f9bd507963560b3c66cb15a5b825caf752e0eb109ac"
++checksum = "6a7eb6f7017bf94ce8cf00da03a8a32d4199fcbee6940c5bba213ca98d01d78f"
  dependencies = [
   "arc-swap",
-- "gix-date 0.10.4",
-+ "gix-date",
-  "gix-features 0.43.1",
-  "gix-fs 0.16.0",
-  "gix-hash 0.19.0",
-  "gix-hashtable 0.9.0",
-  "gix-object 0.50.1",
+- "gix-date 0.11.0",
+- "gix-features 0.44.1",
+- "gix-fs 0.17.0",
+- "gix-hash 0.20.1",
+- "gix-hashtable 0.10.0",
+- "gix-object 0.52.0",
++ "gix-date 0.11.1",
++ "gix-features 0.45.0",
++ "gix-fs 0.18.0",
++ "gix-hash 0.21.0",
++ "gix-hashtable 0.11.0",
++ "gix-object 0.53.0",
   "gix-pack",
-- "gix-path 0.10.20",
-- "gix-quote 0.6.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-path 0.10.22 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-quote 0.6.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
 + "gix-path",
 + "gix-quote",
   "parking_lot",
   "serde",
   "tempfile",
-@@ -4436,15 +4418,16 @@ dependencies = [
+@@ -4701,17 +4712,18 @@ dependencies = [
+ 
  [[package]]
  name = "gix-pack"
- version = "0.60.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#202bc6da79854d1fb6bb32b9c6bb2a6f882c77f5"
+-version = "0.62.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
++version = "0.63.0"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "d8571df89bfca5abb49c3e3372393f7af7e6f8b8dbe2b96303593cef5b263019"
++checksum = "bb0811847c93e98e1694ae0f519fb52af62da1cebeaf0a764840e392c6e41b38"
  dependencies = [
   "clru",
-- "gix-chunk 0.4.11 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-chunk 0.4.12 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-features 0.44.1",
+- "gix-hash 0.20.1",
+- "gix-hashtable 0.10.0",
+- "gix-object 0.52.0",
+- "gix-path 0.10.22 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-tempfile 19.0.1",
 + "gix-chunk",
-  "gix-features 0.43.1",
-  "gix-hash 0.19.0",
-  "gix-hashtable 0.9.0",
-  "gix-object 0.50.1",
-- "gix-path 0.10.20",
++ "gix-features 0.45.0",
++ "gix-hash 0.21.0",
++ "gix-hashtable 0.11.0",
++ "gix-object 0.53.0",
 + "gix-path",
-  "gix-tempfile 18.0.0",
++ "gix-tempfile 20.0.0",
   "memmap2",
   "parking_lot",
-@@ -4457,47 +4440,36 @@ dependencies = [
+  "serde",
+@@ -4723,11 +4735,12 @@ dependencies = [
  [[package]]
  name = "gix-packetline"
- version = "0.19.1"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#202bc6da79854d1fb6bb32b9c6bb2a6f882c77f5"
+ version = "0.20.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "2592fbd36249a2fea11056f7055cc376301ef38d903d157de41998335bbf1f93"
++checksum = "fad0ffb982a289888087a165d3e849cbac724f2aa5431236b050dd2cb9c7de31"
  dependencies = [
   "bstr",
   "faster-hex",
-- "gix-trace 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-trace 0.1.15 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
 + "gix-trace",
-  "thiserror 2.0.12",
+  "thiserror 2.0.17",
  ]
  
- [[package]]
- name = "gix-packetline-blocking"
- version = "0.19.1"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#202bc6da79854d1fb6bb32b9c6bb2a6f882c77f5"
--dependencies = [
-- "bstr",
-- "faster-hex",
-- "gix-trace 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-- "thiserror 2.0.12",
+@@ -4738,68 +4751,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "7cb06c3e4f8eed6e24fd915fa93145e28a511f4ea0e768bae16673e05ed3f366"
+ dependencies = [
+  "bstr",
+- "gix-trace 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-validate 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+- "thiserror 2.0.17",
 -]
 -
 -[[package]]
 -name = "gix-path"
--version = "0.10.19"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "c6279d323d925ad4790602105ae27df4b915e7a7d81e4cdba2603121c03ad111"
-+checksum = "fc4e706f328cd494cc8f932172e123a72b9a4711b0db5e411681432a89bd4c94"
- dependencies = [
-  "bstr",
-- "gix-trace 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
-- "gix-validate 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
-- "home",
-- "once_cell",
-+ "faster-hex",
+-version = "0.10.22"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
+-dependencies = [
+- "bstr",
+- "gix-trace 0.1.15 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-validate 0.10.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
 + "gix-trace",
-  "thiserror 2.0.12",
++ "gix-validate",
+  "thiserror 2.0.17",
  ]
  
  [[package]]
- name = "gix-path"
- version = "0.10.20"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#202bc6da79854d1fb6bb32b9c6bb2a6f882c77f5"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "06d37034a4c67bbdda76f7bcd037b2f7bc0fba0c09a6662b19697a5716e7b2fd"
- dependencies = [
-  "bstr",
-- "gix-trace 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-- "gix-validate 0.10.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-+ "gix-trace",
-+ "gix-validate",
-  "home",
-  "once_cell",
-  "thiserror 2.0.12",
-@@ -4506,21 +4478,23 @@ dependencies = [
- [[package]]
  name = "gix-pathspec"
- version = "0.12.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#202bc6da79854d1fb6bb32b9c6bb2a6f882c77f5"
+-version = "0.13.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
++version = "0.14.0"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "daedead611c9bd1f3640dc90a9012b45f790201788af4d659f28d94071da7fba"
++checksum = "ed9e0c881933c37a7ef45288d6c5779c4a7b3ad240b4c37657e1d9829eb90085"
  dependencies = [
-  "bitflags 2.9.1",
+  "bitflags 2.10.0",
   "bstr",
-  "gix-attributes 0.27.0",
+- "gix-attributes 0.28.1",
++ "gix-attributes 0.29.0",
   "gix-config-value",
-  "gix-glob 0.21.0",
-- "gix-path 0.10.20",
+- "gix-glob 0.22.1",
+- "gix-path 0.10.22 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-glob 0.23.0",
 + "gix-path",
-  "thiserror 2.0.12",
+  "thiserror 2.0.17",
  ]
  
  [[package]]
  name = "gix-prompt"
- version = "0.11.1"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#202bc6da79854d1fb6bb32b9c6bb2a6f882c77f5"
+-version = "0.11.2"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
++version = "0.12.0"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "6ffa1a7a34c81710aaa666a428c142b6c5d640492fcd41267db0740d923c7906"
++checksum = "974b142ea650fb0050a301958f49c8cc68929c36f686e9606a381ce39da34fd9"
  dependencies = [
   "gix-command",
   "gix-config-value",
-@@ -4532,11 +4506,12 @@ dependencies = [
+  "parking_lot",
+- "rustix 1.1.2",
++ "rustix",
+  "thiserror 2.0.17",
+ ]
+ 
  [[package]]
  name = "gix-protocol"
- version = "0.51.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#202bc6da79854d1fb6bb32b9c6bb2a6f882c77f5"
+-version = "0.53.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
++version = "0.54.0"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "12b4b807c47ffcf7c1e5b8119585368a56449f3493da93b931e1d4239364e922"
++checksum = "21348ce0b01fb5e3850e9014733d5ddf6bfeebb100967246572e6b02a29a4fef"
  dependencies = [
   "bstr",
   "gix-credentials",
-- "gix-date 0.10.4",
-+ "gix-date",
-  "gix-features 0.43.1",
-  "gix-hash 0.19.0",
-  "gix-lock 18.0.0",
-@@ -4546,9 +4521,9 @@ dependencies = [
+- "gix-date 0.11.0",
+- "gix-features 0.44.1",
+- "gix-hash 0.20.1",
+- "gix-lock 19.0.0",
++ "gix-date 0.11.1",
++ "gix-features 0.45.0",
++ "gix-hash 0.21.0",
++ "gix-lock 20.0.0",
+  "gix-negotiate",
+- "gix-object 0.52.0",
+- "gix-ref 0.55.0",
++ "gix-object 0.53.0",
++ "gix-ref 0.56.0",
   "gix-refspec",
-  "gix-revwalk 0.21.0",
+- "gix-revwalk 0.23.0",
++ "gix-revwalk 0.24.0",
   "gix-shallow",
-- "gix-trace 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-trace 0.1.15 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
 + "gix-trace",
   "gix-transport",
-- "gix-utils 0.3.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-utils 0.3.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
 + "gix-utils",
   "maybe-async",
   "serde",
-  "thiserror 2.0.12",
-@@ -4562,17 +4537,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "4a375a75b4d663e8bafe3bf4940a18a23755644c13582fa326e99f8f987d83fd"
+  "thiserror 2.0.17",
+@@ -4813,17 +4818,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "e912ec04b7b1566a85ad486db0cab6b9955e3e32bcd3c3a734542ab3af084c5b"
  dependencies = [
   "bstr",
-- "gix-utils 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
-- "thiserror 2.0.12",
+- "gix-utils 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+- "thiserror 2.0.17",
 -]
 -
 -[[package]]
 -name = "gix-quote"
--version = "0.6.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#202bc6da79854d1fb6bb32b9c6bb2a6f882c77f5"
+-version = "0.6.1"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
 -dependencies = [
 - "bstr",
-- "gix-utils 0.3.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-utils 0.3.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
 + "gix-utils",
-  "thiserror 2.0.12",
+  "thiserror 2.0.17",
  ]
  
-@@ -4582,16 +4547,16 @@ version = "0.52.1"
- source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "d1b7985657029684d759f656b09abc3e2c73085596d5cdb494428823970a7762"
- dependencies = [
-- "gix-actor 0.35.2",
-+ "gix-actor",
-  "gix-features 0.42.1",
-  "gix-fs 0.15.0",
+@@ -4839,10 +4834,10 @@ dependencies = [
   "gix-hash 0.18.0",
   "gix-lock 17.1.0",
   "gix-object 0.49.1",
-- "gix-path 0.10.19",
+- "gix-path 0.10.22 (registry+https://github.com/rust-lang/crates.io-index)",
 + "gix-path",
   "gix-tempfile 17.1.0",
-- "gix-utils 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
-- "gix-validate 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-utils 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-validate 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
 + "gix-utils",
 + "gix-validate",
   "memmap2",
-  "thiserror 2.0.12",
-  "winnow 0.7.12",
-@@ -4600,18 +4565,19 @@ dependencies = [
+  "thiserror 2.0.17",
+  "winnow 0.7.14",
+@@ -4850,19 +4845,20 @@ dependencies = [
+ 
  [[package]]
  name = "gix-ref"
- version = "0.53.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#202bc6da79854d1fb6bb32b9c6bb2a6f882c77f5"
+-version = "0.55.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
+-dependencies = [
+- "gix-actor 0.36.0",
+- "gix-features 0.44.1",
+- "gix-fs 0.17.0",
+- "gix-hash 0.20.1",
+- "gix-lock 19.0.0",
+- "gix-object 0.52.0",
+- "gix-path 0.10.22 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-tempfile 19.0.1",
+- "gix-utils 0.3.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-validate 0.10.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++version = "0.56.0"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "4b7a23209d4e4cbdc2086d294f5f3f8707ac6286768847024d952d8cd3278c5b"
- dependencies = [
-- "gix-actor 0.35.3",
-+ "gix-actor",
-  "gix-features 0.43.1",
-  "gix-fs 0.16.0",
-  "gix-hash 0.19.0",
-  "gix-lock 18.0.0",
-  "gix-object 0.50.1",
-- "gix-path 0.10.20",
++checksum = "16f21c66e188cb95207d30c9b2d21b0d234f570dbb97d8fd493081b6990dcb9d"
++dependencies = [
++ "gix-actor 0.36.1",
++ "gix-features 0.45.0",
++ "gix-fs 0.18.0",
++ "gix-hash 0.21.0",
++ "gix-lock 20.0.0",
++ "gix-object 0.53.0",
 + "gix-path",
-  "gix-tempfile 18.0.0",
-- "gix-utils 0.3.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-- "gix-validate 0.10.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-tempfile 20.0.0",
 + "gix-utils",
 + "gix-validate",
   "memmap2",
   "serde",
-  "thiserror 2.0.12",
-@@ -4621,12 +4587,13 @@ dependencies = [
+  "thiserror 2.0.17",
+@@ -4871,32 +4867,34 @@ dependencies = [
+ 
  [[package]]
  name = "gix-refspec"
- version = "0.31.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#202bc6da79854d1fb6bb32b9c6bb2a6f882c77f5"
+-version = "0.33.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
++version = "0.34.0"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "7d29cae1ae31108826e7156a5e60bffacab405f4413f5bc0375e19772cce0055"
++checksum = "853157fd71394f7f382af2e28a7cd78c5c7bd28b7c5d7de7272e1ec97a869159"
  dependencies = [
   "bstr",
-  "gix-hash 0.19.0",
+- "gix-glob 0.22.1",
+- "gix-hash 0.20.1",
++ "gix-glob 0.23.0",
++ "gix-hash 0.21.0",
   "gix-revision",
-- "gix-validate 0.10.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-validate 0.10.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
 + "gix-validate",
   "smallvec",
-  "thiserror 2.0.12",
+  "thiserror 2.0.17",
  ]
-@@ -4634,17 +4601,18 @@ dependencies = [
+ 
  [[package]]
  name = "gix-revision"
- version = "0.35.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#202bc6da79854d1fb6bb32b9c6bb2a6f882c77f5"
+-version = "0.37.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
++version = "0.38.0"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "f651f2b1742f760bb8161d6743229206e962b73d9c33c41f4e4aefa6586cbd3d"
++checksum = "63c1956637d13fe273178f425c04b0458ea678c150cb8ed325957a63cb1136f6"
  dependencies = [
-  "bitflags 2.9.1",
+  "bitflags 2.10.0",
   "bstr",
-  "gix-commitgraph 0.29.0",
-- "gix-date 0.10.4",
-+ "gix-date",
-  "gix-hash 0.19.0",
-  "gix-hashtable 0.9.0",
-  "gix-object 0.50.1",
-  "gix-revwalk 0.21.0",
-- "gix-trace 0.1.13 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-commitgraph 0.30.1",
+- "gix-date 0.11.0",
+- "gix-hash 0.20.1",
+- "gix-hashtable 0.10.0",
+- "gix-object 0.52.0",
+- "gix-revwalk 0.23.0",
+- "gix-trace 0.1.15 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-commitgraph 0.31.0",
++ "gix-date 0.11.1",
++ "gix-hash 0.21.0",
++ "gix-hashtable 0.11.0",
++ "gix-object 0.53.0",
++ "gix-revwalk 0.24.0",
 + "gix-trace",
   "serde",
-  "thiserror 2.0.12",
+  "thiserror 2.0.17",
  ]
-@@ -4656,7 +4624,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "1bc756b73225bf005ddeb871d1ca7b3c33e2417d0d53e56effa5a36765b52b28"
- dependencies = [
-  "gix-commitgraph 0.28.0",
-- "gix-date 0.10.3",
-+ "gix-date",
-  "gix-hash 0.18.0",
-  "gix-hashtable 0.8.1",
-  "gix-object 0.49.1",
-@@ -4667,10 +4635,11 @@ dependencies = [
+@@ -4918,14 +4916,15 @@ dependencies = [
+ 
  [[package]]
  name = "gix-revwalk"
- version = "0.21.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#202bc6da79854d1fb6bb32b9c6bb2a6f882c77f5"
+-version = "0.23.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
++version = "0.24.0"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "06e74f91709729e099af6721bd0fa7d62f243f2005085152301ca5cdd86ec02c"
++checksum = "276d6ce81e71c18e6c9c3de2c5015e85a7495d1bf33e0a7587e997b8bd040715"
  dependencies = [
-  "gix-commitgraph 0.29.0",
-- "gix-date 0.10.4",
-+ "gix-date",
-  "gix-hash 0.19.0",
-  "gix-hashtable 0.9.0",
-  "gix-object 0.50.1",
-@@ -4685,7 +4654,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+- "gix-commitgraph 0.30.1",
+- "gix-date 0.11.0",
+- "gix-hash 0.20.1",
+- "gix-hashtable 0.10.0",
+- "gix-object 0.52.0",
++ "gix-commitgraph 0.31.0",
++ "gix-date 0.11.1",
++ "gix-hash 0.21.0",
++ "gix-hashtable 0.11.0",
++ "gix-object 0.53.0",
+  "smallvec",
+  "thiserror 2.0.17",
+ ]
+@@ -4937,7 +4936,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "d0dabbc78c759ecc006b970339394951b2c8e1e38a37b072c105b80b84c308fd"
  dependencies = [
-  "bitflags 2.9.1",
-- "gix-path 0.10.19",
+  "bitflags 2.10.0",
+- "gix-path 0.10.22 (registry+https://github.com/rust-lang/crates.io-index)",
 + "gix-path",
   "libc",
   "windows-sys 0.59.0",
  ]
-@@ -4693,19 +4662,21 @@ dependencies = [
+@@ -4945,10 +4944,11 @@ dependencies = [
  [[package]]
  name = "gix-sec"
- version = "0.12.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#202bc6da79854d1fb6bb32b9c6bb2a6f882c77f5"
+ version = "0.12.2"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "09f7053ed7c66633b56c57bc6ed3377be3166eaf3dc2df9f1c5ec446df6fdf2c"
++checksum = "ea9962ed6d9114f7f100efe038752f41283c225bb507a2888903ac593dffa6be"
  dependencies = [
-  "bitflags 2.9.1",
-- "gix-path 0.10.20",
+  "bitflags 2.10.0",
+- "gix-path 0.10.22 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
 + "gix-path",
   "libc",
   "serde",
-- "windows-sys 0.60.2",
-+ "windows-sys 0.59.0",
- ]
+  "windows-sys 0.61.2",
+@@ -4956,46 +4956,49 @@ dependencies = [
  
  [[package]]
  name = "gix-shallow"
- version = "0.5.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#202bc6da79854d1fb6bb32b9c6bb2a6f882c77f5"
+-version = "0.6.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
++version = "0.7.0"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "d936745103243ae4c510f19e0760ce73fb0f08096588fdbe0f0d7fb7ce8944b7"
++checksum = "9c1c467fb9f7ec1d33613c2ea5482de514bcb84b8222a793cdc4c71955832356"
  dependencies = [
   "bstr",
-  "gix-hash 0.19.0",
-@@ -4717,7 +4688,8 @@ dependencies = [
+- "gix-hash 0.20.1",
+- "gix-lock 19.0.0",
++ "gix-hash 0.21.0",
++ "gix-lock 20.0.0",
+  "serde",
+  "thiserror 2.0.17",
+ ]
+ 
  [[package]]
  name = "gix-status"
- version = "0.20.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#202bc6da79854d1fb6bb32b9c6bb2a6f882c77f5"
+-version = "0.22.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
++version = "0.23.0"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "2a4afff9b34eeececa8bdc32b42fb318434b6b1391d9f8d45fe455af08dc2d35"
++checksum = "1084eb17030ddbda1705c94ff6f79678dd7f15762deda74edf0f38e33711079c"
  dependencies = [
   "bstr",
   "filetime",
-@@ -4729,7 +4701,7 @@ dependencies = [
-  "gix-hash 0.19.0",
-  "gix-index 0.41.0",
-  "gix-object 0.50.1",
-- "gix-path 0.10.20",
+  "gix-diff",
+  "gix-dir",
+- "gix-features 0.44.1",
++ "gix-features 0.45.0",
+  "gix-filter",
+- "gix-fs 0.17.0",
+- "gix-hash 0.20.1",
+- "gix-index 0.43.0",
+- "gix-object 0.52.0",
+- "gix-path 0.10.22 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-fs 0.18.0",
++ "gix-hash 0.21.0",
++ "gix-index 0.44.0",
++ "gix-object 0.53.0",
 + "gix-path",
   "gix-pathspec",
-  "gix-worktree 0.42.0",
+- "gix-worktree 0.44.0",
++ "gix-worktree 0.45.0",
   "portable-atomic",
-@@ -4739,11 +4711,12 @@ dependencies = [
+  "thiserror 2.0.17",
+ ]
+ 
  [[package]]
  name = "gix-submodule"
- version = "0.20.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#202bc6da79854d1fb6bb32b9c6bb2a6f882c77f5"
+-version = "0.22.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
++version = "0.23.0"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "657cc5dd43cbc7a14d9c5aaf02cfbe9c2a15d077cded3f304adb30ef78852d3e"
++checksum = "fe0b0d02a3c5968a2d86de2a56ab28c3b50aa28d8324d49383b7bd71d26e6d84"
  dependencies = [
   "bstr",
   "gix-config",
-- "gix-path 0.10.20",
+- "gix-path 0.10.22 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
 + "gix-path",
   "gix-pathspec",
   "gix-refspec",
   "gix-url",
-@@ -4768,7 +4741,8 @@ dependencies = [
+@@ -5019,11 +5022,12 @@ dependencies = [
+ 
  [[package]]
  name = "gix-tempfile"
- version = "18.0.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#202bc6da79854d1fb6bb32b9c6bb2a6f882c77f5"
+-version = "19.0.1"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
++version = "20.0.0"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "666c0041bcdedf5fa05e9bef663c897debab24b7dc1741605742412d1d47da57"
++checksum = "816bbb99bbf8cd329e38342594528506f224c4937a6341dbd1d16ee4082f621c"
  dependencies = [
   "dashmap",
-  "gix-fs 0.16.0",
-@@ -4807,11 +4781,6 @@ name = "gix-trace"
- version = "0.1.13"
+- "gix-fs 0.17.0",
++ "gix-fs 0.18.0",
+  "libc",
+  "parking_lot",
+  "tempfile",
+@@ -5055,33 +5059,29 @@ dependencies = [
+ 
+ [[package]]
+ name = "gix-trace"
+-version = "0.1.15"
++version = "0.1.16"
  source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "e2ccaf54b0b1743a695b482ca0ab9d7603744d8d10b2e5d1a332fef337bee658"
+-checksum = "1d3f59a8de2934f6391b6b3a1a7654eae18961fcb9f9c843533fed34ad0f3457"
 -
 -[[package]]
 -name = "gix-trace"
--version = "0.1.13"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#202bc6da79854d1fb6bb32b9c6bb2a6f882c77f5"
+-version = "0.1.15"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
++checksum = "edd971cd6961fb1ebb29a0052a4ab04d8498dbf363c122e137b04753a3bbb5c3"
  dependencies = [
   "tracing-core",
  ]
-@@ -4819,7 +4788,8 @@ dependencies = [
+ 
  [[package]]
  name = "gix-transport"
- version = "0.48.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#202bc6da79854d1fb6bb32b9c6bb2a6f882c77f5"
+-version = "0.50.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
++version = "0.51.0"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "12f7cc0179fc89d53c54e1f9ce51229494864ab4bf136132d69db1b011741ca3"
++checksum = "03c5445af84383b949856a36accfde9f90bdfc10bb1f640f105917f9d5419509"
  dependencies = [
   "base64 0.22.1",
   "bstr",
-@@ -4828,7 +4798,7 @@ dependencies = [
+  "gix-command",
   "gix-credentials",
-  "gix-features 0.43.1",
+- "gix-features 0.44.1",
++ "gix-features 0.45.0",
   "gix-packetline",
-- "gix-quote 0.6.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-quote 0.6.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
 + "gix-quote",
-  "gix-sec 0.12.0",
+  "gix-sec 0.12.2",
   "gix-url",
+- "reqwest 0.12.24",
++ "reqwest 0.12.27",
   "serde",
-@@ -4843,7 +4813,7 @@ checksum = "b8648172f85aca3d6e919c06504b7ac26baef54e04c55eb0100fa588c102cc33"
- dependencies = [
-  "bitflags 2.9.1",
-  "gix-commitgraph 0.28.0",
-- "gix-date 0.10.3",
-+ "gix-date",
-  "gix-hash 0.18.0",
-  "gix-hashtable 0.8.1",
-  "gix-object 0.49.1",
-@@ -4855,11 +4825,12 @@ dependencies = [
+  "thiserror 2.0.17",
+ ]
+@@ -5105,28 +5105,30 @@ dependencies = [
+ 
  [[package]]
  name = "gix-traverse"
- version = "0.47.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#202bc6da79854d1fb6bb32b9c6bb2a6f882c77f5"
+-version = "0.49.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
++version = "0.50.0"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "c7cdc82509d792ba0ad815f86f6b469c7afe10f94362e96c4494525a6601bdd5"
++checksum = "c1f7582730a236aba16b4c9a5e9ac64bcbe7f155a38ae5938320de96760beb23"
  dependencies = [
-  "bitflags 2.9.1",
-  "gix-commitgraph 0.29.0",
-- "gix-date 0.10.4",
-+ "gix-date",
-  "gix-hash 0.19.0",
-  "gix-hashtable 0.9.0",
-  "gix-object 0.50.1",
-@@ -4871,11 +4842,12 @@ dependencies = [
+  "bitflags 2.10.0",
+- "gix-commitgraph 0.30.1",
+- "gix-date 0.11.0",
+- "gix-hash 0.20.1",
+- "gix-hashtable 0.10.0",
+- "gix-object 0.52.0",
+- "gix-revwalk 0.23.0",
++ "gix-commitgraph 0.31.0",
++ "gix-date 0.11.1",
++ "gix-hash 0.21.0",
++ "gix-hashtable 0.11.0",
++ "gix-object 0.53.0",
++ "gix-revwalk 0.24.0",
+  "smallvec",
+  "thiserror 2.0.17",
+ ]
+ 
  [[package]]
  name = "gix-url"
- version = "0.32.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#202bc6da79854d1fb6bb32b9c6bb2a6f882c77f5"
+-version = "0.33.2"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
++version = "0.34.0"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "1b76a9d266254ad287ffd44467cd88e7868799b08f4d52e02d942b93e514d16f"
++checksum = "cff1996dfb9430b3699d89224c674169c1ae355eacc52bf30a03c0b8bffe73d9"
  dependencies = [
   "bstr",
-  "gix-features 0.43.1",
-- "gix-path 0.10.20",
+- "gix-features 0.44.1",
+- "gix-path 0.10.22 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-features 0.45.0",
 + "gix-path",
   "percent-encoding",
   "serde",
-  "thiserror 2.0.12",
-@@ -4887,15 +4859,6 @@ name = "gix-utils"
- version = "0.3.0"
+  "thiserror 2.0.17",
+@@ -5137,15 +5139,6 @@ name = "gix-utils"
+ version = "0.3.1"
  source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "5351af2b172caf41a3728eb4455326d84e0d70fe26fc4de74ab0bd37df4191c5"
+ checksum = "befcdbdfb1238d2854591f760a48711bed85e72d80a10e8f2f93f656746ef7c5"
 -dependencies = [
 - "fastrand",
 - "unicode-normalization",
@@ -2042,52 +1753,64 @@ index 60b520f8d..8406c39d0 100644
 -
 -[[package]]
 -name = "gix-utils"
--version = "0.3.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#202bc6da79854d1fb6bb32b9c6bb2a6f882c77f5"
+-version = "0.3.1"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
  dependencies = [
   "bstr",
   "fastrand",
-@@ -4912,15 +4875,6 @@ dependencies = [
-  "thiserror 2.0.12",
+@@ -5162,15 +5155,6 @@ dependencies = [
+  "thiserror 2.0.17",
  ]
  
 -[[package]]
 -name = "gix-validate"
--version = "0.10.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#202bc6da79854d1fb6bb32b9c6bb2a6f882c77f5"
+-version = "0.10.1"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
 -dependencies = [
 - "bstr",
-- "thiserror 2.0.12",
+- "thiserror 2.0.17",
 -]
 -
  [[package]]
  name = "gix-worktree"
  version = "0.41.0"
-@@ -4936,14 +4890,15 @@ dependencies = [
+@@ -5186,42 +5170,44 @@ dependencies = [
   "gix-ignore 0.15.0",
   "gix-index 0.40.1",
   "gix-object 0.49.1",
-- "gix-path 0.10.19",
-- "gix-validate 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-path 0.10.22 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-validate 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
 + "gix-path",
 + "gix-validate",
  ]
  
  [[package]]
  name = "gix-worktree"
- version = "0.42.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#202bc6da79854d1fb6bb32b9c6bb2a6f882c77f5"
+-version = "0.44.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
++version = "0.45.0"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "55f625ac9126c19bef06dbc6d2703cdd7987e21e35b497bb265ac37d383877b1"
++checksum = "e0ac49293df83b81da60ad8313f0376a5a7d6b11739ea7e97c0e1ba17b63d2a6"
  dependencies = [
   "bstr",
-  "gix-attributes 0.27.0",
-@@ -4954,15 +4909,16 @@ dependencies = [
-  "gix-ignore 0.16.0",
-  "gix-index 0.41.0",
-  "gix-object 0.50.1",
-- "gix-path 0.10.20",
-- "gix-validate 0.10.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-attributes 0.28.1",
+- "gix-features 0.44.1",
+- "gix-fs 0.17.0",
+- "gix-glob 0.22.1",
+- "gix-hash 0.20.1",
+- "gix-ignore 0.17.1",
+- "gix-index 0.43.0",
+- "gix-object 0.52.0",
+- "gix-path 0.10.22 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-validate 0.10.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-attributes 0.29.0",
++ "gix-features 0.45.0",
++ "gix-fs 0.18.0",
++ "gix-glob 0.23.0",
++ "gix-hash 0.21.0",
++ "gix-ignore 0.18.0",
++ "gix-index 0.44.0",
++ "gix-object 0.53.0",
 + "gix-path",
 + "gix-validate",
   "serde",
@@ -2095,2198 +1818,1438 @@ index 60b520f8d..8406c39d0 100644
  
  [[package]]
  name = "gix-worktree-state"
- version = "0.20.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#202bc6da79854d1fb6bb32b9c6bb2a6f882c77f5"
+-version = "0.22.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
++version = "0.23.0"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "06ba9b17cbacc02b25801197b20100f7f9bd621db1e7fce9d3c8ab3175207bf8"
++checksum = "35c6ca09a99ff8d95b4ab4085a94547f89e39164ef23989f9df07257a353f7ef"
  dependencies = [
   "bstr",
-  "gix-features 0.43.1",
-@@ -4972,7 +4928,7 @@ dependencies = [
-  "gix-hash 0.19.0",
-  "gix-index 0.41.0",
-  "gix-object 0.50.1",
-- "gix-path 0.10.20",
+- "gix-features 0.44.1",
++ "gix-features 0.45.0",
+  "gix-filter",
+- "gix-fs 0.17.0",
+- "gix-index 0.43.0",
+- "gix-object 0.52.0",
+- "gix-path 0.10.22 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-worktree 0.44.0",
++ "gix-fs 0.18.0",
++ "gix-index 0.44.0",
++ "gix-object 0.53.0",
 + "gix-path",
-  "gix-worktree 0.42.0",
++ "gix-worktree 0.45.0",
   "io-close",
-  "thiserror 2.0.12",
-@@ -5012,7 +4968,7 @@ dependencies = [
-  "proc-macro-error",
-  "proc-macro2",
-  "quote",
-- "syn 2.0.101",
-+ "syn 2.0.104",
+  "thiserror 2.0.17",
  ]
- 
- [[package]]
-@@ -5091,14 +5047,14 @@ dependencies = [
-  "proc-macro-error",
-  "proc-macro2",
-  "quote",
-- "syn 2.0.101",
-+ "syn 2.0.104",
- ]
- 
- [[package]]
- name = "h2"
--version = "0.3.26"
-+version = "0.3.27"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
-+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
- dependencies = [
-  "bytes",
-  "fnv",
-@@ -5106,7 +5062,7 @@ dependencies = [
-  "futures-sink",
-  "futures-util",
-  "http 0.2.12",
-- "indexmap 2.9.0",
-+ "indexmap 2.10.0",
-  "slab",
-  "tokio",
-  "tokio-util",
-@@ -5115,9 +5071,9 @@ dependencies = [
- 
- [[package]]
- name = "h2"
--version = "0.4.10"
-+version = "0.4.12"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
-+checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
- dependencies = [
-  "atomic-waker",
-  "bytes",
-@@ -5125,7 +5081,7 @@ dependencies = [
-  "futures-core",
-  "futures-sink",
-  "http 1.3.1",
-- "indexmap 2.9.0",
-+ "indexmap 2.10.0",
-  "slab",
-  "tokio",
-  "tokio-util",
-@@ -5208,9 +5164,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
- 
- [[package]]
- name = "hermit-abi"
--version = "0.4.0"
-+version = "0.5.2"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
-+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
- 
- [[package]]
- name = "hex"
-@@ -5341,14 +5297,14 @@ dependencies = [
-  "futures-channel",
-  "futures-core",
-  "futures-util",
-- "h2 0.3.26",
-+ "h2 0.3.27",
-  "http 0.2.12",
-  "http-body 0.4.6",
-  "httparse",
-  "httpdate",
-  "itoa",
-  "pin-project-lite",
-- "socket2 0.5.9",
-+ "socket2 0.5.10",
-  "tokio",
-  "tower-service",
-  "tracing",
-@@ -5364,7 +5320,7 @@ dependencies = [
-  "bytes",
-  "futures-channel",
-  "futures-util",
-- "h2 0.4.10",
-+ "h2 0.4.12",
-  "http 1.3.1",
-  "http-body 1.0.1",
-  "httparse",
-@@ -5392,21 +5348,20 @@ dependencies = [
- 
- [[package]]
- name = "hyper-rustls"
--version = "0.27.5"
-+version = "0.27.7"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
-+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
- dependencies = [
-- "futures-util",
-  "http 1.3.1",
-  "hyper 1.6.0",
-  "hyper-util",
-- "rustls 0.23.27",
-+ "rustls 0.23.31",
-  "rustls-native-certs",
-  "rustls-pki-types",
-  "tokio",
-  "tokio-rustls 0.26.2",
-  "tower-service",
-- "webpki-roots 0.26.11",
-+ "webpki-roots 1.0.2",
- ]
- 
- [[package]]
-@@ -5440,9 +5395,9 @@ dependencies = [
+@@ -5705,9 +5691,9 @@ dependencies = [
  
  [[package]]
  name = "hyper-util"
--version = "0.1.13"
-+version = "0.1.16"
+-version = "0.1.18"
++version = "0.1.19"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "b1c293b6b3d21eca78250dc7dbebd6b9210ec5530e038cbfe0661b5c47ab06e8"
-+checksum = "8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e"
+-checksum = "52e9a2a24dc5c6821e71a7030e1e14b7b632acac55c40e9d2e082c621261bb56"
++checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
  dependencies = [
   "base64 0.22.1",
   "bytes",
-@@ -5456,7 +5411,7 @@ dependencies = [
-  "libc",
-  "percent-encoding",
-  "pin-project-lite",
-- "socket2 0.5.9",
-+ "socket2 0.6.0",
-  "system-configuration 0.6.1",
+@@ -5726,7 +5712,7 @@ dependencies = [
   "tokio",
   "tower-service",
-@@ -5547,9 +5502,9 @@ checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+  "tracing",
+- "windows-registry",
++ "windows-registry 0.6.1",
+ ]
+ 
+ [[package]]
+@@ -5811,9 +5797,9 @@ checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
  
  [[package]]
  name = "icu_properties"
--version = "2.0.0"
-+version = "2.0.1"
+-version = "2.1.1"
++version = "2.1.2"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "2549ca8c7241c82f59c80ba2a6f415d931c5b58d24fb8412caa1a1f02c49139a"
-+checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
+-checksum = "e93fcd3157766c0c8da2f8cff6ce651a31f0810eaa1c51ec363ef790bbb5fb99"
++checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
  dependencies = [
-  "displaydoc",
   "icu_collections",
-@@ -5563,9 +5518,9 @@ dependencies = [
+  "icu_locale_core",
+@@ -5825,9 +5811,9 @@ dependencies = [
  
  [[package]]
  name = "icu_properties_data"
--version = "2.0.0"
-+version = "2.0.1"
+-version = "2.1.1"
++version = "2.1.2"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "8197e866e47b68f8f7d95249e172903bec06004b18b2937f1095d40a0c57de04"
-+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
+-checksum = "02845b3647bb045f1100ecd6480ff52f34c35f82d9880e029d329c21d1054899"
++checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
  
  [[package]]
  name = "icu_provider"
-@@ -5646,9 +5601,9 @@ dependencies = [
+@@ -5974,14 +5960,15 @@ dependencies = [
  
  [[package]]
- name = "indexmap"
--version = "2.9.0"
-+version = "2.10.0"
+ name = "insta"
+-version = "1.44.3"
++version = "1.45.0"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
-+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+-checksum = "b5c943d4415edd8153251b6f197de5eb1640e56d84e8d9159bea190421c73698"
++checksum = "b76866be74d68b1595eb8060cb9191dca9c021db2316558e52ddc5d55d41b66c"
  dependencies = [
-  "equivalent",
-  "hashbrown 0.15.4",
-@@ -5843,7 +5798,7 @@ checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
- dependencies = [
-  "proc-macro2",
-  "quote",
-- "syn 2.0.101",
-+ "syn 2.0.104",
+  "console",
+  "once_cell",
+  "serde",
+  "similar",
++ "tempfile",
  ]
  
  [[package]]
-@@ -5895,9 +5850,9 @@ dependencies = [
+@@ -6061,9 +6048,9 @@ dependencies = [
  
  [[package]]
- name = "jpeg-decoder"
--version = "0.3.1"
-+version = "0.3.2"
+ name = "itoa"
+-version = "1.0.15"
++version = "1.0.16"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0"
-+checksum = "00810f1d8b74be64b13dbf3db89ac67740615d6c891f0e7b6179326533011a07"
+-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
++checksum = "7ee5b5339afb4c41626dde77b7a611bd4f2c202b897852b4bcf5d03eddc61010"
+ 
+ [[package]]
+ name = "javascriptcore-rs"
+@@ -6116,9 +6103,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "jiff-tzdb"
+-version = "0.1.4"
++version = "0.1.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c1283705eb0a21404d2bfd6eef2a7593d240bc42a0bdb39db0ad6fa2ec026524"
++checksum = "68971ebff725b9e2ca27a601c5eb38a4c5d64422c4cbab0c535f248087eda5c2"
+ 
+ [[package]]
+ name = "jiff-tzdb-platform"
+@@ -6163,9 +6150,9 @@ dependencies = [
  
  [[package]]
  name = "js-sys"
-@@ -5954,7 +5909,7 @@ dependencies = [
-  "log",
-  "secret-service",
-  "security-framework 2.11.1",
-- "security-framework 3.2.0",
-+ "security-framework 3.3.0",
-  "windows-sys 0.60.2",
-  "zeroize",
- ]
-@@ -5997,7 +5952,7 @@ checksum = "02cb977175687f33fa4afa0c95c112b987ea1443e5a51c8f8ff27dc618270cc2"
+-version = "0.3.82"
++version = "0.3.83"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
++checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
  dependencies = [
-  "cssparser",
-  "html5ever",
-- "indexmap 2.9.0",
-+ "indexmap 2.10.0",
-  "selectors",
- ]
- 
-@@ -6027,7 +5982,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "6e9ec52138abedcc58dc17a7c6c0c00a2bdb4f3427c7f63fa97fd0d859155caf"
- dependencies = [
-  "gtk-sys",
-- "libloading",
-+ "libloading 0.7.4",
   "once_cell",
- ]
+  "wasm-bindgen",
+@@ -6316,24 +6303,24 @@ checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
  
-@@ -6048,9 +6003,9 @@ dependencies = [
+ [[package]]
+ name = "libc"
+-version = "0.2.177"
++version = "0.2.178"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
++checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
+ 
+ [[package]]
+ name = "libdbus-sys"
+-version = "0.2.6"
++version = "0.2.7"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "5cbe856efeb50e4681f010e9aaa2bf0a644e10139e54cde10fc83a307c23bd9f"
++checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+ dependencies = [
+  "pkg-config",
+ ]
  
  [[package]]
  name = "libgit2-sys"
--version = "0.18.1+1.9.0"
-+version = "0.18.2+1.9.1"
+-version = "0.18.2+1.9.1"
++version = "0.18.3+1.9.2"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "e1dcb20f84ffcdd825c7a311ae347cce604a6f084a767dec4a4929829645290e"
-+checksum = "1c42fe03df2bd3c53a3a9c7317ad91d80c81cd1fb0caec8d7cc4cd2bfa10c222"
+-checksum = "1c42fe03df2bd3c53a3a9c7317ad91d80c81cd1fb0caec8d7cc4cd2bfa10c222"
++checksum = "c9b3acc4b91781bb0b3386669d325163746af5f6e4f73e6d2d630e09a35f3487"
  dependencies = [
   "cc",
   "libc",
-@@ -6070,11 +6025,21 @@ dependencies = [
-  "winapi",
- ]
+@@ -6365,13 +6352,13 @@ dependencies = [
  
-+[[package]]
-+name = "libloading"
-+version = "0.8.8"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
-+dependencies = [
-+ "cfg-if",
-+ "windows-targets 0.53.3",
-+]
-+
  [[package]]
  name = "libredox"
--version = "0.1.3"
-+version = "0.1.9"
+-version = "0.1.10"
++version = "0.1.11"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
-+checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
+-checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
++checksum = "df15f6eac291ed1cf25865b1ee60399f57e7c227e7f51bdbd4c5270396a9ed50"
  dependencies = [
-  "bitflags 2.9.1",
+  "bitflags 2.10.0",
   "libc",
-@@ -6108,9 +6073,9 @@ dependencies = [
- 
- [[package]]
- name = "libz-rs-sys"
--version = "0.5.0"
-+version = "0.5.1"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "6489ca9bd760fe9642d7644e827b0c9add07df89857b0416ee15c1cc1a3b8c5a"
-+checksum = "172a788537a2221661b480fee8dc5f96c580eb34fa88764d3205dc356c7e4221"
- dependencies = [
-  "zlib-rs",
- ]
-@@ -6157,9 +6122,9 @@ checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
- 
- [[package]]
- name = "litrs"
--version = "0.4.1"
-+version = "0.4.2"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
-+checksum = "f5e54036fe321fd421e10d732f155734c4e4afd610dd556d9a82833ab3ee0bed"
- 
- [[package]]
- name = "lock_api"
-@@ -6244,7 +6209,7 @@ checksum = "88a9689d8d44bf9964484516275f5cd4c9b59457a6940c1d5d0ecbb94510a36b"
- dependencies = [
-  "proc-macro2",
-  "quote",
-- "syn 2.0.101",
-+ "syn 2.0.104",
+- "redox_syscall",
++ "redox_syscall 0.6.0",
  ]
  
  [[package]]
-@@ -6282,7 +6247,7 @@ checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
- dependencies = [
-  "proc-macro2",
-  "quote",
-- "syn 2.0.101",
-+ "syn 2.0.104",
+@@ -6399,15 +6386,6 @@ dependencies = [
+  "vcpkg",
  ]
  
+-[[package]]
+-name = "libz-rs-sys"
+-version = "0.5.2"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "840db8cf39d9ec4dd794376f38acc40d0fc65eec2a8f484f7fd375b84602becd"
+-dependencies = [
+- "zlib-rs",
+-]
+-
  [[package]]
-@@ -6293,9 +6258,9 @@ checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
+ name = "libz-sys"
+ version = "1.1.23"
+@@ -6430,12 +6408,6 @@ dependencies = [
+  "libc",
+ ]
+ 
+-[[package]]
+-name = "linux-raw-sys"
+-version = "0.4.15"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+-
+ [[package]]
+ name = "linux-raw-sys"
+ version = "0.11.0"
+@@ -6465,11 +6437,11 @@ dependencies = [
  
  [[package]]
- name = "memchr"
--version = "2.7.4"
-+version = "2.7.5"
+ name = "log"
+-version = "0.4.28"
++version = "0.4.29"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
-+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
++checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+ dependencies = [
+- "serde",
++ "serde_core",
+  "value-bag",
+ ]
  
- [[package]]
- name = "memmap2"
-@@ -6317,12 +6282,12 @@ dependencies = [
+@@ -6492,8 +6464,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "65fd3f75411f4725061682ed91f131946e912859d0044d39c4ec0aac818d7621"
+ dependencies = [
+  "cc",
+- "objc2 0.6.3",
+- "objc2-foundation 0.3.2",
++ "objc2",
++ "objc2-foundation",
+  "time",
+ ]
  
- [[package]]
- name = "migrations_internals"
--version = "2.2.0"
-+version = "2.2.1"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "fd01039851e82f8799046eabbb354056283fb265c8ec0996af940f4e85a380ff"
-+checksum = "3bda1634d70d5bd53553cf15dca9842a396e8c799982a3ad22998dc44d961f24"
+@@ -6600,7 +6572,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "36c791ecdf977c99f45f23280405d7723727470f6689a5e6dbf513ac547ae10d"
  dependencies = [
   "serde",
-- "toml",
-+ "toml 0.9.5",
+- "toml 0.9.8",
++ "toml 0.9.10+spec-1.1.0",
  ]
  
  [[package]]
-@@ -6360,15 +6325,15 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
- 
- [[package]]
- name = "minisign-verify"
--version = "0.2.3"
-+version = "0.2.4"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "6367d84fb54d4242af283086402907277715b8fe46976963af5ebf173f8efba3"
-+checksum = "e856fdd13623a2f5f2f54676a4ee49502a96a80ef4a62bcedd23d52427c44d43"
- 
- [[package]]
- name = "miniz_oxide"
--version = "0.8.8"
-+version = "0.8.9"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
-+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
- dependencies = [
-  "adler2",
-  "simd-adler32",
-@@ -6376,14 +6341,14 @@ dependencies = [
+@@ -6681,9 +6653,9 @@ dependencies = [
  
  [[package]]
  name = "mio"
--version = "1.0.3"
-+version = "1.0.4"
+-version = "1.1.0"
++version = "1.1.1"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
-+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
+-checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
++checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
  dependencies = [
   "libc",
   "log",
-- "wasi 0.11.0+wasi-snapshot-preview1",
-- "windows-sys 0.52.0",
-+ "wasi 0.11.1+wasi-snapshot-preview1",
-+ "windows-sys 0.59.0",
- ]
+@@ -6699,9 +6671,9 @@ checksum = "dce6dd36094cac388f119d2e9dc82dc730ef91c32a6222170d630e5414b956e6"
  
  [[package]]
-@@ -6394,23 +6359,23 @@ checksum = "4e1d4c44418358edcac6e1d9ce59cea7fb38052429c7704033f1196f0c179e6a"
- 
- [[package]]
- name = "muda"
--version = "0.17.0"
-+version = "0.17.1"
+ name = "moxcms"
+-version = "0.7.10"
++version = "0.7.11"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "58b89bf91c19bf036347f1ab85a81c560f08c0667c8601bece664d860a600988"
-+checksum = "01c1738382f66ed56b3b9c8119e794a2e23148ac8ea214eda86622d4cb9d415a"
+-checksum = "80986bbbcf925ebd3be54c26613d861255284584501595cf418320c078945608"
++checksum = "ac9557c559cd6fc9867e122e20d2cbefc9ca29d80d027a8e39310920ed2f0a97"
  dependencies = [
-  "crossbeam-channel",
+  "num-traits",
+  "pxfm",
+@@ -6717,10 +6689,10 @@ dependencies = [
   "dpi",
   "gtk",
   "keyboard-types",
-  "objc2 0.6.1",
-- "objc2-app-kit 0.3.1",
-+ "objc2-app-kit",
+- "objc2 0.6.3",
++ "objc2",
+  "objc2-app-kit",
   "objc2-core-foundation",
-  "objc2-foundation 0.3.1",
+- "objc2-foundation 0.3.2",
++ "objc2-foundation",
   "once_cell",
-  "png",
+  "png 0.17.16",
   "serde",
-  "thiserror 2.0.12",
-- "windows-sys 0.59.0",
-+ "windows-sys 0.60.2",
- ]
+@@ -6853,7 +6825,7 @@ dependencies = [
+  "kqueue",
+  "libc",
+  "log",
+- "mio 1.1.0",
++ "mio 1.1.1",
+  "notify-types",
+  "walkdir",
+  "windows-sys 0.60.2",
+@@ -6881,9 +6853,9 @@ checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
  
  [[package]]
-@@ -6661,23 +6626,24 @@ dependencies = [
- 
- [[package]]
- name = "num_enum"
--version = "0.7.3"
-+version = "0.7.4"
+ name = "ntapi"
+-version = "0.4.1"
++version = "0.4.2"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
-+checksum = "a973b4e44ce6cad84ce69d797acf9a044532e4184c4f267913d1b546a0727b7a"
+-checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
++checksum = "c70f219e21142367c70c0b30c6a9e3a14d55b4d12a204d897fbec83a0363f081"
  dependencies = [
-  "num_enum_derive",
-+ "rustversion",
+  "winapi",
  ]
- 
- [[package]]
- name = "num_enum_derive"
--version = "0.7.3"
-+version = "0.7.4"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
-+checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
- dependencies = [
-  "proc-macro-crate 3.3.0",
-  "proc-macro2",
-  "quote",
-- "syn 2.0.101",
-+ "syn 2.0.104",
- ]
- 
- [[package]]
-@@ -6724,22 +6690,6 @@ dependencies = [
-  "objc2-exception-helper",
+@@ -7016,22 +6988,6 @@ dependencies = [
+  "malloc_buf",
  ]
  
 -[[package]]
--name = "objc2-app-kit"
+-name = "objc-sys"
+-version = "0.3.5"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
+-
+-[[package]]
+-name = "objc2"
+-version = "0.5.2"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
+-dependencies = [
+- "objc-sys",
+- "objc2-encode",
+-]
+-
+ [[package]]
+ name = "objc2"
+ version = "0.6.3"
+@@ -7049,9 +7005,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
+ dependencies = [
+  "bitflags 2.10.0",
+- "block2 0.6.2",
++ "block2",
+  "libc",
+- "objc2 0.6.3",
++ "objc2",
+  "objc2-cloud-kit",
+  "objc2-core-data",
+  "objc2-core-foundation",
+@@ -7059,8 +7015,8 @@ dependencies = [
+  "objc2-core-image",
+  "objc2-core-text",
+  "objc2-core-video",
+- "objc2-foundation 0.3.2",
+- "objc2-quartz-core 0.3.2",
++ "objc2-foundation",
++ "objc2-quartz-core",
+ ]
+ 
+ [[package]]
+@@ -7070,8 +7026,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
+ dependencies = [
+  "bitflags 2.10.0",
+- "objc2 0.6.3",
+- "objc2-foundation 0.3.2",
++ "objc2",
++ "objc2-foundation",
+ ]
+ 
+ [[package]]
+@@ -7081,8 +7037,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
+ dependencies = [
+  "bitflags 2.10.0",
+- "objc2 0.6.3",
+- "objc2-foundation 0.3.2",
++ "objc2",
++ "objc2-foundation",
+ ]
+ 
+ [[package]]
+@@ -7093,7 +7049,7 @@ checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+ dependencies = [
+  "bitflags 2.10.0",
+  "dispatch2",
+- "objc2 0.6.3",
++ "objc2",
+ ]
+ 
+ [[package]]
+@@ -7104,7 +7060,7 @@ checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+ dependencies = [
+  "bitflags 2.10.0",
+  "dispatch2",
+- "objc2 0.6.3",
++ "objc2",
+  "objc2-core-foundation",
+  "objc2-io-surface",
+ ]
+@@ -7115,8 +7071,8 @@ version = "0.3.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+ dependencies = [
+- "objc2 0.6.3",
+- "objc2-foundation 0.3.2",
++ "objc2",
++ "objc2-foundation",
+ ]
+ 
+ [[package]]
+@@ -7125,8 +7081,8 @@ version = "0.3.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
+ dependencies = [
+- "objc2 0.6.3",
+- "objc2-foundation 0.3.2",
++ "objc2",
++ "objc2-foundation",
+ ]
+ 
+ [[package]]
+@@ -7136,7 +7092,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+ dependencies = [
+  "bitflags 2.10.0",
+- "objc2 0.6.3",
++ "objc2",
+  "objc2-core-foundation",
+  "objc2-core-graphics",
+ ]
+@@ -7148,7 +7104,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
+ dependencies = [
+  "bitflags 2.10.0",
+- "objc2 0.6.3",
++ "objc2",
+  "objc2-core-foundation",
+  "objc2-core-graphics",
+  "objc2-io-surface",
+@@ -7169,18 +7125,6 @@ dependencies = [
+  "cc",
+ ]
+ 
+-[[package]]
+-name = "objc2-foundation"
 -version = "0.2.2"
 -source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
+-checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 -dependencies = [
-- "bitflags 2.9.1",
+- "bitflags 2.10.0",
 - "block2 0.5.1",
 - "libc",
 - "objc2 0.5.2",
-- "objc2-core-data 0.2.2",
-- "objc2-core-image 0.2.2",
-- "objc2-foundation 0.2.2",
-- "objc2-quartz-core 0.2.2",
 -]
 -
  [[package]]
- name = "objc2-app-kit"
- version = "0.3.1"
-@@ -6751,10 +6701,10 @@ dependencies = [
+ name = "objc2-foundation"
+ version = "0.3.2"
+@@ -7188,9 +7132,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+ dependencies = [
+  "bitflags 2.10.0",
+- "block2 0.6.2",
++ "block2",
   "libc",
-  "objc2 0.6.1",
-  "objc2-cloud-kit",
-- "objc2-core-data 0.3.1",
-+ "objc2-core-data",
+- "objc2 0.6.3",
++ "objc2",
   "objc2-core-foundation",
-  "objc2-core-graphics",
-- "objc2-core-image 0.3.1",
-+ "objc2-core-image",
-  "objc2-foundation 0.3.1",
-  "objc2-quartz-core 0.3.1",
  ]
-@@ -6770,18 +6720,6 @@ dependencies = [
-  "objc2-foundation 0.3.1",
+ 
+@@ -7211,7 +7155,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+ dependencies = [
+  "bitflags 2.10.0",
+- "objc2 0.6.3",
++ "objc2",
+  "objc2-core-foundation",
+ ]
+ 
+@@ -7221,22 +7165,10 @@ version = "0.3.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "2a1e6550c4caed348956ce3370c9ffeca70bb1dbed4fa96112e7c6170e074586"
+ dependencies = [
+- "objc2 0.6.3",
++ "objc2",
+  "objc2-core-foundation",
  ]
  
 -[[package]]
--name = "objc2-core-data"
+-name = "objc2-metal"
 -version = "0.2.2"
 -source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
+-checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
 -dependencies = [
-- "bitflags 2.9.1",
+- "bitflags 2.10.0",
 - "block2 0.5.1",
 - "objc2 0.5.2",
 - "objc2-foundation 0.2.2",
 -]
 -
  [[package]]
- name = "objc2-core-data"
- version = "0.3.1"
-@@ -6817,18 +6755,6 @@ dependencies = [
-  "objc2-io-surface",
- ]
- 
+ name = "objc2-osa-kit"
+ version = "0.3.2"
+@@ -7244,22 +7176,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
+ dependencies = [
+  "bitflags 2.10.0",
+- "objc2 0.6.3",
++ "objc2",
+  "objc2-app-kit",
+- "objc2-foundation 0.3.2",
+-]
+-
 -[[package]]
--name = "objc2-core-image"
+-name = "objc2-quartz-core"
 -version = "0.2.2"
 -source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
+-checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
 -dependencies = [
+- "bitflags 2.10.0",
 - "block2 0.5.1",
 - "objc2 0.5.2",
 - "objc2-foundation 0.2.2",
 - "objc2-metal",
--]
--
- [[package]]
- name = "objc2-core-image"
- version = "0.3.1"
-@@ -6862,7 +6788,6 @@ checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
- dependencies = [
-  "bitflags 2.9.1",
-  "block2 0.5.1",
-- "dispatch",
-  "libc",
-  "objc2 0.5.2",
- ]
-@@ -6921,7 +6846,7 @@ checksum = "26bb88504b5a050dbba515d2414607bf5e57dd56b107bc5f0351197a3e7bdc5d"
- dependencies = [
-  "bitflags 2.9.1",
-  "objc2 0.6.1",
-- "objc2-app-kit 0.3.1",
-+ "objc2-app-kit",
-  "objc2-foundation 0.3.1",
++ "objc2-foundation",
  ]
  
-@@ -6970,7 +6895,7 @@ dependencies = [
-  "bitflags 2.9.1",
-  "block2 0.6.1",
-  "objc2 0.6.1",
-- "objc2-app-kit 0.3.1",
-+ "objc2-app-kit",
+ [[package]]
+@@ -7269,9 +7188,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+ dependencies = [
+  "bitflags 2.10.0",
+- "objc2 0.6.3",
++ "objc2",
   "objc2-core-foundation",
-  "objc2-foundation 0.3.1",
- ]
-@@ -6990,6 +6915,12 @@ version = "1.21.3"
- source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
- 
-+[[package]]
-+name = "once_cell_polyfill"
-+version = "1.70.1"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
-+
- [[package]]
- name = "open"
- version = "5.3.2"
-@@ -7004,9 +6935,9 @@ dependencies = [
- 
- [[package]]
- name = "openssl"
--version = "0.10.72"
-+version = "0.10.73"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
-+checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
- dependencies = [
-  "bitflags 2.9.1",
-  "cfg-if",
-@@ -7025,7 +6956,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
- dependencies = [
-  "proc-macro2",
-  "quote",
-- "syn 2.0.101",
-+ "syn 2.0.104",
+- "objc2-foundation 0.3.2",
++ "objc2-foundation",
  ]
  
  [[package]]
-@@ -7036,18 +6967,18 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
- 
- [[package]]
- name = "openssl-src"
--version = "300.5.0+3.5.0"
-+version = "300.5.1+3.5.1"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "e8ce546f549326b0e6052b649198487d91320875da901e7bd11a06d1ee3f9c2f"
-+checksum = "735230c832b28c000e3bc117119e6466a663ec73506bc0a9907ea4187508e42a"
+@@ -7281,7 +7200,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "709fe137109bd1e8b5a99390f77a7d8b2961dafc1a1c5db8f2e60329ad6d895a"
  dependencies = [
-  "cc",
+  "bitflags 2.10.0",
+- "objc2 0.6.3",
++ "objc2",
+  "objc2-core-foundation",
+ ]
+ 
+@@ -7292,8 +7211,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
+ dependencies = [
+  "bitflags 2.10.0",
+- "block2 0.6.2",
+- "objc2 0.6.3",
++ "block2",
++ "objc2",
+  "objc2-cloud-kit",
+  "objc2-core-data",
+  "objc2-core-foundation",
+@@ -7301,8 +7220,8 @@ dependencies = [
+  "objc2-core-image",
+  "objc2-core-location",
+  "objc2-core-text",
+- "objc2-foundation 0.3.2",
+- "objc2-quartz-core 0.3.2",
++ "objc2-foundation",
++ "objc2-quartz-core",
+  "objc2-user-notifications",
+ ]
+ 
+@@ -7312,8 +7231,8 @@ version = "0.3.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
+ dependencies = [
+- "objc2 0.6.3",
+- "objc2-foundation 0.3.2",
++ "objc2",
++ "objc2-foundation",
  ]
  
  [[package]]
- name = "openssl-sys"
--version = "0.9.108"
-+version = "0.9.109"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "e145e1651e858e820e4860f7b9c5e169bc1d8ce1c86043be79fa7b7634821847"
-+checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
+@@ -7323,11 +7242,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "b2e5aaab980c433cf470df9d7af96a7b46a9d892d521a2cbbb2f8a4c16751e7f"
  dependencies = [
-  "cc",
-  "libc",
-@@ -7074,20 +7005,21 @@ dependencies = [
+  "bitflags 2.10.0",
+- "block2 0.6.2",
+- "objc2 0.6.3",
++ "block2",
++ "objc2",
+  "objc2-app-kit",
+  "objc2-core-foundation",
+- "objc2-foundation 0.3.2",
++ "objc2-foundation",
+  "objc2-javascript-core",
+  "objc2-security",
+ ]
+@@ -7357,7 +7276,7 @@ dependencies = [
+  "mime",
+  "parse_link_header",
+  "percent-encoding",
+- "reqwest 0.12.24",
++ "reqwest 0.12.27",
+  "schemars 0.8.22",
+  "serde",
+  "serde_json",
+@@ -7451,15 +7370,15 @@ dependencies = [
  
  [[package]]
  name = "os_info"
--version = "3.11.0"
-+version = "3.12.0"
+-version = "3.13.0"
++version = "3.14.0"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "41fc863e2ca13dc2d5c34fb22ea4a588248ac14db929616ba65c45f21744b1e9"
-+checksum = "d0e1ac5fde8d43c34139135df8ea9ee9465394b2d8d20f032d38998f64afffc3"
+-checksum = "7c39b5918402d564846d5aba164c09a66cc88d232179dfd3e3c619a25a268392"
++checksum = "e4022a17595a00d6a369236fdae483f0de7f0a339960a53118b818238e132224"
  dependencies = [
+  "android_system_properties",
   "log",
-+ "plist",
+  "nix 0.30.1",
+- "objc2 0.6.3",
+- "objc2-foundation 0.3.2",
++ "objc2",
++ "objc2-foundation",
+  "objc2-ui-kit",
   "serde",
-  "windows-sys 0.52.0",
- ]
- 
- [[package]]
- name = "os_pipe"
--version = "1.2.1"
-+version = "1.2.2"
+  "windows-sys 0.61.2",
+@@ -7481,8 +7400,8 @@ version = "0.3.1"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "5ffd2b0a5634335b135d5728d84c5e0fd726954b87111f7506a61c502280d982"
-+checksum = "db335f4760b14ead6290116f2427bf33a14d4f0617d49f78a246de10c1831224"
+ checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
  dependencies = [
-  "libc",
-  "windows-sys 0.59.0",
-@@ -7202,7 +7134,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
- dependencies = [
-  "fixedbitset 0.4.2",
-- "indexmap 2.9.0",
-+ "indexmap 2.10.0",
- ]
- 
- [[package]]
-@@ -7213,7 +7145,7 @@ checksum = "54acf3a685220b533e437e264e4d932cfbdc4cc7ec0cd232ed73c08d03b8a7ca"
- dependencies = [
-  "fixedbitset 0.5.7",
-  "hashbrown 0.15.4",
-- "indexmap 2.9.0",
-+ "indexmap 2.10.0",
+- "objc2 0.6.3",
+- "objc2-foundation 0.3.2",
++ "objc2",
++ "objc2-foundation",
+  "objc2-osa-kit",
   "serde",
- ]
- 
-@@ -7321,7 +7253,7 @@ dependencies = [
-  "phf_shared 0.11.3",
-  "proc-macro2",
-  "quote",
-- "syn 2.0.101",
-+ "syn 2.0.104",
- ]
- 
- [[package]]
-@@ -7368,7 +7300,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
- dependencies = [
-  "proc-macro2",
-  "quote",
-- "syn 2.0.101",
-+ "syn 2.0.104",
- ]
- 
- [[package]]
-@@ -7402,13 +7334,13 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
- 
- [[package]]
- name = "plist"
--version = "1.7.1"
-+version = "1.7.4"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "eac26e981c03a6e53e0aee43c113e3202f5581d5360dae7bd2c70e800dd0451d"
-+checksum = "3af6b589e163c5a788fab00ce0c0366f6efbb9959c2f9874b224936af7fce7e1"
- dependencies = [
-  "base64 0.22.1",
-- "indexmap 2.9.0",
-- "quick-xml 0.32.0",
-+ "indexmap 2.10.0",
-+ "quick-xml 0.38.1",
-  "serde",
-  "time",
- ]
-@@ -7428,24 +7360,23 @@ dependencies = [
- 
- [[package]]
- name = "polling"
--version = "3.7.4"
-+version = "3.10.0"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
-+checksum = "b5bd19146350fe804f7cb2669c851c03d69da628803dab0d98018142aaa5d829"
+  "serde_json",
+@@ -7538,7 +7457,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
  dependencies = [
   "cfg-if",
+  "libc",
+- "redox_syscall",
++ "redox_syscall 0.5.18",
+  "smallvec",
+  "windows-link 0.2.1",
+ ]
+@@ -7826,15 +7745,15 @@ dependencies = [
   "concurrent-queue",
   "hermit-abi",
   "pin-project-lite",
-- "rustix 0.38.44",
-- "tracing",
-- "windows-sys 0.59.0",
-+ "rustix 1.0.8",
-+ "windows-sys 0.60.2",
+- "rustix 1.1.2",
++ "rustix",
+  "windows-sys 0.61.2",
  ]
  
  [[package]]
  name = "portable-atomic"
--version = "1.11.0"
-+version = "1.11.1"
+-version = "1.11.1"
++version = "1.12.0"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
-+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+-checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
++checksum = "f59e70c4aef1e55797c2e8fd94a4f2a973fc972cfde0e0b05f683667b0cd39dd"
  
  [[package]]
  name = "portable-atomic-util"
-@@ -7563,7 +7494,7 @@ version = "3.3.0"
+@@ -7926,7 +7845,7 @@ version = "3.4.0"
  source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+ checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
  dependencies = [
-- "toml_edit 0.22.26",
-+ "toml_edit 0.22.27",
+- "toml_edit 0.23.7",
++ "toml_edit 0.23.10+spec-1.0.0",
  ]
  
  [[package]]
-@@ -7644,7 +7575,7 @@ dependencies = [
-  "itertools",
-  "proc-macro2",
-  "quote",
-- "syn 2.0.101",
-+ "syn 2.0.104",
- ]
+@@ -8090,9 +8009,9 @@ dependencies = [
  
  [[package]]
-@@ -7694,18 +7625,18 @@ dependencies = [
- 
- [[package]]
- name = "quick-xml"
--version = "0.32.0"
-+version = "0.37.5"
+ name = "pxfm"
+-version = "0.1.26"
++version = "0.1.27"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "1d3a6e5838b60e0e8fa7a43f22ade549a37d61f8bdbe636d0d7816191de969c2"
-+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+-checksum = "b3502d6155304a4173a5f2c34b52b7ed0dd085890326cb50fd625fdf39e86b3b"
++checksum = "7186d3822593aa4393561d186d1393b3923e9d6163d3fbfd6e825e3e6cf3e6a8"
  dependencies = [
-  "memchr",
+  "num-traits",
+ ]
+@@ -8322,6 +8241,15 @@ dependencies = [
+  "bitflags 2.10.0",
  ]
  
- [[package]]
- name = "quick-xml"
--version = "0.37.5"
-+version = "0.38.1"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
-+checksum = "9845d9dccf565065824e69f9f235fafba1587031eda353c1f1561cd6a6be78f4"
- dependencies = [
-  "memchr",
- ]
-@@ -7722,8 +7653,8 @@ dependencies = [
-  "quinn-proto",
-  "quinn-udp",
-  "rustc-hash",
-- "rustls 0.23.27",
-- "socket2 0.5.9",
-+ "rustls 0.23.31",
-+ "socket2 0.5.10",
-  "thiserror 2.0.12",
-  "tokio",
-  "tracing",
-@@ -7742,7 +7673,7 @@ dependencies = [
-  "rand 0.9.2",
-  "ring",
-  "rustc-hash",
-- "rustls 0.23.27",
-+ "rustls 0.23.31",
-  "rustls-pki-types",
-  "slab",
-  "thiserror 2.0.12",
-@@ -7753,14 +7684,14 @@ dependencies = [
- 
- [[package]]
- name = "quinn-udp"
--version = "0.5.12"
-+version = "0.5.13"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "ee4e529991f949c5e25755532370b8af5d114acae52326361d68d47af64aa842"
-+checksum = "fcebb1209ee276352ef14ff8732e24cc2b02bbac986cd74a4c81bcb2f9881970"
- dependencies = [
-  "cfg_aliases",
-  "libc",
-  "once_cell",
-- "socket2 0.5.9",
-+ "socket2 0.5.10",
-  "tracing",
-  "windows-sys 0.59.0",
- ]
-@@ -7776,9 +7707,9 @@ dependencies = [
- 
- [[package]]
- name = "r-efi"
--version = "5.2.0"
-+version = "5.3.0"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
-+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
- 
- [[package]]
- name = "radium"
-@@ -7904,9 +7835,9 @@ checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
- 
- [[package]]
- name = "redox_syscall"
--version = "0.5.12"
-+version = "0.5.17"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
-+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
- dependencies = [
-  "bitflags 2.9.1",
- ]
-@@ -7924,9 +7855,9 @@ dependencies = [
- 
++[[package]]
++name = "redox_syscall"
++version = "0.6.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "ec96166dafa0886eb81fe1c0a388bece180fbef2135f97c1e2cf8302e74b43b5"
++dependencies = [
++ "bitflags 2.10.0",
++]
++
  [[package]]
  name = "redox_users"
--version = "0.5.0"
-+version = "0.5.2"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
-+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
- dependencies = [
-  "getrandom 0.2.16",
-  "libredox",
-@@ -7950,7 +7881,7 @@ checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
- dependencies = [
-  "proc-macro2",
-  "quote",
-- "syn 2.0.101",
-+ "syn 2.0.104",
- ]
+ version = "0.4.6"
+@@ -8451,14 +8379,14 @@ dependencies = [
  
  [[package]]
-@@ -8023,7 +7954,7 @@ dependencies = [
+ name = "reqwest"
+-version = "0.12.24"
++version = "0.12.27"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "9d0946410b9f7b082a427e4ef5c8ff541a88b357bc6c637c40db3a68ac70a36f"
++checksum = "8e893f6bece5953520ddbb3f8f46f3ef36dd1fef4ee9b087c4b4a725fd5d10e4"
+ dependencies = [
+  "base64 0.22.1",
+  "bytes",
+  "cookie",
+- "cookie_store",
++ "cookie_store 0.22.0",
   "encoding_rs",
+  "futures-channel",
   "futures-core",
-  "futures-util",
-- "h2 0.3.26",
-+ "h2 0.3.27",
-  "http 0.2.12",
-  "http-body 0.4.6",
-  "hyper 0.14.32",
-@@ -8066,12 +7997,12 @@ dependencies = [
-  "encoding_rs",
-  "futures-core",
-  "futures-util",
-- "h2 0.4.10",
-+ "h2 0.4.12",
-  "http 1.3.1",
-  "http-body 1.0.1",
-  "http-body-util",
-  "hyper 1.6.0",
-- "hyper-rustls 0.27.5",
-+ "hyper-rustls 0.27.7",
-  "hyper-tls",
-  "hyper-util",
-  "js-sys",
-@@ -8082,7 +8013,7 @@ dependencies = [
-  "percent-encoding",
+@@ -8510,7 +8438,7 @@ dependencies = [
+  "mime",
+  "nom 7.1.3",
   "pin-project-lite",
-  "quinn",
-- "rustls 0.23.27",
-+ "rustls 0.23.31",
-  "rustls-native-certs",
-  "rustls-pki-types",
-  "serde",
-@@ -8101,7 +8032,7 @@ dependencies = [
-  "wasm-bindgen-futures",
-  "wasm-streams",
-  "web-sys",
-- "webpki-roots 1.0.0",
-+ "webpki-roots 1.0.2",
+- "reqwest 0.12.24",
++ "reqwest 0.12.27",
+  "thiserror 1.0.69",
  ]
  
- [[package]]
-@@ -8131,25 +8062,27 @@ dependencies = [
- 
- [[package]]
- name = "rfd"
--version = "0.15.0"
-+version = "0.15.4"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "8af382a047821a08aa6bfc09ab0d80ff48d45d8726f7cd8e44891f7cb4a4278e"
-+checksum = "ef2bee61e6cffa4635c72d7d81a84294e28f0930db0ddcb0f66d10244674ebed"
+@@ -8530,17 +8458,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "ef2bee61e6cffa4635c72d7d81a84294e28f0930db0ddcb0f66d10244674ebed"
  dependencies = [
   "ashpd",
-- "block2 0.5.1",
-+ "block2 0.6.1",
-+ "dispatch2",
+- "block2 0.6.2",
++ "block2",
+  "dispatch2",
   "glib-sys",
   "gobject-sys",
   "gtk-sys",
   "js-sys",
   "log",
-- "objc2 0.5.2",
-- "objc2-app-kit 0.2.2",
-- "objc2-foundation 0.2.2",
-+ "objc2 0.6.1",
-+ "objc2-app-kit",
-+ "objc2-core-foundation",
-+ "objc2-foundation 0.3.1",
+- "objc2 0.6.3",
++ "objc2",
+  "objc2-app-kit",
+  "objc2-core-foundation",
+- "objc2-foundation 0.3.2",
++ "objc2-foundation",
   "raw-window-handle",
   "wasm-bindgen",
   "wasm-bindgen-futures",
-  "web-sys",
-- "windows-sys 0.48.0",
-+ "windows-sys 0.59.0",
+@@ -8702,19 +8630,6 @@ dependencies = [
+  "semver",
  ]
  
+-[[package]]
+-name = "rustix"
+-version = "0.38.44"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+-dependencies = [
+- "bitflags 2.10.0",
+- "errno",
+- "libc",
+- "linux-raw-sys 0.4.15",
+- "windows-sys 0.59.0",
+-]
+-
  [[package]]
-@@ -8224,7 +8157,7 @@ checksum = "a6e2b2fd7497540489fa2db285edd43b7ed14c49157157438664278da6e42a7a"
- dependencies = [
-  "proc-macro2",
-  "quote",
-- "syn 2.0.101",
-+ "syn 2.0.104",
+ name = "rustix"
+ version = "1.1.2"
+@@ -8724,7 +8639,7 @@ dependencies = [
+  "bitflags 2.10.0",
+  "errno",
+  "libc",
+- "linux-raw-sys 0.11.0",
++ "linux-raw-sys",
+  "windows-sys 0.61.2",
  ]
  
- [[package]]
-@@ -8253,15 +8186,15 @@ dependencies = [
-  "regex",
-  "relative-path",
-  "rustc_version",
-- "syn 2.0.101",
-+ "syn 2.0.104",
-  "unicode-ident",
- ]
+@@ -8777,9 +8692,9 @@ dependencies = [
  
  [[package]]
- name = "rust_decimal"
--version = "1.37.1"
-+version = "1.37.2"
+ name = "rustls-pki-types"
+-version = "1.13.1"
++version = "1.13.2"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "faa7de2ba56ac291bd90c6b9bece784a52ae1411f9506544b3eae36dd2356d50"
-+checksum = "b203a6425500a03e0919c42d3c47caca51e79f1132046626d2c8871c5092035d"
+-checksum = "708c0f9d5f54ba0272468c1d306a52c495b31fa155e91bc25371e6df7996908c"
++checksum = "21e6f2ab2928ca4291b86736a8bd920a277a399bba1589409d72154ff87c1282"
  dependencies = [
-  "arrayvec",
-  "borsh",
-@@ -8275,9 +8208,9 @@ dependencies = [
- 
- [[package]]
- name = "rustc-demangle"
--version = "0.1.24"
-+version = "0.1.26"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
-+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
- 
- [[package]]
- name = "rustc-hash"
-@@ -8334,14 +8267,14 @@ dependencies = [
- 
- [[package]]
- name = "rustls"
--version = "0.23.27"
-+version = "0.23.31"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
-+checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
- dependencies = [
-  "once_cell",
-  "ring",
-  "rustls-pki-types",
-- "rustls-webpki 0.103.3",
-+ "rustls-webpki 0.103.4",
-  "subtle",
+  "web-time",
   "zeroize",
- ]
-@@ -8355,7 +8288,7 @@ dependencies = [
-  "openssl-probe",
-  "rustls-pki-types",
-  "schannel",
-- "security-framework 3.2.0",
-+ "security-framework 3.3.0",
- ]
- 
- [[package]]
-@@ -8389,9 +8322,9 @@ dependencies = [
- 
- [[package]]
- name = "rustls-webpki"
--version = "0.103.3"
-+version = "0.103.4"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
-+checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
- dependencies = [
-  "ring",
-  "rustls-pki-types",
-@@ -8400,9 +8333,9 @@ dependencies = [
- 
- [[package]]
- name = "rustversion"
--version = "1.0.20"
-+version = "1.0.21"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
-+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+@@ -8814,9 +8729,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
  
  [[package]]
  name = "ryu"
-@@ -8465,6 +8398,18 @@ dependencies = [
-  "serde_json",
- ]
- 
-+[[package]]
-+name = "schemars"
-+version = "1.0.4"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
-+dependencies = [
-+ "dyn-clone",
-+ "ref-cast",
-+ "serde",
-+ "serde_json",
-+]
-+
- [[package]]
- name = "schemars_derive"
- version = "0.8.22"
-@@ -8474,7 +8419,7 @@ dependencies = [
-  "proc-macro2",
-  "quote",
-  "serde_derive_internals",
-- "syn 2.0.101",
-+ "syn 2.0.104",
- ]
- 
- [[package]]
-@@ -8486,7 +8431,7 @@ dependencies = [
-  "proc-macro2",
-  "quote",
-  "serde_derive_internals",
-- "syn 2.0.101",
-+ "syn 2.0.104",
- ]
- 
- [[package]]
-@@ -8513,9 +8458,9 @@ dependencies = [
- 
- [[package]]
- name = "sdd"
--version = "3.0.8"
-+version = "3.0.10"
+-version = "1.0.20"
++version = "1.0.21"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "584e070911c7017da6cb2eb0788d09f43d789029b5877d3e5ecc8acf86ceee21"
-+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
+-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
++checksum = "62049b2877bf12821e8f9ad256ee38fdc31db7387ec2d3b3f403024de2034aea"
  
  [[package]]
- name = "seahash"
-@@ -8567,12 +8512,12 @@ dependencies = [
+ name = "same-file"
+@@ -9103,9 +9018,9 @@ dependencies = [
  
  [[package]]
- name = "security-framework"
--version = "3.2.0"
-+version = "3.3.0"
+ name = "serde_json"
+-version = "1.0.145"
++version = "1.0.146"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
-+checksum = "80fb1d92c5028aa318b4b8bd7302a5bfcf48be96a37fc6fc790f806b0004ee0c"
+-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
++checksum = "217ca874ae0207aac254aa02c957ded05585a90892cc8d87f9e5fa49669dadd8"
  dependencies = [
-  "bitflags 2.9.1",
-- "core-foundation 0.10.0",
-+ "core-foundation 0.10.1",
-  "core-foundation-sys",
-  "libc",
-  "security-framework-sys",
-@@ -8652,7 +8597,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
- dependencies = [
-  "proc-macro2",
-  "quote",
-- "syn 2.0.101",
-+ "syn 2.0.104",
- ]
- 
- [[package]]
-@@ -8663,7 +8608,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
- dependencies = [
-  "proc-macro2",
-  "quote",
-- "syn 2.0.101",
-+ "syn 2.0.104",
- ]
- 
- [[package]]
-@@ -8718,14 +8663,23 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
- dependencies = [
-  "proc-macro2",
-  "quote",
-- "syn 2.0.101",
-+ "syn 2.0.104",
-+]
-+
-+[[package]]
-+name = "serde_spanned"
-+version = "0.6.9"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
-+dependencies = [
-+ "serde",
- ]
+  "indexmap 2.12.1",
+  "itoa",
+@@ -9170,9 +9085,9 @@ dependencies = [
  
  [[package]]
  name = "serde_spanned"
--version = "0.6.8"
-+version = "1.0.0"
+-version = "1.0.3"
++version = "1.0.4"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
-+checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
+-checksum = "e24345aa0fe688594e73770a5f6d1b216508b4f93484c0026d521acd30134392"
++checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
  dependencies = [
-  "serde",
+  "serde_core",
  ]
-@@ -8744,15 +8698,17 @@ dependencies = [
+@@ -9342,9 +9257,9 @@ dependencies = [
  
  [[package]]
- name = "serde_with"
--version = "3.12.0"
-+version = "3.14.0"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "d6b6f7f2fcb69f747921f79f3926bd1e203fce4fef62c268dd3abfb6d86029aa"
-+checksum = "f2c45cd61fefa9db6f254525d46e392b852e0e61d9a1fd36e5bd183450a556d5"
- dependencies = [
-  "base64 0.22.1",
-  "chrono",
-  "hex",
-  "indexmap 1.9.3",
-- "indexmap 2.9.0",
-+ "indexmap 2.10.0",
-+ "schemars 0.9.0",
-+ "schemars 1.0.4",
-  "serde",
-  "serde_derive",
-  "serde_json",
-@@ -8762,14 +8718,14 @@ dependencies = [
- 
- [[package]]
- name = "serde_with_macros"
--version = "3.12.0"
-+version = "3.14.0"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "8d00caa5193a3c8362ac2b73be6b9e768aa5a4b2f721d8f4b339600c3cb51f8e"
-+checksum = "de90945e6565ce0d9a25098082ed4ee4002e047cb59892c318d66821e14bb30f"
- dependencies = [
-  "darling",
-  "proc-macro2",
-  "quote",
-- "syn 2.0.101",
-+ "syn 2.0.104",
- ]
- 
- [[package]]
-@@ -8794,7 +8750,7 @@ checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
- dependencies = [
-  "proc-macro2",
-  "quote",
-- "syn 2.0.101",
-+ "syn 2.0.104",
- ]
- 
- [[package]]
-@@ -8872,12 +8828,13 @@ dependencies = [
- 
- [[package]]
- name = "shared_child"
--version = "1.0.2"
+ name = "shell-words"
+-version = "1.1.0"
 +version = "1.1.1"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "7e297bd52991bbe0686c086957bee142f13df85d1e79b0b21630a99d374ae9dc"
-+checksum = "1e362d9935bc50f019969e2f9ecd66786612daae13e8f277be7bfb66e8bed3f7"
+-checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
++checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
+ 
+ [[package]]
+ name = "shellexpand"
+@@ -9404,9 +9319,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "simd-adler32"
+-version = "0.3.7"
++version = "0.3.8"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
++checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+ 
+ [[package]]
+ name = "simdutf8"
+@@ -9506,24 +9421,24 @@ dependencies = [
+ 
+ [[package]]
+ name = "softbuffer"
+-version = "0.4.6"
++version = "0.4.8"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "18051cdd562e792cad055119e0cdb2cfc137e44e3987532e0f9659a77931bb08"
++checksum = "aac18da81ebbf05109ab275b157c22a653bb3c12cf884450179942f81bcbf6c3"
  dependencies = [
-  "libc",
+  "bytemuck",
+- "cfg_aliases",
+- "core-graphics",
+- "foreign-types",
+  "js-sys",
+- "log",
+- "objc2 0.5.2",
+- "objc2-foundation 0.2.2",
+- "objc2-quartz-core 0.2.2",
++ "ndk",
++ "objc2",
++ "objc2-core-foundation",
++ "objc2-core-graphics",
++ "objc2-foundation",
++ "objc2-quartz-core",
+  "raw-window-handle",
+- "redox_syscall",
++ "redox_syscall 0.5.18",
++ "tracing",
+  "wasm-bindgen",
+  "web-sys",
 - "windows-sys 0.59.0",
-+ "sigchld",
-+ "windows-sys 0.60.2",
++ "windows-sys 0.61.2",
  ]
  
  [[package]]
-@@ -8901,6 +8858,17 @@ version = "1.3.0"
- source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
- 
-+[[package]]
-+name = "sigchld"
-+version = "0.2.4"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "47106eded3c154e70176fc83df9737335c94ce22f821c32d17ed1db1f83badb1"
-+dependencies = [
-+ "libc",
-+ "os_pipe",
-+ "signal-hook",
-+]
-+
- [[package]]
- name = "signal-hook"
- version = "0.3.18"
-@@ -8913,9 +8881,9 @@ dependencies = [
+@@ -9563,17 +9478,15 @@ dependencies = [
  
  [[package]]
- name = "signal-hook-registry"
--version = "1.4.5"
-+version = "1.4.6"
+ name = "sqlite-wasm-rs"
+-version = "0.4.6"
++version = "0.5.1"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
-+checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
+-checksum = "54e4348c16a3d2e2a45437eff67efc5462b60443de76f61b5d0ed9111c626d9d"
++checksum = "05e98301bf8b0540c7de45ecd760539b9c62f5772aed172f08efba597c11cd5d"
  dependencies = [
-  "libc",
- ]
-@@ -8952,12 +8920,9 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
- 
- [[package]]
- name = "slab"
--version = "0.4.9"
-+version = "0.4.10"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
--dependencies = [
-- "autocfg",
--]
-+checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
- 
- [[package]]
- name = "smallvec"
-@@ -8970,9 +8935,9 @@ dependencies = [
- 
- [[package]]
- name = "socket2"
--version = "0.5.9"
-+version = "0.5.10"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
-+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
- dependencies = [
-  "libc",
-  "windows-sys 0.52.0",
-@@ -9099,15 +9064,14 @@ dependencies = [
- 
- [[package]]
- name = "strum_macros"
--version = "0.27.1"
-+version = "0.27.2"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
-+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
- dependencies = [
-  "heck 0.5.0",
-  "proc-macro2",
-  "quote",
-- "rustversion",
-- "syn 2.0.101",
-+ "syn 2.0.104",
++ "cc",
++ "hashbrown 0.16.1",
+  "js-sys",
+- "once_cell",
+  "thiserror 2.0.17",
+- "tokio",
+  "wasm-bindgen",
+- "wasm-bindgen-futures",
+- "web-sys",
  ]
  
  [[package]]
-@@ -9140,9 +9104,9 @@ dependencies = [
- 
- [[package]]
- name = "syn"
--version = "2.0.101"
-+version = "2.0.104"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
-+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+@@ -9790,7 +9703,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "f3a753bdc39c07b192151523a3f77cd0394aa75413802c883a0f6f6a0e5ee2e7"
  dependencies = [
-  "proc-macro2",
-  "quote",
-@@ -9172,7 +9136,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
- dependencies = [
-  "proc-macro2",
-  "quote",
-- "syn 2.0.101",
-+ "syn 2.0.104",
- ]
- 
- [[package]]
-@@ -9186,9 +9150,9 @@ dependencies = [
- 
- [[package]]
- name = "sysinfo"
--version = "0.36.0"
-+version = "0.36.1"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "aab138f5c1bb35231de19049060a87977ad23e04f2303e953bc5c2947ac7dec4"
-+checksum = "252800745060e7b9ffb7b2badbd8b31cfa4aa2e61af879d0a3bf2a317c20217d"
- dependencies = [
-  "libc",
-  "memchr",
-@@ -9249,7 +9213,7 @@ dependencies = [
-  "cfg-expr",
-  "heck 0.5.0",
-  "pkg-config",
-- "toml",
-+ "toml 0.8.23",
-  "version-compare",
- ]
- 
-@@ -9260,7 +9224,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "49c380ca75a231b87b6c9dd86948f035012e7171d1a7c40a9c2890489a7ffd8a"
- dependencies = [
-  "bitflags 2.9.1",
-- "core-foundation 0.10.0",
-+ "core-foundation 0.10.1",
+  "bitflags 2.10.0",
+- "block2 0.6.2",
++ "block2",
+  "core-foundation 0.10.1",
   "core-graphics",
   "crossbeam-channel",
-  "dispatch",
-@@ -9277,7 +9241,7 @@ dependencies = [
+@@ -9807,9 +9720,9 @@ dependencies = [
+  "ndk",
   "ndk-context",
   "ndk-sys",
-  "objc2 0.6.1",
-- "objc2-app-kit 0.3.1",
-+ "objc2-app-kit",
-  "objc2-foundation 0.3.1",
+- "objc2 0.6.3",
++ "objc2",
+  "objc2-app-kit",
+- "objc2-foundation 0.3.2",
++ "objc2-foundation",
   "once_cell",
   "parking_lot",
-@@ -9300,7 +9264,7 @@ checksum = "f4e16beb8b2ac17db28eab8bca40e62dbfbb34c0fcdc6d9826b11b7b5d047dfd"
- dependencies = [
-  "proc-macro2",
-  "quote",
-- "syn 2.0.101",
-+ "syn 2.0.104",
- ]
+  "raw-window-handle",
+@@ -9859,9 +9772,9 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
  
  [[package]]
-@@ -9348,7 +9312,7 @@ dependencies = [
+ name = "tauri"
+-version = "2.9.4"
++version = "2.9.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "15524fc7959bfcaa051ba6d0b3fb1ef18e978de2176c7c6acb977f7fd14d35c7"
++checksum = "8a3868da5508446a7cd08956d523ac3edf0a8bc20bf7e4038f9a95c2800d2033"
+ dependencies = [
+  "anyhow",
+  "bytes",
+@@ -9879,15 +9792,15 @@ dependencies = [
+  "log",
   "mime",
   "muda",
-  "objc2 0.6.1",
-- "objc2-app-kit 0.3.1",
-+ "objc2-app-kit",
-  "objc2-foundation 0.3.1",
+- "objc2 0.6.3",
++ "objc2",
+  "objc2-app-kit",
+- "objc2-foundation 0.3.2",
++ "objc2-foundation",
   "objc2-ui-kit",
+  "objc2-web-kit",
   "percent-encoding",
-@@ -9394,7 +9358,7 @@ dependencies = [
+  "plist",
+  "raw-window-handle",
+- "reqwest 0.12.24",
++ "reqwest 0.12.27",
+  "serde",
+  "serde_json",
+  "serde_repr",
+@@ -9926,7 +9839,7 @@ dependencies = [
   "serde_json",
   "tauri-utils",
   "tauri-winres",
-- "toml",
-+ "toml 0.8.23",
+- "toml 0.9.8",
++ "toml 0.9.10+spec-1.1.0",
   "walkdir",
  ]
  
-@@ -9416,7 +9380,7 @@ dependencies = [
-  "serde",
-  "serde_json",
-  "sha2",
-- "syn 2.0.101",
-+ "syn 2.0.104",
-  "tauri-utils",
-  "thiserror 2.0.12",
-  "time",
-@@ -9434,16 +9398,16 @@ dependencies = [
-  "heck 0.5.0",
-  "proc-macro2",
-  "quote",
-- "syn 2.0.101",
-+ "syn 2.0.104",
-  "tauri-codegen",
-  "tauri-utils",
- ]
- 
- [[package]]
- name = "tauri-plugin"
--version = "2.3.0"
-+version = "2.3.1"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "1d9a0bd00bf1930ad1a604d08b0eb6b2a9c1822686d65d7f4731a7723b8901d3"
-+checksum = "5bd5c1e56990c70a906ef67a9851bbdba9136d26075ee9a2b19c8b46986b3e02"
- dependencies = [
-  "anyhow",
-  "glob",
-@@ -9452,7 +9416,7 @@ dependencies = [
+@@ -9984,7 +9897,7 @@ dependencies = [
   "serde",
   "serde_json",
   "tauri-utils",
-- "toml",
-+ "toml 0.8.23",
+- "toml 0.9.8",
++ "toml 0.9.10+spec-1.1.0",
   "walkdir",
  ]
  
-@@ -9473,9 +9437,9 @@ dependencies = [
+@@ -10020,7 +9933,7 @@ dependencies = [
+  "thiserror 2.0.17",
+  "tracing",
+  "url",
+- "windows-registry",
++ "windows-registry 0.5.3",
+  "windows-result 0.3.4",
+ ]
  
- [[package]]
- name = "tauri-plugin-dialog"
--version = "2.3.0"
-+version = "2.3.2"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "1aefb14219b492afb30b12647b5b1247cadd2c0603467310c36e0f7ae1698c28"
-+checksum = "37e5858cc7b455a73ab4ea2ebc08b5be33682c00ff1bf4cad5537d4fb62499d9"
- dependencies = [
-  "log",
-  "raw-window-handle",
-@@ -9507,7 +9471,7 @@ dependencies = [
+@@ -10060,7 +9973,7 @@ dependencies = [
   "tauri-plugin",
   "tauri-utils",
-  "thiserror 2.0.12",
-- "toml",
-+ "toml 0.8.23",
+  "thiserror 2.0.17",
+- "toml 0.9.8",
++ "toml 0.9.10+spec-1.1.0",
   "url",
  ]
  
-@@ -9677,7 +9641,7 @@ dependencies = [
-  "tokio",
-  "url",
-  "windows-sys 0.60.2",
-- "zip 4.2.0",
-+ "zip 4.3.0",
- ]
+@@ -10071,11 +9984,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "c00685aceab12643cf024f712ab0448ba8fcadf86f2391d49d2e5aa732aacc70"
+ dependencies = [
+  "bytes",
+- "cookie_store",
++ "cookie_store 0.21.1",
+  "data-url",
+  "http 1.4.0",
+  "regex",
+- "reqwest 0.12.24",
++ "reqwest 0.12.27",
+  "schemars 0.8.22",
+  "serde",
+  "serde_json",
+@@ -10098,8 +10011,8 @@ dependencies = [
+  "byte-unit",
+  "fern",
+  "log",
+- "objc2 0.6.3",
+- "objc2-foundation 0.3.2",
++ "objc2",
++ "objc2-foundation",
+  "serde",
+  "serde_json",
+  "serde_repr",
+@@ -10218,7 +10131,7 @@ dependencies = [
+  "minisign-verify",
+  "osakit",
+  "percent-encoding",
+- "reqwest 0.12.24",
++ "reqwest 0.12.27",
+  "semver",
+  "serde",
+  "serde_json",
+@@ -10260,7 +10173,7 @@ dependencies = [
+  "gtk",
+  "http 1.4.0",
+  "jni",
+- "objc2 0.6.3",
++ "objc2",
+  "objc2-ui-kit",
+  "objc2-web-kit",
+  "raw-window-handle",
+@@ -10276,17 +10189,17 @@ dependencies = [
  
  [[package]]
-@@ -9728,7 +9692,7 @@ dependencies = [
+ name = "tauri-runtime-wry"
+-version = "2.9.2"
++version = "2.9.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7950f3bde6bcca6655bc5e76d3d6ec587ceb81032851ab4ddbe1f508bdea2729"
++checksum = "187a3f26f681bdf028f796ccf57cf478c1ee422c50128e5a0a6ebeb3f5910065"
+ dependencies = [
+  "gtk",
+  "http 1.4.0",
   "jni",
   "log",
-  "objc2 0.6.1",
-- "objc2-app-kit 0.3.1",
-+ "objc2-app-kit",
-  "objc2-foundation 0.3.1",
+- "objc2 0.6.3",
++ "objc2",
+  "objc2-app-kit",
+- "objc2-foundation 0.3.2",
++ "objc2-foundation",
   "once_cell",
   "percent-encoding",
-@@ -9775,7 +9739,7 @@ dependencies = [
+  "raw-window-handle",
+@@ -10332,7 +10245,7 @@ dependencies = [
   "serde_with",
   "swift-rs",
-  "thiserror 2.0.12",
-- "toml",
-+ "toml 0.8.23",
+  "thiserror 2.0.17",
+- "toml 0.9.8",
++ "toml 0.9.10+spec-1.1.0",
   "url",
   "urlpattern",
   "uuid",
-@@ -9784,13 +9748,13 @@ dependencies = [
- 
- [[package]]
- name = "tauri-winres"
--version = "0.3.1"
-+version = "0.3.2"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "e8d321dbc6f998d825ab3f0d62673e810c861aac2d0de2cc2c395328f1d113b4"
-+checksum = "7c6d9028d41d4de835e3c482c677a8cb88137ac435d6ff9a71f392d4421576c9"
+@@ -10347,7 +10260,7 @@ checksum = "1087b111fe2b005e42dbdc1990fc18593234238d47453b0c99b7de1c9ab2c1e0"
  dependencies = [
+  "dunce",
   "embed-resource",
-- "indexmap 2.9.0",
-- "toml",
-+ "indexmap 2.10.0",
-+ "toml 0.9.5",
+- "toml 0.9.8",
++ "toml 0.9.10+spec-1.1.0",
  ]
  
  [[package]]
-@@ -9849,7 +9813,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
- dependencies = [
-  "proc-macro2",
-  "quote",
-- "syn 2.0.101",
-+ "syn 2.0.104",
+@@ -10371,7 +10284,7 @@ dependencies = [
+  "fastrand",
+  "getrandom 0.3.4",
+  "once_cell",
+- "rustix 1.1.2",
++ "rustix",
+  "windows-sys 0.61.2",
  ]
  
- [[package]]
-@@ -9860,17 +9824,16 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
- dependencies = [
-  "proc-macro2",
-  "quote",
-- "syn 2.0.101",
-+ "syn 2.0.104",
- ]
- 
- [[package]]
- name = "thread_local"
--version = "1.1.8"
-+version = "1.1.9"
+@@ -10401,7 +10314,7 @@ version = "0.4.3"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
-+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+ checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
  dependencies = [
-  "cfg-if",
-- "once_cell",
+- "rustix 1.1.2",
++ "rustix",
+  "windows-sys 0.60.2",
  ]
  
- [[package]]
-@@ -9971,7 +9934,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+@@ -10558,7 +10471,7 @@ checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
  dependencies = [
-  "proc-macro2",
-  "quote",
-- "syn 2.0.101",
-+ "syn 2.0.104",
- ]
- 
- [[package]]
-@@ -10000,7 +9963,7 @@ version = "0.26.2"
- source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
- dependencies = [
-- "rustls 0.23.27",
-+ "rustls 0.23.31",
-  "tokio",
- ]
- 
-@@ -10042,21 +10005,45 @@ dependencies = [
+  "bytes",
+  "libc",
+- "mio 1.1.0",
++ "mio 1.1.1",
+  "parking_lot",
+  "pin-project-lite",
+  "signal-hook-registry",
+@@ -10649,14 +10562,14 @@ dependencies = [
  
  [[package]]
  name = "toml"
--version = "0.8.22"
-+version = "0.8.23"
+-version = "0.9.8"
++version = "0.9.10+spec-1.1.0"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "05ae329d1f08c4d17a59bed7ff5b5a769d062e64a62d34a3261b219e62cd5aae"
-+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+-checksum = "f0dc8b1fb61449e27716ec0e1bdf0f6b8f3e8f6b05391e8497b8b6d7804ea6d8"
++checksum = "0825052159284a1a8b4d6c0c86cbc801f2da5afd2b225fa548c72f2e74002f48"
  dependencies = [
-  "serde",
-- "serde_spanned",
-- "toml_datetime",
-- "toml_edit 0.22.26",
-+ "serde_spanned 0.6.9",
-+ "toml_datetime 0.6.11",
-+ "toml_edit 0.22.27",
-+]
-+
-+[[package]]
-+name = "toml"
-+version = "0.9.5"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
-+dependencies = [
-+ "indexmap 2.10.0",
-+ "serde",
-+ "serde_spanned 1.0.0",
-+ "toml_datetime 0.7.0",
-+ "toml_parser",
-+ "toml_writer",
-+ "winnow 0.7.12",
- ]
+  "indexmap 2.12.1",
+  "serde_core",
+- "serde_spanned 1.0.3",
+- "toml_datetime 0.7.3",
++ "serde_spanned 1.0.4",
++ "toml_datetime 0.7.5+spec-1.1.0",
+  "toml_parser",
+  "toml_writer",
+  "winnow 0.7.14",
+@@ -10673,9 +10586,9 @@ dependencies = [
  
  [[package]]
  name = "toml_datetime"
--version = "0.6.9"
-+version = "0.6.11"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-+dependencies = [
-+ "serde",
-+]
-+
-+[[package]]
-+name = "toml_datetime"
-+version = "0.7.0"
+-version = "0.7.3"
++version = "0.7.5+spec-1.1.0"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
-+checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
+-checksum = "f2cdb639ebbc97961c51720f858597f7f24c4fc295327923af55b74c3c724533"
++checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
  dependencies = [
-  "serde",
+  "serde_core",
  ]
-@@ -10067,8 +10054,8 @@ version = "0.19.15"
- source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
- dependencies = [
-- "indexmap 2.9.0",
-- "toml_datetime",
-+ "indexmap 2.10.0",
-+ "toml_datetime 0.6.11",
-  "winnow 0.5.40",
- ]
- 
-@@ -10078,30 +10065,45 @@ version = "0.20.7"
- source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
- dependencies = [
-- "indexmap 2.9.0",
-- "toml_datetime",
-+ "indexmap 2.10.0",
-+ "toml_datetime 0.6.11",
-  "winnow 0.5.40",
- ]
+@@ -10706,30 +10619,30 @@ dependencies = [
  
  [[package]]
  name = "toml_edit"
--version = "0.22.26"
-+version = "0.22.27"
+-version = "0.23.7"
++version = "0.23.10+spec-1.0.0"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
-+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+-checksum = "6485ef6d0d9b5d0ec17244ff7eb05310113c3f316f2d14200d4de56b3cb98f8d"
++checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
  dependencies = [
-- "indexmap 2.9.0",
-+ "indexmap 2.10.0",
-  "serde",
-- "serde_spanned",
-- "toml_datetime",
-+ "serde_spanned 0.6.9",
-+ "toml_datetime 0.6.11",
-  "toml_write",
-  "winnow 0.7.12",
+  "indexmap 2.12.1",
+- "toml_datetime 0.7.3",
++ "toml_datetime 0.7.5+spec-1.1.0",
+  "toml_parser",
+  "winnow 0.7.14",
  ]
  
-+[[package]]
-+name = "toml_parser"
-+version = "1.0.2"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "b551886f449aa90d4fe2bdaa9f4a2577ad2dde302c61ecf262d80b116db95c10"
-+dependencies = [
-+ "winnow 0.7.12",
-+]
-+
  [[package]]
- name = "toml_write"
--version = "0.1.1"
-+version = "0.1.2"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
-+
-+[[package]]
-+name = "toml_writer"
-+version = "1.0.2"
+ name = "toml_parser"
+-version = "1.0.4"
++version = "1.0.6+spec-1.1.0"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076"
-+checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
+-checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
++checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+ dependencies = [
+  "winnow 0.7.14",
+ ]
+ 
+ [[package]]
+ name = "toml_writer"
+-version = "1.0.4"
++version = "1.0.6+spec-1.1.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "df8b2b54733674ad286d16267dcfc7a71ed5c776e4ac7aa3c3e2561f7c637bf2"
++checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
  
  [[package]]
  name = "tonic"
-@@ -10114,7 +10116,7 @@ dependencies = [
-  "axum 0.7.9",
-  "base64 0.22.1",
+@@ -10792,9 +10705,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "tower-http"
+-version = "0.6.7"
++version = "0.6.8"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "9cf146f99d442e8e68e585f5d798ccd3cad9a7835b917e09728880a862706456"
++checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+ dependencies = [
+  "bitflags 2.10.0",
   "bytes",
-- "h2 0.4.10",
-+ "h2 0.4.12",
-  "http 1.3.1",
-  "http-body 1.0.1",
-  "http-body-util",
-@@ -10124,7 +10126,7 @@ dependencies = [
-  "percent-encoding",
-  "pin-project",
-  "prost",
-- "socket2 0.5.9",
-+ "socket2 0.5.10",
-  "tokio",
-  "tokio-stream",
-  "tower 0.4.13",
-@@ -10225,13 +10227,13 @@ dependencies = [
+@@ -10822,9 +10735,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
  
  [[package]]
- name = "tracing-attributes"
--version = "0.1.28"
-+version = "0.1.30"
+ name = "tracing"
+-version = "0.1.43"
++version = "0.1.44"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
-+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+-checksum = "2d15d90a0b5c19378952d479dc858407149d7bb45a14de0142f6c534b16fc647"
++checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
  dependencies = [
-  "proc-macro2",
-  "quote",
-- "syn 2.0.101",
-+ "syn 2.0.104",
- ]
+  "log",
+  "pin-project-lite",
+@@ -10857,9 +10770,9 @@ dependencies = [
  
  [[package]]
-@@ -10287,16 +10289,16 @@ dependencies = [
- 
- [[package]]
- name = "tray-icon"
--version = "0.21.0"
-+version = "0.21.1"
+ name = "tracing-core"
+-version = "0.1.35"
++version = "0.1.36"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "2da75ec677957aa21f6e0b361df0daab972f13a5bee3606de0638fd4ee1c666a"
-+checksum = "a0d92153331e7d02ec09137538996a7786fe679c629c279e82a6be762b7e6fe2"
+-checksum = "7a04e24fab5c89c6a36eb8558c9656f30d81de51dfa4d3b45f26b21d61fa0a6c"
++checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
  dependencies = [
-  "crossbeam-channel",
+  "once_cell",
+  "valuable",
+@@ -10916,11 +10829,11 @@ dependencies = [
   "dirs 6.0.0",
   "libappindicator",
   "muda",
-  "objc2 0.6.1",
-- "objc2-app-kit 0.3.1",
-+ "objc2-app-kit",
+- "objc2 0.6.3",
++ "objc2",
+  "objc2-app-kit",
   "objc2-core-foundation",
   "objc2-core-graphics",
-  "objc2-foundation 0.3.1",
-@@ -10602,9 +10604,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+- "objc2-foundation 0.3.2",
++ "objc2-foundation",
+  "once_cell",
+  "png 0.17.16",
+  "serde",
+@@ -11092,9 +11005,9 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
  
  [[package]]
- name = "wasi"
--version = "0.11.0+wasi-snapshot-preview1"
-+version = "0.11.1+wasi-snapshot-preview1"
+ name = "unicode-width"
+-version = "0.2.0"
++version = "0.2.2"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
-+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+-checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
++checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
  
  [[package]]
- name = "wasi"
-@@ -10637,7 +10639,7 @@ dependencies = [
-  "log",
-  "proc-macro2",
-  "quote",
-- "syn 2.0.101",
-+ "syn 2.0.104",
-  "wasm-bindgen-shared",
- ]
+ name = "untrusted"
+@@ -11255,9 +11168,9 @@ dependencies = [
  
-@@ -10672,7 +10674,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+ [[package]]
+ name = "wasm-bindgen"
+-version = "0.2.105"
++version = "0.2.106"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "da95793dfc411fbbd93f5be7715b0578ec61fe87cb1a42b12eb625caa5c5ea60"
++checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
  dependencies = [
-  "proc-macro2",
-  "quote",
-- "syn 2.0.101",
-+ "syn 2.0.104",
-  "wasm-bindgen-backend",
-  "wasm-bindgen-shared",
- ]
-@@ -10701,13 +10703,13 @@ dependencies = [
+  "cfg-if",
+  "once_cell",
+@@ -11268,9 +11181,9 @@ dependencies = [
  
  [[package]]
- name = "wayland-backend"
--version = "0.3.10"
-+version = "0.3.11"
+ name = "wasm-bindgen-futures"
+-version = "0.4.55"
++version = "0.4.56"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "fe770181423e5fc79d3e2a7f4410b7799d5aab1de4372853de3c6aa13ca24121"
-+checksum = "673a33c33048a5ade91a6b139580fa174e19fb0d23f396dca9fa15f2e1e49b35"
+-checksum = "551f88106c6d5e7ccc7cd9a16f312dd3b5d36ea8b4954304657d5dfba115d4a0"
++checksum = "836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c"
+ dependencies = [
+  "cfg-if",
+  "js-sys",
+@@ -11281,9 +11194,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "wasm-bindgen-macro"
+-version = "0.2.105"
++version = "0.2.106"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "04264334509e04a7bf8690f2384ef5265f05143a4bff3889ab7a3269adab59c2"
++checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
+ dependencies = [
+  "quote",
+  "wasm-bindgen-macro-support",
+@@ -11291,9 +11204,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "wasm-bindgen-macro-support"
+-version = "0.2.105"
++version = "0.2.106"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "420bc339d9f322e562942d52e115d57e950d12d88983a14c79b86859ee6c7ebc"
++checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
+ dependencies = [
+  "bumpalo",
+  "proc-macro2",
+@@ -11304,9 +11217,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "wasm-bindgen-shared"
+-version = "0.2.105"
++version = "0.2.106"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
++checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
+ dependencies = [
+  "unicode-ident",
+ ]
+@@ -11332,7 +11245,7 @@ checksum = "673a33c33048a5ade91a6b139580fa174e19fb0d23f396dca9fa15f2e1e49b35"
  dependencies = [
   "cc",
-  "downcast-rs",
-- "rustix 0.38.44",
-+ "rustix 1.0.8",
+  "downcast-rs 1.2.1",
+- "rustix 1.1.2",
++ "rustix",
   "scoped-tls",
   "smallvec",
   "wayland-sys",
-@@ -10715,21 +10717,21 @@ dependencies = [
- 
- [[package]]
- name = "wayland-client"
--version = "0.31.10"
-+version = "0.31.11"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "978fa7c67b0847dbd6a9f350ca2569174974cd4082737054dbb7fbb79d7d9a61"
-+checksum = "c66a47e840dc20793f2264eb4b3e4ecb4b75d91c0dd4af04b456128e0bdd449d"
+@@ -11345,7 +11258,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "c66a47e840dc20793f2264eb4b3e4ecb4b75d91c0dd4af04b456128e0bdd449d"
  dependencies = [
-  "bitflags 2.9.1",
-- "rustix 0.38.44",
-+ "rustix 1.0.8",
+  "bitflags 2.10.0",
+- "rustix 1.1.2",
++ "rustix",
   "wayland-backend",
   "wayland-scanner",
  ]
+@@ -11399,9 +11312,9 @@ dependencies = [
  
  [[package]]
- name = "wayland-protocols"
--version = "0.32.8"
-+version = "0.32.9"
+ name = "web-sys"
+-version = "0.3.82"
++version = "0.3.83"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "779075454e1e9a521794fed15886323ea0feda3f8b0fc1390f5398141310422a"
-+checksum = "efa790ed75fbfd71283bd2521a1cfdc022aabcc28bdcff00851f9e4ae88d9901"
+-checksum = "3a1f95c0d03a47f4ae1f7a64643a6bb97465d9b740f0fa8f90ea33915c99a9a1"
++checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
  dependencies = [
-  "bitflags 2.9.1",
-  "wayland-backend",
-@@ -10739,9 +10741,9 @@ dependencies = [
- 
- [[package]]
- name = "wayland-protocols-wlr"
--version = "0.3.8"
-+version = "0.3.9"
+  "js-sys",
+  "wasm-bindgen",
+@@ -11555,10 +11468,10 @@ version = "0.6.0"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "1cb6cdc73399c0e06504c437fe3cf886f25568dd5454473d565085b36d6a8bbf"
-+checksum = "efd94963ed43cf9938a090ca4f7da58eb55325ec8200c3848963e98dc25b78ec"
- dependencies = [
-  "bitflags 2.9.1",
-  "wayland-backend",
-@@ -10752,9 +10754,9 @@ dependencies = [
- 
- [[package]]
- name = "wayland-scanner"
--version = "0.31.6"
-+version = "0.31.7"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "896fdafd5d28145fce7958917d69f2fd44469b1d4e861cb5961bcbeebc6d1484"
-+checksum = "54cb1e9dc49da91950bdfd8b848c49330536d9d1fb03d4bfec8cae50caa50ae3"
- dependencies = [
-  "proc-macro2",
-  "quick-xml 0.37.5",
-@@ -10763,9 +10765,9 @@ dependencies = [
- 
- [[package]]
- name = "wayland-sys"
--version = "0.31.6"
-+version = "0.31.7"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "dbcebb399c77d5aa9fa5db874806ee7b4eba4e73650948e8f93963f128896615"
-+checksum = "34949b42822155826b41db8e5d0c1be3a2bd296c747577a43a3e6daefc296142"
- dependencies = [
-  "dlib",
-  "log",
-@@ -10844,18 +10846,9 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
- 
- [[package]]
- name = "webpki-roots"
--version = "0.26.11"
--source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
--dependencies = [
-- "webpki-roots 1.0.0",
--]
--
--[[package]]
--name = "webpki-roots"
--version = "1.0.0"
-+version = "1.0.2"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "2853738d1cc4f2da3a225c18ec6c3721abb31961096e9dbf5ab35fa88b19cfdb"
-+checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
- dependencies = [
-  "rustls-pki-types",
- ]
-@@ -10882,7 +10875,7 @@ checksum = "1d228f15bba3b9d56dde8bddbee66fa24545bd17b48d5128ccf4a8742b18e431"
- dependencies = [
-  "proc-macro2",
-  "quote",
-- "syn 2.0.101",
-+ "syn 2.0.104",
- ]
- 
- [[package]]
-@@ -10898,9 +10891,9 @@ dependencies = [
- 
- [[package]]
- name = "weezl"
--version = "0.1.8"
-+version = "0.1.10"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
-+checksum = "a751b3277700db47d3e574514de2eced5e54dc8a5436a3bf7a0b248b2cee16f3"
- 
- [[package]]
- name = "winapi"
-@@ -10940,7 +10933,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "d9bec5a31f3f9362f2258fd0e9c9dd61a9ca432e7306cc78c444258f0dce9a9c"
  dependencies = [
-  "objc2 0.6.1",
-- "objc2-app-kit 0.3.1",
-+ "objc2-app-kit",
+- "objc2 0.6.3",
++ "objc2",
+  "objc2-app-kit",
   "objc2-core-foundation",
-  "objc2-foundation 0.3.1",
+- "objc2-foundation 0.3.2",
++ "objc2-foundation",
   "raw-window-handle",
-@@ -10980,7 +10973,7 @@ dependencies = [
-  "windows-interface",
-  "windows-link",
-  "windows-result",
-- "windows-strings 0.4.2",
-+ "windows-strings",
+  "windows-sys 0.59.0",
+  "windows-version",
+@@ -11720,6 +11633,17 @@ dependencies = [
+  "windows-strings 0.4.2",
  ]
  
++[[package]]
++name = "windows-registry"
++version = "0.6.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
++dependencies = [
++ "windows-link 0.2.1",
++ "windows-result 0.4.1",
++ "windows-strings 0.5.1",
++]
++
  [[package]]
-@@ -11002,7 +10995,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
- dependencies = [
-  "proc-macro2",
-  "quote",
-- "syn 2.0.101",
-+ "syn 2.0.104",
- ]
+ name = "windows-result"
+ version = "0.3.4"
+@@ -12126,15 +12050,14 @@ checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
  
  [[package]]
-@@ -11013,7 +11006,7 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
- dependencies = [
-  "proc-macro2",
-  "quote",
-- "syn 2.0.101",
-+ "syn 2.0.104",
- ]
- 
- [[package]]
-@@ -11034,13 +11027,13 @@ dependencies = [
- 
- [[package]]
- name = "windows-registry"
--version = "0.4.0"
-+version = "0.5.3"
+ name = "wl-clipboard-rs"
+-version = "0.9.2"
++version = "0.9.3"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
-+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+-checksum = "8e5ff8d0e60065f549fafd9d6cb626203ea64a798186c80d8e7df4f8af56baeb"
++checksum = "e9651471a32e87d96ef3a127715382b2d11cc7c8bb9822ded8a7cc94072eb0a3"
  dependencies = [
-+ "windows-link",
-  "windows-result",
-- "windows-strings 0.3.1",
-- "windows-targets 0.53.2",
-+ "windows-strings",
- ]
- 
- [[package]]
-@@ -11052,15 +11045,6 @@ dependencies = [
-  "windows-link",
- ]
- 
--[[package]]
--name = "windows-strings"
--version = "0.3.1"
--source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
--dependencies = [
-- "windows-link",
--]
--
- [[package]]
- name = "windows-strings"
- version = "0.4.2"
-@@ -11112,7 +11096,7 @@ version = "0.60.2"
- source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+  "libc",
+  "log",
+  "os_pipe",
+- "rustix 0.38.44",
+- "tempfile",
++ "rustix",
+  "thiserror 2.0.17",
+  "tree_magic_mini",
+  "wayland-backend",
+@@ -12156,7 +12079,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "728b7d4c8ec8d81cab295e0b5b8a4c263c0d41a785fb8f8c4df284e5411140a2"
  dependencies = [
-- "windows-targets 0.53.2",
-+ "windows-targets 0.53.3",
- ]
- 
- [[package]]
-@@ -11163,10 +11147,11 @@ dependencies = [
- 
- [[package]]
- name = "windows-targets"
--version = "0.53.2"
-+version = "0.53.3"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
-+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
- dependencies = [
-+ "windows-link",
-  "windows_aarch64_gnullvm 0.53.0",
-  "windows_aarch64_msvc 0.53.0",
-  "windows_i686_gnu 0.53.0",
-@@ -11405,12 +11390,12 @@ dependencies = [
- 
- [[package]]
- name = "winreg"
--version = "0.52.0"
-+version = "0.55.0"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
-+checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
- dependencies = [
-  "cfg-if",
-- "windows-sys 0.48.0",
-+ "windows-sys 0.59.0",
- ]
- 
- [[package]]
-@@ -11469,7 +11454,7 @@ dependencies = [
+  "base64 0.22.1",
+- "block2 0.6.2",
++ "block2",
+  "cookie",
+  "crossbeam-channel",
+  "dirs 6.0.0",
+@@ -12171,10 +12094,10 @@ dependencies = [
+  "kuchikiki",
   "libc",
   "ndk",
-  "objc2 0.6.1",
-- "objc2-app-kit 0.3.1",
-+ "objc2-app-kit",
+- "objc2 0.6.3",
++ "objc2",
+  "objc2-app-kit",
   "objc2-core-foundation",
-  "objc2-foundation 0.3.1",
+- "objc2-foundation 0.3.2",
++ "objc2-foundation",
   "objc2-ui-kit",
-@@ -11540,9 +11525,9 @@ checksum = "ec107c4503ea0b4a98ef47356329af139c0a4f7750e621cf2973cd3385ebcb3d"
+  "objc2-web-kit",
+  "once_cell",
+@@ -12231,7 +12154,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+ dependencies = [
+  "gethostname",
+- "rustix 1.1.2",
++ "rustix",
+  "x11rb-protocol",
+ ]
  
- [[package]]
- name = "xattr"
--version = "1.5.0"
-+version = "1.5.1"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "0d65cbf2f12c15564212d48f4e3dfb87923d25d611f2aed18f4cb23f0413d89e"
-+checksum = "af3a19837351dc82ba89f8a125e22a3c475f05aba604acc023d62b2739ae2909"
+@@ -12248,7 +12171,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
  dependencies = [
   "libc",
-  "rustix 1.0.8",
-@@ -11593,7 +11578,7 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
- dependencies = [
-  "proc-macro2",
-  "quote",
-- "syn 2.0.101",
-+ "syn 2.0.104",
-  "synstructure",
- ]
- 
-@@ -11620,7 +11605,6 @@ dependencies = [
-  "serde_repr",
-  "sha1",
-  "static_assertions",
-- "tokio",
-  "tracing",
-  "uds_windows",
-  "windows-sys 0.52.0",
-@@ -11654,13 +11638,14 @@ dependencies = [
-  "ordered-stream",
-  "serde",
-  "serde_repr",
-+ "tokio",
-  "tracing",
-  "uds_windows",
-  "windows-sys 0.59.0",
-  "winnow 0.7.12",
-  "zbus_macros 5.9.0",
-  "zbus_names 4.2.0",
-- "zvariant 5.5.3",
-+ "zvariant 5.6.0",
+- "rustix 1.1.2",
++ "rustix",
  ]
  
  [[package]]
-@@ -11672,7 +11657,7 @@ dependencies = [
-  "proc-macro-crate 3.3.0",
-  "proc-macro2",
-  "quote",
-- "syn 2.0.101",
-+ "syn 2.0.104",
-  "zvariant_utils 2.1.0",
- ]
- 
-@@ -11685,9 +11670,9 @@ dependencies = [
-  "proc-macro-crate 3.3.0",
-  "proc-macro2",
-  "quote",
-- "syn 2.0.101",
-+ "syn 2.0.104",
-  "zbus_names 4.2.0",
-- "zvariant 5.5.3",
-+ "zvariant 5.6.0",
-  "zvariant_utils 3.2.0",
- ]
- 
-@@ -11711,27 +11696,27 @@ dependencies = [
-  "serde",
-  "static_assertions",
-  "winnow 0.7.12",
-- "zvariant 5.5.3",
-+ "zvariant 5.6.0",
- ]
- 
- [[package]]
- name = "zerocopy"
--version = "0.8.25"
-+version = "0.8.26"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
-+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
- dependencies = [
-  "zerocopy-derive",
- ]
- 
- [[package]]
- name = "zerocopy-derive"
--version = "0.8.25"
-+version = "0.8.26"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
-+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
- dependencies = [
-  "proc-macro2",
-  "quote",
-- "syn 2.0.101",
-+ "syn 2.0.104",
- ]
- 
- [[package]]
-@@ -11751,7 +11736,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
- dependencies = [
-  "proc-macro2",
-  "quote",
-- "syn 2.0.101",
-+ "syn 2.0.104",
-  "synstructure",
- ]
- 
-@@ -11772,7 +11757,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
- dependencies = [
-  "proc-macro2",
-  "quote",
-- "syn 2.0.101",
-+ "syn 2.0.104",
- ]
- 
- [[package]]
-@@ -11788,9 +11773,9 @@ dependencies = [
- 
- [[package]]
- name = "zerovec"
--version = "0.11.2"
-+version = "0.11.4"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
-+checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
- dependencies = [
-  "yoke",
-  "zerofrom",
-@@ -11805,7 +11790,7 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
- dependencies = [
-  "proc-macro2",
-  "quote",
-- "syn 2.0.101",
-+ "syn 2.0.104",
- ]
- 
- [[package]]
-@@ -11825,7 +11810,7 @@ dependencies = [
-  "flate2",
-  "getrandom 0.3.3",
-  "hmac",
-- "indexmap 2.9.0",
-+ "indexmap 2.10.0",
-  "lzma-rs",
-  "memchr",
-  "pbkdf2",
-@@ -11840,21 +11825,21 @@ dependencies = [
- 
- [[package]]
- name = "zip"
--version = "4.2.0"
-+version = "4.3.0"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "95ab361742de920c5535880f89bbd611ee62002bf11341d16a5f057bb8ba6899"
-+checksum = "9aed4ac33e8eb078c89e6cbb1d5c4c7703ec6d299fc3e7c3695af8f8b423468b"
- dependencies = [
-  "arbitrary",
-  "crc32fast",
-- "indexmap 2.9.0",
-+ "indexmap 2.10.0",
-  "memchr",
- ]
+@@ -12517,9 +12440,9 @@ dependencies = [
  
  [[package]]
  name = "zlib-rs"
--version = "0.5.0"
-+version = "0.5.1"
+-version = "0.5.2"
++version = "0.5.4"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "868b928d7949e09af2f6086dfc1e01936064cc7a819253bce650d4e2a2d63ba8"
-+checksum = "626bd9fa9734751fc50d6060752170984d7053f5a39061f524cda68023d4db8a"
+-checksum = "2f06ae92f42f5e5c42443fd094f245eb656abf56dd7cce9b8b263236565e00f2"
++checksum = "51f936044d677be1a1168fae1d03b583a285a5dd9d8cbf7b24c23aa1fc775235"
  
  [[package]]
- name = "zopfli"
-@@ -11906,21 +11891,21 @@ dependencies = [
-  "enumflags2",
-  "serde",
-  "static_assertions",
-- "url",
-  "zvariant_derive 4.2.0",
- ]
- 
- [[package]]
- name = "zvariant"
--version = "5.5.3"
-+version = "5.6.0"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "9d30786f75e393ee63a21de4f9074d4c038d52c5b1bb4471f955db249f9dffb1"
-+checksum = "d91b3680bb339216abd84714172b5138a4edac677e641ef17e1d8cb1b3ca6e6f"
- dependencies = [
-  "endi",
-  "enumflags2",
-  "serde",
-+ "url",
-  "winnow 0.7.12",
-- "zvariant_derive 5.5.3",
-+ "zvariant_derive 5.6.0",
-  "zvariant_utils 3.2.0",
- ]
- 
-@@ -11933,20 +11918,20 @@ dependencies = [
-  "proc-macro-crate 3.3.0",
-  "proc-macro2",
-  "quote",
-- "syn 2.0.101",
-+ "syn 2.0.104",
-  "zvariant_utils 2.1.0",
- ]
- 
- [[package]]
- name = "zvariant_derive"
--version = "5.5.3"
-+version = "5.6.0"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "75fda702cd42d735ccd48117b1630432219c0e9616bf6cb0f8350844ee4d9580"
-+checksum = "3a8c68501be459a8dbfffbe5d792acdd23b4959940fc87785fb013b32edbc208"
- dependencies = [
-  "proc-macro-crate 3.3.0",
-  "proc-macro2",
-  "quote",
-- "syn 2.0.101",
-+ "syn 2.0.104",
-  "zvariant_utils 3.2.0",
- ]
- 
-@@ -11958,7 +11943,7 @@ checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
- dependencies = [
-  "proc-macro2",
-  "quote",
-- "syn 2.0.101",
-+ "syn 2.0.104",
- ]
- 
- [[package]]
-@@ -11971,6 +11956,6 @@ dependencies = [
-  "quote",
-  "serde",
-  "static_assertions",
-- "syn 2.0.101",
-+ "syn 2.0.104",
-  "winnow 0.7.12",
- ]
+ name = "zune-core"
 diff --git a/Cargo.toml b/Cargo.toml
-index c560a9b64..718574be8 100644
+index aa9aea478..11e2a4194 100644
 --- a/Cargo.toml
 +++ b/Cargo.toml
-@@ -5,7 +5,7 @@ resolver = "2"
- [workspace.dependencies]
- bstr = "1.11.1"
+@@ -65,7 +65,7 @@ gitbutler-workspace = { path = "crates/gitbutler-workspace" }
+ 
+ bstr = "1.12.1"
  # Add the `tracing` or `tracing-detail` features to see more of gitoxide in the logs. Useful to see which programs it invokes.
--gix = { version = "0.73.0", git = "https://github.com/GitoxideLabs/gitoxide", branch = "main", default-features = false, features = [
-+gix = { version = "0.73.0", default-features = false, features = [
+-gix = { version = "0.75.0", git = "https://github.com/GitoxideLabs/gitoxide", branch = "main", default-features = false, features = [
++gix = { version = "0.76.0", default-features = false, features = [
  ] }
+ ts-rs = { version = "11.1.0", features = ["serde-compat", "no-serde-warnings"] }
  gix-testtools = "0.16.1"
- insta = "1.43.1"
+diff --git a/crates/gitbutler-git/Cargo.toml b/crates/gitbutler-git/Cargo.toml
+index 6a2272521..265fb1a25 100644
+--- a/crates/gitbutler-git/Cargo.toml
++++ b/crates/gitbutler-git/Cargo.toml
+@@ -62,7 +62,7 @@ windows = { version = "0.62.0", features = [
+ ] }
+ tokio = { workspace = true, optional = true, features = ["sync", "rt"] }
+ # TODO: use released version once published.
+-file-id = { git = "https://github.com/notify-rs/notify", rev = "978fe719b066a8ce76b9a9d346546b1569eecfb6", version = "0.2.3" }
++file-id = { version = "0.2.3" }
+ 
+ [dev-dependencies]
+ snapbox.workspace = true

--- a/pkgs/by-name/gi/gitbutler/gix-from-crates-io.patch
+++ b/pkgs/by-name/gi/gitbutler/gix-from-crates-io.patch
@@ -1,8 +1,17 @@
 diff --git a/Cargo.lock b/Cargo.lock
-index 6ee5075ea..291e43241 100644
+index 8d2058cf7..25899ae3b 100644
 --- a/Cargo.lock
 +++ b/Cargo.lock
-@@ -157,9 +157,9 @@ dependencies = [
+@@ -34,7 +34,7 @@ version = "0.7.8"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+ dependencies = [
+- "getrandom 0.2.16",
++ "getrandom 0.2.17",
+  "once_cell",
+  "version_check",
+ ]
+@@ -145,9 +145,9 @@ dependencies = [
  
  [[package]]
  name = "anstyle-svg"
@@ -14,7 +23,7 @@ index 6ee5075ea..291e43241 100644
  dependencies = [
   "anstyle",
   "anstyle-lossy",
-@@ -203,11 +203,11 @@ dependencies = [
+@@ -191,11 +191,11 @@ dependencies = [
   "clipboard-win",
   "image",
   "log",
@@ -28,11 +37,51 @@ index 6ee5075ea..291e43241 100644
   "parking_lot",
   "percent-encoding",
   "windows-sys 0.60.2",
-@@ -299,16 +299,16 @@ dependencies = [
+@@ -205,9 +205,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "arc-swap"
+-version = "1.8.0"
++version = "1.8.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "51d03449bb8ca2cc2ef70869af31463d1ae5ccc8fa3e334b307203fbf815207e"
++checksum = "9ded5f9a03ac8f24d1b8a25101ee812cd32cdc8c50a4c50237de2c4915850e73"
+ dependencies = [
+  "rustversion",
+ ]
+@@ -218,27 +218,6 @@ version = "0.7.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+ 
+-[[package]]
+-name = "ashpd"
+-version = "0.11.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "6cbdf310d77fd3aaee6ea2093db7011dc2d35d2eb3481e5607f1f8d942ed99df"
+-dependencies = [
+- "enumflags2",
+- "futures-channel",
+- "futures-util",
+- "rand 0.9.2",
+- "raw-window-handle",
+- "serde",
+- "serde_repr",
+- "tokio",
+- "url",
+- "wayland-backend",
+- "wayland-client",
+- "wayland-protocols",
+- "zbus 5.12.0",
+-]
+-
+ [[package]]
+ name = "async-broadcast"
+ version = "0.7.2"
+@@ -290,16 +269,16 @@ dependencies = [
   "futures-lite",
   "parking",
   "polling",
-- "rustix 1.1.2",
+- "rustix 1.1.3",
 + "rustix",
   "slab",
   "windows-sys 0.61.2",
@@ -48,16 +97,16 @@ index 6ee5075ea..291e43241 100644
  dependencies = [
   "event-listener",
   "event-listener-strategy",
-@@ -329,7 +329,7 @@ dependencies = [
-  "eventsource-stream",
-  "futures",
-  "rand 0.9.2",
-- "reqwest 0.12.24",
-+ "reqwest 0.12.27",
-  "reqwest-eventsource",
-  "secrecy",
+@@ -326,7 +305,7 @@ dependencies = [
   "serde",
-@@ -345,9 +345,9 @@ dependencies = [
+  "serde_json",
+  "serde_urlencoded",
+- "thiserror 2.0.17",
++ "thiserror 2.0.18",
+  "tokio",
+  "tokio-stream",
+  "tokio-util",
+@@ -336,13 +315,13 @@ dependencies = [
  
  [[package]]
  name = "async-openai-macros"
@@ -69,37 +118,102 @@ index 6ee5075ea..291e43241 100644
  dependencies = [
   "proc-macro2",
   "quote",
-@@ -369,7 +369,7 @@ dependencies = [
+- "syn 2.0.112",
++ "syn 2.0.114",
+ ]
+ 
+ [[package]]
+@@ -360,7 +339,7 @@ dependencies = [
   "cfg-if",
   "event-listener",
   "futures-lite",
-- "rustix 1.1.2",
+- "rustix 1.1.3",
 + "rustix",
  ]
  
  [[package]]
-@@ -395,7 +395,7 @@ dependencies = [
+@@ -371,7 +350,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.112",
++ "syn 2.0.114",
+ ]
+ 
+ [[package]]
+@@ -386,7 +365,7 @@ dependencies = [
   "cfg-if",
   "futures-core",
   "futures-io",
-- "rustix 1.1.2",
+- "rustix 1.1.3",
 + "rustix",
   "signal-hook-registry",
   "slab",
   "windows-sys 0.61.2",
-@@ -455,9 +455,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+@@ -411,7 +390,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.112",
++ "syn 2.0.114",
+ ]
  
  [[package]]
- name = "axum"
--version = "0.8.7"
-+version = "0.8.8"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "5b098575ebe77cb6d14fc7f32749631a6e44edbef6b796f89b020e99ba20d425"
-+checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+@@ -428,7 +407,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
  dependencies = [
-  "axum-core",
-  "base64 0.22.1",
-@@ -600,22 +600,13 @@ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.112",
++ "syn 2.0.114",
+ ]
+ 
+ [[package]]
+@@ -468,9 +447,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+ 
+ [[package]]
+ name = "aws-lc-rs"
+-version = "1.15.2"
++version = "1.15.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "6a88aab2464f1f25453baa7a07c84c5b7684e274054ba06817f382357f77a288"
++checksum = "7b7b6141e96a8c160799cc2d5adecd5cbbe5054cb8c7c4af53da0f83bb7ad256"
+ dependencies = [
+  "aws-lc-sys",
+  "zeroize",
+@@ -478,9 +457,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "aws-lc-sys"
+-version = "0.35.0"
++version = "0.37.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b45afffdee1e7c9126814751f88dddc747f41d91da16c9551a0f1e8a11e788a1"
++checksum = "5c34dda4df7017c8db52132f0f8a2e0f8161649d15723ed63fc00c82d0f2081a"
+ dependencies = [
+  "cc",
+  "cmake",
+@@ -526,9 +505,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "axum-core"
+-version = "0.5.5"
++version = "0.5.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "59446ce19cd142f8833f856eb31f3eb097812d1479ab224f54d72428ca21ea22"
++checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+ dependencies = [
+  "bytes",
+  "futures-core",
+@@ -550,7 +529,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+ dependencies = [
+  "futures-core",
+- "getrandom 0.2.16",
++ "getrandom 0.2.17",
+  "instant",
+  "pin-project-lite",
+  "rand 0.8.5",
+@@ -635,22 +614,13 @@ dependencies = [
   "generic-array",
  ]
  
@@ -123,7 +237,16 @@ index 6ee5075ea..291e43241 100644
  ]
  
  [[package]]
-@@ -697,9 +688,9 @@ dependencies = [
+@@ -695,7 +665,7 @@ dependencies = [
+  "proc-macro-crate 3.4.0",
+  "proc-macro2",
+  "quote",
+- "syn 2.0.112",
++ "syn 2.0.114",
+ ]
+ 
+ [[package]]
+@@ -732,9 +702,9 @@ dependencies = [
  
  [[package]]
  name = "bumpalo"
@@ -135,61 +258,139 @@ index 6ee5075ea..291e43241 100644
  
  [[package]]
  name = "but"
-@@ -795,7 +786,7 @@ dependencies = [
-  "gitbutler-stack",
-  "gix",
-  "itertools",
-- "reqwest 0.12.24",
-+ "reqwest 0.12.27",
+@@ -797,7 +767,7 @@ dependencies = [
+  "posthog-rs",
+  "regex",
   "rmcp",
-  "schemars 1.1.0",
-  "serde",
-@@ -975,7 +966,7 @@ dependencies = [
-  "parking_lot",
+- "schemars 1.2.0",
++ "schemars 1.2.1",
+  "self_cell",
   "serde",
   "serde_json",
-- "toml 0.9.8",
-+ "toml 0.9.10+spec-1.1.0",
+@@ -840,7 +810,7 @@ dependencies = [
+  "gix",
+  "itertools",
+  "rmcp",
+- "schemars 1.2.0",
++ "schemars 1.2.1",
+  "serde",
+  "serde-error",
+  "serde_json",
+@@ -901,7 +871,7 @@ dependencies = [
+  "insta",
+  "itertools",
+  "open",
+- "schemars 1.2.0",
++ "schemars 1.2.1",
+  "serde",
+  "serde-error",
+  "serde_json",
+@@ -918,7 +888,7 @@ version = "0.0.0"
+ dependencies = [
+  "convert_case 0.10.0",
+  "quote",
+- "syn 2.0.112",
++ "syn 2.0.114",
+ ]
+ 
+ [[package]]
+@@ -933,7 +903,7 @@ dependencies = [
+  "chrono",
+  "gitbutler-project",
+  "gix",
+- "schemars 1.2.0",
++ "schemars 1.2.1",
+  "serde",
+  "serde_json",
+  "uuid",
+@@ -1020,7 +990,7 @@ dependencies = [
+  "rand 0.9.2",
+  "serde",
+  "serde_json",
+- "toml 0.9.10+spec-1.1.0",
++ "toml 0.9.11+spec-1.1.0",
   "tracing",
   "ts-rs",
-  "uuid",
-@@ -1089,7 +1080,7 @@ dependencies = [
+  "unicode-segmentation",
+@@ -1134,7 +1104,7 @@ dependencies = [
   "anyhow",
   "gix",
   "serde",
-- "toml 0.9.8",
-+ "toml 0.9.10+spec-1.1.0",
+- "toml 0.9.10+spec-1.1.0",
++ "toml 0.9.11+spec-1.1.0",
   "walkdir",
  ]
  
-@@ -1122,7 +1113,7 @@ dependencies = [
-  "gitbutler-user",
-  "http 1.4.0",
-  "octorust",
-- "reqwest 0.12.24",
-+ "reqwest 0.12.27",
+@@ -1259,7 +1229,7 @@ dependencies = [
+  "futures",
+  "gix",
+  "reqwest 0.12.28",
+- "schemars 1.2.0",
++ "schemars 1.2.1",
   "serde",
   "serde_json",
- ]
-@@ -1205,7 +1196,7 @@ dependencies = [
-  "itertools",
+  "strum",
+@@ -1287,7 +1257,7 @@ dependencies = [
   "md5",
   "serde",
-- "toml 0.9.8",
-+ "toml 0.9.10+spec-1.1.0",
+  "snapbox",
+- "toml 0.9.10+spec-1.1.0",
++ "toml 0.9.11+spec-1.1.0",
   "tracing",
  ]
  
-@@ -1256,7 +1247,7 @@ dependencies = [
+@@ -1338,7 +1308,7 @@ dependencies = [
   "petgraph",
   "serde",
   "tempfile",
-- "toml 0.9.8",
-+ "toml 0.9.10+spec-1.1.0",
+- "toml 0.9.10+spec-1.1.0",
++ "toml 0.9.11+spec-1.1.0",
   "tracing",
  ]
  
-@@ -1598,9 +1589,9 @@ dependencies = [
+@@ -1512,7 +1482,7 @@ dependencies = [
+  "gitbutler-stack",
+  "gix",
+  "ollama-rs",
+- "schemars 1.2.0",
++ "schemars 1.2.1",
+  "serde",
+  "serde-error",
+  "serde_json",
+@@ -1601,7 +1571,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "8c6d47a4e2961fb8721bcfc54feae6455f2f64e7054f9bc67e875f0e77f4c58d"
+ dependencies = [
+  "rust_decimal",
+- "schemars 1.2.0",
++ "schemars 1.2.1",
+  "serde",
+  "utf8-width",
+ ]
+@@ -1630,9 +1600,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "bytemuck"
+-version = "1.24.0"
++version = "1.25.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
++checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+ 
+ [[package]]
+ name = "byteorder"
+@@ -1648,9 +1618,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+ 
+ [[package]]
+ name = "bytes"
+-version = "1.11.0"
++version = "1.11.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
++checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+ dependencies = [
+  "serde",
+ ]
+@@ -1691,9 +1661,9 @@ dependencies = [
  
  [[package]]
  name = "camino"
@@ -201,65 +402,200 @@ index 6ee5075ea..291e43241 100644
  dependencies = [
   "serde_core",
  ]
-@@ -1635,7 +1626,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "374b7c592d9c00c1f4972ea58390ac6b18cbb6ab79011f3bdc90a0b82ca06b77"
- dependencies = [
+@@ -1718,7 +1688,7 @@ dependencies = [
+  "semver",
   "serde",
-- "toml 0.9.8",
-+ "toml 0.9.10+spec-1.1.0",
+  "serde_json",
+- "thiserror 2.0.17",
++ "thiserror 2.0.18",
  ]
  
  [[package]]
-@@ -1649,9 +1640,9 @@ dependencies = [
+@@ -1728,7 +1698,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "374b7c592d9c00c1f4972ea58390ac6b18cbb6ab79011f3bdc90a0b82ca06b77"
+ dependencies = [
+  "serde",
+- "toml 0.9.10+spec-1.1.0",
++ "toml 0.9.11+spec-1.1.0",
+ ]
+ 
+ [[package]]
+@@ -1742,9 +1712,9 @@ dependencies = [
  
  [[package]]
  name = "cc"
 -version = "1.2.48"
-+version = "1.2.50"
++version = "1.2.55"
  source = "registry+https://github.com/rust-lang/crates.io-index"
 -checksum = "c481bdbf0ed3b892f6f806287d72acd515b352a4ec27a208489b8c1bc839633a"
-+checksum = "9f50d563227a1c37cc0a263f64eca3334388c01c5e4c4861a9def205c614383c"
++checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
  dependencies = [
   "find-msvc-tools",
   "jobserver",
-@@ -1758,9 +1749,9 @@ dependencies = [
+@@ -1804,9 +1774,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "chrono"
+-version = "0.4.42"
++version = "0.4.43"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
++checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+ dependencies = [
+  "iana-time-zone",
+  "js-sys",
+@@ -1828,9 +1798,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "clap"
+-version = "4.5.54"
++version = "4.5.56"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c6e6ff9dcd79cff5cd969a17a545d79e84ab086e444102a591e288a8aa3ce394"
++checksum = "a75ca66430e33a14957acc24c5077b503e7d374151b2b4b3a10c83b4ceb4be0e"
+ dependencies = [
+  "clap_builder",
+  "clap_derive",
+@@ -1838,9 +1808,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "clap_builder"
+-version = "4.5.54"
++version = "4.5.56"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "fa42cf4d2b7a41bc8f663a7cab4031ebafa1bf3875705bfaf8466dc60ab52c00"
++checksum = "793207c7fa6300a0608d1080b858e5fdbe713cdc1c8db9fb17777d8a13e63df0"
+ dependencies = [
+  "anstream",
+  "anstyle",
+@@ -1851,32 +1821,32 @@ dependencies = [
  
  [[package]]
  name = "clap_complete"
--version = "4.5.61"
-+version = "4.5.62"
+-version = "4.5.64"
++version = "4.5.65"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "39615915e2ece2550c0149addac32fb5bd312c657f43845bb9088cb9c8a7c992"
-+checksum = "004eef6b14ce34759aa7de4aea3217e368f463f46a3ed3764ca4b5a4404003b4"
+-checksum = "4c0da80818b2d95eca9aa614a30783e42f62bf5fdfee24e68cfb960b071ba8d1"
++checksum = "430b4dc2b5e3861848de79627b2bedc9f3342c7da5173a14eaa5d0f8dc18ae5d"
  dependencies = [
   "clap",
  ]
-@@ -2000,6 +1991,24 @@ dependencies = [
-  "url",
+ 
+ [[package]]
+ name = "clap_derive"
+-version = "4.5.49"
++version = "4.5.55"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
++checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+ dependencies = [
+  "anstyle",
+  "heck 0.5.0",
+  "proc-macro2",
+  "pulldown-cmark",
+  "quote",
+- "syn 2.0.112",
++ "syn 2.0.114",
  ]
  
-+[[package]]
-+name = "cookie_store"
-+version = "0.22.0"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "3fc4bff745c9b4c7fb1e97b25d13153da2bc7796260141df62378998d070207f"
-+dependencies = [
-+ "cookie",
-+ "document-features",
-+ "idna",
-+ "log",
-+ "publicsuffix",
-+ "serde",
-+ "serde_derive",
-+ "serde_json",
-+ "time",
-+ "url",
-+]
-+
  [[package]]
- name = "core-foundation"
- version = "0.9.4"
-@@ -2309,9 +2318,9 @@ checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
+ name = "clap_lex"
+-version = "0.7.6"
++version = "0.7.7"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
++checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+ 
+ [[package]]
+ name = "cli-prompts"
+@@ -1948,11 +1918,11 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+ 
+ [[package]]
+ name = "colored"
+-version = "3.0.0"
++version = "3.1.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
++checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
+ dependencies = [
+- "windows-sys 0.59.0",
++ "windows-sys 0.61.2",
+ ]
+ 
+ [[package]]
+@@ -2053,7 +2023,7 @@ version = "0.1.16"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+ dependencies = [
+- "getrandom 0.2.16",
++ "getrandom 0.2.17",
+  "once_cell",
+  "tiny-keccak",
+ ]
+@@ -2318,7 +2288,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
+ dependencies = [
+  "quote",
+- "syn 2.0.112",
++ "syn 2.0.114",
+ ]
+ 
+ [[package]]
+@@ -2328,7 +2298,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
+ dependencies = [
+  "quote",
+- "syn 2.0.112",
++ "syn 2.0.114",
+ ]
+ 
+ [[package]]
+@@ -2340,7 +2310,7 @@ dependencies = [
+  "curl-sys",
+  "libc",
+  "schannel",
+- "socket2 0.6.1",
++ "socket2 0.6.2",
+  "windows-sys 0.59.0",
+ ]
+ 
+@@ -2389,7 +2359,7 @@ dependencies = [
+  "proc-macro2",
+  "quote",
+  "strsim",
+- "syn 2.0.112",
++ "syn 2.0.114",
+ ]
+ 
+ [[package]]
+@@ -2403,7 +2373,7 @@ dependencies = [
+  "proc-macro2",
+  "quote",
+  "strsim",
+- "syn 2.0.112",
++ "syn 2.0.114",
+ ]
+ 
+ [[package]]
+@@ -2414,7 +2384,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+ dependencies = [
+  "darling_core 0.20.11",
+  "quote",
+- "syn 2.0.112",
++ "syn 2.0.114",
+ ]
+ 
+ [[package]]
+@@ -2425,7 +2395,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+ dependencies = [
+  "darling_core 0.21.3",
+  "quote",
+- "syn 2.0.112",
++ "syn 2.0.114",
+ ]
+ 
+ [[package]]
+@@ -2456,9 +2426,9 @@ checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
  
  [[package]]
  name = "dbus"
@@ -271,7 +607,40 @@ index 6ee5075ea..291e43241 100644
  dependencies = [
   "libc",
   "libdbus-sys",
-@@ -2403,18 +2412,18 @@ dependencies = [
+@@ -2501,7 +2471,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.112",
++ "syn 2.0.114",
+ ]
+ 
+ [[package]]
+@@ -2522,7 +2492,7 @@ dependencies = [
+  "darling 0.20.11",
+  "proc-macro2",
+  "quote",
+- "syn 2.0.112",
++ "syn 2.0.114",
+ ]
+ 
+ [[package]]
+@@ -2532,7 +2502,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+ dependencies = [
+  "derive_builder_core",
+- "syn 2.0.112",
++ "syn 2.0.114",
+ ]
+ 
+ [[package]]
+@@ -2545,14 +2515,14 @@ dependencies = [
+  "proc-macro2",
+  "quote",
+  "rustc_version",
+- "syn 2.0.112",
++ "syn 2.0.114",
+ ]
  
  [[package]]
  name = "deser-hjson"
@@ -283,30 +652,7 @@ index 6ee5075ea..291e43241 100644
  dependencies = [
   "serde",
  ]
- 
- [[package]]
- name = "diesel"
--version = "2.3.4"
-+version = "2.3.5"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "0c415189028b232660655e4893e8bc25ca7aee8e96888db66d9edb400535456a"
-+checksum = "e130c806dccc85428c564f2dc5a96e05b6615a27c9a28776bd7761a9af4bb552"
- dependencies = [
-  "chrono",
-  "diesel_derives",
-@@ -2426,9 +2435,9 @@ dependencies = [
- 
- [[package]]
- name = "diesel_derives"
--version = "2.3.5"
-+version = "2.3.6"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "8587cbca3c929fb198e7950d761d31ca72b80aa6e07c1b7bec5879d187720436"
-+checksum = "c30b2969f923fa1f73744b92bb7df60b858df8832742d9a3aceb79236c0be1d2"
- dependencies = [
-  "diesel_table_macro_syntax",
-  "dsl_auto_type",
-@@ -2558,9 +2567,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+@@ -2649,9 +2619,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
  dependencies = [
   "bitflags 2.10.0",
@@ -318,7 +664,22 @@ index 6ee5075ea..291e43241 100644
  ]
  
  [[package]]
-@@ -2585,9 +2594,9 @@ dependencies = [
+@@ -2662,23 +2632,14 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.112",
+-]
+-
+-[[package]]
+-name = "dlib"
+-version = "0.5.2"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
+-dependencies = [
+- "libloading 0.8.9",
++ "syn 2.0.114",
+ ]
  
  [[package]]
  name = "dlopen2"
@@ -330,7 +691,7 @@ index 6ee5075ea..291e43241 100644
  dependencies = [
   "dlopen2_derive",
   "libc",
-@@ -2597,9 +2606,9 @@ dependencies = [
+@@ -2688,13 +2649,13 @@ dependencies = [
  
  [[package]]
  name = "dlopen2_derive"
@@ -342,16 +703,33 @@ index 6ee5075ea..291e43241 100644
  dependencies = [
   "proc-macro2",
   "quote",
-@@ -2701,7 +2710,7 @@ dependencies = [
+- "syn 2.0.112",
++ "syn 2.0.114",
+ ]
+ 
+ [[package]]
+@@ -2732,9 +2693,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "dtoa"
+-version = "1.0.10"
++version = "1.0.11"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d6add3b8cff394282be81f3fc1a0605db594ed69890078ca6e2cab1c408bcf04"
++checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
+ 
+ [[package]]
+ name = "dtoa-short"
+@@ -2772,7 +2733,7 @@ dependencies = [
   "cc",
   "memchr",
   "rustc_version",
-- "toml 0.9.8",
-+ "toml 0.9.10+spec-1.1.0",
+- "toml 0.9.10+spec-1.1.0",
++ "toml 0.9.11+spec-1.1.0",
   "vswhom",
   "winreg 0.55.0",
  ]
-@@ -2729,9 +2738,9 @@ dependencies = [
+@@ -2800,9 +2761,9 @@ dependencies = [
  
  [[package]]
  name = "endi"
@@ -363,7 +741,25 @@ index 6ee5075ea..291e43241 100644
  
  [[package]]
  name = "enumflags2"
-@@ -2902,14 +2911,6 @@ dependencies = [
+@@ -2822,7 +2783,7 @@ checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.112",
++ "syn 2.0.114",
+ ]
+ 
+ [[package]]
+@@ -2945,7 +2906,7 @@ checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.112",
++ "syn 2.0.114",
+ ]
+ 
+ [[package]]
+@@ -2985,31 +2946,22 @@ dependencies = [
   "windows-sys 0.60.2",
  ]
  
@@ -377,38 +773,124 @@ index 6ee5075ea..291e43241 100644
 -
  [[package]]
  name = "filetime"
- version = "0.2.26"
-@@ -3292,7 +3293,7 @@ version = "1.1.0"
+-version = "0.2.26"
++version = "0.2.27"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "bc0505cd1b6fa6580283f6bdf70a73fcf4aba1184038c90902b92b3dd0df63ed"
++checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+ dependencies = [
+  "cfg-if",
+  "libc",
+  "libredox",
+- "windows-sys 0.60.2",
+ ]
+ 
+ [[package]]
+ name = "find-msvc-tools"
+-version = "0.1.5"
++version = "0.1.9"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
++checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+ 
+ [[package]]
+ name = "fixedbitset"
+@@ -3019,9 +2971,9 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+ 
+ [[package]]
+ name = "flate2"
+-version = "1.1.5"
++version = "1.1.9"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
++checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+ dependencies = [
+  "crc32fast",
+  "miniz_oxide",
+@@ -3084,7 +3036,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.112",
++ "syn 2.0.114",
+ ]
+ 
+ [[package]]
+@@ -3218,7 +3170,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.112",
++ "syn 2.0.114",
+ ]
+ 
+ [[package]]
+@@ -3390,7 +3342,7 @@ version = "1.1.0"
  source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
  dependencies = [
-- "rustix 1.1.2",
+- "rustix 1.1.3",
 + "rustix",
   "windows-link 0.2.1",
  ]
  
-@@ -3398,9 +3399,9 @@ dependencies = [
+@@ -3407,9 +3359,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "getrandom"
+-version = "0.2.16"
++version = "0.2.17"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
++checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+ dependencies = [
+  "cfg-if",
+  "js-sys",
+@@ -3441,7 +3393,7 @@ dependencies = [
+  "proc-macro-error2",
+  "proc-macro2",
+  "quote",
+- "syn 2.0.112",
++ "syn 2.0.114",
+ ]
+ 
+ [[package]]
+@@ -3490,21 +3442,21 @@ checksum = "8df306e4dfc91752e89b74c88ee876c8518890600f82255254828f9192dd003c"
+ dependencies = [
+  "getset",
+  "nom 8.0.0",
+- "thiserror 2.0.17",
++ "thiserror 2.0.18",
+  "url",
+ ]
  
  [[package]]
  name = "git2"
--version = "0.20.2"
-+version = "0.20.3"
+-version = "0.20.3"
++version = "0.20.4"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "2deb07a133b1520dc1a5690e9bd08950108873d7ed5de38dcc74d3b5ebffa110"
-+checksum = "3e2b37e2f62729cdada11f0e6b3b6fe383c69c29fc619e391223e12856af308c"
+-checksum = "3e2b37e2f62729cdada11f0e6b3b6fe383c69c29fc619e391223e12856af308c"
++checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
  dependencies = [
   "bitflags 2.10.0",
   "libc",
-@@ -3418,7 +3419,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "587d0dd757ea38f8a7b4761026162f6b9ab39e2cc7eba386852371841f5fe69b"
- dependencies = [
-  "git2",
-- "gix-path 0.10.22 (registry+https://github.com/rust-lang/crates.io-index)",
-+ "gix-path",
+  "libgit2-sys",
+  "log",
+- "openssl-probe",
++ "openssl-probe 0.1.6",
+  "openssl-sys",
+  "url",
+ ]
+@@ -3519,7 +3471,7 @@ dependencies = [
+  "gix-path 0.10.22",
   "log",
   "shellexpand",
-  "thiserror 2.0.17",
-@@ -3601,7 +3602,7 @@ name = "gitbutler-git"
+- "thiserror 2.0.17",
++ "thiserror 2.0.18",
+ ]
+ 
+ [[package]]
+@@ -3677,7 +3629,7 @@ name = "gitbutler-git"
  version = "0.0.0"
  dependencies = [
   "anyhow",
@@ -417,7 +899,16 @@ index 6ee5075ea..291e43241 100644
   "futures",
   "gix",
   "nix 0.30.1",
-@@ -3634,7 +3635,7 @@ name = "gitbutler-notify-debouncer"
+@@ -3685,7 +3637,7 @@ dependencies = [
+  "serde",
+  "snapbox",
+  "sysinfo",
+- "thiserror 2.0.17",
++ "thiserror 2.0.18",
+  "tokio",
+  "tracing",
+  "windows 0.62.2",
+@@ -3696,7 +3648,7 @@ name = "gitbutler-notify-debouncer"
  version = "0.0.0"
  dependencies = [
   "deser-hjson",
@@ -426,994 +917,1075 @@ index 6ee5075ea..291e43241 100644
   "gitbutler-notify-debouncer",
   "mock_instant",
   "notify",
-@@ -3661,7 +3662,7 @@ dependencies = [
+@@ -3723,7 +3675,7 @@ dependencies = [
   "gitbutler-stack",
   "gitbutler-testsupport",
   "serde",
-- "toml 0.9.8",
-+ "toml 0.9.10+spec-1.1.0",
+- "toml 0.9.10+spec-1.1.0",
++ "toml 0.9.11+spec-1.1.0",
   "tracing",
   "uuid",
  ]
-@@ -3689,7 +3690,7 @@ dependencies = [
+@@ -3750,7 +3702,7 @@ dependencies = [
   "serde",
   "strum",
   "tempfile",
-- "toml 0.9.8",
-+ "toml 0.9.10+spec-1.1.0",
+- "toml 0.9.10+spec-1.1.0",
++ "toml 0.9.11+spec-1.1.0",
   "tracing",
  ]
  
-@@ -3764,7 +3765,7 @@ dependencies = [
+@@ -3786,7 +3738,7 @@ dependencies = [
+  "git2",
+  "gix",
+  "serde",
+- "thiserror 2.0.17",
++ "thiserror 2.0.18",
+ ]
+ 
+ [[package]]
+@@ -3823,8 +3775,8 @@ dependencies = [
+  "serde",
   "serde_json",
   "tempfile",
-  "thiserror 2.0.17",
-- "toml 0.9.8",
-+ "toml 0.9.10+spec-1.1.0",
+- "thiserror 2.0.17",
+- "toml 0.9.10+spec-1.1.0",
++ "thiserror 2.0.18",
++ "toml 0.9.11+spec-1.1.0",
   "tracing",
-  "uuid",
  ]
-@@ -3817,7 +3818,7 @@ dependencies = [
+ 
+@@ -3871,7 +3823,7 @@ dependencies = [
   "itertools",
   "serde",
   "tempfile",
-- "toml 0.9.8",
-+ "toml 0.9.10+spec-1.1.0",
+- "toml 0.9.10+spec-1.1.0",
++ "toml 0.9.11+spec-1.1.0",
  ]
  
  [[package]]
-@@ -3996,54 +3997,55 @@ dependencies = [
+@@ -3970,7 +3922,7 @@ name = "gitbutler-url"
+ version = "0.0.0"
+ dependencies = [
+  "bstr",
+- "thiserror 2.0.17",
++ "thiserror 2.0.18",
+  "url",
+ ]
  
+@@ -4030,58 +3982,59 @@ dependencies = [
  [[package]]
  name = "gix"
--version = "0.75.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
-+version = "0.76.0"
+ version = "0.78.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "0da205378175c7e08c1d9357be8e6056c541d5907c29842d025b2a732ce06d52"
++checksum = "3428a03ace494ae40308bd3df0b37e7eb7403e24389f27abdff30abf2b5adf17"
  dependencies = [
-- "gix-actor 0.36.0",
-- "gix-attributes 0.28.1",
-+ "gix-actor 0.36.1",
-+ "gix-attributes 0.29.0",
+- "gix-actor 0.38.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-attributes 0.30.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-actor",
++ "gix-attributes",
   "gix-command",
-- "gix-commitgraph 0.30.1",
-+ "gix-commitgraph 0.31.0",
+- "gix-commitgraph 0.32.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-commitgraph",
   "gix-config",
   "gix-credentials",
-- "gix-date 0.11.0",
-+ "gix-date 0.11.1",
+- "gix-date 0.13.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-date",
   "gix-diff",
   "gix-dir",
-- "gix-discover 0.43.0",
-- "gix-features 0.44.1",
-+ "gix-discover 0.44.0",
-+ "gix-features 0.45.0",
+- "gix-discover 0.46.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-error 0.0.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-features 0.46.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-discover",
++ "gix-error",
++ "gix-features",
   "gix-filter",
-- "gix-fs 0.17.0",
-- "gix-glob 0.22.1",
-- "gix-hash 0.20.1",
-- "gix-hashtable 0.10.0",
-- "gix-ignore 0.17.1",
-- "gix-index 0.43.0",
-- "gix-lock 19.0.0",
-+ "gix-fs 0.18.0",
-+ "gix-glob 0.23.0",
-+ "gix-hash 0.21.0",
-+ "gix-hashtable 0.11.0",
-+ "gix-ignore 0.18.0",
-+ "gix-index 0.44.0",
-+ "gix-lock 20.0.0",
+- "gix-fs 0.19.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-glob 0.24.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-hash 0.22.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-hashtable 0.12.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-ignore 0.19.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-index 0.46.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-lock 21.0.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-fs",
++ "gix-glob",
++ "gix-hash",
++ "gix-hashtable",
++ "gix-ignore",
++ "gix-index",
++ "gix-lock",
   "gix-mailmap",
   "gix-merge",
   "gix-negotiate",
-- "gix-object 0.52.0",
-+ "gix-object 0.53.0",
+- "gix-object 0.55.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-object",
   "gix-odb",
   "gix-pack",
-- "gix-path 0.10.22 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-+ "gix-path",
+- "gix-path 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-path 0.11.0",
   "gix-pathspec",
   "gix-prompt",
   "gix-protocol",
-- "gix-ref 0.55.0",
-+ "gix-ref 0.56.0",
+- "gix-ref 0.58.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-ref",
   "gix-refspec",
   "gix-revision",
-- "gix-revwalk 0.23.0",
-+ "gix-revwalk 0.24.0",
-  "gix-sec 0.12.2",
+- "gix-revwalk 0.26.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-sec 0.13.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-revwalk",
++ "gix-sec",
   "gix-shallow",
   "gix-status",
   "gix-submodule",
-- "gix-tempfile 19.0.1",
-- "gix-trace 0.1.15 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-+ "gix-tempfile 20.0.0",
+- "gix-tempfile 21.0.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-trace 0.1.17 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-tempfile",
 + "gix-trace",
   "gix-transport",
-- "gix-traverse 0.49.0",
-+ "gix-traverse 0.50.0",
+- "gix-traverse 0.52.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-traverse",
   "gix-url",
 - "gix-utils 0.3.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-- "gix-validate 0.10.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-- "gix-worktree 0.44.0",
+- "gix-validate 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-worktree 0.47.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
 + "gix-utils",
-+ "gix-validate",
-+ "gix-worktree 0.45.0",
++ "gix-validate 0.11.0",
++ "gix-worktree",
   "gix-worktree-state",
   "serde",
   "smallvec",
-@@ -4058,7 +4060,7 @@ checksum = "987a51a7e66db6ef4dc030418eb2a42af6b913a79edd8670766122d8af3ba59e"
- dependencies = [
-  "bstr",
-  "gix-date 0.10.7",
-- "gix-utils 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
-+ "gix-utils",
-  "itoa",
-  "thiserror 2.0.17",
-  "winnow 0.7.14",
-@@ -4066,12 +4068,13 @@ dependencies = [
- 
- [[package]]
- name = "gix-actor"
--version = "0.36.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
-+version = "0.36.1"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "636ca0d7bf8f7ad8ba84a5dda8312c8944b275be09d88b072e08f57d3e47c1e8"
- dependencies = [
-  "bstr",
-- "gix-date 0.11.0",
-- "gix-utils 0.3.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-+ "gix-date 0.11.1",
-+ "gix-utils",
-  "itoa",
-  "serde",
-  "thiserror 2.0.17",
-@@ -4086,9 +4089,9 @@ checksum = "6f50d813d5c2ce9463ba0c29eea90060df08e38ad8f34b8a192259f8bce5c078"
- dependencies = [
-  "bstr",
-  "gix-glob 0.20.1",
-- "gix-path 0.10.22 (registry+https://github.com/rust-lang/crates.io-index)",
-- "gix-quote 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
-- "gix-trace 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
-+ "gix-path",
-+ "gix-quote",
-+ "gix-trace",
-  "kstring",
-  "smallvec",
-  "thiserror 2.0.17",
-@@ -4097,14 +4100,15 @@ dependencies = [
- 
- [[package]]
- name = "gix-attributes"
--version = "0.28.1"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
-+version = "0.29.0"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "f47dabf8a50f1558c3a55d978440c7c4f22f87ac897bef03b4edbc96f6115966"
- dependencies = [
-  "bstr",
-- "gix-glob 0.22.1",
-- "gix-path 0.10.22 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-- "gix-quote 0.6.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-- "gix-trace 0.1.15 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-+ "gix-glob 0.23.0",
-+ "gix-path",
-+ "gix-quote",
-+ "gix-trace",
-  "kstring",
-  "serde",
-  "smallvec",
-@@ -4121,14 +4125,6 @@ dependencies = [
-  "thiserror 2.0.17",
+- "thiserror 2.0.17",
++ "thiserror 2.0.18",
  ]
  
+ [[package]]
+@@ -4091,22 +4044,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "b50ce5433eaa46187349e59089eea71b0397caa71991b2fa3e124120426d7d15"
+ dependencies = [
+  "bstr",
+- "gix-date 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-utils 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "gix-date",
++ "gix-utils",
+  "itoa",
+- "thiserror 2.0.17",
+- "winnow 0.7.14",
+-]
+-
+-[[package]]
+-name = "gix-actor"
+-version = "0.38.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
+-dependencies = [
+- "bstr",
+- "gix-date 0.13.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-error 0.0.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+  "serde",
++ "thiserror 2.0.18",
+  "winnow 0.7.14",
+ ]
+ 
+@@ -4117,30 +4059,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "f868f013fee0ebb5c85fae848c34a0b9ef7438acfbaec0c82a3cdbd5eac730a0"
+ dependencies = [
+  "bstr",
+- "gix-glob 0.24.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-path 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-quote 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-trace 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+- "kstring",
+- "smallvec",
+- "thiserror 2.0.17",
+- "unicode-bom",
+-]
+-
+-[[package]]
+-name = "gix-attributes"
+-version = "0.30.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
+-dependencies = [
+- "bstr",
+- "gix-glob 0.24.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-path 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-quote 0.6.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-trace 0.1.17 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-glob",
++ "gix-path 0.11.0",
++ "gix-quote",
++ "gix-trace",
+  "kstring",
+  "serde",
+  "smallvec",
+- "thiserror 2.0.17",
++ "thiserror 2.0.18",
+  "unicode-bom",
+ ]
+ 
+@@ -4150,15 +4076,7 @@ version = "0.2.15"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "5e150161b8a75b5860521cb876b506879a3376d3adc857ec7a9d35e7c6a5e531"
+ dependencies = [
+- "thiserror 2.0.17",
+-]
+-
 -[[package]]
 -name = "gix-bitmap"
 -version = "0.2.15"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 -dependencies = [
 - "thiserror 2.0.17",
--]
--
- [[package]]
- name = "gix-chunk"
- version = "0.4.12"
-@@ -4138,23 +4134,16 @@ dependencies = [
-  "thiserror 2.0.17",
++ "thiserror 2.0.18",
  ]
  
--[[package]]
--name = "gix-chunk"
--version = "0.4.12"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
--dependencies = [
-- "thiserror 2.0.17",
+ [[package]]
+@@ -4167,26 +4085,19 @@ version = "0.5.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "63e516efaac951ed21115b11d5514b120c26ccb493d0c0b9ea6cc10edf4fdf44"
+ dependencies = [
+- "gix-error 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 -]
 -
+-[[package]]
+-name = "gix-chunk"
+-version = "0.5.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
+-dependencies = [
+- "gix-error 0.0.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-error",
+ ]
+ 
  [[package]]
  name = "gix-command"
- version = "0.6.3"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
+ version = "0.7.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "095c8367c9dc4872a7706fbc39c7f34271b88b541120a4365ff0e36366f66e62"
++checksum = "745bc165b7da500acc26d24888379ae0dfd1ecabe3a47420cdcb92feefb0561d"
  dependencies = [
   "bstr",
-- "gix-path 0.10.22 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-path 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
 - "gix-quote 0.6.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-- "gix-trace 0.1.15 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-+ "gix-path",
+- "gix-trace 0.1.17 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-path 0.11.0",
 + "gix-quote",
 + "gix-trace",
   "shell-words",
  ]
  
-@@ -4165,7 +4154,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "e05050fd6caa6c731fe3bd7f9485b3b520be062d3d139cb2626e052d6c127951"
+@@ -4197,21 +4108,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "d0dda2e4d5a61d4a16a780f61f2b7e9406ad1f8da97c35c09ef501f3fdf74de0"
  dependencies = [
   "bstr",
-- "gix-chunk 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-chunk 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-error 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-hash 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "memmap2",
+-]
+-
+-[[package]]
+-name = "gix-commitgraph"
+-version = "0.32.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
+-dependencies = [
+- "bstr",
+- "gix-chunk 0.5.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-error 0.0.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-hash 0.22.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
 + "gix-chunk",
-  "gix-hash 0.18.0",
-  "memmap2",
-  "thiserror 2.0.17",
-@@ -4173,12 +4162,13 @@ dependencies = [
- 
- [[package]]
- name = "gix-commitgraph"
--version = "0.30.1"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
-+version = "0.31.0"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "efdcba8048045baf15225daf949d597c3e6183d130245e22a7fbd27084abe63a"
- dependencies = [
-  "bstr",
-- "gix-chunk 0.4.12 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-- "gix-hash 0.20.1",
-+ "gix-chunk",
-+ "gix-hash 0.21.0",
++ "gix-error",
++ "gix-hash",
   "memmap2",
   "serde",
-  "thiserror 2.0.17",
-@@ -4186,15 +4176,16 @@ dependencies = [
- 
+ ]
+@@ -4219,18 +4118,19 @@ dependencies = [
  [[package]]
  name = "gix-config"
--version = "0.48.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
-+version = "0.49.0"
+ version = "0.51.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "7f15f96a354d296b505575870c4ebe279552a67132b61223869181d11894859d"
++checksum = "9a153dd4f5789fdf242e19e3f7105f2a114df198570225976fe4a108bac9dee4"
  dependencies = [
   "bstr",
   "gix-config-value",
-- "gix-features 0.44.1",
-- "gix-glob 0.22.1",
-- "gix-path 0.10.22 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-- "gix-ref 0.55.0",
-+ "gix-features 0.45.0",
-+ "gix-glob 0.23.0",
-+ "gix-path",
-+ "gix-ref 0.56.0",
-  "gix-sec 0.12.2",
+- "gix-features 0.46.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-glob 0.24.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-path 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-ref 0.58.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-sec 0.13.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-features",
++ "gix-glob",
++ "gix-path 0.11.0",
++ "gix-ref",
++ "gix-sec",
   "memchr",
   "smallvec",
-@@ -4205,29 +4196,31 @@ dependencies = [
- 
+- "thiserror 2.0.17",
++ "thiserror 2.0.18",
+  "unicode-bom",
+  "winnow 0.7.14",
+ ]
+@@ -4238,31 +4138,33 @@ dependencies = [
  [[package]]
  name = "gix-config-value"
--version = "0.15.3"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
-+version = "0.16.0"
+ version = "0.17.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "2409cffa4fe8b303847d5b6ba8df9da9ba65d302fc5ee474ea0cac5afde79840"
++checksum = "563361198101cedc975fe5760c91ac2e4126eec22216e81b659b45289feaf1ea"
  dependencies = [
   "bitflags 2.10.0",
   "bstr",
-- "gix-path 0.10.22 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-+ "gix-path",
+- "gix-path 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-path 0.11.0",
   "libc",
-  "thiserror 2.0.17",
+- "thiserror 2.0.17",
++ "thiserror 2.0.18",
  ]
  
  [[package]]
  name = "gix-credentials"
--version = "0.32.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
-+version = "0.33.0"
+ version = "0.35.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "752cc9d771a65c0a6e7ac601848a08513e9e2b9e25804a354108305e2ef18c5a"
++checksum = "b6ef04ac6b0b9cb75b02afaab4045eafb7b59be41815fbfaaa184a2280af2146"
  dependencies = [
   "bstr",
   "gix-command",
   "gix-config-value",
-- "gix-date 0.11.0",
-- "gix-path 0.10.22 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-+ "gix-date 0.11.1",
-+ "gix-path",
+- "gix-date 0.13.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-path 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-date",
++ "gix-path 0.11.0",
   "gix-prompt",
-  "gix-sec 0.12.2",
-- "gix-trace 0.1.15 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-sec 0.13.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-trace 0.1.17 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-sec",
 + "gix-trace",
   "gix-url",
   "serde",
-  "thiserror 2.0.17",
-@@ -4248,8 +4241,9 @@ dependencies = [
+- "thiserror 2.0.17",
++ "thiserror 2.0.18",
+ ]
  
  [[package]]
- name = "gix-date"
--version = "0.11.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
-+version = "0.11.1"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "c0a1259955c76335c9d1a8c511811b10dbc800ffeeca3daea1e0aadd0c98f6b7"
+@@ -4272,19 +4174,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "12553b32d1da25671f31c0b084bf1e5cb6d5ef529254d04ec33cdc890bd7f687"
  dependencies = [
   "bstr",
+- "gix-error 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "itoa",
+- "jiff",
+- "smallvec",
+-]
+-
+-[[package]]
+-name = "gix-date"
+-version = "0.13.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
+-dependencies = [
+- "bstr",
+- "gix-error 0.0.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-error",
   "itoa",
-@@ -4261,43 +4255,45 @@ dependencies = [
- 
+  "jiff",
+  "serde",
+@@ -4294,43 +4184,45 @@ dependencies = [
  [[package]]
  name = "gix-diff"
--version = "0.55.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
-+version = "0.56.0"
+ version = "0.58.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "3ebc8f56f3300d3c5f98d927b11762ef98e35ddbf9ebf3bdbdb53dbc6d9cbb7e"
++checksum = "26bcd367b2c5dbf6bec9ce02ca59eab179fc82cf39f15ec83549ee25c255c99f"
  dependencies = [
   "bstr",
-- "gix-attributes 0.28.1",
-+ "gix-attributes 0.29.0",
+- "gix-attributes 0.30.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-attributes",
   "gix-command",
   "gix-filter",
-- "gix-fs 0.17.0",
-- "gix-hash 0.20.1",
-- "gix-index 0.43.0",
-- "gix-object 0.52.0",
-- "gix-path 0.10.22 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-+ "gix-fs 0.18.0",
-+ "gix-hash 0.21.0",
-+ "gix-index 0.44.0",
-+ "gix-object 0.53.0",
-+ "gix-path",
+- "gix-fs 0.19.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-hash 0.22.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-index 0.46.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-object 0.55.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-path 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-fs",
++ "gix-hash",
++ "gix-index",
++ "gix-object",
++ "gix-path 0.11.0",
   "gix-pathspec",
-- "gix-tempfile 19.0.1",
-- "gix-trace 0.1.15 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-- "gix-traverse 0.49.0",
-- "gix-worktree 0.44.0",
-+ "gix-tempfile 20.0.0",
+- "gix-tempfile 21.0.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-trace 0.1.17 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-traverse 0.52.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-worktree 0.47.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-tempfile",
 + "gix-trace",
-+ "gix-traverse 0.50.0",
-+ "gix-worktree 0.45.0",
++ "gix-traverse",
++ "gix-worktree",
   "imara-diff",
-  "thiserror 2.0.17",
+- "thiserror 2.0.17",
++ "thiserror 2.0.18",
  ]
  
  [[package]]
  name = "gix-dir"
--version = "0.17.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
-+version = "0.18.0"
+ version = "0.20.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "40d285a847a95b3c76c0f7b17143bdc68c917d3f9f772bfd4c83fbadb7497067"
++checksum = "004129e2c93798141d68ff08cb7f1b3d909c0212747fb8b05c8989635ba90a4e"
  dependencies = [
   "bstr",
-- "gix-discover 0.43.0",
-- "gix-fs 0.17.0",
-- "gix-ignore 0.17.1",
-- "gix-index 0.43.0",
-- "gix-object 0.52.0",
-- "gix-path 0.10.22 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-+ "gix-discover 0.44.0",
-+ "gix-fs 0.18.0",
-+ "gix-ignore 0.18.0",
-+ "gix-index 0.44.0",
-+ "gix-object 0.53.0",
-+ "gix-path",
+- "gix-discover 0.46.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-fs 0.19.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-ignore 0.19.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-index 0.46.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-object 0.55.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-path 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-discover",
++ "gix-fs",
++ "gix-ignore",
++ "gix-index",
++ "gix-object",
++ "gix-path 0.11.0",
   "gix-pathspec",
-- "gix-trace 0.1.15 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-trace 0.1.17 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
 - "gix-utils 0.3.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-- "gix-worktree 0.44.0",
+- "gix-worktree 0.47.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "thiserror 2.0.17",
 + "gix-trace",
 + "gix-utils",
-+ "gix-worktree 0.45.0",
-  "thiserror 2.0.17",
++ "gix-worktree",
++ "thiserror 2.0.18",
  ]
- 
-@@ -4311,7 +4307,7 @@ dependencies = [
-  "dunce",
-  "gix-fs 0.15.0",
-  "gix-hash 0.18.0",
-- "gix-path 0.10.22 (registry+https://github.com/rust-lang/crates.io-index)",
-+ "gix-path",
-  "gix-ref 0.52.1",
-  "gix-sec 0.11.0",
-  "thiserror 2.0.17",
-@@ -4319,15 +4315,16 @@ dependencies = [
  
  [[package]]
- name = "gix-discover"
--version = "0.43.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
-+version = "0.44.0"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "3f2fe2922c3358a93f5e5b62c1c6d856f59ed863f5fd2da1929f66567d3b0e12"
+@@ -4341,25 +4233,11 @@ checksum = "950b027b861c6863ddf1b075672ec1ef2006b95c4d12284fc1ec4cdb1ab6639e"
  dependencies = [
   "bstr",
   "dunce",
-- "gix-fs 0.17.0",
-- "gix-hash 0.20.1",
-- "gix-path 0.10.22 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-- "gix-ref 0.55.0",
-+ "gix-fs 0.18.0",
-+ "gix-hash 0.21.0",
-+ "gix-path",
-+ "gix-ref 0.56.0",
-  "gix-sec 0.12.2",
-  "thiserror 2.0.17",
+- "gix-fs 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-path 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-ref 0.58.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-sec 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "thiserror 2.0.17",
+-]
+-
+-[[package]]
+-name = "gix-discover"
+-version = "0.46.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
+-dependencies = [
+- "bstr",
+- "dunce",
+- "gix-fs 0.19.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-path 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-ref 0.58.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-sec 0.13.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "thiserror 2.0.17",
++ "gix-fs",
++ "gix-path 0.11.0",
++ "gix-ref",
++ "gix-sec",
++ "thiserror 2.0.18",
  ]
-@@ -4338,9 +4335,9 @@ version = "0.42.1"
- source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "56f4399af6ec4fd9db84dd4cf9656c5c785ab492ab40a7c27ea92b4241923fed"
- dependencies = [
-- "gix-path 0.10.22 (registry+https://github.com/rust-lang/crates.io-index)",
-- "gix-trace 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
-- "gix-utils 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
-+ "gix-path",
-+ "gix-trace",
-+ "gix-utils",
-  "libc",
-  "prodash 29.0.2",
-  "walkdir",
-@@ -4348,40 +4345,42 @@ dependencies = [
  
+ [[package]]
+@@ -4371,44 +4249,23 @@ dependencies = [
+  "bstr",
+ ]
+ 
+-[[package]]
+-name = "gix-error"
+-version = "0.0.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
+-dependencies = [
+- "bstr",
+-]
+-
  [[package]]
  name = "gix-features"
--version = "0.44.1"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
-+version = "0.45.0"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "ba0ba40b1ca17f2cb3987c8d54e596aba924201cd8e5947098b441067e6686a0"
+ version = "0.46.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "6a407957e21dc5e6c87086e50e5114a2f9240f9cb11699588a6d900d53cb6c70"
+-dependencies = [
+- "gix-path 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-trace 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-utils 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc",
+- "prodash",
+- "walkdir",
+-]
+-
+-[[package]]
+-name = "gix-features"
+-version = "0.46.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
  dependencies = [
   "bytes",
   "crc32fast",
   "crossbeam-channel",
-- "gix-path 0.10.22 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-- "gix-trace 0.1.15 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-path 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-trace 0.1.17 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
 - "gix-utils 0.3.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-+ "gix-path",
++ "gix-path 0.11.0",
 + "gix-trace",
 + "gix-utils",
   "libc",
-- "libz-rs-sys",
   "once_cell",
   "parking_lot",
-  "prodash 30.0.1",
-  "thiserror 2.0.17",
+  "prodash",
+- "thiserror 2.0.17",
++ "thiserror 2.0.18",
   "walkdir",
-+ "zlib-rs",
+  "zlib-rs",
  ]
- 
+@@ -4416,21 +4273,22 @@ dependencies = [
  [[package]]
  name = "gix-filter"
--version = "0.22.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
-+version = "0.23.0"
+ version = "0.25.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "22c005832d42de07bacdef53d3b87f6067e765b9753f85788655a1b4a20fc2b6"
++checksum = "7240442915cdd74e1f889566695ce0d0c23c7185b13318a1232ce646af0d18ad"
  dependencies = [
   "bstr",
   "encoding_rs",
-- "gix-attributes 0.28.1",
-+ "gix-attributes 0.29.0",
+- "gix-attributes 0.30.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-attributes",
   "gix-command",
-- "gix-hash 0.20.1",
-- "gix-object 0.52.0",
-+ "gix-hash 0.21.0",
-+ "gix-object 0.53.0",
+- "gix-hash 0.22.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-object 0.55.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-hash",
++ "gix-object",
   "gix-packetline",
-- "gix-path 0.10.22 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-path 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
 - "gix-quote 0.6.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-- "gix-trace 0.1.15 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-trace 0.1.17 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
 - "gix-utils 0.3.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-+ "gix-path",
++ "gix-path 0.11.0",
 + "gix-quote",
 + "gix-trace",
 + "gix-utils",
   "smallvec",
-  "thiserror 2.0.17",
+- "thiserror 2.0.17",
++ "thiserror 2.0.18",
  ]
-@@ -4395,21 +4394,22 @@ dependencies = [
+ 
+ [[package]]
+@@ -4441,23 +4299,10 @@ checksum = "ba74fa163d3b2ba821d5cd207d55fe3daac3d1099613a8559c812d2b15b3c39a"
+ dependencies = [
   "bstr",
   "fastrand",
-  "gix-features 0.42.1",
-- "gix-path 0.10.22 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-features 0.46.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-path 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
 - "gix-utils 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
-+ "gix-path",
-+ "gix-utils",
-  "thiserror 2.0.17",
- ]
- 
- [[package]]
- name = "gix-fs"
--version = "0.17.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
-+version = "0.18.0"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "95b160a13547a64d67a02d894e4f5502a2a5f98635c89931f6bb9c7a4c80c7db"
- dependencies = [
-  "bstr",
-  "fastrand",
-- "gix-features 0.44.1",
-- "gix-path 0.10.22 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "thiserror 2.0.17",
+-]
+-
+-[[package]]
+-name = "gix-fs"
+-version = "0.19.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
+-dependencies = [
+- "bstr",
+- "fastrand",
+- "gix-features 0.46.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-path 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
 - "gix-utils 0.3.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-+ "gix-features 0.45.0",
-+ "gix-path",
+- "thiserror 2.0.17",
++ "gix-features",
++ "gix-path 0.11.0",
 + "gix-utils",
-  "thiserror 2.0.17",
- ]
- 
-@@ -4422,18 +4422,19 @@ dependencies = [
-  "bitflags 2.10.0",
-  "bstr",
-  "gix-features 0.42.1",
-- "gix-path 0.10.22 (registry+https://github.com/rust-lang/crates.io-index)",
-+ "gix-path",
++ "thiserror 2.0.18",
  ]
  
  [[package]]
- name = "gix-glob"
--version = "0.22.1"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
-+version = "0.23.0"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "e8546300aee4c65c5862c22a3e321124a69b654a61a8b60de546a9284812b7e2"
+@@ -4468,19 +4313,8 @@ checksum = "b03e6cd88cc0dc1eafa1fddac0fb719e4e74b6ea58dd016e71125fde4a326bee"
  dependencies = [
   "bitflags 2.10.0",
   "bstr",
-- "gix-features 0.44.1",
-- "gix-path 0.10.22 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-+ "gix-features 0.45.0",
-+ "gix-path",
+- "gix-features 0.46.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-path 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+-]
+-
+-[[package]]
+-name = "gix-glob"
+-version = "0.24.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
+-dependencies = [
+- "bitflags 2.10.0",
+- "bstr",
+- "gix-features 0.46.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-path 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-features",
++ "gix-path 0.11.0",
   "serde",
  ]
  
-@@ -4451,11 +4452,12 @@ dependencies = [
- 
- [[package]]
- name = "gix-hash"
--version = "0.20.1"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
-+version = "0.21.0"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "0799db4b114b97da340a3acd6b65f4ef4d325a590acef867ab0e51729b8b761c"
+@@ -4491,21 +4325,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "2b8e11ea6bbd0fd4ab4a1c66812dd3cc25921a41315b120f352997725a4c79d6"
  dependencies = [
   "faster-hex",
-- "gix-features 0.44.1",
-+ "gix-features 0.45.0",
+- "gix-features 0.46.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "sha1-checked",
+- "thiserror 2.0.17",
+-]
+-
+-[[package]]
+-name = "gix-hash"
+-version = "0.22.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
+-dependencies = [
+- "faster-hex",
+- "gix-features 0.46.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-features",
   "serde",
   "sha1-checked",
-  "thiserror 2.0.17",
-@@ -4474,10 +4476,11 @@ dependencies = [
+- "thiserror 2.0.17",
++ "thiserror 2.0.18",
+ ]
  
  [[package]]
- name = "gix-hashtable"
--version = "0.10.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
-+version = "0.11.0"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "222f7428636020bef272a87ed833ea48bf5fb3193f99852ae16fbb5a602bd2f0"
+@@ -4514,17 +4337,7 @@ version = "0.12.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "52f1eecdd006390cbed81f105417dbf82a6fe40842022006550f2e32484101da"
  dependencies = [
-- "gix-hash 0.20.1",
-+ "gix-hash 0.21.0",
+- "gix-hash 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "hashbrown 0.16.1",
+- "parking_lot",
+-]
+-
+-[[package]]
+-name = "gix-hashtable"
+-version = "0.12.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
+-dependencies = [
+- "gix-hash 0.22.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-hash",
   "hashbrown 0.16.1",
   "parking_lot",
  ]
-@@ -4490,20 +4493,21 @@ checksum = "ae358c3c96660b10abc7da63c06788dfded603e717edbd19e38c6477911b71c8"
+@@ -4536,21 +4349,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "8953d87c13267e296d547f0fc7eaa8aa8fa5b2a9a34ab1cd5857f25240c7d299"
  dependencies = [
   "bstr",
-  "gix-glob 0.20.1",
-- "gix-path 0.10.22 (registry+https://github.com/rust-lang/crates.io-index)",
-- "gix-trace 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
-+ "gix-path",
-+ "gix-trace",
-  "unicode-bom",
- ]
- 
- [[package]]
- name = "gix-ignore"
--version = "0.17.1"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
-+version = "0.18.0"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "dfa727fdf54fd9fb53fa3fbb1a5c17172d3073e8e336bf155f3cac3e25b81b21"
- dependencies = [
-  "bstr",
-- "gix-glob 0.22.1",
-- "gix-path 0.10.22 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-- "gix-trace 0.1.15 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-+ "gix-glob 0.23.0",
-+ "gix-path",
+- "gix-glob 0.24.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-path 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-trace 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+- "unicode-bom",
+-]
+-
+-[[package]]
+-name = "gix-ignore"
+-version = "0.19.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
+-dependencies = [
+- "bstr",
+- "gix-glob 0.24.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-path 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-trace 0.1.17 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-glob",
++ "gix-path 0.11.0",
 + "gix-trace",
   "serde",
   "unicode-bom",
  ]
-@@ -4518,47 +4522,48 @@ dependencies = [
+@@ -4565,50 +4366,23 @@ dependencies = [
   "bstr",
   "filetime",
   "fnv",
 - "gix-bitmap 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
-+ "gix-bitmap",
-  "gix-features 0.42.1",
-  "gix-fs 0.15.0",
-  "gix-hash 0.18.0",
-  "gix-lock 17.1.0",
-  "gix-object 0.49.1",
-  "gix-traverse 0.46.2",
+- "gix-features 0.46.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-fs 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-hash 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-lock 21.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-object 0.55.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-traverse 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)",
 - "gix-utils 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
-- "gix-validate 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
-+ "gix-utils",
-+ "gix-validate",
-  "hashbrown 0.14.5",
-  "itoa",
-  "libc",
-  "memmap2",
-- "rustix 1.1.2",
-+ "rustix",
-  "smallvec",
-  "thiserror 2.0.17",
- ]
- 
- [[package]]
- name = "gix-index"
--version = "0.43.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
-+version = "0.44.0"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "015374c00aff762bb21dafbb73a2267583392b320cb4aef156805838752a4152"
- dependencies = [
-  "bitflags 2.10.0",
-  "bstr",
-  "filetime",
-  "fnv",
+- "gix-validate 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "hashbrown 0.16.1",
+- "itoa",
+- "libc",
+- "memmap2",
+- "rustix 1.1.3",
+- "smallvec",
+- "thiserror 2.0.17",
+-]
+-
+-[[package]]
+-name = "gix-index"
+-version = "0.46.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
+-dependencies = [
+- "bitflags 2.10.0",
+- "bstr",
+- "filetime",
+- "fnv",
 - "gix-bitmap 0.2.15 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-- "gix-features 0.44.1",
-- "gix-fs 0.17.0",
-- "gix-hash 0.20.1",
-- "gix-lock 19.0.0",
-- "gix-object 0.52.0",
-- "gix-traverse 0.49.0",
+- "gix-features 0.46.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-fs 0.19.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-hash 0.22.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-lock 21.0.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-object 0.55.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-traverse 0.52.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
 - "gix-utils 0.3.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-- "gix-validate 0.10.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-validate 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
 + "gix-bitmap",
-+ "gix-features 0.45.0",
-+ "gix-fs 0.18.0",
-+ "gix-hash 0.21.0",
-+ "gix-lock 20.0.0",
-+ "gix-object 0.53.0",
-+ "gix-traverse 0.50.0",
++ "gix-features",
++ "gix-fs",
++ "gix-hash",
++ "gix-lock",
++ "gix-object",
++ "gix-traverse",
 + "gix-utils",
-+ "gix-validate",
++ "gix-validate 0.11.0",
   "hashbrown 0.16.1",
   "itoa",
   "libc",
   "memmap2",
-- "rustix 1.1.2",
+- "rustix 1.1.3",
 + "rustix",
   "serde",
   "smallvec",
-  "thiserror 2.0.17",
-@@ -4571,67 +4576,71 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "570f8b034659f256366dc90f1a24924902f20acccd6a15be96d44d1269e7a796"
- dependencies = [
-  "gix-tempfile 17.1.0",
-- "gix-utils 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
-+ "gix-utils",
-  "thiserror 2.0.17",
+- "thiserror 2.0.17",
++ "thiserror 2.0.18",
  ]
  
  [[package]]
- name = "gix-lock"
--version = "19.0.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
-+version = "20.0.0"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "beefa8f90ef048ab98375217777c6e74c53c9639b0c2978ea1886c41e7005322"
+@@ -4617,70 +4391,63 @@ version = "21.0.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "e16d406220ef9df105645a9ddcaa42e8c882ba920344ace866d0403570aea599"
  dependencies = [
-- "gix-tempfile 19.0.1",
+- "gix-tempfile 21.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-utils 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+- "thiserror 2.0.17",
+-]
+-
+-[[package]]
+-name = "gix-lock"
+-version = "21.0.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
+-dependencies = [
+- "gix-tempfile 21.0.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
 - "gix-utils 0.3.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-+ "gix-tempfile 20.0.0",
+- "thiserror 2.0.17",
++ "gix-tempfile",
 + "gix-utils",
-  "thiserror 2.0.17",
++ "thiserror 2.0.18",
  ]
  
  [[package]]
  name = "gix-mailmap"
--version = "0.28.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
-+version = "0.28.1"
+ version = "0.30.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "b3b7272fbfa52a197c0c4ec857a2ffb5710c6265f258ba43a4860695d4bcea00"
++checksum = "2e6fd521cb582620b7066b5b420ace1951cb84fe2241fa239b227e1a94fa25dc"
  dependencies = [
   "bstr",
-- "gix-actor 0.36.0",
-- "gix-date 0.11.0",
-+ "gix-actor 0.36.1",
-+ "gix-date 0.11.1",
+- "gix-actor 0.38.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-date 0.13.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-actor",
++ "gix-date",
   "serde",
-  "thiserror 2.0.17",
+- "thiserror 2.0.17",
++ "thiserror 2.0.18",
  ]
  
  [[package]]
  name = "gix-merge"
--version = "0.8.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
-+version = "0.9.0"
+ version = "0.11.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "4d27d44aac025200b77c00329c5a4c98b91254912c480cdf561bd772dd1d58c4"
++checksum = "d468c28f6b092626b93e24e6785fc890a87ca26823c37aefb411a40152504c17"
  dependencies = [
   "bstr",
   "gix-command",
   "gix-diff",
   "gix-filter",
-- "gix-fs 0.17.0",
-- "gix-hash 0.20.1",
-- "gix-index 0.43.0",
-- "gix-object 0.52.0",
-- "gix-path 0.10.22 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-fs 0.19.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-hash 0.22.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-index 0.46.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-object 0.55.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-path 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
 - "gix-quote 0.6.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-+ "gix-fs 0.18.0",
-+ "gix-hash 0.21.0",
-+ "gix-index 0.44.0",
-+ "gix-object 0.53.0",
-+ "gix-path",
++ "gix-fs",
++ "gix-hash",
++ "gix-index",
++ "gix-object",
++ "gix-path 0.11.0",
 + "gix-quote",
   "gix-revision",
-- "gix-revwalk 0.23.0",
-- "gix-tempfile 19.0.1",
-- "gix-trace 0.1.15 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-- "gix-worktree 0.44.0",
-+ "gix-revwalk 0.24.0",
-+ "gix-tempfile 20.0.0",
+- "gix-revwalk 0.26.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-tempfile 21.0.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-trace 0.1.17 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-worktree 0.47.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-revwalk",
++ "gix-tempfile",
 + "gix-trace",
-+ "gix-worktree 0.45.0",
++ "gix-worktree",
   "imara-diff",
-  "thiserror 2.0.17",
+- "thiserror 2.0.17",
++ "thiserror 2.0.18",
  ]
  
  [[package]]
  name = "gix-negotiate"
--version = "0.23.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
-+version = "0.24.0"
+ version = "0.26.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "0873ebf26bd54c5c8c83635dc1963ebf644d351601d6a0d3e5c712dffdace135"
++checksum = "00dff6d49869f16b8900da7c27b886a45cbf641b1e45aab355d012afe4266b7f"
  dependencies = [
   "bitflags 2.10.0",
-- "gix-commitgraph 0.30.1",
-- "gix-date 0.11.0",
-- "gix-hash 0.20.1",
-- "gix-object 0.52.0",
-- "gix-revwalk 0.23.0",
-+ "gix-commitgraph 0.31.0",
-+ "gix-date 0.11.1",
-+ "gix-hash 0.21.0",
-+ "gix-object 0.53.0",
-+ "gix-revwalk 0.24.0",
+- "gix-commitgraph 0.32.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-date 0.13.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-hash 0.22.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-object 0.55.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-revwalk 0.26.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-commitgraph",
++ "gix-date",
++ "gix-hash",
++ "gix-object",
++ "gix-revwalk",
   "smallvec",
-  "thiserror 2.0.17",
+- "thiserror 2.0.17",
++ "thiserror 2.0.18",
  ]
-@@ -4648,9 +4657,9 @@ dependencies = [
-  "gix-features 0.42.1",
-  "gix-hash 0.18.0",
-  "gix-hashtable 0.8.1",
-- "gix-path 0.10.22 (registry+https://github.com/rust-lang/crates.io-index)",
-- "gix-utils 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
-- "gix-validate 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
-+ "gix-path",
-+ "gix-utils",
-+ "gix-validate",
-  "itoa",
-  "smallvec",
-  "thiserror 2.0.17",
-@@ -4659,18 +4668,19 @@ dependencies = [
  
  [[package]]
- name = "gix-object"
--version = "0.52.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
-+version = "0.53.0"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "7ec9557a30ab9abfec4d67975413e3099509ed5da599c901ea40f7da52755128"
+@@ -4690,92 +4457,75 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "4d3f705c977d90ace597049252ae1d7fec907edc0fa7616cc91bf5508d0f4006"
  dependencies = [
   "bstr",
-- "gix-actor 0.36.0",
-- "gix-date 0.11.0",
-- "gix-features 0.44.1",
-- "gix-hash 0.20.1",
-- "gix-hashtable 0.10.0",
-- "gix-path 0.10.22 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-actor 0.38.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-date 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-features 0.46.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-hash 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-hashtable 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-path 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-utils 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-validate 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "itoa",
+- "smallvec",
+- "thiserror 2.0.17",
+- "winnow 0.7.14",
+-]
+-
+-[[package]]
+-name = "gix-object"
+-version = "0.55.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
+-dependencies = [
+- "bstr",
+- "gix-actor 0.38.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-date 0.13.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-features 0.46.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-hash 0.22.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-hashtable 0.12.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-path 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
 - "gix-utils 0.3.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-- "gix-validate 0.10.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-+ "gix-actor 0.36.1",
-+ "gix-date 0.11.1",
-+ "gix-features 0.45.0",
-+ "gix-hash 0.21.0",
-+ "gix-hashtable 0.11.0",
-+ "gix-path",
+- "gix-validate 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-actor",
++ "gix-date",
++ "gix-features",
++ "gix-hash",
++ "gix-hashtable",
++ "gix-path 0.11.0",
 + "gix-utils",
-+ "gix-validate",
++ "gix-validate 0.11.0",
   "itoa",
   "serde",
   "smallvec",
-@@ -4680,19 +4690,20 @@ dependencies = [
+- "thiserror 2.0.17",
++ "thiserror 2.0.18",
+  "winnow 0.7.14",
+ ]
  
  [[package]]
  name = "gix-odb"
--version = "0.72.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
-+version = "0.73.0"
+ version = "0.75.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "6a7eb6f7017bf94ce8cf00da03a8a32d4199fcbee6940c5bba213ca98d01d78f"
++checksum = "1d59882d2fdab5e609b0c452a6ef9a3bd12ef6b694be4f82ab8f126ad0969864"
  dependencies = [
   "arc-swap",
-- "gix-date 0.11.0",
-- "gix-features 0.44.1",
-- "gix-fs 0.17.0",
-- "gix-hash 0.20.1",
-- "gix-hashtable 0.10.0",
-- "gix-object 0.52.0",
-+ "gix-date 0.11.1",
-+ "gix-features 0.45.0",
-+ "gix-fs 0.18.0",
-+ "gix-hash 0.21.0",
-+ "gix-hashtable 0.11.0",
-+ "gix-object 0.53.0",
+- "gix-features 0.46.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-fs 0.19.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-hash 0.22.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-hashtable 0.12.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-object 0.55.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-features",
++ "gix-fs",
++ "gix-hash",
++ "gix-hashtable",
++ "gix-object",
   "gix-pack",
-- "gix-path 0.10.22 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-path 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
 - "gix-quote 0.6.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-+ "gix-path",
++ "gix-path 0.11.0",
 + "gix-quote",
   "parking_lot",
   "serde",
   "tempfile",
-@@ -4701,17 +4712,18 @@ dependencies = [
+- "thiserror 2.0.17",
++ "thiserror 2.0.18",
+ ]
  
  [[package]]
  name = "gix-pack"
--version = "0.62.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
-+version = "0.63.0"
+ version = "0.65.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "bb0811847c93e98e1694ae0f519fb52af62da1cebeaf0a764840e392c6e41b38"
++checksum = "8c44db57ebbbeaad9972c2a60662142660427a1f0a7529314d53fefb4fedad24"
  dependencies = [
   "clru",
-- "gix-chunk 0.4.12 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-- "gix-features 0.44.1",
-- "gix-hash 0.20.1",
-- "gix-hashtable 0.10.0",
-- "gix-object 0.52.0",
-- "gix-path 0.10.22 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-- "gix-tempfile 19.0.1",
+- "gix-chunk 0.5.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-error 0.0.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-features 0.46.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-hash 0.22.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-hashtable 0.12.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-object 0.55.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-path 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-tempfile 21.0.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
 + "gix-chunk",
-+ "gix-features 0.45.0",
-+ "gix-hash 0.21.0",
-+ "gix-hashtable 0.11.0",
-+ "gix-object 0.53.0",
-+ "gix-path",
-+ "gix-tempfile 20.0.0",
++ "gix-error",
++ "gix-features",
++ "gix-hash",
++ "gix-hashtable",
++ "gix-object",
++ "gix-path 0.11.0",
++ "gix-tempfile",
   "memmap2",
   "parking_lot",
   "serde",
-@@ -4723,11 +4735,12 @@ dependencies = [
+  "smallvec",
+- "thiserror 2.0.17",
++ "thiserror 2.0.18",
+  "uluru",
+ ]
+ 
  [[package]]
  name = "gix-packetline"
- version = "0.20.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
+ version = "0.21.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "fad0ffb982a289888087a165d3e849cbac724f2aa5431236b050dd2cb9c7de31"
++checksum = "6c333badf342e9c2392800a96b9f2cf5bcb33906d2577d6ec923756ff4008a3f"
  dependencies = [
   "bstr",
   "faster-hex",
-- "gix-trace 0.1.15 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-trace 0.1.17 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "thiserror 2.0.17",
 + "gix-trace",
-  "thiserror 2.0.17",
++ "thiserror 2.0.18",
  ]
  
-@@ -4738,68 +4751,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ [[package]]
+@@ -4785,9 +4535,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "7cb06c3e4f8eed6e24fd915fa93145e28a511f4ea0e768bae16673e05ed3f366"
  dependencies = [
   "bstr",
-- "gix-trace 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
-- "gix-validate 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-trace 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
++ "gix-trace",
+  "gix-validate 0.10.1",
+- "thiserror 2.0.17",
++ "thiserror 2.0.18",
+ ]
+ 
+ [[package]]
+@@ -4797,71 +4547,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "c7c3cd795cad18c7acbc6bafe34bfb34ac7273ee81133793f9d1516dd9faf922"
+ dependencies = [
+  "bstr",
+- "gix-trace 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-validate 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
 - "thiserror 2.0.17",
 -]
 -
 -[[package]]
 -name = "gix-path"
--version = "0.10.22"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
+-version = "0.11.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 -dependencies = [
 - "bstr",
-- "gix-trace 0.1.15 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-- "gix-validate 0.10.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-trace 0.1.17 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-validate 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "thiserror 2.0.17",
 + "gix-trace",
-+ "gix-validate",
-  "thiserror 2.0.17",
++ "gix-validate 0.11.0",
++ "thiserror 2.0.18",
  ]
  
  [[package]]
  name = "gix-pathspec"
--version = "0.13.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
-+version = "0.14.0"
+ version = "0.15.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "ed9e0c881933c37a7ef45288d6c5779c4a7b3ad240b4c37657e1d9829eb90085"
++checksum = "3df6fd8e514d8b99ec5042ee17909a17750ccf54d0b8b30c850954209c800322"
  dependencies = [
   "bitflags 2.10.0",
   "bstr",
-- "gix-attributes 0.28.1",
-+ "gix-attributes 0.29.0",
+- "gix-attributes 0.30.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-attributes",
   "gix-config-value",
-- "gix-glob 0.22.1",
-- "gix-path 0.10.22 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-+ "gix-glob 0.23.0",
-+ "gix-path",
-  "thiserror 2.0.17",
+- "gix-glob 0.24.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-path 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "thiserror 2.0.17",
++ "gix-glob",
++ "gix-path 0.11.0",
++ "thiserror 2.0.18",
  ]
  
  [[package]]
  name = "gix-prompt"
--version = "0.11.2"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
-+version = "0.12.0"
+ version = "0.13.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "974b142ea650fb0050a301958f49c8cc68929c36f686e9606a381ce39da34fd9"
++checksum = "6d48536da48fa4ae9d99bf46479f37a19a58427711e1927c80790856d4a490f6"
  dependencies = [
   "gix-command",
   "gix-config-value",
   "parking_lot",
-- "rustix 1.1.2",
+- "rustix 1.1.3",
+- "thiserror 2.0.17",
 + "rustix",
-  "thiserror 2.0.17",
++ "thiserror 2.0.18",
  ]
  
  [[package]]
  name = "gix-protocol"
--version = "0.53.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
-+version = "0.54.0"
+ version = "0.56.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "21348ce0b01fb5e3850e9014733d5ddf6bfeebb100967246572e6b02a29a4fef"
++checksum = "54f20837b0c70b65f6ac77886be033de3b69d5879f99128b47c42665ab0a17c2"
  dependencies = [
   "bstr",
   "gix-credentials",
-- "gix-date 0.11.0",
-- "gix-features 0.44.1",
-- "gix-hash 0.20.1",
-- "gix-lock 19.0.0",
-+ "gix-date 0.11.1",
-+ "gix-features 0.45.0",
-+ "gix-hash 0.21.0",
-+ "gix-lock 20.0.0",
+- "gix-date 0.13.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-features 0.46.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-hash 0.22.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-lock 21.0.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-date",
++ "gix-features",
++ "gix-hash",
++ "gix-lock",
   "gix-negotiate",
-- "gix-object 0.52.0",
-- "gix-ref 0.55.0",
-+ "gix-object 0.53.0",
-+ "gix-ref 0.56.0",
+- "gix-object 0.55.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-ref 0.58.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-object",
++ "gix-ref",
   "gix-refspec",
-- "gix-revwalk 0.23.0",
-+ "gix-revwalk 0.24.0",
+- "gix-revwalk 0.26.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-revwalk",
   "gix-shallow",
-- "gix-trace 0.1.15 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-trace 0.1.17 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
 + "gix-trace",
   "gix-transport",
 - "gix-utils 0.3.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
 + "gix-utils",
   "maybe-async",
   "serde",
-  "thiserror 2.0.17",
-@@ -4813,17 +4818,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+- "thiserror 2.0.17",
++ "thiserror 2.0.18",
+  "winnow 0.7.14",
+ ]
+ 
+@@ -4872,18 +4614,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "e912ec04b7b1566a85ad486db0cab6b9955e3e32bcd3c3a734542ab3af084c5b"
  dependencies = [
   "bstr",
@@ -1424,325 +1996,383 @@ index 6ee5075ea..291e43241 100644
 -[[package]]
 -name = "gix-quote"
 -version = "0.6.1"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 -dependencies = [
 - "bstr",
 - "gix-utils 0.3.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "thiserror 2.0.17",
 + "gix-utils",
-  "thiserror 2.0.17",
++ "thiserror 2.0.18",
  ]
  
-@@ -4839,10 +4834,10 @@ dependencies = [
-  "gix-hash 0.18.0",
-  "gix-lock 17.1.0",
-  "gix-object 0.49.1",
-- "gix-path 0.10.22 (registry+https://github.com/rust-lang/crates.io-index)",
-+ "gix-path",
-  "gix-tempfile 17.1.0",
-- "gix-utils 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
-- "gix-validate 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
-+ "gix-utils",
-+ "gix-validate",
-  "memmap2",
-  "thiserror 2.0.17",
-  "winnow 0.7.14",
-@@ -4850,19 +4845,20 @@ dependencies = [
- 
  [[package]]
- name = "gix-ref"
--version = "0.55.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
+@@ -4892,72 +4624,54 @@ version = "0.58.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "5cf780dcd9ac99fd3fcfc8523479a0e2ffd55f5e0be63e5e3248fb7e46cff966"
+ dependencies = [
+- "gix-actor 0.38.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-features 0.46.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-fs 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-hash 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-lock 21.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-object 0.55.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-path 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-tempfile 21.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-utils 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-validate 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "memmap2",
+- "thiserror 2.0.17",
+- "winnow 0.7.14",
+-]
+-
+-[[package]]
+-name = "gix-ref"
+-version = "0.58.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 -dependencies = [
-- "gix-actor 0.36.0",
-- "gix-features 0.44.1",
-- "gix-fs 0.17.0",
-- "gix-hash 0.20.1",
-- "gix-lock 19.0.0",
-- "gix-object 0.52.0",
-- "gix-path 0.10.22 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-- "gix-tempfile 19.0.1",
+- "gix-actor 0.38.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-features 0.46.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-fs 0.19.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-hash 0.22.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-lock 21.0.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-object 0.55.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-path 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-tempfile 21.0.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
 - "gix-utils 0.3.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-- "gix-validate 0.10.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-+version = "0.56.0"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "16f21c66e188cb95207d30c9b2d21b0d234f570dbb97d8fd493081b6990dcb9d"
-+dependencies = [
-+ "gix-actor 0.36.1",
-+ "gix-features 0.45.0",
-+ "gix-fs 0.18.0",
-+ "gix-hash 0.21.0",
-+ "gix-lock 20.0.0",
-+ "gix-object 0.53.0",
-+ "gix-path",
-+ "gix-tempfile 20.0.0",
+- "gix-validate 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-actor",
++ "gix-features",
++ "gix-fs",
++ "gix-hash",
++ "gix-lock",
++ "gix-object",
++ "gix-path 0.11.0",
++ "gix-tempfile",
 + "gix-utils",
-+ "gix-validate",
++ "gix-validate 0.11.0",
   "memmap2",
   "serde",
-  "thiserror 2.0.17",
-@@ -4871,32 +4867,34 @@ dependencies = [
+- "thiserror 2.0.17",
++ "thiserror 2.0.18",
+  "winnow 0.7.14",
+ ]
  
  [[package]]
  name = "gix-refspec"
--version = "0.33.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
-+version = "0.34.0"
+ version = "0.36.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "853157fd71394f7f382af2e28a7cd78c5c7bd28b7c5d7de7272e1ec97a869159"
++checksum = "60ce400a770a7952e45267803192cc2d1fe0afa08e2c08dde32e04c7908c6e61"
  dependencies = [
   "bstr",
-- "gix-glob 0.22.1",
-- "gix-hash 0.20.1",
-+ "gix-glob 0.23.0",
-+ "gix-hash 0.21.0",
+- "gix-error 0.0.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-glob 0.24.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-hash 0.22.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-error",
++ "gix-glob",
++ "gix-hash",
   "gix-revision",
-- "gix-validate 0.10.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-+ "gix-validate",
+- "gix-validate 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-validate 0.11.0",
   "smallvec",
-  "thiserror 2.0.17",
+- "thiserror 2.0.17",
++ "thiserror 2.0.18",
  ]
  
  [[package]]
  name = "gix-revision"
--version = "0.37.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
-+version = "0.38.0"
+ version = "0.40.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "63c1956637d13fe273178f425c04b0458ea678c150cb8ed325957a63cb1136f6"
++checksum = "c719cf7d669439e1fca735bd1c4de54d43c5d30e8883fd6063c4924b213d70c9"
  dependencies = [
   "bitflags 2.10.0",
   "bstr",
-- "gix-commitgraph 0.30.1",
-- "gix-date 0.11.0",
-- "gix-hash 0.20.1",
-- "gix-hashtable 0.10.0",
-- "gix-object 0.52.0",
-- "gix-revwalk 0.23.0",
-- "gix-trace 0.1.15 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-+ "gix-commitgraph 0.31.0",
-+ "gix-date 0.11.1",
-+ "gix-hash 0.21.0",
-+ "gix-hashtable 0.11.0",
-+ "gix-object 0.53.0",
-+ "gix-revwalk 0.24.0",
+- "gix-commitgraph 0.32.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-date 0.13.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-error 0.0.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-hash 0.22.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-hashtable 0.12.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-object 0.55.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-revwalk 0.26.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-trace 0.1.17 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-commitgraph",
++ "gix-date",
++ "gix-error",
++ "gix-hash",
++ "gix-hashtable",
++ "gix-object",
++ "gix-revwalk",
 + "gix-trace",
   "serde",
-  "thiserror 2.0.17",
  ]
-@@ -4918,14 +4916,15 @@ dependencies = [
+ 
+@@ -4967,29 +4681,14 @@ version = "0.26.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "194a50b30aa0c6e6de43c723359c5809a96275a3aa92d323ef7f58b1cdd60f16"
+ dependencies = [
+- "gix-commitgraph 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-date 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-error 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-hash 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-hashtable 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-object 0.55.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "smallvec",
+- "thiserror 2.0.17",
+-]
+-
+-[[package]]
+-name = "gix-revwalk"
+-version = "0.26.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
+-dependencies = [
+- "gix-commitgraph 0.32.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-date 0.13.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-error 0.0.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-hash 0.22.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-hashtable 0.12.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-object 0.55.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-commitgraph",
++ "gix-date",
++ "gix-error",
++ "gix-hash",
++ "gix-hashtable",
++ "gix-object",
+  "smallvec",
+- "thiserror 2.0.17",
++ "thiserror 2.0.18",
+ ]
  
  [[package]]
- name = "gix-revwalk"
--version = "0.23.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
-+version = "0.24.0"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "276d6ce81e71c18e6c9c3de2c5015e85a7495d1bf33e0a7587e997b8bd040715"
- dependencies = [
-- "gix-commitgraph 0.30.1",
-- "gix-date 0.11.0",
-- "gix-hash 0.20.1",
-- "gix-hashtable 0.10.0",
-- "gix-object 0.52.0",
-+ "gix-commitgraph 0.31.0",
-+ "gix-date 0.11.1",
-+ "gix-hash 0.21.0",
-+ "gix-hashtable 0.11.0",
-+ "gix-object 0.53.0",
-  "smallvec",
-  "thiserror 2.0.17",
- ]
-@@ -4937,7 +4936,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "d0dabbc78c759ecc006b970339394951b2c8e1e38a37b072c105b80b84c308fd"
+@@ -4999,18 +4698,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "beeb3bc63696cf7acb5747a361693ebdbcaf25b5d27d2308f38e9782983e7bce"
  dependencies = [
   "bitflags 2.10.0",
-- "gix-path 0.10.22 (registry+https://github.com/rust-lang/crates.io-index)",
-+ "gix-path",
-  "libc",
-  "windows-sys 0.59.0",
- ]
-@@ -4945,10 +4944,11 @@ dependencies = [
- [[package]]
- name = "gix-sec"
- version = "0.12.2"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "ea9962ed6d9114f7f100efe038752f41283c225bb507a2888903ac593dffa6be"
- dependencies = [
-  "bitflags 2.10.0",
-- "gix-path 0.10.22 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-+ "gix-path",
+- "gix-path 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc",
+- "windows-sys 0.61.2",
+-]
+-
+-[[package]]
+-name = "gix-sec"
+-version = "0.13.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
+-dependencies = [
+- "bitflags 2.10.0",
+- "gix-path 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-path 0.11.0",
   "libc",
   "serde",
   "windows-sys 0.61.2",
-@@ -4956,46 +4956,49 @@ dependencies = [
- 
+@@ -5019,49 +4707,52 @@ dependencies = [
  [[package]]
  name = "gix-shallow"
--version = "0.6.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
-+version = "0.7.0"
+ version = "0.8.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "9c1c467fb9f7ec1d33613c2ea5482de514bcb84b8222a793cdc4c71955832356"
++checksum = "f4f4660fed3786d28e7e57d31b2de9ab3bf846068e187ccc52ee513de19a0073"
  dependencies = [
   "bstr",
-- "gix-hash 0.20.1",
-- "gix-lock 19.0.0",
-+ "gix-hash 0.21.0",
-+ "gix-lock 20.0.0",
+- "gix-hash 0.22.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-lock 21.0.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-hash",
++ "gix-lock",
   "serde",
-  "thiserror 2.0.17",
+- "thiserror 2.0.17",
++ "thiserror 2.0.18",
  ]
  
  [[package]]
  name = "gix-status"
--version = "0.22.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
-+version = "0.23.0"
+ version = "0.25.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "1084eb17030ddbda1705c94ff6f79678dd7f15762deda74edf0f38e33711079c"
++checksum = "b0c994dbca7f038cfcde6337673523bab6e6b4f544b5046f5120a02bdeafff33"
  dependencies = [
   "bstr",
   "filetime",
   "gix-diff",
   "gix-dir",
-- "gix-features 0.44.1",
-+ "gix-features 0.45.0",
+- "gix-features 0.46.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-features",
   "gix-filter",
-- "gix-fs 0.17.0",
-- "gix-hash 0.20.1",
-- "gix-index 0.43.0",
-- "gix-object 0.52.0",
-- "gix-path 0.10.22 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-+ "gix-fs 0.18.0",
-+ "gix-hash 0.21.0",
-+ "gix-index 0.44.0",
-+ "gix-object 0.53.0",
-+ "gix-path",
+- "gix-fs 0.19.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-hash 0.22.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-index 0.46.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-object 0.55.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-path 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-fs",
++ "gix-hash",
++ "gix-index",
++ "gix-object",
++ "gix-path 0.11.0",
   "gix-pathspec",
-- "gix-worktree 0.44.0",
-+ "gix-worktree 0.45.0",
+- "gix-worktree 0.47.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-worktree",
   "portable-atomic",
-  "thiserror 2.0.17",
+- "thiserror 2.0.17",
++ "thiserror 2.0.18",
  ]
  
  [[package]]
  name = "gix-submodule"
--version = "0.22.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
-+version = "0.23.0"
+ version = "0.25.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "fe0b0d02a3c5968a2d86de2a56ab28c3b50aa28d8324d49383b7bd71d26e6d84"
++checksum = "db1840fe723c6264ee596e5a179e1b9a2df59351f09bae9cea570a472a790bc0"
  dependencies = [
   "bstr",
   "gix-config",
-- "gix-path 0.10.22 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-+ "gix-path",
+- "gix-path 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-path 0.11.0",
   "gix-pathspec",
   "gix-refspec",
   "gix-url",
-@@ -5019,11 +5022,12 @@ dependencies = [
+- "thiserror 2.0.17",
++ "thiserror 2.0.18",
+ ]
  
  [[package]]
- name = "gix-tempfile"
--version = "19.0.1"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
-+version = "20.0.0"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "816bbb99bbf8cd329e38342594528506f224c4937a6341dbd1d16ee4082f621c"
+@@ -5069,24 +4760,13 @@ name = "gix-tempfile"
+ version = "21.0.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "d280bba7c547170e42d5228fc6e76c191fb5a7c88808ff61af06460404d1fd91"
+-dependencies = [
+- "gix-fs 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc",
+- "parking_lot",
+- "signal-hook 0.4.1",
+- "signal-hook-registry",
+- "tempfile",
+-]
+-
+-[[package]]
+-name = "gix-tempfile"
+-version = "21.0.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
  dependencies = [
   "dashmap",
-- "gix-fs 0.17.0",
-+ "gix-fs 0.18.0",
+- "gix-fs 0.19.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-fs",
   "libc",
   "parking_lot",
++ "signal-hook 0.4.3",
++ "signal-hook-registry",
   "tempfile",
-@@ -5055,33 +5059,29 @@ dependencies = [
+ ]
  
- [[package]]
- name = "gix-trace"
--version = "0.1.15"
-+version = "0.1.16"
+@@ -5100,11 +4780,11 @@ dependencies = [
+  "crc",
+  "fastrand",
+  "fs_extra",
+- "gix-discover 0.46.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-fs 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-lock 21.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-tempfile 21.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-worktree 0.47.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "gix-discover",
++ "gix-fs",
++ "gix-lock",
++ "gix-tempfile",
++ "gix-worktree",
+  "io-close",
+  "is_ci",
+  "parking_lot",
+@@ -5118,32 +4798,28 @@ name = "gix-trace"
+ version = "0.1.17"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "1d3f59a8de2934f6391b6b3a1a7654eae18961fcb9f9c843533fed34ad0f3457"
+ checksum = "6e42a4c2583357721ba2d887916e78df504980f22f1182df06997ce197b89504"
 -
 -[[package]]
 -name = "gix-trace"
--version = "0.1.15"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
-+checksum = "edd971cd6961fb1ebb29a0052a4ab04d8498dbf363c122e137b04753a3bbb5c3"
+-version = "0.1.17"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
  dependencies = [
-  "tracing-core",
+- "tracing",
++ "tracing-core",
  ]
  
  [[package]]
  name = "gix-transport"
--version = "0.50.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
-+version = "0.51.0"
+ version = "0.53.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "03c5445af84383b949856a36accfde9f90bdfc10bb1f640f105917f9d5419509"
++checksum = "de1064c7ffa5a915014a6a5b71fbc5299462ae655348bed23e083b4a735076c3"
  dependencies = [
   "base64 0.22.1",
   "bstr",
   "gix-command",
   "gix-credentials",
-- "gix-features 0.44.1",
-+ "gix-features 0.45.0",
+- "gix-features 0.46.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-features",
   "gix-packetline",
 - "gix-quote 0.6.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-sec 0.13.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
 + "gix-quote",
-  "gix-sec 0.12.2",
++ "gix-sec",
   "gix-url",
-- "reqwest 0.12.24",
-+ "reqwest 0.12.27",
+  "reqwest 0.13.1",
   "serde",
-  "thiserror 2.0.17",
+- "thiserror 2.0.17",
++ "thiserror 2.0.18",
  ]
-@@ -5105,28 +5105,30 @@ dependencies = [
  
  [[package]]
- name = "gix-traverse"
--version = "0.49.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
-+version = "0.50.0"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "c1f7582730a236aba16b4c9a5e9ac64bcbe7f155a38ae5938320de96760beb23"
+@@ -5153,42 +4829,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "37f8b53b4c56b01c43a4491c4edfe2ce66c654eb86232205172ceb1650d21c55"
  dependencies = [
   "bitflags 2.10.0",
-- "gix-commitgraph 0.30.1",
-- "gix-date 0.11.0",
-- "gix-hash 0.20.1",
-- "gix-hashtable 0.10.0",
-- "gix-object 0.52.0",
-- "gix-revwalk 0.23.0",
-+ "gix-commitgraph 0.31.0",
-+ "gix-date 0.11.1",
-+ "gix-hash 0.21.0",
-+ "gix-hashtable 0.11.0",
-+ "gix-object 0.53.0",
-+ "gix-revwalk 0.24.0",
+- "gix-commitgraph 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-date 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-hash 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-hashtable 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-object 0.55.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-revwalk 0.26.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "smallvec",
+- "thiserror 2.0.17",
+-]
+-
+-[[package]]
+-name = "gix-traverse"
+-version = "0.52.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
+-dependencies = [
+- "bitflags 2.10.0",
+- "gix-commitgraph 0.32.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-date 0.13.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-hash 0.22.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-hashtable 0.12.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-object 0.55.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-revwalk 0.26.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-commitgraph",
++ "gix-date",
++ "gix-hash",
++ "gix-hashtable",
++ "gix-object",
++ "gix-revwalk",
   "smallvec",
-  "thiserror 2.0.17",
+- "thiserror 2.0.17",
++ "thiserror 2.0.18",
  ]
  
  [[package]]
  name = "gix-url"
--version = "0.33.2"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
-+version = "0.34.0"
+ version = "0.35.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "cff1996dfb9430b3699d89224c674169c1ae355eacc52bf30a03c0b8bffe73d9"
++checksum = "1ca2e50308a8373069e71970939f43ea4a1b5f422cf807d048ebcf07dcc02b2c"
  dependencies = [
   "bstr",
-- "gix-features 0.44.1",
-- "gix-path 0.10.22 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-+ "gix-features 0.45.0",
-+ "gix-path",
+- "gix-path 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-path 0.11.0",
   "percent-encoding",
   "serde",
-  "thiserror 2.0.17",
-@@ -5137,15 +5139,6 @@ name = "gix-utils"
+- "thiserror 2.0.17",
++ "thiserror 2.0.18",
+ ]
+ 
+ [[package]]
+@@ -5196,15 +4857,6 @@ name = "gix-utils"
  version = "0.3.1"
  source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "befcdbdfb1238d2854591f760a48711bed85e72d80a10e8f2f93f656746ef7c5"
@@ -1754,115 +2384,229 @@ index 6ee5075ea..291e43241 100644
 -[[package]]
 -name = "gix-utils"
 -version = "0.3.1"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
  dependencies = [
   "bstr",
   "fastrand",
-@@ -5162,15 +5155,6 @@ dependencies = [
-  "thiserror 2.0.17",
+@@ -5218,7 +4870,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "5b1e63a5b516e970a594f870ed4571a8fdcb8a344e7bd407a20db8bd61dbfde4"
+ dependencies = [
+  "bstr",
+- "thiserror 2.0.17",
++ "thiserror 2.0.18",
+ ]
+ 
+ [[package]]
+@@ -5230,14 +4882,6 @@ dependencies = [
+  "bstr",
  ]
  
 -[[package]]
 -name = "gix-validate"
--version = "0.10.1"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
+-version = "0.11.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 -dependencies = [
 - "bstr",
-- "thiserror 2.0.17",
 -]
 -
  [[package]]
  name = "gix-worktree"
- version = "0.41.0"
-@@ -5186,42 +5170,44 @@ dependencies = [
-  "gix-ignore 0.15.0",
-  "gix-index 0.40.1",
-  "gix-object 0.49.1",
-- "gix-path 0.10.22 (registry+https://github.com/rust-lang/crates.io-index)",
-- "gix-validate 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
-+ "gix-path",
-+ "gix-validate",
- ]
- 
- [[package]]
- name = "gix-worktree"
--version = "0.44.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
-+version = "0.45.0"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "e0ac49293df83b81da60ad8313f0376a5a7d6b11739ea7e97c0e1ba17b63d2a6"
+ version = "0.47.0"
+@@ -5245,50 +4889,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "ef2ad658586ec0039b03e96c664f08b7cb7a2b7cca6947a9c856c9ed59b807b1"
  dependencies = [
   "bstr",
-- "gix-attributes 0.28.1",
-- "gix-features 0.44.1",
-- "gix-fs 0.17.0",
-- "gix-glob 0.22.1",
-- "gix-hash 0.20.1",
-- "gix-ignore 0.17.1",
-- "gix-index 0.43.0",
-- "gix-object 0.52.0",
-- "gix-path 0.10.22 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-- "gix-validate 0.10.1 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-+ "gix-attributes 0.29.0",
-+ "gix-features 0.45.0",
-+ "gix-fs 0.18.0",
-+ "gix-glob 0.23.0",
-+ "gix-hash 0.21.0",
-+ "gix-ignore 0.18.0",
-+ "gix-index 0.44.0",
-+ "gix-object 0.53.0",
-+ "gix-path",
-+ "gix-validate",
+- "gix-attributes 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-fs 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-glob 0.24.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-hash 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-ignore 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-index 0.46.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-object 0.55.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-path 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "gix-validate 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+-]
+-
+-[[package]]
+-name = "gix-worktree"
+-version = "0.47.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
+-dependencies = [
+- "bstr",
+- "gix-attributes 0.30.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-fs 0.19.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-glob 0.24.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-hash 0.22.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-ignore 0.19.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-index 0.46.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-object 0.55.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-path 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-validate 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-attributes",
++ "gix-fs",
++ "gix-glob",
++ "gix-hash",
++ "gix-ignore",
++ "gix-index",
++ "gix-object",
++ "gix-path 0.11.0",
++ "gix-validate 0.11.0",
   "serde",
  ]
  
  [[package]]
  name = "gix-worktree-state"
--version = "0.22.0"
--source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#169c17c099eb366ee11ba99c3d957f2403ae1bf5"
-+version = "0.23.0"
+ version = "0.25.0"
+-source = "git+https://github.com/GitoxideLabs/gitoxide?branch=main#75ac1d05b3c97eda9a20f22c6cd7f90554df37ab"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "35c6ca09a99ff8d95b4ab4085a94547f89e39164ef23989f9df07257a353f7ef"
++checksum = "9895abc7654cbd8e102d6a765d3bdfa1567fcd5d2849b8e3d3da6405d64913c9"
  dependencies = [
   "bstr",
-- "gix-features 0.44.1",
-+ "gix-features 0.45.0",
+- "gix-features 0.46.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-features",
   "gix-filter",
-- "gix-fs 0.17.0",
-- "gix-index 0.43.0",
-- "gix-object 0.52.0",
-- "gix-path 0.10.22 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
-- "gix-worktree 0.44.0",
-+ "gix-fs 0.18.0",
-+ "gix-index 0.44.0",
-+ "gix-object 0.53.0",
-+ "gix-path",
-+ "gix-worktree 0.45.0",
+- "gix-fs 0.19.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-index 0.46.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-object 0.55.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-path 0.11.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
+- "gix-worktree 0.47.0 (git+https://github.com/GitoxideLabs/gitoxide?branch=main)",
++ "gix-fs",
++ "gix-index",
++ "gix-object",
++ "gix-path 0.11.0",
++ "gix-worktree",
   "io-close",
-  "thiserror 2.0.17",
+- "thiserror 2.0.17",
++ "thiserror 2.0.18",
  ]
-@@ -5705,9 +5691,9 @@ dependencies = [
+ 
+ [[package]]
+@@ -5325,7 +4953,7 @@ dependencies = [
+  "proc-macro-error",
+  "proc-macro2",
+  "quote",
+- "syn 2.0.112",
++ "syn 2.0.114",
+ ]
+ 
+ [[package]]
+@@ -5417,7 +5045,7 @@ dependencies = [
+  "proc-macro-error",
+  "proc-macro2",
+  "quote",
+- "syn 2.0.112",
++ "syn 2.0.114",
+ ]
+ 
+ [[package]]
+@@ -5432,7 +5060,7 @@ dependencies = [
+  "futures-sink",
+  "futures-util",
+  "http 0.2.12",
+- "indexmap 2.12.1",
++ "indexmap 2.13.0",
+  "slab",
+  "tokio",
+  "tokio-util",
+@@ -5441,9 +5069,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "h2"
+-version = "0.4.12"
++version = "0.4.13"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
++checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+ dependencies = [
+  "atomic-waker",
+  "bytes",
+@@ -5451,7 +5079,7 @@ dependencies = [
+  "futures-core",
+  "futures-sink",
+  "http 1.4.0",
+- "indexmap 2.12.1",
++ "indexmap 2.13.0",
+  "slab",
+  "tokio",
+  "tokio-util",
+@@ -5715,7 +5343,7 @@ dependencies = [
+  "bytes",
+  "futures-channel",
+  "futures-core",
+- "h2 0.4.12",
++ "h2 0.4.13",
+  "http 1.4.0",
+  "http-body 1.0.1",
+  "httparse",
+@@ -5751,13 +5379,13 @@ dependencies = [
+  "http 1.4.0",
+  "hyper 1.8.1",
+  "hyper-util",
+- "rustls 0.23.35",
++ "rustls 0.23.36",
+  "rustls-native-certs",
+  "rustls-pki-types",
+  "tokio",
+  "tokio-rustls 0.26.4",
+  "tower-service",
+- "webpki-roots 1.0.4",
++ "webpki-roots 1.0.5",
+ ]
+ 
+ [[package]]
+@@ -5791,14 +5419,13 @@ dependencies = [
  
  [[package]]
  name = "hyper-util"
 -version = "0.1.18"
-+version = "0.1.19"
++version = "0.1.20"
  source = "registry+https://github.com/rust-lang/crates.io-index"
 -checksum = "52e9a2a24dc5c6821e71a7030e1e14b7b632acac55c40e9d2e082c621261bb56"
-+checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
++checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
  dependencies = [
   "base64 0.22.1",
   "bytes",
-@@ -5726,7 +5712,7 @@ dependencies = [
+  "futures-channel",
+- "futures-core",
+  "futures-util",
+  "http 1.4.0",
+  "http-body 1.0.1",
+@@ -5807,8 +5434,8 @@ dependencies = [
+  "libc",
+  "percent-encoding",
+  "pin-project-lite",
+- "socket2 0.6.1",
+- "system-configuration",
++ "socket2 0.6.2",
++ "system-configuration 0.7.0",
   "tokio",
   "tower-service",
   "tracing",
-- "windows-registry",
-+ "windows-registry 0.6.1",
- ]
+@@ -5817,9 +5444,9 @@ dependencies = [
  
  [[package]]
-@@ -5811,9 +5797,9 @@ checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+ name = "iana-time-zone"
+-version = "0.1.64"
++version = "0.1.65"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
++checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+ dependencies = [
+  "android_system_properties",
+  "core-foundation-sys",
+@@ -5841,9 +5468,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "ico"
+-version = "0.4.0"
++version = "0.5.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "cc50b891e4acf8fe0e71ef88ec43ad82ee07b3810ad09de10f1d01f072ed4b98"
++checksum = "3e795dff5605e0f04bff85ca41b51a96b83e80b281e96231bcaaf1ac35103371"
+ dependencies = [
+  "byteorder",
+  "png 0.17.16",
+@@ -5897,9 +5524,9 @@ checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
  
  [[package]]
  name = "icu_properties"
@@ -1874,7 +2618,7 @@ index 6ee5075ea..291e43241 100644
  dependencies = [
   "icu_collections",
   "icu_locale_core",
-@@ -5825,9 +5811,9 @@ dependencies = [
+@@ -5911,9 +5538,9 @@ dependencies = [
  
  [[package]]
  name = "icu_properties_data"
@@ -1886,37 +2630,49 @@ index 6ee5075ea..291e43241 100644
  
  [[package]]
  name = "icu_provider"
-@@ -5974,14 +5960,15 @@ dependencies = [
+@@ -6009,9 +5636,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "indexmap"
+-version = "2.12.1"
++version = "2.13.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
++checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+ dependencies = [
+  "equivalent",
+  "hashbrown 0.16.1",
+@@ -6060,9 +5687,9 @@ dependencies = [
  
  [[package]]
  name = "insta"
--version = "1.44.3"
-+version = "1.45.0"
+-version = "1.46.0"
++version = "1.46.3"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "b5c943d4415edd8153251b6f197de5eb1640e56d84e8d9159bea190421c73698"
-+checksum = "b76866be74d68b1595eb8060cb9191dca9c021db2316558e52ddc5d55d41b66c"
+-checksum = "1b66886d14d18d420ab5052cbff544fc5d34d0b2cdd35eb5976aaa10a4a472e5"
++checksum = "e82db8c87c7f1ccecb34ce0c24399b8a73081427f3c7c50a5d597925356115e4"
  dependencies = [
   "console",
   "once_cell",
-  "serde",
-  "similar",
-+ "tempfile",
- ]
+@@ -6098,9 +5725,9 @@ checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
  
  [[package]]
-@@ -6061,9 +6048,9 @@ dependencies = [
- 
- [[package]]
- name = "itoa"
--version = "1.0.15"
-+version = "1.0.16"
+ name = "iri-string"
+-version = "0.7.9"
++version = "0.7.10"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
-+checksum = "7ee5b5339afb4c41626dde77b7a611bd4f2c202b897852b4bcf5d03eddc61010"
- 
- [[package]]
- name = "javascriptcore-rs"
-@@ -6116,9 +6103,9 @@ dependencies = [
+-checksum = "4f867b9d1d896b67beb18518eda36fdb77a32ea590de864f1325b294a6d14397"
++checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+ dependencies = [
+  "memchr",
+  "serde",
+@@ -6209,14 +5836,14 @@ checksum = "e0c84ee7f197eca9a86c6fd6cb771e55eb991632f15f2bc3ca6ec838929e6e78"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.112",
++ "syn 2.0.114",
+ ]
  
  [[package]]
  name = "jiff-tzdb"
@@ -1928,27 +2684,37 @@ index 6ee5075ea..291e43241 100644
  
  [[package]]
  name = "jiff-tzdb-platform"
-@@ -6163,9 +6150,9 @@ dependencies = [
+@@ -6261,9 +5888,9 @@ dependencies = [
  
  [[package]]
  name = "js-sys"
 -version = "0.3.82"
-+version = "0.3.83"
++version = "0.3.85"
  source = "registry+https://github.com/rust-lang/crates.io-index"
 -checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
-+checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
++checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
  dependencies = [
   "once_cell",
   "wasm-bindgen",
-@@ -6316,24 +6303,24 @@ checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
+@@ -6357,7 +5984,7 @@ checksum = "02cb977175687f33fa4afa0c95c112b987ea1443e5a51c8f8ff27dc618270cc2"
+ dependencies = [
+  "cssparser",
+  "html5ever",
+- "indexmap 2.12.1",
++ "indexmap 2.13.0",
+  "selectors",
+ ]
  
- [[package]]
- name = "libc"
--version = "0.2.177"
-+version = "0.2.178"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
-+checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
+@@ -6387,7 +6014,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "6e9ec52138abedcc58dc17a7c6c0c00a2bdb4f3427c7f63fa97fd0d859155caf"
+ dependencies = [
+  "gtk-sys",
+- "libloading 0.7.4",
++ "libloading",
+  "once_cell",
+ ]
+ 
+@@ -6405,9 +6032,9 @@ checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
  
  [[package]]
  name = "libdbus-sys"
@@ -1960,51 +2726,36 @@ index 6ee5075ea..291e43241 100644
  dependencies = [
   "pkg-config",
  ]
+@@ -6436,25 +6063,15 @@ dependencies = [
+  "winapi",
+ ]
  
- [[package]]
- name = "libgit2-sys"
--version = "0.18.2+1.9.1"
-+version = "0.18.3+1.9.2"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "1c42fe03df2bd3c53a3a9c7317ad91d80c81cd1fb0caec8d7cc4cd2bfa10c222"
-+checksum = "c9b3acc4b91781bb0b3386669d325163746af5f6e4f73e6d2d630e09a35f3487"
- dependencies = [
-  "cc",
-  "libc",
-@@ -6365,13 +6352,13 @@ dependencies = [
- 
+-[[package]]
+-name = "libloading"
+-version = "0.8.9"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+-dependencies = [
+- "cfg-if",
+- "windows-link 0.2.1",
+-]
+-
  [[package]]
  name = "libredox"
 -version = "0.1.10"
-+version = "0.1.11"
++version = "0.1.12"
  source = "registry+https://github.com/rust-lang/crates.io-index"
 -checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
-+checksum = "df15f6eac291ed1cf25865b1ee60399f57e7c227e7f51bdbd4c5270396a9ed50"
++checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
  dependencies = [
   "bitflags 2.10.0",
   "libc",
 - "redox_syscall",
-+ "redox_syscall 0.6.0",
++ "redox_syscall 0.7.0",
  ]
  
  [[package]]
-@@ -6399,15 +6386,6 @@ dependencies = [
-  "vcpkg",
- ]
- 
--[[package]]
--name = "libz-rs-sys"
--version = "0.5.2"
--source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "840db8cf39d9ec4dd794376f38acc40d0fc65eec2a8f484f7fd375b84602becd"
--dependencies = [
-- "zlib-rs",
--]
--
- [[package]]
- name = "libz-sys"
- version = "1.1.23"
-@@ -6430,12 +6408,6 @@ dependencies = [
+@@ -6504,12 +6121,6 @@ dependencies = [
   "libc",
  ]
  
@@ -2017,22 +2768,7 @@ index 6ee5075ea..291e43241 100644
  [[package]]
  name = "linux-raw-sys"
  version = "0.11.0"
-@@ -6465,11 +6437,11 @@ dependencies = [
- 
- [[package]]
- name = "log"
--version = "0.4.28"
-+version = "0.4.29"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
-+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
- dependencies = [
-- "serde",
-+ "serde_core",
-  "value-bag",
- ]
- 
-@@ -6492,8 +6464,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+@@ -6565,8 +6176,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "65fd3f75411f4725061682ed91f131946e912859d0044d39c4ec0aac818d7621"
  dependencies = [
   "cc",
@@ -2043,16 +2779,25 @@ index 6ee5075ea..291e43241 100644
   "time",
  ]
  
-@@ -6600,7 +6572,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "36c791ecdf977c99f45f23280405d7723727470f6689a5e6dbf513ac547ae10d"
+@@ -6612,7 +6223,7 @@ checksum = "88a9689d8d44bf9964484516275f5cd4c9b59457a6940c1d5d0ecbb94510a36b"
  dependencies = [
-  "serde",
-- "toml 0.9.8",
-+ "toml 0.9.10+spec-1.1.0",
+  "proc-macro2",
+  "quote",
+- "syn 2.0.112",
++ "syn 2.0.114",
  ]
  
  [[package]]
-@@ -6681,9 +6653,9 @@ dependencies = [
+@@ -6644,7 +6255,7 @@ checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.112",
++ "syn 2.0.114",
+ ]
+ 
+ [[package]]
+@@ -6744,9 +6355,9 @@ dependencies = [
  
  [[package]]
  name = "mio"
@@ -2064,7 +2809,7 @@ index 6ee5075ea..291e43241 100644
  dependencies = [
   "libc",
   "log",
-@@ -6699,9 +6671,9 @@ checksum = "dce6dd36094cac388f119d2e9dc82dc730ef91c32a6222170d630e5414b956e6"
+@@ -6762,9 +6373,9 @@ checksum = "dce6dd36094cac388f119d2e9dc82dc730ef91c32a6222170d630e5414b956e6"
  
  [[package]]
  name = "moxcms"
@@ -2076,7 +2821,7 @@ index 6ee5075ea..291e43241 100644
  dependencies = [
   "num-traits",
   "pxfm",
-@@ -6717,10 +6689,10 @@ dependencies = [
+@@ -6780,14 +6391,14 @@ dependencies = [
   "dpi",
   "gtk",
   "keyboard-types",
@@ -2089,7 +2834,30 @@ index 6ee5075ea..291e43241 100644
   "once_cell",
   "png 0.17.16",
   "serde",
-@@ -6853,7 +6825,7 @@ dependencies = [
+- "thiserror 2.0.17",
++ "thiserror 2.0.18",
+  "windows-sys 0.60.2",
+ ]
+ 
+@@ -6797,7 +6408,7 @@ version = "0.7.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
+ dependencies = [
+- "getrandom 0.2.16",
++ "getrandom 0.2.17",
+ ]
+ 
+ [[package]]
+@@ -6809,7 +6420,7 @@ dependencies = [
+  "libc",
+  "log",
+  "openssl",
+- "openssl-probe",
++ "openssl-probe 0.1.6",
+  "openssl-sys",
+  "schannel",
+  "security-framework 2.11.1",
+@@ -6948,7 +6559,7 @@ dependencies = [
   "kqueue",
   "libc",
   "log",
@@ -2098,7 +2866,35 @@ index 6ee5075ea..291e43241 100644
   "notify-types",
   "walkdir",
   "windows-sys 0.60.2",
-@@ -6881,9 +6853,9 @@ checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
+@@ -6956,29 +6567,32 @@ dependencies = [
+ 
+ [[package]]
+ name = "notify-rust"
+-version = "4.11.7"
++version = "4.12.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "6442248665a5aa2514e794af3b39661a8e73033b1cc5e59899e1276117ee4400"
++checksum = "21af20a1b50be5ac5861f74af1a863da53a11c38684d9818d82f1c42f7fdc6c2"
+ dependencies = [
+  "futures-lite",
+  "log",
+  "mac-notification-sys",
+  "serde",
+  "tauri-winrt-notification",
+- "zbus 5.12.0",
++ "zbus 5.13.2",
+ ]
+ 
+ [[package]]
+ name = "notify-types"
+-version = "2.0.0"
++version = "2.1.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
++checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
++dependencies = [
++ "bitflags 2.10.0",
++]
  
  [[package]]
  name = "ntapi"
@@ -2110,7 +2906,28 @@ index 6ee5075ea..291e43241 100644
  dependencies = [
   "winapi",
  ]
-@@ -7016,22 +6988,6 @@ dependencies = [
+@@ -7027,9 +6641,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "num-conv"
+-version = "0.1.0"
++version = "0.2.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
++checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+ 
+ [[package]]
+ name = "num-integer"
+@@ -7090,7 +6704,7 @@ dependencies = [
+  "proc-macro-crate 3.4.0",
+  "proc-macro2",
+  "quote",
+- "syn 2.0.112",
++ "syn 2.0.114",
+ ]
+ 
+ [[package]]
+@@ -7111,22 +6725,6 @@ dependencies = [
   "malloc_buf",
  ]
  
@@ -2133,7 +2950,7 @@ index 6ee5075ea..291e43241 100644
  [[package]]
  name = "objc2"
  version = "0.6.3"
-@@ -7049,9 +7005,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+@@ -7144,9 +6742,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
  dependencies = [
   "bitflags 2.10.0",
@@ -2145,7 +2962,7 @@ index 6ee5075ea..291e43241 100644
   "objc2-cloud-kit",
   "objc2-core-data",
   "objc2-core-foundation",
-@@ -7059,8 +7015,8 @@ dependencies = [
+@@ -7154,8 +6752,8 @@ dependencies = [
   "objc2-core-image",
   "objc2-core-text",
   "objc2-core-video",
@@ -2156,7 +2973,7 @@ index 6ee5075ea..291e43241 100644
  ]
  
  [[package]]
-@@ -7070,8 +7026,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+@@ -7165,8 +6763,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
  dependencies = [
   "bitflags 2.10.0",
@@ -2167,7 +2984,7 @@ index 6ee5075ea..291e43241 100644
  ]
  
  [[package]]
-@@ -7081,8 +7037,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+@@ -7176,8 +6774,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
  dependencies = [
   "bitflags 2.10.0",
@@ -2178,7 +2995,7 @@ index 6ee5075ea..291e43241 100644
  ]
  
  [[package]]
-@@ -7093,7 +7049,7 @@ checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+@@ -7188,7 +6786,7 @@ checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
  dependencies = [
   "bitflags 2.10.0",
   "dispatch2",
@@ -2187,7 +3004,7 @@ index 6ee5075ea..291e43241 100644
  ]
  
  [[package]]
-@@ -7104,7 +7060,7 @@ checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+@@ -7199,7 +6797,7 @@ checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
  dependencies = [
   "bitflags 2.10.0",
   "dispatch2",
@@ -2196,7 +3013,7 @@ index 6ee5075ea..291e43241 100644
   "objc2-core-foundation",
   "objc2-io-surface",
  ]
-@@ -7115,8 +7071,8 @@ version = "0.3.2"
+@@ -7210,8 +6808,8 @@ version = "0.3.2"
  source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
  dependencies = [
@@ -2207,7 +3024,7 @@ index 6ee5075ea..291e43241 100644
  ]
  
  [[package]]
-@@ -7125,8 +7081,8 @@ version = "0.3.2"
+@@ -7220,8 +6818,8 @@ version = "0.3.2"
  source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
  dependencies = [
@@ -2218,7 +3035,7 @@ index 6ee5075ea..291e43241 100644
  ]
  
  [[package]]
-@@ -7136,7 +7092,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+@@ -7231,7 +6829,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
  dependencies = [
   "bitflags 2.10.0",
@@ -2227,7 +3044,7 @@ index 6ee5075ea..291e43241 100644
   "objc2-core-foundation",
   "objc2-core-graphics",
  ]
-@@ -7148,7 +7104,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+@@ -7243,7 +6841,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
  dependencies = [
   "bitflags 2.10.0",
@@ -2236,7 +3053,7 @@ index 6ee5075ea..291e43241 100644
   "objc2-core-foundation",
   "objc2-core-graphics",
   "objc2-io-surface",
-@@ -7169,18 +7125,6 @@ dependencies = [
+@@ -7264,18 +6862,6 @@ dependencies = [
   "cc",
  ]
  
@@ -2255,7 +3072,7 @@ index 6ee5075ea..291e43241 100644
  [[package]]
  name = "objc2-foundation"
  version = "0.3.2"
-@@ -7188,9 +7132,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+@@ -7283,9 +6869,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
  dependencies = [
   "bitflags 2.10.0",
@@ -2267,7 +3084,7 @@ index 6ee5075ea..291e43241 100644
   "objc2-core-foundation",
  ]
  
-@@ -7211,7 +7155,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+@@ -7306,7 +6892,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
  dependencies = [
   "bitflags 2.10.0",
@@ -2276,7 +3093,7 @@ index 6ee5075ea..291e43241 100644
   "objc2-core-foundation",
  ]
  
-@@ -7221,22 +7165,10 @@ version = "0.3.2"
+@@ -7316,22 +6902,10 @@ version = "0.3.2"
  source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "2a1e6550c4caed348956ce3370c9ffeca70bb1dbed4fa96112e7c6170e074586"
  dependencies = [
@@ -2300,7 +3117,7 @@ index 6ee5075ea..291e43241 100644
  [[package]]
  name = "objc2-osa-kit"
  version = "0.3.2"
-@@ -7244,22 +7176,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+@@ -7339,22 +6913,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
  dependencies = [
   "bitflags 2.10.0",
@@ -2325,7 +3142,7 @@ index 6ee5075ea..291e43241 100644
  ]
  
  [[package]]
-@@ -7269,9 +7188,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+@@ -7364,9 +6925,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
  dependencies = [
   "bitflags 2.10.0",
@@ -2337,7 +3154,7 @@ index 6ee5075ea..291e43241 100644
  ]
  
  [[package]]
-@@ -7281,7 +7200,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+@@ -7376,7 +6937,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "709fe137109bd1e8b5a99390f77a7d8b2961dafc1a1c5db8f2e60329ad6d895a"
  dependencies = [
   "bitflags 2.10.0",
@@ -2346,7 +3163,7 @@ index 6ee5075ea..291e43241 100644
   "objc2-core-foundation",
  ]
  
-@@ -7292,8 +7211,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+@@ -7387,8 +6948,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
  dependencies = [
   "bitflags 2.10.0",
@@ -2357,7 +3174,7 @@ index 6ee5075ea..291e43241 100644
   "objc2-cloud-kit",
   "objc2-core-data",
   "objc2-core-foundation",
-@@ -7301,8 +7220,8 @@ dependencies = [
+@@ -7396,8 +6957,8 @@ dependencies = [
   "objc2-core-image",
   "objc2-core-location",
   "objc2-core-text",
@@ -2368,7 +3185,7 @@ index 6ee5075ea..291e43241 100644
   "objc2-user-notifications",
  ]
  
-@@ -7312,8 +7231,8 @@ version = "0.3.2"
+@@ -7407,8 +6968,8 @@ version = "0.3.2"
  source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
  dependencies = [
@@ -2379,7 +3196,7 @@ index 6ee5075ea..291e43241 100644
  ]
  
  [[package]]
-@@ -7323,11 +7242,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+@@ -7418,11 +6979,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "b2e5aaab980c433cf470df9d7af96a7b46a9d892d521a2cbbb2f8a4c16751e7f"
  dependencies = [
   "bitflags 2.10.0",
@@ -2394,16 +3211,70 @@ index 6ee5075ea..291e43241 100644
   "objc2-javascript-core",
   "objc2-security",
  ]
-@@ -7357,7 +7276,7 @@ dependencies = [
-  "mime",
-  "parse_link_header",
-  "percent-encoding",
-- "reqwest 0.12.24",
-+ "reqwest 0.12.27",
-  "schemars 0.8.22",
+@@ -7445,11 +7006,11 @@ dependencies = [
+  "async-stream",
+  "log",
+  "reqwest 0.12.28",
+- "schemars 1.2.0",
++ "schemars 1.2.1",
   "serde",
   "serde_json",
-@@ -7451,15 +7370,15 @@ dependencies = [
+  "static_assertions",
+- "thiserror 2.0.17",
++ "thiserror 2.0.18",
+  "url",
+ ]
+ 
+@@ -7482,15 +7043,15 @@ dependencies = [
+ 
+ [[package]]
+ name = "opener"
+-version = "0.8.3"
++version = "0.8.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "cb9024962ab91e00c89d2a14352a8d0fc1a64346bf96f1839b45c09149564e47"
++checksum = "a2fa337e0cf13357c13ef1dc108df1333eb192f75fc170bea03fcf1fd404c2ee"
+ dependencies = [
+  "bstr",
+  "normpath",
+  "url",
+- "windows-sys 0.60.2",
+- "zbus 5.12.0",
++ "windows-sys 0.61.2",
++ "zbus 5.13.2",
+ ]
+ 
+ [[package]]
+@@ -7516,7 +7077,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.112",
++ "syn 2.0.114",
+ ]
+ 
+ [[package]]
+@@ -7525,11 +7086,17 @@ version = "0.1.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+ 
++[[package]]
++name = "openssl-probe"
++version = "0.2.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
++
+ [[package]]
+ name = "openssl-src"
+-version = "300.5.4+3.5.4"
++version = "300.5.5+3.5.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a507b3792995dae9b0df8a1c1e3771e8418b7c2d9f0baeba32e6fe8b06c7cb72"
++checksum = "3f1787d533e03597a7934fd0a765f0d28e94ecc5fb7789f8053b1e699a56f709"
+ dependencies = [
+  "cc",
+ ]
+@@ -7575,15 +7142,15 @@ dependencies = [
  
  [[package]]
  name = "os_info"
@@ -2423,7 +3294,7 @@ index 6ee5075ea..291e43241 100644
   "objc2-ui-kit",
   "serde",
   "windows-sys 0.61.2",
-@@ -7481,8 +7400,8 @@ version = "0.3.1"
+@@ -7605,12 +7172,12 @@ version = "0.3.1"
  source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
  dependencies = [
@@ -2434,7 +3305,12 @@ index 6ee5075ea..291e43241 100644
   "objc2-osa-kit",
   "serde",
   "serde_json",
-@@ -7538,7 +7457,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+- "thiserror 2.0.17",
++ "thiserror 2.0.18",
+ ]
+ 
+ [[package]]
+@@ -7672,7 +7239,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
  dependencies = [
   "cfg-if",
   "libc",
@@ -2443,11 +3319,56 @@ index 6ee5075ea..291e43241 100644
   "smallvec",
   "windows-link 0.2.1",
  ]
-@@ -7826,15 +7745,15 @@ dependencies = [
+@@ -7703,7 +7270,7 @@ checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+ dependencies = [
+  "fixedbitset",
+  "hashbrown 0.15.5",
+- "indexmap 2.12.1",
++ "indexmap 2.13.0",
+  "serde",
+ ]
+ 
+@@ -7811,7 +7378,7 @@ dependencies = [
+  "phf_shared 0.11.3",
+  "proc-macro2",
+  "quote",
+- "syn 2.0.112",
++ "syn 2.0.114",
+ ]
+ 
+ [[package]]
+@@ -7838,7 +7405,7 @@ version = "0.11.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+ dependencies = [
+- "siphasher 1.0.1",
++ "siphasher 1.0.2",
+ ]
+ 
+ [[package]]
+@@ -7858,7 +7425,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.112",
++ "syn 2.0.114",
+ ]
+ 
+ [[package]]
+@@ -7897,7 +7464,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
+ dependencies = [
+  "base64 0.22.1",
+- "indexmap 2.12.1",
++ "indexmap 2.13.0",
+  "quick-xml 0.38.4",
+  "serde",
+  "time",
+@@ -7939,21 +7506,21 @@ dependencies = [
   "concurrent-queue",
   "hermit-abi",
   "pin-project-lite",
-- "rustix 1.1.2",
+- "rustix 1.1.3",
 + "rustix",
   "windows-sys 0.61.2",
  ]
@@ -2455,14 +3376,22 @@ index 6ee5075ea..291e43241 100644
  [[package]]
  name = "portable-atomic"
 -version = "1.11.1"
-+version = "1.12.0"
++version = "1.13.1"
  source = "registry+https://github.com/rust-lang/crates.io-index"
 -checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
-+checksum = "f59e70c4aef1e55797c2e8fd94a4f2a973fc972cfde0e0b05f683667b0cd39dd"
++checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
  
  [[package]]
  name = "portable-atomic-util"
-@@ -7926,7 +7845,7 @@ version = "3.4.0"
+-version = "0.2.4"
++version = "0.2.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
++checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
+ dependencies = [
+  "portable-atomic",
+ ]
+@@ -8039,7 +7606,7 @@ version = "3.4.0"
  source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
  dependencies = [
@@ -2471,7 +3400,68 @@ index 6ee5075ea..291e43241 100644
  ]
  
  [[package]]
-@@ -8090,9 +8009,9 @@ dependencies = [
+@@ -8085,7 +7652,7 @@ dependencies = [
+  "proc-macro-error-attr2",
+  "proc-macro2",
+  "quote",
+- "syn 2.0.112",
++ "syn 2.0.114",
+ ]
+ 
+ [[package]]
+@@ -8096,9 +7663,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
+ 
+ [[package]]
+ name = "proc-macro2"
+-version = "1.0.103"
++version = "1.0.106"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
++checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+ dependencies = [
+  "unicode-ident",
+ ]
+@@ -8114,9 +7681,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "prost"
+-version = "0.14.1"
++version = "0.14.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7231bd9b3d3d33c86b58adbac74b5ec0ad9f496b19d22801d773636feaa95f3d"
++checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+ dependencies = [
+  "bytes",
+  "prost-derive",
+@@ -8124,22 +7691,22 @@ dependencies = [
+ 
+ [[package]]
+ name = "prost-derive"
+-version = "0.14.1"
++version = "0.14.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
++checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+ dependencies = [
+  "anyhow",
+  "itertools",
+  "proc-macro2",
+  "quote",
+- "syn 2.0.112",
++ "syn 2.0.114",
+ ]
+ 
+ [[package]]
+ name = "prost-types"
+-version = "0.14.1"
++version = "0.14.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b9b4db3d6da204ed77bb26ba83b6122a73aeb2e87e25fbf7ad2e84c4ccbf8f72"
++checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+ dependencies = [
+  "prost",
+ ]
+@@ -8193,9 +7760,9 @@ dependencies = [
  
  [[package]]
  name = "pxfm"
@@ -2483,15 +3473,97 @@ index 6ee5075ea..291e43241 100644
  dependencies = [
   "num-traits",
  ]
-@@ -8322,6 +8241,15 @@ dependencies = [
+@@ -8236,9 +7803,9 @@ dependencies = [
+  "quinn-proto",
+  "quinn-udp",
+  "rustc-hash",
+- "rustls 0.23.35",
+- "socket2 0.6.1",
+- "thiserror 2.0.17",
++ "rustls 0.23.36",
++ "socket2 0.6.2",
++ "thiserror 2.0.18",
+  "tokio",
+  "tracing",
+  "web-time",
+@@ -8257,10 +7824,10 @@ dependencies = [
+  "rand 0.9.2",
+  "ring",
+  "rustc-hash",
+- "rustls 0.23.35",
++ "rustls 0.23.36",
+  "rustls-pki-types",
+  "slab",
+- "thiserror 2.0.17",
++ "thiserror 2.0.18",
+  "tinyvec",
+  "tracing",
+  "web-time",
+@@ -8275,16 +7842,16 @@ dependencies = [
+  "cfg_aliases",
+  "libc",
+  "once_cell",
+- "socket2 0.6.1",
++ "socket2 0.6.2",
+  "tracing",
+  "windows-sys 0.60.2",
+ ]
+ 
+ [[package]]
+ name = "quote"
+-version = "1.0.42"
++version = "1.0.44"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
++checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+ dependencies = [
+  "proc-macro2",
+ ]
+@@ -8333,7 +7900,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+ dependencies = [
+  "rand_chacha 0.9.0",
+- "rand_core 0.9.3",
++ "rand_core 0.9.5",
+ ]
+ 
+ [[package]]
+@@ -8363,7 +7930,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+ dependencies = [
+  "ppv-lite86",
+- "rand_core 0.9.3",
++ "rand_core 0.9.5",
+ ]
+ 
+ [[package]]
+@@ -8381,14 +7948,14 @@ version = "0.6.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+ dependencies = [
+- "getrandom 0.2.16",
++ "getrandom 0.2.17",
+ ]
+ 
+ [[package]]
+ name = "rand_core"
+-version = "0.9.3"
++version = "0.9.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
++checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+ dependencies = [
+  "getrandom 0.3.4",
+ ]
+@@ -8426,13 +7993,22 @@ dependencies = [
   "bitflags 2.10.0",
  ]
  
 +[[package]]
 +name = "redox_syscall"
-+version = "0.6.0"
++version = "0.7.0"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "ec96166dafa0886eb81fe1c0a388bece180fbef2135f97c1e2cf8302e74b43b5"
++checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
 +dependencies = [
 + "bitflags 2.10.0",
 +]
@@ -2499,37 +3571,148 @@ index 6ee5075ea..291e43241 100644
  [[package]]
  name = "redox_users"
  version = "0.4.6"
-@@ -8451,14 +8379,14 @@ dependencies = [
- 
- [[package]]
- name = "reqwest"
--version = "0.12.24"
-+version = "0.12.27"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "9d0946410b9f7b082a427e4ef5c8ff541a88b357bc6c637c40db3a68ac70a36f"
-+checksum = "8e893f6bece5953520ddbb3f8f46f3ef36dd1fef4ee9b087c4b4a725fd5d10e4"
+ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
  dependencies = [
-  "base64 0.22.1",
-  "bytes",
-  "cookie",
-- "cookie_store",
-+ "cookie_store 0.22.0",
-  "encoding_rs",
-  "futures-channel",
-  "futures-core",
-@@ -8510,7 +8438,7 @@ dependencies = [
-  "mime",
-  "nom 7.1.3",
-  "pin-project-lite",
-- "reqwest 0.12.24",
-+ "reqwest 0.12.27",
+- "getrandom 0.2.16",
++ "getrandom 0.2.17",
+  "libredox",
   "thiserror 1.0.69",
  ]
- 
-@@ -8530,17 +8458,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "ef2bee61e6cffa4635c72d7d81a84294e28f0930db0ddcb0f66d10244674ebed"
+@@ -8443,9 +8019,9 @@ version = "0.5.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
  dependencies = [
-  "ashpd",
+- "getrandom 0.2.16",
++ "getrandom 0.2.17",
+  "libredox",
+- "thiserror 2.0.17",
++ "thiserror 2.0.18",
+ ]
+ 
+ [[package]]
+@@ -8465,14 +8041,14 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.112",
++ "syn 2.0.114",
+ ]
+ 
+ [[package]]
+ name = "regex"
+-version = "1.12.2"
++version = "1.12.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
++checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+ dependencies = [
+  "aho-corasick",
+  "memchr",
+@@ -8482,9 +8058,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "regex-automata"
+-version = "0.4.13"
++version = "0.4.14"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
++checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+ dependencies = [
+  "aho-corasick",
+  "memchr",
+@@ -8493,9 +8069,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "regex-syntax"
+-version = "0.8.8"
++version = "0.8.9"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
++checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+ 
+ [[package]]
+ name = "relative-path"
+@@ -8541,7 +8117,7 @@ dependencies = [
+  "serde_json",
+  "serde_urlencoded",
+  "sync_wrapper 0.1.2",
+- "system-configuration",
++ "system-configuration 0.5.1",
+  "tokio",
+  "tokio-rustls 0.24.1",
+  "tower-service",
+@@ -8567,7 +8143,7 @@ dependencies = [
+  "futures-channel",
+  "futures-core",
+  "futures-util",
+- "h2 0.4.12",
++ "h2 0.4.13",
+  "http 1.4.0",
+  "http-body 1.0.1",
+  "http-body-util",
+@@ -8583,7 +8159,7 @@ dependencies = [
+  "percent-encoding",
+  "pin-project-lite",
+  "quinn",
+- "rustls 0.23.35",
++ "rustls 0.23.36",
+  "rustls-native-certs",
+  "rustls-pki-types",
+  "serde",
+@@ -8602,7 +8178,7 @@ dependencies = [
+  "wasm-bindgen-futures",
+  "wasm-streams",
+  "web-sys",
+- "webpki-roots 1.0.4",
++ "webpki-roots 1.0.5",
+ ]
+ 
+ [[package]]
+@@ -8617,7 +8193,7 @@ dependencies = [
+  "futures-channel",
+  "futures-core",
+  "futures-util",
+- "h2 0.4.12",
++ "h2 0.4.13",
+  "http 1.4.0",
+  "http-body 1.0.1",
+  "http-body-util",
+@@ -8630,18 +8206,22 @@ dependencies = [
+  "percent-encoding",
+  "pin-project-lite",
+  "quinn",
+- "rustls 0.23.35",
++ "rustls 0.23.36",
+  "rustls-pki-types",
+  "rustls-platform-verifier",
++ "serde",
++ "serde_json",
+  "sync_wrapper 1.0.2",
+  "tokio",
+  "tokio-rustls 0.26.4",
++ "tokio-util",
+  "tower",
+  "tower-http",
+  "tower-service",
+  "url",
+  "wasm-bindgen",
+  "wasm-bindgen-futures",
++ "wasm-streams",
+  "web-sys",
+ ]
+ 
+@@ -8672,27 +8252,26 @@ dependencies = [
+ 
+ [[package]]
+ name = "rfd"
+-version = "0.15.4"
++version = "0.16.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ef2bee61e6cffa4635c72d7d81a84294e28f0930db0ddcb0f66d10244674ebed"
++checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+ dependencies = [
+- "ashpd",
 - "block2 0.6.2",
 + "block2",
   "dispatch2",
@@ -2547,7 +3730,111 @@ index 6ee5075ea..291e43241 100644
   "raw-window-handle",
   "wasm-bindgen",
   "wasm-bindgen-futures",
-@@ -8702,19 +8630,6 @@ dependencies = [
+  "web-sys",
+- "windows-sys 0.59.0",
++ "windows-sys 0.60.2",
+ ]
+ 
+ [[package]]
+@@ -8703,7 +8282,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+ dependencies = [
+  "cc",
+  "cfg-if",
+- "getrandom 0.2.16",
++ "getrandom 0.2.17",
+  "libc",
+  "untrusted",
+  "windows-sys 0.52.0",
+@@ -8711,9 +8290,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "rkyv"
+-version = "0.7.45"
++version = "0.7.46"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "9008cd6385b9e161d8229e1f6549dd23c3d022f132a2ea37ac3a10ac4935779b"
++checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
+ dependencies = [
+  "bitvec",
+  "bytecheck",
+@@ -8729,9 +8308,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "rkyv_derive"
+-version = "0.7.45"
++version = "0.7.46"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "503d1d27590a2b0a3a4ca4c94755aa2875657196ecbf401a42eff41d7de532c0"
++checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+@@ -8751,10 +8330,10 @@ dependencies = [
+  "paste",
+  "pin-project-lite",
+  "rmcp-macros",
+- "schemars 1.2.0",
++ "schemars 1.2.1",
+  "serde",
+  "serde_json",
+- "thiserror 2.0.17",
++ "thiserror 2.0.18",
+  "tokio",
+  "tokio-util",
+  "tracing",
+@@ -8770,7 +8349,17 @@ dependencies = [
+  "proc-macro2",
+  "quote",
+  "serde_json",
+- "syn 2.0.112",
++ "syn 2.0.114",
++]
++
++[[package]]
++name = "rsqlite-vfs"
++version = "0.1.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "a8a1f2315036ef6b1fbacd1972e8ee7688030b0a2121edfc2a6550febd41574d"
++dependencies = [
++ "hashbrown 0.16.1",
++ "thiserror 2.0.18",
+ ]
+ 
+ [[package]]
+@@ -8798,7 +8387,7 @@ dependencies = [
+  "regex",
+  "relative-path",
+  "rustc_version",
+- "syn 2.0.112",
++ "syn 2.0.114",
+  "unicode-ident",
+ ]
+ 
+@@ -8830,9 +8419,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "rust_decimal"
+-version = "1.39.0"
++version = "1.40.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "35affe401787a9bd846712274d97654355d21b2a2c092a3139aabe31e9022282"
++checksum = "61f703d19852dbf87cbc513643fa81428361eb6940f1ac14fd58155d295a3eb0"
+ dependencies = [
+  "arrayvec",
+  "borsh",
+@@ -8846,9 +8435,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "rustc-demangle"
+-version = "0.1.26"
++version = "0.1.27"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
++checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+ 
+ [[package]]
+ name = "rustc-hash"
+@@ -8865,19 +8454,6 @@ dependencies = [
   "semver",
  ]
  
@@ -2566,8 +3853,8 @@ index 6ee5075ea..291e43241 100644
 -
  [[package]]
  name = "rustix"
- version = "1.1.2"
-@@ -8724,7 +8639,7 @@ dependencies = [
+ version = "1.1.3"
+@@ -8887,7 +8463,7 @@ dependencies = [
   "bitflags 2.10.0",
   "errno",
   "libc",
@@ -2576,67 +3863,250 @@ index 6ee5075ea..291e43241 100644
   "windows-sys 0.61.2",
  ]
  
-@@ -8777,9 +8692,9 @@ dependencies = [
+@@ -8905,26 +8481,26 @@ dependencies = [
+ 
+ [[package]]
+ name = "rustls"
+-version = "0.23.35"
++version = "0.23.36"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
++checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+ dependencies = [
+  "aws-lc-rs",
+  "once_cell",
+  "ring",
+  "rustls-pki-types",
+- "rustls-webpki 0.103.8",
++ "rustls-webpki 0.103.9",
+  "subtle",
+  "zeroize",
+ ]
+ 
+ [[package]]
+ name = "rustls-native-certs"
+-version = "0.8.2"
++version = "0.8.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "9980d917ebb0c0536119ba501e90834767bffc3d60641457fd84a1f3fd337923"
++checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+ dependencies = [
+- "openssl-probe",
++ "openssl-probe 0.2.1",
+  "rustls-pki-types",
+  "schannel",
+  "security-framework 3.5.1",
+@@ -8941,9 +8517,9 @@ dependencies = [
  
  [[package]]
  name = "rustls-pki-types"
 -version = "1.13.1"
-+version = "1.13.2"
++version = "1.14.0"
  source = "registry+https://github.com/rust-lang/crates.io-index"
 -checksum = "708c0f9d5f54ba0272468c1d306a52c495b31fa155e91bc25371e6df7996908c"
-+checksum = "21e6f2ab2928ca4291b86736a8bd920a277a399bba1589409d72154ff87c1282"
++checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
  dependencies = [
   "web-time",
   "zeroize",
-@@ -8814,9 +8729,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+@@ -8960,10 +8536,10 @@ dependencies = [
+  "jni",
+  "log",
+  "once_cell",
+- "rustls 0.23.35",
++ "rustls 0.23.36",
+  "rustls-native-certs",
+  "rustls-platform-verifier-android",
+- "rustls-webpki 0.103.8",
++ "rustls-webpki 0.103.9",
+  "security-framework 3.5.1",
+  "security-framework-sys",
+  "webpki-root-certs",
+@@ -8988,9 +8564,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "rustls-webpki"
+-version = "0.103.8"
++version = "0.103.9"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
++checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+ dependencies = [
+  "aws-lc-rs",
+  "ring",
+@@ -9006,9 +8582,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
  
  [[package]]
  name = "ryu"
 -version = "1.0.20"
-+version = "1.0.21"
++version = "1.0.22"
  source = "registry+https://github.com/rust-lang/crates.io-index"
 -checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
-+checksum = "62049b2877bf12821e8f9ad256ee38fdc31db7387ec2d3b3f403024de2034aea"
++checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
  
  [[package]]
  name = "same-file"
-@@ -9103,9 +9018,9 @@ dependencies = [
+@@ -9066,14 +8642,14 @@ dependencies = [
+ 
+ [[package]]
+ name = "schemars"
+-version = "1.2.0"
++version = "1.2.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "54e910108742c57a770f492731f99be216a52fadd361b06c8fb59d74ccc267d2"
++checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+ dependencies = [
+  "chrono",
+  "dyn-clone",
+  "ref-cast",
+- "schemars_derive 1.2.0",
++ "schemars_derive 1.2.1",
+  "serde",
+  "serde_json",
+ ]
+@@ -9087,27 +8663,21 @@ dependencies = [
+  "proc-macro2",
+  "quote",
+  "serde_derive_internals",
+- "syn 2.0.112",
++ "syn 2.0.114",
+ ]
+ 
+ [[package]]
+ name = "schemars_derive"
+-version = "1.2.0"
++version = "1.2.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "4908ad288c5035a8eb12cfdf0d49270def0a268ee162b75eeee0f85d155a7c45"
++checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+  "serde_derive_internals",
+- "syn 2.0.112",
++ "syn 2.0.114",
+ ]
+ 
+-[[package]]
+-name = "scoped-tls"
+-version = "1.0.1"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+-
+ [[package]]
+ name = "scopeguard"
+ version = "1.2.0"
+@@ -9283,7 +8853,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.112",
++ "syn 2.0.114",
+ ]
+ 
+ [[package]]
+@@ -9294,16 +8864,16 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.112",
++ "syn 2.0.114",
+ ]
  
  [[package]]
  name = "serde_json"
--version = "1.0.145"
-+version = "1.0.146"
+-version = "1.0.148"
++version = "1.0.149"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
-+checksum = "217ca874ae0207aac254aa02c957ded05585a90892cc8d87f9e5fa49669dadd8"
+-checksum = "3084b546a1dd6289475996f182a22aba973866ea8e8b02c51d9f46b1336a22da"
++checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
  dependencies = [
-  "indexmap 2.12.1",
+- "indexmap 2.12.1",
++ "indexmap 2.13.0",
   "itoa",
-@@ -9170,9 +9085,9 @@ dependencies = [
- 
- [[package]]
- name = "serde_spanned"
--version = "1.0.3"
-+version = "1.0.4"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "e24345aa0fe688594e73770a5f6d1b216508b4f93484c0026d521acd30134392"
-+checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+  "memchr",
+  "serde",
+@@ -9352,7 +8922,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
  dependencies = [
-  "serde_core",
+  "proc-macro2",
+  "quote",
+- "syn 2.0.112",
++ "syn 2.0.114",
  ]
-@@ -9342,9 +9257,9 @@ dependencies = [
  
  [[package]]
- name = "shell-words"
--version = "1.1.0"
-+version = "1.1.1"
+@@ -9395,9 +8965,9 @@ dependencies = [
+  "chrono",
+  "hex",
+  "indexmap 1.9.3",
+- "indexmap 2.12.1",
++ "indexmap 2.13.0",
+  "schemars 0.9.0",
+- "schemars 1.2.0",
++ "schemars 1.2.1",
+  "serde_core",
+  "serde_json",
+  "serde_with_macros",
+@@ -9413,16 +8983,17 @@ dependencies = [
+  "darling 0.21.3",
+  "proc-macro2",
+  "quote",
+- "syn 2.0.112",
++ "syn 2.0.114",
+ ]
+ 
+ [[package]]
+ name = "serial_test"
+-version = "3.2.0"
++version = "3.3.1"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
-+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
+-checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
++checksum = "0d0b343e184fc3b7bb44dff0705fffcf4b3756ba6aff420dddd8b24ca145e555"
+ dependencies = [
+- "futures",
++ "futures-executor",
++ "futures-util",
+  "log",
+  "once_cell",
+  "parking_lot",
+@@ -9432,13 +9003,13 @@ dependencies = [
  
  [[package]]
- name = "shellexpand"
-@@ -9404,9 +9319,9 @@ dependencies = [
+ name = "serial_test_derive"
+-version = "3.2.0"
++version = "3.3.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
++checksum = "6f50427f258fb77356e4cd4aa0e87e2bd2c66dbcee41dc405282cae2bfc26c83"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.112",
++ "syn 2.0.114",
+ ]
+ 
+ [[package]]
+@@ -9460,7 +9031,7 @@ checksum = "772ee033c0916d670af7860b6e1ef7d658a4629a6d0b4c8c3e67f09b3765b75d"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.112",
++ "syn 2.0.114",
+ ]
+ 
+ [[package]]
+@@ -9569,9 +9140,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "signal-hook"
+-version = "0.4.1"
++version = "0.4.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2a37d01603c37b5466f808de79f845c7116049b0579adb70a6b7d47c1fa3a952"
++checksum = "3b57709da74f9ff9f4a27dce9526eec25ca8407c45a7887243b031a58935fb8e"
+ dependencies = [
+  "libc",
+  "signal-hook-registry",
+@@ -9600,9 +9171,9 @@ dependencies = [
  
  [[package]]
  name = "simd-adler32"
@@ -2648,7 +4118,51 @@ index 6ee5075ea..291e43241 100644
  
  [[package]]
  name = "simdutf8"
-@@ -9506,24 +9421,24 @@ dependencies = [
+@@ -9624,15 +9195,15 @@ checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+ 
+ [[package]]
+ name = "siphasher"
+-version = "1.0.1"
++version = "1.0.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
++checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+ 
+ [[package]]
+ name = "slab"
+-version = "0.4.11"
++version = "0.4.12"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
++checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+ 
+ [[package]]
+ name = "smallvec"
+@@ -9645,9 +9216,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "snapbox"
+-version = "0.6.23"
++version = "0.6.24"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "96fa1ce81be900d083b30ec2d481e6658c2acfaa2cfc7be45ccc2cc1b820edb3"
++checksum = "6c1abc378119f77310836665f8523018532cf7e3faeb3b10b01da5a7321bf8e1"
+ dependencies = [
+  "anstream",
+  "anstyle",
+@@ -9680,9 +9251,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "socket2"
+-version = "0.6.1"
++version = "0.6.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
++checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+ dependencies = [
+  "libc",
+  "windows-sys 0.60.2",
+@@ -9690,24 +9261,24 @@ dependencies = [
  
  [[package]]
  name = "softbuffer"
@@ -2661,7 +4175,7 @@ index 6ee5075ea..291e43241 100644
   "bytemuck",
 - "cfg_aliases",
 - "core-graphics",
-- "foreign-types",
+- "foreign-types 0.5.0",
   "js-sys",
 - "log",
 - "objc2 0.5.2",
@@ -2684,29 +4198,92 @@ index 6ee5075ea..291e43241 100644
  ]
  
  [[package]]
-@@ -9563,17 +9478,15 @@ dependencies = [
+@@ -9747,14 +9318,13 @@ dependencies = [
  
  [[package]]
  name = "sqlite-wasm-rs"
--version = "0.4.6"
-+version = "0.5.1"
+-version = "0.5.1"
++version = "0.5.2"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "54e4348c16a3d2e2a45437eff67efc5462b60443de76f61b5d0ed9111c626d9d"
-+checksum = "05e98301bf8b0540c7de45ecd760539b9c62f5772aed172f08efba597c11cd5d"
+-checksum = "05e98301bf8b0540c7de45ecd760539b9c62f5772aed172f08efba597c11cd5d"
++checksum = "2f4206ed3a67690b9c29b77d728f6acc3ce78f16bf846d83c94f76400320181b"
  dependencies = [
-+ "cc",
-+ "hashbrown 0.16.1",
+  "cc",
+- "hashbrown 0.16.1",
   "js-sys",
-- "once_cell",
-  "thiserror 2.0.17",
-- "tokio",
+- "thiserror 2.0.17",
++ "rsqlite-vfs",
   "wasm-bindgen",
-- "wasm-bindgen-futures",
-- "web-sys",
+ ]
+ 
+@@ -9819,7 +9389,7 @@ dependencies = [
+  "heck 0.5.0",
+  "proc-macro2",
+  "quote",
+- "syn 2.0.112",
++ "syn 2.0.114",
  ]
  
  [[package]]
-@@ -9790,7 +9703,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+@@ -9871,9 +9441,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "syn"
+-version = "2.0.112"
++version = "2.0.114"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "21f182278bf2d2bcb3c88b1b08a37df029d71ce3d3ae26168e3c653b213b99d4"
++checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+@@ -9903,7 +9473,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.112",
++ "syn 2.0.114",
+ ]
+ 
+ [[package]]
+@@ -9937,7 +9507,18 @@ checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+ dependencies = [
+  "bitflags 1.3.2",
+  "core-foundation 0.9.4",
+- "system-configuration-sys",
++ "system-configuration-sys 0.5.0",
++]
++
++[[package]]
++name = "system-configuration"
++version = "0.7.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
++dependencies = [
++ "bitflags 2.10.0",
++ "core-foundation 0.9.4",
++ "system-configuration-sys 0.6.0",
+ ]
+ 
+ [[package]]
+@@ -9950,6 +9531,16 @@ dependencies = [
+  "libc",
+ ]
+ 
++[[package]]
++name = "system-configuration-sys"
++version = "0.6.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
++dependencies = [
++ "core-foundation-sys",
++ "libc",
++]
++
+ [[package]]
+ name = "system-deps"
+ version = "6.2.2"
+@@ -9970,7 +9561,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "f3a753bdc39c07b192151523a3f77cd0394aa75413802c883a0f6f6a0e5ee2e7"
  dependencies = [
   "bitflags 2.10.0",
@@ -2715,7 +4292,7 @@ index 6ee5075ea..291e43241 100644
   "core-foundation 0.10.1",
   "core-graphics",
   "crossbeam-channel",
-@@ -9807,9 +9720,9 @@ dependencies = [
+@@ -9987,9 +9578,9 @@ dependencies = [
   "ndk",
   "ndk-context",
   "ndk-sys",
@@ -2727,19 +4304,28 @@ index 6ee5075ea..291e43241 100644
   "once_cell",
   "parking_lot",
   "raw-window-handle",
-@@ -9859,9 +9772,9 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+@@ -10011,7 +9602,7 @@ checksum = "f4e16beb8b2ac17db28eab8bca40e62dbfbb34c0fcdc6d9826b11b7b5d047dfd"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.112",
++ "syn 2.0.114",
+ ]
+ 
+ [[package]]
+@@ -10039,9 +9630,9 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
  
  [[package]]
  name = "tauri"
--version = "2.9.4"
-+version = "2.9.5"
+-version = "2.9.5"
++version = "2.10.1"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "15524fc7959bfcaa051ba6d0b3fb1ef18e978de2176c7c6acb977f7fd14d35c7"
-+checksum = "8a3868da5508446a7cd08956d523ac3edf0a8bc20bf7e4038f9a95c2800d2033"
+-checksum = "8a3868da5508446a7cd08956d523ac3edf0a8bc20bf7e4038f9a95c2800d2033"
++checksum = "1025aa560c1eaa14ef96de5540cbe13ed6be1933ebe4398338c96bc370b807c6"
  dependencies = [
   "anyhow",
   "bytes",
-@@ -9879,15 +9792,15 @@ dependencies = [
+@@ -10059,15 +9650,15 @@ dependencies = [
   "log",
   "mime",
   "muda",
@@ -2753,62 +4339,200 @@ index 6ee5075ea..291e43241 100644
   "percent-encoding",
   "plist",
   "raw-window-handle",
-- "reqwest 0.12.24",
-+ "reqwest 0.12.27",
+- "reqwest 0.12.28",
++ "reqwest 0.13.1",
   "serde",
   "serde_json",
   "serde_repr",
-@@ -9926,7 +9839,7 @@ dependencies = [
+@@ -10078,7 +9669,7 @@ dependencies = [
+  "tauri-runtime",
+  "tauri-runtime-wry",
+  "tauri-utils",
+- "thiserror 2.0.17",
++ "thiserror 2.0.18",
+  "tokio",
+  "tray-icon",
+  "url",
+@@ -10090,9 +9681,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "tauri-build"
+-version = "2.5.3"
++version = "2.5.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "17fcb8819fd16463512a12f531d44826ce566f486d7ccd211c9c8cebdaec4e08"
++checksum = "76809f63061c8b25537b87f46b8733b31397cf419706dc874e1602be6479ba90"
+ dependencies = [
+  "anyhow",
+  "cargo_toml",
+@@ -10106,15 +9697,15 @@ dependencies = [
   "serde_json",
   "tauri-utils",
   "tauri-winres",
-- "toml 0.9.8",
-+ "toml 0.9.10+spec-1.1.0",
+- "toml 0.9.10+spec-1.1.0",
++ "toml 0.9.11+spec-1.1.0",
   "walkdir",
  ]
  
-@@ -9984,7 +9897,7 @@ dependencies = [
+ [[package]]
+ name = "tauri-codegen"
+-version = "2.5.2"
++version = "2.5.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "9fa9844cefcf99554a16e0a278156ae73b0d8680bbc0e2ad1e4287aadd8489cf"
++checksum = "8b2ebe49d690ccaea93aa81fff99277d4f445968f085ba13be67859151e9e4b8"
+ dependencies = [
+  "base64 0.22.1",
+  "brotli",
+@@ -10128,9 +9719,9 @@ dependencies = [
+  "serde",
+  "serde_json",
+  "sha2",
+- "syn 2.0.112",
++ "syn 2.0.114",
+  "tauri-utils",
+- "thiserror 2.0.17",
++ "thiserror 2.0.18",
+  "time",
+  "url",
+  "uuid",
+@@ -10139,23 +9730,23 @@ dependencies = [
+ 
+ [[package]]
+ name = "tauri-macros"
+-version = "2.5.2"
++version = "2.5.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "3764a12f886d8245e66b7ee9b43ccc47883399be2019a61d80cf0f4117446fde"
++checksum = "1119f651b0187c686c0fc72c66bba311e560e1b5f61869086ce788d43be6cf41"
+ dependencies = [
+  "heck 0.5.0",
+  "proc-macro2",
+  "quote",
+- "syn 2.0.112",
++ "syn 2.0.114",
+  "tauri-codegen",
+  "tauri-utils",
+ ]
+ 
+ [[package]]
+ name = "tauri-plugin"
+-version = "2.5.2"
++version = "2.5.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "0e1d0a4860b7ff570c891e1d2a586bf1ede205ff858fbc305e0b5ae5d14c1377"
++checksum = "692a77abd8b8773e107a42ec0e05b767b8d2b7ece76ab36c6c3947e34df9f53f"
+ dependencies = [
+  "anyhow",
+  "glob",
+@@ -10164,7 +9755,7 @@ dependencies = [
   "serde",
   "serde_json",
   "tauri-utils",
-- "toml 0.9.8",
-+ "toml 0.9.10+spec-1.1.0",
+- "toml 0.9.10+spec-1.1.0",
++ "toml 0.9.11+spec-1.1.0",
   "walkdir",
  ]
  
-@@ -10020,7 +9933,7 @@ dependencies = [
-  "thiserror 2.0.17",
-  "tracing",
-  "url",
-- "windows-registry",
-+ "windows-registry 0.5.3",
-  "windows-result 0.3.4",
+@@ -10180,14 +9771,14 @@ dependencies = [
+  "serde_json",
+  "tauri",
+  "tauri-plugin",
+- "thiserror 2.0.17",
++ "thiserror 2.0.18",
  ]
  
-@@ -10060,7 +9973,7 @@ dependencies = [
+ [[package]]
+ name = "tauri-plugin-deep-link"
+-version = "2.4.5"
++version = "2.4.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "6e82759f7c7d51de3cbde51c04b3f2332de52436ed84541182cd8944b04e9e73"
++checksum = "444b091f24f2f6bdb4a305b54d3961f629c11861c685aceeea9a1972f89e43d5"
+ dependencies = [
+  "dunce",
+  "plist",
+@@ -10197,7 +9788,7 @@ dependencies = [
+  "tauri",
   "tauri-plugin",
   "tauri-utils",
-  "thiserror 2.0.17",
-- "toml 0.9.8",
-+ "toml 0.9.10+spec-1.1.0",
+- "thiserror 2.0.17",
++ "thiserror 2.0.18",
+  "tracing",
+  "url",
+  "windows-registry 0.5.3",
+@@ -10206,9 +9797,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "tauri-plugin-dialog"
+-version = "2.4.2"
++version = "2.6.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "313f8138692ddc4a2127c4c9607d616a46f5c042e77b3722450866da0aad2f19"
++checksum = "9204b425d9be8d12aa60c2a83a289cf7d1caae40f57f336ed1155b3a5c0e359b"
+ dependencies = [
+  "log",
+  "raw-window-handle",
+@@ -10218,15 +9809,15 @@ dependencies = [
+  "tauri",
+  "tauri-plugin",
+  "tauri-plugin-fs",
+- "thiserror 2.0.17",
++ "thiserror 2.0.18",
   "url",
  ]
  
-@@ -10071,11 +9984,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "c00685aceab12643cf024f712ab0448ba8fcadf86f2391d49d2e5aa732aacc70"
+ [[package]]
+ name = "tauri-plugin-fs"
+-version = "2.4.4"
++version = "2.4.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "47df422695255ecbe7bac7012440eddaeefd026656171eac9559f5243d3230d9"
++checksum = "ed390cc669f937afeb8b28032ce837bac8ea023d975a2e207375ec05afaf1804"
+ dependencies = [
+  "anyhow",
+  "dunce",
+@@ -10239,16 +9830,16 @@ dependencies = [
+  "tauri",
+  "tauri-plugin",
+  "tauri-utils",
+- "thiserror 2.0.17",
+- "toml 0.9.10+spec-1.1.0",
++ "thiserror 2.0.18",
++ "toml 0.9.11+spec-1.1.0",
+  "url",
+ ]
+ 
+ [[package]]
+ name = "tauri-plugin-http"
+-version = "2.5.4"
++version = "2.5.7"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c00685aceab12643cf024f712ab0448ba8fcadf86f2391d49d2e5aa732aacc70"
++checksum = "d8f069451c4e87e7e2636b7f065a4c52866c4ce5e60e2d53fa1038edb6d184dc"
  dependencies = [
   "bytes",
-- "cookie_store",
-+ "cookie_store 0.21.1",
-  "data-url",
-  "http 1.4.0",
-  "regex",
-- "reqwest 0.12.24",
-+ "reqwest 0.12.27",
-  "schemars 0.8.22",
-  "serde",
-  "serde_json",
-@@ -10098,8 +10011,8 @@ dependencies = [
+  "cookie_store 0.21.1",
+@@ -10262,7 +9853,7 @@ dependencies = [
+  "tauri",
+  "tauri-plugin",
+  "tauri-plugin-fs",
+- "thiserror 2.0.17",
++ "thiserror 2.0.18",
+  "tokio",
+  "url",
+  "urlpattern",
+@@ -10270,23 +9861,23 @@ dependencies = [
+ 
+ [[package]]
+ name = "tauri-plugin-log"
+-version = "2.7.1"
++version = "2.8.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d5709c792b8630290b5d9811a1f8fe983dd925fc87c7fc7f4923616458cd00b6"
++checksum = "7545bd67f070a4500432c826e2e0682146a1d6712aee22a2786490156b574d93"
+ dependencies = [
+  "android_logger",
   "byte-unit",
   "fern",
   "log",
@@ -2819,16 +4543,131 @@ index 6ee5075ea..291e43241 100644
   "serde",
   "serde_json",
   "serde_repr",
-@@ -10218,7 +10131,7 @@ dependencies = [
+  "swift-rs",
+  "tauri",
+  "tauri-plugin",
+- "thiserror 2.0.17",
++ "thiserror 2.0.18",
+  "time",
+ ]
+ 
+@@ -10305,7 +9896,7 @@ dependencies = [
+  "sys-locale",
+  "tauri",
+  "tauri-plugin",
+- "thiserror 2.0.17",
++ "thiserror 2.0.18",
+ ]
+ 
+ [[package]]
+@@ -10320,9 +9911,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "tauri-plugin-shell"
+-version = "2.3.3"
++version = "2.3.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c374b6db45f2a8a304f0273a15080d98c70cde86178855fc24653ba657a1144c"
++checksum = "8457dbf9e2bab1edd8df22bb2c20857a59a9868e79cb3eac5ed639eec4d0c73b"
+ dependencies = [
+  "encoding_rs",
+  "log",
+@@ -10335,38 +9926,38 @@ dependencies = [
+  "shared_child",
+  "tauri",
+  "tauri-plugin",
+- "thiserror 2.0.17",
++ "thiserror 2.0.18",
+  "tokio",
+ ]
+ 
+ [[package]]
+ name = "tauri-plugin-single-instance"
+-version = "2.3.6"
++version = "2.3.7"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "dd707f8c86b4e3004e2c141fa24351f1909ba40ce1b8437e30d5ed5277dd3710"
++checksum = "acba6b5ca527a96cdfcc96ae09b09ccb91ddff5e33978ca6873b96ea16bb404c"
+ dependencies = [
+  "serde",
+  "serde_json",
+  "tauri",
+  "tauri-plugin-deep-link",
+- "thiserror 2.0.17",
++ "thiserror 2.0.18",
+  "tracing",
+  "windows-sys 0.60.2",
+- "zbus 5.12.0",
++ "zbus 5.13.2",
+ ]
+ 
+ [[package]]
+ name = "tauri-plugin-store"
+-version = "2.4.1"
++version = "2.4.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "59a77036340a97eb5bbe1b3209c31e5f27f75e6f92a52fd9dd4b211ef08bf310"
++checksum = "5ca1a8ff83c269b115e98726ffc13f9e548a10161544a92ad121d6d0a96e16ea"
+ dependencies = [
+  "dunce",
+  "serde",
+  "serde_json",
+  "tauri",
+  "tauri-plugin",
+- "thiserror 2.0.17",
++ "thiserror 2.0.18",
+  "tokio",
+  "tracing",
+ ]
+@@ -10384,9 +9975,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "tauri-plugin-updater"
+-version = "2.9.0"
++version = "2.10.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "27cbc31740f4d507712550694749572ec0e43bdd66992db7599b89fbfd6b167b"
++checksum = "3fe8e9bebd88fc222938ffdfbdcfa0307081423bd01e3252fc337d8bde81fc61"
+ dependencies = [
+  "base64 0.22.1",
+  "dirs 6.0.0",
+@@ -10398,7 +9989,8 @@ dependencies = [
   "minisign-verify",
   "osakit",
   "percent-encoding",
-- "reqwest 0.12.24",
-+ "reqwest 0.12.27",
+- "reqwest 0.12.28",
++ "reqwest 0.13.1",
++ "rustls 0.23.36",
   "semver",
   "serde",
   "serde_json",
-@@ -10260,7 +10173,7 @@ dependencies = [
+@@ -10406,7 +9998,7 @@ dependencies = [
+  "tauri",
+  "tauri-plugin",
+  "tempfile",
+- "thiserror 2.0.17",
++ "thiserror 2.0.18",
+  "time",
+  "tokio",
+  "url",
+@@ -10426,28 +10018,28 @@ dependencies = [
+  "serde_json",
+  "tauri",
+  "tauri-plugin",
+- "thiserror 2.0.17",
++ "thiserror 2.0.18",
+ ]
+ 
+ [[package]]
+ name = "tauri-runtime"
+-version = "2.9.2"
++version = "2.10.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "87f766fe9f3d1efc4b59b17e7a891ad5ed195fa8d23582abb02e6c9a01137892"
++checksum = "b885ffeac82b00f1f6fd292b6e5aabfa7435d537cef57d11e38a489956535651"
+ dependencies = [
+  "cookie",
+  "dpi",
   "gtk",
   "http 1.4.0",
   "jni",
@@ -2837,15 +4676,23 @@ index 6ee5075ea..291e43241 100644
   "objc2-ui-kit",
   "objc2-web-kit",
   "raw-window-handle",
-@@ -10276,17 +10189,17 @@ dependencies = [
+  "serde",
+  "serde_json",
+  "tauri-utils",
+- "thiserror 2.0.17",
++ "thiserror 2.0.18",
+  "url",
+  "webkit2gtk",
+  "webview2-com",
+@@ -10456,17 +10048,17 @@ dependencies = [
  
  [[package]]
  name = "tauri-runtime-wry"
--version = "2.9.2"
-+version = "2.9.3"
+-version = "2.9.3"
++version = "2.10.0"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "7950f3bde6bcca6655bc5e76d3d6ec587ceb81032851ab4ddbe1f508bdea2729"
-+checksum = "187a3f26f681bdf028f796ccf57cf478c1ee422c50128e5a0a6ebeb3f5910065"
+-checksum = "187a3f26f681bdf028f796ccf57cf478c1ee422c50128e5a0a6ebeb3f5910065"
++checksum = "5204682391625e867d16584fedc83fc292fb998814c9f7918605c789cd876314"
  dependencies = [
   "gtk",
   "http 1.4.0",
@@ -2859,43 +4706,144 @@ index 6ee5075ea..291e43241 100644
   "once_cell",
   "percent-encoding",
   "raw-window-handle",
-@@ -10332,7 +10245,7 @@ dependencies = [
+@@ -10483,9 +10075,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "tauri-utils"
+-version = "2.8.1"
++version = "2.8.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "76a423c51176eb3616ee9b516a9fa67fed5f0e78baaba680e44eb5dd2cc37490"
++checksum = "fcd169fccdff05eff2c1033210b9b94acd07a47e6fa9a3431cf09cfd4f01c87e"
+ dependencies = [
+  "anyhow",
+  "brotli",
+@@ -10511,8 +10103,8 @@ dependencies = [
+  "serde_json",
   "serde_with",
   "swift-rs",
-  "thiserror 2.0.17",
-- "toml 0.9.8",
-+ "toml 0.9.10+spec-1.1.0",
+- "thiserror 2.0.17",
+- "toml 0.9.10+spec-1.1.0",
++ "thiserror 2.0.18",
++ "toml 0.9.11+spec-1.1.0",
   "url",
   "urlpattern",
   "uuid",
-@@ -10347,7 +10260,7 @@ checksum = "1087b111fe2b005e42dbdc1990fc18593234238d47453b0c99b7de1c9ab2c1e0"
+@@ -10527,7 +10119,7 @@ checksum = "1087b111fe2b005e42dbdc1990fc18593234238d47453b0c99b7de1c9ab2c1e0"
  dependencies = [
   "dunce",
   "embed-resource",
-- "toml 0.9.8",
-+ "toml 0.9.10+spec-1.1.0",
+- "toml 0.9.10+spec-1.1.0",
++ "toml 0.9.11+spec-1.1.0",
  ]
  
  [[package]]
-@@ -10371,7 +10284,7 @@ dependencies = [
+@@ -10537,7 +10129,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9"
+ dependencies = [
+  "quick-xml 0.37.5",
+- "thiserror 2.0.17",
++ "thiserror 2.0.18",
+  "windows 0.61.3",
+  "windows-version",
+ ]
+@@ -10551,7 +10143,7 @@ dependencies = [
   "fastrand",
   "getrandom 0.3.4",
   "once_cell",
-- "rustix 1.1.2",
+- "rustix 1.1.3",
 + "rustix",
   "windows-sys 0.61.2",
  ]
  
-@@ -10401,7 +10314,7 @@ version = "0.4.3"
+@@ -10581,7 +10173,7 @@ version = "0.4.3"
  source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
  dependencies = [
-- "rustix 1.1.2",
+- "rustix 1.1.3",
 + "rustix",
   "windows-sys 0.60.2",
  ]
  
-@@ -10558,7 +10471,7 @@ checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
+@@ -10611,11 +10203,11 @@ dependencies = [
+ 
+ [[package]]
+ name = "thiserror"
+-version = "2.0.17"
++version = "2.0.18"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
++checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+ dependencies = [
+- "thiserror-impl 2.0.17",
++ "thiserror-impl 2.0.18",
+ ]
+ 
+ [[package]]
+@@ -10626,18 +10218,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.112",
++ "syn 2.0.114",
+ ]
+ 
+ [[package]]
+ name = "thiserror-impl"
+-version = "2.0.17"
++version = "2.0.18"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
++checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.112",
++ "syn 2.0.114",
+ ]
+ 
+ [[package]]
+@@ -10665,9 +10257,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "time"
+-version = "0.3.44"
++version = "0.3.46"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
++checksum = "9da98b7d9b7dad93488a84b8248efc35352b0b2657397d4167e7ad67e5d535e5"
+ dependencies = [
+  "deranged",
+  "itoa",
+@@ -10675,22 +10267,22 @@ dependencies = [
+  "num-conv",
+  "num_threads",
+  "powerfmt",
+- "serde",
++ "serde_core",
+  "time-core",
+  "time-macros",
+ ]
+ 
+ [[package]]
+ name = "time-core"
+-version = "0.1.6"
++version = "0.1.8"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
++checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+ 
+ [[package]]
+ name = "time-macros"
+-version = "0.2.24"
++version = "0.2.26"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
++checksum = "78cc610bac2dcee56805c99642447d4c5dbde4d01f752ffea0199aee1f601dc4"
+ dependencies = [
+  "num-conv",
+  "time-core",
+@@ -10738,11 +10330,11 @@ checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
  dependencies = [
   "bytes",
   "libc",
@@ -2904,38 +4852,85 @@ index 6ee5075ea..291e43241 100644
   "parking_lot",
   "pin-project-lite",
   "signal-hook-registry",
-@@ -10649,14 +10562,14 @@ dependencies = [
+- "socket2 0.6.1",
++ "socket2 0.6.2",
+  "tokio-macros",
+  "tracing",
+  "windows-sys 0.61.2",
+@@ -10756,7 +10348,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.112",
++ "syn 2.0.114",
+ ]
+ 
+ [[package]]
+@@ -10785,15 +10377,15 @@ version = "0.26.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+ dependencies = [
+- "rustls 0.23.35",
++ "rustls 0.23.36",
+  "tokio",
+ ]
+ 
+ [[package]]
+ name = "tokio-stream"
+-version = "0.1.17"
++version = "0.1.18"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
++checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+ dependencies = [
+  "futures-core",
+  "pin-project-lite",
+@@ -10814,9 +10406,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "tokio-util"
+-version = "0.7.17"
++version = "0.7.18"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2efa149fe76073d6e8fd97ef4f4eca7b67f599660115591483572e406e165594"
++checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+ dependencies = [
+  "bytes",
+  "futures-core",
+@@ -10839,11 +10431,11 @@ dependencies = [
  
  [[package]]
  name = "toml"
--version = "0.9.8"
-+version = "0.9.10+spec-1.1.0"
+-version = "0.9.10+spec-1.1.0"
++version = "0.9.11+spec-1.1.0"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "f0dc8b1fb61449e27716ec0e1bdf0f6b8f3e8f6b05391e8497b8b6d7804ea6d8"
-+checksum = "0825052159284a1a8b4d6c0c86cbc801f2da5afd2b225fa548c72f2e74002f48"
+-checksum = "0825052159284a1a8b4d6c0c86cbc801f2da5afd2b225fa548c72f2e74002f48"
++checksum = "f3afc9a848309fe1aaffaed6e1546a7a14de1f935dc9d89d32afd9a44bab7c46"
  dependencies = [
-  "indexmap 2.12.1",
+- "indexmap 2.12.1",
++ "indexmap 2.13.0",
   "serde_core",
-- "serde_spanned 1.0.3",
-- "toml_datetime 0.7.3",
-+ "serde_spanned 1.0.4",
-+ "toml_datetime 0.7.5+spec-1.1.0",
-  "toml_parser",
-  "toml_writer",
-  "winnow 0.7.14",
-@@ -10673,9 +10586,9 @@ dependencies = [
- 
- [[package]]
- name = "toml_datetime"
--version = "0.7.3"
-+version = "0.7.5+spec-1.1.0"
+  "serde_spanned 1.0.4",
+  "toml_datetime 0.7.5+spec-1.1.0",
+@@ -10876,7 +10468,7 @@ version = "0.19.15"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "f2cdb639ebbc97961c51720f858597f7f24c4fc295327923af55b74c3c724533"
-+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+ checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
  dependencies = [
-  "serde_core",
+- "indexmap 2.12.1",
++ "indexmap 2.13.0",
+  "toml_datetime 0.6.3",
+  "winnow 0.5.40",
  ]
-@@ -10706,30 +10619,30 @@ dependencies = [
+@@ -10887,7 +10479,7 @@ version = "0.20.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
+ dependencies = [
+- "indexmap 2.12.1",
++ "indexmap 2.13.0",
+  "serde",
+  "serde_spanned 0.6.9",
+  "toml_datetime 0.6.3",
+@@ -10896,11 +10488,11 @@ dependencies = [
  
  [[package]]
  name = "toml_edit"
@@ -2945,71 +4940,113 @@ index 6ee5075ea..291e43241 100644
 -checksum = "6485ef6d0d9b5d0ec17244ff7eb05310113c3f316f2d14200d4de56b3cb98f8d"
 +checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
  dependencies = [
-  "indexmap 2.12.1",
-- "toml_datetime 0.7.3",
-+ "toml_datetime 0.7.5+spec-1.1.0",
+- "indexmap 2.12.1",
++ "indexmap 2.13.0",
+  "toml_datetime 0.7.5+spec-1.1.0",
   "toml_parser",
   "winnow 0.7.14",
- ]
- 
- [[package]]
- name = "toml_parser"
--version = "1.0.4"
-+version = "1.0.6+spec-1.1.0"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
-+checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
- dependencies = [
-  "winnow 0.7.14",
- ]
- 
- [[package]]
- name = "toml_writer"
--version = "1.0.4"
-+version = "1.0.6+spec-1.1.0"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "df8b2b54733674ad286d16267dcfc7a71ed5c776e4ac7aa3c3e2561f7c637bf2"
-+checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+@@ -10923,15 +10515,15 @@ checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
  
  [[package]]
  name = "tonic"
-@@ -10792,9 +10705,9 @@ dependencies = [
- 
- [[package]]
- name = "tower-http"
--version = "0.6.7"
-+version = "0.6.8"
+-version = "0.14.2"
++version = "0.14.3"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "9cf146f99d442e8e68e585f5d798ccd3cad9a7835b917e09728880a862706456"
-+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+-checksum = "eb7613188ce9f7df5bfe185db26c5814347d110db17920415cf2fbcad85e7203"
++checksum = "a286e33f82f8a1ee2df63f4fa35c0becf4a85a0cb03091a15fd7bf0b402dc94a"
  dependencies = [
-  "bitflags 2.10.0",
+  "async-trait",
+  "axum",
+  "base64 0.22.1",
   "bytes",
-@@ -10822,9 +10735,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+- "h2 0.4.12",
++ "h2 0.4.13",
+  "http 1.4.0",
+  "http-body 1.0.1",
+  "http-body-util",
+@@ -10940,7 +10532,7 @@ dependencies = [
+  "hyper-util",
+  "percent-encoding",
+  "pin-project",
+- "socket2 0.6.1",
++ "socket2 0.6.2",
+  "sync_wrapper 1.0.2",
+  "tokio",
+  "tokio-stream",
+@@ -10952,9 +10544,9 @@ dependencies = [
  
  [[package]]
- name = "tracing"
--version = "0.1.43"
-+version = "0.1.44"
+ name = "tonic-prost"
+-version = "0.14.2"
++version = "0.14.3"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "2d15d90a0b5c19378952d479dc858407149d7bb45a14de0142f6c534b16fc647"
-+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+-checksum = "66bd50ad6ce1252d87ef024b3d64fe4c3cf54a86fb9ef4c631fdd0ded7aeaa67"
++checksum = "d6c55a2d6a14174563de34409c9f92ff981d006f56da9c6ecd40d9d4a31500b0"
  dependencies = [
-  "log",
+  "bytes",
+  "prost",
+@@ -10963,13 +10555,13 @@ dependencies = [
+ 
+ [[package]]
+ name = "tower"
+-version = "0.5.2"
++version = "0.5.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
++checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+ dependencies = [
+  "futures-core",
+  "futures-util",
+- "indexmap 2.12.1",
++ "indexmap 2.13.0",
   "pin-project-lite",
-@@ -10857,9 +10770,9 @@ dependencies = [
+  "slab",
+  "sync_wrapper 1.0.2",
+@@ -11029,7 +10621,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
+ dependencies = [
+  "crossbeam-channel",
+- "thiserror 2.0.17",
++ "thiserror 2.0.18",
+  "time",
+  "tracing-subscriber",
+ ]
+@@ -11042,7 +10634,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.112",
++ "syn 2.0.114",
+ ]
  
  [[package]]
- name = "tracing-core"
--version = "0.1.35"
-+version = "0.1.36"
+@@ -11057,12 +10649,12 @@ dependencies = [
+ 
+ [[package]]
+ name = "tracing-forest"
+-version = "0.3.0"
++version = "0.3.1"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "7a04e24fab5c89c6a36eb8558c9656f30d81de51dfa4d3b45f26b21d61fa0a6c"
-+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+-checksum = "92bdb3c949c9e81b71f78ba782f956b896019d82cc2f31025d21e04adab4d695"
++checksum = "f09cb459317a3811f76644334473239d696cd8efc606963ae7d1c308cead3b74"
  dependencies = [
-  "once_cell",
-  "valuable",
-@@ -10916,11 +10829,11 @@ dependencies = [
+  "smallvec",
+- "thiserror 2.0.17",
++ "thiserror 2.0.18",
+  "tracing",
+  "tracing-subscriber",
+ ]
+@@ -11098,23 +10690,23 @@ dependencies = [
+ 
+ [[package]]
+ name = "tray-icon"
+-version = "0.21.2"
++version = "0.21.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e3d5572781bee8e3f994d7467084e1b1fd7a93ce66bd480f8156ba89dee55a2b"
++checksum = "a5e85aa143ceb072062fc4d6356c1b520a51d636e7bc8e77ec94be3608e5e80c"
+ dependencies = [
+  "crossbeam-channel",
   "dirs 6.0.0",
   "libappindicator",
   "muda",
@@ -3023,109 +5060,330 @@ index 6ee5075ea..291e43241 100644
   "once_cell",
   "png 0.17.16",
   "serde",
-@@ -11092,9 +11005,9 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+- "thiserror 2.0.17",
++ "thiserror 2.0.18",
+  "windows-sys 0.60.2",
+ ]
  
- [[package]]
- name = "unicode-width"
--version = "0.2.0"
-+version = "0.2.2"
+@@ -11141,7 +10733,7 @@ version = "11.1.0"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
-+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+ checksum = "4994acea2522cd2b3b85c1d9529a55991e3ad5e25cdcd3de9d505972c4379424"
+ dependencies = [
+- "thiserror 2.0.17",
++ "thiserror 2.0.18",
+  "ts-rs-macros",
+ ]
+ 
+@@ -11153,7 +10745,7 @@ checksum = "ee6ff59666c9cbaec3533964505d39154dc4e0a56151fdea30a09ed0301f62e2"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.112",
++ "syn 2.0.114",
+  "termcolor",
+ ]
+ 
+@@ -11170,7 +10762,7 @@ dependencies = [
+  "log",
+  "rand 0.9.2",
+  "sha1",
+- "thiserror 2.0.17",
++ "thiserror 2.0.18",
+  "utf-8",
+ ]
+ 
+@@ -11249,9 +10841,9 @@ dependencies = [
  
  [[package]]
- name = "untrusted"
-@@ -11255,9 +11168,9 @@ dependencies = [
+ name = "unicase"
+-version = "2.8.1"
++version = "2.9.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
++checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+ 
+ [[package]]
+ name = "unicode-bom"
+@@ -11294,14 +10886,15 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+ 
+ [[package]]
+ name = "url"
+-version = "2.5.7"
++version = "2.5.8"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
++checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+ dependencies = [
+  "form_urlencoded",
+  "idna",
+  "percent-encoding",
+  "serde",
++ "serde_derive",
+ ]
+ 
+ [[package]]
+@@ -11342,9 +10935,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+ 
+ [[package]]
+ name = "uuid"
+-version = "1.19.0"
++version = "1.20.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
++checksum = "ee48d38b119b0cd71fe4141b30f5ba9c7c5d9f4e7a3a8b4a674e4b6ef789976f"
+ dependencies = [
+  "getrandom 0.3.4",
+  "js-sys",
+@@ -11435,18 +11028,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+ 
+ [[package]]
+ name = "wasip2"
+-version = "1.0.1+wasi-0.2.4"
++version = "1.0.2+wasi-0.2.9"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
++checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+ dependencies = [
+  "wit-bindgen",
+ ]
  
  [[package]]
  name = "wasm-bindgen"
 -version = "0.2.105"
-+version = "0.2.106"
++version = "0.2.108"
  source = "registry+https://github.com/rust-lang/crates.io-index"
 -checksum = "da95793dfc411fbbd93f5be7715b0578ec61fe87cb1a42b12eb625caa5c5ea60"
-+checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
++checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
  dependencies = [
   "cfg-if",
   "once_cell",
-@@ -11268,9 +11181,9 @@ dependencies = [
+@@ -11457,11 +11050,12 @@ dependencies = [
  
  [[package]]
  name = "wasm-bindgen-futures"
 -version = "0.4.55"
-+version = "0.4.56"
++version = "0.4.58"
  source = "registry+https://github.com/rust-lang/crates.io-index"
 -checksum = "551f88106c6d5e7ccc7cd9a16f312dd3b5d36ea8b4954304657d5dfba115d4a0"
-+checksum = "836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c"
++checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
  dependencies = [
   "cfg-if",
++ "futures-util",
   "js-sys",
-@@ -11281,9 +11194,9 @@ dependencies = [
+  "once_cell",
+  "wasm-bindgen",
+@@ -11470,9 +11064,9 @@ dependencies = [
  
  [[package]]
  name = "wasm-bindgen-macro"
 -version = "0.2.105"
-+version = "0.2.106"
++version = "0.2.108"
  source = "registry+https://github.com/rust-lang/crates.io-index"
 -checksum = "04264334509e04a7bf8690f2384ef5265f05143a4bff3889ab7a3269adab59c2"
-+checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
++checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
  dependencies = [
   "quote",
   "wasm-bindgen-macro-support",
-@@ -11291,9 +11204,9 @@ dependencies = [
+@@ -11480,22 +11074,22 @@ dependencies = [
  
  [[package]]
  name = "wasm-bindgen-macro-support"
 -version = "0.2.105"
-+version = "0.2.106"
++version = "0.2.108"
  source = "registry+https://github.com/rust-lang/crates.io-index"
 -checksum = "420bc339d9f322e562942d52e115d57e950d12d88983a14c79b86859ee6c7ebc"
-+checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
++checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
  dependencies = [
   "bumpalo",
   "proc-macro2",
-@@ -11304,9 +11217,9 @@ dependencies = [
+  "quote",
+- "syn 2.0.112",
++ "syn 2.0.114",
+  "wasm-bindgen-shared",
+ ]
  
  [[package]]
  name = "wasm-bindgen-shared"
 -version = "0.2.105"
-+version = "0.2.106"
++version = "0.2.108"
  source = "registry+https://github.com/rust-lang/crates.io-index"
 -checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
-+checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
++checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
  dependencies = [
   "unicode-ident",
  ]
-@@ -11332,7 +11245,7 @@ checksum = "673a33c33048a5ade91a6b139580fa174e19fb0d23f396dca9fa15f2e1e49b35"
+@@ -11515,35 +11109,34 @@ dependencies = [
+ 
+ [[package]]
+ name = "wayland-backend"
+-version = "0.3.11"
++version = "0.3.12"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "673a33c33048a5ade91a6b139580fa174e19fb0d23f396dca9fa15f2e1e49b35"
++checksum = "fee64194ccd96bf648f42a65a7e589547096dfa702f7cadef84347b66ad164f9"
  dependencies = [
   "cc",
-  "downcast-rs 1.2.1",
-- "rustix 1.1.2",
+  "downcast-rs",
+- "rustix 1.1.3",
+- "scoped-tls",
 + "rustix",
-  "scoped-tls",
   "smallvec",
   "wayland-sys",
-@@ -11345,7 +11258,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "c66a47e840dc20793f2264eb4b3e4ecb4b75d91c0dd4af04b456128e0bdd449d"
+ ]
+ 
+ [[package]]
+ name = "wayland-client"
+-version = "0.31.11"
++version = "0.31.12"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c66a47e840dc20793f2264eb4b3e4ecb4b75d91c0dd4af04b456128e0bdd449d"
++checksum = "b8e6faa537fbb6c186cb9f1d41f2f811a4120d1b57ec61f50da451a0c5122bec"
  dependencies = [
   "bitflags 2.10.0",
-- "rustix 1.1.2",
+- "rustix 1.1.3",
 + "rustix",
   "wayland-backend",
   "wayland-scanner",
  ]
-@@ -11399,9 +11312,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "wayland-protocols"
+-version = "0.32.9"
++version = "0.32.10"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "efa790ed75fbfd71283bd2521a1cfdc022aabcc28bdcff00851f9e4ae88d9901"
++checksum = "baeda9ffbcfc8cd6ddaade385eaf2393bd2115a69523c735f12242353c3df4f3"
+ dependencies = [
+  "bitflags 2.10.0",
+  "wayland-backend",
+@@ -11553,9 +11146,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "wayland-protocols-wlr"
+-version = "0.3.9"
++version = "0.3.10"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "efd94963ed43cf9938a090ca4f7da58eb55325ec8200c3848963e98dc25b78ec"
++checksum = "e9597cdf02cf0c34cd5823786dce6b5ae8598f05c2daf5621b6e178d4f7345f3"
+ dependencies = [
+  "bitflags 2.10.0",
+  "wayland-backend",
+@@ -11566,31 +11159,29 @@ dependencies = [
+ 
+ [[package]]
+ name = "wayland-scanner"
+-version = "0.31.7"
++version = "0.31.8"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "54cb1e9dc49da91950bdfd8b848c49330536d9d1fb03d4bfec8cae50caa50ae3"
++checksum = "5423e94b6a63e68e439803a3e153a9252d5ead12fd853334e2ad33997e3889e3"
+ dependencies = [
+  "proc-macro2",
+- "quick-xml 0.37.5",
++ "quick-xml 0.38.4",
+  "quote",
+ ]
+ 
+ [[package]]
+ name = "wayland-sys"
+-version = "0.31.7"
++version = "0.31.8"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "34949b42822155826b41db8e5d0c1be3a2bd296c747577a43a3e6daefc296142"
++checksum = "1e6dbfc3ac5ef974c92a2235805cc0114033018ae1290a72e474aa8b28cbbdfd"
+ dependencies = [
+- "dlib",
+- "log",
+  "pkg-config",
+ ]
  
  [[package]]
  name = "web-sys"
 -version = "0.3.82"
-+version = "0.3.83"
++version = "0.3.85"
  source = "registry+https://github.com/rust-lang/crates.io-index"
 -checksum = "3a1f95c0d03a47f4ae1f7a64643a6bb97465d9b740f0fa8f90ea33915c99a9a1"
-+checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
++checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
  dependencies = [
   "js-sys",
   "wasm-bindgen",
-@@ -11555,10 +11468,10 @@ version = "0.6.0"
+@@ -11608,9 +11199,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "webkit2gtk"
+-version = "2.0.1"
++version = "2.0.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "76b1bc1e54c581da1e9f179d0b38512ba358fb1af2d634a1affe42e37172361a"
++checksum = "a1027150013530fb2eaf806408df88461ae4815a45c541c8975e61d6f2fc4793"
+ dependencies = [
+  "bitflags 1.3.2",
+  "cairo-rs",
+@@ -11632,9 +11223,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "webkit2gtk-sys"
+-version = "2.0.1"
++version = "2.0.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "62daa38afc514d1f8f12b8693d30d5993ff77ced33ce30cd04deebc267a6d57c"
++checksum = "916a5f65c2ef0dfe12fff695960a2ec3d4565359fdbb2e9943c974e06c734ea5"
+ dependencies = [
+  "bitflags 1.3.2",
+  "cairo-sys-rs",
+@@ -11667,18 +11258,18 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+ 
+ [[package]]
+ name = "webpki-roots"
+-version = "1.0.4"
++version = "1.0.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b2878ef029c47c6e8cf779119f20fcf52bde7ad42a731b2a304bc221df17571e"
++checksum = "12bed680863276c63889429bfd6cab3b99943659923822de1c8a39c49e4d722c"
+ dependencies = [
+  "rustls-pki-types",
+ ]
+ 
+ [[package]]
+ name = "webview2-com"
+-version = "0.38.0"
++version = "0.38.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d4ba622a989277ef3886dd5afb3e280e3dd6d974b766118950a08f8f678ad6a4"
++checksum = "7130243a7a5b33c54a444e54842e6a9e133de08b5ad7b5861cd8ed9a6a5bc96a"
+ dependencies = [
+  "webview2-com-macros",
+  "webview2-com-sys",
+@@ -11690,22 +11281,22 @@ dependencies = [
+ 
+ [[package]]
+ name = "webview2-com-macros"
+-version = "0.8.0"
++version = "0.8.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1d228f15bba3b9d56dde8bddbee66fa24545bd17b48d5128ccf4a8742b18e431"
++checksum = "67a921c1b6914c367b2b823cd4cde6f96beec77d30a939c8199bb377cf9b9b54"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.112",
++ "syn 2.0.114",
+ ]
+ 
+ [[package]]
+ name = "webview2-com-sys"
+-version = "0.38.0"
++version = "0.38.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "36695906a1b53a3bf5c4289621efedac12b73eeb0b89e7e1a89b517302d5d75c"
++checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
+ dependencies = [
+- "thiserror 2.0.17",
++ "thiserror 2.0.18",
+  "windows 0.61.3",
+  "windows-core 0.61.2",
+ ]
+@@ -11753,10 +11344,10 @@ version = "0.6.0"
  source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "d9bec5a31f3f9362f2258fd0e9c9dd61a9ca432e7306cc78c444258f0dce9a9c"
  dependencies = [
@@ -3138,25 +5396,33 @@ index 6ee5075ea..291e43241 100644
   "raw-window-handle",
   "windows-sys 0.59.0",
   "windows-version",
-@@ -11720,6 +11633,17 @@ dependencies = [
-  "windows-strings 0.4.2",
+@@ -11861,7 +11452,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.112",
++ "syn 2.0.114",
  ]
  
-+[[package]]
-+name = "windows-registry"
-+version = "0.6.1"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
-+dependencies = [
-+ "windows-link 0.2.1",
-+ "windows-result 0.4.1",
-+ "windows-strings 0.5.1",
-+]
-+
  [[package]]
- name = "windows-result"
- version = "0.3.4"
-@@ -12126,15 +12050,14 @@ checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+@@ -11872,7 +11463,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.112",
++ "syn 2.0.114",
+ ]
+ 
+ [[package]]
+@@ -12329,22 +11920,21 @@ dependencies = [
+ 
+ [[package]]
+ name = "wit-bindgen"
+-version = "0.46.0"
++version = "0.51.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
++checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
  
  [[package]]
  name = "wl-clipboard-rs"
@@ -3171,12 +5437,21 @@ index 6ee5075ea..291e43241 100644
   "os_pipe",
 - "rustix 0.38.44",
 - "tempfile",
+- "thiserror 2.0.17",
 + "rustix",
-  "thiserror 2.0.17",
++ "thiserror 2.0.18",
   "tree_magic_mini",
   "wayland-backend",
-@@ -12156,7 +12079,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "728b7d4c8ec8d81cab295e0b5b8a4c263c0d41a785fb8f8c4df284e5411140a2"
+  "wayland-client",
+@@ -12360,12 +11950,12 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+ 
+ [[package]]
+ name = "wry"
+-version = "0.53.5"
++version = "0.54.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "728b7d4c8ec8d81cab295e0b5b8a4c263c0d41a785fb8f8c4df284e5411140a2"
++checksum = "5ed1a195b0375491dd15a7066a10251be217ce743cf4bbbbdcf5391d6473bee0"
  dependencies = [
   "base64 0.22.1",
 - "block2 0.6.2",
@@ -3184,7 +5459,7 @@ index 6ee5075ea..291e43241 100644
   "cookie",
   "crossbeam-channel",
   "dirs 6.0.0",
-@@ -12171,10 +12094,10 @@ dependencies = [
+@@ -12380,10 +11970,10 @@ dependencies = [
   "kuchikiki",
   "libc",
   "ndk",
@@ -3197,54 +5472,305 @@ index 6ee5075ea..291e43241 100644
   "objc2-ui-kit",
   "objc2-web-kit",
   "once_cell",
-@@ -12231,7 +12154,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+@@ -12392,7 +11982,7 @@ dependencies = [
+  "sha2",
+  "soup3",
+  "tao-macros",
+- "thiserror 2.0.17",
++ "thiserror 2.0.18",
+  "url",
+  "webkit2gtk",
+  "webkit2gtk-sys",
+@@ -12440,7 +12030,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
  dependencies = [
   "gethostname",
-- "rustix 1.1.2",
+- "rustix 1.1.3",
 + "rustix",
   "x11rb-protocol",
  ]
  
-@@ -12248,7 +12171,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+@@ -12457,7 +12047,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
  dependencies = [
   "libc",
-- "rustix 1.1.2",
+- "rustix 1.1.3",
 + "rustix",
  ]
  
  [[package]]
-@@ -12517,9 +12440,9 @@ dependencies = [
+@@ -12495,7 +12085,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.112",
++ "syn 2.0.114",
+  "synstructure",
+ ]
+ 
+@@ -12533,9 +12123,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "zbus"
+-version = "5.12.0"
++version = "5.13.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b622b18155f7a93d1cd2dc8c01d2d6a44e08fb9ebb7b3f9e6ed101488bad6c91"
++checksum = "1bfeff997a0aaa3eb20c4652baf788d2dfa6d2839a0ead0b3ff69ce2f9c4bdd1"
+ dependencies = [
+  "async-broadcast",
+  "async-executor",
+@@ -12551,19 +12141,19 @@ dependencies = [
+  "futures-core",
+  "futures-lite",
+  "hex",
+- "nix 0.30.1",
++ "libc",
+  "ordered-stream",
++ "rustix",
+  "serde",
+  "serde_repr",
+- "tokio",
+  "tracing",
+  "uds_windows",
+  "uuid",
+  "windows-sys 0.61.2",
+  "winnow 0.7.14",
+- "zbus_macros 5.12.0",
+- "zbus_names 4.2.0",
+- "zvariant 5.8.0",
++ "zbus_macros 5.13.2",
++ "zbus_names 4.3.1",
++ "zvariant 5.9.2",
+ ]
+ 
+ [[package]]
+@@ -12575,23 +12165,23 @@ dependencies = [
+  "proc-macro-crate 3.4.0",
+  "proc-macro2",
+  "quote",
+- "syn 2.0.112",
++ "syn 2.0.114",
+  "zvariant_utils 2.1.0",
+ ]
+ 
+ [[package]]
+ name = "zbus_macros"
+-version = "5.12.0"
++version = "5.13.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1cdb94821ca8a87ca9c298b5d1cbd80e2a8b67115d99f6e4551ac49e42b6a314"
++checksum = "0bbd5a90dbe8feee5b13def448427ae314ccd26a49cac47905cafefb9ff846f1"
+ dependencies = [
+  "proc-macro-crate 3.4.0",
+  "proc-macro2",
+  "quote",
+- "syn 2.0.112",
+- "zbus_names 4.2.0",
+- "zvariant 5.8.0",
+- "zvariant_utils 3.2.1",
++ "syn 2.0.114",
++ "zbus_names 4.3.1",
++ "zvariant 5.9.2",
++ "zvariant_utils 3.3.0",
+ ]
+ 
+ [[package]]
+@@ -12607,34 +12197,33 @@ dependencies = [
+ 
+ [[package]]
+ name = "zbus_names"
+-version = "4.2.0"
++version = "4.3.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7be68e64bf6ce8db94f63e72f0c7eb9a60d733f7e0499e628dfab0f84d6bcb97"
++checksum = "ffd8af6d5b78619bab301ff3c560a5bd22426150253db278f164d6cf3b72c50f"
+ dependencies = [
+  "serde",
+- "static_assertions",
+  "winnow 0.7.14",
+- "zvariant 5.8.0",
++ "zvariant 5.9.2",
+ ]
+ 
+ [[package]]
+ name = "zerocopy"
+-version = "0.8.31"
++version = "0.8.37"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "fd74ec98b9250adb3ca554bdde269adf631549f51d8a8f8f0a10b50f1cb298c3"
++checksum = "7456cf00f0685ad319c5b1693f291a650eaf345e941d082fc4e03df8a03996ac"
+ dependencies = [
+  "zerocopy-derive",
+ ]
+ 
+ [[package]]
+ name = "zerocopy-derive"
+-version = "0.8.31"
++version = "0.8.37"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
++checksum = "1328722bbf2115db7e19d69ebcc15e795719e2d66b60827c6a69a117365e37a0"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.112",
++ "syn 2.0.114",
+ ]
+ 
+ [[package]]
+@@ -12654,7 +12243,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.112",
++ "syn 2.0.114",
+  "synstructure",
+ ]
+ 
+@@ -12669,13 +12258,13 @@ dependencies = [
+ 
+ [[package]]
+ name = "zeroize_derive"
+-version = "1.4.2"
++version = "1.4.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
++checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.112",
++ "syn 2.0.114",
+ ]
+ 
+ [[package]]
+@@ -12708,7 +12297,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.112",
++ "syn 2.0.114",
+ ]
+ 
+ [[package]]
+@@ -12720,21 +12309,21 @@ dependencies = [
+  "arbitrary",
+  "bzip2",
+  "crc32fast",
+- "indexmap 2.12.1",
++ "indexmap 2.13.0",
+  "memchr",
+ ]
  
  [[package]]
  name = "zlib-rs"
--version = "0.5.2"
-+version = "0.5.4"
+-version = "0.6.0"
++version = "0.5.5"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "2f06ae92f42f5e5c42443fd094f245eb656abf56dd7cce9b8b263236565e00f2"
-+checksum = "51f936044d677be1a1168fae1d03b583a285a5dd9d8cbf7b24c23aa1fc775235"
+-checksum = "a7948af682ccbc3342b6e9420e8c51c1fe5d7bf7756002b4a3c6cabfe96a7e3c"
++checksum = "40990edd51aae2c2b6907af74ffb635029d5788228222c4bb811e9351c0caad3"
+ 
+ [[package]]
+ name = "zmij"
+-version = "1.0.6"
++version = "1.0.19"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "aac060176f7020d62c3bcc1cdbcec619d54f48b07ad1963a3f80ce7a0c17755f"
++checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"
  
  [[package]]
  name = "zune-core"
+@@ -12766,17 +12355,17 @@ dependencies = [
+ 
+ [[package]]
+ name = "zvariant"
+-version = "5.8.0"
++version = "5.9.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2be61892e4f2b1772727be11630a62664a1826b62efa43a6fe7449521cb8744c"
++checksum = "68b64ef4f40c7951337ddc7023dd03528a57a3ce3408ee9da5e948bd29b232c4"
+ dependencies = [
+  "endi",
+  "enumflags2",
+  "serde",
+  "url",
+  "winnow 0.7.14",
+- "zvariant_derive 5.8.0",
+- "zvariant_utils 3.2.1",
++ "zvariant_derive 5.9.2",
++ "zvariant_utils 3.3.0",
+ ]
+ 
+ [[package]]
+@@ -12788,21 +12377,21 @@ dependencies = [
+  "proc-macro-crate 3.4.0",
+  "proc-macro2",
+  "quote",
+- "syn 2.0.112",
++ "syn 2.0.114",
+  "zvariant_utils 2.1.0",
+ ]
+ 
+ [[package]]
+ name = "zvariant_derive"
+-version = "5.8.0"
++version = "5.9.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "da58575a1b2b20766513b1ec59d8e2e68db2745379f961f86650655e862d2006"
++checksum = "484d5d975eb7afb52cc6b929c13d3719a20ad650fea4120e6310de3fc55e415c"
+ dependencies = [
+  "proc-macro-crate 3.4.0",
+  "proc-macro2",
+  "quote",
+- "syn 2.0.112",
+- "zvariant_utils 3.2.1",
++ "syn 2.0.114",
++ "zvariant_utils 3.3.0",
+ ]
+ 
+ [[package]]
+@@ -12813,18 +12402,18 @@ checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.112",
++ "syn 2.0.114",
+ ]
+ 
+ [[package]]
+ name = "zvariant_utils"
+-version = "3.2.1"
++version = "3.3.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c6949d142f89f6916deca2232cf26a8afacf2b9fdc35ce766105e104478be599"
++checksum = "f75c23a64ef8f40f13a6989991e643554d9bef1d682a281160cf0c1bc389c5e9"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+  "serde",
+- "syn 2.0.112",
++ "syn 2.0.114",
+  "winnow 0.7.14",
+ ]
 diff --git a/Cargo.toml b/Cargo.toml
-index aa9aea478..11e2a4194 100644
+index 66d3fa1b0..c2eef79a2 100644
 --- a/Cargo.toml
 +++ b/Cargo.toml
-@@ -65,7 +65,7 @@ gitbutler-workspace = { path = "crates/gitbutler-workspace" }
- 
+@@ -191,7 +191,7 @@ rusqlite = { version = "0.38.0", features = ["bundled"] }
+ backoff = "0.4.0"
  bstr = "1.12.1"
  # Add the `tracing` or `tracing-detail` features to see more of gitoxide in the logs. Useful to see which programs it invokes.
--gix = { version = "0.75.0", git = "https://github.com/GitoxideLabs/gitoxide", branch = "main", default-features = false, features = [
-+gix = { version = "0.76.0", default-features = false, features = [
+-gix = { version = "0.78.0", git = "https://github.com/GitoxideLabs/gitoxide", branch = "main", default-features = false, features = [
++gix = { version = "0.78.0", default-features = false, features = [
  ] }
  ts-rs = { version = "11.1.0", features = ["serde-compat", "no-serde-warnings"] }
- gix-testtools = "0.16.1"
+ gix-testtools = "0.18.0"
 diff --git a/crates/gitbutler-git/Cargo.toml b/crates/gitbutler-git/Cargo.toml
-index 6a2272521..265fb1a25 100644
+index ab08487cf..91b2734a6 100644
 --- a/crates/gitbutler-git/Cargo.toml
 +++ b/crates/gitbutler-git/Cargo.toml
-@@ -62,7 +62,7 @@ windows = { version = "0.62.0", features = [
+@@ -59,7 +59,7 @@ windows = { version = "0.62.0", features = [
  ] }
  tokio = { workspace = true, optional = true, features = ["sync", "rt"] }
  # TODO: use released version once published.


### PR DESCRIPTION
Hi,
this updates `gitbutler` to the current 0.18.3 release.
The "re-run until enough tests are excluded" strategy is quite brittle, but I don't see any easy improvements there. I guess some of the things (like tests only working in debug builds) could be tackled upstream.

FWIW here's the release notes for each `.0` release:
- [0.18.0](https://github.com/gitbutlerapp/gitbutler/releases/tag/release%2F0.18.0)
- [0.17.0](https://github.com/gitbutlerapp/gitbutler/releases/tag/release%2F0.17.0)
- [0.16.0](https://github.com/gitbutlerapp/gitbutler/releases/tag/release%2F0.16.0)

Closes https://github.com/NixOS/nixpkgs/issues/456654

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` (-gha) on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
