### PR TITLE
qbt_go: init at v2.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4863,6 +4863,11 @@
     githubId = 31200881;
     keys = [ { fingerprint = "5D03 A5E6 0754 A3E3 CA57 5037 E838 CED8 1CFF D3F9"; } ];
   };
+  chungyinleo = {
+    name = "chungyinleo";
+    github = "chungyinleo";
+    githubId = 137068225;
+  };
   chvp = {
     email = "nixpkgs@cvpetegem.be";
     matrix = "@charlotte:vanpetegem.me";

--- a/pkgs/by-name/qb/qbt_go/package.nix
+++ b/pkgs/by-name/qb/qbt_go/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  stdenv,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+}:
+
+buildGoModule rec {
+  pname = "qbt_go";
+  version = "2.2.0";
+
+  src = fetchFromGitHub {
+    owner = "ludviglundgren";
+    repo = "qbittorrent-cli";
+    tag = "v${version}";
+    hash = "sha256-7d5z/+948tfxkrs/s9Zv9guCCEIOuZhE9P954N4TD/g=";
+  };
+
+  vendorHash = "sha256-we4iI4s8PvBak67lTZZ3jLThQ3bqBhkEh3QRGcQgH80=";
+
+  postPatch = ''
+    substituteInPlace cmd/qbt/main.go \
+      --replace-fail 'Use:   "qbt"' 'Use:   "qbt_go"'
+    mv cmd/qbt cmd/qbt_go
+  '';
+
+  nativeBuildInputs = [ installShellFiles ];
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd qbt_go \
+      --bash <($out/bin/qbt_go completion bash) \
+      --zsh <($out/bin/qbt_go completion zsh) \
+      --fish <($out/bin/qbt_go completion fish)
+  '';
+
+  meta = {
+    description = "Cli to manage qBittorrent";
+    homepage = "https://github.com/ludviglundgren/qbittorrent-cli";
+    license = lib.licenses.mit;
+    platforms = with lib.platforms; linux ++ darwin;
+    maintainers = with lib.maintainers; [ chungyinleo ];
+    mainProgram = "qbt_go";
+  };
+}

--- a/pkgs/by-name/qb/qbt_go/package.nix
+++ b/pkgs/by-name/qb/qbt_go/package.nix
@@ -8,19 +8,21 @@
 
 buildGoModule rec {
   pname = "qbt_go";
-  version = "2.2.0";
+  version = "2.3.0";
+
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "ludviglundgren";
     repo = "qbittorrent-cli";
     tag = "v${version}";
-    hash = "sha256-7d5z/+948tfxkrs/s9Zv9guCCEIOuZhE9P954N4TD/g=";
+    hash = "sha256-T2U7DP1LsRv1PJwsA3tl2gkUONZ/g/l/eulhSMBp4OQ=";
   };
 
-  vendorHash = "sha256-we4iI4s8PvBak67lTZZ3jLThQ3bqBhkEh3QRGcQgH80=";
+  vendorHash = "sha256-x9WarAz+EQ4PDn1+tRNzhMoNvmP6BuMf7fylLsR2JCQ=";
 
   postPatch = ''
-    substituteInPlace cmd/qbt/main.go \
+    substituteInPlace cmd/root.go \
       --replace-fail 'Use:   "qbt"' 'Use:   "qbt_go"'
     mv cmd/qbt cmd/qbt_go
   '';


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Add myself to maintainers

New package [`qbittorrent-cli`](https://github.com/ludviglundgren/qbittorrent-cli) written in go. Different from the one already in nixpkgs, thought the repo has the same name.
Renamed the executable to avoid conflict.
Replaced the executable names in shell completions.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
