### PR TITLE
haskell.compiler.ghc9123: init at 9.12.3

### DIFF
--- a/pkgs/development/compilers/ghc/9.12.3.nix
+++ b/pkgs/development/compilers/ghc/9.12.3.nix
@@ -1,0 +1,4 @@
+import ./common-hadrian.nix {
+  version = "9.12.3";
+  sha256 = "209023906ce460e5288c9844b728a7f704868269489dc724ed097da550f6e869";
+}

--- a/pkgs/development/haskell-modules/configuration-ghc-9.12.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.12.x.nix
@@ -126,7 +126,5 @@ with haskellLib;
   # Test failure because of GHC bug:
   #   https://gitlab.haskell.org/ghc/ghc/-/issues/25937
   #   https://github.com/sol/interpolate/issues/20
-  interpolate =
-    assert super.ghc.version == "9.12.2";
-    dontCheck super.interpolate;
+  interpolate = dontCheckIf (lib.versionOlder self.ghc.version "9.12.3") super.interpolate;
 }

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -178,6 +178,14 @@ in
         inherit (buildPackages.darwin) xattr autoSignDarwinBinariesHook;
         inherit buildTargetLlvmPackages llvmPackages;
       };
+      ghc9123 = callPackage ../development/compilers/ghc/9.12.3.nix {
+        bootPkgs =
+          # No suitable bindist packaged yet
+          bb.packages.ghc9103;
+        inherit (buildPackages.python3Packages) sphinx;
+        inherit (buildPackages.darwin) xattr autoSignDarwinBinariesHook;
+        inherit buildTargetLlvmPackages llvmPackages;
+      };
       ghc912 = compiler.ghc9122;
       ghc9141 = callPackage ../development/compilers/ghc/9.14.1.nix {
         bootPkgs =
@@ -287,6 +295,11 @@ in
       ghc9122 = callPackage ../development/haskell-modules {
         buildHaskellPackages = bh.packages.ghc9122;
         ghc = bh.compiler.ghc9122;
+        compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-9.12.x.nix { };
+      };
+      ghc9123 = callPackage ../development/haskell-modules {
+        buildHaskellPackages = bh.packages.ghc9123;
+        ghc = bh.compiler.ghc9123;
         compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-9.12.x.nix { };
       };
       ghc912 = packages.ghc9122;

--- a/pkgs/top-level/release-haskell.nix
+++ b/pkgs/top-level/release-haskell.nix
@@ -68,7 +68,8 @@ let
     ghc984
     ghc9102
     ghc9103
-    ghc9122
+    ghc9122 # TODO(@sternenseemann): drop
+    ghc9123
   ];
 
   # packagePlatforms applied to `haskell.packages.*`
@@ -540,6 +541,7 @@ let
       Cabal_3_10_3_0 = lib.subtractLists [
         # time < 1.13 conflicts with time == 1.14.*
         compilerNames.ghc9122
+        compilerNames.ghc9123
       ] released;
       Cabal_3_12_1_0 = released;
       Cabal_3_14_2_0 = released;
@@ -558,6 +560,7 @@ let
         compilerNames.ghc9102
         compilerNames.ghc9103
         compilerNames.ghc9122
+        compilerNames.ghc9123
       ] released;
       hpack = released;
       hsdns = released;
@@ -570,9 +573,11 @@ let
       ghc-lib-parser-ex = released;
       ghc-source-gen = lib.subtractLists [
         compilerNames.ghc9122
+        compilerNames.ghc9123
       ] released;
       ghc-tags = lib.subtractLists [
         compilerNames.ghc9122
+        compilerNames.ghc9123
       ] released;
       hashable = released;
       primitive = released;
@@ -585,6 +590,7 @@ let
         compilerNames.ghc9102
         compilerNames.ghc9103
         compilerNames.ghc9122
+        compilerNames.ghc9123
       ] released;
     })
     {


### PR DESCRIPTION
https://www.haskell.org/ghc/blog/20251227-ghc-9.12.3-released.html


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
