### PR TITLE
aonsoku: 0.9.1 -> 0.10.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -28689,6 +28689,11 @@
     githubId = 3028542;
     name = "Guillermo NWDD";
   };
+  xoconoch = {
+    name = "Xoconoch";
+    github = "Xoconoch";
+    githubId = 93692082;
+  };
   xokdvium = {
     email = "sergei@zimmerman.foo";
     github = "xokdvium";

--- a/pkgs/by-name/ao/aonsoku/package.nix
+++ b/pkgs/by-name/ao/aonsoku/package.nix
@@ -1,59 +1,104 @@
 {
   lib,
+  stdenv,
   fetchFromGitHub,
-  rustPlatform,
-  cargo-tauri,
   nodejs,
-  pnpm_8,
+  pnpm_9,
   fetchPnpmDeps,
   pnpmConfigHook,
-  pkg-config,
-  wrapGAppsHook3,
-  openssl,
-  webkitgtk_4_1,
-  glib-networking,
+  makeWrapper,
+  electron,
   nix-update-script,
+  makeDesktopItem,
+  copyDesktopItems,
 }:
-rustPlatform.buildRustPackage (finalAttrs: {
+
+stdenv.mkDerivation (finalAttrs: {
   pname = "aonsoku";
-  version = "0.9.1";
+  version = "0.11.0";
 
   src = fetchFromGitHub {
     owner = "victoralvesf";
     repo = "aonsoku";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-qlc7P222e6prYG30iVTAZhP772za3H7gVszfWvOr2NM=";
+    hash = "sha256-GsHaGbC1eRwehdl5/kSPqH+o86NTvGty58kl0yWRksE=";
   };
 
-  # lockfileVersion: '6.0' need old pnpm
+  patches = [
+    ./remove_updater.patch
+  ];
+
   pnpmDeps = fetchPnpmDeps {
-    inherit (finalAttrs) pname version src;
-    pnpm = pnpm_8;
-    fetcherVersion = 1;
-    hash = "sha256-h1rcM+H2c0lk7bpGeQT5ue9bQIggrCFHkj4o7KxnH08=";
+    inherit (finalAttrs)
+      pname
+      version
+      src
+      ;
+    pnpm = pnpm_9;
+    fetcherVersion = 3;
+    hash = "sha256-aESsE0993zjImSUq5P+QfXxn/U7DwLxfInvbaeEeFYo=";
   };
-
-  cargoRoot = "src-tauri";
-  buildAndTestSubdir = finalAttrs.cargoRoot;
-
-  cargoHash = "sha256-8UtfL8iB1XKP31GT9Ok5hIQSobQTm681uiluG+IhK/s=";
-
-  patches = [ ./remove_updater.patch ];
 
   nativeBuildInputs = [
     nodejs
+    pnpm_9
     pnpmConfigHook
-    pnpm_8
-    cargo-tauri.hook
-    pkg-config
-    wrapGAppsHook3
+    makeWrapper
+    electron
+    copyDesktopItems
   ];
 
-  buildInputs = [
-    openssl
-    webkitgtk_4_1
-    glib-networking
+  buildInputs = [ finalAttrs.pnpmDeps ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "aonsoku";
+      desktopName = "Aonsoku";
+      comment = "Modern desktop client for Navidrome/Subsonic servers";
+      exec = "Aonsoku";
+      icon = "aonsoku";
+      categories = [
+        "AudioVideo"
+        "Audio"
+        "Music"
+        "Player"
+      ];
+      startupWMClass = "Aonsoku";
+    })
   ];
+
+  preConfigure = ''
+    export ELECTRON_SKIP_BINARY_DOWNLOAD=1
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+    pnpm run electron:build
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/aonsoku/out
+    cp -r out/* $out/lib/aonsoku/out/
+
+    mkdir -p $out/lib/aonsoku/out/main/resources
+    cp -r resources/* $out/lib/aonsoku/out/main/resources/
+
+    cp -r node_modules $out/lib/aonsoku/
+
+    mkdir -p $out/bin
+    makeWrapper ${electron}/bin/electron $out/bin/Aonsoku \
+      --add-flags $out/lib/aonsoku/out/main/index.js \
+      --set ELECTRON_IS_DEV 0
+
+    mkdir -p $out/share/icons/hicolor/512x512/apps
+    cp resources/icons/icon.png \
+      $out/share/icons/hicolor/512x512/apps/aonsoku.png
+
+    runHook postInstall
+  '';
 
   passthru.updateScript = nix-update-script { };
 
@@ -62,7 +107,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/victoralvesf/aonsoku";
     changelog = "https://github.com/victoralvesf/aonsoku/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ genga898 ];
+    maintainers = with lib.maintainers; [
+      genga898
+      xoconoch
+    ];
     mainProgram = "Aonsoku";
   };
 })

--- a/pkgs/by-name/ao/aonsoku/remove_updater.patch
+++ b/pkgs/by-name/ao/aonsoku/remove_updater.patch
@@ -1,39 +1,20 @@
-diff --git a/src-tauri/src/main.rs b/src-tauri/src/main.rs
-index 112ee8e..35137f2 100644
---- a/src-tauri/src/main.rs
-+++ b/src-tauri/src/main.rs
-@@ -50,7 +50,6 @@ fn main() {
-             Ok(())
-         })
-         .plugin(tauri_plugin_shell::init())
--        .plugin(tauri_plugin_updater::Builder::new().build())
-         .plugin(tauri_plugin_process::init())
-         .plugin(tauri_plugin_os::init())
-         .invoke_handler(tauri::generate_handler![commands::download_file])
-diff --git a/src-tauri/tauri.conf.json b/src-tauri/tauri.conf.json
-index 3afc5f6..19785e5 100644
---- a/src-tauri/tauri.conf.json
-+++ b/src-tauri/tauri.conf.json
-@@ -8,7 +8,6 @@
-   "bundle": {
-     "active": true,
-     "category": "Music",
--    "createUpdaterArtifacts": true,
-     "targets": "all",
-     "icon": [
-       "icons/32x32.png",
-@@ -26,14 +25,6 @@
-   "productName": "Aonsoku",
-   "mainBinaryName": "Aonsoku",
-   "identifier": "com.victoralvesf.aonsoku",
--  "plugins": {
--    "updater": {
--      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDRDNTlENjZCNTJFRDdDRDAKUldUUWZPMVNhOVpaVENsbXg5RTM1TzFnME43TmZoaHU5bWplS1VSSW9YcE1QT0w1ZHRIWHNUOVoK",
--      "endpoints": [
--        "https://github.com/victoralvesf/aonsoku/releases/latest/download/latest.json"
--      ]
--    }
--  },
-   "app": {
-     "withGlobalTauri": true,
-     "security": {
+diff --git a/src/app/observers/update-observer.tsx b/src/app/observers/update-observer.tsx
+index 5f6b0d3..7c1aabc 100644
+--- a/src/app/observers/update-observer.tsx
++++ b/src/app/observers/update-observer.tsx
+@@ -25,14 +25,14 @@ export function UpdateObserver() {
+   const { openDialog, setOpenDialog, remindOnNextBoot, setRemindOnNextBoot } =
+     useAppUpdate()
+   const [updateHasStarted, setUpdateHasStarted] = useState(false)
+ 
+   const { data: updateInfo } = useQuery({
+     queryKey: [queryKeys.update.check],
+-    queryFn: async () => await window.api.checkForUpdates(),
+-    enabled: !remindOnNextBoot && isProd,
++    queryFn: async () => ({ files: [] }),
++    enabled: false,
+     refetchOnWindowFocus: false,
+     refetchOnMount: false,
+     staleTime: Infinity,
+     gcTime: Infinity,
+   })


### PR DESCRIPTION
Aonsoku is no longer a tauri application, it is now an electron one. 

Changelog: https://github.com/victoralvesf/aonsoku/releases/tag/v0.10.2 (although it does not mention any breaking changes).

Note: In order for discord rich presence to properly work, an application ID is needed, which is not provided by the developer of Aonsoku. What would be the course of action here? Is there such a thing as an "Official NixOS discord application ID"?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
