### PR TITLE
manager-io-server: init at 25.12.21.3153

### DIFF
--- a/pkgs/by-name/ma/manager-io-server/package.nix
+++ b/pkgs/by-name/ma/manager-io-server/package.nix
@@ -1,0 +1,83 @@
+{ lib
+, stdenvNoCC
+, stdenv
+, fetchurl
+, patchelf
+, makeWrapper
+, icu
+, openssl
+, zlib
+}:
+
+let
+  pname = "manager-io-server";
+  version = "25.12.21.3153";
+
+  arch =
+    if stdenvNoCC.hostPlatform.isAarch64 then "arm64"
+    else if stdenvNoCC.hostPlatform.isx86_64 then "x64"
+    else throw "Unsupported platform: ${stdenvNoCC.hostPlatform.system}";
+
+  hashes = {
+    x64   = "sha256-JbdFJzFOdik2bfp6xNIOPi50Vru8YAqskSqX+a2fJ/4=";
+    arm64 = "sha256-VrWTshqFe0cygkcyA6ijEBzjwocMRdaWeiknkHCWk5k=";
+  };
+
+  src = fetchurl {
+    url = "https://github.com/Manager-io/Manager/releases/download/${version}/ManagerServer-linux-${arch}.tar.gz";
+    hash = hashes.${arch} or (throw "Missing hash for arch=${arch}");
+  };
+
+  rpath = lib.makeLibraryPath [
+    stdenv.cc.cc
+    icu
+    openssl
+    zlib
+  ];
+in
+stdenvNoCC.mkDerivation {
+  inherit pname version src;
+
+  nativeBuildInputs = [ patchelf makeWrapper ];
+
+  # Avoid unintended fixups; we only do the patchelf we explicitly want.
+  dontStrip = true;
+  dontPatchELF = true;
+
+  unpackPhase = "true";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/libexec/${pname}"
+    tar -xzf "$src" -C "$out/libexec/${pname}"
+    chmod +x "$out/libexec/${pname}/ManagerServer"
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    appDir="$out/libexec/${pname}"
+    bin="$appDir/ManagerServer"
+
+    patchelf --set-interpreter "$(cat ${stdenv.cc}/nix-support/dynamic-linker)" "$bin"
+    patchelf --set-rpath "${rpath}" "$bin"
+
+    mkdir -p "$out/bin"
+
+    # Keep upstream executable name (ManagerServer) and preserve caller PWD
+    makeWrapper "$bin" "$out/bin/ManagerServer" \
+      --set ASPNETCORE_ENVIRONMENT Production \
+      --set DOTNET_SYSTEM_GLOBALIZATION_INVARIANT 0 \
+      --prefix LD_LIBRARY_PATH : "$appDir:${rpath}"
+  '';
+
+  meta = with lib; {
+    description = "Manager.io Server Edition (ManagerServer)";
+    homepage = "https://www.manager.io/server-edition";
+    license = licenses.unfree;
+    platforms = [ "x86_64-linux" "aarch64-linux" ];
+    mainProgram = "ManagerServer";
+    sourceProvenance = [ sourceTypes.binaryNativeCode ];
+  };
+}


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/30926

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
