### PR TITLE
mosh: add withClient to allow perlless server-only builds

### DIFF
--- a/pkgs/by-name/mo/mosh/package.nix
+++ b/pkgs/by-name/mo/mosh/package.nix
@@ -15,6 +15,8 @@
   fetchpatch,
   withUtempter ? stdenv.hostPlatform.isLinux && !stdenv.hostPlatform.isMusl,
   libutempter,
+  # build server binary only when set to false (useful for perlless systems)
+  withClient ? true,
 }:
 
 stdenv.mkDerivation rec {
@@ -41,6 +43,8 @@ stdenv.mkDerivation rec {
     zlib
     openssl
     bash-completion
+  ]
+  ++ lib.optionals withClient [
     perl
   ]
   ++ lib.optional withUtempter libutempter;
@@ -70,9 +74,17 @@ stdenv.mkDerivation rec {
 
   configureFlags = [ "--enable-completion" ] ++ lib.optional withUtempter "--with-utempter";
 
-  postInstall = ''
-    wrapProgram $out/bin/mosh --prefix PERL5LIB : $PERL5LIB
-  '';
+  postInstall =
+    if withClient then
+      ''
+        wrapProgram $out/bin/mosh --prefix PERL5LIB : $PERL5LIB
+      ''
+    else
+      ''
+        rm $out/bin/mosh
+        rm $out/bin/mosh-client
+        rm -r $out/share/{man,bash-completion}
+      '';
 
   meta = {
     homepage = "https://mosh.org/";


### PR DESCRIPTION
Mosh only needs the runtime Perl dependency for the `mosh` executable itself, i.e. the client. Server-only builds without a runtime Perl dependency are possible and explicitly mentioned by upstream.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
