### PR TITLE
nixosTests.{ft2-clone,pt2-clone,sfxr-qt}: fix

### DIFF
--- a/nixos/tests/ft2-clone.nix
+++ b/nixos/tests/ft2-clone.nix
@@ -11,6 +11,13 @@
       imports = [
         ./common/x11.nix
       ];
+
+      boot.kernelModules = [ "snd-dummy" ];
+      services.pulseaudio = {
+        enable = true;
+        systemWide = true;
+      };
+      services.pipewire.enable = false;
       environment.systemPackages = [ pkgs.ft2-clone ];
     };
 
@@ -18,8 +25,6 @@
 
   testScript = ''
     machine.wait_for_x()
-    # Add a dummy sound card, or the program won't start
-    machine.execute("modprobe snd-dummy")
 
     machine.execute("ft2-clone >&2 &")
 

--- a/nixos/tests/pt2-clone.nix
+++ b/nixos/tests/pt2-clone.nix
@@ -12,7 +12,12 @@
         ./common/x11.nix
       ];
 
-      services.xserver.enable = true;
+      boot.kernelModules = [ "snd-dummy" ];
+      services.pulseaudio = {
+        enable = true;
+        systemWide = true;
+      };
+      services.pipewire.enable = false;
       environment.systemPackages = [ pkgs.pt2-clone ];
     };
 
@@ -20,16 +25,13 @@
 
   testScript = ''
     machine.wait_for_x()
-    # Add a dummy sound card, or the program won't start
-    machine.execute("modprobe snd-dummy")
 
     machine.execute("pt2-clone >&2 &")
 
     machine.wait_for_window(r"ProTracker")
     machine.sleep(5)
     # One of the few words that actually get recognized
-    if "LENGTH" not in machine.get_screen_text():
-        raise Exception("Program did not start successfully")
+    machine.wait_for_text("LENGTH")
     machine.screenshot("screen")
   '';
 }

--- a/nixos/tests/sfxr-qt.nix
+++ b/nixos/tests/sfxr-qt.nix
@@ -5,7 +5,7 @@
     maintainers = [ fgaz ];
   };
 
-  machine =
+  nodes.machine =
     { config, pkgs, ... }:
     {
       imports = [
@@ -13,6 +13,12 @@
       ];
 
       services.xserver.enable = true;
+      boot.kernelModules = [ "snd-dummy" ];
+      services.pulseaudio = {
+        enable = true;
+        systemWide = true;
+      };
+      services.pipewire.enable = false;
       environment.systemPackages = [ pkgs.sfxr-qt ];
     };
 


### PR DESCRIPTION
Provide a usable audio device so the programs can start


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
