### PR TITLE
nixos/freshrss: improve + nixosTests.freshrss: improve

### DIFF
--- a/nixos/modules/services/web-apps/freshrss.nix
+++ b/nixos/modules/services/web-apps/freshrss.nix
@@ -357,15 +357,15 @@ in
 
           script =
             let
+              isUserAuth = cfg.authType == "form" || cfg.authType == "none";
+
               userScriptArgs = ''--user ${cfg.defaultUser} ${
                 optionalString (cfg.authType == "form") ''--password "$(cat ${cfg.passwordFile})"''
               }'';
-              updateUserScript = optionalString (cfg.authType == "form" || cfg.authType == "none") ''
-                ./cli/update-user.php ${userScriptArgs}
-              '';
-              createUserScript = optionalString (cfg.authType == "form" || cfg.authType == "none") ''
-                ./cli/create-user.php ${userScriptArgs}
-              '';
+              mkUserScript = name: optionalString isUserAuth ''./cli/${name}.php ${userScriptArgs}'';
+
+              updateUserScript = mkUserScript "update-user";
+              createUserScript = mkUserScript "create-user";
             in
             ''
               # do installation or reconfigure

--- a/nixos/tests/freshrss/caddy-sqlite.nix
+++ b/nixos/tests/freshrss/caddy-sqlite.nix
@@ -22,7 +22,7 @@
   testScript = ''
     machine.wait_for_unit("multi-user.target")
     machine.wait_for_open_port(80)
-    response = machine.succeed("curl -vvv -s -H 'Host: freshrss' http://localhost:80/i/")
+    response = machine.succeed("curl --fail-with-body --silent --header 'Host: freshrss' http://localhost:80/i/")
     assert '<title>Login · FreshRSS</title>' in response, "Login page didn't load successfully"
   '';
 }

--- a/nixos/tests/freshrss/extensions.nix
+++ b/nixos/tests/freshrss/extensions.nix
@@ -20,17 +20,18 @@
   ];
 
   testScript = ''
+    from lxml import etree
+
     machine.wait_for_unit("multi-user.target")
     machine.wait_for_open_port(80)
-    response = machine.succeed("curl -s http://localhost:80/i/?c=extension")
+    response = machine.succeed("curl --fail-with-body --silent http://localhost:80/i/?c=extension")
     assert '<span class="ext_name disabled">YouTube Video Feed</span>' in response, "Extension not present in extensions page."
 
     # enable Title-Wrap extension
-    from lxml import etree
     tree = etree.HTML(response)
     csrf = tree.xpath("/html/body/header/nav/form/input/@value")[0]
-    response = machine.succeed(f"curl --fail-with-body -s 'http://localhost:80/i/?c=extension&a=enable&e=Title-Wrap' -d '_csrf={csrf}'")
+    machine.succeed(f"curl --fail-with-body --silent 'http://localhost:80/i/?c=extension&a=enable&e=Title-Wrap' -d '_csrf={csrf}'")
     # verify that the Title-Wrap css is accessible.
-    machine.succeed("curl --fail-with-body -s 'http://localhost:80/ext.php?1=&f=xExtension-TitleWrap/static/title_wrap.css'")
+    machine.succeed("curl --fail-with-body --silent 'http://localhost:80/ext.php?1=&f=xExtension-TitleWrap/static/title_wrap.css'")
   '';
 }

--- a/nixos/tests/freshrss/http-auth.nix
+++ b/nixos/tests/freshrss/http-auth.nix
@@ -15,7 +15,7 @@
   testScript = ''
     machine.wait_for_unit("multi-user.target")
     machine.wait_for_open_port(80)
-    response = machine.succeed("curl -vvv -s -H 'Host: freshrss' -H 'Remote-User: testuser' http://localhost:80/i/")
+    response = machine.succeed("curl --fail-with-body --silent -H 'Remote-User: testuser' http://localhost:80/i/")
     assert 'Account: testuser' in response, "http_auth method didn't work."
   '';
 }

--- a/nixos/tests/freshrss/nginx-sqlite.nix
+++ b/nixos/tests/freshrss/nginx-sqlite.nix
@@ -20,7 +20,7 @@
   testScript = ''
     machine.wait_for_unit("multi-user.target")
     machine.wait_for_open_port(80)
-    response = machine.succeed("curl -vvv -s -H 'Host: freshrss' http://localhost:80/i/")
+    response = machine.succeed("curl --fail-with-body --silent http://localhost:80/i/")
     assert '<title>Login · FreshRSS</title>' in response, "Login page didn't load successfully"
   '';
 }

--- a/nixos/tests/freshrss/none-auth.nix
+++ b/nixos/tests/freshrss/none-auth.nix
@@ -14,7 +14,7 @@
   testScript = ''
     machine.wait_for_unit("multi-user.target")
     machine.wait_for_open_port(80)
-    response = machine.succeed("curl -vvv -s http://localhost:80/i/")
+    response = machine.succeed("curl --fail-with-body --silent http://localhost:80/i/")
     assert '<title> · FreshRSS</title>' in response, "FreshRSS stream page didn't load successfully"
   '';
 }

--- a/nixos/tests/freshrss/pgsql.nix
+++ b/nixos/tests/freshrss/pgsql.nix
@@ -46,7 +46,7 @@
     machine.wait_for_unit("multi-user.target")
     machine.wait_for_open_port(5432)
     machine.wait_for_open_port(80)
-    response = machine.succeed("curl -vvv -s -H 'Host: freshrss' http://localhost:80/i/")
+    response = machine.succeed("curl --fail-with-body --silent http://localhost:80/i/")
     assert '<title>Login · FreshRSS</title>' in response, "Login page didn't load successfully"
   '';
 }

--- a/pkgs/servers/web-apps/freshrss/extensions/default.nix
+++ b/pkgs/servers/web-apps/freshrss/extensions/default.nix
@@ -9,12 +9,12 @@
 let
   buildFreshRssExtension = (callPackage ./freshrss-utils.nix { }).buildFreshRssExtension;
 
-  official_extensions_version = "unstable-2024-04-27";
+  official_extensions_version = "unstable-2025-12-26";
   official_extensions_src = fetchFromGitHub {
     owner = "FreshRSS";
     repo = "Extensions";
-    rev = "71de129744ba37fd4cf363b78445f5345bc6d0b7";
-    hash = "sha256-A+hOjbGNfhwTOAMeo08MUdqfWxxetzLz865oQQDsQlg=";
+    rev = "42c32bfd9af2d816933cf310e24d25888a8e167d";
+    hash = "sha256-El488QK3xWQM01GsuyBizud6VghXsRDqiOblnMfjVxE=";
   };
 
   baseExtensions =
@@ -102,6 +102,20 @@ let
         meta = {
           description = "FreshRSS extension instead of truncating the title is wrapped";
           homepage = "https://github.com/FreshRSS/Extensions/tree/master/xExtension-TitleWrap";
+          license = lib.licenses.agpl3Only;
+          maintainers = [ lib.maintainers.stunkymonkey ];
+        };
+      };
+
+      unsafe-auto-login = buildFreshRssExtension {
+        FreshRssExtUniqueId = "UnsafeAutologin";
+        pname = "unsafe-auto-login";
+        version = official_extensions_version;
+        src = official_extensions_src;
+        sourceRoot = "${official_extensions_src.name}/xExtension-UnsafeAutologin";
+        meta = {
+          description = "FreshRSS extension to bring back unsafe autologin functionality.";
+          homepage = "https://github.com/FreshRSS/Extensions/tree/master/xExtension-UnsafeAutologin";
           license = lib.licenses.agpl3Only;
           maintainers = [ lib.maintainers.stunkymonkey ];
         };


### PR DESCRIPTION
followup from #473921

ping @edwrap

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
