### PR TITLE
python3Packages.boinor: init at 0.19.0-unstable-2025-12-27

### DIFF
--- a/pkgs/development/python-modules/boinor/default.nix
+++ b/pkgs/development/python-modules/boinor/default.nix
@@ -1,0 +1,153 @@
+{
+  lib,
+  httpx,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pythonOlder,
+  astropy,
+  astroquery,
+  jplephem,
+  matplotlib,
+  numba,
+  numpy,
+  notebook,
+  ipywidgets,
+  pandas,
+  ipython,
+  plotly,
+  pyerfa,
+  scipy,
+  flit-core,
+  wheel,
+  jupyter-client,
+  jupytext,
+  jupyter,
+  myst-parser,
+  nbsphinx,
+  nbconvert,
+  sgp4,
+  sphinx,
+  sphinx-autoapi,
+  sphinx-rtd-theme,
+  sphinx-hoverxref,
+  sphinx-notfound-page,
+  sphinx-copybutton,
+  sphinxcontrib-bibtex,
+  coverage,
+  hypothesis,
+  mypy,
+  pre-commit,
+  pytest_7,
+  pytest-cov,
+  pytest-doctestplus,
+  pytest-mpl,
+  pytest-mypy,
+  pytest-remotedata,
+  pytest-xdist,
+  pytest-benchmark,
+  tox,
+  vulture,
+}:
+buildPythonPackage {
+  pname = "boinor";
+  version = "0.19.0-unstable-2025-12-27";
+  pyproject = true;
+
+  #NOTE: doesnt work on 3.10 due to nixpkgs numpy
+  disabled = pythonOlder "3.11";
+
+  src = fetchFromGitHub {
+    owner = "boinor";
+    repo = "boinor";
+    rev = "8e89b601b9d394a815562884c6fd39228d2b9f24";
+    hash = "sha256-FqoT0Zuff5MNiIYDwMRqULZqs31Mq57ZJCI9uzmEypM=";
+  };
+
+  build-system = [
+    flit-core
+    numpy
+    wheel
+  ];
+
+  #NOTE: plotly<7
+  dependencies = [
+    astropy
+    astroquery
+    jplephem
+    matplotlib
+    numba
+    numpy
+    pandas
+    plotly
+    pyerfa
+    scipy
+  ];
+
+  # using like https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/development/python-modules/astropy/default.nix#L89
+  optional-dependencies = lib.fix (self: {
+    #NOTE: not in nixpkgs?
+    # cesium = [
+    #   czml3 # ~=0.5.3
+    # ];
+    jupyter = [
+      notebook
+      ipywidgets
+    ];
+    doc = [
+      httpx
+      ipython
+      ipywidgets
+      jupyter-client
+      jupytext
+      jupyter
+      myst-parser # NOTE: #>=0.13.1,<1.0.0", wrong version in nixpkgs?
+      nbsphinx
+      nbconvert
+      sgp4
+      sphinx # <9.0
+      sphinx-autoapi
+      # sphinx-gallery #NOTE: missing in nixpkgs
+      sphinx-rtd-theme # NOTE: ~=1.0.0, wrong in nixpkgs?
+      sphinx-hoverxref # NOTE: ==0.7b1, wrong in nixpkgs?
+      sphinx-notfound-page
+      sphinx-copybutton
+      # sphinx-github-role #NOTE: missing in nixpkgs
+      sphinxcontrib-bibtex
+    ];
+    all = [
+    ]
+    ++ self.jupyter
+    ++ self.doc;
+  });
+
+  nativeCheckInputs = [
+    coverage
+    hypothesis
+    # import-linter[toml] #NOTE: missing in nixpkgs?
+    # interrogate #NOTE: missing in nixpkgs?
+    mypy
+    pre-commit
+    pytest_7
+    pytest-cov # NOTE: <2.6.0, wrong version in nixpkgs
+    pytest-doctestplus
+    pytest-mpl
+    pytest-mypy
+    pytest-remotedata
+    pytest-xdist
+    # pytest-timestamps # NOTE: missing in nixpkgs
+    pytest-benchmark
+    tox
+    vulture
+  ];
+
+  disabledTests = [
+    "test_planetary_fixed" # NOTE: fails. maybe open issue upstream
+  ];
+
+  meta = {
+    homepage = "https://github.com/boinor/boinor";
+    description = "Open source pure Python library for interactive Astrodynamics and Orbital Mechanics";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ petingoso ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2140,6 +2140,8 @@ self: super: with self; {
 
   boilerpy3 = callPackage ../development/python-modules/boilerpy3 { };
 
+  boinor = callPackage ../development/python-modules/boinor { };
+
   bokeh = callPackage ../development/python-modules/bokeh { };
 
   bokeh-sampledata = callPackage ../development/python-modules/bokeh-sampledata { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Added a working version of the package.
3.10 is not supported due to numpy on nixpkgs dropping it;
Some optional dependencies aren't present but tests pass (with some skips). Could be bissected to find minimal needed but currently works.
Tested working in 3.12 and 3.13
If running locally, be warned tests take 5+min. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
