### PR TITLE
audiosource: init at 1.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11018,6 +11018,11 @@
     githubId = 207392575;
     name = "Isaac Kabel";
   };
+  ikci = {
+    github = "ikcii";
+    githubId = 48479629;
+    name = "ikci";
+  };
   ikervagyok = {
     email = "ikervagyok@gmail.com";
     github = "ikervagyok";

--- a/pkgs/by-name/au/audiosource/package.nix
+++ b/pkgs/by-name/au/audiosource/package.nix
@@ -1,0 +1,80 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchurl,
+  makeWrapper,
+  installShellFiles,
+  python3,
+  android-tools,
+  pulseaudio,
+  coreutils,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "audiosource";
+  version = "1.4";
+
+  src = fetchFromGitHub {
+    owner = "gdzx";
+    repo = "audiosource";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-SlX8gjs7X5jfoeU6pyk4n8f6oMJgneGVt0pmFs48+mQ=";
+  };
+
+  patches = [
+    # Removes build-related logic from the script that is unused in the package and fixes a small bug with adb args on new Android versions
+    ./unused-logic-removal-and-args-fix.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace audiosource \
+      --replace-fail "@apkPath@" "$out/share/audiosource/audiosource.apk"
+  '';
+
+  nativeBuildInputs = [
+    makeWrapper
+    installShellFiles
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/share/audiosource
+    cp ${finalAttrs.passthru.apk} $out/share/audiosource/audiosource.apk
+
+    installBin audiosource
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/audiosource \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          python3
+          android-tools
+          pulseaudio
+          coreutils
+        ]
+      }
+  '';
+
+  passthru.apk = fetchurl {
+    url = "https://github.com/gdzx/audiosource/releases/download/v${finalAttrs.version}/audiosource.apk";
+    hash = "sha256-vDIF+NZ3JgTT67Dem4qeajWsA5m/MFt2nRDpWUqC9aU=";
+  };
+
+  meta = {
+    description = "Use an Android device as a USB microphone";
+    homepage = "https://github.com/gdzx/audiosource";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ikci ];
+    mainProgram = "audiosource";
+    platforms = lib.platforms.linux;
+    sourceProvenance = with lib.sourceTypes; [
+      fromSource
+      binaryBytecode
+    ];
+  };
+})

--- a/pkgs/by-name/au/audiosource/unused-logic-removal-and-args-fix.patch
+++ b/pkgs/by-name/au/audiosource/unused-logic-removal-and-args-fix.patch
@@ -1,0 +1,82 @@
+diff --git a/audiosource b/audiosource
+index b06127a..0bccddf 100755
+--- a/audiosource
++++ b/audiosource
+@@ -2,15 +2,7 @@
+ 
+ set -eu
+ 
+-AUDIOSOURCE_PROFILE=${AUDIOSOURCE_PROFILE:-debug}
+-
+-if [ "$AUDIOSOURCE_PROFILE" = 'release' ]; then
+-	AUDIOSOURCE_DEFAULT_APK=app/build/outputs/apk/release/app-release.apk
+-else
+-	AUDIOSOURCE_DEFAULT_APK=app/build/outputs/apk/debug/app-debug.apk
+-fi
+-
+-AUDIOSOURCE_APK=${AUDIOSOURCE_APK:-"$AUDIOSOURCE_DEFAULT_APK"}
++AUDIOSOURCE_APK=${AUDIOSOURCE_APK:-"@apkPath@"}
+ ANDROID_SERIAL=${ANDROID_SERIAL:-}
+ 
+ PYSOCAT="$(cat <<EOF
+@@ -81,22 +73,12 @@ install() {
+ 
+ 	echo '[+] Installing Audio Source'
+ 
+-	adb install -rtg "$AUDIOSOURCE_APK" || {
++	adb install -r -t -g "$AUDIOSOURCE_APK" || {
+ 		adb uninstall fr.dzx.audiosource
+-		adb install -tg "$AUDIOSOURCE_APK"
++		adb install -t -g "$AUDIOSOURCE_APK"
+ 	}
+ }
+ 
+-_release() {
+-	AUDIOSOURCE_PROFILE=release
+-	AUDIOSOURCE_APK=app/build/outputs/apk/release/app-release.apk
+-
+-	build
+-
+-	cp -a "$AUDIOSOURCE_APK" audiosource.apk
+-	sha256sum audiosource.apk > audiosource.apk.sha256
+-}
+-
+ _unload() {
+ 	for id in `pactl list modules short | sed -n "/module-pipe-source\tsource_name=$AUDIOSOURCE_NAME/p" | cut -f1`; do
+ 		pactl unload-module "$id"
+@@ -146,7 +128,7 @@ volume() {
+ 
+ main_help() {
+ 	cat <<-EOF
+-		Usage: ./audiosource [-s SERIAL] COMMAND [ARGS...]
++		Usage: audiosource [-s SERIAL] COMMAND [ARGS...]
+ 
+ 		Options:
+ 
+@@ -154,15 +136,13 @@ main_help() {
+ 
+ 		Commands:
+ 
+-		   build         Build Audio Source APK (default: debug)
+-		   install       Install Audio Source to Android device (default: debug)
++		   install       Install Audio Source to Android device
+ 		   run           Run Audio Source and start forwarding
+ 		   volume LEVEL  Set volume to LEVEL (for example, 250%)
+ 
+ 		Environment:
+ 
+-		   AUDIOSOURCE_APK      APK path (default: app/build/outputs/apk/\$profile/app-\$profile.apk)
+-		   AUDIOSOURCE_PROFILE  Build profile (debug or release, default: build)
++		   AUDIOSOURCE_APK      APK path (default: @apkPath@)
+ 		   AUDIOSOURCE_NAME     Name of the PulseAudio source (default: android-<serial-hash>)
+ 		   ANDROID_SERIAL       Device serial number to connect to (default: unset)
+ 	EOF
+@@ -200,7 +180,7 @@ main() {
+ 	shift
+ 
+ 	case "$cmd" in
+-		build|install|run|volume|_release)
++		install|run|volume)
+ 			"$cmd" "$@"
+ 			;;
+ 		*)


### PR DESCRIPTION
Adds [audiosource](https://github.com/gdzx/audiosource) package at version 1.4.

audiosource is a small bash script (with some stringified python) that connects to an Android phone with the audiosource apk running, allowing users to use their Android phone as a PC microphone.

The upstream script is designed to build the APK from source using Gradle. To keep the derivation maintainable and avoid a complex Android SDK build environment, this package uses the pre-compiled APK from the official GitHub release.

I have patched the wrapper script to:
  - Remove the local build/release logic.
  - Point the `install` command to the APK stored in the Nix store.
  - Fix some minor syntax issues with ADB flags.

I will likely submit the above mentioned ADB flag fix upstream soon.

The project has received no commits in the past ~five months, but that is most likely due to it being a simple and fully finished program. The person behind it has been active very recently as seen [here](https://git.dzx.fr/gdzx/kconf/commit/226b52fe32887de1c3674a4606f748f8c9a70444) so I doubt that upstream abandonment is going to be an issue in the nearest future.

This is my first real attempt at FOSS contributions, I hope I did everything as well as possible.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
