### PR TITLE
mquickjs: init at 0-unstable-2025-12-27

### DIFF
--- a/pkgs/by-name/mq/mquickjs/package.nix
+++ b/pkgs/by-name/mq/mquickjs/package.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  fetchFromGitHub,
+  stdenv,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation {
+  pname = "mquickjs";
+  version = "0-unstable-2025-12-27";
+
+  src = fetchFromGitHub {
+    owner = "bellard";
+    repo = "mquickjs";
+    rev = "0bbe1636ca003564bf6a3f6021bd728e1d722fa9";
+    hash = "sha256-A4L1qHY3tY5fHQeCbPYIDJ3TdY5Bg9eTjLdhVin14dY=";
+  };
+
+  makeFlags = [
+    "CC=${stdenv.cc.targetPrefix}cc"
+    "HOST_CC=${stdenv.cc.targetPrefix}cc"
+  ];
+
+  strictDeps = true;
+
+  enableParallelBuilding = true;
+
+  doCheck = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 ./mqjs -t $out/bin
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    PATH="$out/bin:$PATH"
+
+    # Programs exit with code 1 when testing help, so grep for a string
+    (mqjs --help 2>&1 || true) | grep --quiet "MicroQuickJS"
+
+    mqjs --eval "console.log('Output from eval');" | grep --quiet "Output from eval"
+
+    runHook postInstallCheck
+  '';
+
+  passthru = {
+    updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
+  };
+
+  meta = {
+    homepage = "https://github.com/bellard/mquickjs";
+    description = "Micro QuickJS, a JavaScript engine for microcontrollers";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ xiaoxiangmoe ];
+    mainProgram = "mqjs";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
