### PR TITLE
treewide: move LDFLAGS into env for structuredAttrs

### DIFF
--- a/pkgs/applications/terminal-emulators/rxvt-unicode/default.nix
+++ b/pkgs/applications/terminal-emulators/rxvt-unicode/default.nix
@@ -135,12 +135,16 @@ stdenv.mkDerivation {
   ]
   ++ lib.optional emojiSupport "--enable-wide-glyphs";
 
-  LDFLAGS = [
-    "-lfontconfig"
-    "-lXrender"
-    "-lpthread"
-  ];
-  CFLAGS = [ "-I${freetype.dev}/include/freetype2" ];
+  env = {
+    LDFLAGS = toString [
+      "-lfontconfig"
+      "-lXrender"
+      "-lpthread"
+    ];
+    CFLAGS = toString [
+      "-I${freetype.dev}/include/freetype2"
+    ];
+  };
 
   preConfigure = ''
     # without this the terminfo won't be compiled by tic, see man tic

--- a/pkgs/by-name/gi/gifsicle/package.nix
+++ b/pkgs/by-name/gi/gifsicle/package.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
 
   configureFlags = lib.optional (!gifview) "--disable-gifview";
 
-  LDFLAGS = lib.optionalString static "-static";
+  env.LDFLAGS = lib.optionalString static "-static";
 
   doCheck = true;
   checkPhase = ''

--- a/pkgs/by-name/if/iftop/package.nix
+++ b/pkgs/by-name/if/iftop/package.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
 
   # Explicitly link against libgcc_s, to work around the infamous
   # "libgcc_s.so.1 must be installed for pthread_cancel to work".
-  LDFLAGS = lib.optionalString stdenv.hostPlatform.isLinux "-lgcc_s";
+  env.LDFLAGS = lib.optionalString stdenv.hostPlatform.isLinux "-lgcc_s";
 
   buildInputs = [
     ncurses

--- a/pkgs/by-name/lc/lcms2/package.nix
+++ b/pkgs/by-name/lc/lcms2/package.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   ];
 
   # See https://trac.macports.org/ticket/60656
-  LDFLAGS = if stdenv.hostPlatform.isDarwin then "-Wl,-w" else null;
+  env = lib.optionalAttrs stdenv.hostPlatform.isDarwin { LDFLAGS = "-Wl,-w"; };
 
   meta = {
     description = "Color management engine";

--- a/pkgs/by-name/li/libax25/package.nix
+++ b/pkgs/by-name/li/libax25/package.nix
@@ -29,10 +29,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   configureFlags = [ "--sysconfdir=/etc" ];
 
-  LDFLAGS = lib.optionals stdenv.hostPlatform.isStatic [
-    "-static-libgcc"
-    "-static"
-  ];
+  env = lib.optionalAttrs stdenv.hostPlatform.isStatic {
+    LDFLAGS = toString [
+      "-static-libgcc"
+      "-static"
+    ];
+  };
 
   meta = {
     description = "AX.25 library for hamradio applications";

--- a/pkgs/by-name/sp/spral/package.nix
+++ b/pkgs/by-name/sp/spral/package.nix
@@ -67,7 +67,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   mesonFlags = [ (lib.mesonBool "tests" true) ];
 
-  LDFLAGS = lib.optionals stdenv.hostPlatform.isDarwin [ "-lomp" ];
+  env = lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+    LDFLAGS = "-lomp";
+  };
 
   doCheck = true;
 

--- a/pkgs/development/compilers/llvm/common/lld/default.nix
+++ b/pkgs/development/compilers/llvm/common/lld/default.nix
@@ -64,7 +64,9 @@ stdenv.mkDerivation (finalAttrs: {
   ++ devExtraCmakeFlags;
 
   # Musl's default stack size is too small for lld to be able to link Firefox.
-  LDFLAGS = lib.optionalString stdenv.hostPlatform.isMusl "-Wl,-z,stack-size=2097152";
+  env = lib.optionalAttrs stdenv.hostPlatform.isMusl {
+    LDFLAGS = "-Wl,-z,stack-size=2097152";
+  };
 
   outputs = [
     "out"

--- a/pkgs/development/compilers/llvm/common/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/common/llvm/default.nix
@@ -453,9 +453,9 @@ stdenv.mkDerivation (
       '';
 
     # E.g. Mesa uses the build-id as a cache key (see #93946):
-    LDFLAGS = optionalString (
-      enableSharedLibraries && !stdenv.hostPlatform.isDarwin
-    ) "-Wl,--build-id=sha1";
+    env = lib.optionalAttrs (enableSharedLibraries && !stdenv.hostPlatform.isDarwin) {
+      LDFLAGS = "-Wl,--build-id=sha1";
+    };
 
     cmakeBuildType = "Release";
 

--- a/pkgs/development/interpreters/guile/2.0.nix
+++ b/pkgs/development/interpreters/guile/2.0.nix
@@ -90,14 +90,6 @@ builder rec {
     })
   ];
 
-  # Explicitly link against libgcc_s, to work around the infamous
-  # "libgcc_s.so.1 must be installed for pthread_cancel to work".
-
-  # don't have "libgcc_s.so.1" on darwin
-  LDFLAGS = lib.optionalString (
-    !stdenv.hostPlatform.isDarwin && !stdenv.hostPlatform.isMusl
-  ) "-lgcc_s";
-
   configureFlags = [
     "--with-libreadline-prefix"
   ]
@@ -118,6 +110,12 @@ builder rec {
 
   env = {
     NIX_CFLAGS_COMPILE = "-std=gnu17";
+  }
+  // lib.optionalAttrs (!stdenv.hostPlatform.isDarwin && !stdenv.hostPlatform.isMusl) {
+    # Explicitly link against libgcc_s, to work around the infamous
+    # "libgcc_s.so.1 must be installed for pthread_cancel to work".
+    # don't have "libgcc_s.so.1" on darwin
+    LDFLAGS = "-lgcc_s";
   };
 
   postInstall = ''

--- a/pkgs/development/interpreters/guile/2.2.nix
+++ b/pkgs/development/interpreters/guile/2.2.nix
@@ -85,7 +85,9 @@ builder rec {
   # "libgcc_s.so.1 must be installed for pthread_cancel to work".
 
   # don't have "libgcc_s.so.1" on clang
-  LDFLAGS = lib.optionalString (stdenv.cc.isGNU && !stdenv.hostPlatform.isStatic) "-lgcc_s";
+  env = lib.optionalAttrs (stdenv.cc.isGNU && !stdenv.hostPlatform.isStatic) {
+    LDFLAGS = "-lgcc_s";
+  };
 
   configureFlags = [
     "--with-libreadline-prefix=${lib.getDev readline}"

--- a/pkgs/development/interpreters/guile/3.0.nix
+++ b/pkgs/development/interpreters/guile/3.0.nix
@@ -100,11 +100,16 @@ builder rec {
     sha256 = "12wvwdna9j8795x59ldryv9d84c1j3qdk2iskw09306idfsis207";
   });
 
-  # Explicitly link against libgcc_s, to work around the infamous
-  # "libgcc_s.so.1 must be installed for pthread_cancel to work".
-
-  # don't have "libgcc_s.so.1" on clang
-  LDFLAGS = lib.optionalString (stdenv.cc.isGNU && !stdenv.hostPlatform.isStatic) "-lgcc_s";
+  env = {
+    # Fix build with gcc15
+    NIX_CFLAGS_COMPILE = toString [ "-std=gnu17" ];
+  }
+  // lib.optionalAttrs (stdenv.cc.isGNU && !stdenv.hostPlatform.isStatic) {
+    # Explicitly link against libgcc_s, to work around the infamous
+    # "libgcc_s.so.1 must be installed for pthread_cancel to work".
+    # don't have "libgcc_s.so.1" on clang
+    LDFLAGS = "-lgcc_s";
+  };
 
   configureFlags = [
     "--with-libreadline-prefix=${lib.getDev readline}"
@@ -125,9 +130,6 @@ builder rec {
   # At least on x86_64-darwin '-flto' autodetection is not correct:
   #  https://github.com/NixOS/nixpkgs/pull/160051#issuecomment-1046193028
   ++ lib.optional (stdenv.hostPlatform.isDarwin) "--disable-lto";
-
-  # Fix build with gcc15
-  env.NIX_CFLAGS_COMPILE = toString [ "-std=gnu17" ];
 
   postInstall = ''
     wrapProgram $out/bin/guile-snarf --prefix PATH : "${gawk}/bin"

--- a/pkgs/development/libraries/gettext/default.nix
+++ b/pkgs/development/libraries/gettext/default.nix
@@ -35,8 +35,6 @@ stdenv.mkDerivation rec {
     "info"
   ];
 
-  LDFLAGS = lib.optionalString stdenv.hostPlatform.isSunOS "-lm -lmd -lmp -luutil -lnvpair -lnsl -lidmap -lavl -lsec";
-
   configureFlags = [
     "--disable-csharp"
   ]
@@ -102,6 +100,9 @@ stdenv.mkDerivation rec {
     # https://github.com/Homebrew/homebrew-core/pull/199639
     # https://savannah.gnu.org/bugs/index.php?66541
     am_cv_func_iconv_works = "yes";
+  }
+  // lib.optionalAttrs stdenv.hostPlatform.isSunOS {
+    LDFLAGS = "-lm -lmd -lmp -luutil -lnvpair -lnsl -lidmap -lavl -lsec";
   };
 
   enableParallelBuilding = true;

--- a/pkgs/development/python-modules/google-crc32c/default.nix
+++ b/pkgs/development/python-modules/google-crc32c/default.nix
@@ -29,8 +29,10 @@ buildPythonPackage rec {
 
   dependencies = [ cffi ];
 
-  LDFLAGS = "-L${crc32c}/lib";
-  CFLAGS = "-I${crc32c}/include";
+  env = {
+    LDFLAGS = "-L${crc32c}/lib";
+    CFLAGS = "-I${crc32c}/include";
+  };
 
   nativeCheckInputs = [
     pytestCheckHook

--- a/pkgs/development/rocm-modules/6/migraphx/default.nix
+++ b/pkgs/development/rocm-modules/6/migraphx/default.nix
@@ -119,7 +119,7 @@ stdenv.mkDerivation (finalAttrs: {
     python3Packages.onnx
   ];
 
-  LDFLAGS = "-Wl,--allow-shlib-undefined";
+  env.LDFLAGS = "-Wl,--allow-shlib-undefined";
 
   cmakeFlags = [
     "-DMIGRAPHX_ENABLE_GPU=ON"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
