### PR TITLE
treewide: move PKG_CONFIG env variables into env for structuredAttrs

### DIFF
--- a/pkgs/applications/emulators/cdemu/libmirage.nix
+++ b/pkgs/applications/emulators/cdemu/libmirage.nix
@@ -34,8 +34,11 @@ in
 stdenv.mkDerivation {
   inherit pname version src;
 
-  PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_GIRDIR = "${placeholder "out"}/share/gir-1.0";
-  PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_TYPELIBDIR = "${placeholder "out"}/lib/girepository-1.0";
+  env = {
+    PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_GIRDIR = "${placeholder "out"}/share/gir-1.0";
+    PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_TYPELIBDIR = "${placeholder "out"}/lib/girepository-1.0";
+  };
+
   buildInputs = [
     glib
     libsndfile

--- a/pkgs/applications/networking/instant-messengers/pidgin/pidgin-plugins/purple-discord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin/pidgin-plugins/purple-discord/default.nix
@@ -28,8 +28,10 @@ stdenv.mkDerivation {
     json-glib
   ];
 
-  PKG_CONFIG_PURPLE_PLUGINDIR = "${placeholder "out"}/lib/purple-2";
-  PKG_CONFIG_PURPLE_DATADIR = "${placeholder "out"}/share";
+  env = {
+    PKG_CONFIG_PURPLE_PLUGINDIR = "${placeholder "out"}/lib/purple-2";
+    PKG_CONFIG_PURPLE_DATADIR = "${placeholder "out"}/share";
+  };
 
   meta = {
     homepage = "https://github.com/EionRobb/purple-discord";

--- a/pkgs/applications/networking/instant-messengers/pidgin/pidgin-plugins/purple-googlechat/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin/pidgin-plugins/purple-googlechat/default.nix
@@ -28,8 +28,10 @@ stdenv.mkDerivation {
     protobuf
   ];
 
-  PKG_CONFIG_PURPLE_PLUGINDIR = "${placeholder "out"}/lib/purple-2";
-  PKG_CONFIG_PURPLE_DATADIR = "${placeholder "out"}/share";
+  env = {
+    PKG_CONFIG_PURPLE_PLUGINDIR = "${placeholder "out"}/lib/purple-2";
+    PKG_CONFIG_PURPLE_DATADIR = "${placeholder "out"}/share";
+  };
 
   meta = {
     homepage = "https://github.com/EionRobb/purple-googlechat";

--- a/pkgs/applications/networking/instant-messengers/pidgin/pidgin-plugins/purple-slack/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin/pidgin-plugins/purple-slack/default.nix
@@ -20,8 +20,10 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ pidgin ];
 
-  PKG_CONFIG_PURPLE_PLUGINDIR = "${placeholder "out"}/lib/purple-2";
-  PKG_CONFIG_PURPLE_DATAROOTDIR = "${placeholder "out"}/share";
+  env = {
+    PKG_CONFIG_PURPLE_PLUGINDIR = "${placeholder "out"}/lib/purple-2";
+    PKG_CONFIG_PURPLE_DATAROOTDIR = "${placeholder "out"}/share";
+  };
 
   meta = {
     homepage = "https://github.com/dylex/slack-libpurple";

--- a/pkgs/applications/networking/mailreaders/evolution/evolution/default.nix
+++ b/pkgs/applications/networking/mailreaders/evolution/evolution/default.nix
@@ -144,8 +144,10 @@ stdenv.mkDerivation rec {
     };
   };
 
-  PKG_CONFIG_CAMEL_1_2_CAMEL_PROVIDERDIR = "${placeholder "out"}/lib/evolution-data-server/camel-providers";
-  PKG_CONFIG_LIBEDATASERVERUI_1_2_UIMODULEDIR = "${placeholder "out"}/lib/evolution-data-server/ui-modules";
+  env = {
+    PKG_CONFIG_CAMEL_1_2_CAMEL_PROVIDERDIR = "${placeholder "out"}/lib/evolution-data-server/camel-providers";
+    PKG_CONFIG_LIBEDATASERVERUI_1_2_UIMODULEDIR = "${placeholder "out"}/lib/evolution-data-server/ui-modules";
+  };
 
   meta = {
     homepage = "https://gitlab.gnome.org/GNOME/evolution";

--- a/pkgs/by-name/bo/bolt/package.nix
+++ b/pkgs/by-name/bo/bolt/package.nix
@@ -90,8 +90,10 @@ stdenv.mkDerivation rec {
 
   doInstallCheck = true;
 
-  PKG_CONFIG_SYSTEMD_SYSTEMDSYSTEMUNITDIR = "${placeholder "out"}/lib/systemd/system";
-  PKG_CONFIG_UDEV_UDEVDIR = "${placeholder "out"}/lib/udev";
+  env = {
+    PKG_CONFIG_SYSTEMD_SYSTEMDSYSTEMUNITDIR = "${placeholder "out"}/lib/systemd/system";
+    PKG_CONFIG_UDEV_UDEVDIR = "${placeholder "out"}/lib/udev";
+  };
 
   meta = {
     description = "Thunderbolt 3 device management daemon";

--- a/pkgs/by-name/ca/casync/package.nix
+++ b/pkgs/by-name/ca/casync/package.nix
@@ -64,7 +64,8 @@ stdenv.mkDerivation {
     patchShebangs test/http-server.py
   '';
 
-  PKG_CONFIG_UDEV_UDEVDIR = "lib/udev";
+  env.PKG_CONFIG_UDEV_UDEVDIR = "lib/udev";
+
   mesonFlags =
     lib.optionals (!fuseSupport) [ "-Dfuse=false" ]
     ++ lib.optionals (!udevSupport) [ "-Dudev=false" ]

--- a/pkgs/by-name/db/dbus-broker/package.nix
+++ b/pkgs/by-name/db/dbus-broker/package.nix
@@ -155,9 +155,11 @@ stdenv.mkDerivation (finalAttrs: {
     "-D=system-console-users=gdm,sddm,lightdm"
   ];
 
-  PKG_CONFIG_SYSTEMD_SYSTEMDSYSTEMUNITDIR = "${placeholder "out"}/lib/systemd/system";
-  PKG_CONFIG_SYSTEMD_SYSTEMDUSERUNITDIR = "${placeholder "out"}/lib/systemd/user";
-  PKG_CONFIG_SYSTEMD_CATALOGDIR = "${placeholder "out"}/lib/systemd/catalog";
+  env = {
+    PKG_CONFIG_SYSTEMD_SYSTEMDSYSTEMUNITDIR = "${placeholder "out"}/lib/systemd/system";
+    PKG_CONFIG_SYSTEMD_SYSTEMDUSERUNITDIR = "${placeholder "out"}/lib/systemd/user";
+    PKG_CONFIG_SYSTEMD_CATALOGDIR = "${placeholder "out"}/lib/systemd/catalog";
+  };
 
   postInstall = ''
     install -Dm444 $src/README.md $out/share/doc/dbus-broker/README

--- a/pkgs/by-name/eo/eos-installer/package.nix
+++ b/pkgs/by-name/eo/eos-installer/package.nix
@@ -61,7 +61,7 @@ stdenv.mkDerivation rec {
     ''}"
   ];
 
-  PKG_CONFIG_SYSTEMD_SYSTEMDSYSTEMUNITDIR = "${placeholder "out"}/lib/systemd/system";
+  env.PKG_CONFIG_SYSTEMD_SYSTEMDSYSTEMUNITDIR = "${placeholder "out"}/lib/systemd/system";
 
   doCheck = true;
 

--- a/pkgs/by-name/es/espeakup/package.nix
+++ b/pkgs/by-name/es/espeakup/package.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     systemd
   ];
 
-  PKG_CONFIG_SYSTEMD_SYSTEMDSYSTEMUNITDIR = "${placeholder "out"}/lib/systemd/system";
+  env.PKG_CONFIG_SYSTEMD_SYSTEMDSYSTEMUNITDIR = "${placeholder "out"}/lib/systemd/system";
 
   meta = {
     homepage = "https://github.com/linux-speakup/espeakup";

--- a/pkgs/by-name/fl/fluent-bit/package.nix
+++ b/pkgs/by-name/fl/fluent-bit/package.nix
@@ -102,7 +102,7 @@ stdenv.mkDerivation (finalAttrs: {
   # We fix this by setting the systemd package's `systemdsystemunitdir` pkg-config variable.
   #
   # https://man.openbsd.org/pkg-config.1#PKG_CONFIG_$PACKAGE_$VARIABLE
-  PKG_CONFIG_SYSTEMD_SYSTEMDSYSTEMUNITDIR = "${placeholder "out"}/lib/systemd/system";
+  env.PKG_CONFIG_SYSTEMD_SYSTEMDSYSTEMUNITDIR = "${placeholder "out"}/lib/systemd/system";
 
   outputs = [
     "out"

--- a/pkgs/by-name/fn/fnott/package.nix
+++ b/pkgs/by-name/fn/fnott/package.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-II8fij64ufwXg71VoSayVpSFim9+2w3j4gdTRDBrYQE=";
   };
 
-  PKG_CONFIG_DBUS_1_SESSION_BUS_SERVICES_DIR = "${placeholder "out"}/share/dbus-1/services";
+  env.PKG_CONFIG_DBUS_1_SESSION_BUS_SERVICES_DIR = "${placeholder "out"}/share/dbus-1/services";
 
   strictDeps = true;
   depsBuildBuild = [

--- a/pkgs/by-name/fp/fprintd/package.nix
+++ b/pkgs/by-name/fp/fprintd/package.nix
@@ -80,12 +80,14 @@ stdenv.mkDerivation (finalAttrs: {
     "-Dsystemd_system_unit_dir=${placeholder "out"}/lib/systemd/system"
   ];
 
-  PKG_CONFIG_DBUS_1_INTERFACES_DIR = "${placeholder "out"}/share/dbus-1/interfaces";
-  PKG_CONFIG_POLKIT_GOBJECT_1_POLICYDIR = "${placeholder "out"}/share/polkit-1/actions";
-  PKG_CONFIG_DBUS_1_DATADIR = "${placeholder "out"}/share";
+  env = {
+    PKG_CONFIG_DBUS_1_INTERFACES_DIR = "${placeholder "out"}/share/dbus-1/interfaces";
+    PKG_CONFIG_POLKIT_GOBJECT_1_POLICYDIR = "${placeholder "out"}/share/polkit-1/actions";
+    PKG_CONFIG_DBUS_1_DATADIR = "${placeholder "out"}/share";
 
-  # FIXME: Ugly hack for tests to find libpam_wrapper.so
-  LIBRARY_PATH = lib.makeLibraryPath [ python3.pkgs.pypamtest ];
+    # FIXME: Ugly hack for tests to find libpam_wrapper.so
+    LIBRARY_PATH = lib.makeLibraryPath [ python3.pkgs.pypamtest ];
+  };
 
   mesonCheckFlags = [
     # PAM related checks are timing out

--- a/pkgs/by-name/gn/gnome-applets/package.nix
+++ b/pkgs/by-name/gn/gnome-applets/package.nix
@@ -63,7 +63,7 @@ stdenv.mkDerivation (finalAttrs: {
   doCheck = true;
 
   # Don't try to install modules to gnome panel's directory, as it's read only
-  PKG_CONFIG_LIBGNOME_PANEL_MODULESDIR = "${placeholder "out"}/lib/gnome-panel/modules";
+  env.PKG_CONFIG_LIBGNOME_PANEL_MODULESDIR = "${placeholder "out"}/lib/gnome-panel/modules";
 
   passthru = {
     updateScript = gnome.updateScript {

--- a/pkgs/by-name/gn/gnome-flashback/package.nix
+++ b/pkgs/by-name/gn/gnome-flashback/package.nix
@@ -98,8 +98,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
-  PKG_CONFIG_LIBGNOME_PANEL_LAYOUTSDIR = "${placeholder "out"}/share/gnome-panel/layouts";
-  PKG_CONFIG_LIBGNOME_PANEL_MODULESDIR = "${placeholder "out"}/lib/gnome-panel/modules";
+  env = {
+    PKG_CONFIG_LIBGNOME_PANEL_LAYOUTSDIR = "${placeholder "out"}/share/gnome-panel/layouts";
+    PKG_CONFIG_LIBGNOME_PANEL_MODULESDIR = "${placeholder "out"}/lib/gnome-panel/modules";
+  };
 
   passthru = {
     updateScript = gnome.updateScript {

--- a/pkgs/by-name/lo/logiops/package.nix
+++ b/pkgs/by-name/lo/logiops/package.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation (oldAttrs: {
     "-DDBUS_SYSTEM_POLICY_INSTALL_DIR=${placeholder "out"}/share/dbus-1/system.d"
   ];
 
-  PKG_CONFIG_SYSTEMD_SYSTEMDSYSTEMUNITDIR = "${placeholder "out"}/lib/systemd/system";
+  env.PKG_CONFIG_SYSTEMD_SYSTEMDSYSTEMUNITDIR = "${placeholder "out"}/lib/systemd/system";
 
   meta = {
     description = "Unofficial userspace driver for HID++ Logitech devices";

--- a/pkgs/by-name/lo/logiops_0_2_3/package.nix
+++ b/pkgs/by-name/lo/logiops_0_2_3/package.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-1v728hbIM2ODtB+r6SYzItczRJCsbuTvhYD2OUM1+/E=";
   };
 
-  PKG_CONFIG_SYSTEMD_SYSTEMDSYSTEMUNITDIR = "${placeholder "out"}/lib/systemd/system";
+  env.PKG_CONFIG_SYSTEMD_SYSTEMDSYSTEMUNITDIR = "${placeholder "out"}/lib/systemd/system";
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/by-name/ma/magpie/package.nix
+++ b/pkgs/by-name/ma/magpie/package.nix
@@ -149,7 +149,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   # Install udev files into our own tree.
-  PKG_CONFIG_UDEV_UDEVDIR = "${placeholder "out"}/lib/udev";
+  env.PKG_CONFIG_UDEV_UDEVDIR = "${placeholder "out"}/lib/udev";
 
   separateDebugInfo = true;
 

--- a/pkgs/by-name/mu/mutter/package.nix
+++ b/pkgs/by-name/mu/mutter/package.nix
@@ -198,7 +198,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   # Install udev files into our own tree.
-  PKG_CONFIG_UDEV_UDEVDIR = "${placeholder "out"}/lib/udev";
+  env.PKG_CONFIG_UDEV_UDEVDIR = "${placeholder "out"}/lib/udev";
 
   separateDebugInfo = true;
   strictDeps = true;

--- a/pkgs/by-name/mu/mutter46/package.nix
+++ b/pkgs/by-name/mu/mutter46/package.nix
@@ -184,7 +184,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   # Install udev files into our own tree.
-  PKG_CONFIG_UDEV_UDEVDIR = "${placeholder "out"}/lib/udev";
+  env.PKG_CONFIG_UDEV_UDEVDIR = "${placeholder "out"}/lib/udev";
 
   separateDebugInfo = true;
 

--- a/pkgs/by-name/ne/nemo-fileroller/package.nix
+++ b/pkgs/by-name/ne/nemo-fileroller/package.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
       --replace "GNOMELOCALEDIR" "${cinnamon-translations}/share/locale"
   '';
 
-  PKG_CONFIG_LIBNEMO_EXTENSION_EXTENSIONDIR = "${placeholder "out"}/${nemo.extensiondir}";
+  env.PKG_CONFIG_LIBNEMO_EXTENSION_EXTENSIONDIR = "${placeholder "out"}/${nemo.extensiondir}";
 
   meta = {
     homepage = "https://github.com/linuxmint/nemo-extensions/tree/master/nemo-fileroller";

--- a/pkgs/by-name/ne/nemo-python/package.nix
+++ b/pkgs/by-name/ne/nemo-python/package.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation rec {
       --replace "get_option('prefix'), get_option('libdir')" "'${python3}/lib'"
   '';
 
-  PKG_CONFIG_LIBNEMO_EXTENSION_EXTENSIONDIR = "${placeholder "out"}/${nemo.extensiondir}";
+  env.PKG_CONFIG_LIBNEMO_EXTENSION_EXTENSIONDIR = "${placeholder "out"}/${nemo.extensiondir}";
 
   passthru.nemoPythonExtensionDeps = [ python3.pkgs.pygobject3 ];
 

--- a/pkgs/by-name/ne/networkmanager-strongswan/package.nix
+++ b/pkgs/by-name/ne/networkmanager-strongswan/package.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
     "--with-gtk4"
   ];
 
-  PKG_CONFIG_LIBNM_VPNSERVICEDIR = "${placeholder "out"}/lib/NetworkManager/VPN";
+  env.PKG_CONFIG_LIBNM_VPNSERVICEDIR = "${placeholder "out"}/lib/NetworkManager/VPN";
 
   passthru = {
     networkManagerPlugin = "VPN/nm-strongswan-service.name";

--- a/pkgs/by-name/po/power-profiles-daemon/package.nix
+++ b/pkgs/by-name/po/power-profiles-daemon/package.nix
@@ -108,7 +108,7 @@ stdenv.mkDerivation (finalAttrs: {
   # Only need to wrap the Python tool (powerprofilectl)
   dontWrapGApps = true;
 
-  PKG_CONFIG_POLKIT_GOBJECT_1_POLICYDIR = "${placeholder "out"}/share/polkit-1/actions";
+  env.PKG_CONFIG_POLKIT_GOBJECT_1_POLICYDIR = "${placeholder "out"}/share/polkit-1/actions";
 
   postPatch = ''
     patchShebangs --build \

--- a/pkgs/by-name/sp/spice-gtk/package.nix
+++ b/pkgs/by-name/sp/spice-gtk/package.nix
@@ -135,7 +135,7 @@ stdenv.mkDerivation rec {
     wayland-protocols
   ];
 
-  PKG_CONFIG_POLKIT_GOBJECT_1_POLICYDIR = "${placeholder "out"}/share/polkit-1/actions";
+  env.PKG_CONFIG_POLKIT_GOBJECT_1_POLICYDIR = "${placeholder "out"}/share/polkit-1/actions";
 
   mesonFlags = [
     "-Dusb-acl-helper-dir=${placeholder "out"}/bin"

--- a/pkgs/by-name/to/touchegg/package.nix
+++ b/pkgs/by-name/to/touchegg/package.nix
@@ -71,7 +71,7 @@ stdenv.mkDerivation (finalAttrs: {
     libxcb
   ]);
 
-  PKG_CONFIG_SYSTEMD_SYSTEMDSYSTEMUNITDIR = "${placeholder "out"}/lib/systemd/system";
+  env.PKG_CONFIG_SYSTEMD_SYSTEMDSYSTEMUNITDIR = "${placeholder "out"}/lib/systemd/system";
 
   passthru = {
     updateScript = nix-update-script { };

--- a/pkgs/by-name/vi/virt-v2v/package.nix
+++ b/pkgs/by-name/vi/virt-v2v/package.nix
@@ -91,7 +91,7 @@ stdenv.mkDerivation (finalAttrs: {
     ln -s "${pkgsCross.mingwW64.rhsrvany}/bin/" $out/share/virt-tools
   '';
 
-  PKG_CONFIG_BASH_COMPLETION_COMPLETIONSDIR = "${placeholder "out"}/share/bash-completion/completions";
+  env.PKG_CONFIG_BASH_COMPLETION_COMPLETIONSDIR = "${placeholder "out"}/share/bash-completion/completions";
 
   passthru.tests.version = testers.testVersion { package = finalAttrs.finalPackage; };
 

--- a/pkgs/by-name/wa/waffle/package.nix
+++ b/pkgs/by-name/wa/waffle/package.nix
@@ -71,7 +71,7 @@ stdenv.mkDerivation rec {
     wayland-scanner
   ];
 
-  PKG_CONFIG_BASH_COMPLETION_COMPLETIONSDIR = "${placeholder "out"}/share/bash-completion/completions";
+  env.PKG_CONFIG_BASH_COMPLETION_COMPLETIONSDIR = "${placeholder "out"}/share/bash-completion/completions";
 
   postInstall = ''
     wrapProgram $out/bin/wflinfo \

--- a/pkgs/desktops/pantheon/services/contractor/default.nix
+++ b/pkgs/desktops/pantheon/services/contractor/default.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
     libgee
   ];
 
-  PKG_CONFIG_DBUS_1_SESSION_BUS_SERVICES_DIR = "${placeholder "out"}/share/dbus-1/services";
+  env.PKG_CONFIG_DBUS_1_SESSION_BUS_SERVICES_DIR = "${placeholder "out"}/share/dbus-1/services";
 
   passthru = {
     updateScript = nix-update-script { };

--- a/pkgs/development/libraries/gcr/4.nix
+++ b/pkgs/development/libraries/gcr/4.nix
@@ -99,7 +99,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   doCheck = false; # fails 21 out of 603 tests, needs dbus daemon
 
-  PKG_CONFIG_SYSTEMD_SYSTEMDUSERUNITDIR = "${placeholder "out"}/lib/systemd/user";
+  env.PKG_CONFIG_SYSTEMD_SYSTEMDUSERUNITDIR = "${placeholder "out"}/lib/systemd/user";
 
   postPatch = ''
     patchShebangs gcr/fixtures/

--- a/pkgs/development/libraries/gcr/default.nix
+++ b/pkgs/development/libraries/gcr/default.nix
@@ -90,7 +90,7 @@ stdenv.mkDerivation rec {
 
   doCheck = false; # fails 21 out of 603 tests, needs dbus daemon
 
-  PKG_CONFIG_SYSTEMD_SYSTEMDUSERUNITDIR = "${placeholder "out"}/lib/systemd/user";
+  env.PKG_CONFIG_SYSTEMD_SYSTEMDUSERUNITDIR = "${placeholder "out"}/lib/systemd/user";
 
   postPatch = ''
     patchShebangs gcr/fixtures/

--- a/pkgs/development/libraries/goocanvas/2.x.nix
+++ b/pkgs/development/libraries/goocanvas/2.x.nix
@@ -55,8 +55,11 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--disable-python"
   ];
-  PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_GIRDIR = "$(dev)/share/gir-1.0";
-  PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_TYPELIBDIR = "$(out)/lib/girepository-1.0";
+
+  env = {
+    PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_GIRDIR = "$(dev)/share/gir-1.0";
+    PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_TYPELIBDIR = "$(out)/lib/girepository-1.0";
+  };
 
   passthru = {
     updateScript = gnome.updateScript {

--- a/pkgs/development/libraries/goocanvas/3.x.nix
+++ b/pkgs/development/libraries/goocanvas/3.x.nix
@@ -54,8 +54,10 @@ stdenv.mkDerivation (finalAttrs: {
     glib
   ];
 
-  PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_GIRDIR = "$(dev)/share/gir-1.0";
-  PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_TYPELIBDIR = "$(out)/lib/girepository-1.0";
+  env = {
+    PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_GIRDIR = "$(dev)/share/gir-1.0";
+    PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_TYPELIBDIR = "$(out)/lib/girepository-1.0";
+  };
 
   passthru = {
     updateScript = gnome.updateScript {

--- a/pkgs/development/libraries/indicator-application/gtk3.nix
+++ b/pkgs/development/libraries/indicator-application/gtk3.nix
@@ -59,8 +59,10 @@ stdenv.mkDerivation rec {
     "localstatedir=\${TMPDIR}"
   ];
 
-  PKG_CONFIG_SYSTEMD_SYSTEMDUSERUNITDIR = "$(out)/lib/systemd/user";
-  PKG_CONFIG_INDICATOR3_0_4_INDICATORDIR = "$(out)/lib/indicators3/7/";
+  env = {
+    PKG_CONFIG_SYSTEMD_SYSTEMDUSERUNITDIR = "$(out)/lib/systemd/user";
+    PKG_CONFIG_INDICATOR3_0_4_INDICATORDIR = "$(out)/lib/indicators3/7/";
+  };
 
   # Upstart is not used in NixOS
   postFixup = ''

--- a/pkgs/development/libraries/libhandy/default.nix
+++ b/pkgs/development/libraries/libhandy/default.nix
@@ -82,8 +82,10 @@ stdenv.mkDerivation rec {
   ];
 
   # Uses define_variable in pkg-config, but we still need it to use the glade output
-  PKG_CONFIG_GLADEUI_2_0_MODULEDIR = "${placeholder "glade"}/lib/glade/modules";
-  PKG_CONFIG_GLADEUI_2_0_CATALOGDIR = "${placeholder "glade"}/share/glade/catalogs";
+  env = {
+    PKG_CONFIG_GLADEUI_2_0_MODULEDIR = "${placeholder "glade"}/lib/glade/modules";
+    PKG_CONFIG_GLADEUI_2_0_CATALOGDIR = "${placeholder "glade"}/share/glade/catalogs";
+  };
 
   doCheck = !stdenv.hostPlatform.isDarwin;
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
