### PR TITLE
byobu: Fixes issue #131353 (automatic launch-failure)

### DIFF
--- a/pkgs/by-name/by/byobu/package.nix
+++ b/pkgs/by-name/by/byobu/package.nix
@@ -69,6 +69,13 @@ stdenv.mkDerivation (finalAttrs: {
       # scripts points to the filename and byobu matches against this to know
       # which backend to start with
       bname="$(basename $file)"
+
+      # Don't wrap byobu-launch to fix failing automatic byobu launches
+      # See: https://github.com/NixOS/nixpkgs/issues/131353
+      if [ $bname == "byobu-launch" ]; then
+        continue
+      fi
+
       mv "$file" "$out/bin/.$bname"
       makeWrapper "$out/bin/.$bname" "$out/bin/$bname" \
         --argv0 $bname \


### PR DESCRIPTION
Skip wrapping for byobu-launch to prevent failures in automatic launches.
_(If you enable automatic launches with `byobu-enable` a immediate logout followed instead of launching byobu)_

This is a rewritten version of PR https://github.com/NixOS/nixpkgs/pull/279950 :
-  It that makes less changes to the code
-  It patches the correct file.

The package.nix in master and unstable are the same as the one of 25.11 so it should be merged in all 3.
_(Although for I am only sending a PR to master)_


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] **Rebuilding my system using my own fork of NixOS/Nixpkgs and trying it**
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
