### PR TITLE
iverilog: disable on x86_64-darwin, modernize

### DIFF
--- a/pkgs/by-name/iv/iverilog/package.nix
+++ b/pkgs/by-name/iv/iverilog/package.nix
@@ -94,5 +94,10 @@ stdenv.mkDerivation rec {
     ];
     maintainers = with lib.maintainers; [ thoughtpolice ];
     platforms = lib.platforms.all;
+    badPlatforms = [
+      # Several tests fail with:
+      # ==> Failed - running iverilog.
+      "x86_64-darwin"
+    ];
   };
 }

--- a/pkgs/by-name/iv/iverilog/package.nix
+++ b/pkgs/by-name/iv/iverilog/package.nix
@@ -14,28 +14,19 @@
   readline,
   zlib,
   buildPackages,
+  addBinToPathHook,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "iverilog";
   version = "12.0";
 
   src = fetchFromGitHub {
     owner = "steveicarus";
     repo = "iverilog";
-    rev = "v${lib.replaceStrings [ "." ] [ "_" ] version}";
+    tag = "v${lib.replaceStrings [ "." ] [ "_" ] finalAttrs.version}";
     hash = "sha256-J9hedSmC6mFVcoDnXBtaTXigxrSCFa2AhhFd77ueo7I=";
   };
-
-  nativeBuildInputs = [
-    autoconf
-    bison
-    flex
-    gperf
-  ];
-
-  CC_FOR_BUILD = "${buildPackages.stdenv.cc}/bin/cc";
-  CXX_FOR_BUILD = "${buildPackages.stdenv.cc}/bin/c++";
 
   patches = [
     # NOTE(jleightcap): `-Werror=format-security` warning patched shortly after release, backport the upstream fix
@@ -45,6 +36,21 @@ stdenv.mkDerivation rec {
       hash = "sha256-fMWfBsCl2fuXe+6AR10ytb8QpC84bXlP5RSdrqsWzEk=";
     })
   ];
+
+  nativeBuildInputs = [
+    autoconf
+    bison
+    flex
+    gperf
+  ];
+
+  env = {
+    CC_FOR_BUILD = "${lib.getExe' buildPackages.stdenv.cc "cc"}";
+    CXX_FOR_BUILD = "${lib.getExe' buildPackages.stdenv.cc "cc++"}";
+  }
+  // lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+    NIX_CFLAGS_COMPILE = "-Wno-error=implicit-function-declaration";
+  };
 
   buildInputs = [
     bzip2
@@ -56,10 +62,6 @@ stdenv.mkDerivation rec {
   preConfigure = "sh autoconf.sh";
 
   enableParallelBuilding = true;
-
-  env = lib.optionalAttrs stdenv.hostPlatform.isDarwin {
-    NIX_CFLAGS_COMPILE = "-Wno-error=implicit-function-declaration";
-  };
 
   # NOTE(jleightcap): the `make check` target only runs a "Hello, World"-esque sanity check.
   # the tests in the doInstallCheck phase run a full regression test suite.
@@ -76,18 +78,21 @@ stdenv.mkDerivation rec {
         docopt
       ]
     ))
+    addBinToPathHook
   ];
 
   installCheckPhase = ''
     runHook preInstallCheck
-    export PATH="$PATH:$out/bin"
+
     sh .github/test.sh
+
     runHook postInstallCheck
   '';
 
   meta = {
     description = "Icarus Verilog compiler";
     homepage = "https://steveicarus.github.io/iverilog";
+    downloadPage = "https://github.com/steveicarus/iverilog";
     license = with lib.licenses; [
       gpl2Plus
       lgpl21Plus
@@ -100,4 +105,4 @@ stdenv.mkDerivation rec {
       "x86_64-darwin"
     ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- **iverilog: disable on x86_64-darwin**
- **iverilog: modernize**

cc @thoughtpolice

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
