### PR TITLE
prometheus-tailscale-exporter: 0.2.5 -> 0.3.0

### DIFF
--- a/nixos/tests/prometheus-exporters.nix
+++ b/nixos/tests/prometheus-exporters.nix
@@ -1901,24 +1901,23 @@ let
               # testing the NixOS module.
               (pkgs.writeText "allow-running-without-credentials" ''
                 diff --git a/cmd/tailscale-exporter/root.go b/cmd/tailscale-exporter/root.go
-                index 2ff11cb..2fb576f 100644
+                index 14089f9..2bb9a25 100644
                 --- a/cmd/tailscale-exporter/root.go
                 +++ b/cmd/tailscale-exporter/root.go
-                @@ -137,14 +137,6 @@ func runExporter(cmd *cobra.Command, args []string) error {
-                ''\t// Create HTTP client that automatically handles token refresh
-                ''\thttpClient := oauthConfig.Client(context.Background())
+                @@ -162,13 +162,6 @@ func runExporter(cmd *cobra.Command, args []string) error {
+                ''\t''\t}
 
-                -''\t// Test OAuth token generation
-                -''\ttoken, err := oauthConfig.Token(context.Background())
-                -''\tif err != nil {
-                -''\t''\treturn fmt.Errorf("failed to obtain OAuth token: %w", err)
-                -''\t}
-                -''\tlogger.Info("OAuth token obtained", "token_type", token.TokenType)
-                -''\tlogger.Info("Successfully obtained OAuth token", "expires", token.Expiry)
+                ''\t''\thttpClient := oauthConfig.Client(context.Background())
+                -''\t''\ttoken, err := oauthConfig.Token(context.Background())
+                -''\t''\tif err != nil {
+                -''\t''\t''\treturn fmt.Errorf("failed to obtain OAuth token: %w", err)
+                -''\t''\t}
+                -''\t''\tlogger.Info("OAuth token obtained", "token_type", token.TokenType)
+                -''\t''\tlogger.Info("Successfully obtained OAuth token", "expires", token.Expiry)
                 -
-                ''\t// Default labels for all metrics
-                ''\tdefaultLabels := prometheus.Labels{"tailnet": tailnet}
-                ''\treg := prometheus.WrapRegistererWith(
+                ''\t''\ttsCollector, err := tailscale.NewTailscaleCollector(
+                ''\t''\t''\tlogger,
+                ''\t''\t''\thttpClient,
               '')
             ];
           };

--- a/pkgs/by-name/pr/prometheus-tailscale-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-tailscale-exporter/package.nix
@@ -8,16 +8,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "tailscale-exporter";
-  version = "0.2.5";
+  version = "0.3.0";
 
   src = fetchFromGitHub {
     owner = "adinhodovic";
     repo = "tailscale-exporter";
     tag = finalAttrs.version;
-    hash = "sha256-6iQtGfQsXVmwFaSA7B1AG+kbtSyKVWFbEld1lMb0DnE=";
+    hash = "sha256-zZxKTEm23iXv4qYwx6gBtBuz5pduuIXLwMX0ZrrYxZs=";
   };
 
-  vendorHash = "sha256-Nbx6LyGGhdgI4oEtbyqhJ2H1lY6BfSL/ROH/Dh4UOk0=";
+  vendorHash = "sha256-WHtmis8r62th90BrM+f63yuyRkW4bVT/vPDfcIJ3Fg8=";
 
   subPackages = [
     "cmd/tailscale-exporter"


### PR DESCRIPTION
This PR bumps the Prometheus Tailscale exporter and fixes the corresponding NixOS service test, which broke because patch needed to make the exporter test pass was no longer applicable with the new code.

Supersedes: #468190
Fixes: #474051

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
