### PR TITLE
torcs: 1.3.7 -> 1.3.8

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -20704,6 +20704,12 @@
     githubId = 20472367;
     name = "Peter Hebden";
   };
+  pixel-87 = {
+    email = "edwardoliverthomas@gmail.com";
+    github = "pixel-87";
+    githubId = 149434768;
+    name = "Ed Thomas";
+  };
   pixelsergey = {
     email = "sergey.ichtchenko@gmail.com";
     github = "PixelSergey";

--- a/pkgs/by-name/to/torcs/package.nix
+++ b/pkgs/by-name/to/torcs/package.nix
@@ -26,29 +26,17 @@
 
 stdenv.mkDerivation rec {
   pname = "torcs";
-  version = "1.3.7";
+  version = "1.3.8";
 
   src = fetchurl {
     url = "mirror://sourceforge/torcs/torcs-${version}.tar.bz2";
-    sha256 = "0kdq0sc7dsfzlr0ggbxggcbkivc6yp30nqwjwcaxg9295s3b06wa";
+    sha256 = "sha256-S5Z3NUX7NkEZgqbziXIF64/VciedTOVp8s4HsI6Jp68=";
   };
 
   patches = [
     (fetchpatch {
-      url = "https://salsa.debian.org/games-team/torcs/raw/fb0711c171b38c4648dc7c048249ec20f79eb8e2/debian/patches/gcc6-isnan.patch";
-      sha256 = "16scmq30vwb8429ah9d4ws0v1w6ai59lvn7hcgnvfzyap42ry876";
-    })
-    (fetchpatch {
       url = "https://salsa.debian.org/games-team/torcs/raw/fb0711c171b38c4648dc7c048249ec20f79eb8e2/debian/patches/format-argument.patch";
       sha256 = "04advcx88yh23ww767iysydzhp370x7cqp2wf9hk2y1qvw7mxsja";
-    })
-    (fetchpatch {
-      url = "https://salsa.debian.org/games-team/torcs/raw/fb0711c171b38c4648dc7c048249ec20f79eb8e2/debian/patches/glibc-default-source.patch";
-      sha256 = "0k4hgpddnhv68mdc9ics7ah8q54j60g394d7zmcmzg6l3bjd9pyp";
-    })
-    (fetchpatch {
-      url = "https://salsa.debian.org/games-team/torcs/raw/32bbe77c68b4de07b28c34497f3c0ad666ee618d/debian/patches/gcc7.patch";
-      sha256 = "09iilnvdv8h7b4nb1372arszkbz9hbzsck4rimzz1xjdh9ydniw9";
     })
   ];
 
@@ -89,7 +77,7 @@ stdenv.mkDerivation rec {
     description = "Car racing game";
     homepage = "https://torcs.sourceforge.net/";
     license = lib.licenses.gpl2Plus;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ pixel-87 ];
     platforms = lib.platforms.linux;
     hydraPlatforms = [ ];
   };


### PR DESCRIPTION
Updates `torcs` to 1.3.8.

**changes**
- Updated version to 1.3.8.
- removed old Debian patches as new version builds without them, except for `format-argument.patch`
- Added myself as a maintainer.


## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
