### PR TITLE
versionCheckHook: use coreutils env; gzip: add passthru test

### DIFF
--- a/pkgs/by-name/ve/versionCheckHook/hook.sh
+++ b/pkgs/by-name/ve/versionCheckHook/hook.sh
@@ -10,7 +10,7 @@ _handleCmdOutput(){
       done
     fi
 
-    versionOutput="$(env \
+    versionOutput="$(@envCommand@ \
         --chdir=/ \
         --argv0="$(basename "${command[0]}")" \
         "${envArgs[@]}" \

--- a/pkgs/by-name/ve/versionCheckHook/package.nix
+++ b/pkgs/by-name/ve/versionCheckHook/package.nix
@@ -1,12 +1,14 @@
 {
   lib,
   makeSetupHook,
+  coreutils,
 }:
 
 makeSetupHook {
   name = "version-check-hook";
   substitutions = {
     storeDir = builtins.storeDir;
+    envCommand = lib.getExe' coreutils "env"; # Cannot call it env, because it isn't an attrset of environment variables!
   };
   meta = {
     description = "Lookup for $version in the output of --help and --version";

--- a/pkgs/tools/compression/gzip/default.nix
+++ b/pkgs/tools/compression/gzip/default.nix
@@ -5,6 +5,10 @@
   makeShellWrapper,
   updateAutotoolsGnuConfigScriptsHook,
   runtimeShellPackage,
+  # Tests
+  gzip,
+  less,
+  perl,
 }:
 
 # Note: this package is used for bootstrapping fetchurl, and thus
@@ -44,6 +48,12 @@ stdenv.mkDerivation rec {
     "ZLESS_PROG=zless"
   ];
 
+  nativeCheckInputs = [
+    less
+    perl
+  ];
+  doCheck = false;
+
   # Many gzip executables are shell scripts that depend upon other gzip
   # executables being in $PATH.  Rather than try to re-write all the
   # internal cross-references, just add $out/bin to PATH at the top of
@@ -59,6 +69,10 @@ stdenv.mkDerivation rec {
     wrapProgram $out/bin/gzip \
       --add-flags "\''${GZIP_NO_TIMESTAMPS:+-n}"
   '';
+
+  passthru = {
+    tests.makecheck = gzip.overrideAttrs { doCheck = true; };
+  };
 
   meta = {
     homepage = "https://www.gnu.org/software/gzip/";


### PR DESCRIPTION
When running `nix-build -A gzip.passthru.test` without the second commit, the first commit fails, because it pulls in `less` during the bootstrap, and `less` uses `versionCheckHook`, which needs `coreutils` 9.5+, but (due to the outdated bootstrap tools) only has `coreutils` 9.4 for the in-bootstrap compilation.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
