### PR TITLE
llvmPackages.compiler-rt: fix nolibc build

### DIFF
--- a/pkgs/development/compilers/llvm/common/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/common/compiler-rt/default.nix
@@ -10,7 +10,6 @@
   cmake,
   ninja,
   python3,
-  libllvm,
   jq,
   libcxx,
   linuxHeaders,
@@ -61,6 +60,7 @@ stdenv.mkDerivation (finalAttrs: {
         ''
         + ''
           cp -r ${monorepoSrc}/compiler-rt "$out"
+          cp -r ${monorepoSrc}/llvm "$out"
         ''
       )
     else
@@ -90,7 +90,6 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     cmake
     python3
-    libllvm.dev
     ninja
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [ jq ];


### PR DESCRIPTION
This PR fixes compiler-rt with stdenvNoLibc when using it with pkgsCross. Previously it would error because it was pulling libllvm in and libllvm has a .cmake file that expects shared libraries to be present:

<img width="1020" height="615" alt="image" src="https://github.com/user-attachments/assets/8abcd3da-4714-48e5-b118-b1f97bf19927" />

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
