### PR TITLE
treewide: use tags instead of rev, remove unnecessary string interpolation

### DIFF
--- a/maintainers/scripts/update-octave-packages
+++ b/maintainers/scripts/update-octave-packages
@@ -351,20 +351,20 @@ def _update_package(path, target):
         text = _replace_value('hash', sri_hash, text)
 
     if fetcher == 'fetchFromGitHub':
-        # in the case of fetchFromGitHub, it's common to see `rev = version;` or `rev = "v${version}";`
+        # in the case of fetchFromGitHub, it's common to see `tag = version;` or `tag = "v${version}";`
         # in which no string value is meant to be substituted. However, we can just overwrite the previous value.
-        regex = '(rev\s+=\s+[^;]*;)'
+        regex = '(tag\s+=\s+[^;]*;)'
         regex = re.compile(regex)
         matches = regex.findall(text)
         n = len(matches)
 
         if n == 0:
-            raise ValueError("Unable to find rev value for {}.".format(pname))
+            raise ValueError("Unable to find tag value for {}.".format(pname))
         else:
-            # forcefully rewrite rev, incase tagging conventions changed for a release
+            # forcefully rewrite tag, incase tagging conventions changed for a release
             match = matches[0]
-            text = text.replace(match, f'rev = "refs/tags/{prefix}${{version}}";')
-            # incase there's no prefix, just rewrite without interpolation
+            text = text.replace(match, f'tag = "{prefix}${{version}}";')
+            # in case there's no prefix, just rewrite without interpolation
             text = text.replace('"${version}";', 'version;')
 
     with open(path, 'w') as f:

--- a/pkgs/applications/audio/mopidy/spotify.nix
+++ b/pkgs/applications/audio/mopidy/spotify.nix
@@ -14,7 +14,7 @@ pythonPackages.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "mopidy";
     repo = "mopidy-spotify";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-pM+kqeWYiPXv9DZDBTgwiEwC6Sbqv6uz5vJ5odcixOw=";
   };
 

--- a/pkgs/applications/audio/zynaddsubfx/mruby-zest/default.nix
+++ b/pkgs/applications/audio/zynaddsubfx/mruby-zest/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = pname;
     repo = "${pname}-build";
-    rev = "refs/tags/${version}";
+    tag = version;
     fetchSubmodules = true;
     sha256 = "sha256-rIb6tQimwrUj+623IU5zDyKNWsNYYBElLQClOsP+5Dc=";
   };

--- a/pkgs/applications/misc/electrum/grs.nix
+++ b/pkgs/applications/misc/electrum/grs.nix
@@ -39,7 +39,7 @@ python3.pkgs.buildPythonApplication {
   src = fetchFromGitHub {
     owner = "Groestlcoin";
     repo = "electrum-grs";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     sha256 = "1k078jg3bw4n3kcxy917m30x1skxm679w8hcw8mlxb94ikrjc66h";
   };
 

--- a/pkgs/applications/networking/cluster/helm/plugins/helm-dt.nix
+++ b/pkgs/applications/networking/cluster/helm/plugins/helm-dt.nix
@@ -10,7 +10,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "vmware-labs";
     repo = "distribution-tooling-for-helm";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-/fU56Dw7tvUnby4S78tyH/dasg4n3rb0hMlIkzvrv4M=";
   };
 

--- a/pkgs/applications/networking/gns3/gui.nix
+++ b/pkgs/applications/networking/gns3/gui.nix
@@ -23,7 +23,7 @@ python3Packages.buildPythonApplication rec {
     inherit hash;
     owner = "GNS3";
     repo = "gns3-gui";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
   };
 
   nativeBuildInputs = [ wrapQtAppsHook ];

--- a/pkgs/applications/networking/gns3/server.nix
+++ b/pkgs/applications/networking/gns3/server.nix
@@ -25,7 +25,7 @@ python3Packages.buildPythonApplication {
     inherit hash;
     owner = "GNS3";
     repo = "gns3-server";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
   };
 
   # GNS3 2.3.26 requires a static BusyBox for the Docker integration

--- a/pkgs/applications/office/libreoffice/src-collabora/help.nix
+++ b/pkgs/applications/office/libreoffice/src-collabora/help.nix
@@ -1,6 +1,6 @@
 { fetchgit, ... }:
 fetchgit {
   url = "https://gerrit.libreoffice.org/help";
-  rev = "refs/tags/cp-25.04.1-1";
+  tag = "cp-25.04.1-1";
   hash = "sha256-jKcrkvdxpebCTeILrjA7bKfcsWw8VFjS7eimJI1dgFQ=";
 }

--- a/pkgs/applications/office/libreoffice/src-collabora/main.nix
+++ b/pkgs/applications/office/libreoffice/src-collabora/main.nix
@@ -1,7 +1,7 @@
 { fetchgit, ... }:
 fetchgit {
   url = "https://gerrit.libreoffice.org/core";
-  rev = "refs/tags/cp-25.04.1-1";
+  tag = "cp-25.04.1-1";
   hash = "sha256-WhNNKL1RC0hWi21wH5EJRZ8V8U7jk6z8h3E3mVR56zk=";
   fetchSubmodules = false;
 }

--- a/pkgs/applications/office/libreoffice/src-collabora/translations.nix
+++ b/pkgs/applications/office/libreoffice/src-collabora/translations.nix
@@ -1,6 +1,6 @@
 { fetchgit, ... }:
 fetchgit {
   url = "https://gerrit.libreoffice.org/translations";
-  rev = "refs/tags/cp-25.04.1-1";
+  tag = "cp-25.04.1-1";
   hash = "sha256-kZ5LwhEMWYv9peYPjTL14wjYv4LHUMtaM7XGYSVw68U=";
 }

--- a/pkgs/applications/video/obs-studio/plugins/obs-advanced-masks.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-advanced-masks.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "FiniteSingularity";
     repo = "obs-advanced-masks";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-NtmOWKk3eZeRa3TvclZpg4sj8lbOoY8hUhxs1z6kEW4=";
   };
 

--- a/pkgs/applications/video/obs-studio/plugins/obs-dvd-screensaver.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-dvd-screensaver.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "wimpysworld";
     repo = "obs-dvd-screensaver";
-    tag = "${finalAttrs.version}";
+    tag = finalAttrs.version;
     hash = "sha256-eUfy3m0r/sLrGLbp3en1ofcVVWZ+t2rZ4knjwfrorhw=";
   };
   strictDeps = true;

--- a/pkgs/applications/video/obs-studio/plugins/obs-media-controls.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-media-controls.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "exeldro";
     repo = "obs-media-controls";
-    tag = "${finalAttrs.version}";
+    tag = finalAttrs.version;
     hash = "sha256-r9fqpg0G9rzGSqq5FUS8ul58rj0796aGZIND8PCJ9jk=";
   };
 

--- a/pkgs/applications/video/obs-studio/plugins/obs-recursion-effect.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-recursion-effect.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "exeldro";
     repo = "obs-recursion-effect";
-    tag = "${finalAttrs.version}";
+    tag = finalAttrs.version;
     hash = "sha256-PeWJy423QbX4NULuS15LJ/IR/W+tXCJD9TjZdJOGk6A=";
   };
 

--- a/pkgs/applications/video/obs-studio/plugins/obs-vnc.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-vnc.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "norihiro";
     repo = "obs-vnc";
-    tag = "${finalAttrs.version}";
+    tag = finalAttrs.version;
     hash = "sha256-bveTfyhHH7RAM24Lp0mWlt52ao9Rn6vCuKjfQH+B8Rw=";
   };
 

--- a/pkgs/applications/virtualization/OVMF/default.nix
+++ b/pkgs/applications/virtualization/OVMF/default.nix
@@ -91,7 +91,7 @@ let
       "debian/PkKek-1-*.pem"
       "debian/patches/OvmfPkg-X64-add-opt-org.tianocore-UninstallMemAttrPr.patch"
     ];
-    rev = "refs/tags/debian/2025.02-8";
+    tag = "debian/2025.02-8";
     hash = "sha256-n/6T5UBwW8U49mYhITRZRgy2tNdipeU4ZgGGDu9OTkg=";
   };
 

--- a/pkgs/by-name/a2/a2jmidid/package.nix
+++ b/pkgs/by-name/a2/a2jmidid/package.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     domain = "gitea.ladish.org";
     owner = "LADI";
     repo = "a2jmidid";
-    rev = "refs/tags/${version}";
+    tag = version;
     fetchSubmodules = true;
     hash = "sha256-PZKGhHmPMf0AucPruOLB9DniM5A3BKdghFCrd5pTzeM=";
   };

--- a/pkgs/by-name/ab/abiword/package.nix
+++ b/pkgs/by-name/ab/abiword/package.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     domain = "gitlab.gnome.org";
     owner = "World";
     repo = "AbiWord";
-    rev = "refs/tags/release-${version}";
+    tag = "release-${version}";
     hash = "sha256-dYbJ726Zuxs7+VTTCWHYQLsVZ/86hRUBQRac6toO4UI=";
   };
 

--- a/pkgs/by-name/ap/apache-airflow/python-package.nix
+++ b/pkgs/by-name/ap/apache-airflow/python-package.nix
@@ -71,7 +71,7 @@ let
   airflow-src = fetchFromGitHub {
     owner = "apache";
     repo = "airflow";
-    rev = "refs/tags/${version}";
+    tag = version;
     # Download using the git protocol rather than using tarballs, because the
     # GitHub archive tarballs don't appear to include tests
     forceFetchGit = true;

--- a/pkgs/by-name/ap/apbs/package.nix
+++ b/pkgs/by-name/ap/apbs/package.nix
@@ -19,7 +19,7 @@ let
     src = fetchFromGitHub {
       owner = "Electrostatics";
       repo = "fetk";
-      rev = "refs/tags/${finalAttrs.version}";
+      tag = finalAttrs.version;
       hash = "sha256-uFA1JRR05cNcUGaJj9IyGNONB2hU9IOBPzOj/HucNH4=";
     };
 
@@ -57,7 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "Electrostatics";
     repo = "apbs";
-    rev = "refs/tags/v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-2DnHU9hMDl4OJBaTtcRiB+6R7gAeFcuOUy7aI63A3gQ=";
   };
 

--- a/pkgs/by-name/ap/apksigner/package.nix
+++ b/pkgs/by-name/ap/apksigner/package.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     # use pname here because the final jar uses this as the filename
     name = pname;
     url = "https://android.googlesource.com/platform/tools/apksig";
-    rev = "refs/tags/android-15.0.0_r30";
+    tag = "android-15.0.0_r30";
     hash = "sha256-f/PggxvBv8nYUyL9Ukd4YVpunpRWbLL5UYsYhsiDWRE=";
   };
 

--- a/pkgs/by-name/ap/apostrophe/package.nix
+++ b/pkgs/by-name/ap/apostrophe/package.nix
@@ -26,7 +26,7 @@ let
     owner = "World";
     repo = "apostrophe";
     domain = "gitlab.gnome.org";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-Sj5Y4QPMYavdXbU+iVv76qOFNhgBjAeX9+/TvQHZzeI=";
   };
 
@@ -36,7 +36,7 @@ let
 
     # keep in sync with upstream shipped version
     # in build-aux/flatpak/org.gnome.gitlab.somas.Apostrophe.json
-    rev = "refs/tags/5.1.0";
+    tag = "5.1.0";
     hash = "sha256-L6KVBw20K67lHT07Ws+ZC2DwdURahqyuyjAaK0kTgN0=";
   };
 in

--- a/pkgs/by-name/as/ascii/package.nix
+++ b/pkgs/by-name/as/ascii/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitLab {
     owner = "esr";
     repo = "ascii";
-    rev = "refs/tags/${finalAttrs.version}";
+    tag = finalAttrs.version;
     hash = "sha256-TE9YR5Va9tXaf2ZyNxz7d8lZRTgnD4Lz7FyqRDl1HNY=";
   };
 

--- a/pkgs/by-name/aw/aws-shell/package.nix
+++ b/pkgs/by-name/aw/aws-shell/package.nix
@@ -15,7 +15,7 @@ python3Packages.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "awslabs";
     repo = "aws-shell";
-    rev = "refs/tags/${version}";
+    tag = version;
     hash = "sha256-m96XaaFDFQaD2YPjw8D1sGJ5lex4Is4LQ5RhGzVPvH4=";
   };
 

--- a/pkgs/by-name/ba/barlow/package.nix
+++ b/pkgs/by-name/ba/barlow/package.nix
@@ -11,7 +11,7 @@ stdenvNoCC.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "jpt";
     repo = "barlow";
-    tag = "${version}";
+    tag = version;
     hash = "sha256-FG68o6qN/296RhSNDHFXYXbkhlXSZJgGhVjzlJqsksY=";
   };
 

--- a/pkgs/by-name/br/brlcad/package.nix
+++ b/pkgs/by-name/br/brlcad/package.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "BRL-CAD";
     repo = "brlcad";
-    rev = "refs/tags/rel-${lib.replaceStrings [ "." ] [ "-" ] version}";
+    tag = "rel-${lib.replaceStrings [ "." ] [ "-" ] version}";
     hash = "sha256-23UTeH4gY2x/QGYZ64glAkf6LmsXBAppIOHgoUdxgpo=";
   };
 

--- a/pkgs/by-name/bu/buildpack/package.nix
+++ b/pkgs/by-name/bu/buildpack/package.nix
@@ -16,7 +16,7 @@ buildGoModule {
   src = fetchFromGitHub {
     owner = "buildpacks";
     repo = "pack";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-QCN0UvWa5u9XX5LvY3yD8Xz2s1XzZUg/WXnAfWwZnY0=";
   };
 

--- a/pkgs/by-name/ca/cached-nix-shell/package.nix
+++ b/pkgs/by-name/ca/cached-nix-shell/package.nix
@@ -10,7 +10,7 @@ let
   blake3-src = fetchFromGitHub {
     owner = "BLAKE3-team";
     repo = "BLAKE3";
-    rev = "refs/tags/1.5.1";
+    tag = "1.5.1";
     hash = "sha256-STWAnJjKrtb2Xyj6i1ACwxX/gTkQo5jUHilcqcgJYxc=";
   };
 in
@@ -21,7 +21,7 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "xzfc";
     repo = "cached-nix-shell";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-LI/hecqeRg3eCzU2bASJA8VoG4nvrSeHSeaGYn7M/UI=";
   };
 

--- a/pkgs/by-name/ca/canaille/package.nix
+++ b/pkgs/by-name/ca/canaille/package.nix
@@ -20,7 +20,7 @@ python.pkgs.buildPythonApplication rec {
   src = fetchFromGitLab {
     owner = "yaal";
     repo = "canaille";
-    rev = "refs/tags/${version}";
+    tag = version;
     hash = "sha256-FL02ADM7rUU43XR71UWr4FLr/NeUau7zRwTMOSFm1T4=";
   };
 

--- a/pkgs/by-name/ca/catppuccinifier-gui/package.nix
+++ b/pkgs/by-name/ca/catppuccinifier-gui/package.nix
@@ -23,7 +23,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "lighttigerXIV";
     repo = "catppuccinifier";
-    tag = "${finalAttrs.version}";
+    tag = finalAttrs.version;
     hash = "sha256-e8sLYp+0YhC/vAn4vag9UUaw3VYDRERGnLD1RuW1TXE=";
   };
 

--- a/pkgs/by-name/ce/ceph/package.nix
+++ b/pkgs/by-name/ce/ceph/package.nix
@@ -153,7 +153,7 @@ let
     src = fetchFromGitHub {
       owner = "facebook";
       repo = "rocksdb";
-      rev = "refs/tags/v7.9.2";
+      tag = "v7.9.2";
       hash = "sha256-5P7IqJ14EZzDkbjaBvbix04ceGGdlWBuVFH/5dpD5VM=";
     };
   };

--- a/pkgs/by-name/ch/chance/package.nix
+++ b/pkgs/by-name/ch/chance/package.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitLab {
     owner = "zelikos";
     repo = "rollit";
-    rev = "refs/tags/${finalAttrs.version}";
+    tag = finalAttrs.version;
     hash = "sha256-25+/TvTba/QF7+QE8+O7u4yc9BNi0pcZeNj11dGkEfg=";
   };
 

--- a/pkgs/by-name/ch/chiptrack/package.nix
+++ b/pkgs/by-name/ch/chiptrack/package.nix
@@ -39,7 +39,7 @@ rustPlatform.buildRustPackage.override { stdenv = clangStdenv; } rec {
   src = fetchFromGitHub {
     owner = "jturcotte";
     repo = "chiptrack";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-yQP5hFM5qBWdaF192PBvM4il6qpmlgUCeuwDCiw/LaQ=";
   };
 
@@ -75,7 +75,7 @@ rustPlatform.buildRustPackage.override { stdenv = clangStdenv; } rec {
           owner = "rust-skia";
           repo = "skia";
           # see rust-skia:skia-bindings/Cargo.toml#package.metadata skia
-          rev = "refs/tags/m129-0.77.1";
+          tag = "m129-0.77.1";
           hash = "sha256-WRVuQpfRnYrE7KGFRFx66fXtMFmtJbC3xUcRPK1JoOM=";
         };
         # The externals for skia are taken from skia/DEPS

--- a/pkgs/by-name/cn/cns11643-kai/package.nix
+++ b/pkgs/by-name/cn/cns11643-kai/package.nix
@@ -11,7 +11,7 @@ stdenvNoCC.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "rypervenche";
     repo = "cns11643-fonts";
-    rev = "refs/tags/${version}";
+    tag = version;
     hash = "sha256-A/4iwNvyzOYEpBzxKeq1xM/6aU6EOCATAr0lQlyckKQ=";
   };
 

--- a/pkgs/by-name/co/codd/package.nix
+++ b/pkgs/by-name/co/codd/package.nix
@@ -24,7 +24,7 @@ let
     src = fetchFromGitHub {
       owner = "mzabani";
       repo = "codd";
-      rev = "refs/tags/v${version}";
+      tag = "v${version}";
       hash = "sha256-KdZCL09TERy/PolQyYYykEbPtG5yhxrLZSSo9n6p2WE=";
     };
 

--- a/pkgs/by-name/co/commitlint-rs/package.nix
+++ b/pkgs/by-name/co/commitlint-rs/package.nix
@@ -14,7 +14,7 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "KeisukeYamashita";
     repo = "commitlint-rs";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-rNCMvIVJ/aOTNMyAmwX3Ir6IjHf6wxZ1XlGIWp7omkQ=";
   };
 

--- a/pkgs/by-name/co/conduktor-ctl/package.nix
+++ b/pkgs/by-name/co/conduktor-ctl/package.nix
@@ -13,7 +13,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "conduktor";
     repo = "ctl";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-zaguB4LLkzXlMQCEVOWkUUsEovU53F0B51w3BnVjre8=";
   };
 

--- a/pkgs/by-name/cr/create-dmg/package.nix
+++ b/pkgs/by-name/cr/create-dmg/package.nix
@@ -11,7 +11,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "create-dmg";
     repo = "create-dmg";
-    rev = "refs/tags/v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-oWrQT9nuFcJRwwXd5q4IqhG7M77aaazBG0+JSHAzPvw=";
   };
 

--- a/pkgs/by-name/da/davix/package.nix
+++ b/pkgs/by-name/da/davix/package.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "cern-fts";
     repo = "davix";
-    rev = "refs/tags/R_${lib.replaceStrings [ "." ] [ "_" ] version}";
+    tag = "R_${lib.replaceStrings [ "." ] [ "_" ] version}";
     hash = "sha256-n4NeHBgQwGwgHAFQzPc3oEP9k3F/sqrTmkI/zHW+Miw=";
   };
 

--- a/pkgs/by-name/da/davs2/package.nix
+++ b/pkgs/by-name/da/davs2/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "pkuvcl";
     repo = "davs2";
-    rev = "refs/tags/${finalAttrs.version}";
+    tag = finalAttrs.version;
     hash = "sha256-SUY3arrVsFecMcbpmQP0+4rtcSRfQc6pzxZDcEuMWPU=";
   };
 

--- a/pkgs/by-name/de/debootstrap/package.nix
+++ b/pkgs/by-name/de/debootstrap/package.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
     domain = "salsa.debian.org";
     owner = "installer-team";
     repo = "debootstrap";
-    rev = "refs/tags/${version}";
+    tag = version;
     hash = "sha256-4vINaMRo6IrZ6e2/DAJ06ODy2BWm4COR1JDSY52upUc=";
   };
 

--- a/pkgs/by-name/de/defuddle-cli/package.nix
+++ b/pkgs/by-name/de/defuddle-cli/package.nix
@@ -12,7 +12,7 @@ buildNpmPackage rec {
   src = fetchFromGitHub {
     owner = "kepano";
     repo = "defuddle-cli";
-    tag = "${version}";
+    tag = version;
     hash = "sha256-28XmpFKzBKNhRkPOGaacJVw8hjQUZq2nwuR0vNo8aW0=";
   };
 

--- a/pkgs/by-name/de/deterministic-zip/package.nix
+++ b/pkgs/by-name/de/deterministic-zip/package.nix
@@ -11,7 +11,7 @@ buildGoModule (finalAttrs: {
   src = fetchFromGitHub {
     owner = "timo-reymann";
     repo = "deterministic-zip";
-    tag = "${finalAttrs.version}";
+    tag = finalAttrs.version;
     hash = "sha256-rvheo/DkQTfpVy8fVRRwRA4G9mdMNArptxNT0sxdqnc=";
   };
 

--- a/pkgs/by-name/di/diffnav/package.nix
+++ b/pkgs/by-name/di/diffnav/package.nix
@@ -13,7 +13,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "dlvhdr";
     repo = "diffnav";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-QDPH7vBoA4YCmC+CLmeBdspwOhFEV3iSiyBYX6lwOLA=";
   };
 

--- a/pkgs/by-name/do/dovecot-fts-flatcurve/package.nix
+++ b/pkgs/by-name/do/dovecot-fts-flatcurve/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "slusarz";
     repo = "dovecot-fts-flatcurve";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-96sR/pl0G0sSjh/YrXdgVgASJPhrL32xHCbBGrDxzoU=";
   };
 

--- a/pkgs/by-name/ec/ecwolf/package.nix
+++ b/pkgs/by-name/ec/ecwolf/package.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromBitbucket {
     owner = "ecwolf";
     repo = "ecwolf";
-    rev = "refs/tags/${finalAttrs.version}";
+    tag = finalAttrs.version;
     hash = "sha256-T5K6B2fWMKMLB/662p/YLEv0Od9n0vUakznyoOnr0kI=";
   };
 

--- a/pkgs/by-name/en/entangle/package.nix
+++ b/pkgs/by-name/en/entangle/package.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitLab {
     owner = "entangle";
     repo = "entangle";
-    rev = "refs/tags/v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     sha256 = "hz2WSDOjriQSavFlDT+35x1X5MeInq80ZrSP1WR/td0=";
   };
 

--- a/pkgs/by-name/eq/equicord/package.nix
+++ b/pkgs/by-name/eq/equicord/package.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "Equicord";
     repo = "Equicord";
-    tag = "${finalAttrs.version}";
+    tag = finalAttrs.version;
     hash = "sha256-ce5n7E+eJLPnj/dUnaaDi4R8kKO4+iOcQgdtOin4NcM=";
   };
 

--- a/pkgs/by-name/es/esphome/dashboard.nix
+++ b/pkgs/by-name/es/esphome/dashboard.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "esphome";
     repo = "dashboard";
-    rev = "refs/tags/${version}";
+    tag = version;
     hash = "sha256-PZf9YLtHqeR+5BRVv1yOMVt6NVlbJTj98ukGnO0RV0Q=";
   };
 

--- a/pkgs/by-name/et/ethercat/package.nix
+++ b/pkgs/by-name/et/ethercat/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitLab {
     owner = "etherlab.org";
     repo = "ethercat";
-    rev = "refs/tags/${finalAttrs.version}";
+    tag = finalAttrs.version;
     hash = "sha256-yIlaAjPNcA7yIiCe+2kwk5IHIkwUv8bTxK0H3hu91MI=";
   };
 

--- a/pkgs/by-name/ez/eztrace/package.nix
+++ b/pkgs/by-name/ez/eztrace/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitLab {
     owner = "eztrace";
     repo = "eztrace";
-    tag = "${finalAttrs.version}";
+    tag = finalAttrs.version;
     hash = "sha256-ccW4YjEf++tkdIJLze2x8B/SWbBBXnYt8UV9OH8+KGU=";
   };
 

--- a/pkgs/by-name/fl/flamerobin/package.nix
+++ b/pkgs/by-name/fl/flamerobin/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "mariuz";
     repo = "flamerobin";
-    tag = "${finalAttrs.version}";
+    tag = finalAttrs.version;
     hash = "sha256-IwJEFF3vP0BC9PoMoY+XPLT+ygXnFXP/TWaqjdQWs8s=";
   };
 

--- a/pkgs/by-name/fl/flightgear/package.nix
+++ b/pkgs/by-name/fl/flightgear/package.nix
@@ -41,7 +41,7 @@ let
     src = fetchFromGitLab {
       owner = "flightgear";
       repo = "fgdata";
-      tag = "${version}";
+      tag = version;
       hash = "sha256-LNHO/W8p4b8fYcehdfVecldKQ9uJp1zlg60xdgDC45c=";
     };
 
@@ -62,7 +62,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitLab {
     owner = "flightgear";
     repo = "flightgear";
-    tag = "${version}";
+    tag = version;
     hash = "sha256-m4bbWwMXwKJrMkb6svGrIZhcsPghrTMgFs8JCx3Wn/A=";
   };
 

--- a/pkgs/by-name/fn/fnlfmt/package.nix
+++ b/pkgs/by-name/fn/fnlfmt/package.nix
@@ -13,8 +13,8 @@ stdenv.mkDerivation rec {
   src = fetchFromSourcehut {
     owner = "~technomancy";
     repo = "fnlfmt";
-    rev = "refs/tags/${version}";
-    hash = "sha256-LYHhKC8iA4N8DdCH8GfSOkN/e+W3YjkFhVSDQraKoFk=";
+    tag = version;
+    hash = "sha256-wbeWAv4xhxh7M6tRd9qpgBRtg1/fqg0AUPvh2M5f60Q=";
   };
 
   nativeBuildInputs = [ luaPackages.fennel ];
@@ -25,7 +25,6 @@ stdenv.mkDerivation rec {
     "PREFIX=$(out)"
     "FENNEL=${luaPackages.fennel}/bin/fennel"
   ];
-  sourceRoot = [ "${src.name}/tags/${version}" ];
 
   doInstallCheck = true;
   installCheckPhase = ''

--- a/pkgs/by-name/fo/footage/package.nix
+++ b/pkgs/by-name/fo/footage/package.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitLab {
     owner = "adhami3310";
     repo = "Footage";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-VEL96JrJ5eJEoX2miiB4dqGUXizNlYWCUZkkYkh09B8=";
   };
 

--- a/pkgs/by-name/fp/fprintd/package.nix
+++ b/pkgs/by-name/fp/fprintd/package.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
     domain = "gitlab.freedesktop.org";
     owner = "libfprint";
     repo = "fprintd";
-    rev = "refs/tags/v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-aGIz50S0zfE3rV6QJp8iQz3uUVn8WAL68KU70j8GyOU=";
   };
 

--- a/pkgs/by-name/ga/galene-stream/package.nix
+++ b/pkgs/by-name/ga/galene-stream/package.nix
@@ -19,7 +19,7 @@ python3Packages.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "erdnaxe";
     repo = "galene-stream";
-    tag = "${version}";
+    tag = version;
     hash = "sha256-3TdU3vBVuFle+jon2oJLa/rTLIiwYkvzscTDbMEXD1Q=";
   };
 

--- a/pkgs/by-name/ge/geoclue2/package.nix
+++ b/pkgs/by-name/ge/geoclue2/package.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
     domain = "gitlab.freedesktop.org";
     owner = "geoclue";
     repo = "geoclue";
-    rev = "refs/tags/${finalAttrs.version}";
+    tag = finalAttrs.version;
     hash = "sha256-LwL1WtCdHb/NwPr3/OLISwaAwplhJwiZT9vUdX29Bbs=";
   };
 

--- a/pkgs/by-name/gl/gle/package.nix
+++ b/pkgs/by-name/gl/gle/package.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "linas";
     repo = "glextrusion";
-    rev = "refs/tags/${pname}-${version}";
+    tag = "${pname}-${version}";
     sha256 = "sha256-yvCu0EOwxOMN6upeHX+C2sIz1YVjjB/320g+Mf24S6g=";
   };
 

--- a/pkgs/by-name/hy/hygg/package.nix
+++ b/pkgs/by-name/hy/hygg/package.nix
@@ -15,7 +15,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "kruseio";
     repo = "hygg";
-    tag = "${finalAttrs.version}";
+    tag = finalAttrs.version;
     hash = "sha256-wxgHlRqe/g9LppWWTzft9hTA8heuFvGkKvA7nG2PsxA=";
   };
 

--- a/pkgs/by-name/i3/i3status-rust/package.nix
+++ b/pkgs/by-name/i3/i3status-rust/package.nix
@@ -27,7 +27,7 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "greshake";
     repo = "i3status-rust";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-Eam0MDACJN/a8J1Za7Xwy0Jlv/KGNn4M13C2yaCgLnU=";
   };
 

--- a/pkgs/by-name/il/illuminanced/package.nix
+++ b/pkgs/by-name/il/illuminanced/package.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "mikhail-m1";
     repo = "illuminanced";
-    tag = "${finalAttrs.version}";
+    tag = finalAttrs.version;
     hash = "sha256-ZEVma0uj9rsWB+vfUL7w3dHxI/ppBCG23TirGE+RREk=";
   };
 

--- a/pkgs/by-name/in/intel-gpu-tools/package.nix
+++ b/pkgs/by-name/in/intel-gpu-tools/package.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
     domain = "gitlab.freedesktop.org";
     owner = "drm";
     repo = "igt-gpu-tools";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-Lt/mqx13nHyD5QiDl8oWGiYIiK006uQvbbzHH44LB/0=";
   };
 

--- a/pkgs/by-name/in/invidious-router/package.nix
+++ b/pkgs/by-name/in/invidious-router/package.nix
@@ -14,7 +14,7 @@ buildGoModule {
   src = fetchFromGitLab {
     owner = "gaincoder";
     repo = "invidious-router";
-    rev = "refs/tags/${version}";
+    tag = version;
     hash = "sha256-YcMtZq4VMHr6XqHcsAAEmMF6jF1j1wb7Lq4EK42QAEo=";
   };
 

--- a/pkgs/by-name/ip/ipinfo/package.nix
+++ b/pkgs/by-name/ip/ipinfo/package.nix
@@ -11,7 +11,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = pname;
     repo = "cli";
-    rev = "refs/tags/${pname}-${version}";
+    tag = "${pname}-${version}";
     hash = "sha256-sdQdCP2NotrdeqYrSd9c6sExFeuX54I4fxJfEyULPuk=";
   };
 

--- a/pkgs/by-name/jo/jogger/package.nix
+++ b/pkgs/by-name/jo/jogger/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
     domain = "codeberg.org";
     owner = "baarkerlounger";
     repo = "jogger";
-    rev = "refs/tags/${finalAttrs.version}";
+    tag = finalAttrs.version;
     hash = "sha256-bju9XXMT6HRHG9QViO+FQCYQ+llrC+GP/AlIha0mxkM=";
   };
 

--- a/pkgs/by-name/ju/justbuild/package.nix
+++ b/pkgs/by-name/ju/justbuild/package.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "just-buildsystem";
     repo = "justbuild";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-ZTwe6S0AH1yQt5mABtIeWuMbiVSKeOZWMFI26fthLsM=";
   };
 

--- a/pkgs/by-name/ka/kapacitor/package.nix
+++ b/pkgs/by-name/ka/kapacitor/package.nix
@@ -17,7 +17,7 @@ let
     src = fetchFromGitHub {
       owner = "influxdata";
       repo = "flux";
-      rev = "refs/tags/v${libflux_version}";
+      tag = "v${libflux_version}";
       hash = "sha256-v9MUR+PcxAus91FiHYrMN9MbNOTWewh7MT6/t/QWQcM=";
     };
     patches = [
@@ -73,7 +73,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "influxdata";
     repo = "kapacitor";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-vxaLfJq0NFAJst0/AEhNJUl9dAaZY3blZAFthseMSX0=";
   };
 

--- a/pkgs/by-name/ka/kazv/package.nix
+++ b/pkgs/by-name/ka/kazv/package.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
     domain = "lily-is.land";
     owner = "kazv";
     repo = "kazv";
-    rev = "refs/tags/v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-WBS7TJJw0t57V4+NxsG8V8q4UKQXB8kRpWocvNy1Eto=";
   };
 

--- a/pkgs/by-name/ko/komari-agent/package.nix
+++ b/pkgs/by-name/ko/komari-agent/package.nix
@@ -12,7 +12,7 @@ buildGoModule (finalAttrs: {
   src = fetchFromGitHub {
     owner = "komari-monitor";
     repo = "komari-agent";
-    tag = "${finalAttrs.version}";
+    tag = finalAttrs.version;
     hash = "sha256-aWCsaiYkpj0D9hr7V3pxSk14pMD2E117vwemt9Ckqv0=";
   };
 

--- a/pkgs/by-name/ko/koodousfinder/package.nix
+++ b/pkgs/by-name/ko/koodousfinder/package.nix
@@ -13,7 +13,7 @@ python3.pkgs.buildPythonApplication {
     owner = "teixeira0xfffff";
     repo = "KoodousFinder";
     # Not properly tagged, https://github.com/teixeira0xfffff/KoodousFinder/issues/7
-    #rev = "refs/tags/v${version}";
+    #tag = "v${version}";
     rev = "d9dab5572f44e5cd45c04e6fcda38956897855d1";
     hash = "sha256-skCbt2lDKgSyZdHY3WImbr6CF0icrDPTIXNV1736gKk=";
   };

--- a/pkgs/by-name/la/last/package.nix
+++ b/pkgs/by-name/la/last/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitLab {
     owner = "mcfrith";
     repo = "last";
-    rev = "refs/tags/${version}";
+    tag = version;
     hash = "sha256-U1FGP6jzB36HLwTFKm/VMZWPPjo6mVuV/ePhGIkQgpg=";
   };
 

--- a/pkgs/by-name/li/lib2geom/package.nix
+++ b/pkgs/by-name/li/lib2geom/package.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitLab {
     owner = "inkscape";
     repo = "lib2geom";
-    rev = "refs/tags/${finalAttrs.version}";
+    tag = finalAttrs.version;
     hash = "sha256-kbcnefzNhUj/ZKZaB9r19bpI68vxUKOLVAwUXSr/zz0=";
   };
 

--- a/pkgs/by-name/li/libkazv/package.nix
+++ b/pkgs/by-name/li/libkazv/package.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
     domain = "lily-is.land";
     owner = "kazv";
     repo = "libkazv";
-    rev = "refs/tags/v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-bKujiuAR5otF7nc/BdVWVaEW9fSxdh2bcAgsQ5UO1Aw=";
   };
 

--- a/pkgs/by-name/li/libloot/package.nix
+++ b/pkgs/by-name/li/libloot/package.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "loot";
     repo = "libloot";
-    rev = "refs/tags/${finalAttrs.version}";
+    tag = finalAttrs.version;
     hash = "sha256-l8AdqJ0lZH4rBcf4WV3ju+sIHYam6USXCXTqyRPzgeo=";
   };
 

--- a/pkgs/by-name/li/libsfdo/package.nix
+++ b/pkgs/by-name/li/libsfdo/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation (finalAttrs: {
     domain = "gitlab.freedesktop.org";
     owner = "vyivel";
     repo = "libsfdo";
-    rev = "refs/tags/v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-xT1pKKElwKSd43XTKuBY+9rogquV1IAAYgWV5lEpAHk=";
   };
 

--- a/pkgs/by-name/ma/magic-vlsi/package.nix
+++ b/pkgs/by-name/ma/magic-vlsi/package.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "RTimothyEdwards";
     repo = "magic";
-    tag = "${version}";
+    tag = version;
     sha256 = "sha256-P5qfMsn3DGHjeF7zsZWeG9j38C6j5UEwUqGyjaEVO1E=";
     leaveDotGit = true;
   };

--- a/pkgs/by-name/ma/matrix-synapse-unwrapped/plugins/s3-storage-provider.nix
+++ b/pkgs/by-name/ma/matrix-synapse-unwrapped/plugins/s3-storage-provider.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "matrix-org";
     repo = "synapse-s3-storage-provider";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-aeacw6Fpv4zFhZI4LdsJiV2pcOAMv3aV5CicnwYRxw8=";
   };
 

--- a/pkgs/by-name/me/meritous/package.nix
+++ b/pkgs/by-name/me/meritous/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitLab {
     owner = "meritous";
     repo = "meritous";
-    rev = "refs/tags/v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-6KK2anjX+fPsYf4HSOHQ0EQBINqZiVbxo1RmBR6pslg=";
   };
 

--- a/pkgs/by-name/mf/mfaktc/package.nix
+++ b/pkgs/by-name/mf/mfaktc/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "primesearch";
     repo = "mfaktc";
-    tag = "${finalAttrs.version}";
+    tag = finalAttrs.version;
     fetchSubmodules = true;
     hash = "sha256-7lJ3+v9exe+n+Txkn1vsvSPYLEP4l/0UgHpc6lAGv1Y=";
   };

--- a/pkgs/by-name/ml/mlmmj/package.nix
+++ b/pkgs/by-name/ml/mlmmj/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     domain = "codeberg.org";
     owner = "mlmmj";
     repo = "mlmmj";
-    rev = "refs/tags/RELEASE_" + lib.replaceStrings [ "." ] [ "_" ] version;
+    tag = "RELEASE_" + lib.replaceStrings [ "." ] [ "_" ] version;
     hash = "sha256-kAo04onxVve3kCaM4h1APsjs3C4iePabkBFJeqvnPxo=";
   };
 

--- a/pkgs/by-name/mo/mov-cli/mov-cli-test.nix
+++ b/pkgs/by-name/mo/mov-cli/mov-cli-test.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "mov-cli";
     repo = "mov-cli-test";
-    rev = "refs/tags/${version}";
+    tag = version;
     hash = "sha256-INdPAJxPxfo5bKg4Xn1r7bildxznXrTJxmDI21wylnI=";
   };
 

--- a/pkgs/by-name/mp/mpv/scripts/webtorrent-mpv-hook.nix
+++ b/pkgs/by-name/mp/mpv/scripts/webtorrent-mpv-hook.nix
@@ -20,7 +20,7 @@ let
     src = fetchFromGitHub {
       owner = "murat-dogan";
       repo = "node-datachannel";
-      rev = "refs/tags/v${nodeDatachannel.version}";
+      tag = "v${nodeDatachannel.version}";
       hash = "sha256-r5tBg645ikIWm+RU7Muw/JYyd7AMpkImD0Xygtm1MUk=";
     };
 

--- a/pkgs/by-name/nb/nbfc-linux/package.nix
+++ b/pkgs/by-name/nb/nbfc-linux/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "nbfc-linux";
     repo = "nbfc-linux";
-    tag = "${finalAttrs.version}";
+    tag = finalAttrs.version;
     hash = "sha256-ARUhm1K3A0bzVRen6VO3KvomkPl1S7vx2+tmg2ZtL8s=";
   };
 

--- a/pkgs/by-name/ni/nix-fast-build/package.nix
+++ b/pkgs/by-name/ni/nix-fast-build/package.nix
@@ -17,7 +17,7 @@ python3Packages.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "Mic92";
     repo = "nix-fast-build";
-    rev = "refs/tags/${version}";
+    tag = version;
     hash = "sha256-6X4BW+3C2nfkorMfe+tuoeYrdddxPtLqOJ1rZxuxPrc=";
   };
 

--- a/pkgs/by-name/no/nodeinfo/package.nix
+++ b/pkgs/by-name/no/nodeinfo/package.nix
@@ -12,7 +12,7 @@ buildGoModule rec {
     domain = "codeberg.org";
     owner = "thefederationinfo";
     repo = "nodeinfo-go";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-XwK3QeVDQMZD5G79XPJTAJyilVgYFVgZORHYTBI0gIQ=";
   };
 

--- a/pkgs/by-name/np/npm-check-updates/package.nix
+++ b/pkgs/by-name/np/npm-check-updates/package.nix
@@ -11,7 +11,7 @@ buildNpmPackage rec {
   src = fetchFromGitHub {
     owner = "raineorshine";
     repo = "npm-check-updates";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-I9X98vqQgLgWt7q9Tr+0b+IlpTsPZDBQd+PVZlgpzyE=";
   };
 

--- a/pkgs/by-name/nu/nunicode/package.nix
+++ b/pkgs/by-name/nu/nunicode/package.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromBitbucket {
     owner = "alekseyt";
     repo = "nunicode";
-    rev = "refs/tags/${finalAttrs.version}";
+    tag = finalAttrs.version;
     hash = "sha256-6255YdX7eYSAj0EAE4RgX1m4XDNIF/Nc4ZCvXzTxpag=";
   };
 

--- a/pkgs/by-name/oc/ocis/web.nix
+++ b/pkgs/by-name/oc/ocis/web.nix
@@ -14,7 +14,7 @@ stdenvNoCC.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "owncloud";
     repo = "web";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-hupdtK/V74+X7/eXoDmUjFvSKuhnoOtNQz7o6TLJXG4=";
   };
 

--- a/pkgs/by-name/oc/octoprint/plugins.nix
+++ b/pkgs/by-name/oc/octoprint/plugins.nix
@@ -513,7 +513,7 @@ in
     src = fetchFromGitHub {
       owner = "jneilliii";
       repo = "OctoPrint-STLViewer";
-      rev = "refs/tags/${version}";
+      tag = version;
       sha256 = "sha256-S7zjEbyo59OJpa7INCv1o4ybQ+Sy6a3EJ5AJ6wiBe1Y=";
     };
 

--- a/pkgs/by-name/ok/oklch-color-picker/package.nix
+++ b/pkgs/by-name/ok/oklch-color-picker/package.nix
@@ -18,7 +18,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "eero-lehtinen";
     repo = "oklch-color-picker";
-    tag = "${finalAttrs.version}";
+    tag = finalAttrs.version;
     hash = "sha256-dbsE1mYt/GhpkWIBS6MejiKKKz1B+h/3wqGKHCp0p2Q=";
   };
 

--- a/pkgs/by-name/op/openllm/package.nix
+++ b/pkgs/by-name/op/openllm/package.nix
@@ -11,7 +11,7 @@ let
         version = "23.1.2";
         build-system = [ super.poetry-core ];
         src = oldAttrs.src.override {
-          rev = "refs/tags/v${version}";
+          tag = "v${version}";
           hash = "sha256-YO4Clbo5fmXbysxwwM2qCHJwO5KwDC05VctRVFruJcw=";
         };
       });
@@ -27,7 +27,7 @@ python.pkgs.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "bentoml";
     repo = "openllm";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-4KIpe6KjbBDDUj0IjzSccxjgZyBoaUVIQJYk1+W01Vo=";
   };
 

--- a/pkgs/by-name/or/orocos-kdl/package.nix
+++ b/pkgs/by-name/or/orocos-kdl/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "orocos";
     repo = "orocos_kinematics_dynamics";
-    tag = "${version}";
+    tag = version;
     hash = "sha256-4pPU+6uMMYLGq2V46wmg6lHFVhwFXrEg7PfnWGAI2is=";
     fetchSubmodules = true; # Needed to build Python bindings
   };

--- a/pkgs/by-name/os/os-agent/package.nix
+++ b/pkgs/by-name/os/os-agent/package.nix
@@ -12,7 +12,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "home-assistant";
     repo = "os-agent";
-    tag = "${version}";
+    tag = version;
     hash = "sha256-x0bVY476Gm5D1drRmyszdshrO0Vi/baDsG3ulysu0Kg=";
   };
 

--- a/pkgs/by-name/ou/outfly/package.nix
+++ b/pkgs/by-name/ou/outfly/package.nix
@@ -22,7 +22,7 @@ rustPlatform.buildRustPackage rec {
     domain = "codeberg.org";
     owner = "outfly";
     repo = "outfly";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-FRvu3FgbT3i5888ll573nhb7naYx04Oi8nrcfgEHxUo=";
   };
 

--- a/pkgs/by-name/pa/package-version-server/package.nix
+++ b/pkgs/by-name/pa/package-version-server/package.nix
@@ -14,7 +14,7 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "zed-industries";
     repo = "package-version-server";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-/YyJ8+tKrNKVrN+F/oHgtExBBRatIIOvWr9mAyTHA3E=";
   };
 

--- a/pkgs/by-name/pa/pandoc-mustache/package.nix
+++ b/pkgs/by-name/pa/pandoc-mustache/package.nix
@@ -14,7 +14,7 @@ python3Packages.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "michaelstepner";
     repo = "pandoc-mustache";
-    tag = "${version}";
+    tag = version;
     hash = "sha256-lgbQV4X2N4VuIEtjeSA542yqGdIs5QQ7+bdCoy/aloE=";
   };
 

--- a/pkgs/by-name/pc/pcmanfm/package.nix
+++ b/pkgs/by-name/pc/pcmanfm/package.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "lxde";
     repo = "pcmanfm";
-    tag = "${finalAttrs.version}";
+    tag = finalAttrs.version;
     hash = "sha256-4kJDCnld//Vbe2KbrLoYZJ/dutagY/GImoOnbpQIdDY=";
   };
 

--- a/pkgs/by-name/pc/pcsclite/package.nix
+++ b/pkgs/by-name/pc/pcsclite/package.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
     domain = "salsa.debian.org";
     owner = "rousseau";
     repo = "PCSC";
-    rev = "refs/tags/${finalAttrs.version}";
+    tag = finalAttrs.version;
     hash = "sha256-37qeWGEuutF0cOOidoLchKJLQCvJFdVRZXepWzD4pZs=";
   };
 

--- a/pkgs/by-name/ph/phylophlan/package.nix
+++ b/pkgs/by-name/ph/phylophlan/package.nix
@@ -17,7 +17,7 @@ let
     src = fetchFromGitHub {
       owner = "biobakery";
       repo = "phylophlan";
-      rev = "refs/tags/${finalAttrs.version}";
+      tag = finalAttrs.version;
       hash = "sha256-KlWKt2tH2lQBh/eQ2Hbcu2gXHEFfmFEc6LrybluxINc=";
     };
 

--- a/pkgs/by-name/po/poetry/plugins/poetry-plugin-poeblix.nix
+++ b/pkgs/by-name/po/poetry/plugins/poetry-plugin-poeblix.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "spoorn";
     repo = "poeblix";
-    rev = "refs/tags/${version}";
+    tag = version;
     hash = "sha256-TKadEOk9kM3ZYsQmE2ftzjHNGNKI17p0biMr+Nskigs=";
   };
 

--- a/pkgs/by-name/po/pokemmo-installer/package.nix
+++ b/pkgs/by-name/po/pokemmo-installer/package.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitLab {
     owner = "coringao";
     repo = "pokemmo-installer";
-    rev = "refs/tags/${finalAttrs.version}";
+    tag = finalAttrs.version;
     hash = "sha256-uSbnXBpkeGM9X6DU7AikT7hG/emu67PXuGdm6xfB8To=";
   };
 

--- a/pkgs/by-name/pr/pretix/package.nix
+++ b/pkgs/by-name/pr/pretix/package.nix
@@ -21,7 +21,7 @@ let
         version = "2.3.0";
         src = fetchFromGitHub {
           inherit (oldAttrs.src) owner repo;
-          rev = "refs/tags/v${version}";
+          tag = "v${version}";
           hash = "sha256-oGg5MD9p4PSUVkt5pGLwjAF4SHHf4Aqr+/3FsuFaybY=";
         };
       });
@@ -47,7 +47,7 @@ let
   src = fetchFromGitHub {
     owner = "pretix";
     repo = "pretix";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-O9HAslZ8xbmLgJi3y91M6mc1oIvJZ8nRJyFRuNorRHs=";
   };
 

--- a/pkgs/by-name/pr/prisma-language-server/package.nix
+++ b/pkgs/by-name/pr/prisma-language-server/package.nix
@@ -11,7 +11,7 @@ buildNpmPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "prisma";
     repo = "language-tools";
-    tag = "${finalAttrs.version}";
+    tag = finalAttrs.version;
     hash = "sha256-hcLjvIi7EZQSr99OLHGWesziBc5HhkvD+dmGOTgOY/c=";
   };
 

--- a/pkgs/by-name/pr/professor/package.nix
+++ b/pkgs/by-name/pr/professor/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
   src = fetchFromGitLab {
     owner = "hepcedar";
     repo = "professor";
-    rev = "refs/tags/professor-2.4.2";
+    tag = "professor-2.4.2";
     hash = "sha256-z2Ub7SUTz4Hj3ajnzOV/QXZ+cH2v6zJv9UZM2M2y1Hg=";
     # workaround unpacking to case-sensitive filesystems
     postFetch = ''

--- a/pkgs/by-name/qu/quickder/package.nix
+++ b/pkgs/by-name/qu/quickder/package.nix
@@ -22,7 +22,7 @@ let
           src = fetchFromGitHub {
             owner = "pyparsing";
             repo = "pyparsing";
-            rev = "refs/tags/${version}";
+            tag = version;
             hash = "sha256-0B8DjO4kLgvt4sYsk8CZI+5icdKy73XE2tWeqVLqO5A=";
           };
         });

--- a/pkgs/by-name/ra/ratman/package.nix
+++ b/pkgs/by-name/ra/ratman/package.nix
@@ -19,7 +19,7 @@ rustPlatform.buildRustPackage rec {
     domain = "codeberg.org";
     owner = "irdest";
     repo = "irdest";
-    tag = "${version}";
+    tag = version;
     hash = "sha256-rdKfKbikyqs0Y/y9A8XRVSKenjHD5rS3blxwy98Tvmg=";
   };
 

--- a/pkgs/by-name/re/realmd/package.nix
+++ b/pkgs/by-name/re/realmd/package.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation (finalAttrs: {
     domain = "gitlab.freedesktop.org";
     owner = "realmd";
     repo = "realmd";
-    rev = "refs/tags/${finalAttrs.version}";
+    tag = finalAttrs.version;
     hash = "sha256-lmNlrXOOUSDk/8H/ge0IRA64bnau9nYUIkW6OyVxbBg=";
   };
 

--- a/pkgs/by-name/rh/rhsrvany/package.nix
+++ b/pkgs/by-name/rh/rhsrvany/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "rwmjones";
     repo = "rhsrvany";
-    rev = "refs/tags/v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-eeEiAdm7NO5fFYKtHQbeBq4RhP8Xwgw2p2Wkm+n0EWM=";
   };
 

--- a/pkgs/by-name/ro/root/clang-root.nix
+++ b/pkgs/by-name/ro/root/clang-root.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   src = fetchgit {
     url = "https://github.com/root-project/llvm-project";
-    rev = "refs/tags/ROOT-llvm${version}";
+    tag = "ROOT-llvm${version}";
     hash = "sha256-qEoQVv/Aw9gqKSNa8ZJGqPzwXvH1yXiSOkvrUWeXI+g=";
   };
 

--- a/pkgs/by-name/ro/root/package.nix
+++ b/pkgs/by-name/ro/root/package.nix
@@ -67,7 +67,7 @@ stdenv.mkDerivation (finalAttrs: {
     repo = "clad";
     # Make sure that this is the same tag as in the ROOT build files!
     # https://github.com/root-project/root/blob/master/interpreter/cling/tools/plugins/clad/CMakeLists.txt#L76
-    rev = "refs/tags/v2.0";
+    tag = "v2.0";
     hash = "sha256-Oj7gGSvnGuYdggonPWjrwPn/06cD+ig3eefRh7xaiPs=";
   };
 

--- a/pkgs/by-name/sa/safe-rm/package.nix
+++ b/pkgs/by-name/sa/safe-rm/package.nix
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage rec {
 
   src = fetchgit {
     url = "https://git.launchpad.net/safe-rm";
-    rev = "refs/tags/${pname}-${version}";
+    tag = "${pname}-${version}";
     sha256 = "sha256-7+4XwsjzLBCQmHDYNwhlN4Yg3eL43GUEbq8ROtuP2Kw=";
   };
 

--- a/pkgs/by-name/sa/satyrographos/package.nix
+++ b/pkgs/by-name/sa/satyrographos/package.nix
@@ -10,7 +10,7 @@ let
   src = fetchFromGitHub {
     owner = "na4zagin3";
     repo = "satyrographos";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     sha256 = "sha256-f9iJTr4nV7dFCMkI8+zv9qvYWRSw8H/xbbZm2LR9cB4=";
   };
 in

--- a/pkgs/by-name/si/simgear/package.nix
+++ b/pkgs/by-name/si/simgear/package.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitLab {
     owner = "flightgear";
     repo = "simgear";
-    tag = "${version}";
+    tag = version;
     hash = "sha256-1zbw/lIjTbVwhxHPvXRlxPmYJeWmKvPE/RDrTL0PXb4=";
   };
 

--- a/pkgs/by-name/si/sing-geoip/package.nix
+++ b/pkgs/by-name/si/sing-geoip/package.nix
@@ -14,7 +14,7 @@ let
     src = fetchFromGitHub {
       owner = "SagerNet";
       repo = "sing-geoip";
-      rev = "refs/tags/${version}";
+      tag = version;
       hash = "sha256-nIrbiECK25GyuPEFqMvPdZUShC2JC1NI60Y10SsoWyY=";
     };
 

--- a/pkgs/by-name/sk/skyscraper/package.nix
+++ b/pkgs/by-name/sk/skyscraper/package.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "Gemba";
     repo = "skyscraper";
-    rev = "refs/tags/${finalAttrs.version}";
+    tag = finalAttrs.version;
     hash = "sha256-z6Y5JUKvwxYgE7sdXvRNOsbUTON5i/DX1q9y4wRXixE=";
   };
 

--- a/pkgs/by-name/sp/spot/package.nix
+++ b/pkgs/by-name/sp/spot/package.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "xou816";
     repo = "spot";
-    rev = "refs/tags/${version}";
+    tag = version;
     hash = "sha256-7zWK0wkh53ojnoznv4T/X//JeyKJVKOrfYF0IkvciIY=";
   };
 

--- a/pkgs/by-name/sr/sr2t/package.nix
+++ b/pkgs/by-name/sr/sr2t/package.nix
@@ -12,7 +12,7 @@ python3.pkgs.buildPythonApplication rec {
   src = fetchFromGitLab {
     owner = "0bs1d1an";
     repo = "sr2t";
-    rev = "refs/tags/${version}";
+    tag = version;
     hash = "sha256-BPsYnKBTxt5WUd2+WumMdVi8p6iryOWG2MjI97qbaCw=";
   };
 

--- a/pkgs/by-name/st/startup-disk/package.nix
+++ b/pkgs/by-name/st/startup-disk/package.nix
@@ -15,7 +15,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   src = fetchFromGitLab {
     owner = "davide125";
     repo = "startup-disk";
-    tag = "${finalAttrs.version}";
+    tag = finalAttrs.version;
     hash = "sha256-258whEX6hKqfrk2aII15tuFEuB7NQUCNLEmi3OCOWV4=";
     domain = "gitlab.gnome.org";
   };

--- a/pkgs/by-name/su/sums/package.nix
+++ b/pkgs/by-name/su/sums/package.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitLab {
     owner = "leesonwai";
     repo = "sums";
-    tag = "${finalAttrs.version}";
+    tag = finalAttrs.version;
     hash = "sha256-X+AMUH8nJli0Um1bH0gDGLnfHGknqea3DZxH+tdTEr8=";
   };
 

--- a/pkgs/by-name/su/supergfxctl-plasmoid/package.nix
+++ b/pkgs/by-name/su/supergfxctl-plasmoid/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitLab {
     owner = "jhyub";
     repo = "supergfxctl-plasmoid";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-Un2uVTde18qloZoWk6bbscyvsBTIAdK1CfxYAZg1+F4=";
   };
 

--- a/pkgs/by-name/tc/tcld/package.nix
+++ b/pkgs/by-name/tc/tcld/package.nix
@@ -14,7 +14,7 @@ buildGoModule (finalAttrs: {
   src = fetchFromGitHub {
     owner = "temporalio";
     repo = "tcld";
-    rev = "refs/tags/v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-Jnm6l9Jj1mi9esDS6teKTEMhq7V1QD/dTl3qFhKsW4o=";
     # Populate values from the git repository; by doing this in 'postFetch' we
     # can delete '.git' afterwards and the 'src' should stay reproducible.

--- a/pkgs/by-name/te/textidote/package.nix
+++ b/pkgs/by-name/te/textidote/package.nix
@@ -25,7 +25,7 @@ let
     src = fetchFromGitHub {
       owner = "sylvainhalle";
       repo = "textidote";
-      rev = "refs/tags/v${version}";
+      tag = "v${version}";
       hash = "sha256-QMSoxk5jDn6qsdxffXJ/S4eTIzLjJdAEbdaK8MZIavI=";
     };
 

--- a/pkgs/by-name/te/textlint-rule-common-misspellings/package.nix
+++ b/pkgs/by-name/te/textlint-rule-common-misspellings/package.nix
@@ -42,7 +42,7 @@ let
     src = fetchFromGitHub {
       owner = "textlint";
       repo = "textlint-rule-helper";
-      rev = "refs/tags/v${finalAttrs.version}";
+      tag = "v${finalAttrs.version}";
       hash = "sha256-SVeL/3KC/yazSGsmn5We8fJAuVqfcspzN7i2a4+EOlI=";
     };
 

--- a/pkgs/by-name/te/textpieces/package.nix
+++ b/pkgs/by-name/te/textpieces/package.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitLab {
     owner = "liferooter";
     repo = "textpieces";
-    tag = "${finalAttrs.version}";
+    tag = finalAttrs.version;
     hash = "sha256-BUhcPnvi6cuhaYYNZV9pvOLH/cIV3t7ncpG55fBjqwo=";
   };
 

--- a/pkgs/by-name/th/threema-desktop/package.nix
+++ b/pkgs/by-name/th/threema-desktop/package.nix
@@ -14,7 +14,7 @@ let
   electronSrc = fetchFromGitHub {
     owner = "threema-ch";
     repo = "threema-web-electron";
-    rev = "refs/tags/${version}";
+    tag = version;
     hash = "sha256-u1rzKFDrLxU/o7Oc2o/WBwbAncNWKJ9GAUBaNDPViZI=";
   };
 
@@ -25,7 +25,7 @@ let
     src = fetchFromGitHub {
       owner = "threema-ch";
       repo = "threema-web";
-      rev = "refs/tags/v${version}";
+      tag = "v${version}";
       hash = "sha256-GmyWKJdDgiRS7XxNjCyvt92Bn48kpP3+ZsfRouyUCM0=";
     };
 

--- a/pkgs/by-name/ty/typioca/package.nix
+++ b/pkgs/by-name/ty/typioca/package.nix
@@ -13,7 +13,7 @@ buildGoModule (finalAttrs: {
   src = fetchFromGitHub {
     owner = "bloznelis";
     repo = "typioca";
-    tag = "${finalAttrs.version}";
+    tag = finalAttrs.version;
     hash = "sha256-fViYwewzhJUJjMupCYk1UsnnPAhByYZqYkuKD6MJNnE=";
   };
 

--- a/pkgs/by-name/un/unfs3/package.nix
+++ b/pkgs/by-name/un/unfs3/package.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "unfs3";
     repo = "unfs3";
-    rev = "refs/tags/unfs3-${version}";
+    tag = "unfs3-${version}";
     hash = "sha256-5iAriIutBhwyZVS7AG2fnkrHOI7pNAKfYv062Cy0WXw=";
   };
 

--- a/pkgs/by-name/ur/urlfinder/package.nix
+++ b/pkgs/by-name/ur/urlfinder/package.nix
@@ -11,7 +11,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "projectdiscovery";
     repo = "urlfinder";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-dtCXCRnI05822+a5Os+I+ZAmL/hC884PRCIPlEY3jok=";
   };
 

--- a/pkgs/by-name/vm/vmmlib/package.nix
+++ b/pkgs/by-name/vm/vmmlib/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "Eyescale";
     repo = "vmmlib";
-    tag = "${version}";
+    tag = version;
     hash = "sha256-QEfeQcE66XbsFTN/Fojgldem5C+RhbOBmRyBX3sfUrg=";
 
     fetchSubmodules = true;

--- a/pkgs/by-name/wa/wayback-x11/package.nix
+++ b/pkgs/by-name/wa/wayback-x11/package.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
     domain = "gitlab.freedesktop.org";
     owner = "wayback";
     repo = "wayback";
-    tag = "${finalAttrs.version}";
+    tag = finalAttrs.version;
     hash = "sha256-/H0+zOAdrejHMNRcc94Wjgc4/s/M1rUegPcX+pBQcrY=";
   };
 

--- a/pkgs/by-name/wh/wheelwizard/package.nix
+++ b/pkgs/by-name/wh/wheelwizard/package.nix
@@ -19,7 +19,7 @@ buildDotnetModule rec {
   src = fetchFromGitHub {
     owner = "TeamWheelWizard";
     repo = "WheelWizard";
-    tag = "${version}";
+    tag = version;
     hash = "sha256-DuEI6bmvNP6wRuZX9Do0FGDsu80ldy0SCefBk6gqT9s=";
   };
   postPatch = ''

--- a/pkgs/by-name/wh/whitesur-icon-theme/package.nix
+++ b/pkgs/by-name/wh/whitesur-icon-theme/package.nix
@@ -36,7 +36,7 @@ lib.checkListOfEnum "${pname}: theme variants"
     src = fetchFromGitHub {
       owner = "vinceliuice";
       repo = "WhiteSur-icon-theme";
-      tag = "${version}";
+      tag = version;
       hash = "sha256-oBKDvCVHEjN6JT0r0G+VndzijEWU9L8AvDhHQTmw2E4=";
     };
 

--- a/pkgs/by-name/wi/wine-discord-ipc-bridge/package.nix
+++ b/pkgs/by-name/wi/wine-discord-ipc-bridge/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "0e4ef622";
     repo = "wine-discord-ipc-bridge";
-    rev = "refs/tags/v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-jzsbOKMakNQ6RNMlioX088fGzFBDxOP45Atlsfm2RKg=";
   };
 

--- a/pkgs/by-name/wy/wyoming-faster-whisper/package.nix
+++ b/pkgs/by-name/wy/wyoming-faster-whisper/package.nix
@@ -12,7 +12,7 @@ python3Packages.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "rhasspy";
     repo = "wyoming-faster-whisper";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-MKB6gZdGdAYoNK8SRiDHG8xtMZ5mXdaSn+bH4T6o/K4=";
   };
 

--- a/pkgs/by-name/wy/wyoming-openwakeword/package.nix
+++ b/pkgs/by-name/wy/wyoming-openwakeword/package.nix
@@ -12,7 +12,7 @@ python3Packages.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "rhasspy";
     repo = "wyoming-openwakeword";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-yYDZ1wOhCTdYGeRmtbOgx5/zkF0Baxmha7eO/i0p49g=";
   };
 

--- a/pkgs/by-name/xa/xavs2/package.nix
+++ b/pkgs/by-name/xa/xavs2/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "pkuvcl";
     repo = "xavs2";
-    rev = "refs/tags/${finalAttrs.version}";
+    tag = finalAttrs.version;
     hash = "sha256-4w/WTXvRQbohKL+YALQCCYglHQKVvehlUYfitX/lLPw=";
   };
 

--- a/pkgs/by-name/xf/xfitter/package.nix
+++ b/pkgs/by-name/xf/xfitter/package.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation {
   src = fetchFromGitLab {
     owner = "fitters";
     repo = "xfitter";
-    rev = "refs/tags/2.2.0_Future_Freeze";
+    tag = "2.2.0_Future_Freeze";
     domain = "gitlab.cern.ch";
     hash = "sha256-wanxgldvBEuAEOeVok3XgRVStcn9APd+Nj7vpRZUtGs=";
   };

--- a/pkgs/by-name/xl/xlogo/package.nix
+++ b/pkgs/by-name/xl/xlogo/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     group = "xorg";
     owner = "app";
     repo = "xlogo";
-    rev = "refs/tags/xlogo-${version}";
+    tag = "xlogo-${version}";
     hash = "sha256-KjJhuiFVn34vEZbC7ds4MrcXCHq9PcIpAuaCGBX/EXc=";
   };
 

--- a/pkgs/by-name/xr/xr-hardware/package.nix
+++ b/pkgs/by-name/xr/xr-hardware/package.nix
@@ -13,7 +13,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     domain = "gitlab.freedesktop.org";
     owner = "monado/utilities";
     repo = "xr-hardware";
-    rev = "refs/tags/${finalAttrs.version}";
+    tag = finalAttrs.version;
     hash = "sha256-w35/LoozCJz0ytHEHWsEdCaYYwyGU6sE13iMckVdOzY=";
   };
 

--- a/pkgs/by-name/yg/yggdrasil-jumper/package.nix
+++ b/pkgs/by-name/yg/yggdrasil-jumper/package.nix
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "one-d-wide";
     repo = "yggdrasil-jumper";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-dElC+q76dE3SlVY4+aauNmeqcNdfj0mMjg51WRuywJI=";
   };
 

--- a/pkgs/by-name/zl/zlcompressor/package.nix
+++ b/pkgs/by-name/zl/zlcompressor/package.nix
@@ -34,7 +34,7 @@ clangStdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "ZL-Audio";
     repo = "ZLCompressor";
-    tag = "${finalAttrs.version}";
+    tag = finalAttrs.version;
     hash = "sha256-G7tgRenRB6aYpi+BSiQzwSsekvCw4JPUuy1iXVj7HN0=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/zl/zlequalizer/package.nix
+++ b/pkgs/by-name/zl/zlequalizer/package.nix
@@ -34,7 +34,7 @@ clangStdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "ZL-Audio";
     repo = "ZLEqualizer";
-    tag = "${finalAttrs.version}";
+    tag = finalAttrs.version;
     hash = "sha256-ix3UcTs9CEJ2TCJLdpvZOaoB0wgNDrvSQhZzer8yMRw=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/zl/zlsplitter/package.nix
+++ b/pkgs/by-name/zl/zlsplitter/package.nix
@@ -34,7 +34,7 @@ clangStdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "ZL-Audio";
     repo = "ZLSplitter";
-    tag = "${finalAttrs.version}";
+    tag = finalAttrs.version;
     hash = "sha256-6ICXL1jX6MMYf5VasTW9osJ2BNb6jqWfeAtmmEp6L/4=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/zm/zmqpp/package.nix
+++ b/pkgs/by-name/zm/zmqpp/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "zeromq";
     repo = "zmqpp";
-    tag = "${finalAttrs.version}";
+    tag = finalAttrs.version;
     hash = "sha256-UZyJpBEOf/Ys+i2tiBTjv4PlM5fHjjNLWuGhpgcmYyM=";
   };
 

--- a/pkgs/by-name/zu/zulip-term/package.nix
+++ b/pkgs/by-name/zu/zulip-term/package.nix
@@ -17,7 +17,7 @@ let
         src = fetchFromGitHub {
           owner = "urwid";
           repo = "urwid";
-          rev = "refs/tags/${version}";
+          tag = version;
           hash = "sha256-oPb2h/+gaqkZTXIiESjExMfBNnOzDvoMkXvkZ/+KVwo=";
         };
         doCheck = false;

--- a/pkgs/desktops/lomiri/applications/lomiri-mediaplayer-app/default.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri-mediaplayer-app/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitLab {
     owner = "ubports";
     repo = "development/core/lomiri-mediaplayer-app";
-    tag = "${finalAttrs.version}";
+    tag = finalAttrs.version;
     hash = "sha256-A1tAXQXDwVZ3ILFcJKCtbOm1iNxPFOXQIS6p7fPbqwM=";
   };
 

--- a/pkgs/desktops/lomiri/qml/qqc2-suru-style/default.nix
+++ b/pkgs/desktops/lomiri/qml/qqc2-suru-style/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitLab {
     owner = "ubports";
     repo = "development/core/qqc2-suru-style";
-    rev = "refs/tags/${finalAttrs.version}";
+    tag = finalAttrs.version;
     hash = "sha256-kAgHsNWwUWxHg26bTMmlq8m9DR4+ob4pl/oUX7516hM=";
   };
 

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -610,7 +610,7 @@ with haskellLib;
       src = pkgs.fetchgit {
         name = "git-annex-${super.git-annex.version}-src";
         url = "git://git-annex.branchable.com/";
-        rev = "refs/tags/" + super.git-annex.version;
+        tag = super.git-annex.version;
         sha256 = "sha256-+OLFMrqpf1Ooy7CQ9S+N/H5R5+aHQtbO1pYwDF4ln8A=";
         # delete android and Android directories which cause issues on
         # darwin (case insensitive directory). Since we don't need them

--- a/pkgs/development/libraries/accounts-qt/default.nix
+++ b/pkgs/development/libraries/accounts-qt/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitLab {
     owner = "accounts-sso";
     repo = "libaccounts-qt";
-    rev = "refs/tags/VERSION_${finalAttrs.version}";
+    tag = "VERSION_${finalAttrs.version}";
     hash = "sha256-mPZgD4r7vlUP6wklvZVknGqTXZBckSOtNzK7p6e2qSA=";
   };
 

--- a/pkgs/development/lisp-modules/packages.nix
+++ b/pkgs/development/lisp-modules/packages.nix
@@ -479,7 +479,7 @@ let
         src = pkgs.fetchFromGitHub {
           owner = "fukamachi";
           repo = "qlot";
-          rev = "refs/tags/${version}";
+          tag = version;
           hash = "sha256-j9iT25Yz9Z6llCKwwiHlVNKLqwuKvY194LrAzXuljsE=";
         };
 

--- a/pkgs/development/ocaml-modules/synchronizer/default.nix
+++ b/pkgs/development/ocaml-modules/synchronizer/default.nix
@@ -15,7 +15,7 @@ buildDunePackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "OCamlPro";
     repo = "synchronizer";
-    tag = "${finalAttrs.version}";
+    tag = finalAttrs.version;
     hash = "sha256-0XtPHpDlyH1h8W2ZlRvJbZjCN9WP5mzk2N01WFd8eLQ=";
   };
 

--- a/pkgs/development/octave-modules/bim/default.nix
+++ b/pkgs/development/octave-modules/bim/default.nix
@@ -13,7 +13,7 @@ buildOctavePackage rec {
   src = fetchFromGitHub {
     owner = "carlodefalco";
     repo = "bim";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     sha256 = "sha256-nK/VZ+thMuMU5RBiNYpzylOuVxKbcfSyrXZfka5+g4I=";
   };
 

--- a/pkgs/development/python-modules/alabaster/default.nix
+++ b/pkgs/development/python-modules/alabaster/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "sphinx-doc";
     repo = "alabaster";
-    rev = "refs/tags/${version}";
+    tag = version;
     hash = "sha256-aQEhFZUJs0TptfpjQVoIVI9V9a+xKjE2OfStSaJKHGI=";
   };
 

--- a/pkgs/development/python-modules/atpublic/default.nix
+++ b/pkgs/development/python-modules/atpublic/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
   src = fetchFromGitLab {
     owner = "warsaw";
     repo = "public";
-    rev = "refs/tags/${version}";
+    tag = version;
     hash = "sha256-cqum+4hREu0jO9iFoUUzfzn597BoMAhG+aanwnh8hb8=";
   };
 

--- a/pkgs/development/python-modules/backports-strenum/default.nix
+++ b/pkgs/development/python-modules/backports-strenum/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "clbarnes";
     repo = "backports.strenum";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-j5tALFrLeZ8k+GwAaq0ocmcQWvdWkRUHbOVq5Du4mu0=";
   };
 

--- a/pkgs/development/python-modules/bacpypes/default.nix
+++ b/pkgs/development/python-modules/bacpypes/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "JoelBender";
     repo = "bacpypes";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-BHCHI36nTqBj2dkHB/Y5qkC4uJCmzbHGzSFWKNsIdbc=";
   };
 

--- a/pkgs/development/python-modules/biocframe/default.nix
+++ b/pkgs/development/python-modules/biocframe/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "BiocPy";
     repo = "BiocFrame";
-    tag = "${version}";
+    tag = version;
     hash = "sha256-2O4YINYo9ehiBuZSHZmBmNIwud7GkNzAMWEv2/7oSs8=";
   };
 

--- a/pkgs/development/python-modules/biocutils/default.nix
+++ b/pkgs/development/python-modules/biocutils/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "BiocPy";
     repo = "BiocUtils";
-    tag = "${version}";
+    tag = version;
     hash = "sha256-ziKVF2cxOIRt8cEMOsbf5HAgBGG2vLp+DSMpL+hH6JM=";
   };
 

--- a/pkgs/development/python-modules/cle/default.nix
+++ b/pkgs/development/python-modules/cle/default.nix
@@ -23,7 +23,7 @@ let
   binaries = fetchFromGitHub {
     owner = "angr";
     repo = "binaries";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-XXJBySIT3ylK1nd3suP2bq4bVSVah/1XhOmkEONbCoY=";
   };
 in
@@ -37,7 +37,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "angr";
     repo = "cle";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-rWbZzm5hWi/C+te8zeQChxqYHO0S795tJ6Znocq9TTs=";
   };
 

--- a/pkgs/development/python-modules/colcon-cd/default.nix
+++ b/pkgs/development/python-modules/colcon-cd/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "colcon";
     repo = "colcon-cd";
-    tag = "${version}";
+    tag = version;
     hash = "sha256-eOo1DqTvYazr+wWraG9PZe0tTCgaAvhWtELG5rlaGSs=";
   };
 

--- a/pkgs/development/python-modules/colored/default.nix
+++ b/pkgs/development/python-modules/colored/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
   src = fetchFromGitLab {
     owner = "dslackw";
     repo = "colored";
-    rev = "refs/tags/${version}";
+    tag = version;
     hash = "sha256-PPaPw7pCZJeBz6h5omZ+kcRXsqi6ncLYGM7FNfZ0r4w=";
   };
 

--- a/pkgs/development/python-modules/conjure-python-client/default.nix
+++ b/pkgs/development/python-modules/conjure-python-client/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "palantir";
     repo = "conjure-python-client";
-    tag = "${version}";
+    tag = version;
     hash = "sha256-dfoP0/v0yFAyBo4wADDGGTggVuFBoG53e5WTBvKQaS0=";
   };
 

--- a/pkgs/development/python-modules/crontab/default.nix
+++ b/pkgs/development/python-modules/crontab/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   src = fetchFromGitLab {
     owner = "doctormo";
     repo = "python-crontab";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-eJXtvTRwokbewWrTArHJ2FXGDLvlkGA/5ZZR01koMW8=";
   };
 

--- a/pkgs/development/python-modules/csaf-tool/default.nix
+++ b/pkgs/development/python-modules/csaf-tool/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "anthonyharrison";
     repo = "csaf";
-    tag = "${version}";
+    tag = version;
     hash = "sha256-LR6r03z0nvvAQgFHaTWfukoJmLZ6SLPXfbp/G8N/HtM=";
   };
 

--- a/pkgs/development/python-modules/cython/0.nix
+++ b/pkgs/development/python-modules/cython/0.nix
@@ -43,7 +43,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "cython";
     repo = "cython";
-    rev = "refs/tags/${version}";
+    tag = version;
     hash = "sha256-XsEy2NrG7hq+VXRCRbD4BRaBieU6mVoE0GT52L3mMhs=";
   };
 

--- a/pkgs/development/python-modules/dedupe-pylbfgs/default.nix
+++ b/pkgs/development/python-modules/dedupe-pylbfgs/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "dedupeio";
     repo = "pylbfgs";
-    tag = "${version}";
+    tag = version;
     hash = "sha256-H416dgZQxyqsnhmlK5keW8cJWY6gea4mebVuP0IEVOU=";
   };
 

--- a/pkgs/development/python-modules/defang/default.nix
+++ b/pkgs/development/python-modules/defang/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
   src = fetchFromBitbucket {
     owner = "johannestaas";
     repo = "defang";
-    rev = "refs/tags/${version}";
+    tag = version;
     hash = "sha256-OJfayJeVf2H1/jg7/fu2NiHhRHNCaLGI29SY8BnJyxI=";
   };
 

--- a/pkgs/development/python-modules/discord-webhook/default.nix
+++ b/pkgs/development/python-modules/discord-webhook/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "lovvskillz";
     repo = "python-discord-webhook";
-    tag = "${version}";
+    tag = version;
     hash = "sha256-7nVvtXo1XjQExZSCF9VaYSCeEByJY2jn5KbVGTi33f0=";
   };
 

--- a/pkgs/development/python-modules/django-crossdomainmedia/default.nix
+++ b/pkgs/development/python-modules/django-crossdomainmedia/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage {
     repo = "django-crossdomainmedia";
     # Release is not tagged yet
     # https://github.com/stefanw/django-crossdomainmedia/issues/1
-    # rev = "refs/tags/v${version}";
+    # tag = "v${version}";
     rev = "45af45a82e2630d99381758c7660fe9bdad06d2d";
     hash = "sha256-nwFUm+cxokZ38c5D77z15gIO/kg49oRACOl6+eGGEtQ=";
   };

--- a/pkgs/development/python-modules/django-jquery-js/default.nix
+++ b/pkgs/development/python-modules/django-jquery-js/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
   src = fetchFromBitbucket {
     owner = "tim_heap";
     repo = "django-jquery";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-TzMo31jFhcvlrmq2TJgQyds9n8eATaChnyhnQ7bwdzs=";
   };
 

--- a/pkgs/development/python-modules/django/4.nix
+++ b/pkgs/development/python-modules/django/4.nix
@@ -53,7 +53,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "django";
     repo = "django";
-    rev = "refs/tags/${version}";
+    tag = version;
     hash = "sha256-vdY85Ib2knRFLPmZZ6ojiD5R9diuvpVut1+nOVXSp0Y=";
   };
 

--- a/pkgs/development/python-modules/django/5_2.nix
+++ b/pkgs/development/python-modules/django/5_2.nix
@@ -48,7 +48,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "django";
     repo = "django";
-    rev = "refs/tags/${version}";
+    tag = version;
     hash = "sha256-9URe8hB15WP92AU1YgGGFfZhVxn59gfBRrORZ04L+F0=";
   };
 

--- a/pkgs/development/python-modules/dmgbuild/default.nix
+++ b/pkgs/development/python-modules/dmgbuild/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "dmgbuild";
     repo = "dmgbuild";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-PozYxmXumFnptIgb4FM4b/Q5tx0MIS2bVw2kCuGucA8=";
   };
 

--- a/pkgs/development/python-modules/ewmhlib/default.nix
+++ b/pkgs/development/python-modules/ewmhlib/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "Kalmat";
     repo = "EWMHlib";
-    tag = "refs/tags/v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-NELOgUV8KuN+CqmoSbLYImguHlp8dyhGmJtoxJjOBkA=";
   };
 

--- a/pkgs/development/python-modules/exif/default.nix
+++ b/pkgs/development/python-modules/exif/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
   src = fetchFromGitLab {
     owner = "TNThieding";
     repo = "exif";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-uiHL3m0C6+YnAHRLwzMCSzffrQsSyVcuem6FBtTLxek=";
   };
 

--- a/pkgs/development/python-modules/ffcv/default.nix
+++ b/pkgs/development/python-modules/ffcv/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "libffcv";
     repo = pname;
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-L2mwGFivq/gtAw+1D6U2jbW6VxYgetHX7OUrjwyybqE=";
   };
 

--- a/pkgs/development/python-modules/fipy/default.nix
+++ b/pkgs/development/python-modules/fipy/default.nix
@@ -30,7 +30,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "usnistgov";
     repo = "fipy";
-    rev = "refs/tags/${version}";
+    tag = version;
     hash = "sha256-usuAj+bIzbCSxYuKeUDxEESbjxPCwYwdD/opaBbgl1w=";
   };
 

--- a/pkgs/development/python-modules/flit-scm/default.nix
+++ b/pkgs/development/python-modules/flit-scm/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   src = fetchFromGitLab {
     owner = "WillDaSilva";
     repo = "flit_scm";
-    rev = "refs/tags/${version}";
+    tag = version;
     hash = "sha256-2nx9kWq/2TzauOW+c67g9a3JZ2dhBM4QzKyK/sqWOPo=";
   };
 

--- a/pkgs/development/python-modules/fslpy/default.nix
+++ b/pkgs/development/python-modules/fslpy/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     domain = "git.fmrib.ox.ac.uk";
     owner = "fsl";
     repo = "fslpy";
-    rev = "refs/tags/${version}";
+    tag = version;
     hash = "sha256-lY/7TNOqGK0pRm5Rne1nrqXVQDZPkHwlZV9ITsOwp9Q=";
   };
 

--- a/pkgs/development/python-modules/gmpy/default.nix
+++ b/pkgs/development/python-modules/gmpy/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "aleaxit";
     repo = "gmpy";
-    rev = "refs/tags/gmpy_${lib.replaceStrings [ "." ] [ "_" ] version}";
+    tag = "gmpy_${lib.replaceStrings [ "." ] [ "_" ] version}";
     hash = "sha256-kMidOjhKJlDRu2qaiq9c+XcwD1tNAoPhRTvvGcOJe8I=";
   };
 

--- a/pkgs/development/python-modules/hatch-jupyter-builder/default.nix
+++ b/pkgs/development/python-modules/hatch-jupyter-builder/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "jupyterlab";
     repo = "hatch-jupyter-builder";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-QDWHVdjtexUNGRL+dVehdBwahSW2HmNkZKkQyuOghyI=";
   };
 

--- a/pkgs/development/python-modules/hledger-utils/default.nix
+++ b/pkgs/development/python-modules/hledger-utils/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
   src = fetchFromGitLab {
     owner = "nobodyinperson";
     repo = "hledger-utils";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-Qu4nUcAGTACmLhwc7fkLxITOyFnUHv85qMhtViFumVs=";
   };
 

--- a/pkgs/development/python-modules/jaxlib/default.nix
+++ b/pkgs/development/python-modules/jaxlib/default.nix
@@ -230,7 +230,7 @@ let
       owner = "google";
       repo = "jax";
       # google/jax contains tags for jax and jaxlib. Only use jaxlib tags!
-      rev = "refs/tags/${pname}-v${version}";
+      tag = "${pname}-v${version}";
       hash = "sha256-qSHPwi3is6Ts7pz5s4KzQHBMbcjGp+vAOsejW3o36Ek=";
     };
 

--- a/pkgs/development/python-modules/jupyterhub/default.nix
+++ b/pkgs/development/python-modules/jupyterhub/default.nix
@@ -121,7 +121,7 @@ buildPythonPackage rec {
         version = "0.21.2";
         src = fetchFromGitHub {
           inherit (prev.src) owner repo;
-          rev = "refs/tags/v${final.version}";
+          tag = "v${final.version}";
           hash = "sha256-AVVvdo/CDF9IU6l779sLc7wKz5h3kzMttdDNTPLYxtQ=";
         };
       }

--- a/pkgs/development/python-modules/marqo/default.nix
+++ b/pkgs/development/python-modules/marqo/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "marqo-ai";
     repo = "py-marqo";
-    rev = "refs/tags/${version}";
+    tag = version;
     hash = "sha256-phO7aR7kQJHw5qxrpMI5DtOaXlaHMsKfaC3UquyD/Rw=";
   };
 

--- a/pkgs/development/python-modules/miniaudio/default.nix
+++ b/pkgs/development/python-modules/miniaudio/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "irmen";
     repo = "pyminiaudio";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-H3o2IWGuMqLrJTzQ7w636Ito6f57WBtMXpXXzrZ7UD8=";
   };
 

--- a/pkgs/development/python-modules/nbxmpp/default.nix
+++ b/pkgs/development/python-modules/nbxmpp/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
     domain = "dev.gajim.org";
     owner = "gajim";
     repo = "python-nbxmpp";
-    rev = "refs/tags/${version}";
+    tag = version;
     hash = "sha256-q910WbBp0TBqXw8WfYniliVGnr4Hi6dDhVDqZszSL0c=";
   };
 

--- a/pkgs/development/python-modules/nexusrpc/default.nix
+++ b/pkgs/development/python-modules/nexusrpc/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "nexus-rpc";
     repo = "sdk-python";
-    rev = "refs/tags/${version}";
+    tag = version;
     hash = "sha256-i2FfJ3aCncbqLY2oBG8zAPTbgxzH30MSmZxhDltN4JA=";
     fetchSubmodules = true;
   };

--- a/pkgs/development/python-modules/obfsproxy/default.nix
+++ b/pkgs/development/python-modules/obfsproxy/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchgit {
     url = "https://git.torproject.org/pluggable-transports/obfsproxy.git";
-    rev = "refs/tags/${pname}-${version}";
+    tag = "${pname}-${version}";
     sha256 = "04ja1cl8xzqnwrd2gi6nlnxbmjri141bzwa5gybvr44d8h3k2nfa";
   };
 

--- a/pkgs/development/python-modules/openpyxl/default.nix
+++ b/pkgs/development/python-modules/openpyxl/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     domain = "foss.heptapod.net";
     owner = "openpyxl";
     repo = "openpyxl";
-    rev = "refs/tags/${version}";
+    tag = version;
     hash = "sha256-vp+TIWcHCAWlDaBcmC7w/kV7DZTZpa6463NusaJmqKo=";
   };
 

--- a/pkgs/development/python-modules/pluginlib/default.nix
+++ b/pkgs/development/python-modules/pluginlib/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "Rockhopper-Technologies";
     repo = "pluginlib";
-    tag = "${version}";
+    tag = version;
     hash = "sha256-mt3VE8iJPCmbws8bAdYMK9to446z8FQtsMZOlkLVUIU=";
   };
 

--- a/pkgs/development/python-modules/plum-py/default.nix
+++ b/pkgs/development/python-modules/plum-py/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
   src = fetchFromGitLab {
     owner = "dangass";
     repo = "plum";
-    rev = "refs/tags/${version}";
+    tag = version;
     hash = "sha256-gZSRqijKdjqOZe1+4aeycpCPsh6HC5sRbyVjgK+g4wM=";
   };
 

--- a/pkgs/development/python-modules/pykakasi/default.nix
+++ b/pkgs/development/python-modules/pykakasi/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
     domain = "codeberg.org";
     owner = "miurahr";
     repo = "pykakasi";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-b2lYYdg1RW1xRD3hym7o1EnxzN/U5txVTWRifwZn3k0=";
   };
 

--- a/pkgs/development/python-modules/pymonctl/default.nix
+++ b/pkgs/development/python-modules/pymonctl/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "Kalmat";
     repo = "PyMonCtl";
-    tag = "refs/tags/v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-eFB+HqYBud836VNEA8q8o1KQKA+GHwSC0YfU1KCbDXw=";
   };
 

--- a/pkgs/development/python-modules/python-apt/default.nix
+++ b/pkgs/development/python-modules/python-apt/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
     domain = "salsa.debian.org";
     owner = "apt-team";
     repo = "python-apt";
-    rev = "refs/tags/${version}";
+    tag = version;
     hash = "sha256-3mRMqbhKy5CYwpSttq8MgXY147Ov3lPuZaTjUMtmHik=";
   };
 

--- a/pkgs/development/python-modules/pywinbox/default.nix
+++ b/pkgs/development/python-modules/pywinbox/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "Kalmat";
     repo = "PyWinBox";
-    tag = "refs/tags/v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-Z/gedrIFNpQvzRWqGxMEl5MoEIo9znZz/FZLMVl0Eb4=";
   };
 

--- a/pkgs/development/python-modules/qiskit-finance/default.nix
+++ b/pkgs/development/python-modules/qiskit-finance/default.nix
@@ -32,7 +32,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "qiskit";
     repo = pname;
-    rev = "refs/tags/${version}";
+    tag = version;
     hash = "sha256-zYhYhojCzlENzgYSenwewjeVHUBX2X6eQbbzc9znBsk=";
   };
 

--- a/pkgs/development/python-modules/qiskit-nature/default.nix
+++ b/pkgs/development/python-modules/qiskit-nature/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "Qiskit";
     repo = pname;
-    rev = "refs/tags/${version}";
+    tag = version;
     hash = "sha256-SVzg3McB885RMyAp90Kr6/iVKw3Su9ucTob2jBckBo0=";
   };
 

--- a/pkgs/development/python-modules/qiskit-optimization/default.nix
+++ b/pkgs/development/python-modules/qiskit-optimization/default.nix
@@ -28,7 +28,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "qiskit";
     repo = pname;
-    rev = "refs/tags/${version}";
+    tag = version;
     hash = "sha256-kzEuICajlV8mgD0YLhwFJaDQVxYZo9jv3sr/r/P0VG0=";
   };
 

--- a/pkgs/development/python-modules/raincloudy/default.nix
+++ b/pkgs/development/python-modules/raincloudy/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "vanstinator";
     repo = "raincloudy";
-    rev = "refs/tags/${version}";
+    tag = version;
     hash = "sha256-qCkBVirM09iA1sXiOB9FJns8bHjQq7rRk8XbRWrtBDI=";
   };
 

--- a/pkgs/development/python-modules/skybellpy/default.nix
+++ b/pkgs/development/python-modules/skybellpy/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "MisterWil";
     repo = "skybellpy";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-/+9KYxXYTN0T6PoccAA/pwdwWqOzCSZdNxj6xi6oG74=";
   };
 

--- a/pkgs/development/python-modules/spacy/lookups-data.nix
+++ b/pkgs/development/python-modules/spacy/lookups-data.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "explosion";
     repo = "spacy-lookups-data";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-6sKZ+GgCjLWYnV96nub4xEUFh1qpPQpbnoxyOVrvcD0=";
   };
 

--- a/pkgs/development/python-modules/tensorflow-probability/default.nix
+++ b/pkgs/development/python-modules/tensorflow-probability/default.nix
@@ -50,7 +50,7 @@ let
     src = fetchFromGitHub {
       owner = "tensorflow";
       repo = "probability";
-      rev = "refs/tags/v${version}";
+      tag = "v${version}";
       hash = "sha256-LXQfGFgnM7WYUQjJ2Y3jskdeJ/dEKz+Afg+UOQjv5kc=";
     };
 

--- a/pkgs/development/python-modules/terminaltables3/default.nix
+++ b/pkgs/development/python-modules/terminaltables3/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "matthewdeanmartin";
     repo = "terminaltables3";
-    #rev = "refs/tags/v${version}";
+    #tag = "v${version}";
     rev = "f1c465b36eb9b91a984d8864b21376e7c37075b8";
     hash = "sha256-UcEovh1Eb4QNPwLGDjCphPlJSSkOdhCJ2fK3tuSWOTc=";
   };

--- a/pkgs/development/python-modules/tololib/default.nix
+++ b/pkgs/development/python-modules/tololib/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
   src = fetchFromGitLab {
     owner = "MatthiasLohr";
     repo = "tololib";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-dfyc96VcauERv2E5I6nOIXAHbmTHiRLqS+0XH0GB5HM=";
   };
 

--- a/pkgs/development/python-modules/torch-tb-profiler/default.nix
+++ b/pkgs/development/python-modules/torch-tb-profiler/default.nix
@@ -14,7 +14,7 @@ let
   repo = fetchFromGitHub {
     owner = "pytorch";
     repo = "kineto";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-nAtqGCv8q3Tati3NOGWWLb+gXdvO3qmECeC1WG2Mt3M=";
   };
 in

--- a/pkgs/development/python-modules/vbuild/default.nix
+++ b/pkgs/development/python-modules/vbuild/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "manatlan";
     repo = "vbuild";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-p9v1FiYn0cI+f/25hvjwm7eb1GqxXvNnmXBGwZe9fk0=";
   };
 

--- a/pkgs/development/python-modules/virt-firmware/default.nix
+++ b/pkgs/development/python-modules/virt-firmware/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
   src = fetchFromGitLab {
     owner = "kraxel";
     repo = "virt-firmware";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-kuFTKMhBVlgCBYLTO23IUz/tRLoMRHxjWPIaauu/PWw=";
   };
 

--- a/pkgs/development/python-modules/vmprof/default.nix
+++ b/pkgs/development/python-modules/vmprof/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "vmprof";
     repo = "vmprof-python";
-    rev = "refs/tags/${version}";
+    tag = version;
     hash = "sha256-7k6mtEdPmp1eNzB4l/k/ExSYtRJVmRxcx50ql8zR36k=";
   };
 

--- a/pkgs/development/python-modules/yeelight/default.nix
+++ b/pkgs/development/python-modules/yeelight/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
   src = fetchFromGitLab {
     owner = "stavros";
     repo = "python-yeelight";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-WLEXTDVcSpGCmfEI31cQXGf9+4EIUCkcaeaj25f4ERU=";
   };
 

--- a/pkgs/development/python-modules/zipfile2/default.nix
+++ b/pkgs/development/python-modules/zipfile2/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "cournape";
     repo = "zipfile2";
-    #rev = "refs/tags/v${version}";
+    #tag = "v${version}";
     rev = "8823f7253772e5c5811343306a591c00c764c6d0";
     hash = "sha256-jDOyIj0sQS1dIsar4nyk5V2mme3Zc6VTms49/4n93ho=";
   };

--- a/pkgs/development/python-modules/zope-index/default.nix
+++ b/pkgs/development/python-modules/zope-index/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "zopefoundation";
     repo = "zope.index";
-    tag = "${version}";
+    tag = version;
     hash = "sha256-dHapd/+pJh6qzVx9FGSMmPsGbz8NhAoPqufXm3FOuM8=";
   };
 

--- a/pkgs/development/tools/prospector/default.nix
+++ b/pkgs/development/tools/prospector/default.nix
@@ -16,7 +16,7 @@ python3.pkgs.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "PyCQA";
     repo = pname;
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-94JGKX91d2kul+KMYohga9KCOj6RN/YKpD8e4nWSOOM=";
   };
 

--- a/pkgs/os-specific/linux/jool/source.nix
+++ b/pkgs/os-specific/linux/jool/source.nix
@@ -5,7 +5,7 @@ rec {
   src = fetchFromGitHub {
     owner = "NICMx";
     repo = "Jool";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-fAs289FFdUnddkikm4ceA9d/w1qqqaWuPXmAiq3cIA8=";
   };
 }

--- a/pkgs/servers/home-assistant/appdaemon.nix
+++ b/pkgs/servers/home-assistant/appdaemon.nix
@@ -12,7 +12,7 @@ python3Packages.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "AppDaemon";
     repo = "appdaemon";
-    rev = "refs/tags/${version}";
+    tag = version;
     hash = "sha256-lcGQQz+kPefHSyc2RNQ4gHgraRJPvn/FcgMJGvCtC48=";
   };
 

--- a/pkgs/servers/home-assistant/custom-components/versatile_thermostat/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/versatile_thermostat/package.nix
@@ -15,7 +15,7 @@ buildHomeAssistantComponent rec {
   src = fetchFromGitHub {
     inherit owner;
     repo = domain;
-    rev = "refs/tags/${version}";
+    tag = version;
     hash = "sha256-zSpeiSK8FyXlM1U8jjSVl1nLQX/IplvKHfS6XZUNxo4=";
   };
 

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -50,7 +50,7 @@ let
         src = fetchFromGitHub {
           owner = "tkdrob";
           repo = "aioskybell";
-          rev = "refs/tags/${version}";
+          tag = version;
           hash = "sha256-aBT1fDFtq1vasTvCnAXKV2vmZ6LBLZqRCiepv1HDJ+Q=";
         };
       });
@@ -60,7 +60,7 @@ let
         src = fetchFromGitHub {
           owner = "bachya";
           repo = "aiowatttime";
-          rev = "refs/tags/${version}";
+          tag = version;
           hash = "sha256-tWnxGLJT+CRFvkhxFamHxnLXBvoR8tfOvzH1o1i5JJg=";
         };
         postPatch = ''
@@ -110,7 +110,7 @@ let
         src = fetchFromGitHub {
           owner = "burnash";
           repo = "gspread";
-          rev = "refs/tags/v${version}";
+          tag = "v${version}";
           hash = "sha256-i+QbnF0Y/kUMvt91Wzb8wseO/1rZn9xzeA5BWg1haks=";
         };
         dependencies = with self; [
@@ -136,7 +136,7 @@ let
         src = fetchFromGitHub {
           owner = "engrbm87";
           repo = "notifications_android_tv";
-          rev = "refs/tags/${version}";
+          tag = version;
           hash = "sha256-adkcUuPl0jdJjkBINCTW4Kmc16C/HzL+jaRZB/Qr09A=";
         };
 
@@ -155,7 +155,7 @@ let
         version = "2.2";
         src = fetchFromGitHub {
           inherit (oldAttrs.src) owner repo;
-          rev = "refs/tags/${version}";
+          tag = version;
           hash = "sha256-GGp7nKFH01m1KW6yMkKlAdd26bDi8JDWva6OQ0CWMIw=";
         };
       });
@@ -211,7 +211,7 @@ let
         src = fetchFromGitHub {
           owner = "gagebenne";
           repo = "pydexcom";
-          rev = "refs/tags/${version}";
+          tag = version;
           hash = "sha256-ItDGnUUUTwCz4ZJtFVlMYjjoBPn2h8QZgLzgnV2T/Qk=";
         };
       });
@@ -221,7 +221,7 @@ let
         src = fetchFromGitHub {
           owner = "ChrisMandich";
           repo = "PyFlume";
-          rev = "refs/tags/v${version}";
+          tag = "v${version}";
           hash = "sha256-kIE3y/qlsO9Y1MjEQcX0pfaBeIzCCHk4f1Xa215BBHo=";
         };
         dependencies = oldAttrs.propagatedBuildInputs or [ ] ++ [
@@ -234,7 +234,7 @@ let
         src = fetchFromGitHub {
           owner = "AustinBrunkhorst";
           repo = "pysnooz";
-          rev = "refs/tags/v${version}";
+          tag = "v${version}";
           hash = "sha256-hJwIObiuFEAVhgZXYB9VCeAlewBBnk0oMkP83MUCpyU=";
         };
         patches = [ ];
@@ -246,7 +246,7 @@ let
         src = fetchFromGitHub {
           owner = "home-assistant-libs";
           repo = "pytradfri";
-          rev = "refs/tags/${version}";
+          tag = version;
           hash = "sha256-xOdTzG0bF5p1QpkXv2btwrVugQRjSwdAj8bXcC0IoQg=";
         };
         patches = [ ];

--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -680,7 +680,7 @@ let
         name = "secure-token";
         owner = "kaltura";
         repo = "nginx-secure-token-module";
-        rev = "refs/tags/${version}";
+        tag = version;
         hash = "sha256-qYTjGS9pykRqMFmNls52YKxEdXYhHw+18YC2zzdjEpU=";
       };
 
@@ -978,7 +978,7 @@ let
         name = "video-thumbextractor";
         owner = "wandenberg";
         repo = "nginx-video-thumbextractor-module";
-        rev = "refs/tags/${version}";
+        tag = version;
         hash = "sha256-F2cuzCbJdGYX0Zmz9MSXTB7x8+FBR6pPpXtLlDRCcj8=";
       };
 

--- a/pkgs/servers/monitoring/nagios-plugins/labs_consol_de/default.nix
+++ b/pkgs/servers/monitoring/nagios-plugins/labs_consol_de/default.nix
@@ -66,7 +66,7 @@ in
     src = fetchFromGitHub {
       owner = "lausser";
       repo = "check_mssql_health";
-      rev = "refs/tags/${version}";
+      tag = version;
       hash = "sha256-K6sGrms9z59a9rkZNulwKBexGF2Nkqqak/cRg12ynxc=";
       fetchSubmodules = true;
     };
@@ -82,7 +82,7 @@ in
     src = fetchFromGitHub {
       owner = "lausser";
       repo = "check_nwc_health";
-      rev = "refs/tags/${version}";
+      tag = version;
       hash = "sha256-r8Cb9RnEohNp0GxMAIaj7e08dTWZhuV1jz4/b8tuJ6k=";
       fetchSubmodules = true;
     };
@@ -98,7 +98,7 @@ in
     src = fetchFromGitHub {
       owner = "lausser";
       repo = "check_ups_health";
-      rev = "refs/tags/${version}";
+      tag = version;
       hash = "sha256-ZGSTPVJObP49/tDASOCh4wVdMKajheHD+xVTiFf101k=";
       fetchSubmodules = true;
     };

--- a/pkgs/servers/monitoring/prometheus/consul-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/consul-exporter.nix
@@ -11,7 +11,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "prometheus";
     repo = "consul_exporter";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-2X1nJIUwp7kqqz/D3x4bq6vHg1N8zC9AWCn02qsAyAQ=";
   };
 

--- a/pkgs/servers/monitoring/prometheus/imap-mailstat-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/imap-mailstat-exporter.nix
@@ -12,7 +12,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "bt909";
     repo = "imap-mailstat-exporter";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-aR/94C9SI+FPs3zg3bpexmgGYrhxghyHwpXj25x0yuw=";
   };
 

--- a/pkgs/servers/monitoring/prometheus/sabnzbd-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/sabnzbd-exporter.nix
@@ -14,7 +14,7 @@ python3Packages.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "msroest";
     repo = pname;
-    rev = "refs/tags/${version}";
+    tag = version;
     hash = "sha256-9oL9Zbzzbr0hZjOdkaH86Tho6gaR+/6uAMreLwYzB8o=";
   };
 

--- a/pkgs/servers/monitoring/prometheus/unbound-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/unbound-exporter.nix
@@ -15,7 +15,7 @@ buildGoModule {
   src = fetchFromGitHub {
     owner = "letsencrypt";
     repo = "unbound_exporter";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-xVc6xES3YdKIaP6rwAzI0/RLoer7bcq7VAmfjYii8VI=";
   };
 

--- a/pkgs/servers/sql/postgresql/ext/ip4r.nix
+++ b/pkgs/servers/sql/postgresql/ext/ip4r.nix
@@ -13,7 +13,7 @@ postgresqlBuildExtension (finalAttrs: {
   src = fetchFromGitHub {
     owner = "RhodiumToad";
     repo = "ip4r";
-    tag = "${finalAttrs.version}";
+    tag = finalAttrs.version;
     hash = "sha256-3chAD4f4A6VlXVSI0kfC/ANcnFy4vBp4FZpT6QRAueQ=";
   };
 

--- a/pkgs/servers/sql/postgresql/ext/pg_relusage.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_relusage.nix
@@ -12,7 +12,7 @@ postgresqlBuildExtension (finalAttrs: {
   src = fetchFromGitHub {
     owner = "adept";
     repo = "pg_relusage";
-    tag = "${finalAttrs.version}";
+    tag = finalAttrs.version;
     hash = "sha256-8hJNjQ9MaBk3J9a73l+yQMwMW/F2N8vr5PO2o+5GvYs=";
   };
 

--- a/pkgs/servers/sql/postgresql/ext/pgroonga.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgroonga.nix
@@ -16,7 +16,7 @@ postgresqlBuildExtension (finalAttrs: {
   src = fetchFromGitHub {
     owner = "pgroonga";
     repo = "pgroonga";
-    tag = "${finalAttrs.version}";
+    tag = finalAttrs.version;
     hash = "sha256-PwUnjwqnmoWQ9kKZuKsAVzVBRyKvT+aexrm5eeRiRIQ=";
   };
 

--- a/pkgs/shells/fish/plugins/plugin-git.nix
+++ b/pkgs/shells/fish/plugins/plugin-git.nix
@@ -11,7 +11,7 @@ buildFishPlugin rec {
   src = fetchFromGitHub {
     owner = "jhillyerd";
     repo = "plugin-git";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-p7vvwisu3mvVOE1DcALbzuGJqWBcE1h71UjaopGdxE0=";
   };
 

--- a/pkgs/shells/fish/plugins/spark.nix
+++ b/pkgs/shells/fish/plugins/spark.nix
@@ -11,7 +11,7 @@ let
     src = fetchFromGitHub {
       owner = "jorgebucaran";
       repo = "spark.fish";
-      rev = "refs/tags/${self.version}";
+      tag = self.version;
       hash = "sha256-AIFj7lz+QnqXGMBCfLucVwoBR3dcT0sLNPrQxA5qTuU=";
     };
 

--- a/pkgs/shells/nushell/plugins/net.nix
+++ b/pkgs/shells/nushell/plugins/net.nix
@@ -13,7 +13,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "fennewald";
     repo = "nu_plugin_net";
-    tag = "${finalAttrs.version}";
+    tag = finalAttrs.version;
     hash = "sha256-HiNydU40FprxVmRRZtnXom2kFYI04mbeuGTq8+BMh7o=";
   };
 

--- a/pkgs/tools/audio/liquidsoap/full.nix
+++ b/pkgs/tools/audio/liquidsoap/full.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "savonet";
     repo = "liquidsoap";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-EQFWFtgWvwsV+ZhO36Sd7mpxYOnd4Vv6Z+6xsgi335k=";
   };
 

--- a/pkgs/tools/audio/yabridge/default.nix
+++ b/pkgs/tools/audio/yabridge/default.nix
@@ -18,7 +18,7 @@ let
   asio = fetchFromGitHub {
     owner = "chriskohlhoff";
     repo = "asio";
-    rev = "refs/tags/asio-1-28-2";
+    tag = "asio-1-28-2";
     hash = "sha256-8Sw0LuAqZFw+dxlsTstlwz5oaz3+ZnKBuvSdLW6/DKQ=";
   };
 
@@ -26,7 +26,7 @@ let
   bitsery = fetchFromGitHub {
     owner = "fraillt";
     repo = "bitsery";
-    rev = "refs/tags/v5.2.3";
+    tag = "v5.2.3";
     hash = "sha256-rmfcIYCrANycFuLtibQ5wOPwpMVhpTMpdGsUfpR3YsM=";
   };
 
@@ -34,7 +34,7 @@ let
   clap = fetchFromGitHub {
     owner = "free-audio";
     repo = "clap";
-    rev = "refs/tags/1.1.9";
+    tag = "1.1.9";
     hash = "sha256-z2P0U2NkDK1/5oDV35jn/pTXCcspuM1y2RgZyYVVO3w=";
   };
 
@@ -42,7 +42,7 @@ let
   function2 = fetchFromGitHub {
     owner = "Naios";
     repo = "function2";
-    rev = "refs/tags/4.2.3";
+    tag = "4.2.3";
     hash = "sha256-+fzntJn1fRifOgJhh5yiv+sWR9pyaeeEi2c1+lqX3X8=";
   };
 
@@ -50,7 +50,7 @@ let
   ghc_filesystem = fetchFromGitHub {
     owner = "gulrak";
     repo = "filesystem";
-    rev = "refs/tags/v1.5.14";
+    tag = "v1.5.14";
     hash = "sha256-XZ0IxyNIAs2tegktOGQevkLPbWHam/AOFT+M6wAWPFg=";
   };
 
@@ -58,7 +58,7 @@ let
   tomlplusplus = fetchFromGitHub {
     owner = "marzer";
     repo = "tomlplusplus";
-    rev = "refs/tags/v3.4.0";
+    tag = "v3.4.0";
     hash = "sha256-h5tbO0Rv2tZezY58yUbyRVpsfRjY3i+5TPkkxr6La8M=";
   };
 
@@ -66,7 +66,7 @@ let
   vst3 = fetchFromGitHub {
     owner = "robbert-vdh";
     repo = "vst3sdk";
-    rev = "refs/tags/v3.7.7_build_19-patched";
+    tag = "v3.7.7_build_19-patched";
     fetchSubmodules = true;
     hash = "sha256-LsPHPoAL21XOKmF1Wl/tvLJGzjaCLjaDAcUtDvXdXSU=";
   };
@@ -79,7 +79,7 @@ multiStdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "robbert-vdh";
     repo = "yabridge";
-    rev = "refs/tags/${finalAttrs.version}";
+    tag = finalAttrs.version;
     hash = "sha256-4eA3vQFklIWkhtbd3Nw39bnJT6gPcni79ZyQVqU4+GQ=";
   };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Replaced `rev = "refs/tags/` with `tag = "` and removed string interpolations on tags where unnecessary.
- Updated `maintainers/scripts/update-octave-packages` accordingly.

I just left `postgre-sql` untouched because there is a comment stating that the use of git revs is on purpose.

I didn't try to build all affected packages, but I did build 1 package for each 'type' of git provider. 

Changes were split into individual commits for ease of review. Let me know if they should be squashed or on the contrary, split into multiple PRs.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
