### PR TITLE
ocamlPackages.ppx_regexp: init at 0.5.1

### DIFF
--- a/pkgs/development/ocaml-modules/ppx_regexp/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_regexp/default.nix
@@ -1,0 +1,41 @@
+{
+  applyPatches,
+  buildDunePackage,
+  fetchpatch,
+  fetchurl,
+  lib,
+  ppxlib,
+  qcheck,
+  re,
+}:
+
+buildDunePackage (finalAttrs: {
+  pname = "ppx_regexp";
+  version = "0.5.1";
+  src = applyPatches {
+    src = fetchurl {
+      url = "https://github.com/paurkedal/ppx_regexp/releases/download/v${finalAttrs.version}/ppx_regexp-v${finalAttrs.version}.tbz";
+      hash = "sha256-JQg7xHxsoiS1LZWOMnLJOMERWJVEbtUmyjMPA6LVDKg=";
+    };
+    patches = lib.optional (lib.versionAtLeast ppxlib.version "0.36") (fetchpatch {
+      url = "https://patch-diff.githubusercontent.com/raw/paurkedal/ppx_regexp/pull/17.patch";
+      hash = "sha256-aijwUbTv6vT3IX1u8gZK9l7ndfKVRhfdKl62aa63UnA=";
+      includes = [ "*.ml" ];
+    });
+  };
+
+  propagatedBuildInputs = [
+    ppxlib
+    re
+  ];
+
+  checkInputs = [ qcheck ];
+  doCheck = false; # Tests are failing. This might be related to a recent update of qcheck.
+
+  meta = {
+    description = "Regular Expression Matching with OCaml Patterns";
+    homepage = "https://github.com/paurkedal/ppx_regexp";
+    license = lib.licenses.lgpl3Plus;
+    maintainers = [ lib.maintainers.vog ];
+  };
+})

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1805,6 +1805,8 @@ let
 
         ppx_monad = callPackage ../development/ocaml-modules/ppx_monad { };
 
+        ppx_regexp = callPackage ../development/ocaml-modules/ppx_regexp { };
+
         ppx_repr = callPackage ../development/ocaml-modules/repr/ppx.nix { };
 
         ppx_show = callPackage ../development/ocaml-modules/ppx_show { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
