### PR TITLE
aefs: fix build with c23

### DIFF
--- a/pkgs/by-name/ae/aefs/fix-build-with-c23.patch
+++ b/pkgs/by-name/ae/aefs/fix-build-with-c23.patch
@@ -1,0 +1,75 @@
+From 5fbcd63a4fb8baca13184a2cc718ebf3ebbef245 Mon Sep 17 00:00:00 2001
+From: Moraxyc <i@qaq.li>
+Date: Sun, 28 Dec 2025 00:24:11 +0800
+Subject: [PATCH] fix build with c23
+
+---
+ emxdoc/input.c | 10 +++++-----
+ system/types.h |  5 +----
+ 2 files changed, 6 insertions(+), 9 deletions(-)
+
+diff --git a/emxdoc/input.c b/emxdoc/input.c
+index 50fd7a0..7d9ad4a 100644
+--- a/emxdoc/input.c
++++ b/emxdoc/input.c
+@@ -31,7 +31,7 @@ Boston, MA 02111-1307, USA.  */
+ struct cond
+ {
+   int start_line;
+-  int true;
++  int is_true;
+   int else_seen;
+ };
+ 
+@@ -225,7 +225,7 @@ redo:
+           if (cond_sp + 1 >= COND_STACK_SIZE)
+             fatal ("%s:%d: Conditional stack overflow", input_fname, line_no);
+           ++cond_sp;
+-          cond_stack[cond_sp].true = c1;
++          cond_stack[cond_sp].is_true = c1;
+           cond_stack[cond_sp].start_line = line_no;
+           cond_stack[cond_sp].else_seen = FALSE;
+           goto redo;
+@@ -240,7 +240,7 @@ redo:
+                    input_fname, line_no, escape, escape,
+                    cond_stack[cond_sp].start_line);
+           cond_stack[cond_sp].else_seen = TRUE;
+-          cond_stack[cond_sp].true = !cond_stack[cond_sp].true;
++          cond_stack[cond_sp].is_true = !cond_stack[cond_sp].is_true;
+           goto redo;
+         }
+       else if (strcmp (p, "endif") == 0)
+@@ -254,12 +254,12 @@ redo:
+       else if (p[0] == 'h' && p[1] >= '1' && p[1] <= '0' + SECTION_LEVELS)
+         {
+           /* Support h1 inside if */
+-          if (cond_sp >= 0 && !cond_stack[cond_sp].true)
++          if (cond_sp >= 0 && !cond_stack[cond_sp].is_true)
+             ++ref_no;
+         }
+     }
+ 
+-  if (cond_sp >= 0 && !cond_stack[cond_sp].true)
++  if (cond_sp >= 0 && !cond_stack[cond_sp].is_true)
+     goto redo;
+ 
+   p = input;
+diff --git a/system/types.h b/system/types.h
+index 48b8013..327833f 100644
+--- a/system/types.h
++++ b/system/types.h
+@@ -21,10 +21,7 @@
+ #define _TYPES_H
+ 
+ #include "config.h"
+-
+-
+-/* Booleans (C++/C99) style. */
+-typedef int bool;
++#include <stdbool.h>
+ 
+ #ifndef true
+ #define true 1
+-- 
+2.51.2
+

--- a/pkgs/by-name/ae/aefs/package.nix
+++ b/pkgs/by-name/ae/aefs/package.nix
@@ -18,6 +18,11 @@ stdenv.mkDerivation {
     hash = "sha256-a3YQWxJ7+bYhf1W1kdIykV8U1R4dcDZJ7K3NvNxbF0s=";
   };
 
+  # fix build with c23
+  #   ../system/types.h:27:13: error: 'bool' cannot be defined via 'typedef'
+  #   input.c:228:31: error: expected identifier before 'true'
+  patches = [ ./fix-build-with-c23.patch ];
+
   # autoconf's AC_CHECK_HEADERS and AC_CHECK_LIBS fail to detect libfuse on
   # Darwin if FUSE_USE_VERSION isn't set at configure time.
   #


### PR DESCRIPTION
https://hydra.nixos.org/build/316530732
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
