### PR TITLE
fmd-server: init at 0.13.0

### DIFF
--- a/pkgs/by-name/fm/fmd-server/package.nix
+++ b/pkgs/by-name/fm/fmd-server/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitLab,
+  nix-update-script,
+  versionCheckHook,
+}:
+let
+  version = "0.13.0";
+in
+buildGoModule {
+  pname = "fmd-server";
+  inherit version;
+  src = fetchFromGitLab {
+    owner = "fmd-foss";
+    repo = "fmd-server";
+    tag = "v${version}";
+    hash = "sha256-pIVsdoen45YWG/V8qW/DE/yet4o+8MqpVHgHh70Fty8=";
+  };
+
+  vendorHash = "sha256-d8QP6k7vEX0jBcpIMZymgOFYyKqGhND4Xa+mANg172s=";
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "version";
+
+  doInstallCheck = true;
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Server to communicate with the FindMyDevice app and save the latest (encrypted) location";
+    homepage = "https://fmd-foss.org/";
+    downloadPage = "https://gitlab.com/fmd-foss/fmd-server";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ j0hax ];
+    teams = [ lib.teams.ngi ];
+    mainProgram = "fmd-server";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Continuation of https://github.com/NixOS/nixpkgs/pull/326998. The project has evolved quite a bit since then, making packaging much simpler, as we only need to build one single Go module.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
