### PR TITLE
kde6Packages.sddm: split unwrapped build out of wrapper expression

### DIFF
--- a/pkgs/applications/display-managers/sddm/default.nix
+++ b/pkgs/applications/display-managers/sddm/default.nix
@@ -3,41 +3,41 @@
   callPackage,
   runCommand,
   wrapQtAppsHook,
-  unwrapped ? callPackage ./unwrapped.nix { },
+  sddm-unwrapped,
   extraPackages ? [ ],
 }:
 runCommand "sddm-wrapped"
   {
-    inherit (unwrapped) version outputs;
+    inherit (sddm-unwrapped) version outputs;
 
-    buildInputs = unwrapped.buildInputs ++ extraPackages;
+    buildInputs = sddm-unwrapped.buildInputs ++ extraPackages;
     nativeBuildInputs = [ wrapQtAppsHook ];
 
     strictDeps = true;
 
     passthru = {
-      inherit unwrapped;
-      inherit (unwrapped.passthru) tests;
+      unwrapped = sddm-unwrapped;
+      inherit (sddm-unwrapped.passthru) tests;
     };
 
-    meta = unwrapped.meta;
+    meta = sddm-unwrapped.meta;
   }
   ''
     mkdir -p $out/bin
 
-    cd ${unwrapped}
+    cd ${sddm-unwrapped}
 
     for i in *; do
       if [ "$i" == "bin" ]; then
         continue
       fi
-      ln -s ${unwrapped}/$i $out/$i
+      ln -s ${sddm-unwrapped}/$i $out/$i
     done
 
     for i in bin/*; do
-      makeQtWrapper ${unwrapped}/$i $out/$i --set SDDM_GREETER_DIR $out/bin
+      makeQtWrapper ${sddm-unwrapped}/$i $out/$i --set SDDM_GREETER_DIR $out/bin
     done
 
     mkdir -p $man
-    ln -s ${lib.getMan unwrapped}/* $man/
+    ln -s ${lib.getMan sddm-unwrapped}/* $man/
   ''

--- a/pkgs/top-level/qt6-packages.nix
+++ b/pkgs/top-level/qt6-packages.nix
@@ -138,6 +138,7 @@ makeScopeWithSplicing' {
         callPackage ../development/libraries/sailfish-access-control-plugin
           { };
 
+      sddm-unwrapped = kdePackages.callPackage ../applications/display-managers/sddm/unwrapped.nix { };
       sddm = kdePackages.callPackage ../applications/display-managers/sddm { };
 
       sierra-breeze-enhanced =


### PR DESCRIPTION
This makes overlaying sddm somewhat easier. Before:

```
  (self: super: {
    qt6Packages = super.qt6Packages.overrideScope (qtself: qtsuper: {
      sddm = qtsuper.sddm.override (o: {
        unwrapped = qtsuper.sddm.unwrapped.overrideAttrs (o: {
          patches = o.patches ++ [./sddm.patch];
        });
      });
    });
  })
```

After:
```
  (self: super: {
    qt6Packages = super.qt6Packages.overrideScope (qtself: qtsuper: {
      sddm-unwrapped = qtsuper.sddm-unwrapped.overrideAttrs (o: {
        patches = o.patches ++ [./sddm.patch];
      });
    })
  })
```

cc maintainers @ttuegel @k900
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux (no change to derivations)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
