### PR TITLE
arcan: 0.7.0.1 -> 0.7.1

### DIFF
--- a/pkgs/by-name/ar/arcan/package.nix
+++ b/pkgs/by-name/ar/arcan/package.nix
@@ -4,7 +4,6 @@
   callPackage,
   cmake,
   espeak-ng,
-  fetchpatch2,
   ffmpeg,
   file,
   freetype,
@@ -163,17 +162,6 @@ stdenv.mkDerivation (finalAttrs: {
     + ''
       popd
     '';
-
-  patches = [
-    # Upstream patch to support ffmpeg 8
-    (fetchpatch2 {
-      name = "0001-build-fix-build-with-latest-ffmpeg.patch";
-      url = "https://chiselapp.com/user/letoram/repository/arcan/vpatch?from=cc6f24de2134282a&to=25bbde5eec7033d3";
-      hash = "sha256-i8d/X/xmEGWpO9fG6BerW//JnosPwDolXvMFsuv39IM=";
-      stripLen = 1;
-      extraPrefix = "src/";
-    })
-  ];
 
   postPatch = ''
     substituteInPlace ./src/platform/posix/paths.c \

--- a/pkgs/by-name/ar/arcan/sources.nix
+++ b/pkgs/by-name/ar/arcan/sources.nix
@@ -1,5 +1,6 @@
 {
   fetchFromGitHub,
+  fetchFromGitea,
 }:
 
 {
@@ -7,13 +8,14 @@
     let
       self = {
         pname = "arcan";
-        version = "0.7.0.1";
+        version = "0.7.1";
 
-        src = fetchFromGitHub {
+        src = fetchFromGitea {
+          domain = "codeberg.org";
           owner = "letoram";
           repo = "arcan";
           tag = self.version;
-          hash = "sha256-AbIMZOyEvRQzlmNetImLnBBoSaFUsy4k1NNSO0mI8FI=";
+          hash = "sha256-rADO6xLkUa3iIOSOR96fr1mR7wAUJpsSPoVn+CTNyOo=";
         };
       };
     in

--- a/pkgs/by-name/ca/cat9/package.nix
+++ b/pkgs/by-name/ca/cat9/package.nix
@@ -1,18 +1,19 @@
 {
   lib,
-  fetchFromGitHub,
+  fetchFromGitea,
   stdenvNoCC,
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "cat9";
-  version = "0-unstable-2024-06-17";
+  version = "0-unstable-2025-12-26";
 
-  src = fetchFromGitHub {
+  src = fetchFromGitea {
+    domain = "codeberg.org";
     owner = "letoram";
     repo = "cat9";
-    rev = "f00e8791c1826065d4a93ace12e55ab5732d17a7";
-    hash = "sha256-xFw6r7SQK0T5j7hVK3U39U2Q/qZow6Ad/R0Cl6nqUQw=";
+    rev = "8d2b30545c3e87c8f2e161d755b53c23a48bcf05";
+    hash = "sha256-KSXfa7K8SxnyPmSNCXZs8C+gGYxkLRu0MFbJ3cotSEQ=";
   };
 
   dontConfigure = true;

--- a/pkgs/by-name/du/durden/package.nix
+++ b/pkgs/by-name/du/durden/package.nix
@@ -1,18 +1,19 @@
 {
   lib,
   stdenvNoCC,
-  fetchFromGitHub,
+  fetchFromGitea,
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "durden";
-  version = "0-unstable-2024-06-23";
+  version = "0.6.3";
 
-  src = fetchFromGitHub {
+  src = fetchFromGitea {
+    domain = "codeberg.org";
     owner = "letoram";
     repo = "durden";
-    rev = "dffb94b69355ffa9cda074c1d0a48af74b78c220";
-    hash = "sha256-sBhlBk4vAYwedw4VerUfY80SXbVoEDid54si6qwDeXs=";
+    tag = finalAttrs.version;
+    hash = "sha256-dWLOLOICcVjqYTw8KAPM2/xgB9mTSEdGGIHD1WSrIvA=";
   };
 
   dontConfigure = true;

--- a/pkgs/by-name/xa/xarcan/package.nix
+++ b/pkgs/by-name/xa/xarcan/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitHub,
+  fetchFromGitea,
   arcan,
   audit,
   dbus,
@@ -40,15 +40,16 @@
   unstableGitUpdater,
 }:
 
-stdenv.mkDerivation (finalPackages: {
+stdenv.mkDerivation (finalPackages: rec {
   pname = "xarcan";
-  version = "0-unstable-2024-08-26";
+  version = "0.7.1";
 
-  src = fetchFromGitHub {
+  src = fetchFromGitea {
+    domain = "codeberg.org";
     owner = "letoram";
     repo = "xarcan";
-    rev = "5672116f627de492fb4df0b33d36b78041cd3931";
-    hash = "sha256-xZX6uLs/H/wONKrUnYxSynHK7CL7FDfzWvSjtXxT8es=";
+    tag = version;
+    hash = "sha256-j20Wz/Ae4QTincAPgMoj19EfKAPxIGm0Jgmi4sUR88o=";
   };
 
   nativeBuildInputs = [
@@ -114,7 +115,7 @@ stdenv.mkDerivation (finalPackages: {
   passthru.updateScript = unstableGitUpdater { };
 
   meta = {
-    homepage = "https://github.com/letoram/letoram";
+    homepage = "https://codeberg.org/letoram/xarcan";
     description = "Patched Xserver that bridges connections to Arcan";
     mainProgram = "Xarcan";
     longDescription = ''


### PR DESCRIPTION
## Things done

Update Arcan packages to the new 0.7.1 release and switch to the Codeberg mirror, as per the [release announcement](https://arcan-fe.com/2025/12/27/arcan-0-7-1-minutes-to-midnight/):
> It has been quite a while since we switched from GitHub to Fossil for development. Since we don’t expect people to tool around an uncommon tool we also mirror to git hosted on Codeberg.
>
> A final friendly warning to packagers is to use those repositories. The ones on GitHub will no longer receive any mirror updates and any changes over there are likely to be of a more incendiary nature.

The codeberg mirror seems the better option here, because the current fossil host (chiselapp.com) does not have the best uptime track record (due to the usual scraper reasons recently). If the fossil upstream moves to self-hosted in the future, we can probably switch to fossil instead.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
