### PR TITLE
maintainers: add `gabyx` to `gitlab` teams

### DIFF
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -422,6 +422,7 @@ with lib.maintainers;
 
   gitlab = {
     members = [
+      gabyx
       krav
       leona
       talyz


### PR DESCRIPTION
- You may add me to the `gitlab` teams. I may help with the recent added VM test for the Gitlab Runner etc and the documentation around this.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
