### PR TITLE
btop: Allowing gpu usage in btop

### DIFF
--- a/nixos/modules/hardware/video/btop.nix
+++ b/nixos/modules/hardware/video/btop.nix
@@ -1,0 +1,30 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.btop;
+in
+{
+  options = {
+    programs.btop = {
+      enable = lib.mkEnableOption "a setcap wrapper for btop";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    security.wrappers.btop = {
+      owner = "root";
+      group = "root";
+      source = "${pkgs.btop}/bin/btop";
+      capabilities = "cap_perfmon+ep";
+    };
+  };
+
+  meta = {
+    maintainers = with lib.maintainers; [ mytagssma ];
+  };
+}


### PR DESCRIPTION
### Summary

This PR adds a small NixOS module that provides an optional `security.wrappers` setup for `btop`, granting it the `cap_perfmon` capability when explicitly enabled.

`btop` can display CPU and GPU performance counters via Linux perf events, but on NixOS this functionality is unavailable by default because the binary lacks the required capability. Users currently have to either run `btop` as root or manually apply `setcap`, which is impermanent and non-declarative.

This module offers a declarative, opt-in solution that aligns with NixOS security practices by:
- avoiding full root privileges,
- limiting escalation to the minimal required capability,
- and making the configuration reproducible.

The module does not change default behavior; it only takes effect when `programs.btop.enable = true` is set.

---

### Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin

- Tested, as applicable:
  - [ ] NixOS tests in nixos/tests (not applicable for a simple wrapper module)
  - [ ] Package tests at `passthru.tests`
  - [ ] Tests in lib/tests or pkgs/test
- [ ] Ran `nixpkgs-review` on this PR
- [x] Tested basic functionality of the wrapped binary (`btop`):
  - Verified GPU and perf counters are visible without running as root

- Nixpkgs Release Notes
  - [ ] Package update

- NixOS Release Notes
  - [x] Module addition

- [x] Fits CONTRIBUTING.md, pkgs/README.md, maintainers/README.md, and related guidelines

---

### Notes for reviewers

- The module is intentionally minimal and opt-in.
- `cap_perfmon` is required for access to perf events used by `btop` for detailed CPU and GPU metrics.
- This follows existing patterns for performance tools that rely on Linux capabilities rather than SUID.