### PR TITLE
bpflinter: init at v0.1.5

### DIFF
--- a/pkgs/by-name/bp/bpflinter/package.nix
+++ b/pkgs/by-name/bp/bpflinter/package.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  fetchpatch,
+  nix-update-script,
+  fetchCrate,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "bpflinter";
+  version = "0.1.5";
+  src = fetchCrate {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-oX4fgUKOASiI/NMFSjr6afmyg1VBK44lqni+xBXlZLo=";
+  };
+
+  cargoHash = "sha256-3TIWrqgePnBMEJFB5fkch5ycU4NXE6JlbUpq9/8DbHc=";
+
+  passthru.updateScript = nix-update-script { };
+  meta = {
+    mainProgram = "bpflinter";
+    description = "Linting functionality for BPF C programs";
+    homepage = "https://github.com/d-e-s-o/bpflint";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ fzakaria ];
+  };
+})


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
