### PR TITLE
nixos/activation: avoid build failure with large activation script

### DIFF
--- a/nixos/modules/system/activation/activation-script.nix
+++ b/nixos/modules/system/activation/activation-script.nix
@@ -50,8 +50,6 @@ let
       ) withHeadlines;
     in
     ''
-      #!${pkgs.runtimeShell}
-
       source ${./lib/lib.sh}
 
       systemConfig='@out@'

--- a/nixos/tests/restart-by-activation-script.nix
+++ b/nixos/tests/restart-by-activation-script.nix
@@ -6,7 +6,7 @@
   };
 
   nodes.machine =
-    { pkgs, ... }:
+    { pkgs, lib, ... }:
     {
       imports = [ ../modules/profiles/minimal.nix ];
 
@@ -45,6 +45,14 @@
             fi
           fi
         '';
+      };
+
+      # Make sure we don't crash on long activation scripts
+      specialisation.longscript.configuration = {
+        system.activationScripts.long = {
+          supportsDryActivation = true;
+          text = lib.concatStringsSep "\n" (lib.genList (i: ''# line number ${toString i}'') 1000000);
+        };
       };
     };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Two improvements:
  * use `writeShellApplication` (which uses `passAsFile` instead of passing the activation script as an env var into the derivation. We disable shellcheck and the bash options that this builder usually adds to avoid issues with out-of-tree activation scripts.
  * use `sed` instead of `substituteInPlace`, since the substitute functions load the file content into a shell variable

This avoids issues when the activation is too long to fit in a shell variable.
Before this commit, a very large activation script, would cause build failures because of different limits on the file content size, e.g.
```
➜ nix build -f . nixosTests.restartByActivationScript.nodes.machine.system.build.toplevel -vL
this derivation will be built:
  /nix/store/xw6anpfjyamnycjg58cmj01sz3ididyl-nixos-system-machine-test.drv
building '/nix/store/xw6anpfjyamnycjg58cmj01sz3ididyl-nixos-system-machine-test.drv'...
 nixos-system-machine-test> error: executing '/nix/store/rlq03x4cwf8zn73hxaxnx0zn5q9kifls-bash-5.3p3/bin/bash': Argument list too long
error: builder for '/nix/store/xw6anpfjyamnycjg58cmj01sz3ididyl-nixos-system-machine-test.drv' failed with exit code 1;
       last 1 log lines:
       > error: executing '/nix/store/rlq03x4cwf8zn73hxaxnx0zn5q9kifls-bash-5.3p3/bin/bash': Argument list too long
       For full logs, run:
        nix log /nix/store/xw6anpfjyamnycjg58cmj01sz3ididyl-nixos-system-machine-test.drv
 ```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
