### PR TITLE
[staging-next] python314Packages.numpy: fix build with python3.14.1

### DIFF
--- a/pkgs/development/python-modules/numpy/2.nix
+++ b/pkgs/development/python-modules/numpy/2.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch2,
   python,
   numpy_2,
   pythonAtLeast,
@@ -73,12 +74,25 @@ buildPythonPackage rec {
     hash = "sha256-CMgJmsjPLgMCWN2iJk0OzcKIlnRRcayrTAns51S4B6k=";
   };
 
-  patches = lib.optionals python.hasDistutilsCxxPatch [
-    # We patch cpython/distutils to fix https://bugs.python.org/issue1222585
-    # Patching of numpy.distutils is needed to prevent it from undoing the
-    # patch to distutils.
-    ./numpy-distutils-C++.patch
-  ];
+  patches =
+    lib.optionals python.hasDistutilsCxxPatch [
+      # We patch cpython/distutils to fix https://bugs.python.org/issue1222585
+      # Patching of numpy.distutils is needed to prevent it from undoing the
+      # patch to distutils.
+      ./numpy-distutils-C++.patch
+    ]
+    ++
+      lib.optionals
+        (pythonAtLeast "3.14" && stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64)
+        [
+          # don't assert RecursionError in monster dtype test
+          # see https://github.com/numpy/numpy/pull/30375
+          (fetchpatch2 {
+            url = "https://github.com/numpy/numpy/commit/eeaf04662e07cc8e2041f3e25bbd3698949a0c02.patch?full_index=1";
+            excludes = [ ".github/workflows/macos.yml" ];
+            hash = "sha256-bLPLExlKnX18MXhbZxzCHniaAE0yTSyK9WuQyFyYHOI=";
+          })
+        ];
 
   postPatch = ''
     # remove needless reference to full Python path stored in built wheel


### PR DESCRIPTION
hydra failure: https://hydra.nixos.org/build/317371333
upstream issue: https://github.com/numpy/numpy/pull/30370
upsteam fix: https://github.com/numpy/numpy/pull/30375

we can simply skip the failing test. Here we use fetchpatch so we don't miss to delete this patch in the next numpy release.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
