### PR TITLE
nodejs: Mark most BE Linux targets unsupported

### DIFF
--- a/pkgs/development/web/nodejs/nodejs.nix
+++ b/pkgs/development/web/nodejs/nodejs.nix
@@ -556,7 +556,12 @@ let
         changelog = "https://github.com/nodejs/node/releases/tag/v${version}";
         license = lib.licenses.mit;
         maintainers = with lib.maintainers; [ aduh95 ];
-        platforms = lib.platforms.linux ++ lib.platforms.darwin ++ lib.platforms.freebsd;
+        # https://github.com/nodejs/node/blob/732ab9d658e057af5191d4ecd156d38487509462/BUILDING.md#platform-list
+        platforms =
+          (lib.lists.intersectLists (
+            lib.platforms.linux ++ lib.platforms.darwin ++ lib.platforms.freebsd
+          ) lib.platforms.littleEndian)
+          ++ [ "s390x-linux" ];
         # This broken condition is likely too conservative. Feel free to loosen it if it works.
         broken =
           !canExecute && !canEmulate && (stdenv.buildPlatform.parsed.cpu != stdenv.hostPlatform.parsed.cpu);


### PR DESCRIPTION
Closes #458983

...although not in a way that I like.

From https://github.com/nodejs/node/issues/58277:

> We do not support big-endian linux-ppc64, only Linux on ppc64le and AIX/IBMi on ppc64be are supported. For a full list of supported platforms, please refer to: https://github.com/nodejs/node/blob/main/BUILDING.md#platform-list

> Linux on ppc64be hasn't been supported on V8 for quite some time, and any functionality it had was more a matter of chance. Its support was formally removed in this CL http://crrev.com/c/5796844 . Currently, Linux on ppc64 is only supported in little-endian mode.

> No the above CL and it's followup (part 2) removed both ppc32 and ppc big-endian support (including 64 bit). We are unable to test your CL and will not support or evaluate any future changes on Linux ppc64be.

Node versions before the CL already segfault during the build for me, and I as a standalone person do not have the spoons to debug & maintain an entire JavaScript engine on ppc64 on my own.

Based on upstream's list of supported targets, s390x-linux is the only BE Linux target they support. Mark all BE Linux targets except s390x-linux unsupported.

CC @aduh95 (I assume CI won't ping automatically because this is 0 rebuilds on everything it checks on)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
