### PR TITLE
starfox64recomp: init at 1.0.3

### DIFF
--- a/pkgs/by-name/sm/sm64tools/package.nix
+++ b/pkgs/by-name/sm/sm64tools/package.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  installShellFiles,
+  capstone,
+  libpng,
+  libyaml,
+  stb,
+  zlib,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "sm64tools";
+  version = "0.3.2";
+
+  src = fetchFromGitHub {
+    owner = "queueRAM";
+    repo = "sm64tools";
+    tag = "sm64extendv${finalAttrs.version}";
+    hash = "sha256-QWHD4TwTWYYSWE/zaCKdnSjsfoHPS21xNdTx0mP1imo=";
+  };
+
+  hardeningDisable = [ "format" ];
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    installShellFiles
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeFeature "CMAKE_POLICY_VERSION_MINIMUM" "3.5")
+  ];
+
+  buildInputs = [
+    capstone
+    libpng
+    libyaml
+    stb
+    zlib
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    installBin {f3d,f3d2obj,mio0,mipsdisasm,n64cksum,n64graphics,n64split,sm64compress,sm64extend,sm64geo,sm64walk}
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Collection of tools for Super Mario 64 ROM hacking";
+    homepage = "https://github.com/queueRAM/sm64tools";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ qubitnano ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/st/starfox64recomp/package.nix
+++ b/pkgs/by-name/st/starfox64recomp/package.nix
@@ -1,0 +1,173 @@
+{
+  lib,
+  sf64baserom ? null,
+  requireFile,
+  fetchurl,
+  fetchFromGitHub,
+  llvmPackages_19,
+  cmake,
+  copyDesktopItems,
+  installShellFiles,
+  makeWrapper,
+  ninja,
+  pkg-config,
+  python3,
+  wrapGAppsHook3,
+  SDL2,
+  gtk3,
+  vulkan-loader,
+  makeDesktopItem,
+  n64recomp,
+  sm64tools,
+  directx-shader-compiler,
+}:
+
+let
+
+  baseRom =
+    if sf64baserom != null then
+      sf64baserom
+    else
+      requireFile {
+        name = "starfox64.us.rev1.z64";
+        message = ''
+          starfox64recomp only supports the US version 1.1 of Starfox 64.
+          Please dump your copy and rename it to starfox64.us.rev1.z64
+          and add it to the nix store using
+          nix-store --add-fixed sha256 starfox64.us.rev1.z64
+          See https://dumping.guide/carts/nintendo/n64 for more details.
+        '';
+        hash = "sha256-OFvPGQHtEvsRUvPCJ9GWjMVK5B6FZtpmaV33GvQKVz8=";
+      };
+
+  comptool = fetchurl {
+    name = "comptool.py";
+    url = "https://raw.githubusercontent.com/sonicdcer/sf64/83eeee7d96fbe5a6b6fa013e13ed7eda8213b3e3/tools/comptool.py";
+    hash = "sha256-md56iEj6DKODKm3U0XrAygiaRlUgvFCSWfWyyh4lmzw=";
+  };
+
+in
+
+llvmPackages_19.stdenv.mkDerivation (finalAttrs: {
+  pname = "starfox64recomp";
+  version = "1.0.3";
+
+  src = fetchFromGitHub {
+    owner = "sonicdcer";
+    repo = "Starfox64Recomp";
+    tag = finalAttrs.version;
+    hash = "sha256-JhrVF7YjDrZcmL+7S8g/g5SQ3WcxnM9LJryT0Ss3uMw=";
+    fetchSubmodules = true;
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    copyDesktopItems
+    installShellFiles
+    llvmPackages_19.lld
+    makeWrapper
+    ninja
+    pkg-config
+    python3
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    SDL2
+    gtk3
+    vulkan-loader
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "Starfox64Recompiled";
+      icon = "Starfox64Recompiled";
+      exec = "Starfox64Recompiled";
+      comment = "Recompilation of Starfox 64";
+      desktopName = "Starfox64Recompiled";
+      categories = [ "Game" ];
+    })
+  ];
+
+  preConfigure = ''
+    ln -s ${baseRom} ./starfox64.us.rev1.z64
+    cp ${n64recomp}/bin/* .
+    ln -s ${sm64tools}/bin/mio0 .
+    ln -s ${comptool} comptool.py
+
+    python3 ./comptool.py -dse baserom starfox64.us.rev1.z64 starfox64.us.rev1.uncompressed.z64
+
+    ./N64Recomp us.rev1.toml
+    ./RSPRecomp aspMain.us.rev1.toml
+
+    substituteInPlace lib/rt64/CMakeLists.txt \
+      --replace-fail "\''${PROJECT_SOURCE_DIR}/src/contrib/dxc/lib/x64" "${directx-shader-compiler}/lib/" \
+      --replace-fail "\''${PROJECT_SOURCE_DIR}/src/contrib/dxc/bin/x64/dxc-linux" "${directx-shader-compiler}/bin/dxc" \
+      --replace-fail "\''${PROJECT_SOURCE_DIR}/src/contrib/dxc/inc" "${directx-shader-compiler.src}/include/dxc"
+
+    substituteInPlace CMakeLists.txt \
+      --replace-fail "\''${PROJECT_SOURCE_DIR}/lib/rt64/src/contrib/dxc/lib/x64" "${directx-shader-compiler}/lib/" \
+      --replace-fail "\''${PROJECT_SOURCE_DIR}/lib/rt64/src/contrib/dxc/bin/x64/dxc-linux" "${directx-shader-compiler}/bin/dxc"
+  '';
+
+  # This is required or else nothing will build
+  hardeningDisable = [
+    "format"
+    "pic"
+    "stackprotector"
+    "zerocallusedregs"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    installBin Starfox64Recompiled
+    install -Dm644 -t $out/share ../recompcontrollerdb.txt
+    install -Dm644 ../icons/512.png $out/share/icons/hicolor/512x512/apps/Starfox64Recompiled.png
+    cp -r ../assets $out/share/
+    ln -s $out/share/recompcontrollerdb.txt $out/bin/recompcontrollerdb.txt
+    ln -s $out/share/assets $out/bin/assets
+
+    install -Dm644 -t $out/share/licenses/starfox64recompiled/N64ModernRuntime ../lib/N64ModernRuntime/COPYING
+    install -Dm644 -t $out/share/licenses/starfox64recompiled/RmlUi ../lib/RmlUi/LICENSE.txt
+    install -Dm644 -t $out/share/licenses/starfox64recompiled/lunasvg ../lib/lunasvg/LICENSE
+    install -Dm644 -t $out/share/licenses/starfox64recompiled/rt64 ../lib/rt64/LICENSE
+
+    runHook postInstall
+  '';
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+       --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ vulkan-loader ]}
+     )
+  '';
+
+  # The game will segfault when not run from the same directory as the binary.
+  postFixup = ''
+    wrapProgram $out/bin/Starfox64Recompiled --chdir "$out/bin/"
+  '';
+
+  meta = {
+    description = "Static recompilation of Starfox 64 for PC (Windows/Linux)";
+    homepage = "https://github.com/sonicdcer/Starfox64Recomp";
+    license = with lib.licenses; [
+
+      # Starfox64Recompiled
+      gpl3Plus
+
+      # N64ModernRuntime
+      gpl3Only
+
+      # RT64, RmlUi, lunasvg, sse2neon
+      mit
+
+      # reverse engineering
+      unfree
+    ];
+    maintainers = with lib.maintainers; [ qubitnano ];
+    mainProgram = "Starfox64Recompiled";
+    platforms = [ "x86_64-linux" ];
+  };
+})


### PR DESCRIPTION
https://github.com/sonicdcer/Starfox64Recomp

Starfox 64: Recompiled is a project that uses N64: Recompiled to statically recompile Starfox 64 into a native port with many new features, enhancements, and extensive mod support. This project uses RT64 as the rendering engine to provide some of these enhancements.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
