### PR TITLE
protege: 5.6.4 -> 5.6.8

### DIFF
--- a/pkgs/by-name/pr/protege/enforce-plugin-versions.patch
+++ b/pkgs/by-name/pr/protege/enforce-plugin-versions.patch
@@ -1,43 +1,41 @@
-diff --git a/pom.xml b/pom.xml
-index 839bed04..4cb5f392 100644
 --- a/pom.xml
 +++ b/pom.xml
-@@ -358,6 +358,30 @@
+@@ -347,6 +347,30 @@
  						<release>11</release>
  					</configuration>
  				</plugin>
++				
++				<plugin>
++          <groupId>org.apache.maven.plugins</groupId>
++          <artifactId>maven-install-plugin</artifactId>
++          <version>3.1.1</version>
++        </plugin>
 +
-+                                <plugin>
-+					<groupId>org.apache.maven.plugins</groupId>
-+					<artifactId>maven-install-plugin</artifactId>
-+					<version>3.1.1</version>
-+                                </plugin>
++        <plugin>
++          <groupId>org.apache.maven.plugins</groupId>
++          <artifactId>maven-site-plugin</artifactId>
++          <version>3.12.1</version>
++        </plugin>
 +
-+                                <plugin>
-+					<groupId>org.apache.maven.plugins</groupId>
-+					<artifactId>maven-site-plugin</artifactId>
-+					<version>3.12.1</version>
-+                                </plugin>
++        <plugin>
++          <groupId>org.apache.maven.plugins</groupId>
++          <artifactId>maven-deploy-plugin</artifactId>
++          <version>3.1.1</version>
++        </plugin>
 +
-+                                <plugin>
-+					<groupId>org.apache.maven.plugins</groupId>
-+					<artifactId>maven-deploy-plugin</artifactId>
-+					<version>3.1.1</version>
-+                                </plugin>
-+
-+                                <plugin>
-+					<groupId>org.apache.maven.plugins</groupId>
-+					<artifactId>maven-jar-plugin</artifactId>
-+					<version>3.3.0</version>
-+                                </plugin>
- 							
++        <plugin>
++          <groupId>org.apache.maven.plugins</groupId>
++          <artifactId>maven-jar-plugin</artifactId>
++          <version>3.3.0</version>
++        </plugin>
+ 
  				<plugin>
  					<groupId>org.apache.maven.plugins</groupId>
-@@ -476,6 +494,7 @@
+@@ -465,6 +489,7 @@
  								<requireMavenVersion>
  									<version>3.6.3</version>
  								</requireMavenVersion>
-+                                                                <requirePluginVersions/>
++								<requirePluginVersions/>
  							</rules>
  						</configuration>
  					</execution>

--- a/pkgs/by-name/pr/protege/package.nix
+++ b/pkgs/by-name/pr/protege/package.nix
@@ -11,17 +11,17 @@
 
 maven.buildMavenPackage rec {
   pname = "protege";
-  version = "5.6.4";
+  version = "5.6.8";
 
   src = fetchFromGitHub {
     owner = "protegeproject";
     repo = "protege";
     rev = version;
-    hash = "sha256-Q3MHa7nCeF31n7JPltcemFBc/sJwGA9Ev0ymjQhY/U0=";
+    hash = "sha256-GplMEVEBYSTTzrGzbHlbQTXqJYka6r0QfBZFVCS7wCs=";
   };
 
   mvnJdk = jdk11;
-  mvnHash = "sha256-kemP2gDv1CYuaoK0fwzBxdLTusarPasf2jCDQj/HPYE=";
+  mvnHash = "sha256-xC/zLPPLbQ8tZIkCZHOfY6FEaWXFF5ZC1LX4ovaSSqg=";
 
   patches = [
     # Pin built-in Maven plugins to avoid checksum variations on Maven updates


### PR DESCRIPTION
Protege 5.6.4 -> 5.6.8

Changelog: https://github.com/protegeproject/protege-distribution/releases/tag/protege-5.6.8

Updated the package to the latest version and regenerated enforce-plugin-versions.patch to match the new pom.xml structure.


- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

