### PR TITLE
gst_all_1.gst-plugins-good: Fix linking to aalib on ppc64

### DIFF
--- a/pkgs/development/libraries/gstreamer/good/1001-gst-plugins-good-Fix-aalib-ppc64.patch
+++ b/pkgs/development/libraries/gstreamer/good/1001-gst-plugins-good-Fix-aalib-ppc64.patch
@@ -1,0 +1,12 @@
+diff '--color=auto' -ruN a/ext/aalib/meson.build b/ext/aalib/meson.build
+--- a/ext/aalib/meson.build	2025-08-07 20:06:46.000000000 +0200
++++ b/ext/aalib/meson.build	2025-12-16 03:37:14.470649713 +0100
+@@ -38,7 +38,7 @@
+       c_args : gst_plugins_good_args,
+       link_args : noseh_link_args,
+       include_directories : [configinc],
+-      dependencies : [gstvideo_dep, gstbase_dep, libaa_dep],
++      dependencies : [gstvideo_dep, gstbase_dep, libaa_dep, libm],
+       install : true,
+       install_dir : plugins_install_dir
+     )

--- a/pkgs/development/libraries/gstreamer/good/default.nix
+++ b/pkgs/development/libraries/gstreamer/good/default.nix
@@ -91,6 +91,10 @@ stdenv.mkDerivation (finalAttrs: {
     (replaceVars ./souploader.diff {
       nixLibSoup3Path = "${lib.getLib libsoup_3}/lib";
     })
+
+    # Linking against static aalib needs libm
+    # TODO submit upstream
+    ./1001-gst-plugins-good-Fix-aalib-ppc64.patch
   ];
 
   strictDeps = true;


### PR DESCRIPTION
Patch will be submitted to upstream. Opening this here now so I don't forget about this.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
