### PR TITLE
{spandsp,spandsp3}: Disable failing tests on ppc64

### DIFF
--- a/pkgs/development/libraries/spandsp/common.nix
+++ b/pkgs/development/libraries/spandsp/common.nix
@@ -167,6 +167,15 @@ stdenv.mkDerivation (finalAttrs: {
 
     # Seemingly runs forever, with tons of output
     "v22bis_tests"
+  ]
+  # These happen on ppc64, but I imagine they're related more to the endianness than the rest of the arch
+  ++ lib.optionals (!stdenv.hostPlatform.isLittleEndian) [
+    # Test failed: most significant one 32 - ffffffff 0 0
+    "bit_operations_tests"
+
+    # Output energy is 79.524135% of input energy.
+    # Difference energy is 174.579784% of the total.
+    "lpc10_tests"
   ];
 
   checkPhase = ''


### PR DESCRIPTION
Likely related to big-endian.

---

Still need to check if same issues happen on upstream's latest commit, and make a bug report / find the fix accordingly.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
