### PR TITLE
crusader: add Apache-2.0 to license

### DIFF
--- a/pkgs/by-name/cr/crusader/package.nix
+++ b/pkgs/by-name/cr/crusader/package.nix
@@ -79,7 +79,10 @@ rustPlatform.buildRustPackage rec {
     description = "Network throughput and latency tester";
     homepage = "https://github.com/Zoxc/crusader";
     changelog = "https://github.com/Zoxc/crusader/blob/v${version}/CHANGELOG.md";
-    license = lib.licenses.mit;
+    license = with lib.licenses; [
+      mit
+      asl20
+    ];
     maintainers = with lib.maintainers; [ x123 ];
     platforms = lib.platforms.all;
     mainProgram = "crusader";


### PR DESCRIPTION
The upstream Crusader repository is dual-licensed under MIT and Apache-2.0.
- https://github.com/Zoxc/crusader/blob/master/LICENSE-MIT
- https://github.com/Zoxc/crusader/blob/master/LICENSE-APACHE

This PR updates the license metadata to reflect both licenses.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin

- Tested, as applicable:

  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.

- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.

- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.

- NixOS Release Notes

  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.