### PR TITLE
[staging-next] ace-of-penguins: fix build with gcc 15

### DIFF
--- a/pkgs/by-name/ac/ace-of-penguins/fix-gcc-15.patch
+++ b/pkgs/by-name/ac/ace-of-penguins/fix-gcc-15.patch
@@ -1,0 +1,22 @@
+diff --git a/lib/table.c b/lib/table.c
+index befe696..cc08415 100644
+--- a/lib/table.c
++++ b/lib/table.c
+@@ -297,10 +297,11 @@ check_dclick(int x, int y, int t)
+ }
+ 
+ int help_is_showing = 0;
+-static void help_nothing() { help_is_showing = 0; }
++static void help_nothing(void) { help_is_showing = 0; }
++static void help_nothing_args(int a, int b, int c) { help_is_showing = 0; }
+ void (*help_redraw)(void) = help_nothing;
+-void (*help_click)(int x, int y, int b) = help_nothing;
+-void (*help_key)(int c, int x, int y) = help_nothing;
++void (*help_click)(int x, int y, int b) = help_nothing_args;
++void (*help_key)(int c, int x, int y) = help_nothing_args;
+ 
+ static int no_resize = 0;
+ void
+-- 
+2.51.2
+

--- a/pkgs/by-name/ac/ace-of-penguins/package.nix
+++ b/pkgs/by-name/ac/ace-of-penguins/package.nix
@@ -25,6 +25,8 @@ stdenv.mkDerivation (finalAttrs: {
     # make-imglib.c:205:5: error: 'return' with no value, in function returning non-void [-Wreturn-mismatch]
     # imagelib.c:109:17: error: implicit declaration of function 'malloc' [-Wimplicit-function-declaration]
     ./fix-gcc-14.patch
+    # error: initialization of 'void (*)(int,  int,  int)' from incompatible pointer type 'void (*)(void)' [-Wincompatible-pointer-types]
+    ./fix-gcc-15.patch
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
https://hydra.nixos.org/build/316530443
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
