### PR TITLE
glasgow:  0-unstable-2025-07-28 -> 0-unstable-2025-12-22

### DIFF
--- a/nixos/modules/hardware/glasgow.nix
+++ b/nixos/modules/hardware/glasgow.nix
@@ -22,6 +22,7 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ pkgs.glasgow ];
     services.udev.packages = [ pkgs.glasgow ];
     users.groups.plugdev = { };
   };

--- a/pkgs/by-name/gl/glasgow/package.nix
+++ b/pkgs/by-name/gl/glasgow/package.nix
@@ -10,7 +10,7 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "glasgow";
-  version = "0-unstable-2025-07-28";
+  version = "0-unstable-2025-12-22";
   # Similar to `pdm show`, but without the commit counter
   pdmVersion =
     let
@@ -18,16 +18,17 @@ python3.pkgs.buildPythonApplication rec {
       rev = lib.substring 0 7 src.rev;
     in
     "${tag}.1.dev0+g${rev}";
-  # the latest commit ID touching the `firmware` directory, can differ from rev!
-  firmwareGitRev = "4fe35360";
+  # The latest commit ID touching the `firmware` directory, before a "deploy firmware" commit.
+  # Differs from rev!
+  firmwareGitRev = "8b5afc70";
 
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "GlasgowEmbedded";
     repo = "glasgow";
-    rev = "18442e9684cdda4bb2cbd2be9c31b3c6dffc625a";
-    hash = "sha256-b0kpgCHMk5Ylj4hY29sHRzY/zI1JXReHioHxHSO4h5E=";
+    rev = "ccee116d8b59f25ed0874d152f6b9f9974b185f1";
+    hash = "sha256-2fF0lPfRtpci76q4fEhWAwLBXP0kfIP3dH5z8u/+yd8=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/fx2/default.nix
+++ b/pkgs/development/python-modules/fx2/default.nix
@@ -10,14 +10,14 @@
 
 buildPythonPackage rec {
   pname = "fx2";
-  version = "0.13";
+  version = "0.14";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "whitequark";
     repo = "libfx2";
     rev = "v${version}";
-    hash = "sha256-PtWxjT+97+EeNMN36zOT1+ost/w3lRRkaON3Cl3dpp4=";
+    hash = "sha256-uMgf1VL3yvkLUfRlBn9NKcerfHfcFg9yEgHGWmwyh8I=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Successfully flashed the firmware and tested UART works.

cc @whitequark

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
