### PR TITLE
python3Packages.pymc: 5.26.1 -> 5.27.0

### DIFF
--- a/pkgs/development/python-modules/bambi/default.nix
+++ b/pkgs/development/python-modules/bambi/default.nix
@@ -91,9 +91,10 @@ buildPythonPackage rec {
     "test_model_without_intercept"
     "test_non_distributional_model"
     "test_normal_with_splines"
-    "test_predict_new_groups_fail"
     "test_predict_new_groups"
+    "test_predict_new_groups_fail"
     "test_predict_offset"
+    "test_same_variable_conditional_and_group"
     "test_set_alias_warnings"
     "test_subplot_kwargs"
     "test_transforms"
@@ -113,8 +114,6 @@ buildPythonPackage rec {
   ];
 
   disabledTestPaths = [
-    # bayeux-ml is not available
-    "tests/test_alternative_samplers.py"
     # Tests require network access
     "tests/test_interpret.py"
     "tests/test_interpret_messages.py"

--- a/pkgs/development/python-modules/pymc/default.nix
+++ b/pkgs/development/python-modules/pymc/default.nix
@@ -18,18 +18,20 @@
   scipy,
   threadpoolctl,
   typing-extensions,
+
+  writableTmpDirAsHomeHook,
 }:
 
 buildPythonPackage rec {
   pname = "pymc";
-  version = "5.26.1";
+  version = "5.27.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pymc-devs";
     repo = "pymc";
     tag = "v${version}";
-    hash = "sha256-j1v8MzAFfOmkN7pDcF91dS5Xprls8qfTQHWdaFUO4GU=";
+    hash = "sha256-wBeWydrHrF+wNZnqWa2k8tCaUvjcoiSrmY85LUhrQds=";
   };
 
   build-system = [
@@ -48,6 +50,13 @@ buildPythonPackage rec {
     scipy
     threadpoolctl
     typing-extensions
+  ];
+
+  nativeBuildInputs = [
+    # Arviz (imported by pymc) wants to write a stamp file to the homedir at import time.
+    # Without $HOME being writable, `pythonImportsCheck` fails.
+    # https://github.com/arviz-devs/arviz/commit/4db612908f588d89bb5bfb6b83a08ada3d54fd02
+    writableTmpDirAsHomeHook
   ];
 
   # The test suite is computationally intensive and test failures are not

--- a/pkgs/development/python-modules/pytensor/default.nix
+++ b/pkgs/development/python-modules/pytensor/default.nix
@@ -3,6 +3,7 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch,
 
   # build-system
   setuptools,
@@ -33,7 +34,7 @@
 
 buildPythonPackage rec {
   pname = "pytensor";
-  version = "2.36.0";
+  version = "2.36.1";
   pyproject = true;
 
   src = fetchFromGitHub {
@@ -43,8 +44,17 @@ buildPythonPackage rec {
     postFetch = ''
       sed -i 's/git_refnames = "[^"]*"/git_refnames = " (tag: ${src.tag})"/' $out/pytensor/_version.py
     '';
-    hash = "sha256-tzwiPp0+xNKmndTn9Y1AXiqscQWaCC8gKgQHEtkyGag=";
+    hash = "sha256-rXLtrkuwmEe5+64Aao490VqD96LJ37/mxekWOzWRMlw=";
   };
+
+  patches = [
+    # https://github.com/pymc-devs/pytensor/pull/1805
+    (fetchpatch {
+      name = "fix-test-tri-nonconcrete-jax-compatibility.patch";
+      url = "https://github.com/pymc-devs/pytensor/commit/86310f074267e24d1b3b99ecf3d9cc0b593b170d.patch";
+      hash = "sha256-KRywJLixmdDJ1GGYsd5Twjiwgce0ZFxUidhTgM6Obmg=";
+    })
+  ];
 
   build-system = [
     setuptools
@@ -160,7 +170,6 @@ buildPythonPackage rec {
     # Don't run the most compute-intense tests
     "tests/scan/"
     "tests/tensor/"
-    "tests/sparse/sandbox/"
   ];
 
   passthru.updateScript = nix-update-script {


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/pymc-devs/pymc/compare/v5.26.1...v5.27.0
Changelog: https://github.com/pymc-devs/pymc/releases/tag/v5.27.0

cc @nidabdella

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc