### PR TITLE
lm_sensors: fix configuration files being ignored

### DIFF
--- a/pkgs/by-name/lm/lm_sensors/package.nix
+++ b/pkgs/by-name/lm/lm_sensors/package.nix
@@ -62,8 +62,6 @@ stdenv.mkDerivation {
     "SBINDIR=${placeholder "bin"}/bin"
     "INCLUDEDIR=${placeholder "dev"}/include"
     "MANDIR=${placeholder "man"}/share/man"
-    # This is a dependency of the library.
-    "ETCDIR=${placeholder "out"}/etc"
     "BUILD_SHARED_LIB=${if stdenv.hostPlatform.isStatic then "0" else "1"}"
     "BUILD_STATIC_LIB=${if stdenv.hostPlatform.isStatic then "1" else "0"}"
 
@@ -71,6 +69,10 @@ stdenv.mkDerivation {
     "AR=${stdenv.cc.targetPrefix}ar"
   ]
   ++ lib.optional sensord "PROG_EXTRA=sensord";
+
+  installFlags = [
+    "ETCDIR=${placeholder "out"}/etc"
+  ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
This PR fixes an issue where lm_sensors would not use standard configuration files (`/etc/sensors3.conf` and `/etc/sensors.d/*`). To be completely honest, I'm not very sure what the options I tweaked actually do, so please verify before merging :). 

For reference, `git bisect` shows the issue originated in ca828efb7580de4b9eb623874a483b2ba7ca210b, so this fix just undoes the part that seems related.

Resolves #437830.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
