### PR TITLE
srv: init at 0.1.0

### DIFF
--- a/pkgs/by-name/sr/srv/package.nix
+++ b/pkgs/by-name/sr/srv/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule rec {
+  pname = "srv";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "stubbedev";
+    repo = "srv";
+    rev = "v${version}";
+    hash = "sha256-iMoR72iZG4HfGDggyoJzMzo16eiSFKqqLBQF+aZ0m9g=";
+  };
+
+  vendorHash = "sha256-wwoPmFZGqFnPfWIDJ9H+g+d79F6FDB3gwFdrQLhlHHk=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.Version=${version}"
+    "-X main.Commit=${src.rev}"
+    "-X main.BuildDate=1970-01-01T00:00:00Z"
+  ];
+
+  meta = {
+    description = "CLI tool for managing sites with Traefik reverse proxy";
+    homepage = "https://github.com/stubbedev/srv";
+    changelog = "https://github.com/stubbedev/srv/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ];
+    mainProgram = "srv";
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION
## Description

Add `srv`, a CLI tool for managing sites with Traefik reverse proxy.

### Features
- Supports both production domains (automatic Let's Encrypt SSL) and local development (trusted *.test domains via mkcert)
- Docker-based deployment with Traefik reverse proxy
- Local DNS server integration for development domains
- Static site hosting with nginx
- Docker Compose site management

### Package Details
- **Homepage:** https://github.com/stubbedev/srv
- **License:** MIT
- **Platforms:** Unix-like systems

### Testing
Built successfully with `nix-build -A srv` on x86_64-linux.

### Checklist
- [x] Builds successfully
- [x] Tests pass (go tests included in build)
- [x] Package placed in correct location (`pkgs/by-name/sr/srv/`)
- [x] Proper meta attributes set
- [x] Used fetchFromGitHub with tagged release
- [x] vendorHash verified