### PR TITLE
everforest-gtk-theme: 0-unstable-2025-10-15 -> 0-unstable-2025-10-23

### DIFF
--- a/pkgs/by-name/ev/everforest-gtk-theme/package.nix
+++ b/pkgs/by-name/ev/everforest-gtk-theme/package.nix
@@ -4,17 +4,18 @@
   fetchFromGitHub,
   gnome-themes-extra,
   gtk-engine-murrine,
+  sassc,
 }:
 
 stdenvNoCC.mkDerivation {
   pname = "everforest-gtk-theme";
-  version = "0-unstable-2025-10-15";
+  version = "0-unstable-2025-10-23";
 
   src = fetchFromGitHub {
     owner = "Fausto-Korpsvart";
     repo = "Everforest-GTK-Theme";
-    rev = "930a5dc57f7a06e8c6538d531544e41c56dbb27a";
-    hash = "sha256-mlJE7gVElWUjJIZnAL5ztchphmaU82llol+YdKqnSxg=";
+    rev = "9b8be4d6648ae9eaae3dd550105081f8c9054825";
+    hash = "sha256-XHO6NoXJwwZ8gBzZV/hJnVq5BvkEKYWvqLBQT00dGdE=";
   };
 
   propagatedUserEnvPkgs = [
@@ -23,6 +24,7 @@ stdenvNoCC.mkDerivation {
 
   buildInputs = [
     gnome-themes-extra
+    sassc
   ];
 
   dontBuild = true;
@@ -31,9 +33,13 @@ stdenvNoCC.mkDerivation {
     runHook preInstall
     mkdir -p "$out/share/"{themes,icons}
     cp -a icons/* "$out/share/icons/"
-    cp -a themes/* "$out/share/themes/"
+    bash themes/install.sh -d "$out/share/themes" -c dark -n Everforest
+    bash themes/install.sh -d "$out/share/themes" -c light -n Everforest
     runHook postInstall
   '';
+  # Use either "Everforest-Dark" or "Everforest-Light" for the theme name.
+
+  dontFixup = true;
 
   meta = {
     description = "Everforest colour palette for GTK";


### PR DESCRIPTION
Package updated to latest commit from 2025-10-23.

I changed the installPhase because as it was the package didn't actually build anything and the theme didn't work. The theme now works, I've tested it using Home Manager with the following example config:
```nix
gtk = {
    enable = true;
    theme = {
        package = pkgs.everforest-gtk-theme;
        name = "Everforest-Dark";
    };
    iconTheme = {
        package = pkgs.everforest-gtk-theme;
        name = "Everforest-Dark";
    };
};
```
I disabled the `fixupPhase` because it seems like the build would hang indefinitely during this phase. I don't think it is necessary either since its mostly CSS files being produced.

This is my second PR (and the first one didn't go anywhere) so if I'm doing something wrong, I'm sorry and please let me know! I want to improve!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
