### PR TITLE
unoconv: fix patch to remove all LooseVersion calls

### DIFF
--- a/pkgs/by-name/un/unoconv/0001-Remove-compatibility-fixes-for-very-old-LO-OO.patch
+++ b/pkgs/by-name/un/unoconv/0001-Remove-compatibility-fixes-for-very-old-LO-OO.patch
@@ -1,14 +1,4 @@
-From 363d17cec4d097a8160926467db33978da4001cf Mon Sep 17 00:00:00 2001
-From: flakeuser <2792697+Jdogzz@users.noreply.github.com>
-Date: Wed, 17 Dec 2025 17:44:21 -0800
-Subject: [PATCH] Remove compatibility fixes for very old LO/OO.
-
----
- unoconv | 11 ++---------
- 1 file changed, 2 insertions(+), 9 deletions(-)
-
 diff --git a/unoconv b/unoconv
-index 6aa1bfa..ae2159f 100755
 --- a/unoconv
 +++ b/unoconv
 @@ -16,7 +16,6 @@
@@ -31,18 +21,15 @@ index 6aa1bfa..ae2159f 100755
                  if op.userProfile:
                      args.append("-env:UserInstallation=file://" + realpath(op.userProfile))
                  info(2, '%s listener arguments are %s.' % (product.ooName, args))
-@@ -1287,10 +1283,7 @@ def die(ret, msg=None):
-         if convertor.desktop.getCurrentFrame():
-             info(2, 'Trying to stop %s GUI listener.' % product.ooName)
-             try:
--                if product.ooName != "LibreOffice" or product.ooSetupVersion <= 3.3:
--                    subprocess.Popen([office.binary, "-headless", "-invisible", "-nocrashreport", "-nodefault", "-nofirststartwizard", "-nologo", "-norestore", "-unaccept=%s" % op.connection], env=os.environ)
--                else:
--                    subprocess.Popen([office.binary, "--headless", "--invisible", "--nocrashreport", "--nodefault", "--nofirststartwizard", "--nologo", "--norestore", "--unaccept=%s" % op.connection], env=os.environ)
-+                subprocess.Popen([office.binary, "--headless", "--invisible", "--nocrashreport", "--nodefault", "--nofirststartwizard", "--nologo", "--norestore", "--unaccept=%s" % op.connection], env=os.environ)
-                 ooproc.wait()
-                 info(2, '%s listener successfully disabled.' % product.ooName)
-             except Exception as e:
--- 
-2.51.2
-
+@@ -1228,10 +1224,7 @@ class Listener:
+             else:
+                 info(1, "Existing %s listener found, nothing to do." % product.ooName)
+                 return
+-            if product.ooName != "LibreOffice" or LooseVersion(product.ooSetupVersion) <= LooseVersion('3.3'):
+-                cmd = [office.binary, "-headless", "-invisible", "-nocrashreport", "-nodefault", "-nologo", "-nofirststartwizard", "-norestore", "-accept=%s" % op.connection]
+-            else:
+-                cmd = [office.binary, "--headless", "--invisible", "--nocrashreport", "--nodefault", "--nologo", "--nofirststartwizard", "--norestore", "--accept=%s" % op.connection]
++            cmd = [office.binary, "--headless", "--invisible", "--nocrashreport", "--nodefault", "--nologo", "--nofirststartwizard", "--norestore", "--accept=%s" % op.connection]
+ 
+             # The rationale for using subprocess.Popen is to be able to handle
+             # a SIGTERM signal below and properly terminate the started office


### PR DESCRIPTION
Follows https://github.com/NixOS/nixpkgs/pull/471860 and updates the vendored patch to fully remove calls to distutils functions (i.e., `LooseVersion`).

The last successfully built version (`/nix/store/p8rlxxj6a0591p9k9ky68y58nvnqfd95-unoconv-0.9.0`, https://hydra.nixos.org/build/316981031) still has occurrences of `LooseVersion` in `.unconv-wrapped` whereas with this PR, no such occurrences remain.

## Things done

- Built on platform:
  - [x] x86_64-linux
- Tested, as applicable:
  - [x] Ran `nixpkgs-review` on this PR.
  - [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
