### PR TITLE
dash-mpd-cli: enable sandbox feature on Linux

### DIFF
--- a/pkgs/by-name/da/dash-mpd-cli/dash-mpd-rs-nix-sandbox.patch
+++ b/pkgs/by-name/da/dash-mpd-cli/dash-mpd-rs-nix-sandbox.patch
@@ -1,0 +1,14 @@
+diff --git a/src/sandbox.rs b/src/sandbox.rs
+index df19776..990a550 100644
+--- a/src/sandbox.rs
++++ b/src/sandbox.rs
+@@ -143,8 +143,7 @@ pub fn restrict_thread(downloader: &DashDownloader) -> Result<(), DashMpdError>
+     rw_dirs.push(String::from(cwd.to_string_lossy()));
+     trace!("Sandbox: allowing r+w filesystem access to directories {rw_dirs:?}");
+     let mut rx_dirs = Vec::new();
+-    rx_dirs.push(String::from("/usr"));
+-    rx_dirs.push(String::from("/lib"));
++    rx_dirs.push(String::from("@storeDir@"));
+     // We need to add all the directories on the $PATH environment variable, because the default
+     // values of ffmpeg_location and so on are filenames without directory, so if they are in a
+     // non-standard directory we need to make that accessible.

--- a/pkgs/by-name/da/dash-mpd-cli/package.nix
+++ b/pkgs/by-name/da/dash-mpd-cli/package.nix
@@ -4,18 +4,24 @@
   rustPlatform,
   fetchFromGitHub,
   makeWrapper,
-  bento4,
   protobuf,
+  bento4,
   ffmpeg,
   gpac,
   libxslt,
   shaka-packager,
   nix-update-script,
+  replaceVars,
   runCommand,
   versionCheckHook,
 }:
 
 let
+  # Patch the dash-mpd crate to allow access to the Nix store in the sandbox.
+  dash-mpd-patch = replaceVars ./dash-mpd-rs-nix-sandbox.patch {
+    storeDir = builtins.storeDir;
+  };
+
   # dash-mpd-cli looks for a binary named `shaka-packager`, while
   # shaka-packager provides `packager`.
   shaka-packager-wrapped = runCommand "shaka-packager-wrapped" { } ''
@@ -37,6 +43,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
   cargoHash = "sha256-MmZwiH1Qzb5MiwhEYsCVo4xD5YmJ+mObpkgc6J0sfuw=";
 
   __structuredAttrs = true;
+
+  postPatch = ''
+    patch -d $cargoDepsCopy/*/dash-mpd-* -i ${dash-mpd-patch} -p 1
+  '';
+
+  buildFeatures = lib.optionals stdenvNoCC.hostPlatform.isLinux [ "sandbox" ];
 
   nativeBuildInputs = [
     makeWrapper


### PR DESCRIPTION
dash-mpd-cli 0.2.29 added experimental support for sandboxing using the Landlock LSM on Linux. By default dash-mpd-cli allows [read and execute permissions for /lib, /usr, and any paths in $PATH and $LD_LIBRARY_PATH][1]. This does not work as-is on Nix as the dynamic libraries used by the runtime binaries (such as ffmpeg) do not live under /lib or /usr. Instead, patch the dash-mpd-rs crate to allow /nix in the sandbox.

[1]: https://github.com/emarsden/dash-mpd-rs/blob/7d0ee20f5686a409e1c263c55fdd7832aca0c141/src/sandbox.rs#L44-L51

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
