### PR TITLE
noriskclient-launcher-unwrapped: 0.6.14 -> 0.6.16

### DIFF
--- a/pkgs/by-name/no/noriskclient-launcher-unwrapped/disable-bundling.patch
+++ b/pkgs/by-name/no/noriskclient-launcher-unwrapped/disable-bundling.patch
@@ -1,17 +1,17 @@
 diff --git a/src-tauri/tauri.conf.json b/src-tauri/tauri.conf.json
-index bb58d13..c1046f8 100644
+index 5f41e46..12d859e 100644
 --- a/src-tauri/tauri.conf.json
 +++ b/src-tauri/tauri.conf.json
-@@ -100,7 +100,7 @@
+@@ -109,7 +109,7 @@
          }
        }
      },
 -    "active": true,
 +    "active": false,
-     "targets": ["app", "dmg", "deb", "appimage", "nsis"],
-     "icon": [
-       "icons/32x32.png",
-@@ -109,7 +109,7 @@
+     "targets": [
+       "app",
+       "dmg",
+@@ -124,7 +124,7 @@
        "icons/icon.icns",
        "icons/icon.ico"
      ],
@@ -19,4 +19,4 @@ index bb58d13..c1046f8 100644
 +    "createUpdaterArtifacts": false,
      "fileAssociations": [
        {
-         "ext": ["noriskpack"],
+         "ext": [

--- a/pkgs/by-name/no/noriskclient-launcher-unwrapped/package.nix
+++ b/pkgs/by-name/no/noriskclient-launcher-unwrapped/package.nix
@@ -18,18 +18,18 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "noriskclient-launcher-unwrapped";
-  version = "0.6.14";
+  version = "0.6.16";
 
   src = fetchFromGitHub {
     owner = "NoRiskClient";
     repo = "noriskclient-launcher";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-9UUNIS8r/695maQ2j2+Wj2L5qy55Wfs/MNhKJnwC6GI=";
+    hash = "sha256-xYbQC7KLYKB2nU+bTl8jMMkfSuq7p8RNr8nJyLEQb1c=";
   };
 
   yarnOfflineCache = fetchYarnDeps {
     yarnLock = "${finalAttrs.src}/yarn.lock";
-    hash = "sha256-IWgP4VEyEBNsxALKGMpk8WZCIc76qcEu5K+kYqsdYkQ=";
+    hash = "sha256-tRvtYeOUn3xm7dhLWnzlpS8SK8NVVQAtNgvyiM48X28=";
   };
 
   patches = [
@@ -45,7 +45,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       --replace-fail "libayatana-appindicator3.so.1" "${libayatana-appindicator}/lib/libayatana-appindicator3.so.1"
   '';
 
-  cargoHash = "sha256-heSUEW7r9Lt26Fu68Jo/7BHW6Qmp8GrRSavukCS+ySk=";
+  cargoHash = "sha256-mldZg4Y12o6Laf2RJSeLzKCcqBpFesUbHhmxRjT9MDI=";
 
   cargoRoot = "src-tauri";
   buildAndTestSubdir = finalAttrs.cargoRoot;


### PR DESCRIPTION
Diff: https://github.com/NoRiskClient/noriskclient-launcher/compare/v0.6.14...v0.6.16
Sorry for the longer wait, I had to wait for another package to get built by Hydra :)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
