### PR TITLE
ivpn-service: Add v2ray support

### DIFF
--- a/pkgs/by-name/iv/ivpn-service/package.nix
+++ b/pkgs/by-name/iv/ivpn-service/package.nix
@@ -9,6 +9,7 @@
   obfs4,
   iproute2,
   dnscrypt-proxy,
+  v2ray,
   iptables,
   gawk,
   util-linux,
@@ -55,7 +56,9 @@ buildGoModule (finalAttrs: {
       --replace 'wgToolBinaryPath = path.Join(installDir, "wireguard-tools/wg")' \
       'wgToolBinaryPath = "${wireguard-tools}/bin/wg"' \
       --replace 'dnscryptproxyBinPath = path.Join(installDir, "dnscrypt-proxy/dnscrypt-proxy")' \
-      'dnscryptproxyBinPath = "${dnscrypt-proxy}/bin/dnscrypt-proxy"'
+      'dnscryptproxyBinPath = "${dnscrypt-proxy}/bin/dnscrypt-proxy"' \
+      --replace-fail 'v2rayBinaryPath = path.Join(installDir, "v2ray/v2ray")' \
+      'v2rayBinaryPath = "${v2ray}/bin/v2ray"'
   '';
 
   ldflags = [

--- a/pkgs/by-name/iv/ivpn-service/package.nix
+++ b/pkgs/by-name/iv/ivpn-service/package.nix
@@ -38,24 +38,24 @@ buildGoModule (finalAttrs: {
 
   postPatch = ''
     substituteInPlace daemon/service/platform/platform_linux.go \
-      --replace 'openVpnBinaryPath = "/usr/sbin/openvpn"' \
+      --replace-fail 'openVpnBinaryPath = "/usr/sbin/openvpn"' \
       'openVpnBinaryPath = "${openvpn}/bin/openvpn"' \
-      --replace 'routeCommand = "/sbin/ip route"' \
+      --replace-fail 'routeCommand = "/sbin/ip route"' \
       'routeCommand = "${iproute2}/bin/ip route"'
 
     substituteInPlace daemon/netinfo/netinfo_linux.go \
-      --replace 'retErr := shell.ExecAndProcessOutput(log, outParse, "", "/sbin/ip", "route")' \
+      --replace-fail 'retErr := shell.ExecAndProcessOutput(log, outParse, "", "/sbin/ip", "route")' \
       'retErr := shell.ExecAndProcessOutput(log, outParse, "", "${iproute2}/bin/ip", "route")'
 
     substituteInPlace daemon/service/platform/platform_linux_release.go \
-      --replace 'installDir := "/opt/ivpn"' "installDir := \"$out\"" \
-      --replace 'obfsproxyStartScript = path.Join(installDir, "obfsproxy/obfs4proxy")' \
+      --replace-fail 'installDir := "/opt/ivpn"' "installDir := \"$out\"" \
+      --replace-fail 'obfsproxyStartScript = path.Join(installDir, "obfsproxy/obfs4proxy")' \
       'obfsproxyStartScript = "${lib.getExe obfs4}"' \
-      --replace 'wgBinaryPath = path.Join(installDir, "wireguard-tools/wg-quick")' \
+      --replace-fail 'wgBinaryPath = path.Join(installDir, "wireguard-tools/wg-quick")' \
       'wgBinaryPath = "${wireguard-tools}/bin/wg-quick"' \
-      --replace 'wgToolBinaryPath = path.Join(installDir, "wireguard-tools/wg")' \
+      --replace-fail 'wgToolBinaryPath = path.Join(installDir, "wireguard-tools/wg")' \
       'wgToolBinaryPath = "${wireguard-tools}/bin/wg"' \
-      --replace 'dnscryptproxyBinPath = path.Join(installDir, "dnscrypt-proxy/dnscrypt-proxy")' \
+      --replace-fail 'dnscryptproxyBinPath = path.Join(installDir, "dnscrypt-proxy/dnscrypt-proxy")' \
       'dnscryptproxyBinPath = "${dnscrypt-proxy}/bin/dnscrypt-proxy"' \
       --replace-fail 'v2rayBinaryPath = path.Join(installDir, "v2ray/v2ray")' \
       'v2rayBinaryPath = "${v2ray}/bin/v2ray"'

--- a/pkgs/by-name/iv/ivpn-service/package.nix
+++ b/pkgs/by-name/iv/ivpn-service/package.nix
@@ -85,6 +85,7 @@ buildGoModule (finalAttrs: {
           iptables
           gawk
           util-linux
+          iproute2
         ]
       }
   '';


### PR DESCRIPTION
Add v2ray build tag support for obfuscation

## Things done


- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
