### PR TITLE
nixos-rebuild-ng: don't pass local flake evaluation flags to remote builders

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
@@ -40,19 +40,23 @@ def get_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.ArgumentPa
     common_build_flags.add_argument("--print-build-logs", "-L", action="store_true")
     common_build_flags.add_argument("--show-trace", action="store_true")
 
+    # Flags that apply to both flake evaluation and building
     flake_common_flags = argparse.ArgumentParser(add_help=False, allow_abbrev=False)
-    flake_common_flags.add_argument("--accept-flake-config", action="store_true")
-    flake_common_flags.add_argument("--refresh", action="store_true")
-    flake_common_flags.add_argument("--impure", action="store_true")
     flake_common_flags.add_argument("--offline", action="store_true")
     flake_common_flags.add_argument("--no-net", action="store_true")
-    flake_common_flags.add_argument("--recreate-lock-file", action="store_true")
-    flake_common_flags.add_argument("--no-update-lock-file", action="store_true")
-    flake_common_flags.add_argument("--no-write-lock-file", action="store_true")
-    flake_common_flags.add_argument("--no-registries", action="store_true")
-    flake_common_flags.add_argument("--commit-lock-file", action="store_true")
-    flake_common_flags.add_argument("--update-input", action="append")
-    flake_common_flags.add_argument("--override-input", nargs=2, action="append")
+
+    # Flags that only apply during flake evaluation (and thus aren't passed to remote builders)
+    flake_eval_flags = argparse.ArgumentParser(add_help=False, allow_abbrev=False)
+    flake_eval_flags.add_argument("--accept-flake-config", action="store_true")
+    flake_eval_flags.add_argument("--refresh", action="store_true")
+    flake_eval_flags.add_argument("--impure", action="store_true")
+    flake_eval_flags.add_argument("--recreate-lock-file", action="store_true")
+    flake_eval_flags.add_argument("--no-update-lock-file", action="store_true")
+    flake_eval_flags.add_argument("--no-write-lock-file", action="store_true")
+    flake_eval_flags.add_argument("--no-registries", action="store_true")
+    flake_eval_flags.add_argument("--commit-lock-file", action="store_true")
+    flake_eval_flags.add_argument("--update-input", action="append")
+    flake_eval_flags.add_argument("--override-input", nargs=2, action="append")
 
     classic_build_flags = argparse.ArgumentParser(add_help=False, allow_abbrev=False)
     classic_build_flags.add_argument(
@@ -74,6 +78,7 @@ def get_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.ArgumentPa
         "common_flags": common_flags,
         "common_build_flags": common_build_flags,
         "flake_common_flags": flake_common_flags,
+        "flake_eval_flags": flake_eval_flags,
         "classic_build_flags": classic_build_flags,
         "copy_flags": copy_flags,
     }

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/models.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/models.py
@@ -150,8 +150,8 @@ class GroupedNixArgs:
     build_flags: Args
     common_flags: Args
     copy_flags: Args
+    flake_eval_flags: Args
     flake_build_flags: Args
-    flake_common_flags: Args
 
     @classmethod
     def from_parsed_args_groups(cls, args_groups: dict[str, Namespace]) -> Self:
@@ -159,6 +159,7 @@ class GroupedNixArgs:
         common_build_flags = common_flags | vars(args_groups["common_build_flags"])
         build_flags = common_build_flags | vars(args_groups["classic_build_flags"])
         flake_common_flags = common_flags | vars(args_groups["flake_common_flags"])
+        flake_eval_flags = vars(args_groups["flake_eval_flags"])
         flake_build_flags = common_build_flags | flake_common_flags
         copy_flags = common_flags | vars(args_groups["copy_flags"])
         # --no-build-output -> --no-link
@@ -169,8 +170,8 @@ class GroupedNixArgs:
             build_flags=build_flags,
             common_flags=common_flags,
             copy_flags=copy_flags,
+            flake_eval_flags=flake_eval_flags,
             flake_build_flags=flake_build_flags,
-            flake_common_flags=flake_common_flags,
         )
 
 

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/services.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/services.py
@@ -43,7 +43,9 @@ def reexec(
         drv = nix.build_flake(
             NIXOS_REBUILD_ATTR,
             flake,
-            grouped_nix_args.flake_build_flags | {"no_link": True},
+            grouped_nix_args.flake_build_flags
+            | grouped_nix_args.flake_eval_flags
+            | {"no_link": True},
         )
     else:
         build_attr = BuildAttr.from_arg(args.attr, args.file)
@@ -101,7 +103,8 @@ def _get_system_attr(
         case Action.BUILD_IMAGE if flake:
             variants = nix.get_build_image_variants_flake(
                 flake,
-                eval_flags=grouped_nix_args.flake_common_flags,
+                eval_flags=grouped_nix_args.flake_build_flags
+                | grouped_nix_args.flake_eval_flags,
             )
             _validate_image_variant(args.image_variant, variants)
             attr = f"config.system.build.images.{args.image_variant}"
@@ -164,7 +167,8 @@ def _build_system(
                 attr,
                 flake,
                 build_host,
-                eval_flags=grouped_nix_args.flake_common_flags,
+                eval_flags=grouped_nix_args.flake_build_flags
+                | grouped_nix_args.flake_eval_flags,
                 flake_build_flags={"no_link": no_link, "dry_run": dry_run}
                 | grouped_nix_args.flake_build_flags,
                 copy_flags=grouped_nix_args.copy_flags,
@@ -174,7 +178,8 @@ def _build_system(
                 attr,
                 flake,
                 flake_build_flags={"no_link": no_link, "dry_run": dry_run}
-                | grouped_nix_args.flake_build_flags,
+                | grouped_nix_args.flake_build_flags
+                | grouped_nix_args.flake_eval_flags,
             )
         case (Remote(_), None):
             path_to_config = nix.build_remote(
@@ -259,7 +264,8 @@ def _activate_system(
                 image_name = nix.get_build_image_name_flake(
                     flake,
                     args.image_variant,
-                    eval_flags=grouped_nix_args.flake_common_flags,
+                    eval_flags=grouped_nix_args.flake_build_flags
+                    | grouped_nix_args.flake_eval_flags,
                 )
             else:
                 image_name = nix.get_build_image_name(
@@ -322,7 +328,10 @@ def build_and_activate_system(
 
 def edit(flake: Flake | None, grouped_nix_args: GroupedNixArgs) -> None:
     if flake:
-        nix.edit_flake(flake, grouped_nix_args.flake_build_flags)
+        nix.edit_flake(
+            flake,
+            grouped_nix_args.flake_build_flags | grouped_nix_args.flake_eval_flags,
+        )
     else:
         nix.edit()
 
@@ -353,7 +362,10 @@ def repl(
     grouped_nix_args: GroupedNixArgs,
 ) -> None:
     if flake:
-        nix.repl_flake(flake, grouped_nix_args.flake_build_flags)
+        nix.repl_flake(
+            flake,
+            grouped_nix_args.flake_build_flags | grouped_nix_args.flake_eval_flags,
+        )
     else:
         nix.repl(build_attr, grouped_nix_args.build_flags)
 

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
@@ -73,13 +73,8 @@ def test_parse_args() -> None:
         "foo2",
         "bar2",
     ]
-    assert nr.utils.dict_to_flags(g1.flake_common_flags) == [
-        "--option",
-        "foo1",
-        "bar1",
-        "--option",
-        "foo2",
-        "bar2",
+    # flake_eval_flags contains only eval-specific flags
+    assert nr.utils.dict_to_flags(g1.flake_eval_flags) == [
         "--update-input",
         "input1",
         "--update-input",
@@ -90,6 +85,15 @@ def test_parse_args() -> None:
         "--override-input",
         "override2",
         "input2",
+    ]
+    # flake_build_flags contains common build flags (for remote builds)
+    assert nr.utils.dict_to_flags(g1.flake_build_flags) == [
+        "--option",
+        "foo1",
+        "bar1",
+        "--option",
+        "foo2",
+        "bar2",
     ]
 
     r2, g2 = nr.parse_args(

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_services.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_services.py
@@ -23,8 +23,8 @@ def test_reexec(mock_build: Mock, mock_execve: Mock, monkeypatch: MonkeyPatch) -
         build_flags={"build": True},
         common_flags={"common": True},
         copy_flags={"copy": True},
+        flake_eval_flags={"flake_eval": True},
         flake_build_flags={"flake_build": True},
-        flake_common_flags={"flake_common": True},
     )
     s.reexec(argv, args, grouped_nix_args)
     mock_build.assert_has_calls(
@@ -76,14 +76,14 @@ def test_reexec_flake(
         build_flags={"build": True},
         common_flags={"common": True},
         copy_flags={"copy": True},
+        flake_eval_flags={"flake_eval": True},
         flake_build_flags={"flake_build": True},
-        flake_common_flags={"flake_common": True},
     )
     s.reexec(argv, args, grouped_nix_args)
     mock_build.assert_called_once_with(
         s.NIXOS_REBUILD_ATTR,
         n.models.Flake(ANY, ANY),
-        {"flake_build": True, "no_link": True},
+        {"flake_build": True, "flake_eval": True, "no_link": True},
     )
     # do not exec if there is no new version
     mock_execve.assert_not_called()
@@ -122,8 +122,8 @@ def test_reexec_skip_if_already_reexec(mock_build: Mock, mock_execve: Mock) -> N
         build_flags={"build": True},
         common_flags={"common": True},
         copy_flags={"copy": True},
+        flake_eval_flags={"flake_eval": True},
         flake_build_flags={"flake_build": True},
-        flake_common_flags={"flake_common": True},
     )
     s.reexec(argv, args, grouped_nix_args)
     mock_build.assert_not_called()


### PR DESCRIPTION
When using `--build-host` and `--override-input`, `nixos-rebuild` currently passes `--override-input` to the remote builder, which obviously causes build failures if the overridden path is local.

## Things done

Filters out flags that are specific to evaluation so that they aren't passed to remote builders.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
