### PR TITLE
validator-nu: 23.4.11-unstable-2023-12-18 → 25.12.12

### DIFF
--- a/pkgs/by-name/va/validator-nu/package.nix
+++ b/pkgs/by-name/va/validator-nu/package.nix
@@ -1,9 +1,13 @@
 {
+  ant,
+  cacert,
   fetchFromGitHub,
   git,
+  installShellFiles,
   jdk_headless,
   jre_headless,
   makeWrapper,
+  pandoc,
   python3,
   stdenvNoCC,
   lib,
@@ -12,14 +16,13 @@
 
 let
   pname = "validator-nu";
-  version = "23.4.11-unstable-2023-12-18";
+  version = "25.12.12";
 
   src = fetchFromGitHub {
     owner = "validator";
     repo = "validator";
-    rev = "c3a401feb6555affdc891337f5a40af238f9ac2d";
-    fetchSubmodules = true;
-    hash = "sha256-pcA3HXduzFKzoOHhor12qvzbGSSvo3k3Bpy2MvvQlCI=";
+    rev = "7ed7f67468f7f61975dcc78891ea462fce578828";
+    hash = "sha256-cdDmhRyXIdoNWhP4oqu7vRb5abuNXRqvt4P4Dzq48xY=";
   };
 
   deps = stdenvNoCC.mkDerivation {
@@ -27,23 +30,31 @@ let
     inherit version src;
 
     nativeBuildInputs = [
-      git
+      ant
+      cacert
       jdk_headless
       python3
-      python3.pkgs.certifi
     ];
+
+    postPatch = ''
+      substituteInPlace build/build.xml \
+        --replace-fail \
+        'src="https://html.spec.whatwg.org/"' \
+        'src="https://html.spec.whatwg.org/commit-snapshots/0aa021ab4f21a6550f1591a9cc98449aaea9eefa/"'
+    '';
 
     buildPhase = ''
       python checker.py dldeps
     '';
 
     installPhase = ''
-      mkdir "$out"
+      mkdir "$out" "$out/build"
       mv dependencies extras "$out"
+      mv build/html5spec "$out/build"
     '';
 
     outputHashMode = "recursive";
-    outputHash = "sha256-LPtxpUd7LAYZHJL7elgcZOTaTgHqeqquiB9hiuajA6c=";
+    outputHash = "sha256-8cMoLeOnKNqisezkVS2UeVW11gtkGmhvQWrbSVuqbb8=";
   };
 
 in
@@ -51,21 +62,25 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   inherit pname version src;
 
   nativeBuildInputs = [
-    git
+    ant
+    installShellFiles
     jdk_headless
     makeWrapper
+    pandoc
     python3
   ];
 
   postPatch = ''
-    substituteInPlace build/build.py --replace-warn \
+    substituteInPlace build/build.py --replace-fail \
       'validatorVersion = "%s.%s.%s" % (year, month, day)' \
       'validatorVersion = "${finalAttrs.version}"'
   '';
 
   buildPhase = ''
     ln -s '${deps}/dependencies' '${deps}/extras' .
-    JAVA_HOME='${jdk_headless}' python checker.py build
+    ln -s '${deps}/build/html5spec' build/
+    JAVA_HOME='${jdk_headless}' python checker.py --offline build
+    make -C docs VNU_VERSION='${finalAttrs.version}' DATE='date -d @$(SOURCE_DATE_EPOCH)'
   '';
 
   installPhase = ''
@@ -73,6 +88,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
     mkdir -p "$out/bin" "$out/share/java"
     mv build/dist/vnu.jar "$out/share/java/"
+    installManPage docs/*.1
     makeWrapper "${jre_headless}/bin/java" "$out/bin/vnu" \
       --add-flags "-jar '$out/share/java/vnu.jar'"
 


### PR DESCRIPTION
- https://github.com/validator/validator/compare/c3a401feb6555affdc891337f5a40af238f9ac2d...7ed7f67468f7f61975dcc78891ea462fce578828
- Fixes: #472994

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
