### PR TITLE
slidev-cli: init at 52.11.1

### DIFF
--- a/pkgs/by-name/sl/slidev-cli/package.nix
+++ b/pkgs/by-name/sl/slidev-cli/package.nix
@@ -1,0 +1,83 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchPnpmDeps,
+  pnpm,
+  nodejs,
+  pnpmConfigHook,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "slidev-cli";
+  version = "52.11.1";
+
+  src = fetchFromGitHub {
+    owner = "slidevjs";
+    repo = "slidev";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-AYU36NsALC4CCZVr+1PmspX6RKZkxI2xpLNUSccEPwY=";
+  };
+
+  pnpmWorkspaces = [ "@slidev/cli..." ];
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs)
+      pname
+      version
+      src
+      pnpmWorkspaces
+      ;
+    fetcherVersion = 3;
+    hash = "sha256-nZPyqP4NruVIzONHIT6hx1Px9p8mHTK9Xt5wHEcpwBM=";
+  };
+
+  nativeBuildInputs = [
+    nodejs
+    pnpmConfigHook
+    pnpm
+  ];
+
+  buildInputs = [
+    nodejs
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    pnpm -r --filter=@slidev/cli... --parallel run build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    rm -rf node_modules packages/slidev/node_modules
+    pnpm install --force --offline --production --ignore-scripts --filter=@slidev/cli...
+
+    mkdir -p $out/lib/node_modules/slidev-cli/
+    mkdir $out/bin
+    mv ./packages ./node_modules ./package.json $out/lib/node_modules/slidev-cli
+
+    ln -s $out/lib/node_modules/slidev-cli/packages/slidev/bin/slidev.mjs $out/bin/slidev
+    chmod +x $out/bin/slidev
+    patchShebangs $out/bin/slidev
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    changelog = "https://github.com/slidevjs/slidev/releases/tag/v${finalAttrs.version}";
+    description = "Presentation slides for developers";
+    homepage = "https://sli.dev";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      pyrox0
+      pluiedev
+    ];
+    mainProgram = "slidev";
+  };
+})


### PR DESCRIPTION
773 megs of dependencies even after filtering to prod deps this package sucks lmao

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
