### PR TITLE
python3Packages.rocketcea: init at 1.2.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7252,6 +7252,12 @@
     name = "Duncan Dean";
     keys = [ { fingerprint = "9484 44FC E03B 05BA 5AB0  591E C37B 1C1D 44C7 86EE"; } ];
   };
+  duranmartin = {
+    name = "Duran Martin";
+    email = "duranjeppe@gmail.com";
+    github = "duranmartin";
+    githubId = 44565686;
+  };
   DuskyElf = {
     name = "jan Lemata";
     github = "DuskyElf";

--- a/pkgs/development/python-modules/rocketcea/default.nix
+++ b/pkgs/development/python-modules/rocketcea/default.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  gfortran,
+  meson,
+  ninja,
+  meson-python,
+  setuptools,
+  wheel,
+  numpy,
+  scipy,
+  matplotlib,
+}:
+
+buildPythonPackage rec {
+  pname = "rocketcea";
+  version = "1.2.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "sonofeft";
+    repo = "RocketCEA";
+    tag = "v${version}";
+    hash = "sha256-nklc6aofTeOT8LJ//c8R/Ch9tJueJ+yHKLVsMukKmnY=";
+  };
+
+  nativeBuildInputs = [
+    gfortran
+    meson
+    ninja
+  ];
+
+  build-system = [
+    meson-python
+    setuptools
+    wheel
+  ];
+
+  dependencies = [
+    numpy
+    scipy
+    matplotlib
+  ];
+
+  pythonImportsCheck = [ "rocketcea" ];
+
+  meta = {
+    description = "RocketCEA: Wraps NASA CEA for rocket propulsion analysis";
+    homepage = "https://github.com/sonofeft/RocketCEA";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ duranmartin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16721,6 +16721,8 @@ self: super: with self; {
 
   rocket-errbot = callPackage ../development/python-modules/rocket-errbot { };
 
+  rocketcea = callPackage ../development/python-modules/rocketcea { };
+
   rocketchat-api = callPackage ../development/python-modules/rocketchat-api { };
 
   rocksdict = callPackage ../development/python-modules/rocksdict { };


### PR DESCRIPTION
## Description

This PR adds RocketCEA, a Python package that wraps NASA’s Chemical Equilibrium with Applications (CEA) code for rocket propulsion analysis.

Homepage: https://github.com/sonofeft/RocketCEA

Tested interactively via `nix develop` by importing `rocketcea` and running basic CEA calculations.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
