### PR TITLE
nixos/test-driver: Use pytest assertion rewriting

### DIFF
--- a/nixos/lib/test-driver/default.nix
+++ b/nixos/lib/test-driver/default.nix
@@ -12,6 +12,7 @@
   python,
   ruff,
   remote-pdb,
+  pytest,
 
   netpbm,
   nixosTests,
@@ -43,6 +44,7 @@ buildPythonApplication {
     junit-xml
     ptpython
     remote-pdb
+    pytest
   ]
   ++ extraPythonPackages python.pkgs;
 


### PR DESCRIPTION
This switches NixOS tests to use pytest's assertion rewriting mechanism, so that we get more useful information from failures.

For example when forging a random test (adm-sev.nix) that uses assertions to fail instead, without assertion rewriting the error looks like this:

```
!!! Test "Check default settings" failed with error: ""
```

With assertion rewritiing it looks like this:

```
!!! Test "Check default settings" failed with error: "assert 'sev::' in 'root:x:0:\nwheel:x:1:\nkmem:x:2:\ntty:x:3:\nmessagebus:x:4:\ndisk:x:6:\naudio:x:17:\nfloppy:x:18:\nuucp:x:19:\nlp:x:2...xbld28,nixbld29,nixbld3,nixbld30,nixbld31,nixbld32,nixbld4,nixbld5,nixbld6,nixbld7,nixbld8,nixbld9\nnogroup:x:65534:\n'"
```

So you actually know what's going on and don't need to litter your code with things like `assert <foo>, "some context here"`.

I did this mainly because I like to write a lot of tests in my deployments and do all the pytest assertion rewriting dance downstream, but I thought it would be a good idea to actually have this available for all NixOS tests.

The reason why I hesitated so far was that it relies on internal code of pytest, but given that I already use this for the systemd-confinement tests since almost two years and in my deployments for even longer (around 4 years), I'd consider this to be a very minor maintenance burden.

In addition to that, if we someday don't have or want to maintain this part of the code anymore, we can simply drop it and all we get are less useful assertions.

Hydra jobset: https://hydra.build/jobset/aszlig/nixos-test-assertions
Hydra evaluation of this change: https://hydra.build/eval/544619

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
