### PR TITLE
python3Packages.myhdl: unstable-2022-04-26 -> 0.11.51

### DIFF
--- a/pkgs/development/python-modules/myhdl/default.nix
+++ b/pkgs/development/python-modules/myhdl/default.nix
@@ -1,46 +1,87 @@
 {
   lib,
-  fetchFromGitHub,
   buildPythonPackage,
-  iverilog,
+  fetchPypi,
+
+  # build-system
+  setuptools,
+
+  # tests
   ghdl,
-  pytest,
-  pytest-xdist,
+  iverilog,
+  pytestCheckHook,
 }:
 
-buildPythonPackage {
+buildPythonPackage rec {
   pname = "myhdl";
-  # The stable version is from 2019 and it doesn't pass tests
-  version = "unstable-2022-04-26";
-  format = "setuptools";
-  # The pypi src doesn't contain the ci script used in checkPhase
-  src = fetchFromGitHub {
-    owner = "myhdl";
-    repo = "myhdl";
-    rev = "1a4f5cd4e9de2e7bbf1053c3c2bc9526b5cc524a";
-    hash = "sha256-Tgoem88Y6AhlCKVhMm0Khg6GPcrEktYOqV8xcMaNkl4=";
+  version = "0.11.51";
+  pyproject = true;
+
+  # No recent tags on GitHub
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-nZEdYLRjk2rgS3byc4iu9oJazodnoNg63MBUMasGZiw=";
   };
 
-  nativeCheckInputs = [
-    pytest
-    pytest-xdist
-    iverilog
-    ghdl
+  build-system = [
+    setuptools
   ];
+
+  nativeCheckInputs = [
+    ghdl
+    iverilog
+    pytestCheckHook
+  ];
+
+  enabledTestPaths = [
+    "myhdl/test"
+  ];
+
+  disabledTestPaths = [
+    # myhdl.CosimulationError: Premature simulation end
+    # ----------------------------- Captured stdout call -----------------------------
+    # binaryOps.o: Program not runnable, 2 errors.
+    # ----------------------------- Captured stderr call -----------------------------
+    # ../../../../cosimulation/icarus/myhdl.vpi: Unable to find module file `../../../../cosimulation/icarus/myhdl.vpi' or `../../../../cosimulation/icarus/myhdl.vpi.vpi'.
+    # tb_binaryOps.v:24: Error: System task/function $from_myhdl() is not defined by any module.
+    # tb_binaryOps.v:29: Error: System task/function $to_myhdl() is not defined by any module.
+    "myhdl/test/conversion/toVerilog/test_GrayInc.py"
+    "myhdl/test/conversion/toVerilog/test_RandomScrambler.py"
+    "myhdl/test/conversion/toVerilog/test_always_comb.py"
+    "myhdl/test/conversion/toVerilog/test_beh.py"
+    "myhdl/test/conversion/toVerilog/test_bin2gray.py"
+    "myhdl/test/conversion/toVerilog/test_dec.py"
+    "myhdl/test/conversion/toVerilog/test_edge.py"
+    "myhdl/test/conversion/toVerilog/test_fsm.py"
+    "myhdl/test/conversion/toVerilog/test_hec.py"
+    "myhdl/test/conversion/toVerilog/test_inc.py"
+    "myhdl/test/conversion/toVerilog/test_loops.py"
+    "myhdl/test/conversion/toVerilog/test_misc.py"
+    "myhdl/test/conversion/toVerilog/test_ops.py"
+    "myhdl/test/conversion/toVerilog/test_ram.py"
+    "myhdl/test/conversion/toVerilog/test_rom.py"
+  ];
+
+  disabledTests = [
+    # myhdl.CosimulationError: Premature simulation end
+    # ----------------------------- Captured stdout call -----------------------------
+    # binaryOps.o: Program not runnable, 2 errors.
+    # ----------------------------- Captured stderr call -----------------------------
+    # ../../../../cosimulation/icarus/myhdl.vpi: Unable to find module file `../../../../cosimulation/icarus/myhdl.vpi' or `../../../../cosimulation/icarus/myhdl.vpi.vpi'.
+    # tb_binaryOps.v:24: Error: System task/function $from_myhdl() is not defined by any module.
+    # tb_binaryOps.v:29: Error: System task/function $to_myhdl() is not defined by any module.
+    "TestInc"
+    "TestInfer"
+    "testAugmOps"
+    "testBinaryOps"
+    "testUnaryOps"
+  ];
+
   passthru = {
     # If using myhdl as a dependency, use these if needed and not ghdl and
     # verlog from all-packages.nix
     inherit ghdl iverilog;
   };
-  checkPhase = ''
-    runHook preCheck
-
-    for target in {core,iverilog,ghdl}; do
-      env CI_TARGET="$target" bash ./scripts/ci.sh
-    done;
-
-    runHook postCheck
-  '';
 
   meta = {
     description = "Free, open-source package for using Python as a hardware description and verification language";


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Currently broken on `master`.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
