### PR TITLE
nixos-rebuild-ng: fix write_version_suffix with --file

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
@@ -298,7 +298,7 @@ def execute(argv: list[str]) -> None:
     flake = Flake.from_arg(args.flake, target_host)
 
     if can_run and not flake:
-        services.write_version_suffix(grouped_nix_args)
+        services.write_version_suffix(build_attr, grouped_nix_args)
 
     match action:
         case (

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
@@ -355,6 +355,38 @@ def get_build_image_variants(
     return j
 
 
+def get_nixpkgs_path_from_build_attr(
+    build_attr: BuildAttr,
+    instantiate_flags: Args | None = None,
+) -> Path | None:
+    path = (
+        f'"{build_attr.path.resolve()}"'
+        if isinstance(build_attr.path, Path)
+        else build_attr.path
+    )
+    r = run_wrapper(
+        [
+            "nix-instantiate",
+            "--eval",
+            "--strict",
+            "--expr",
+            textwrap.dedent(f"""
+            let
+              value = import {path};
+              set = if builtins.isFunction value then value {{}} else value;
+            in
+              set.{build_attr.to_attr("pkgs.path")}
+            """),
+            *dict_to_flags(instantiate_flags),
+        ],
+        stdout=PIPE,
+        check=False,
+    )
+    if r.returncode:
+        return None
+    return Path(r.stdout.strip())
+
+
 def get_build_image_variants_flake(
     flake: Flake,
     eval_flags: Args | None = None,

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/services.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/services.py
@@ -358,8 +358,11 @@ def repl(
         nix.repl(build_attr, grouped_nix_args.build_flags)
 
 
-def write_version_suffix(grouped_nix_args: GroupedNixArgs) -> None:
-    nixpkgs_path = nix.find_file("nixpkgs", grouped_nix_args.build_flags)
+def write_version_suffix(build_attr: BuildAttr, grouped_nix_args: GroupedNixArgs) -> None:
+    nixpkgs_path = nix.get_nixpkgs_path_from_build_attr(
+        build_attr,
+        instantiate_flags=grouped_nix_args.build_flags,
+    )
     rev = nix.get_nixpkgs_rev(nixpkgs_path)
     if nixpkgs_path and rev:
         try:

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
@@ -163,7 +163,20 @@ def test_execute_nix_boot(mock_run: Mock, tmp_path: Path) -> None:
     mock_run.assert_has_calls(
         [
             call(
-                ["nix-instantiate", "--find-file", "nixpkgs", "-vvv"],
+                [
+                    "nix-instantiate",
+                    "--eval",
+                    "--strict",
+                    "--expr",
+                    textwrap.dedent("""
+                    let
+                      value = import <nixpkgs/nixos>;
+                      set = if builtins.isFunction value then value {} else value;
+                    in
+                      set.pkgs.path
+                    """),
+                    "-vvv",
+                ],
                 stdout=PIPE,
                 check=False,
                 **DEFAULT_RUN_KWARGS,
@@ -552,8 +565,16 @@ def test_execute_nix_switch_build_target_host(
             call(
                 [
                     "nix-instantiate",
-                    "--find-file",
-                    "nixpkgs",
+                    "--eval",
+                    "--strict",
+                    "--expr",
+                    textwrap.dedent("""
+                    let
+                      value = import <nixpkgs/nixos>;
+                      set = if builtins.isFunction value then value {} else value;
+                    in
+                      set.pkgs.path
+                    """),
                     "--include",
                     "nixos-config=./configuration.nix",
                     "--include",
@@ -961,7 +982,19 @@ def test_execute_switch_rollback(mock_run: Mock, tmp_path: Path) -> None:
     mock_run.assert_has_calls(
         [
             call(
-                ["nix-instantiate", "--find-file", "nixpkgs"],
+                [
+                    "nix-instantiate",
+                    "--eval",
+                    "--strict",
+                    "--expr",
+                    textwrap.dedent("""
+                    let
+                      value = import <nixpkgs/nixos>;
+                      set = if builtins.isFunction value then value {} else value;
+                    in
+                      set.pkgs.path
+                    """),
+                ],
                 check=False,
                 stdout=PIPE,
                 **DEFAULT_RUN_KWARGS,


### PR DESCRIPTION
I started using nixos-rebuild-ng with `--file` recently and noticed that it was printing a misleading and useless error:

`error: file 'nixpkgs' was not found in the Nix search path (add it using $NIX_PATH or -I)`

I tracked this down to `services.write_version_suffix`, which looks on `NIX_PATH`, being called when it didn't make sense.

This now updates write_version_suffix to respect `--file` and `--attr`.

(The original version just skipped it.)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
