### PR TITLE
gcc: Allow setting --enable-cxx-flags in platform

### DIFF
--- a/pkgs/development/compilers/gcc/common/pre-configure.nix
+++ b/pkgs/development/compilers/gcc/common/pre-configure.nix
@@ -83,3 +83,14 @@ lib.optionalString (hostPlatform.isSunOS && hostPlatform.is64bit) ''
 + lib.optionalString (
   (!lib.systems.equals targetPlatform hostPlatform) && withoutTargetLibc && enableShared
 ) (import ./libgcc-buildstuff.nix { inherit lib stdenv; })
+
+# Allow setting --enable-cxx-flags (https://gcc.gnu.org/onlinedocs/libstdc++/manual/configure.html)
+# This would better belong in platform-flags.nix, but this value contains spaces, which configureFlags does not support.
++ (
+  let
+    p = targetPlatform.gcc or { } // targetPlatform.parsed.abi;
+  in
+  lib.optionalString (p ? enableCxxFlags) ''
+    configureFlagsArray+=('--enable-cxx-flags=${builtins.concatStringsSep " " p.enableCxxFlags}')
+  ''
+)

--- a/pkgs/development/compilers/gcc/common/pre-configure.nix
+++ b/pkgs/development/compilers/gcc/common/pre-configure.nix
@@ -91,3 +91,14 @@ lib.optionalString (hostPlatform.isSunOS && hostPlatform.is64bit) ''
 + lib.optionalString (!hostIsTarget && withoutTargetLibc && enableShared) (
   import ./libgcc-buildstuff.nix { inherit lib stdenv; }
 )
+
+# Allow setting --enable-cxx-flags (https://gcc.gnu.org/onlinedocs/libstdc++/manual/configure.html)
+# This would better belong in platform-flags.nix, but this value contains spaces, which configureFlags does not support.
++ (
+  let
+    p = targetPlatform.gcc or { } // targetPlatform.parsed.abi;
+  in
+  lib.optionalString (p ? enableCxxFlags) ''
+    configureFlagsArray+=('--enable-cxx-flags=${builtins.concatStringsSep " " p.enableCxxFlags}')
+  ''
+)


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

GCC has a `--enable-cxx-flags` flag, which allows setting compiler flags used to compile libstdc++.

https://gcc.gnu.org/onlinedocs/libstdc++/manual/configure.html

This option is quite important for some embedded platforms.

This PR adds a platform field to allow setting this flag.

For example, for an ARM microcontroller with no exception handling:

```
import <nixpkgs> {
  crossSystem = {
    config = "arm-none-eabi";
    libc = "newlib";
    gcc = {
      cpu = "cortex-m0";
      thumb = true;
    };
    enableCxxFlags = [ "-fno-exceptions" ];
    isStatic = true;
  };
}
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
