### PR TITLE
python313Packages.blessed:1.21.0 -> 1.25-unstable-2025-12-05

### DIFF
--- a/pkgs/development/python-modules/blessed/default.nix
+++ b/pkgs/development/python-modules/blessed/default.nix
@@ -1,40 +1,45 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
-  six,
+  fetchFromGitHub,
+  flit-core,
   wcwidth,
-  pytest,
+  six,
+  pytestCheckHook,
   mock,
   glibcLocales,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "blessed";
-  version = "1.21.0";
-  format = "setuptools";
+  # We need https://github.com/jquast/blessed/pull/311 to fix 3.13
+  version = "1.25-unstable-2025-12-05";
+  pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-7Oi7xHWKuRdkUvTjpxnXAIjrVzl5jNVYLJ4F8qKDN+w=";
+  src = fetchFromGitHub {
+    owner = "jquast";
+    repo = "blessed";
+    rev = "cee680ff7fb3ad31f42ae98582ba74629f1fd6b0";
+    hash = "sha256-4K1W0LXJKkb2wKE6D+IkX3oI5KxkpKbO661W/VTHgts=";
   };
 
+  build-system = [ flit-core ];
+
+  dependencies = [
+    wcwidth
+    six
+  ];
+
   nativeCheckInputs = [
-    pytest
+    pytestCheckHook
     mock
     glibcLocales
   ];
 
   # Default tox.ini parameters not needed
-  checkPhase = ''
+  preCheck = ''
     rm tox.ini
-    pytest
   '';
-
-  propagatedBuildInputs = [
-    wcwidth
-    six
-  ];
 
   meta = {
     homepage = "https://github.com/jquast/blessed";


### PR DESCRIPTION
Fixes https://hydra.nixos.org/build/316666484/nixlog/1

Closes https://github.com/NixOS/nixpkgs/issues/473549

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
