### PR TITLE
{findutils,gnumake,gzip,less}: adopt, cleanup

### DIFF
--- a/pkgs/by-name/le/less/package.nix
+++ b/pkgs/by-name/le/less/package.nix
@@ -54,8 +54,9 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl3Plus;
     mainProgram = "less";
     maintainers = with lib.maintainers; [
-      # not active
+      # dtzWill is not active
       dtzWill
+      mdaniels5757
     ];
     platforms = lib.platforms.unix;
   };

--- a/pkgs/by-name/le/less/package.nix
+++ b/pkgs/by-name/le/less/package.nix
@@ -1,7 +1,6 @@
 {
   lib,
   fetchurl,
-  fetchpatch,
   ncurses,
   pcre2,
   stdenv,

--- a/pkgs/development/tools/build-managers/gnumake/default.nix
+++ b/pkgs/development/tools/build-managers/gnumake/default.nix
@@ -9,6 +9,7 @@
   inBootstrap ? false,
   pkg-config,
   gnumake,
+  directoryListingUpdater,
 }:
 
 let
@@ -52,9 +53,15 @@ stdenv.mkDerivation rec {
   ];
   separateDebugInfo = true;
 
-  passthru.tests = {
-    # make sure that the override doesn't break bootstrapping
-    gnumakeWithGuile = gnumake.override { guileSupport = true; };
+  passthru = {
+    tests = {
+      # make sure that the override doesn't break bootstrapping
+      gnumakeWithGuile = gnumake.override { guileSupport = true; };
+    };
+    updateScript = directoryListingUpdater {
+      inherit pname version;
+      url = "https://ftp.gnu.org/gnu/make/";
+    };
   };
 
   meta = {

--- a/pkgs/development/tools/build-managers/gnumake/default.nix
+++ b/pkgs/development/tools/build-managers/gnumake/default.nix
@@ -77,9 +77,8 @@ stdenv.mkDerivation (finalAttrs: {
       to build and install the program.
     '';
     homepage = "https://www.gnu.org/software/make/";
-
     license = lib.licenses.gpl3Plus;
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.mdaniels5757 ];
     mainProgram = "make";
     platforms = lib.platforms.all;
   };

--- a/pkgs/development/tools/build-managers/gnumake/default.nix
+++ b/pkgs/development/tools/build-managers/gnumake/default.nix
@@ -16,12 +16,12 @@ let
   guileEnabled = guileSupport && !inBootstrap;
 in
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "gnumake";
   version = "4.4.1";
 
   src = fetchurl {
-    url = "mirror://gnu/make/make-${version}.tar.gz";
+    url = "mirror://gnu/make/make-${finalAttrs.version}.tar.gz";
     sha256 = "sha256-3Rb7HWe/q3mnL16DkHNcSePo5wtJRaFasfgd23hlj7M=";
   };
 
@@ -59,7 +59,7 @@ stdenv.mkDerivation rec {
       gnumakeWithGuile = gnumake.override { guileSupport = true; };
     };
     updateScript = directoryListingUpdater {
-      inherit pname version;
+      inherit (finalAttrs) pname version;
       url = "https://ftp.gnu.org/gnu/make/";
     };
   };
@@ -83,4 +83,4 @@ stdenv.mkDerivation rec {
     mainProgram = "make";
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/tools/compression/gzip/default.nix
+++ b/pkgs/tools/compression/gzip/default.nix
@@ -5,6 +5,7 @@
   makeShellWrapper,
   updateAutotoolsGnuConfigScriptsHook,
   runtimeShellPackage,
+  directoryListingUpdater,
 }:
 
 # Note: this package is used for bootstrapping fetchurl, and thus
@@ -59,6 +60,13 @@ stdenv.mkDerivation rec {
     wrapProgram $out/bin/gzip \
       --add-flags "\''${GZIP_NO_TIMESTAMPS:+-n}"
   '';
+
+  passthru = {
+    updateScript = directoryListingUpdater {
+      inherit pname version;
+      url = "https://ftp.gnu.org/gnu/gzip/";
+    };
+  };
 
   meta = {
     homepage = "https://www.gnu.org/software/gzip/";

--- a/pkgs/tools/compression/gzip/default.nix
+++ b/pkgs/tools/compression/gzip/default.nix
@@ -13,12 +13,12 @@
 # cgit) that are needed here should be included directly in Nixpkgs as
 # files.
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "gzip";
   version = "1.14";
 
   src = fetchurl {
-    url = "mirror://gnu/gzip/${pname}-${version}.tar.xz";
+    url = "mirror://gnu/gzip/${finalAttrs.pname}-${finalAttrs.version}.tar.xz";
     hash = "sha256-Aae4gb0iC/32Ffl7hxj4C9/T9q3ThbmT3Pbv0U6MCsY=";
   };
 
@@ -63,7 +63,7 @@ stdenv.mkDerivation rec {
 
   passthru = {
     updateScript = directoryListingUpdater {
-      inherit pname version;
+      inherit (finalAttrs) pname version;
       url = "https://ftp.gnu.org/gnu/gzip/";
     };
   };
@@ -90,4 +90,4 @@ stdenv.mkDerivation rec {
 
     mainProgram = "gzip";
   };
-}
+})

--- a/pkgs/tools/compression/gzip/default.nix
+++ b/pkgs/tools/compression/gzip/default.nix
@@ -71,7 +71,6 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     homepage = "https://www.gnu.org/software/gzip/";
     description = "GNU zip compression program";
-
     longDescription = ''
       gzip (GNU zip) is a popular data compression program written by
       Jean-loup Gailly for the GNU project.  Mark Adler wrote the
@@ -83,11 +82,9 @@ stdenv.mkDerivation (finalAttrs: {
       and we needed a replacement.  The superior compression ratio of gzip
       is just a bonus.
     '';
-
     platforms = lib.platforms.all;
-
     license = lib.licenses.gpl3Plus;
-
     mainProgram = "gzip";
+    maintainers = [ lib.maintainers.mdaniels5757 ];
   };
 })

--- a/pkgs/tools/misc/findutils/default.nix
+++ b/pkgs/tools/misc/findutils/default.nix
@@ -4,6 +4,7 @@
   fetchurl,
   updateAutotoolsGnuConfigScriptsHook,
   coreutils,
+  directoryListingUpdater,
 }:
 
 # Note: this package is used for bootstrapping fetchurl, and thus
@@ -74,6 +75,11 @@ stdenv.mkDerivation rec {
   # https://github.com/NixOS/nixpkgs/pull/192630#discussion_r978985593
   # or you can check libc/include/sys/cdefs.h in bionic source code
   hardeningDisable = lib.optional (stdenv.hostPlatform.libc == "bionic") "fortify";
+
+  passthru.updateScript = directoryListingUpdater {
+    inherit pname version;
+    url = "https://ftp.gnu.org/gnu/findutils/";
+  };
 
   meta = {
     homepage = "https://www.gnu.org/software/findutils/";

--- a/pkgs/tools/misc/findutils/default.nix
+++ b/pkgs/tools/misc/findutils/default.nix
@@ -84,7 +84,6 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = "https://www.gnu.org/software/findutils/";
     description = "GNU Find Utilities, the basic directory searching utilities of the GNU operating system";
-
     longDescription = ''
       The GNU Find Utilities are the basic directory searching
       utilities of the GNU operating system.  These programs are
@@ -102,11 +101,9 @@ stdenv.mkDerivation rec {
           * locate - list files in databases that match a pattern;
           * updatedb - update a file name database;
     '';
-
     platforms = lib.platforms.all;
-
     license = lib.licenses.gpl3Plus;
-
     mainProgram = "find";
+    maintainers = [ lib.maintainers.mdaniels5757 ];
   };
 }

--- a/pkgs/tools/misc/findutils/default.nix
+++ b/pkgs/tools/misc/findutils/default.nix
@@ -12,12 +12,12 @@
 # cgit) that are needed here should be included directly in Nixpkgs as
 # files.
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "findutils";
   version = "4.10.0";
 
   src = fetchurl {
-    url = "mirror://gnu/findutils/findutils-${version}.tar.xz";
+    url = "mirror://gnu/findutils/findutils-${finalAttrs.version}.tar.xz";
     sha256 = "sha256-E4fgtn/yR9Kr3pmPkN+/cMFJE5Glnd/suK5ph4nwpPU=";
   };
 
@@ -77,7 +77,7 @@ stdenv.mkDerivation rec {
   hardeningDisable = lib.optional (stdenv.hostPlatform.libc == "bionic") "fortify";
 
   passthru.updateScript = directoryListingUpdater {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     url = "https://ftp.gnu.org/gnu/findutils/";
   };
 
@@ -106,4 +106,4 @@ stdenv.mkDerivation rec {
     mainProgram = "find";
     maintainers = [ lib.maintainers.mdaniels5757 ];
   };
-}
+})


### PR DESCRIPTION
This should help #416200 a bit.

<s>Passthru tests for gzip will fail until #474203 makes its way to master.</s>

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Verified 0 rebuilds.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
