### PR TITLE
agneyastra: init at 0-unstable-2025-11-06

### DIFF
--- a/pkgs/by-name/ag/agneyastra/package.nix
+++ b/pkgs/by-name/ag/agneyastra/package.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule {
+  pname = "agneyastra";
+  version = "0-unstable-2025-11-06";
+
+  src = fetchFromGitHub {
+    owner = "JA3G3R";
+    repo = "agneyastra";
+    # https://github.com/JA3G3R/agneyastra/issues/1
+    rev = "16a90ecc7189e12261a24b88e6d6ac24b7f3b216";
+    hash = "sha256-I3BzHS7D8ZVRLzx8TlUmebw96wTVwSkAAKsDqJ2Ekj8=";
+  };
+
+  vendorHash = "sha256-urAw78X6mY2O+rLdQvA6eubFk7XmzEzPQPKc/QudVTQ=";
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  meta = {
+    description = "Firebase Misconfiguration Detection Toolkit";
+    homepage = "https://github.com/JA3G3R/agneyastra";
+    # https://github.com/JA3G3R/agneyastra/issues/2
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ fab ];
+    mainProgram = "agneyastra";
+  };
+}


### PR DESCRIPTION
Firebase Misconfiguration Detection Toolkit

https://github.com/JA3G3R/agneyastra

Related https://github.com/NixOS/nixpkgs/issues/81418
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
