### PR TITLE
trafficserver10: init at 10.2.0-rc1

### DIFF
--- a/pkgs/by-name/tr/trafficserver10/package.nix
+++ b/pkgs/by-name/tr/trafficserver10/package.nix
@@ -1,0 +1,160 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  ninja,
+  pkg-config,
+  linuxHeaders,
+  openssl,
+  pcre2,
+  python3,
+  yaml-cpp,
+  zlib,
+  withHwloc ? true,
+  hwloc,
+  withCurl ? true,
+  curl,
+  withCurses ? true,
+  ncurses,
+  withCap ? stdenv.hostPlatform.isLinux,
+  libcap,
+  withUnwind ? stdenv.hostPlatform.isLinux,
+  libunwind,
+  # optional dependencies (everything enabled except for libmaxminddb)
+  withBrotli ? true,
+  brotli,
+  withCjose ? true,
+  cjose,
+  withHiredis ? true,
+  hiredis,
+  withImageMagick ? true,
+  imagemagick,
+  withJansson ? true,
+  jansson,
+  withKyotoCabinet ? true,
+  kyotocabinet,
+  # LuaJIT has no upstream support on some platforms (e.g. riscv64), so enable it
+  # only where it is actually available; otherwise the package fails to evaluate.
+  withLuaJIT ? lib.meta.availableOn stdenv.hostPlatform luajit,
+  luajit,
+  withMaxmindDB ? false,
+  libmaxminddb,
+  # optional features
+  enableWCCP ? true,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "trafficserver10";
+  version = "10.2.0-rc1";
+
+  # 10.2.x drops the legacy PCRE1 dependency and links only PCRE2. There is no
+  # stable 10.2.0 release yet, so this is pinned to the release candidate; it is
+  # meant to be bumped to the stable 10.2.0 tag once it ships. RC tarballs are not
+  # published to the Apache mirror, so the source is fetched from the git tag.
+  src = fetchFromGitHub {
+    owner = "apache";
+    repo = "trafficserver";
+    tag = finalAttrs.version;
+    hash = "sha256-xhmGvycf9KcNSOV9mR/zf2FsVJiAZ5Np4AftcIEamjc=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    pkg-config
+    python3
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ linuxHeaders ];
+
+  buildInputs = [
+    openssl
+    pcre2
+    yaml-cpp
+    zlib
+  ]
+  ++ lib.optional withBrotli brotli
+  ++ lib.optional withCap libcap
+  ++ lib.optional withCjose cjose
+  ++ lib.optional withCurl curl
+  ++ lib.optional withHiredis hiredis
+  ++ lib.optional withHwloc hwloc
+  ++ lib.optional withImageMagick imagemagick
+  ++ lib.optional withJansson jansson
+  ++ lib.optional withKyotoCabinet kyotocabinet
+  ++ lib.optional withCurses ncurses
+  ++ lib.optional withLuaJIT luajit
+  ++ lib.optional withUnwind libunwind
+  ++ lib.optional withMaxmindDB libmaxminddb;
+
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_EXPERIMENTAL_PLUGINS" true)
+    (lib.cmakeBool "EXTERNAL_YAML_CPP" true)
+    # keep default configs and runtime state out of the build's default prefix
+    (lib.cmakeFeature "CMAKE_INSTALL_SYSCONFDIR" "etc")
+    (lib.cmakeFeature "CMAKE_INSTALL_LOCALSTATEDIR" "var")
+    (lib.cmakeBool "ENABLE_WCCP" enableWCCP)
+  ]
+  # TPROXY is a Linux-only kernel feature; FORCE bypasses the /usr/include/linux/in.h check
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    (lib.cmakeFeature "ENABLE_TPROXY" "FORCE")
+  ];
+
+  postInstall = ''
+    # Move default configs to share for NixOS module to use
+    # The Nix store is read-only, so configs must be managed externally
+    mkdir -p $out/share/trafficserver
+    if [ -d "$out/etc" ]; then
+      cp -r $out/etc/* $out/share/trafficserver/
+      rm -rf $out/etc
+    fi
+
+    # Remove empty var directories (runtime state must be managed by NixOS module)
+    rm -rf $out/var
+  '';
+
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    # Verify traffic_via parses Via headers correctly
+    output=$($out/bin/traffic_via '[uScMsEf p eC:t cCMp sF]')
+    echo "$output" | grep -q "Via header is"
+    echo "$output" | grep -q "Length is 22"
+    echo "$output" | grep -q "cache miss"
+
+    runHook postInstallCheck
+  '';
+
+  # Tests require network access and a running server
+  doCheck = false;
+  # The installCheck runs the freshly-built traffic_via, so it can only run when
+  # the build platform can execute host-platform binaries (i.e. not when cross
+  # compiling). This keeps cross builds from requiring emulation.
+  doInstallCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+  enableParallelBuilding = true;
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    homepage = "https://trafficserver.apache.org";
+    changelog = "https://github.com/apache/trafficserver/releases/tag/${finalAttrs.version}";
+    description = "Fast, scalable, and extensible HTTP caching proxy server";
+    longDescription = ''
+      Apache Traffic Server is a high-performance web proxy cache that improves
+      network efficiency and performance by caching frequently-accessed
+      information at the edge of the network. This brings content physically
+      closer to end users, while enabling faster delivery and reduced bandwidth
+      use. Traffic Server is designed to improve content delivery for
+      enterprises, Internet service providers (ISPs), backbone providers, and
+      large intranets by maximizing existing and available bandwidth.
+    '';
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ randomizedcoder ];
+    platforms = lib.platforms.unix;
+    # Traffic Server's lock-free freelist (include/tscore/ink_queue.h) needs an
+    # ABA-safe atomic head: either a lock-free 128-bit CAS (TS_HAS_128BIT_CAS) or
+    # an architecture-specific pointer-tagging layout, hand-coded only for x86_64
+    # and aarch64. riscv64 has neither, so it hits `#error "unsupported processor"`.
+    badPlatforms = lib.platforms.riscv;
+  };
+})


### PR DESCRIPTION
Add [Apache Traffic Server](https://trafficserver.apache.org) 10.x package (`trafficserver10`), the latest major version of the high-performance HTTP caching proxy server.

> ### Update — prepared for the 10.2.x release (PCRE1 removed)
>
> This PR is now staged on **10.2.0-rc1**. The 10.2.x line **drops the legacy PCRE1 (`pcre` 8.45) dependency** raised in review and links **only PCRE2** (`libpcre2-8`). The latest *stable* release (10.1.4) still requires PCRE1 (`find_package(PCRE REQUIRED)` + `cmake/FindPCRE.cmake` are still present), so an RC is currently the only PCRE1-free option.
>
> **This is not intended to merge as an RC.** The plan is to bump to the stable **10.2.0** tag (a one-line version + hash change) as soon as it ships, and merge then. Staging now keeps the package ready and answers the PCRE question with a working, verified build.
>
> Verified on x86_64-linux: `ldd traffic_server` links `libpcre2-8.so.0` and **no** `libpcre.so.1`. Source is fetched via `fetchFromGitHub` because RC tarballs are not published to the Apache release mirror. `cmakeFlags` were also tidied to use `lib.cmake*` helpers.
>
> Since the last push: **native aarch64-linux tested on real hardware**, RISC-V confirmed **unsupported upstream** and now declared via `meta.badPlatforms`, and `doInstallCheck` made cross-compile-safe. Details in [Platform support](#platform-support--multi-arch-testing) below.

This is a **separate package** from the existing `trafficserver` (v9.x) because version 10 has significant breaking changes:

| Aspect | v9 (`trafficserver`) | v10 (`trafficserver10`) |
|--------|---------------------|------------------------|
| Build system | autotools | CMake + Ninja |
| PCRE | PCRE1 only | **PCRE2 only** (PCRE1 dropped in 10.2.x) |
| `tspush` utility | Present | Removed |
| Config location | `$out/etc/` | `$out/share/trafficserver/` |
| **x86_64-linux** | ✓ \* | ✓ (tested) |
| **aarch64-linux** | ✓ \* | ✓ (tested natively) |
| **riscv64-linux** | ✗ \* | ✗ (confirmed — see [Platform support](#platform-support--multi-arch-testing)) |

\* v9 architecture support is **inferred, not tested here** — it is the existing, separately-maintained package. v9 and v10 carry the *same* `include/tscore/ink_queue.h` freelist code, so we would expect the same results, including riscv64 failing identically. We did not build v9 to confirm.

### Features enabled by default

All optional features are enabled for a full-featured build:

- **Brotli** - Compression support (`compress.so` plugin)
- **LuaJIT** - Lua scripting (`tslua.so` plugin)
- **Hiredis** - Redis caching support
- **ImageMagick** - Image transforms (`webp_transform.so` plugin)
- **Jansson** - JSON handling
- **KyotoCabinet** - Key-value storage
- **Cjose** - URI signing / JWT (`uri_signing.so` plugin)
- **WCCP** - Web Cache Communication Protocol

**Disabled by default:**
- **MaxmindDB** - GeoIP lookups (requires separate database files)

Optional features are auto-detected by upstream's CMake (`auto_option`/`find_package`) from the packages present in `buildInputs`. Users can customize them via `.override`:
```nix
trafficserver10.override {
  withMaxmindDB = true;   # Enable MaxmindDB support
  withBrotli = false;     # Disable Brotli if not needed
}
```

LuaJIT is additionally gated on `lib.meta.availableOn` so the package still evaluates on platforms LuaJIT does not support:
```nix
withLuaJIT ? lib.meta.availableOn stdenv.hostPlatform luajit,
```

### Package structure

```
$out/
├── bin/                      # traffic_server, traffic_ctl, traffic_top, etc.
├── lib/                      # Shared libraries
├── libexec/                  # plugins (.so files)
├── include/                  # Development headers
└── share/trafficserver/      # Default config files
```

**Note:** Config files are relocated to `share/` (not `etc/`) because the Nix store is read-only. A NixOS module should copy/symlink these to `/etc/trafficserver/` and create runtime directories.

### Build verification

```bash
# PCRE1 is gone — only PCRE2 is linked:
$ ldd result/bin/traffic_server | grep -i pcre
libpcre2-8.so.0 => .../pcre2-10.47/lib/libpcre2-8.so.0

# Plugin libraries verified (auto-detected):
$ ldd result/libexec/tslua.so | grep lua
libluajit-5.1.so.2 => .../luajit-.../lib/libluajit-5.1.so.2

$ ldd result/libexec/compress.so | grep brotli
libbrotlienc.so.1 => .../brotli-.../lib/libbrotlienc.so.1
```

### Platform support / multi-arch testing

`meta.platforms` stays `lib.platforms.unix`, but **RISC-V is now excluded via `meta.badPlatforms = lib.platforms.riscv`**.

| Arch | Result | How |
|------|--------|-----|
| **x86_64-linux** | ✅ builds + installCheck | native |
| **aarch64-linux** | ✅ builds + `traffic_via` runs | **native, on real hardware** (Raspberry Pi 5, Cortex-A76) |
| **riscv64-linux** | ❌ unsupported upstream | confirmed via **both** native (SpacemiT K1) and cross-compile |

- **aarch64-linux**: built natively on a Raspberry Pi 5 and ran the `traffic_via` installCheck on-device — links only `libpcre2-8`, no PCRE1. Checkbox ticked below.
- **riscv64**: attempted both a native build (SpacemiT K1) and a cross-compile (`pkgsCross.riscv64.trafficserver10`). Both fail identically at:
  ```
  include/tscore/ink_queue.h:177:2: error: #error "unsupported processor"
  ```
  Traffic Server's lock-free freelist needs an ABA-safe atomic list head and picks one of two strategies: a **generic path** when the toolchain provides a lock-free **128-bit compare-and-swap** (`TS_HAS_128BIT_CAS`), otherwise an architecture-specific **pointer-tagging** layout (the freelist version packed into the unused high bits of a 64-bit pointer), which upstream hand-codes only for **x86_64** (48-bit VA) and **aarch64** (52-bit VA). On riscv64 neither applies — there is no lock-free 128-bit CAS (so `TS_HAS_128BIT_CAS` is off in the build; we know because the compile *reaches* the `#else`) and no riscv pointer-tagging case — so it falls through to the `#error`. This is an upstream limitation, not a packaging gap, so the package declares RISC-V a bad platform rather than failing to build. v9 (`trafficserver`) carries the same freelist code, so the same restriction applies there — inferred, not tested.

**Cross-compilation correctness:** `doInstallCheck` is now gated on `stdenv.buildPlatform.canExecute stdenv.hostPlatform`, so cross builds skip the `traffic_via` installCheck (which would otherwise need binfmt/qemu to run a foreign binary) instead of breaking. Native builds are unaffected — the check still runs.

## Things done

- Built on platform:

  - [x] x86_64-linux

  - [x] aarch64-linux

  - [ ] x86_64-darwin

  - [ ] aarch64-darwin

- Tested, as applicable:

  - [ ] [NixOS tests] in [nixos/tests].

  - [ ] [Package tests] at `passthru.tests`.

  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.

- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].

- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - `traffic_server --version` ✓
  - `traffic_via` header parsing (installCheck) ✓ (x86_64 and native aarch64)

- Nixpkgs Release Notes

  - [ ] Package update: when the change is major or breaking.

- NixOS Release Notes

  - [ ] Module addition: when adding a new NixOS module.

  - [ ] Module update: when the change is significant.

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

## Links

- **Homepage:** https://trafficserver.apache.org
- **Tag:** https://github.com/apache/trafficserver/releases/tag/10.2.0-rc1
- **License:** Apache-2.0
