### PR TITLE
nxengine-evo: 2.6.4 -> 2.6.5-1

### DIFF
--- a/pkgs/by-name/nx/nxengine-evo/package.nix
+++ b/pkgs/by-name/nx/nxengine-evo/package.nix
@@ -2,6 +2,7 @@
   lib,
   SDL2,
   SDL2_mixer,
+  SDL2_image,
   callPackage,
   cmake,
   pkg-config,
@@ -9,40 +10,35 @@
   fetchFromGitHub,
   fetchpatch,
   libpng,
+  libjpeg,
   stdenv,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "nxengine-evo";
-  version = "2.6.4";
+  version = "2.6.5-1";
 
   src = fetchFromGitHub {
     owner = "nxengine";
     repo = "nxengine-evo";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-krK2b1E5JUMxRoEWmb3HZMNSIHfUUGXSpyb4/Zdp+5A=";
+    hash = "sha256-UufvtfottD9DrnjN9xhAlkNdW5Ha+vZwf/4uKDtF5ho=";
   };
 
   patches = [
-    # Fix building by adding SDL_MIXER to include path
-    (fetchpatch {
-      url = "https://github.com/nxengine/nxengine-evo/commit/1890127ec4b4b5f8d6cb0fb30a41868e95659840.patch";
-      hash = "sha256-wlsIdN2RugOo94V3qj/AzYgrs2kf0i1Iw5zNOP8WQqI=";
-    })
-    # Fix buffer overflow
-    (fetchpatch {
-      url = "https://github.com/nxengine/nxengine-evo/commit/75b8b8e3b067fd354baa903332f2a3254d1cc017.patch";
-      hash = "sha256-fZVaZAOHgFoNakOR2MfsvRJjuLhbx+5id/bcN8w/WWo=";
-    })
     # Add missing include
     (fetchpatch {
       url = "https://github.com/nxengine/nxengine-evo/commit/0076ebb11bcfec5dc5e2e923a50425f1a33a4133.patch";
       hash = "sha256-8j3fFFw8DMljV7aAFXE+eA+vkbz1HdFTMAJmk3BRU04=";
     })
+    # Update minimum CMake version to 3.10
+    (fetchpatch {
+      url = "https://github.com/nxengine/nxengine-evo/commit/7e228063441da50f65a78bf2213e85b7fceffae9.patch";
+      hash = "sha256-Vi8nE7IdvQbMDrXycw9hLsuHQwbpu1eiUTLSaIcRoUQ=";
+    })
   ];
 
   nativeBuildInputs = [
-    SDL2
     cmake
     ninja
     pkg-config
@@ -51,7 +47,9 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     SDL2
     SDL2_mixer
+    SDL2_image
     libpng
+    libjpeg
   ];
 
   strictDeps = true;
@@ -64,9 +62,8 @@ stdenv.mkDerivation (finalAttrs: {
   installPhase = ''
     runHook preInstall
 
-    cd ..
     mkdir -p $out/bin/ $out/share/nxengine/
-    install bin/* $out/bin/
+    install nxengine-evo $out/bin/
   ''
   + ''
     cp -r ${finalAttrs.finalPackage.assets}/share/nxengine/data $out/share/nxengine/data
@@ -87,7 +84,7 @@ stdenv.mkDerivation (finalAttrs: {
     license = with lib.licenses; [
       gpl3Plus
     ];
-    mainProgram = "nx";
+    mainProgram = "nxengine-evo";
     maintainers = [ ];
     platforms = lib.platforms.linux;
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
### NXEngine-evo
Fixed build failure and updated the package from 2.6.4 to 2.6.5-1.
List of changes since 2.6.4:
- [2.6.5](https://github.com/nxengine/nxengine-evo/releases/tag/v2.6.5)
- [2.6.5-1](https://github.com/nxengine/nxengine-evo/releases/tag/v2.6.5-1)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
