### PR TITLE
libgsf: fix homepage url, add changelog, modernize

### DIFF
--- a/pkgs/by-name/li/libgsf/package.nix
+++ b/pkgs/by-name/li/libgsf/package.nix
@@ -92,7 +92,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "GNOME's Structured File Library";
-    homepage = "https://www.gnome.org/projects/libgsf";
+    homepage = "https://gitlab.gnome.org/GNOME/libgsf";
+    changelog = "https://gitlab.gnome.org/GNOME/libgsf/-/blob/${finalAttrs.src.tag}/ChangeLog";
     license = lib.licenses.lgpl21Only;
     maintainers = with lib.maintainers; [ lovek323 ];
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/li/libgsf/package.nix
+++ b/pkgs/by-name/li/libgsf/package.nix
@@ -18,7 +18,7 @@
   gnome,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libgsf";
   version = "1.14.54";
 
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     domain = "gitlab.gnome.org";
     owner = "GNOME";
     repo = "libgsf";
-    rev = "LIBGSF_${lib.replaceStrings [ "." ] [ "_" ] version}";
+    tag = "LIBGSF_${lib.replaceString "." "_" finalAttrs.version}";
     hash = "sha256-jry6Ezzm3uEofIsJd97EzX+qoOjQEb3H1Y8o65nqmeo=";
   };
 
@@ -69,12 +69,6 @@ stdenv.mkDerivation rec {
     libiconv
   ];
 
-  doCheck = true;
-
-  preCheck = ''
-    patchShebangs ./tests/
-  '';
-
   # checking pkg-config is at least version 0.9.0... ./configure: line 15213: no: command not found
   # configure: error: in `/build/libgsf-1.14.50':
   # configure: error: The pkg-config script could not be found or is too old.  Make sure it
@@ -83,9 +77,15 @@ stdenv.mkDerivation rec {
     export PKG_CONFIG="$(command -v "$PKG_CONFIG")"
   '';
 
+  doCheck = true;
+
+  preCheck = ''
+    patchShebangs ./tests/
+  '';
+
   passthru = {
     updateScript = gnome.updateScript {
-      packageName = pname;
+      packageName = finalAttrs.pname;
       versionPolicy = "odd-unstable";
     };
   };
@@ -102,4 +102,4 @@ stdenv.mkDerivation rec {
       dealing with different structured file formats.
     '';
   };
-}
+})


### PR DESCRIPTION
- **libgsf: modernize**
- **libgsf: fix homepage, add changelog**

Homepage was 404.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
