### PR TITLE
xtrackcad: init at 5.3.1

### DIFF
--- a/pkgs/by-name/xt/xtrackcad/package.nix
+++ b/pkgs/by-name/xt/xtrackcad/package.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  cmake,
+  pkg-config,
+  gtk2,
+  pandoc,
+  libsysprof-capture,
+  pcre2,
+  glib,
+  util-linux,
+  libselinux,
+  libsepol,
+  fribidi,
+  libthai,
+  libdatrie,
+  libxdmcp,
+  libdeflate,
+  lerc,
+  xz,
+  zstd,
+  libwebp,
+  inkscape,
+  libzip,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xtrackcad";
+  version = "5.3.1";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/xtrkcad-fork/xtrkcad-source-${finalAttrs.version}GA.tar.gz";
+    hash = "sha256-WwKgNSwj+QsAEQKcfiw/Eqb2d5QlxMR8H3XWuKDbVyw=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    gtk2
+    pandoc
+    libsysprof-capture
+    pcre2
+    glib
+    util-linux
+    libselinux
+    libsepol
+    fribidi
+    libthai
+    libdatrie
+    libxdmcp
+    libdeflate
+    lerc
+    xz
+    zstd
+    libwebp
+    inkscape
+    libzip
+  ];
+
+  meta = {
+    description = "Model Railway CAD program";
+    homepage = "https://sourceforge.net/projects/xtrkcad-fork/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ thtrf ];
+    mainProgram = "xtrkcad";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
https://sourceforge.net/projects/xtrkcad-fork/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
