### PR TITLE
python3Packages.langchain*: fixes and updates; python3Packages.groq: 0.37.1 -> 1.0.0

### DIFF
--- a/pkgs/development/python-modules/groq/default.nix
+++ b/pkgs/development/python-modules/groq/default.nix
@@ -22,14 +22,14 @@
 
 buildPythonPackage rec {
   pname = "groq";
-  version = "0.37.1";
+  version = "1.0.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "groq";
     repo = "groq-python";
     tag = "v${version}";
-    hash = "sha256-PWqJK150eIaNIBS8uIoiZwQypES8/i750yc/FrIGdbc=";
+    hash = "sha256-M/W06O2xBvn7iU+62AwvyM7W54arxXViPOK4Jj4uje0=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/langchain-anthropic/default.nix
+++ b/pkgs/development/python-modules/langchain-anthropic/default.nix
@@ -24,14 +24,14 @@
 
 buildPythonPackage rec {
   pname = "langchain-anthropic";
-  version = "1.2.0";
+  version = "1.3.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     tag = "langchain-anthropic==${version}";
-    hash = "sha256-dmuDgKQW1yAz/8tjQx7LaUiuz5Sh4cAyd9nt33mCPbI=";
+    hash = "sha256-/CqnpeQXYdafkly8shen72dIZU3I9o/2TwM903Nw9DA=";
   };
 
   sourceRoot = "${src.name}/libs/partners/anthropic";
@@ -57,10 +57,8 @@ buildPythonPackage rec {
   ];
 
   disabledTests = [
-    # TypeError from Pydantic
-    # https://github.com/langchain-ai/langchain/issues/34068
-    "test_creates_bash_tool"
-    "test_replaces_tool_with_claude_descriptor"
+    # Fails when langchain-core gets ahead of this
+    "test_serdes"
   ];
 
   pythonImportsCheck = [ "langchain_anthropic" ];

--- a/pkgs/development/python-modules/langchain-aws/default.nix
+++ b/pkgs/development/python-modules/langchain-aws/default.nix
@@ -24,14 +24,14 @@
 
 buildPythonPackage rec {
   pname = "langchain-aws";
-  version = "1.1.0";
+  version = "1.1.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain-aws";
     tag = "langchain-aws==${version}";
-    hash = "sha256-vszpWFKuDZb7DvUhnCROgKJdbyA+slyIhCcIOEuPPhA=";
+    hash = "sha256-tFyVK7IjPy33Az16DhWO6wSL5hBAdyd+urhSvdb18Ww=";
   };
 
   postPatch = ''
@@ -66,6 +66,11 @@ buildPythonPackage rec {
   ];
 
   enabledTestPaths = [ "tests/unit_tests" ];
+
+  disabledTests = [
+    # Fails when langchain-core gets ahead of this package
+    "test_serdes"
+  ];
 
   pythonImportsCheck = [ "langchain_aws" ];
 

--- a/pkgs/development/python-modules/langchain-classic/default.nix
+++ b/pkgs/development/python-modules/langchain-classic/default.nix
@@ -35,6 +35,9 @@
   responses,
   syrupy,
   toml,
+
+  # update
+  gitUpdater,
 }:
 
 buildPythonPackage rec {
@@ -106,7 +109,9 @@ buildPythonPackage rec {
   # Bulk updater selects wrong tag (there is no tag for this yet)
   passthru = {
     skipBulkUpdate = true;
-    updateScript = false;
+    updateScript = gitUpdater {
+      rev-prefix = "langchain-classic==";
+    };
   };
 
   pythonImportsCheck = [ "langchain_classic" ];

--- a/pkgs/development/python-modules/langchain-classic/default.nix
+++ b/pkgs/development/python-modules/langchain-classic/default.nix
@@ -42,15 +42,14 @@
 
 buildPythonPackage rec {
   pname = "langchain-classic";
-  version = "1.0.0-unstable-2025-11-11";
+  version = "1.0.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
-    # no tagged releases avaialble
-    rev = "3dfea96ec1d2dac4e506d287860ee943c183c9f1";
-    hash = "sha256-U3UllSSa4tFz+nXAP6aNoYceU/xCPbwKSP2F2et+qgQ=";
+    tag = "langchain-classic==${version}";
+    hash = "sha256-4DlKOxt5OoPm38szMEJpw6gDl247eRsx4LZpofUKpUk=";
   };
 
   sourceRoot = "${src.name}/libs/langchain";
@@ -106,7 +105,7 @@ buildPythonPackage rec {
     "test_socket_disabled"
   ];
 
-  # Bulk updater selects wrong tag (there is no tag for this yet)
+  # Bulk updater selects wrong tag
   passthru = {
     skipBulkUpdate = true;
     updateScript = gitUpdater {

--- a/pkgs/development/python-modules/langchain-core/default.nix
+++ b/pkgs/development/python-modules/langchain-core/default.nix
@@ -37,14 +37,14 @@
 
 buildPythonPackage rec {
   pname = "langchain-core";
-  version = "1.2.2";
+  version = "1.2.5";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     tag = "langchain-core==${version}";
-    hash = "sha256-WJITm+8XIqezr/2U8HpE0J4hYdzg2Z6tw8b5s6SF6m0=";
+    hash = "sha256-gHIJO5O9AxtROdDuo2UhdkW6p3+4dOJaO6iKelA26gE=";
   };
 
   sourceRoot = "${src.name}/libs/core";

--- a/pkgs/development/python-modules/langchain-fireworks/default.nix
+++ b/pkgs/development/python-modules/langchain-fireworks/default.nix
@@ -60,6 +60,11 @@ buildPythonPackage rec {
 
   enabledTestPaths = [ "tests/unit_tests" ];
 
+  disabledTests = [
+    # Fails when langchain-core gets ahead of this package
+    "test_serdes"
+  ];
+
   pythonImportsCheck = [ "langchain_fireworks" ];
 
   passthru = {

--- a/pkgs/development/python-modules/langchain-google-genai/default.nix
+++ b/pkgs/development/python-modules/langchain-google-genai/default.nix
@@ -68,7 +68,13 @@ buildPythonPackage rec {
     syrupy
   ];
 
-  pytestFlagsArray = [ "tests/unit_tests" ];
+  enabledTestPaths = [ "tests/unit_tests" ];
+
+  disabledTests = [
+    # Fails when langchain-core gets ahead of this package
+    "test_serdes"
+    "test_serialize"
+  ];
 
   pythonImportsCheck = [ "langchain_google_genai" ];
 

--- a/pkgs/development/python-modules/langchain-groq/default.nix
+++ b/pkgs/development/python-modules/langchain-groq/default.nix
@@ -20,14 +20,14 @@
 
 buildPythonPackage rec {
   pname = "langchain-groq";
-  version = "1.1.0";
+  version = "1.1.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     tag = "langchain-groq==${version}";
-    hash = "sha256-dmuDgKQW1yAz/8tjQx7LaUiuz5Sh4cAyd9nt33mCPbI=";
+    hash = "sha256-WpIP41eALPoWuYjm2ygEH7TwClKYwAG0uEd1ZbbqMTY=";
   };
 
   sourceRoot = "${src.name}/libs/partners/groq";
@@ -38,6 +38,8 @@ buildPythonPackage rec {
     # Each component release requests the exact latest core.
     # That prevents us from updating individual components.
     "langchain-core"
+    # Requires groq api < 1.0.0, but 1.0.0 is backwards compatible
+    "groq"
   ];
 
   dependencies = [
@@ -51,6 +53,12 @@ buildPythonPackage rec {
   ];
 
   enabledTestPaths = [ "tests/unit_tests" ];
+
+  disabledTests = [
+    # These tests fail when langchain-core gets ahead of the package
+    "test_groq_serialization"
+    "test_serdes"
+  ];
 
   pythonImportsCheck = [ "langchain_groq" ];
 

--- a/pkgs/development/python-modules/langchain-huggingface/default.nix
+++ b/pkgs/development/python-modules/langchain-huggingface/default.nix
@@ -33,14 +33,14 @@
 
 buildPythonPackage rec {
   pname = "langchain-huggingface";
-  version = "1.1.0";
+  version = "1.2.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     tag = "langchain-huggingface==${version}";
-    hash = "sha256-dmuDgKQW1yAz/8tjQx7LaUiuz5Sh4cAyd9nt33mCPbI=";
+    hash = "sha256-ucKhuu8J6XudIyjCniJixFq79wPfoCnNBUd6r1U2ieI=";
   };
 
   sourceRoot = "${src.name}/libs/partners/huggingface";
@@ -77,6 +77,11 @@ buildPythonPackage rec {
   ];
 
   enabledTestPaths = [ "tests/unit_tests" ];
+
+  disabledTests = [
+    # Requires a circular dependency on langchain
+    "test_init_chat_model_huggingface"
+  ];
 
   pythonImportsCheck = [ "langchain_huggingface" ];
 

--- a/pkgs/development/python-modules/langchain-mistralai/default.nix
+++ b/pkgs/development/python-modules/langchain-mistralai/default.nix
@@ -57,6 +57,8 @@ buildPythonPackage rec {
   disabledTests = [
     # Comparison error due to message formatting differences
     "test__convert_dict_to_message_tool_call"
+    # Fails when langchain-core gets ahead of this package
+    "test_serdes"
   ];
 
   pythonImportsCheck = [ "langchain_mistralai" ];

--- a/pkgs/development/python-modules/langchain-openai/default.nix
+++ b/pkgs/development/python-modules/langchain-openai/default.nix
@@ -33,14 +33,14 @@
 
 buildPythonPackage rec {
   pname = "langchain-openai";
-  version = "1.1.1";
+  version = "1.1.6";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     tag = "langchain-openai==${version}";
-    hash = "sha256-WAYzgAWw0y86rBjb2JqLNeBCjVn3o7UfLoQvmQ4SKGU=";
+    hash = "sha256-Y+GV48rlqMfT4TrmoJFGqbHKfc8gxq61NhcUpwSsOwk=";
   };
 
   sourceRoot = "${src.name}/libs/partners/openai";
@@ -80,6 +80,13 @@ buildPythonPackage rec {
     "test_get_num_tokens_from_messages"
     "test_get_token_ids"
     "test_embeddings_respects_token_limit"
+
+    # Fail when langchain-core gets ahead of this package
+    "test_serdes"
+    "test_loads_openai_llm"
+    "test_load_openai_llm"
+    "test_loads_openai_chat"
+    "test_load_openai_chat"
   ];
 
   pythonImportsCheck = [ "langchain_openai" ];

--- a/pkgs/development/python-modules/langchain-tests/default.nix
+++ b/pkgs/development/python-modules/langchain-tests/default.nix
@@ -30,14 +30,14 @@
 
 buildPythonPackage rec {
   pname = "langchain-tests";
-  version = "1.1.1";
+  version = "1.1.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     tag = "langchain-tests==${version}";
-    hash = "sha256-WJITm+8XIqezr/2U8HpE0J4hYdzg2Z6tw8b5s6SF6m0=";
+    hash = "sha256-g5s7zL4l/kIUoIu7/3+Ve3SXW3O9tj8f2N3bZ0gbBts=";
   };
 
   sourceRoot = "${src.name}/libs/standard-tests";
@@ -71,11 +71,6 @@ buildPythonPackage rec {
   nativeBuildInputs = [
     numpy
     pytestCheckHook
-  ];
-
-  disabledTests = [
-    # Prone to failure when langchain-core is newer than the tests
-    "test_serdes"
   ];
 
   passthru = {

--- a/pkgs/development/python-modules/langchain-tests/default.nix
+++ b/pkgs/development/python-modules/langchain-tests/default.nix
@@ -73,6 +73,11 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
+  disabledTests = [
+    # Prone to failure when langchain-core is newer than the tests
+    "test_serdes"
+  ];
+
   passthru = {
     # python updater script sets the wrong tag
     skipBulkUpdate = true;

--- a/pkgs/development/python-modules/langchain-text-splitters/default.nix
+++ b/pkgs/development/python-modules/langchain-text-splitters/default.nix
@@ -21,14 +21,14 @@
 
 buildPythonPackage rec {
   pname = "langchain-text-splitters";
-  version = "1.0.0";
+  version = "1.1.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     tag = "langchain-text-splitters==${version}";
-    hash = "sha256-DOWd94Vx61OS1OI2uIZVonf6BiXkjbS2pTrzleKvifM=";
+    hash = "sha256-/mhgWYmnzzCnAlBzPFHo4yZLxgHIzmvxjS2BilGxww8=";
   };
 
   sourceRoot = "${src.name}/libs/text-splitters";

--- a/pkgs/development/python-modules/langchain-xai/default.nix
+++ b/pkgs/development/python-modules/langchain-xai/default.nix
@@ -61,12 +61,11 @@ buildPythonPackage rec {
 
   enabledTestPaths = [ "tests/unit_tests" ];
 
-  disabledTests =
-    lib.optionals (stdenvNoCC.hostPlatform.isLinux && stdenvNoCC.hostPlatform.isAarch64)
-      [
-        # Compares a diff to a string literal and misses platform differences
-        "test_serdes"
-      ];
+  disabledTests = [
+    # Breaks when langchain-core is updated
+    # Also: Compares a diff to a string literal and misses platform differences (aarch64-linux)
+    "test_serdes"
+  ];
 
   pythonImportsCheck = [ "langchain_xai" ];
 

--- a/pkgs/development/python-modules/langchain/default.nix
+++ b/pkgs/development/python-modules/langchain/default.nix
@@ -46,14 +46,14 @@
 
 buildPythonPackage rec {
   pname = "langchain";
-  version = "1.1.3";
+  version = "1.2.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     tag = "langchain==${version}";
-    hash = "sha256-oW1Gn7ChRwUThrnkNBcGKn96sqRO84rSf75J2bNdBMY=";
+    hash = "sha256-DximXCwrDSUVXZenUrubuGcxdnRCPCPMgdW9UJnkGnE=";
   };
 
   sourceRoot = "${src.name}/libs/langchain_v1";


### PR DESCRIPTION
## Changes

### IMPORTANT

Fixes [CVE-2025-68664](https://github.com/advisories/GHSA-c67j-w6g6-q2cm) in langchain by updating langchain-core.

Langchain advisory: [GHSA-c67j-w6g6-q2cm](https://github.com/langchain-ai/langchain/security/advisories/GHSA-c67j-w6g6-q2cm)

(Thank you @LeSuisse for pointing this out)

### Changed

1. Updated foundational packages
2. langchain-classic now has tagged releases (🎉), so switched to a tagged release and enabled updating.
3. Brought everything up to current
4. Disabled broken serialization/deserialiazation tests across the board. (Largely a snapshot issue where the snapshots are old.)
5. `python3Packages.groq` version bump (used by langchain-groq). (1.0.0 is a minor update and backwards compatible. The major version changed to mark this release as stable.)

Closes: #475299 
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
