### PR TITLE
mediathekview: 14.2.0 -> 14.4.2

### DIFF
--- a/pkgs/by-name/me/mediathekview/package.nix
+++ b/pkgs/by-name/me/mediathekview/package.nix
@@ -1,20 +1,21 @@
 {
   lib,
+  pkgs,
   stdenv,
   fetchurl,
   makeWrapper,
   libglvnd,
   libnotify,
-  jre,
+  openjdk25, # 2025-12-25: pkgs.jre points to java 21 and there is no equivalent for jre25
   zip,
 }:
 
-stdenv.mkDerivation rec {
-  version = "14.2.0";
+stdenv.mkDerivation (finalAttrs: {
+  version = "14.4.2";
   pname = "mediathekview";
   src = fetchurl {
-    url = "https://download.mediathekview.de/stabil/MediathekView-${version}-linux.tar.gz";
-    sha256 = "sha256-EWpa6YE9Fk7K14vvsbjadKuGGZGqNhlouDtwj6KpbdE=";
+    url = "https://download.mediathekview.de/stabil/MediathekView-${finalAttrs.version}-linux.tar.gz";
+    sha256 = "sha256-sDZSXYzak2RKQiW1OGpgSvFlkZrttsoOxVqRaodol24=";
   };
 
   nativeBuildInputs = [
@@ -35,21 +36,29 @@ stdenv.mkDerivation rec {
       mkdir -p $out/{bin,lib}
 
       install -m644 MediathekView.jar $out/lib
+      cp -r dependency $out/lib
 
-      makeWrapper ${jre}/bin/java $out/bin/mediathek \
-        --add-flags "-jar $out/lib/MediathekView.jar" \
+      makeWrapper ${openjdk25}/bin/java $out/bin/mediathek \
+        --add-flags "--add-exports=java.desktop/sun.swing=ALL-UNNAMED -XX:MaxRAMPercentage=10.0 -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=compact -XX:+UseStringDeduplication --add-opens=java.desktop/sun.awt.X11=ALL-UNNAMED --enable-native-access=ALL-UNNAMED -cp \"$out/lib/dependency/*:$out/lib/MediathekView.jar\" mediathek.Main" \
         --suffix LD_LIBRARY_PATH : "${libraryPath}"
 
-      makeWrapper ${jre}/bin/java $out/bin/MediathekView \
-        --add-flags "-jar $out/lib/MediathekView.jar" \
-        --suffix LD_LIBRARY_PATH : "${libraryPath}"
+      ln -s $out/bin/mediathek $out/bin/MediathekView
 
-      makeWrapper ${jre}/bin/java $out/bin/MediathekView_ipv4 \
-        --add-flags "-Djava.net.preferIPv4Stack=true -jar $out/lib/MediathekView.jar" \
+      makeWrapper ${openjdk25}/bin/java $out/bin/MediathekView_ipv4 \
+      --add-flags "-Djava.net.preferIPv4Stack=true --add-exports=java.desktop/sun.swing=ALL-UNNAMED -XX:MaxRAMPercentage=10.0 -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=compact -XX:+UseStringDeduplication --add-opens=java.desktop/sun.awt.X11=ALL-UNNAMED --enable-native-access=ALL-UNNAMED -cp \"$out/lib/dependency/*:$out/lib/MediathekView.jar\" mediathek.Main" \
         --suffix LD_LIBRARY_PATH : "${libraryPath}"
 
       runHook postInstall
     '';
+
+  doInstallCheck = true;
+  # sanity to ensure that mediathek can actually start
+  # unfortunately the executable does not print its own version
+  installCheckPhase = ''
+    runHook postCheck
+    ($out/bin/${finalAttrs.meta.mainProgram} --help 2>&1 ||: ) | grep -q 'Diese Version von MediathekView unterst?tzt keine Kommandozeilenausf?hrung.'
+    runHook preCheck
+  '';
 
   meta = {
     description = "Offers access to the Mediathek of different tv stations (ARD, ZDF, Arte, etc.)";
@@ -57,7 +66,7 @@ stdenv.mkDerivation rec {
     sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     license = lib.licenses.gpl3Plus;
     mainProgram = "mediathek";
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ makefu ];
     platforms = lib.platforms.all;
   };
-}
+})


### PR DESCRIPTION
pin java version to openjdk25 as jre in nixpkgs is jre21 use finalAttrs instead of rec
rewirte the java wrapper to include all java flags recommended by mediathekview source code as well as all mandatory flags to get the program working

add sanity install check to ensure both java version and dependencies can at least be loaded by the program
add makefu as maintainer

open upstream issue: vlc and ffmpeg paths are not automatically detected (mediathekview/MediathekView#824)

supersedes #414385


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
