### PR TITLE
waywall: 0-unstable-2025-08-03 -> 0.2025.12.20, add wrapper

### DIFF
--- a/pkgs/by-name/wa/waywall/package.nix
+++ b/pkgs/by-name/wa/waywall/package.nix
@@ -6,6 +6,7 @@
   libspng,
   libxkbcommon,
   luajit,
+  makeWrapper,
   meson,
   ninja,
   pkg-config,
@@ -27,6 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   nativeBuildInputs = [
+    makeWrapper
     meson
     ninja
     pkg-config
@@ -48,6 +50,9 @@ stdenv.mkDerivation (finalAttrs: {
     runHook preInstall
 
     install -Dm755 waywall/waywall -t $out/bin
+
+    wrapProgram $out/bin/waywall \
+      --prefix PATH : ${lib.makeBinPath [ xwayland ]}
 
     runHook postInstall
   '';

--- a/pkgs/by-name/wa/waywall/package.nix
+++ b/pkgs/by-name/wa/waywall/package.nix
@@ -69,6 +69,7 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [
       monkieeboi
+      uku3lig
     ];
     platforms = lib.platforms.linux;
     mainProgram = "waywall";

--- a/pkgs/by-name/wa/waywall/package.nix
+++ b/pkgs/by-name/wa/waywall/package.nix
@@ -15,15 +15,15 @@
   xorg,
   xwayland,
 }:
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "waywall";
-  version = "0-unstable-2025-08-03";
+  version = "0.2025.12.20";
 
   src = fetchFromGitHub {
     owner = "tesselslate";
     repo = "waywall";
-    rev = "d77f51926a203b7ddfe095971e7c6c740dad0ffc";
-    hash = "sha256-ev/A5ksqmWz6hpwUIoxg2k9BwzE4BNCZO4tpXq790zo=";
+    tag = finalAttrs.version;
+    hash = "sha256-sGb/dxXBlzXBvv2IWjgwSE8WM5qB04mYATl0uhSozMQ=";
   };
 
   nativeBuildInputs = [
@@ -68,4 +68,4 @@ stdenv.mkDerivation {
     platforms = lib.platforms.linux;
     mainProgram = "waywall";
   };
-}
+})


### PR DESCRIPTION
Updates waywall and adds a wrapper with xwayland, which is required for stuff like Ninjabrain-Bot.

Changelog: https://github.com/tesselslate/waywall/compare/d77f51926a203b7ddfe095971e7c6c740dad0ffc...0.2025.12.20

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
