### PR TITLE
virtualgamepad-pc: init at 0.4.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -21151,6 +21151,11 @@
     github = "powwu";
     githubId = 20643401;
   };
+  poyo86 = {
+    name = "poyo86";
+    github = "poyo86";
+    githubId = 232233992;
+  };
   poz = {
     name = "Jacek Poziemski";
     email = "poz@poz.pet";

--- a/pkgs/by-name/vi/virtualgamepad-pc/package.nix
+++ b/pkgs/by-name/vi/virtualgamepad-pc/package.nix
@@ -1,0 +1,76 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  qt6,
+  pkg-config,
+  libevdev,
+  qrcodegencpp,
+  fetchpatch,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "virtualgamepad-pc";
+  version = "0.4.1";
+
+  src = fetchFromGitHub {
+    owner = "kitswas";
+    repo = "VirtualGamePad-PC";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-lE/0ucdeShL3RRlKh4UmrlHdajQpQqO2/SA/NwLi0ZM=";
+  };
+
+  passthru.VGP_Data_Exchange = fetchFromGitHub {
+    owner = "kitswas";
+    repo = "VGP_Data_Exchange";
+    rev = "3b1496d03f841b229741b5b4eb6e127ef88ad8a3";
+    hash = "sha256-NW6HbDzBDoQ6MwN749imgmqZhtHC/QpQ9kL03H8tF5U=";
+  };
+
+  patches = [
+    ./qrcodegen.patch
+    # Allow disabling portable build
+    (fetchpatch {
+      url = "https://github.com/kitswas/VirtualGamePad-PC/commit/bdd1a87de9b4212ed9afe0728bdad3f9f615d374.patch";
+      hash = "sha256-melXSRRA6V+zqcfCsO9D7AnoPH8MwmjJBHImcdaoBmM=";
+    })
+  ];
+
+  buildInputs = [
+    qt6.qtbase
+    libevdev
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    qt6.wrapQtAppsHook
+    pkg-config
+    qrcodegencpp
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "PORTABLE_BUILD" false)
+  ];
+
+  postUnpack = ''
+    ln -s ${finalAttrs.passthru.VGP_Data_Exchange}/* source/VGP_Data_Exchange
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm555 VGamepadPC -t $out/bin
+    install -Dm444 $src/res/VGamepadPC.desktop -t $out/share/applications
+    install -Dm444 $src/res/logos/SquareIcon.png $out/share/icons/hicolor/256x256/icons/VGamepadPC.png
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://kitswas.github.io/VirtualGamePad/";
+    description = "Android phone as gamepad for PCs";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ poyo86 ];
+    platforms = lib.platforms.linux;
+    mainProgram = "VGamepadPC";
+  };
+})

--- a/pkgs/by-name/vi/virtualgamepad-pc/qrcodegen.patch
+++ b/pkgs/by-name/vi/virtualgamepad-pc/qrcodegen.patch
@@ -1,0 +1,44 @@
+--- a/src/networking/server.cpp	2025-12-23 00:41:52.712090930 +0100
++++ b/src/networking/server.cpp	2025-12-23 00:44:24.751770289 +0100
+@@ -1,6 +1,6 @@
+ #include "server.hpp"
+ 
+-#include "../../third-party-libs/QR-Code-generator/cpp/qrcodegen.hpp"
++#include <qrcodegen/qrcodegen.hpp>
+ #include "../settings/settings_singleton.hpp"
+ #include "ui_server.h"
+ 
+--- a/CMakeLists.txt	2025-12-23 00:31:18.723532745 +0100
++++ b/CMakeLists.txt	2025-12-23 01:11:16.350376537 +0100
+@@ -55,12 +55,7 @@
+ 
+ add_subdirectory(VGP_Data_Exchange/C)
+ 
+-set(QR_CODE_GEN_SOURCES
+-    third-party-libs/QR-Code-generator/cpp/qrcodegen.cpp
+-    third-party-libs/QR-Code-generator/cpp/qrcodegen.hpp
+-)
+-
+-add_library(QR_Code_Generator SHARED ${QR_CODE_GEN_SOURCES})
++find_library(qrcodegen NAMES libqrcodegencpp.a REQUIRED)
+ 
+ # Manifest file for the application
+ # This file is used to request permissions on Windows
+@@ -128,7 +123,7 @@
+     Qt${QT_VERSION_MAJOR}::Widgets
+     Qt${QT_VERSION_MAJOR}::Network
+     Data_Exchange
+-    QR_Code_Generator
++    libqrcodegencpp.a
+ )
+ 
+ # Platform-specific linking and include directories
+@@ -152,7 +147,7 @@
+ 
+ set(CMAKE_INSTALL_DIR "${CMAKE_SOURCE_DIR}/dist")
+ 
+-install(TARGETS VGamepadPC Data_Exchange QR_Code_Generator
++install(TARGETS VGamepadPC Data_Exchange
+     BUNDLE DESTINATION .
+     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}


### PR DESCRIPTION
# VirtualGamepad-PC
Allows you to use your Android phone as a gamepad. https://kitswas.github.io/VirtualGamePad-PC/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
