### PR TITLE
gpu-usage-waybar: init at 0.1.24

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19145,6 +19145,12 @@
     githubId = 2946283;
     name = "Brian Cohen";
   };
+  nouritsu = {
+    name = "Aneesh Bhave";
+    email = "aneesh1701@gmail.com";
+    github = "nouritsu";
+    githubId = 113834791;
+  };
   nova-madeline = {
     matrix = "@nova:tchncs.de";
     github = "nova-r";

--- a/pkgs/by-name/gp/gpu-usage-waybar/package.nix
+++ b/pkgs/by-name/gp/gpu-usage-waybar/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  autoAddDriverRunpath,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "gpu-usage-waybar";
+  version = "0.1.26";
+
+  src = fetchFromGitHub {
+    owner = "PolpOnline";
+    repo = "gpu-usage-waybar";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-8kj5QQ7yknLct6PfVGz+TiSS6nmQPzDXt2LF0h1hMNE=";
+  };
+
+  cargoHash = "sha256-wGKMZDT+B/AD8onnfslnqKBFgqVJNo/idWKLZOiQb/c=";
+
+  nativeBuildInputs = [
+    autoAddDriverRunpath
+  ];
+
+  meta = {
+    description = "Tool to display GPU usage in Waybar";
+    homepage = "https://github.com/PolpOnline/gpu-usage-waybar";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ nouritsu ];
+    mainProgram = "gpu-usage-waybar";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
## Things done

`gpu-usage-waybar` is a simple utility to display statistics about GPU usage, temperature, power, VRAM and more. It is written in Rust and supports AMD & NVIDIA GPUs. For NVIDIA GPUs, the program uses NVML (dynamically loaded at runtime) and for AMD GPUs, the program uses sysfs.

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
