### PR TITLE
pdfpc: Remove webkitgtk from Darwin build

### DIFF
--- a/pkgs/applications/misc/pdfpc/default.nix
+++ b/pkgs/applications/misc/pdfpc/default.nix
@@ -20,6 +20,8 @@
   discount,
   json-glib,
   nix-update-script,
+  libsoup_3,
+  librsvg,
 }:
 
 stdenv.mkDerivation rec {
@@ -42,22 +44,32 @@ stdenv.mkDerivation rec {
     wrapGAppsHook3
   ];
 
-  buildInputs = [
-    gtk3
-    libgee
-    poppler
-    libpthreadstubs
-    gstreamer
-    gst-plugins-base
-    (gst-plugins-good.override { gtkSupport = true; })
-    gst-libav
-    qrencode
-    webkitgtk_4_1
-    discount
-    json-glib
-  ];
-
-  cmakeFlags = lib.optional stdenv.hostPlatform.isDarwin (lib.cmakeBool "MOVIES" false);
+  cmakeFlags = lib.optional stdenv.hostPlatform.isDarwin (lib.cmakeBool "MDVIEW" false);
+  buildInputs =
+    let
+      platformBuildInputs =
+        if stdenv.hostPlatform.isDarwin then
+          [ librsvg ]
+        else
+          [
+            libpthreadstubs
+            webkitgtk_4_1
+          ];
+    in
+    [
+      (gst-plugins-good.override { gtkSupport = true; })
+      discount
+      gst-libav
+      gst-plugins-base
+      gstreamer
+      gtk3
+      json-glib
+      libgee
+      libsoup_3
+      poppler
+      qrencode
+    ]
+    ++ platformBuildInputs;
 
   passthru.updateScript = nix-update-script { };
 


### PR DESCRIPTION
pdfpc couldn't build on Mac since webkitgtk 4.1 is marked as broken.

However, webkitgtk is optional and not required if the MDVIEW flag is set to false (markdown is rendered through webkitgtk, and this feature removes the functionality to render Markdown).

I also removed the MOVIES flag set to false, since it's not necesarriy anymore.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
