### PR TITLE
klee: 3.1-unstable-2025-07-11 -> 3.2

### DIFF
--- a/pkgs/by-name/kl/klee/klee-uclibc.nix
+++ b/pkgs/by-name/kl/klee/klee-uclibc.nix
@@ -28,13 +28,13 @@ let
     }
   );
 in
-llvmPackages.stdenv.mkDerivation rec {
+llvmPackages.stdenv.mkDerivation (finalAttrs: {
   pname = "klee-uclibc";
   version = "1.4";
   src = fetchFromGitHub {
     owner = "klee";
     repo = "klee-uclibc";
-    rev = "klee_uclibc_v${version}";
+    rev = "klee_uclibc_v${finalAttrs.version}";
     hash = "sha256-sogQK5Ed0k5tf4rrYwCKT4YRKyEovgT25p0BhGvJ1ok=";
   };
 
@@ -113,4 +113,4 @@ llvmPackages.stdenv.mkDerivation rec {
     license = lib.licenses.lgpl3;
     maintainers = with lib.maintainers; [ numinit ];
   };
-}
+})

--- a/pkgs/by-name/kl/klee/package.nix
+++ b/pkgs/by-name/kl/klee/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  llvmPackages,
+  llvmPackages_18,
   callPackage,
   fetchFromGitHub,
   cmake,
@@ -50,16 +50,19 @@ let
 
   # Python used for KLEE tests.
   kleePython = python3.withPackages (ps: with ps; [ tabulate ]);
+
+  # The LLVM we're using. Note that KLEE doesn't yet support 18 but this is the minimum in nixpkgs.
+  llvmPackages = llvmPackages_18;
 in
-llvmPackages.stdenv.mkDerivation {
+llvmPackages.stdenv.mkDerivation (finalAttrs: {
   pname = "klee";
-  version = "3.1-unstable-2025-07-11";
+  version = "3.2";
 
   src = fetchFromGitHub {
     owner = "klee";
     repo = "klee";
-    rev = "1c9fbc1013a6000b39615cc9a5aba83e43a4bf75";
-    hash = "sha256-D93T0mBBrIhQTS42ScUHPrMoqCI55Y6Yp7snLmlriQM=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-8DofxLyTV8Al7ys8vSJpzf6qQV3sw940lGIZBvZqe2c=";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -147,6 +150,7 @@ llvmPackages.stdenv.mkDerivation {
     "KLEE :: Feature/srem.c"
     "KLEE :: InlineAsm/RaiseAsm.c"
     "KLEE :: InlineAsm/asm_lifting.ll"
+    "KLEE :: Intrinsics/Freeze.ll"
     "KLEE :: Intrinsics/IntrinsicTrap.ll"
     "KLEE :: Intrinsics/IsConstant.ll"
     "KLEE :: Intrinsics/Missing.ll"
@@ -278,4 +282,4 @@ llvmPackages.stdenv.mkDerivation {
     # user experience and level of support.
     broken = true;
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11181,10 +11181,6 @@ with pkgs;
 
   klayout = libsForQt5.callPackage ../applications/misc/klayout { };
 
-  klee = callPackage ../applications/science/logic/klee {
-    llvmPackages = llvmPackages_18;
-  };
-
   kotatogram-desktop =
     callPackage ../applications/networking/instant-messengers/telegram/kotatogram-desktop
       { };


### PR DESCRIPTION
Still requires meta.broken = true since it has failing tests with LLVM 18, but it's not an unstable version at least.

Move to by-name while we're at it.

Ref: https://github.com/klee/klee/issues/1754


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
