### PR TITLE
nixosTests.gitlab.runner: correct `aarch` test disabling/enabling

### DIFF
--- a/nixos/modules/services/misc/gitlab.md
+++ b/nixos/modules/services/misc/gitlab.md
@@ -143,7 +143,7 @@ configure a Gitlab Runner with caching and reasonably good security practices.
 
 ::: {#ex-gitlab-runner-podman .example}
 
-## Example: Gitlab Runner with `podman` and Nix Store Caching
+## Gitlab Runner with `podman` and Nix Store Caching
 
 The [VM tested `podman-runner`](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests/gitlab/runner/podman-runner/default.nix)
 (a NixOS module for reuse) configures an advanced Gitlab runner with the following features:

--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -99,7 +99,7 @@ rec {
         (onFullSupported "nixos.tests.firewall")
         (onFullSupported "nixos.tests.fontconfig-default-fonts")
         (onFullSupported "nixos.tests.gitlab.gitlab")
-        (onSystems [ "x86_64-linux" ] "nixos.tests.gitlab.runner")
+        (onFullSupported "nixos.tests.gitlab.runner")
         (onFullSupported "nixos.tests.gnome")
         (onSystems [ "x86_64-linux" ] "nixos.tests.hibernate")
         (onFullSupported "nixos.tests.i3wm")

--- a/nixos/tests/gitlab/runner_test.py
+++ b/nixos/tests/gitlab/runner_test.py
@@ -116,6 +116,9 @@ def test_register_runner(name: str, tokenFile: str):
 def restart_gitlab_runner_service(runnerConfigs):
     print("==> Restart Gitlab Runner")
 
+    if len(runnerConfigs) == 0:
+        raise Exception("You must have at least one runner registered!")
+
     if any([n == "podman" for n in runnerConfigs.keys()]):
         vms.gitlab_runner.wait_for_unit("podman-nix-daemon-container.service")
         vms.gitlab_runner.wait_for_unit("podman-podman-daemon-container.service")


### PR DESCRIPTION
- The current tests did not correctly disable for the `podman` runner which only runs on `x86_64` due to the images pulled.
  The PR correctly disables the `podman` runner on this platform which then should build also on aarch
  
  See the failed build:
  https://hydra.nixos.org/build/317058545/nixlog/52
  
Resolves already merged #474031.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
