### PR TITLE
netexec: 1.4.0 -> 1.5.0

### DIFF
--- a/pkgs/by-name/ne/netexec/package.nix
+++ b/pkgs/by-name/ne/netexec/package.nix
@@ -35,7 +35,7 @@ python.pkgs.buildPythonApplication rec {
     owner = "Pennyw0rth";
     repo = "NetExec";
     tag = "v${version}";
-    hash = "sha256-1yNnnPntJ5aceX3Z8yYAMLv5bSFfCFVp0pgxAySlVfE=";
+    hash = "sha256-gGyaEifIveoeVdeviLiQ6ZIHku//h9Hp84ffktAgxDY=";
   };
 
   pythonRelaxDeps = true;
@@ -43,11 +43,14 @@ python.pkgs.buildPythonApplication rec {
   pythonRemoveDeps = [
     # Fail to detect dev version requirement
     "neo4j"
+    # No python package in nixpkgs; use bloodhound-py instead.
+    "bloodhound-ce"
   ];
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace-fail " @ git+https://github.com/fortra/impacket.git" "" \
+      --replace-fail " @ git+https://github.com/Pennyw0rth/Certipy" "" \
+      --replace-fail " @ git+https://github.com/fortra/impacket" "" \
       --replace-fail " @ git+https://github.com/wbond/oscrypto" "" \
       --replace-fail " @ git+https://github.com/Pennyw0rth/NfsClient" ""
   '';
@@ -66,6 +69,7 @@ python.pkgs.buildPythonApplication rec {
     asyauth
     beautifulsoup4
     bloodhound-py
+    certipy-ad
     dploot
     dsinternals
     impacket
@@ -76,6 +80,7 @@ python.pkgs.buildPythonApplication rec {
     msldap
     neo4j
     paramiko
+    pefile
     pyasn1-modules
     pylnk3
     pynfsclient

--- a/pkgs/by-name/ne/netexec/package.nix
+++ b/pkgs/by-name/ne/netexec/package.nix
@@ -10,11 +10,11 @@ let
     self = python;
     packageOverrides = self: super: {
       impacket = super.impacket.overridePythonAttrs {
-        version = "0.12.0-unstable-2025-03-14";
+        version = "0.14.0-unstable-2025-12-03";
         src = fetchFromGitHub {
           owner = "fortra";
           repo = "impacket";
-          rev = "8b4566b12fc79acb520d045dbae8f13446a9d4d7";
+          rev = "caba5facdd3a01b5d0decc6daf5871839f22f792";
           hash = "sha256-jyn5qSSAipGYhHm2EROwDHa227mnmW+d+0H0/++i1OY=";
         };
         # Fix version to be compliant with Python packaging rules
@@ -28,7 +28,7 @@ let
 in
 python.pkgs.buildPythonApplication rec {
   pname = "netexec";
-  version = "1.4.0";
+  version = "1.5.0";
   pyproject = true;
 
   src = fetchFromGitHub {

--- a/pkgs/by-name/ne/netexec/package.nix
+++ b/pkgs/by-name/ne/netexec/package.nix
@@ -48,6 +48,10 @@ python.pkgs.buildPythonApplication rec {
   ];
 
   postPatch = ''
+    substituteInPlace nxc/first_run.py \
+      --replace-fail "from os import mkdir" "from os import mkdir, chmod" \
+      --replace-fail "shutil.copy(default_path, NXC_PATH)" $'shutil.copy(default_path, CONFIG_PATH)\n        chmod(CONFIG_PATH, 0o600)'
+
     substituteInPlace pyproject.toml \
       --replace-fail " @ git+https://github.com/Pennyw0rth/Certipy" "" \
       --replace-fail " @ git+https://github.com/fortra/impacket" "" \


### PR DESCRIPTION
Update netexec to 1.5.0.

  Changelog: https://github.com/Pennyw0rth/NetExec/releases/tag/v1.5.0

  ## Things done

  - Built on platform:
    - [x] x86_64-linux
    - [ ] aarch64-linux
    - [ ] x86_64-darwin
    - [ ] aarch64-darwin
  - Tested, as applicable:
    - [ ] [NixOS tests] in [nixos/tests].
    - [ ] [Package tests] at `passthru.tests`.
    - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
  - [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
  - [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - Nixpkgs Release Notes
    - [ ] Package update: when the change is major or breaking.
  - NixOS Release Notes
    - [ ] Module addition: when adding a new NixOS module.
    - [ ] Module update: when the change is significant.
  - [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
