### PR TITLE
python3Packages.uvloop: skip flakey test_cancel_post_init

### DIFF
--- a/pkgs/development/python-modules/uvloop/default.nix
+++ b/pkgs/development/python-modules/uvloop/default.nix
@@ -70,6 +70,9 @@ buildPythonPackage rec {
     "tests/test_tcp.py::Test_AIO_TCP::test_create_connection_open_con_addr"
     # ConnectionAbortedError: SSL handshake is taking longer than 15.0 seconds
     "tests/test_tcp.py::Test_AIO_TCPSSL::test_create_connection_ssl_1"
+    # Fails randomly on hydra
+    # https://github.com/MagicStack/uvloop/issues/709
+    "tests/test_process.py::TestAsyncio_AIO_Process::test_cancel_post_init"
   ]
   ++ lib.optionals (pythonOlder "3.11") [
     "tests/test_tcp.py::Test_UV_TCPSSL::test_create_connection_ssl_failed_certificat"

--- a/pkgs/development/python-modules/uvloop/default.nix
+++ b/pkgs/development/python-modules/uvloop/default.nix
@@ -2,9 +2,9 @@
   lib,
   stdenv,
   buildPythonPackage,
-  pythonAtLeast,
   pythonOlder,
   fetchFromGitHub,
+  fetchpatch,
 
   # build-system
   cython,
@@ -82,14 +82,7 @@ buildPythonPackage rec {
     "tests/test_fs_event.py::Test_UV_FS_EVENT_RENAME::test_fs_event_rename"
     # Broken: https://github.com/NixOS/nixpkgs/issues/160904
     "tests/test_context.py::Test_UV_Context::test_create_ssl_server_manual_connection_lost"
-  ]
-  ++
-    lib.optionals
-      (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64 && pythonAtLeast "3.14")
-      [
-        # https://github.com/MagicStack/uvloop/issues/709
-        "tests/test_process.py::TestAsyncio_AIO_Process::test_cancel_post_init"
-      ];
+  ];
 
   preCheck = ''
     # force using installed/compiled uvloop

--- a/pkgs/development/python-modules/uvloop/default.nix
+++ b/pkgs/development/python-modules/uvloop/default.nix
@@ -83,10 +83,13 @@ buildPythonPackage rec {
     # Broken: https://github.com/NixOS/nixpkgs/issues/160904
     "tests/test_context.py::Test_UV_Context::test_create_ssl_server_manual_connection_lost"
   ]
-  ++ lib.optionals (stdenv.hostPlatform.isDarwin && pythonAtLeast "3.14") [
-    # https://github.com/MagicStack/uvloop/issues/709
-    "tests/test_process.py::TestAsyncio_AIO_Process::test_cancel_post_init"
-  ];
+  ++
+    lib.optionals
+      (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64 && pythonAtLeast "3.14")
+      [
+        # https://github.com/MagicStack/uvloop/issues/709
+        "tests/test_process.py::TestAsyncio_AIO_Process::test_cancel_post_init"
+      ];
 
   preCheck = ''
     # force using installed/compiled uvloop


### PR DESCRIPTION
https://github.com/MagicStack/uvloop/issues/709

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
