### PR TITLE
python3Packages.fastapi-cli: 0.0.8 -> 0.0.20

### DIFF
--- a/pkgs/development/python-modules/fastapi-cli/default.nix
+++ b/pkgs/development/python-modules/fastapi-cli/default.nix
@@ -15,14 +15,14 @@
 let
   self = buildPythonPackage rec {
     pname = "fastapi-cli";
-    version = "0.0.8";
+    version = "0.0.20";
     pyproject = true;
 
     src = fetchFromGitHub {
-      owner = "tiangolo";
+      owner = "fastapi";
       repo = "fastapi-cli";
       tag = version;
-      hash = "sha256-7SYsIgRSFZgtIHBC5Ic9Nlh+LtGJDz0Xx1yxMarAuYY=";
+      hash = "sha256-RTxu6WmKmGMVsQ2izd8j8P+gGbXV91gVjb95JC52e8Q=";
     };
 
     build-system = [ pdm-backend ];
@@ -58,8 +58,8 @@ let
 
     meta = {
       description = "Run and manage FastAPI apps from the command line with FastAPI CLI";
-      homepage = "https://github.com/tiangolo/fastapi-cli";
-      changelog = "https://github.com/tiangolo/fastapi-cli/releases/tag/${src.tag}";
+      homepage = "https://github.com/fastapi/fastapi-cli";
+      changelog = "https://github.com/fastapi/fastapi-cli/releases/tag/${src.tag}";
       mainProgram = "fastapi";
       license = lib.licenses.mit;
       maintainers = [ ];


### PR DESCRIPTION
Diff: https://github.com/fastapi/fastapi-cli/compare/0.0.8...0.0.20
Most of the mass rebuilds are from `fastapi` having `fasapi-cli` as an optional build input :D
I can't really test the changes right now (as I can't build over 700 packages), so help with that would be appreciated. The package build fine tho and seems to work as expected.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
