### PR TITLE
imagemagick: fix cross compile

### DIFF
--- a/pkgs/by-name/im/imagemagick/package.nix
+++ b/pkgs/by-name/im/imagemagick/package.nix
@@ -174,7 +174,7 @@ stdenv.mkDerivation (finalAttrs: {
     configDestination=($out/share/ImageMagick-*)
     grep -v '/nix/store' $dev/lib/ImageMagick-*/config-Q16HDRI/configure.xml > $configDestination/configure.xml
     for file in "$dev"/bin/*-config; do
-      substituteInPlace "$file" --replace pkg-config \
+      substituteInPlace "$file" --replace-fail "$PKG_CONFIG" \
         "PKG_CONFIG_PATH='$dev/lib/pkgconfig' '$(command -v $PKG_CONFIG)'"
     done
   ''

--- a/pkgs/development/php-packages/imagick/default.nix
+++ b/pkgs/development/php-packages/imagick/default.nix
@@ -10,7 +10,7 @@ buildPecl {
   pname = "imagick";
 
   version = "3.8.1";
-  sha256 = "sha256-OjWHwKUkwX0NrZZzoWC5DNd26DaDhHThc7VJ7YZDUu4=";
+  hash = "sha256-OjWHwKUkwX0NrZZzoWC5DNd26DaDhHThc7VJ7YZDUu4=";
 
   configureFlags = [ "--with-imagick=${imagemagick.dev}" ];
 

--- a/pkgs/development/php-packages/imagick/default.nix
+++ b/pkgs/development/php-packages/imagick/default.nix
@@ -1,11 +1,9 @@
 {
   buildPecl,
-  fetchpatch,
   lib,
   imagemagick,
   pkg-config,
   pcre2,
-  php,
 }:
 
 buildPecl {
@@ -15,7 +13,11 @@ buildPecl {
   sha256 = "sha256-OjWHwKUkwX0NrZZzoWC5DNd26DaDhHThc7VJ7YZDUu4=";
 
   configureFlags = [ "--with-imagick=${imagemagick.dev}" ];
+
+  depsBuildBuild = [ pkg-config ];
+
   nativeBuildInputs = [ pkg-config ];
+
   buildInputs = [ pcre2 ];
 
   meta = {


### PR DESCRIPTION
Fix RiscV cross-compilation in imagick and imagemagick

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
