### PR TITLE
maintainers: drop gspia

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9945,12 +9945,6 @@
     githubId = 2490088;
     name = "Gregory Schwartz";
   };
-  gspia = {
-    email = "iahogsp@gmail.com";
-    github = "gspia";
-    githubId = 3320792;
-    name = "gspia";
-  };
   gtrunsec = {
     email = "gtrunsec@hardenedlinux.org";
     github = "GTrunSec";

--- a/pkgs/by-name/ki/kitsas/package.nix
+++ b/pkgs/by-name/ki/kitsas/package.nix
@@ -65,7 +65,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/artoh/kitupiikki";
     description = "Accounting tool suitable for Finnish associations and small business";
     mainProgram = "kitsas";
-    maintainers = with lib.maintainers; [ gspia ];
+    maintainers = [ ];
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.unix;
   };


### PR DESCRIPTION
- Last commented in [October of 2024](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Agspia)
- Hasn't created any PRs / Issues since [April of 2021](https://github.com/NixOS/nixpkgs/issues?q=author%3Agspia)
- About 9 [unanswered](https://github.com/NixOS/nixpkgs/issues?q=involves%3Agspia%20-commenter%3Agspia%20-author%3Agspia%20-reviewed-by%3Agspia) PRs / Issues
- Haven't actively maintained their package `kitsas`

See [losing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs.

Pinging @gspia, as they don't seem to be in the `Nixpkgs Maintainers` team. You have one week to respond to this.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
