### PR TITLE
srcOnly: override output{Dev,Bin,...}. fixes #308050

### DIFF
--- a/pkgs/build-support/src-only/default.nix
+++ b/pkgs/build-support/src-only/default.nix
@@ -54,6 +54,19 @@ let
 
     dontInstall = false;
     installPhase = "cp -pr --reflink=auto -- . $out";
+
+    # the original derivation might've set something like outputDev = "lib", but "lib" isn't an output anymore
+    # some things get confused and error if one of these is set to an output that doesn't exist
+    # ex: pkgs/build-support/setup-hooks/multiple-outputs.sh
+    outputDev = "out";
+    outputBin = "out";
+    outputInclude = "out";
+    outputLib = "out";
+    outputDoc = "out";
+    outputDevdoc = "out";
+    outputMan = "out";
+    outputDevman = "out";
+    outputInfo = "out";
   };
 in
 


### PR DESCRIPTION
This wouldn't matter, except pkgs/build-support/setup-hooks/multiple-outputs.sh uses these and errors if they're set to a non-existent output.

Ex: if `outputDev=dev`, then multiple-outputs tries to set `outputInclude=$dev`, but `dev` isn't set.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux: `nix-build --expr 'let pkgs = import ./. {}; in pkgs.srcOnly pkgs.gtk2'`
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality: `nix-build --attr tests.srcOnly`
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
