### PR TITLE
nixos/test-driver: Switch retry() to use monotonic timer

### DIFF
--- a/nixos/lib/test-driver/src/test_driver/driver.py
+++ b/nixos/lib/test-driver/src/test_driver/driver.py
@@ -344,7 +344,7 @@ class Driver:
                     return ret
 
                 with driver.logger.nested(f"waiting for {self.condition.description}"):
-                    retry(condition, timeout=timeout)
+                    retry(condition, timeout_seconds=timeout)
 
         if fun_ is None:
             return Poll

--- a/nixos/lib/test-driver/src/test_driver/machine/__init__.py
+++ b/nixos/lib/test-driver/src/test_driver/machine/__init__.py
@@ -97,15 +97,16 @@ def retry(fn: Callable, timeout: int = 900) -> None:
     """Call the given function repeatedly, with 1 second intervals,
     until it returns True or a timeout is reached.
     """
+    deadline = time.monotonic() + timeout
 
-    for _ in range(timeout):
+    while deadline > time.monotonic():
         if fn(False):
             return
         time.sleep(1)
 
     if not fn(True):
         raise RequestedAssertionFailed(
-            f"action timed out after {timeout} tries with one-second pause in-between"
+            f"action timed out after {timeout} seconds with one-second pause in-between"
         )
 
 

--- a/nixos/lib/test-driver/src/test_driver/machine/__init__.py
+++ b/nixos/lib/test-driver/src/test_driver/machine/__init__.py
@@ -93,20 +93,25 @@ def make_command(args: list) -> str:
     return " ".join(map(shlex.quote, (map(str, args))))
 
 
-def retry(fn: Callable, timeout: int = 900) -> None:
-    """Call the given function repeatedly, with 1 second intervals,
-    until it returns True or a timeout is reached.
-    """
-    deadline = time.monotonic() + timeout
+def retry(fn: Callable, timeout_seconds: int = 900) -> None:
+    """Call the given function repeatedly, with a one second interval between
+    retries, until it returns True or a timeout is reached.
 
-    while deadline > time.monotonic():
+    Note that the timeout shown will include the time of the last attempted run.
+    """
+    start_time = time.monotonic()
+
+    while time.monotonic() - start_time < timeout_seconds:
         if fn(False):
             return
         time.sleep(1)
 
+    elapsed = time.monotonic() - start_time
+
     if not fn(True):
         raise RequestedAssertionFailed(
-            f"action timed out after {timeout} seconds with one-second pause in-between"
+            f"action timed out after {elapsed:.2f} seconds "
+            f"(timeout={timeout_seconds})"
         )
 
 

--- a/nixos/tests/openssh.nix
+++ b/nixos/tests/openssh.nix
@@ -290,23 +290,23 @@ in
   testScript = ''
     start_all()
 
-    server.wait_for_unit("sshd", timeout=30)
-    server_allowed_users.wait_for_unit("sshd", timeout=30)
-    server_localhost_only.wait_for_unit("sshd", timeout=30)
-    server_match_rule.wait_for_unit("sshd", timeout=30)
-    server_no_openssl.wait_for_unit("sshd", timeout=30)
-    server_no_pam.wait_for_unit("sshd", timeout=30)
-    server_null_pam.wait_for_unit("sshd", timeout=30)
+    server.wait_for_unit("sshd", timeout=60)
+    server_allowed_users.wait_for_unit("sshd", timeout=60)
+    server_localhost_only.wait_for_unit("sshd", timeout=60)
+    server_match_rule.wait_for_unit("sshd", timeout=60)
+    server_no_openssl.wait_for_unit("sshd", timeout=60)
+    server_no_pam.wait_for_unit("sshd", timeout=60)
+    server_null_pam.wait_for_unit("sshd", timeout=60)
     server_null_pam.fail("journalctl -u sshd.service | grep 'Unsupported option UsePAM'")
-    server_sftp.wait_for_unit("sshd", timeout=30)
+    server_sftp.wait_for_unit("sshd", timeout=60)
 
-    server_lazy.wait_for_unit("sshd.socket", timeout=30)
-    server_localhost_only_lazy.wait_for_unit("sshd.socket", timeout=30)
-    server_lazy_socket.wait_for_unit("sshd.socket", timeout=30)
+    server_lazy.wait_for_unit("sshd.socket", timeout=60)
+    server_localhost_only_lazy.wait_for_unit("sshd.socket", timeout=60)
+    server_lazy_socket.wait_for_unit("sshd.socket", timeout=60)
 
     # sshd-keygen is a oneshot unit, so just wait for multi-user.target, which
     # pulls it in.
-    server_no_sshd_with_key.wait_for_unit("multi-user.target", timeout=30)
+    server_no_sshd_with_key.wait_for_unit("multi-user.target", timeout=60)
 
     with subtest("manual-authkey"):
         client.succeed(


### PR DESCRIPTION
Switch retry() to use monotonic timer. Tested running these tests with short timeouts:

- Commenting out `networking.useDHCP = false;` in the `temporal` tests to rebreak it from #462916
- `nixosTests.kubo.kubo-fuse`
- `nixosTests.matter-server`
- `nixosTests.openssh` - this spins up multiple VMs at once, so I adjusted it to pass on my i5 laptop
- `nixosTests.powerdns-admin`

Fixes: #470809

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
