### PR TITLE
Cinnamon updates 2025-12-24

### DIFF
--- a/pkgs/by-name/ci/cinnamon/package.nix
+++ b/pkgs/by-name/ci/cinnamon/package.nix
@@ -74,13 +74,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "cinnamon";
-  version = "6.6.2";
+  version = "6.6.3";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "cinnamon";
     tag = version;
-    hash = "sha256-evjXa42mo7wkLh5HDax+2Tsc/x/oG3tPHU1tczoxmJU=";
+    hash = "sha256-BPHHvcE0jmrOo5W4Egv1Hir8t4CSPJGH3oqv1VJ4AUQ=";
   };
 
   patches = [

--- a/pkgs/by-name/mi/mint-l-icons/package.nix
+++ b/pkgs/by-name/mi/mint-l-icons/package.nix
@@ -10,14 +10,14 @@
 
 stdenvNoCC.mkDerivation {
   pname = "mint-l-icons";
-  version = "1.7.9";
+  version = "1.8.0";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "mint-l-icons";
     # They don't really do tags, this is just a named commit.
-    rev = "fa88b00e10b0978e0309acccfa95d80005422b1a";
-    hash = "sha256-XXy1eO0a/5bBnP/inaUa/c09D/6QDmnik1LH382NGIw=";
+    rev = "256fe2e44655ce197701e35aefc40f49fe30356d";
+    hash = "sha256-BYzgGOVmUZBkz6lG1vFXtqiyUf3xnhXsoP+q4aLLMJs=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/by-name/mi/mint-l-theme/package.nix
+++ b/pkgs/by-name/mi/mint-l-theme/package.nix
@@ -6,15 +6,16 @@
   python3Packages,
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation {
   pname = "mint-l-theme";
-  version = "2.0.4";
+  version = "2.0.5";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "mint-l-theme";
-    rev = version;
-    hash = "sha256-jrNVeeqOBDf77Lz68qyjHllA4C3PQRySYQH7Sva2UHU=";
+    # They don't really do tags, this is just a named commit.
+    rev = "112daa4f76ccef08a9c4e3b107957ff862429516";
+    hash = "sha256-Y6rPrEG+Gh2V+TbLDTqVgPSYQMBXWKacYrS1FMzmQVo=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/mi/mint-themes/package.nix
+++ b/pkgs/by-name/mi/mint-themes/package.nix
@@ -8,13 +8,13 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "mint-themes";
-  version = "2.3.5";
+  version = "2.3.6";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "mint-themes";
     rev = version;
-    hash = "sha256-folnnA4By1Dd1amriGiTl5mOxpcnaFjdp/UsjacE8GA=";
+    hash = "sha256-LM5ZAstFr1fU7RhDEnuJKS1+5gOnL6bUJ+u9EFy6+NI=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/mi/mint-y-icons/package.nix
+++ b/pkgs/by-name/mi/mint-y-icons/package.nix
@@ -10,13 +10,13 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "mint-y-icons";
-  version = "1.9.0";
+  version = "1.9.1";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "mint-y-icons";
     rev = version;
-    hash = "sha256-1ymx9qcv7YyIK1+mwKaXn8afh1o6I6jMIZtdvId8dEg=";
+    hash = "sha256-YciWUzvu+2krbSGz5mqpCVRE22T8/gl4Ln4rILB5Tq8=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/by-name/xa/xapp-symbolic-icons/package.nix
+++ b/pkgs/by-name/xa/xapp-symbolic-icons/package.nix
@@ -9,13 +9,13 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "xapp-symbolic-icons";
-  version = "1.0.6";
+  version = "1.0.7";
 
   src = fetchFromGitHub {
     owner = "xapp-project";
     repo = "xapp-symbolic-icons";
     tag = finalAttrs.version;
-    hash = "sha256-vKQLqpKII790bl+oXvKP08sOBCsgpKwHIR2N/bq3pcM=";
+    hash = "sha256-zBU7LyINEKZB3F6AiQe5k5ZGJBdLJAaPXJhGudZ37eY=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--

xapp-symbolic-icons: 1.0.6 -> 1.0.7
mint-y-icons: 1.9.0 -> 1.9.1
mint-themes: 2.3.5 -> 2.3.6
mint-l-theme: 2.0.4 -> 2.0.5
mint-l-icons: 1.7.9 -> 1.8.0
cinnamon: 6.6.2 -> 6.6.3


-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

