### PR TITLE
maintainers: remove dtzWill

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7182,13 +7182,6 @@
     name = "Tom van Dijk";
     keys = [ { fingerprint = "D044 F07B 8863 B681 26BD  79FE 7A98 4C82 07AD BA51"; } ];
   };
-  dtzWill = {
-    email = "w@wdtz.org";
-    github = "dtzWill";
-    githubId = 817330;
-    name = "Will Dietz";
-    keys = [ { fingerprint = "389A 78CB CD88 5E0C 4701  DEB9 FD42 C7D0 D414 94C8"; } ];
-  };
   dudeofawesome = {
     email = "tourist-04.iced@icloud.com";
     github = "dudeofawesome";

--- a/nixos/modules/services/misc/novacomd.nix
+++ b/nixos/modules/services/misc/novacomd.nix
@@ -30,5 +30,5 @@ in
     };
   };
 
-  meta.maintainers = with lib.maintainers; [ dtzWill ];
+  meta.maintainers = [ ];
 }

--- a/nixos/modules/services/networking/iwd.nix
+++ b/nixos/modules/services/networking/iwd.nix
@@ -92,5 +92,5 @@ in
     };
   };
 
-  meta.maintainers = with lib.maintainers; [ dtzWill ];
+  meta.maintainers = [ ];
 }

--- a/nixos/tests/novacomd.nix
+++ b/nixos/tests/novacomd.nix
@@ -2,10 +2,7 @@ import ./make-test-python.nix (
   { pkgs, ... }:
   {
     name = "novacomd";
-    meta = with pkgs.lib.maintainers; {
-      maintainers = [ dtzWill ];
-    };
-
+    meta.maintainers = [ ];
     nodes.machine =
       { ... }:
       {

--- a/pkgs/applications/misc/diff-pdf/default.nix
+++ b/pkgs/applications/misc/diff-pdf/default.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
     description = "Simple tool for visually comparing two PDF files";
     license = lib.licenses.gpl2;
     platforms = lib.platforms.all;
-    maintainers = with lib.maintainers; [ dtzWill ];
+    maintainers = [ ];
     mainProgram = "diff-pdf";
   };
 }

--- a/pkgs/by-name/az/azpainter/package.nix
+++ b/pkgs/by-name/az/azpainter/package.nix
@@ -65,7 +65,7 @@ stdenv.mkDerivation rec {
     description = "Full color painting software for illustration drawing";
     homepage = "http://azsky2.html.xdomain.jp/soft/azpainter.html";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ dtzWill ];
+    maintainers = [ ];
     platforms = with lib.platforms; linux ++ darwin;
     mainProgram = "azpainter";
   };

--- a/pkgs/by-name/ba/bashplotlib/package.nix
+++ b/pkgs/by-name/ba/bashplotlib/package.nix
@@ -29,7 +29,7 @@ python3Packages.buildPythonApplication {
   meta = {
     homepage = "https://github.com/glamp/bashplotlib";
     description = "Plotting in the terminal";
-    maintainers = with lib.maintainers; [ dtzWill ];
+    maintainers = [ ];
     license = lib.licenses.mit;
   };
 }

--- a/pkgs/by-name/bi/bibclean/package.nix
+++ b/pkgs/by-name/bi/bibclean/package.nix
@@ -26,6 +26,6 @@ stdenv.mkDerivation rec {
     homepage = "http://ftp.math.utah.edu/pub/bibclean";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.all;
-    maintainers = with lib.maintainers; [ dtzWill ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/bi/biblatex-check/package.nix
+++ b/pkgs/by-name/bi/biblatex-check/package.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
     description = "Python2/3 script for checking BibLatex .bib files";
     homepage = "https://github.com/Pezmc/BibLatex-Check";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ dtzWill ];
+    maintainers = [ ];
     mainProgram = "biblatex-check";
   };
 }

--- a/pkgs/by-name/ch/chelf/package.nix
+++ b/pkgs/by-name/ch/chelf/package.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     description = "Change or display the stack size of an ELF binary";
     homepage = "https://github.com/Gottox/chelf";
     license = lib.licenses.bsd2;
-    maintainers = with lib.maintainers; [ dtzWill ];
+    maintainers = [ ];
     mainProgram = "chelf";
   };
 }

--- a/pkgs/by-name/cr/crex/package.nix
+++ b/pkgs/by-name/cr/crex/package.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     description = "Explore, test, and check regular expressions in the terminal";
     homepage = "https://octobanana.com/software/crex";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ dtzWill ];
+    maintainers = [ ];
     platforms = lib.platforms.all;
     mainProgram = "crex";
   };

--- a/pkgs/by-name/de/dedup/package.nix
+++ b/pkgs/by-name/de/dedup/package.nix
@@ -46,6 +46,6 @@ stdenv.mkDerivation rec {
       bsd0
       isc
     ];
-    maintainers = with lib.maintainers; [ dtzWill ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/dy/dyncall/package.nix
+++ b/pkgs/by-name/dy/dyncall/package.nix
@@ -35,6 +35,6 @@ stdenv.mkDerivation rec {
     description = "Highly dynamic multi-platform foreign function call interface library";
     homepage = "https://www.dyncall.org";
     license = lib.licenses.isc;
-    maintainers = with lib.maintainers; [ dtzWill ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/el/ell/package.nix
+++ b/pkgs/by-name/el/ell/package.nix
@@ -66,7 +66,6 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [
       mic92
-      dtzWill
     ];
   };
 }

--- a/pkgs/by-name/he/health-check/package.nix
+++ b/pkgs/by-name/he/health-check/package.nix
@@ -39,6 +39,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/ColinIanKing/health-check";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ dtzWill ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/iw/iwd/package.nix
+++ b/pkgs/by-name/iw/iwd/package.nix
@@ -132,7 +132,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.lgpl21Plus;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [
-      dtzWill
       fpletz
     ];
   };

--- a/pkgs/by-name/lc/lcdf-typetools/package.nix
+++ b/pkgs/by-name/lc/lcdf-typetools/package.nix
@@ -24,6 +24,6 @@ stdenv.mkDerivation rec {
     description = "Utilities for manipulating OpenType, PostScript Type 1, and Multiple Master fonts";
     homepage = "https://www.lcdf.org/type";
     license = lib.licenses.gpl2Only;
-    maintainers = with lib.maintainers; [ dtzWill ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/ld/ldns/package.nix
+++ b/pkgs/by-name/ld/ldns/package.nix
@@ -63,7 +63,7 @@ stdenv.mkDerivation rec {
     description = "Library with the aim of simplifying DNS programming in C";
     homepage = "https://www.nlnetlabs.nl/projects/ldns/";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ dtzWill ];
+    maintainers = [ ];
     mainProgram = "drill";
     platforms = lib.platforms.unix;
   };

--- a/pkgs/by-name/le/less/package.nix
+++ b/pkgs/by-name/le/less/package.nix
@@ -53,8 +53,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl3Plus;
     mainProgram = "less";
     maintainers = with lib.maintainers; [
-      # dtzWill is not active
-      dtzWill
       mdaniels5757
     ];
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/li/light/package.nix
+++ b/pkgs/by-name/li/light/package.nix
@@ -45,7 +45,6 @@ stdenv.mkDerivation {
     mainProgram = "light";
     maintainers = with lib.maintainers; [
       puffnfresh
-      dtzWill
     ];
     platforms = lib.platforms.linux;
   };

--- a/pkgs/by-name/mu/musl/package.nix
+++ b/pkgs/by-name/mu/musl/package.nix
@@ -207,7 +207,6 @@ stdenv.mkDerivation rec {
     ];
     maintainers = with lib.maintainers; [
       thoughtpolice
-      dtzWill
     ];
   };
 }

--- a/pkgs/by-name/nu/numatop/package.nix
+++ b/pkgs/by-name/nu/numatop/package.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "numatop";
     homepage = "https://01.org/numatop";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ dtzWill ];
+    maintainers = [ ];
     platforms = [
       "i686-linux"
       "x86_64-linux"

--- a/pkgs/by-name/po/power-calibrate/package.nix
+++ b/pkgs/by-name/po/power-calibrate/package.nix
@@ -27,6 +27,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/ColinIanKing/power-calibrate";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ dtzWill ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/rw/rw/package.nix
+++ b/pkgs/by-name/rw/rw/package.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
       dd with standard style command line flags.
     '';
     license = lib.licenses.isc;
-    maintainers = with lib.maintainers; [ dtzWill ];
+    maintainers = [ ];
     mainProgram = "rw";
   };
 }

--- a/pkgs/by-name/sa/samurai/package.nix
+++ b/pkgs/by-name/sa/samurai/package.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation rec {
       mit
       asl20
     ]; # see LICENSE
-    maintainers = with lib.maintainers; [ dtzWill ];
+    maintainers = [ ];
     mainProgram = "samu";
     platforms = lib.platforms.all;
   };

--- a/pkgs/by-name/tx/txr/package.nix
+++ b/pkgs/by-name/tx/txr/package.nix
@@ -70,9 +70,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     changelog = "https://www.kylheku.com/cgit/txr/tree/RELNOTES?h=txr-${finalAttrs.version}";
     license = lib.licenses.bsd2;
-    maintainers = with lib.maintainers; [
-      dtzWill
-    ];
+    maintainers = [ ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/by-name/vi/vivid/package.nix
+++ b/pkgs/by-name/vi/vivid/package.nix
@@ -24,7 +24,7 @@ rustPlatform.buildRustPackage rec {
       asl20 # or
       mit
     ];
-    maintainers = [ lib.maintainers.dtzWill ];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
     mainProgram = "vivid";
   };

--- a/pkgs/by-name/xb/xbps/package.nix
+++ b/pkgs/by-name/xb/xbps/package.nix
@@ -50,6 +50,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "X Binary Package System";
     platforms = lib.platforms.linux; # known to not work on Darwin, at least
     license = lib.licenses.bsd2;
-    maintainers = with lib.maintainers; [ dtzWill ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/xl/xlayoutdisplay/package.nix
+++ b/pkgs/by-name/xl/xlayoutdisplay/package.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Detects and arranges linux display outputs, using XRandR for detection and xrandr for arrangement";
     homepage = "https://github.com/alex-courtis/xlayoutdisplay";
-    maintainers = with lib.maintainers; [ dtzWill ];
+    maintainers = [ ];
     license = lib.licenses.asl20;
     platforms = lib.platforms.linux;
     mainProgram = "xlayoutdisplay";

--- a/pkgs/by-name/xt/xtruss/package.nix
+++ b/pkgs/by-name/xt/xtruss/package.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     description = "Easy-to-use X protocol tracing program";
     homepage = "https://www.chiark.greenend.org.uk/~sgtatham/xtruss";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ dtzWill ];
+    maintainers = [ ];
     mainProgram = "xtruss";
   };
 }

--- a/pkgs/development/libraries/readline/8.3.nix
+++ b/pkgs/development/libraries/readline/8.3.nix
@@ -114,7 +114,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     license = lib.licenses.gpl3Plus;
 
-    maintainers = with lib.maintainers; [ dtzWill ];
+    maintainers = [ ];
 
     platforms = lib.platforms.unix ++ lib.platforms.windows;
     branch = "8.3";

--- a/pkgs/development/libraries/sqlite/sqlar.nix
+++ b/pkgs/development/libraries/sqlite/sqlar.nix
@@ -41,6 +41,6 @@ stdenv.mkDerivation {
     description = "SQLite Archive utilities";
     license = lib.licenses.bsd2;
     platforms = lib.platforms.all;
-    maintainers = with lib.maintainers; [ dtzWill ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/tools/analysis/rizin/cutter.nix
+++ b/pkgs/development/tools/analysis/rizin/cutter.nix
@@ -93,10 +93,7 @@ let
       homepage = src.meta.homepage;
       license = lib.licenses.gpl3;
       mainProgram = "cutter";
-      maintainers = with lib.maintainers; [
-        mic92
-        dtzWill
-      ];
+      maintainers = with lib.maintainers; [ mic92 ];
       inherit (rizin.meta) platforms;
     };
   };

--- a/pkgs/development/tools/minizinc/ide.nix
+++ b/pkgs/development/tools/minizinc/ide.nix
@@ -92,6 +92,6 @@ stdenv.mkDerivation rec {
     '';
     license = lib.licenses.mpl20;
     platforms = lib.platforms.unix;
-    maintainers = [ lib.maintainers.dtzWill ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/os-specific/linux/fwts/module.nix
+++ b/pkgs/os-specific/linux/fwts/module.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     inherit (fwts.meta) homepage license;
     description = fwts.meta.description + "(efi-runtime kernel module)";
-    maintainers = with lib.maintainers; [ dtzWill ];
+    maintainers = [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/tools/misc/birdfont/default.nix
+++ b/pkgs/tools/misc/birdfont/default.nix
@@ -70,6 +70,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Font editor which can generate fonts in TTF, EOT, SVG and BIRDFONT format";
     homepage = "https://birdfont.org";
     license = lib.licenses.gpl3;
-    maintainers = with lib.maintainers; [ dtzWill ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/tools/misc/birdfont/xmlbird.nix
+++ b/pkgs/tools/misc/birdfont/xmlbird.nix
@@ -41,6 +41,6 @@ stdenv.mkDerivation rec {
     description = "XML parser for Vala and C programs";
     homepage = "https://birdfont.org/xmlbird.php";
     license = lib.licenses.lgpl3;
-    maintainers = with lib.maintainers; [ dtzWill ];
+    maintainers = [ ];
   };
 }


### PR DESCRIPTION
Totally inactive on GitHub since August 2024.

Dropping per [maintainers/README.md](https://github.com/NixOS/nixpkgs/tree/a7808b41c3cfd040fbe03e12a68654db3c02d5bc/maintainers#losing-maintainer-status)

@dtzWill: if you'd like to stay involved, please respond within a week. Even if you don't do so, you are welcome back at any time.

Note that dtzWill must be removed from the `llvm` and `static` teams before this is merged. Cc @RossComputerGuy @alyssais (LLVM team maintainers) @nh2 (static team maintainer).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] <s>Verified 0 rebuilds.</s> 0 rebuilds of packages.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
