### PR TITLE
rust-bindgen: fix for structuredAttrs

### DIFF
--- a/pkgs/development/tools/rust/bindgen/default.nix
+++ b/pkgs/development/tools/rust/bindgen/default.nix
@@ -10,11 +10,8 @@ let
   self =
     runCommand "rust-bindgen-${rust-bindgen-unwrapped.version}"
       {
-        #for substituteAll
-        inherit bash;
         pname = "rust-bindgen";
         inherit (rust-bindgen-unwrapped) version;
-        unwrapped = rust-bindgen-unwrapped;
         meta = rust-bindgen-unwrapped.meta // {
           longDescription = rust-bindgen-unwrapped.meta.longDescription + ''
             This version of bindgen is wrapped with the required compiler flags
@@ -46,9 +43,13 @@ let
       # if you modify the logic to find the right clang flags, also modify rustPlatform.bindgenHook
       ''
         mkdir -p $out/bin
-        export cincludes="$(< ${clang}/nix-support/cc-cflags) $(< ${clang}/nix-support/libc-cflags)"
-        export cxxincludes="$(< ${clang}/nix-support/libcxx-cxxflags)"
-        substituteAll ${./wrapper.sh} $out/bin/bindgen
+        cincludes="$(< ${clang}/nix-support/cc-cflags) $(< ${clang}/nix-support/libc-cflags)"
+        cxxincludes="$(< ${clang}/nix-support/libcxx-cxxflags)"
+        substitute ${./wrapper.sh} $out/bin/bindgen \
+          --replace-fail "@bash@" "${bash}" \
+          --replace-fail "@cxxincludes@" "$cxxincludes" \
+          --replace-fail "@cincludes@" "$cincludes" \
+          --replace-fail "@unwrapped@" "${rust-bindgen-unwrapped}"
         chmod +x $out/bin/bindgen
       '';
 in


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
