### PR TITLE
nixos/uwsm: set default for waylandCompositors

### DIFF
--- a/nixos/modules/programs/wayland/hyprland.nix
+++ b/nixos/modules/programs/wayland/hyprland.nix
@@ -89,6 +89,9 @@ in
           configPackages = lib.mkDefault [ cfg.package ];
         };
 
+        # To make the Hyprland session available in DM
+        services.displayManager.sessionPackages = [ cfg.package ];
+
         systemd = lib.mkIf cfg.systemd.setPath.enable {
           user.extraConfig = ''
             DefaultEnvironment="PATH=/run/wrappers/bin:/etc/profiles/per-user/%u/bin:/nix/var/nix/profiles/default/bin:/run/current-system/sw/bin:$PATH"
@@ -98,18 +101,6 @@ in
 
       (lib.mkIf (cfg.withUWSM) {
         programs.uwsm.enable = true;
-        # Configure UWSM to launch Hyprland from a display manager like SDDM
-        programs.uwsm.waylandCompositors = {
-          hyprland = {
-            prettyName = "Hyprland";
-            comment = "Hyprland compositor managed by UWSM";
-            binPath = "/run/current-system/sw/bin/start-hyprland";
-          };
-        };
-      })
-      (lib.mkIf (!cfg.withUWSM) {
-        # To make a vanilla Hyprland session available in DM
-        services.displayManager.sessionPackages = [ cfg.package ];
       })
 
       (import ./wayland-session.nix {

--- a/nixos/modules/programs/wayland/uwsm.nix
+++ b/nixos/modules/programs/wayland/uwsm.nix
@@ -107,6 +107,7 @@ in
           binPath = "/run/current-system/sw/bin/sway";
         };
       '';
+      default = { };
     };
   };
 
@@ -123,7 +124,7 @@ in
         services.displayManager.enable = true;
       }
 
-      (lib.mkIf cfg.waylandCompositors != {} {
+      (lib.mkIf (cfg.waylandCompositors != { }) {
         services.displayManager.sessionPackages = lib.mapAttrsToList (
           name: value:
           mk_uwsm_desktop_entry {

--- a/nixos/modules/programs/wayland/uwsm.nix
+++ b/nixos/modules/programs/wayland/uwsm.nix
@@ -110,30 +110,35 @@ in
     };
   };
 
-  config = lib.mkIf cfg.enable {
-    environment.systemPackages = [ cfg.package ];
-    systemd.packages = [ cfg.package ];
-    environment.pathsToLink = [ "/share/uwsm" ];
+  config = lib.mkIf cfg.enable (
+    lib.mkMerge [
+      {
+        environment.systemPackages = [ cfg.package ];
+        systemd.packages = [ cfg.package ];
+        environment.pathsToLink = [ "/share/uwsm" ];
 
-    # UWSM recommends dbus broker for better compatibility
-    services.dbus.implementation = "broker";
+        # UWSM recommends dbus broker for better compatibility
+        services.dbus.implementation = "broker";
 
-    services.displayManager = {
-      enable = true;
-      sessionPackages = lib.mapAttrsToList (
-        name: value:
-        mk_uwsm_desktop_entry {
-          inherit name;
-          inherit (value)
-            prettyName
-            comment
-            binPath
-            extraArgs
-            ;
-        }
-      ) cfg.waylandCompositors;
-    };
-  };
+        services.displayManager.enable = true;
+      }
+
+      (lib.mkIf cfg.waylandCompositors != {} {
+        services.displayManager.sessionPackages = lib.mapAttrsToList (
+          name: value:
+          mk_uwsm_desktop_entry {
+            inherit name;
+            inherit (value)
+              prettyName
+              comment
+              binPath
+              extraArgs
+              ;
+          }
+        ) cfg.waylandCompositors;
+      })
+    ]
+  );
 
   meta.maintainers = with lib.maintainers; [
     johnrtitor

--- a/pkgs/by-name/hy/hyprland/package.nix
+++ b/pkgs/by-name/hy/hyprland/package.nix
@@ -194,7 +194,7 @@ customStdenv.mkDerivation (finalAttrs: {
     "NO_XWAYLAND" = !enableXWayland;
     "NO_SYSTEMD" = !withSystemd;
     "CMAKE_DISABLE_PRECOMPILE_HEADERS" = true;
-    "NO_UWSM" = true;
+    "NO_UWSM" = !withSystemd;
     "NO_HYPRPM" = true;
     "TRACY_ENABLE" = false;
   };


### PR DESCRIPTION
- **nixos/uwsm: set default for waylandCompositors**
- **nixos/hyprland: don't set uwsm waylandCompositor**

Supersedes https://github.com/NixOS/nixpkgs/pull/471349

Related:
- https://github.com/NixOS/nixpkgs/pull/471349
- https://github.com/hyprwm/Hyprland/pull/12718
- https://github.com/Vladimir-csp/uwsm/issues/186

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
