### PR TITLE
Add hoymiles-wifi & ha-hoymiles-wifi packages

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17234,6 +17234,12 @@
     githubId = 1472826;
     name = "Max Smolin";
   };
+  maximumstock = {
+    email = "mxmlnstock@gmail.com";
+    github = "maximumstock";
+    githubId = 9075718;
+    name = "Maximilian Stock";
+  };
   maxmosk = {
     email = "maximmosk4@gmail.com";
     github = "maxmosk";

--- a/pkgs/development/python-modules/hoymiles-wifi/default.nix
+++ b/pkgs/development/python-modules/hoymiles-wifi/default.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  # build-system
+  setuptools,
+  # dependencies
+  protobuf,
+  crcmod,
+  cryptography,
+}:
+
+buildPythonPackage rec {
+  pname = "hoymiles-wifi";
+  version = "0.5.5";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "suaveolent";
+    repo = "hoymiles-wifi";
+    tag = "v${version}";
+    hash = "sha256-lI6uEAXhzxQMz2jZ9oDLTnICOc0+ECbWK2MNuK/aUOw=";
+  };
+
+  build-system = [ setuptools ];
+
+  propagatedBuildInputs = [
+    protobuf
+    crcmod
+    cryptography
+  ];
+
+  doCheck = false; # no tests
+
+  pythonImportsCheck = [ "hoymiles_wifi" ];
+
+  meta = {
+    changelog = "https://github.com/suaveolent/hoymiles-wifi/releases/tag/${src.tag}";
+    description = "Library to communicate with Hoymiles DTUs and HMS WiFi enabled microinverters via protobuf";
+    homepage = "https://github.com/suaveolent/hoymiles-wifi";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.maximumstock ];
+  };
+}

--- a/pkgs/servers/home-assistant/custom-components/hoymiles_wifi/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/hoymiles_wifi/package.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  fetchFromGitHub,
+  pytestCheckHook,
+  buildHomeAssistantComponent,
+  hoymiles-wifi,
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "suaveolent";
+  domain = "hoymiles_wifi";
+  version = "0.5.1";
+
+  src = fetchFromGitHub {
+    owner = "suaveolent";
+    repo = "ha-hoymiles-wifi";
+    tag = "v${version}";
+    hash = "sha256-6NxsnRAo8KjlKYfyqosdS0Q34j0KBNNRUWbZmQOvxJk=";
+  };
+
+  dependencies = [ hoymiles-wifi ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  meta = {
+    changelog = "https://github.com/suaveolent/ha-hoymiles-wifi/releases/tag/${src.tag}";
+    description = "Home Assistant custom component for Hoymiles DTUs and the HMS-XXXXW-2T microinverters";
+    homepage = "https://github.com/suaveolent/ha-hoymiles-wifi";
+    maintainers = with lib.maintainers; [ maximumstock ];
+    license = lib.licenses.mit;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7160,6 +7160,8 @@ self: super: with self; {
 
   housekeeping = callPackage ../development/python-modules/housekeeping { };
 
+  hoymiles-wifi = callPackage ../development/python-modules/hoymiles-wifi { };
+
   hpack = callPackage ../development/python-modules/hpack { };
 
   hpccm = callPackage ../development/python-modules/hpccm { };


### PR DESCRIPTION
This PR is adding the Python 3 lib & CLI tool [hoymiles-wifi@0.5.5](https://github.com/suaveolent/hoymiles-wifi) and a corresponding and depending Home-Assistant component package [ha-hoymiles-wifi@0.5.1](https://github.com/suaveolent/ha-hoymiles-wifi) in order to use Hoymiles inverter data in Home-Assistant.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
