### PR TITLE
glfw3: add window position minecraft patch

### DIFF
--- a/pkgs/by-name/gl/glfw3/package.nix
+++ b/pkgs/by-name/gl/glfw3/package.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation {
   };
 
   # Fix linkage issues on X11 (https://github.com/NixOS/nixpkgs/issues/142583)
-  patches = [ ./x11.patch ];
+  patches = [ ./x11.patch ] ++ (lib.optional withMinecraftPatch ./window-position.patch);
   prePatch = lib.optionalString withMinecraftPatch ''
     patches+=(${minecraftPatches}/patches/*.patch)
   '';

--- a/pkgs/by-name/gl/glfw3/window-position.patch
+++ b/pkgs/by-name/gl/glfw3/window-position.patch
@@ -1,0 +1,30 @@
+From 807d9b0efe86e85a54cd2daf7da2ba1591b39f14 Mon Sep 17 00:00:00 2001
+From: uku <hi@uku.moe>
+Date: Sat, 27 Dec 2025 19:25:42 +0100
+Subject: [PATCH] fix: dismiss warning about window position being unavailable
+
+In addition to the other glfw patches, this one is required on certain
+compositors such as niri and waywall to be able to launch Minecraft at
+all.
+---
+ src/wl_window.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/wl_window.c b/src/wl_window.c
+index ad39b2e0..38f86a17 100644
+--- a/src/wl_window.c
++++ b/src/wl_window.c
+@@ -2293,8 +2293,8 @@ void _glfwGetWindowPosWayland(_GLFWwindow* window, int* xpos, int* ypos)
+     // A Wayland client is not aware of its position, so just warn and leave it
+     // as (0, 0)
+ 
+-    _glfwInputError(GLFW_FEATURE_UNAVAILABLE,
+-                    "Wayland: The platform does not provide the window position");
++    fprintf(stderr,
++            "[GLFW] Wayland: The platform does not provide the window position\n");
+ }
+ 
+ void _glfwSetWindowPosWayland(_GLFWwindow* window, int xpos, int ypos)
+-- 
+2.51.2
+


### PR DESCRIPTION
In addition to the other glfw patches, this one is required on certain compositors such as niri and waywall to be able to launch Minecraft at all.

Tested on GNOME and Niri, both with and without waywall.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
