### PR TITLE
argonaut: init at 2.14.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7583,6 +7583,12 @@
     githubId = 20847625;
     name = "Elizabeth Paź";
   };
+  ehrenschwan-gh = {
+    email = "luca@ehrenschwan.dev";
+    github = "ehrenschwan-gh";
+    githubId = 25820532;
+    name = "Luca Schwan";
+  };
   eigengrau = {
     email = "seb@schattenkopie.de";
     name = "Sebastian Reuße";

--- a/pkgs/by-name/ar/argonaut/package.nix
+++ b/pkgs/by-name/ar/argonaut/package.nix
@@ -1,0 +1,53 @@
+{
+  buildGoModule,
+  lib,
+  fetchFromGitHub,
+  testers,
+  versionCheckHook,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "argonaut";
+  version = "2.14.1";
+
+  src = fetchFromGitHub {
+    owner = "darksworm";
+    repo = "argonaut";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-vD7XDgENQWexNNMq41W0eC0snUA+JUZeXIBTCH1lbks=";
+  };
+
+  vendorHash = "sha256-xln/WmZbi0+rHqMMHRgt0ar/EaBDNscCsd/NckJZnMw=";
+  proxyVendor = true;
+  subPackages = [ "cmd/app" ];
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.appVersion=${finalAttrs.version}"
+    "-X main.commit=${finalAttrs.version}"
+    "-X main.buildDate=1970-01-01T00:00:00Z"
+  ];
+
+  doCheck = true;
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
+
+  postInstall = ''
+    mv $out/bin/app $out/bin/argonaut
+  '';
+
+  meta = {
+    description = "Keyboard-first terminal UI for Argo CD";
+    homepage = "https://github.com/darksworm/argonaut";
+    changelog = "https://github.com/darksworm/argonaut/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "argonaut";
+    maintainers = with lib.maintainers; [
+      ehrenschwan-gh
+    ];
+  };
+})


### PR DESCRIPTION
[`argonaut`](https://github.com/darksworm/argonaut) is a tui program for working with ArgoCD. A kubernetes continous delivery platform. It is similar in design to [`k9s`](https://github.com/derailed/k9s)

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
