### PR TITLE
python3Packages.bleak-retry-connector: fix build on Darwin

### DIFF
--- a/pkgs/development/python-modules/bleak-retry-connector/default.nix
+++ b/pkgs/development/python-modules/bleak-retry-connector/default.nix
@@ -29,10 +29,10 @@ buildPythonPackage rec {
 
   dependencies = [
     bleak
+    dbus-fast
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     bluetooth-adapters
-    dbus-fast
   ];
 
   nativeCheckInputs = [

--- a/pkgs/servers/home-assistant/tests.nix
+++ b/pkgs/servers/home-assistant/tests.nix
@@ -200,6 +200,13 @@ let
       # intent fixture mismatch
       "test_error_no_device_on_floor"
     ];
+    homewizard = [
+      # Messages don't match expected due to a change in Homewizard's outputs
+      "test_identify_button"
+      "test_number_entities"
+      "test_select_request_error"
+      "test_switch_entities"
+    ];
     sensor = [
       # Failed: Translation not found for sensor
       "test_validate_unit_change_convertible"

--- a/pkgs/servers/home-assistant/tests.nix
+++ b/pkgs/servers/home-assistant/tests.nix
@@ -88,6 +88,7 @@ let
     miele = getComponentDeps "cloud";
     mjpeg = getComponentDeps "camera";
     mobile_app = getComponentDeps "frontend";
+    mopeka = getComponentDeps "switchbot";
     motioneye = getComponentDeps "camera";
     mqtt = getComponentDeps "camera";
     nest = getComponentDeps "camera" ++ [


### PR DESCRIPTION
Hydra: https://hydra.nixos.org/build/316097571

1. Move `dbus-fast` from Linux only to all platforms (it's required in the check phase for all).
2. Fix broken home-manager modules built by this change.

**Note**: The linux rebuild count is due to the home-assistant modules which are a fairly lightweight rebuild. 


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
