### PR TITLE
fetchFromGitHub: use `fetchgit` when `postCheckout` is not empty

### DIFF
--- a/pkgs/build-support/fetchgithub/default.nix
+++ b/pkgs/build-support/fetchgithub/default.nix
@@ -15,6 +15,7 @@ let
     fetchLFS = false;
     forceFetchGit = false;
     leaveDotGit = null;
+    postCheckout = "";
     rootDir = "";
     sparseCheckout = null;
   };

--- a/pkgs/build-support/fetchgithub/tests.nix
+++ b/pkgs/build-support/fetchgithub/tests.nix
@@ -8,6 +8,14 @@
     hash = "sha256-7DszvbCNTjpzGRmpIVAWXk20P0/XTrWZ79KSOGLrUWY=";
   };
 
+  simple-tag = testers.invalidateFetcherByDrvHash fetchFromGitHub {
+    name = "simple-tag-nix-source";
+    owner = "NixOS";
+    repo = "nix";
+    rev = "2.3.15";
+    hash = "sha256-7DszvbCNTjpzGRmpIVAWXk20P0/XTrWZ79KSOGLrUWY=";
+  };
+
   sparseCheckout = testers.invalidateFetcherByDrvHash fetchFromGitHub {
     name = "sparse-checkout-nix-source";
     owner = "NixOS";

--- a/pkgs/build-support/fetchgithub/tests.nix
+++ b/pkgs/build-support/fetchgithub/tests.nix
@@ -16,6 +16,17 @@
     hash = "sha256-7DszvbCNTjpzGRmpIVAWXk20P0/XTrWZ79KSOGLrUWY=";
   };
 
+  describe-tag = testers.invalidateFetcherByDrvHash fetchFromGitHub {
+    name = "describe-tag-nix-source";
+    owner = "NixOS";
+    repo = "nix";
+    rev = "2.3.15";
+    hash = "sha256-y7l+46lVP2pzJwGON5qEV0EoxWofRoWAym5q9VXvpc8=";
+    postCheckout = ''
+      { git -C "$out" describe || echo "git describe failed"; } | tee "$out"/describe-output.txt
+    '';
+  };
+
   sparseCheckout = testers.invalidateFetcherByDrvHash fetchFromGitHub {
     name = "sparse-checkout-nix-source";
     owner = "NixOS";


### PR DESCRIPTION
## Description

This PR makes `fetchFromGitHub` choose `fetchgit` as its base fetcher if `postCheckout` is specified as a non-empty string.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
