### PR TITLE
[staging-next] python314Packages.html5lib: fix build with python 3.14, cleanup package

### DIFF
--- a/pkgs/development/python-modules/html5lib/default.nix
+++ b/pkgs/development/python-modules/html5lib/default.nix
@@ -27,6 +27,15 @@ buildPythonPackage rec {
       url = "https://github.com/html5lib/html5lib-python/commit/2c19b9899ab3a3e8bd0ca35e5d78544334204169.patch";
       hash = "sha256-VGCeB6o2QO/skeCZs8XLPfgEYVOSRL8cCpG7ajbZWEs=";
     })
+    # support pytest >= 6 with newer python versions
+    (fetchpatch {
+      url = "https://github.com/html5lib/html5lib-python/commit/4a87368b71090f1432df6302f178c4babfcec93f.patch";
+      includes = [
+        "html5lib/tests/tokenizer.py"
+        "html5lib/tests/tree_construction.py"
+      ];
+      hash = "sha256-183wXCqX+8r8DEdWiBpRUGP0RI5tupWrDxiWebC4/LU=";
+    })
     # Fix compatability with Python 3.14
     # https://github.com/html5lib/html5lib-python/pull/583
     ./replace-ast-str.patch
@@ -37,8 +46,6 @@ buildPythonPackage rec {
     webencodings
   ];
 
-  # latest release not compatible with pytest 6
-  doCheck = true;
   nativeCheckInputs = [
     mock
     pytest-expect

--- a/pkgs/development/python-modules/html5lib/default.nix
+++ b/pkgs/development/python-modules/html5lib/default.nix
@@ -27,6 +27,9 @@ buildPythonPackage rec {
       url = "https://github.com/html5lib/html5lib-python/commit/2c19b9899ab3a3e8bd0ca35e5d78544334204169.patch";
       hash = "sha256-VGCeB6o2QO/skeCZs8XLPfgEYVOSRL8cCpG7ajbZWEs=";
     })
+    # Fix compatability with Python 3.14
+    # https://github.com/html5lib/html5lib-python/pull/583
+    ./replace-ast-str.patch
   ];
 
   propagatedBuildInputs = [
@@ -35,7 +38,7 @@ buildPythonPackage rec {
   ];
 
   # latest release not compatible with pytest 6
-  doCheck = false;
+  doCheck = true;
   nativeCheckInputs = [
     mock
     pytest-expect

--- a/pkgs/development/python-modules/html5lib/replace-ast-str.patch
+++ b/pkgs/development/python-modules/html5lib/replace-ast-str.patch
@@ -1,0 +1,27 @@
+From 379f9476c2a5ee370cd7ec856ee9092cace88499 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Miro=20Hron=C4=8Dok?= <miro@hroncok.cz>
+Date: Wed, 30 Oct 2024 15:44:40 +0100
+Subject: [PATCH] Avoid ast.Str on Python 3.8+
+
+It has been deprecated since Python 3.8 and was removed from Python 3.14+.
+---
+ setup.py | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/setup.py b/setup.py
+index 30ee0575..62272c18 100644
+--- a/setup.py
++++ b/setup.py
+@@ -93,8 +93,9 @@ def default_environment():
+         if (len(a.targets) == 1 and
+                 isinstance(a.targets[0], ast.Name) and
+                 a.targets[0].id == "__version__" and
+-                isinstance(a.value, ast.Str)):
+-            version = a.value.s
++                ((sys.version_info >= (3, 8) and isinstance(a.value, ast.Constant)) or
++                    isinstance(a.value, ast.Str))):
++            version = a.value.value if sys.version_info >= (3, 8) else a.value.s
+ 
+ setup(name='html5lib',
+       version=version,
+


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
