### PR TITLE
ncps: 0.4.0 -> 0.5.0

### DIFF
--- a/pkgs/by-name/nc/ncps/package.nix
+++ b/pkgs/by-name/nc/ncps/package.nix
@@ -3,6 +3,7 @@
   curl,
   dbmate,
   fetchFromGitHub,
+  go,
   lib,
   minio,
   minio-client,
@@ -24,6 +25,14 @@ let
     ldflags = [
       "-X github.com/kalbasit/ncps/cmd.Version=v${finalAttrs.version}"
     ];
+
+    # XXX: ncps is built with Go 1.25.5 that is available in release-25.11 but
+    # master is currently still using 1.25.4 (update waiting in the
+    # staging/staging-next branches.) This is a workaround for this issue and
+    # will automatically becomes no-op once Go is updated.
+    preBuild = lib.optionalString (go.version == "1.25.4") ''
+      sed -e 's:go 1.25.5:go 1.25.4:g' -i go.mod
+    '';
 
     vendorHash = "sha256-3YPKlz7+x7nYCqKmOroaiUyZGKIQMGFxcNyPnrA9Tio=";
 

--- a/pkgs/by-name/nc/ncps/package.nix
+++ b/pkgs/by-name/nc/ncps/package.nix
@@ -1,34 +1,112 @@
 {
   buildGoModule,
+  curl,
   dbmate,
   fetchFromGitHub,
   lib,
+  minio,
+  minio-client,
+  python3,
 }:
 
 let
   finalAttrs = {
     pname = "ncps";
-    version = "0.4.0";
+    version = "0.5.0";
 
     src = fetchFromGitHub {
       owner = "kalbasit";
       repo = "ncps";
       tag = "v${finalAttrs.version}";
-      hash = "sha256-A2HLbob9MHHCUNIC1OBwyFeE6KuEIdXW75hPSZMgicI=";
+      hash = "sha256-3ncDDJ0vqmM6Aer/qnEgGZ/eglFmY0oAnMsLJseMQg8=";
     };
 
     ldflags = [
       "-X github.com/kalbasit/ncps/cmd.Version=v${finalAttrs.version}"
     ];
 
-    vendorHash = "sha256-Plc1L23qOYj1evVIG+O3OxVAKVeEIA+Z6sP4Z/T1SxU=";
+    vendorHash = "sha256-3YPKlz7+x7nYCqKmOroaiUyZGKIQMGFxcNyPnrA9Tio=";
 
     doCheck = true;
     checkFlags = [ "-race" ];
 
     nativeBuildInputs = [
+      curl # used for checking MinIO health check
       dbmate # used for testing
+      minio # S3-compatible storage for integration tests
+      minio-client # mc CLI for MinIO setup
+      python3 # used for generating the ports
     ];
+
+    # Start MinIO before running tests to enable S3 integration tests
+    preCheck = ''
+      echo "🚀 Starting MinIO for S3 integration tests..."
+
+      # Create temporary directories for MinIO data and config
+      export MINIO_DATA_DIR=$(mktemp -d)
+      export HOME=$(mktemp -d)
+
+      # Configure MinIO credentials (must be set before starting MinIO)
+      export MINIO_ROOT_USER=admin
+      export MINIO_ROOT_PASSWORD=password
+      export MINIO_REGION=us-east-1
+
+      # Generate random free ports using python
+      # We bind to port 0, get the assigned port, and close the socket immediately.
+      # In a Nix sandbox, the race condition risk (port being stolen between check and use) is negligible.
+      export MINIO_PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("", 0)); print(s.getsockname()[1]); s.close()')
+      export CONSOLE_PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("", 0)); print(s.getsockname()[1]); s.close()')
+
+      # Export S3 test environment variables
+      export NCPS_TEST_S3_BUCKET="test-bucket"
+      export NCPS_TEST_S3_ENDPOINT="http://127.0.0.1:$MINIO_PORT"
+      export NCPS_TEST_S3_REGION="us-east-1"
+      export NCPS_TEST_S3_ACCESS_KEY_ID="test-access-key"
+      export NCPS_TEST_S3_SECRET_ACCESS_KEY="test-secret-key"
+
+      # Start MinIO server in background
+      minio server "$MINIO_DATA_DIR" \
+        --address "127.0.0.1:$MINIO_PORT" \
+        --console-address "127.0.0.1:$CONSOLE_PORT" &
+      export MINIO_PID=$!
+
+      # Wait for MinIO to be ready
+      echo "⏳ Waiting for MinIO to be ready..."
+      for i in {1..30}; do
+        if curl -sf "$NCPS_TEST_S3_ENDPOINT/minio/health/live"; then
+          echo "✅ MinIO is ready"
+          break
+        fi
+        if [ $i -eq 30 ]; then
+          echo "❌ MinIO failed to start"
+          kill $MINIO_PID 2>/dev/null || true
+          exit 1
+        fi
+        sleep 1
+      done
+
+      # Setup admin alias
+      mc alias set local "$NCPS_TEST_S3_ENDPOINT" "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD"
+
+      # Create test bucket
+      mc mb "local/$NCPS_TEST_S3_BUCKET" || true
+
+      # Create service account for tests
+      mc admin user svcacct add \
+        --access-key "$NCPS_TEST_S3_ACCESS_KEY_ID" \
+        --secret-key "$NCPS_TEST_S3_SECRET_ACCESS_KEY" \
+        local admin || true
+
+      echo "✅ MinIO configured for S3 integration tests"
+    '';
+
+    # Stop MinIO after tests complete
+    postCheck = ''
+      echo "🛑 Stopping MinIO..."
+      kill $MINIO_PID 2>/dev/null || true
+      rm -rf "$MINIO_DATA_DIR"
+      echo "✅ MinIO stopped and cleaned up"
+    '';
 
     postInstall = ''
       mkdir -p $out/share/ncps


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/kalbasit/ncps/releases/tag/v0.5.0

The build is currently failing because 25.11 has Go v1.25.5 but the master branch is still using Go 1.25.4. The version update is in staging, I will wait a bit before working around it...

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
