### PR TITLE
typora: init darwin at 1.12.4; refactor

### DIFF
--- a/pkgs/by-name/ty/typora/update.sh
+++ b/pkgs/by-name/ty/typora/update.sh
@@ -5,8 +5,11 @@ set -euo pipefail
 
 version=$(curl -s "https://typora.io/#linux" | sed -E -n 's/.*typora_([0-9.]+)_amd64.*/\1/p')
 
-amd64_hash=$(nix-hash --type sha256 --to-sri $(nix-prefetch-url https://download.typora.io/linux/typora_${version}_amd64.deb))
-update-source-version typora $version $amd64_hash --system=x86_64-linux --ignore-same-version
+linux_amd64_hash=$(nix-hash --type sha256 --to-sri $(nix-prefetch-url https://download.typora.io/linux/typora_${version}_amd64.deb))
+update-source-version typora $version $linux_amd64_hash --system=x86_64-linux --ignore-same-version
 
-arm64_hash=$(nix-hash --type sha256 --to-sri $(nix-prefetch-url https://download.typora.io/linux/typora_${version}_arm64.deb))
-update-source-version typora $version $arm64_hash --system=aarch64-linux --ignore-same-version
+linux_arm64_hash=$(nix-hash --type sha256 --to-sri $(nix-prefetch-url https://download.typora.io/linux/typora_${version}_arm64.deb))
+update-source-version typora $version $linux_arm64_hash --system=aarch64-linux --ignore-same-version
+
+darwin_arm64_hash=$(nix-hash --type sha256 --to-sri $(nix-prefetch-url https://download.typora.io/mac/Typora-${version}.dmg))
+update-source-version typora $version $darwin_arm64_hash --system=aarch64-darwin --ignore-same-version


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
