### PR TITLE
dwarf-fortress: 53.06 -> 53.08

### DIFF
--- a/pkgs/games/dwarf-fortress/df.lock.json
+++ b/pkgs/games/dwarf-fortress/df.lock.json
@@ -1,28 +1,28 @@
 {
   "game": {
     "latest": {
-      "linux": "53.06",
+      "linux": "53.08",
       "darwin": "0.47.05"
     },
     "versions": {
-      "53.06": {
+      "53.08": {
         "df": {
-          "version": "53.06",
+          "version": "53.08",
           "urls": {
             "linux": {
-              "url": "https://www.bay12games.com/dwarves/df_53_06_linux.tar.bz2",
-              "outputHash": "sha256-PSoYP9XVgAYMPih3uP2pCMwkWic3jPkz+V5j9g0KO1A="
+              "url": "https://www.bay12games.com/dwarves/df_53_08_linux.tar.bz2",
+              "outputHash": "sha256-0h6vA9n33Qt/y4v9UIuQl7p//SuQOkRV8Moe3MYAfIw="
             }
           }
         },
         "hack": {
-          "version": "53.06-r1",
+          "version": "53.08-r1",
           "git": {
             "url": "https://github.com/DFHack/dfhack.git",
-            "revision": "53.06-r1",
-            "outputHash": "sha256-tjhfr7UKGaiuzjanFrYeG8CS20EDjPchB2fQr/hz9HI="
+            "revision": "53.08-r1",
+            "outputHash": "sha256-LM3lsM1SZR1fKyhfTdbYBOYe+qbGcIkpvJYT3j16OSM="
           },
-          "xmlRev": "24322fe4a30209399c1c5fe903726828edd9032b"
+          "xmlRev": "da0b52eb3ad79866b1228a880be3b734cfac7b55"
         }
       },
       "52.05": {

--- a/pkgs/games/dwarf-fortress/wrapper/default.nix
+++ b/pkgs/games/dwarf-fortress/wrapper/default.nix
@@ -18,7 +18,7 @@
   expect,
   xvfb-run,
   writeText,
-  enableStoneSense ? false,
+  enableStoneSense ? enableDFHack,
   enableTWBT ? false,
   twbt,
   themes ? { },


### PR DESCRIPTION
New dependency on fmt requires some cmake hackery per:

https://github.com/dfhack/dfhack/blob/53.08-r1/docs/dev/compile/Compile.rst#building-dfhack-offline


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
