### PR TITLE
telepresence2: fix build process

### DIFF
--- a/pkgs/by-name/te/telepresence2/package.nix
+++ b/pkgs/by-name/te/telepresence2/package.nix
@@ -1,23 +1,30 @@
 {
   lib,
   fetchFromGitHub,
+  fetchurl,
   buildGoModule,
   fuse,
+  runCommand,
+  jq,
+  gnused,
+  gawk,
+  gnugrep,
 }:
 
 let
+  fuseftpVersion = "0.6.9";
   fuseftp = buildGoModule rec {
     pname = "go-fuseftp";
-    version = "0.6.6";
+    version = fuseftpVersion;
 
     src = fetchFromGitHub {
       owner = "datawire";
       repo = "go-fuseftp";
       rev = "v${version}";
-      hash = "sha256-70VmT8F+RNiDk6fnrzDktdfNhZk20sXF+b3TBTAkNHo=";
+      hash = "sha256-iJTVcOsaDICQWqIsMTHWg/MDb++ZIfKnnAPrcumcRWk=";
     };
 
-    vendorHash = "sha256-wp4jOmeVdfuRwdclCzBonNCkhgsNUBOBL6gxlrznC1A=";
+    vendorHash = "sha256-ZQUlgrC80gwIGTepNXI67Y9SYtarey3Y63eCqZAXXao=";
 
     buildInputs = [ fuse ];
 
@@ -27,6 +34,12 @@ let
     ];
 
     subPackages = [ "pkg/main" ];
+  };
+
+  k8sVersion = "v1.34.2";
+  k8sDefsJson = fetchurl {
+    url = "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/${k8sVersion}-standalone/_definitions.json";
+    hash = "sha256-IMEXD8MeTgAhBn6dnElp7uKtVLv4UcuDI51pQ4o953Q=";
   };
 in
 buildGoModule rec {
@@ -44,22 +57,86 @@ buildGoModule rec {
     fuseftp
   ];
 
+  nativeBuildInputs = [
+    jq
+  ];
+
   # telepresence depends on fuseftp existing as a built binary, as it gets embedded
   # CGO gets disabled to match their build process as that is how it's done upstream
   preBuild = ''
     cp ${fuseftp}/bin/main ./pkg/client/remotefs/fuseftp.bits
+
+    mkdir -p charts/telepresence-oss
+    cp ${k8sDefsJson} charts/telepresence-oss/k8s-defs.json
+
     export CGO_ENABLED=0
   '';
 
   vendorHash = "sha256-Zroh9/FKG+wm8nX+t+TpJQeT2nFi8UrzxAWnNAaMt8Q=";
 
+  # ldflags copied from Makefile
+  # ref: https://github.com/telepresenceio/telepresence/blob/7a2b9f553fb51ef252df957916c7b831bd65c1ce/build-aux/main.mk#L250-L251
   ldflags = [
     "-s"
     "-w"
     "-X=github.com/telepresenceio/telepresence/v2/pkg/version.Version=${src.rev}"
   ];
 
+  preConfigure = ''
+    HELM_VERSION=$(go mod edit -json | jq -r '.Require[] | select(.Path == "helm.sh/helm/v3") | .Version')
+    ldflags="$ldflags -X github.com/telepresenceio/telepresence/v2/pkg/version.HelmVersion=$HELM_VERSION"
+  '';
+
   subPackages = [ "cmd/telepresence" ];
+
+  passthru.tests = {
+    k8s-version-matches =
+      runCommand "telepresence2-k8s-version-test"
+        {
+          nativeBuildInputs = [
+            gnugrep
+            gnused
+            gawk
+          ];
+        }
+        ''
+          # ref: https://github.com/telepresenceio/telepresence/blob/7a2b9f553fb51ef252df957916c7b831bd65c1ce/build-aux/main.mk#L545
+          actual_version=$(grep 'k8s.io/client-go' ${src}/go.mod | awk '{print $2}' | sed -e 's/v0\./v1./')
+          expected_version="${k8sVersion}"
+
+          if [ "$actual_version" != "$expected_version" ]; then
+            echo "FAIL: k8s version mismatch in telepresence2" >&2
+            echo "  Hardcoded in Nix: $expected_version" >&2
+            echo "  Found in go.mod:  $actual_version" >&2
+            echo "  Update k8sVersion variable & hash in telepresence2 package" >&2
+            exit 1
+          fi
+
+          echo "PASS: k8s version $actual_version matches" | tee $out
+        '';
+    fuseftp-version-matches =
+      runCommand "telepresence2-fuseftp-version-test"
+        {
+          nativeBuildInputs = [
+            gnugrep
+            gawk
+          ];
+        }
+        ''
+          actual_version=$(grep 'github.com/telepresenceio/go-fuseftp/rpc' ${src}/go.mod | awk '{print $2}')
+          expected_version="v${fuseftpVersion}"
+
+          if [ "$actual_version" != "$expected_version" ]; then
+            echo "FAIL: fuseftp version mismatch in telepresence2" >&2
+            echo "  Hardcoded in Nix: $expected_version" >&2
+            echo "  Found in go.mod:  $actual_version" >&2
+            echo "  Update fuseftpVersion variable & hash in telepresence2 package" >&2
+            exit 1
+          fi
+
+          echo "PASS: fuseftp version $actual_version matches" | tee $out
+        '';
+  };
 
   meta = {
     description = "Local development against a remote Kubernetes or OpenShift cluster";
@@ -69,6 +146,7 @@ buildGoModule rec {
       mausch
       vilsol
       wrbbz
+      thesn
     ];
     mainProgram = "telepresence";
   };


### PR DESCRIPTION
The current telepresence package is missing a `k8s-defs.json` definitions file. This PR packages that file and also adds tests ensuring the version of `fuseftp` and `k8s-defs` are matching the telepresence version. I used the official makefile build process as reference.
Based on https://github.com/NixOS/nixpkgs/pull/425925

Fixes https://github.com/NixOS/nixpkgs/issues/424252
Closes https://github.com/NixOS/nixpkgs/pull/425925

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
