### PR TITLE
spotix: init at 0-unstable-2025-12-21

### DIFF
--- a/pkgs/by-name/sp/spotix/package.nix
+++ b/pkgs/by-name/sp/spotix/package.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  gitMinimal,
+  pkg-config,
+  alsa-lib,
+  glib,
+  gtk3,
+  pango,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "spotix";
+  version = "0-unstable-2025-12-21";
+
+  src = fetchFromGitHub {
+    owner = "skyline69";
+    repo = "spotix";
+    rev = "c551160b13b14b841d2c636ab14cc71f70e65f07";
+    leaveDotGit = true;
+    hash = "sha256-DY+G9uwpkE4AbhoarYmQ6JQFjeKr/AIddHavnGTxCzs=";
+    # hash = "sha256-uMQm0XF0Myd59xho9HeM954PP53AXdXRQ5HO+LBH35A=";
+  };
+
+  preBuild = ''
+    rm -rf spotix-core/build.rs
+    # mkdir -p $OUT_DIR
+    # echo "https://github.com/skyline69/spotix" > $OUT_DIR/remote-url.txt
+    # echo "" > $OUT_DIR/remote-url.txt
+    # echo "" > $OUT_DIR/build-time.txt
+    substituteInPlace spotix-core/src/lib.rs \
+      --replace-fail \
+        'pub const BUILD_TIME: &str = include!(concat!(env!("OUT_DIR"), "/build-time.txt"));' \
+        'pub const BUILD_TIME: &str = "";' \
+      --replace-fail \
+        'pub const REMOTE_URL: &str = include!(concat!(env!("OUT_DIR"), "/remote-url.txt"));' \
+        'pub const REMOTE_URL: &str = "https://github.com/skyline69/spotix";'
+  '';
+
+  env = {
+    # OUT_DIR = "${placeholder "out"}";
+  };
+
+  nativeBuildInputs = [
+    gitMinimal
+    pkg-config
+  ];
+
+  buildInputs = [
+    alsa-lib
+    glib
+    gtk3
+    pango
+  ];
+
+  cargoHash = "sha256-4hCFldc3bKJJkYYDUvs6wZ48+jixLJgq1cy81j+SKb4=";
+
+  meta = {
+    description = "Fast, native Spotify client written in Rust";
+    homepage = "https://github.com/skyline69/spotix";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+    mainProgram = "spotix";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Add [spotix](https://github.com/skyline69/spotix), a fast, native Spotify client written in Rust.

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
