### PR TITLE
aws-cdk-cli.tests: fix the eval

### DIFF
--- a/pkgs/by-name/aw/aws-cdk-cli/package.nix
+++ b/pkgs/by-name/aw/aws-cdk-cli/package.nix
@@ -101,7 +101,7 @@ stdenv.mkDerivation (finalAttrs: {
   dontFixup = true;
 
   passthru = {
-    tests.version = testers.testVersion { package = finalAttrs.package; };
+    tests.version = testers.testVersion { package = finalAttrs.finalPackage; };
     updateScript = nix-update-script {
       extraArgs = [
         "--version-regex"


### PR DESCRIPTION
Without the change the eval fails on `master` as:

    $ nix build --no-link -f. aws-cdk-cli.tests
    error:
       … while evaluating the attribute 'version'
         at pkgs/by-name/aw/aws-cdk-cli/package.nix:104:5:
          103|   passthru = {
          104|     tests.version = testers.testVersion { package = finalAttrs.package; };
             |     ^
          105|     updateScript = nix-update-script {

       … while evaluating the 'name' attribute of a derivation

       … while evaluating a branch condition
         at lib/strings.nix:2882:5:
         2881|     # First detect the common case of already valid strings, to speed those up
         2882|     if stringLength string <= 207 && okRegex string != null then
             |     ^
         2883|       unsafeDiscardStringContext string

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: attribute 'package' missing
       at pkgs/by-name/aw/aws-cdk-cli/package.nix:104:53:
          103|   passthru = {
          104|     tests.version = testers.testVersion { package = finalAttrs.package; };
             |                                                     ^
          105|     updateScript = nix-update-script {


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
