### PR TITLE
clipse: v1.1.0 -> v1.2.0

### DIFF
--- a/pkgs/by-name/cl/clipse/package.nix
+++ b/pkgs/by-name/cl/clipse/package.nix
@@ -2,26 +2,59 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
+  stdenv,
+  enableWayland ? true,
+  enableX11 ? false,
 }:
 
-buildGoModule rec {
+let
   pname = "clipse";
-  version = "1.1.0";
+  version = "1.2.0";
 
-  src = fetchFromGitHub {
-    owner = "savedra1";
-    repo = "clipse";
-    rev = "v${version}";
-    hash = "sha256-yUkHT7SZT7Eudvk1n43V+WGWqUKtXaV+p4ySMK/XzQw=";
-  };
+  tags =
+    if stdenv.hostPlatform.isDarwin then
+      [ "darwin" ]
+    else if enableWayland then
+      [ "wayland" ]
+    else if enableX11 then
+      [ "linux" ]
+    else
+      [ ];
 
-  vendorHash = "sha256-+9uoB/1g4qucdM8RJRs+fSc5hpcgaCK0GrUOFgHWeKo=";
+  cgoEnabled = enableX11 || stdenv.hostPlatform.isDarwin;
 
-  meta = {
-    description = "Useful clipboard manager TUI for Unix";
-    homepage = "https://github.com/savedra1/clipse";
-    license = lib.licenses.mit;
-    mainProgram = "clipse";
-    maintainers = [ lib.maintainers.savedra1 ];
-  };
-}
+  packageName = if enableX11 then "${pname}-x11" else pname;
+in
+(
+  assert lib.assertMsg (
+    stdenv.hostPlatform.isLinux -> (lib.xor enableX11 enableWayland)
+  ) "Exactly one of enableWayland, enableX11 must be true";
+
+  buildGoModule {
+    pname = packageName;
+    inherit version;
+
+    src = fetchFromGitHub {
+      owner = "savedra1";
+      repo = "clipse";
+      rev = "v${version}";
+      hash = "sha256-17ZzmgXm8aJGG4D48wJv+rBCvJZMH3b2trHwhTqwb8s=";
+    };
+
+    vendorHash = "sha256-6lOUSRo1y4u8+8G/L6BvhU052oYrsthqxrsgUtbGhYM=";
+
+    inherit tags;
+
+    env = {
+      CGO_ENABLED = if cgoEnabled then "1" else "0";
+    };
+
+    meta = {
+      description = "Useful clipboard manager TUI for Unix";
+      homepage = "https://github.com/savedra1/clipse";
+      license = lib.licenses.mit;
+      mainProgram = "clipse";
+      maintainers = [ lib.maintainers.savedra1 ];
+    };
+  }
+)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14154,4 +14154,9 @@ with pkgs;
   gpac-unstable = callPackage ../by-name/gp/gpac/package.nix {
     releaseChannel = "unstable";
   };
+
+  clipse-x11 = callPackage ../by-name/cl/clipse/package.nix {
+    enableWayland = false;
+    enableX11 = true;
+  };
 }


### PR DESCRIPTION
Need to update the Nix package to stay in-line with the latest clipse release. Recent updates have introduced CGO to the project, meaning the build now requires different tags depending on the display server used on the host machine. I have therefore added passthru's for x11 and darwin, that will enable CGO if building in those environments. Wayland Linux is set as the default when installing without using a passthru.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
