### PR TITLE
python3Packages.langsmith: 0.4.59 -> 0.5.1

### DIFF
--- a/pkgs/development/python-modules/langsmith/default.nix
+++ b/pkgs/development/python-modules/langsmith/default.nix
@@ -18,16 +18,14 @@
 
   # tests
   anthropic,
+  attrs,
   dataclasses-json,
-  fastapi,
-  freezegun,
-  instructor,
+  multipart,
   opentelemetry-sdk,
   pytest-asyncio,
+  pytest-socket,
   pytest-vcr,
   pytestCheckHook,
-  uvicorn,
-  attr,
 }:
 
 buildPythonPackage rec {
@@ -60,46 +58,41 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     anthropic
+    attrs
     dataclasses-json
-    fastapi
-    freezegun
-    instructor
     opentelemetry-sdk
     pytest-asyncio
+    multipart
+    pytest-socket
     pytest-vcr
     pytestCheckHook
-    uvicorn
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isLinux [ attr ];
+  ];
+
+  # evaluation and external tests require OpenAPI key
+  # integration tests are all marked flaky
+  enabledTestPaths = [
+    "tests/unit_tests"
+  ];
+
+  disabledTestMarks = [
+    "flaky"
+  ];
 
   disabledTests = [
-    # These tests require network access
-    "integration_tests"
     # due to circular import
     "test_as_runnable"
     "test_as_runnable_batch"
     "test_as_runnable_async"
     "test_as_runnable_async_batch"
-    # Test requires git repo
-    "test_git_info"
-    # Tests require OpenAI API key
-    "test_chat_async_api"
-    "test_chat_sync_api"
-    "test_completions_async_api"
-    "test_completions_sync_api"
   ];
 
   disabledTestPaths = [
-    # Circular import
-    "tests/integration_tests/"
+    # due to circular import
     "tests/unit_tests/test_client.py"
     "tests/unit_tests/evaluation/test_runner.py"
-    "tests/unit_tests/evaluation/test_runner.py"
-    # Require a Langsmith API key
-    "tests/evaluation/test_evaluation.py"
-    "tests/external/test_instructor_evals.py"
-    # Marked as flaky in source
-    "tests/unit_tests/test_run_helpers.py"
+    # flaky time comparisons
+    # https://github.com/langchain-ai/langsmith-sdk/issues/2245
+    "tests/unit_tests/test_uuid_v7.py"
   ];
 
   pythonImportsCheck = [ "langsmith" ];

--- a/pkgs/development/python-modules/langsmith/default.nix
+++ b/pkgs/development/python-modules/langsmith/default.nix
@@ -30,14 +30,14 @@
 
 buildPythonPackage rec {
   pname = "langsmith";
-  version = "0.4.59";
+  version = "0.5.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langsmith-sdk";
     tag = "v${version}";
-    hash = "sha256-IL1lwV+WkIpYAlx+n08XlzbvzyDMUQCCZKmA+ImBIqU=";
+    hash = "sha256-6iJk8JfGIhrAcEXrsJKWn0G2jJ2kitWjx/YJCWcGNfY=";
   };
 
   sourceRoot = "${src.name}/python";


### PR DESCRIPTION
Hydra: https://hydra.nixos.org/build/316403093

1. Tests in `test_uuid_v7.py` are flaky due to a race condition. Added to `disabledTestPaths` and filed https://github.com/langchain-ai/langsmith-sdk/issues/2245
2. Narrowed `enabledTestPaths` to `tests/unit_tests` and cleaned up disabled tests and paths. (We had disabled the `evaluation`, `external`, and most `integration` tests already, this just makes it formal.)
3. Cleaned up `nativeCheckInputs` to only what is necessary. Note the use of `attrs` across all platforms due to eliminating unneeded check inputs.
4. Version bump (required a new test dependency)


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
