### PR TITLE
dwz: 0.14 -> 0.16; debugedit: 5.0 -> 5.2

### DIFF
--- a/pkgs/by-name/de/debugedit/package.nix
+++ b/pkgs/by-name/de/debugedit/package.nix
@@ -61,7 +61,7 @@ stdenv.mkDerivation rec {
     description = "Provides programs and scripts for creating debuginfo and source file distributions, collect build-ids and rewrite source paths in DWARF data for debugging, tracing and profiling";
     homepage = "https://sourceware.org/debugedit/";
     license = lib.licenses.gpl3Plus;
-    platforms = lib.platforms.all;
+    platforms = [ lib.systems.inspect.patterns.isElf ];
     maintainers = with lib.maintainers; [ deliciouslytyped ];
   };
 }

--- a/pkgs/by-name/de/debugedit/package.nix
+++ b/pkgs/by-name/de/debugedit/package.nix
@@ -1,31 +1,55 @@
 #TODO@deliciouslytyped The tool seems to unnecessarily force mutable access for the debugedit `-l` feature
 {
   fetchgit,
+  fetchpatch,
   lib,
   stdenv,
   autoreconfHook,
   pkg-config,
   elfutils,
+  xxHash,
   help2man,
   util-linux,
+  cpio,
+  gdb,
+  dwz,
 }:
 stdenv.mkDerivation rec {
   pname = "debugedit";
-  version = "5.0";
+  version = "5.2";
+
+  src = fetchgit {
+    url = "git://sourceware.org/git/debugedit.git";
+    tag = "debugedit-${version}";
+    hash = "sha256-6SOw5t9Hnb9Picx18LwqLwaPieueO6mXl8/vGnU+81E=";
+  };
+
+  patches = [
+    # fix: No build ID note found in ...
+    # caused by gcc not configured to produce build-id by default
+    (fetchpatch {
+      url = "https://sourceware.org/git/?p=debugedit.git;a=commitdiff_plain;h=c011f478dca2c89d52958a8999b99663d14db85d";
+      hash = "sha256-fOjXKA3U1YM+ZMieLhWiXdJj79IJ+iFNH0x+Asn/EMY=";
+    })
+  ];
 
   nativeBuildInputs = [
     autoreconfHook
     pkg-config
     help2man
   ];
-  buildInputs = [ elfutils ];
-  nativeCheckInputs = [ util-linux ]; # Tests use `rev`
 
-  src = fetchgit {
-    url = "git://sourceware.org/git/debugedit.git";
-    rev = "debugedit-${version}";
-    sha256 = "VTZ7ybQT3DfKIfK0lH+JiehCJyJ+qpQ0bAn1/f+Pscs=";
-  };
+  buildInputs = [
+    elfutils
+    xxHash
+  ];
+
+  nativeCheckInputs = [
+    util-linux # Tests use `rev`
+    cpio
+    gdb
+    dwz
+  ];
 
   preBuild = ''
     patchShebangs scripts/find-debuginfo.in

--- a/pkgs/by-name/dw/dwz/package.nix
+++ b/pkgs/by-name/dw/dwz/package.nix
@@ -3,20 +3,41 @@
   stdenv,
   fetchurl,
   elfutils,
+  xxHash,
+  dejagnu,
+  gdb,
 }:
 
 stdenv.mkDerivation rec {
   pname = "dwz";
-  version = "0.14";
+  version = "0.16";
 
   src = fetchurl {
-    url = "https://www.sourceware.org/ftp/${pname}/releases/${pname}-${version}.tar.gz";
-    sha256 = "07qdvzfk4mvbqj5z3aff7vc195dxqn1mi27w2dzs1w2zhymnw01k";
+    url = "https://www.sourceware.org/ftp/dwz/releases/dwz-${version}.tar.gz";
+    hash = "sha256-R1hT4bSebtjMLQqQnHpPwcxXHrzPxmJ4/UM0Lb4n1Q4=";
   };
+
+  postPatch = ''
+    patchShebangs --build testsuite
+  '';
 
   nativeBuildInputs = [ elfutils ];
 
+  buildInputs = [
+    xxHash
+    elfutils
+  ];
+
   makeFlags = [ "prefix=${placeholder "out"}" ];
+
+  doCheck = true;
+
+  nativeCheckInputs = [
+    dejagnu
+    gdb
+  ];
+
+  strictDeps = true;
 
   meta = {
     homepage = "https://sourceware.org/dwz/";

--- a/pkgs/by-name/dw/dwz/package.nix
+++ b/pkgs/by-name/dw/dwz/package.nix
@@ -45,6 +45,6 @@ stdenv.mkDerivation rec {
     mainProgram = "dwz";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ jbcrail ];
-    platforms = lib.platforms.linux;
+    platforms = [ lib.systems.inspect.patterns.isElf ];
   };
 }


### PR DESCRIPTION
This is required to fix GCC 15 compilation in https://github.com/NixOS/nixpkgs/pull/471587

This also blocks build of flatpak-builder

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
