### PR TITLE
debian-patches.sh: fix lib prefix in url

### DIFF
--- a/maintainers/scripts/debian-patches.sh
+++ b/maintainers/scripts/debian-patches.sh
@@ -8,9 +8,16 @@ DEB_URL=https://sources.debian.org/data/main
 declare -a deb_patches
 mapfile -t deb_patches < $1
 
-# First letter
-deb_prefix="${deb_patches[0]:0:1}"
-prefix="${DEB_URL}/${deb_prefix}/${deb_patches[0]}/debian/patches"
+pkgname="${deb_patches[0]}"
+# See https://sources.debian.org/data/main/ for patterns of prefixes
+if [[ $pkgname == lib* ]]; then
+    sub_prefix="${pkgname:3:1}"
+    deb_prefix="lib${sub_prefix}"
+else
+    deb_prefix="${pkgname:0:1}"
+fi
+
+prefix="${DEB_URL}/${deb_prefix}/${pkgname}/debian/patches"
 
 if [[ -n "$2" ]]; then
     exec 1> $2


### PR DESCRIPTION
Found in https://github.com/NixOS/nixpkgs/pull/474520. For example, `libcryptui` is not `l` prefix, but `libc` prefix.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
