### PR TITLE
ocamlPackages.ppx_mikmatch: init at 1.3

### DIFF
--- a/pkgs/development/ocaml-modules/ppx_mikmatch/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_mikmatch/default.nix
@@ -1,0 +1,40 @@
+{
+  buildDunePackage,
+  fetchurl,
+  lib,
+  menhir,
+  ounit2,
+  ppxlib,
+  re,
+}:
+
+buildDunePackage (finalAttrs: {
+  pname = "ppx_mikmatch";
+  version = "1.3";
+  src = fetchurl {
+    name = "ppx_mikmatch-${finalAttrs.version}.tar.gz";
+    url = "https://codeload.github.com/ahrefs/ppx_mikmatch/tar.gz/refs/tags/${finalAttrs.version}";
+    hash = "sha256-i97gSyutefbJbDZv/yjaeHfV1CU6j3RSaQ1oPjiz8hg=";
+  };
+
+  minimalOCamlVersion = "5.3";
+
+  nativeBuildInputs = [ menhir ];
+  propagatedBuildInputs = [
+    ppxlib
+    re
+  ];
+
+  checkInputs = [ ounit2 ];
+  doCheck = true;
+
+  meta = {
+    description = "Matching Regular Expressions with OCaml Patterns using Mikmatch's syntax";
+    homepage = "https://github.com/ahrefs/ppx_mikmatch";
+    license = lib.licenses.lgpl3Plus;
+    maintainers = [
+      lib.maintainers.vog
+      lib.maintainers.zazedd
+    ];
+  };
+})

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1816,6 +1816,8 @@ let
 
         ppx_lun = callPackage ../development/ocaml-modules/lun/ppx.nix { };
 
+        ppx_mikmatch = callPackage ../development/ocaml-modules/ppx_mikmatch { };
+
         ppx_monad = callPackage ../development/ocaml-modules/ppx_monad { };
 
         ppx_repr = callPackage ../development/ocaml-modules/repr/ppx.nix { };


### PR DESCRIPTION
This OCaml package is a great alternative to ppx_regexp: Finally we have readable, indentable, composable regex support that is very efficient even on dispatching.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
