### PR TITLE
pkgsLLVM.git-doc: improve eval error

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1156,13 +1156,18 @@ with pkgs;
   # Git with SVN support, but without GUI.
   gitSVN = lowPrio (git.override { svnSupport = true; });
 
-  git-doc = lib.addMetaAttrs {
-    description = "Additional documentation for Git";
-    longDescription = ''
-      This package contains additional documentation (HTML and text files) that
-      is referenced in the man pages of Git.
-    '';
-  } gitFull.doc;
+  git-doc =
+    # doc attribute is not present at least for pkgsLLVM
+    if (gitFull ? doc) then
+      lib.addMetaAttrs {
+        description = "Additional documentation for Git";
+        longDescription = ''
+          This package contains additional documentation (HTML and text files) that
+          is referenced in the man pages of Git.
+        '';
+      } gitFull.doc
+    else
+      throw "'git-doc' can't be evaluated as 'gitFull' does not expose 'doc' attribute";
 
   gitMinimal = git.override {
     withManual = false;


### PR DESCRIPTION
Before the change `pkgsLLVM.git-doc` evaluated to uncatchable error:

    $ nix build --no-link -f. pkgsLLVM.git-doc
    error:
       … while evaluating a branch condition
         at pkgs/top-level/splice.nix:59:11:
           58|           # on to splice them together.
           59|           if lib.isDerivation defaultValue then
             |           ^
           60|             augmentedValue

       … while evaluating the attribute 'git-doc'
         at pkgs/top-level/all-packages.nix:1159:3:
         1158|
         1159|   git-doc = lib.addMetaAttrs {
             |   ^
         1160|     description = "Additional documentation for Git";

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: attribute 'doc' missing
       at pkgs/top-level/all-packages.nix:1165:5:
         1164|     '';
         1165|   } gitFull.doc;
             |     ^
         1166|
       Did you mean src?

After the change it's more typical `throw` error:

    $ nix build --no-link -f. pkgsLLVM.git-doc
     error:
       … while evaluating a branch condition
         at pkgs/top-level/splice.nix:59:11:
           58|           # on to splice them together.
           59|           if lib.isDerivation defaultValue then
             |           ^
           60|             augmentedValue

       … while evaluating the attribute 'git-doc'
         at pkgs/top-level/all-packages.nix:1159:3:
         1158|
         1159|   git-doc =
             |   ^
         1160|     # doc attribnute is not present at least for pkgsLLVM

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: 'git-doc' can't be evaluated as 'gitFull' does no expose 'doc' attribute


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
