### PR TITLE
anvil-editor: 0.6.3 -> 0.7

### DIFF
--- a/pkgs/by-name/an/anvil-editor/package.nix
+++ b/pkgs/by-name/an/anvil-editor/package.nix
@@ -16,13 +16,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "anvil-editor";
-  version = "0.6.3";
+  version = "0.7";
 
   # has to update vendorHash of extra package manually
   # nixpkgs-update: no auto update
   src = fetchzip {
     url = "https://anvil-editor.net/releases/anvil-src-v${finalAttrs.version}.tar.gz";
-    hash = "sha256-GPzd1oKkf160ya0sxUd72wego0BvwCerZ5SiY2q0EDE=";
+    hash = "sha256-9lJg8IMt6+GJm5a7j7ZyhbwvAmlBKvtdOv9FD9MQdrA=";
   };
 
   modRoot = "anvil/editor";
@@ -32,7 +32,7 @@ buildGoModule (finalAttrs: {
   anvilExtras = buildGoModule {
     pname = "anvil-editor-extras";
     inherit (finalAttrs) version src meta;
-    vendorHash = "sha256-q/PunSBe+gWTWyf8rjfikK56rP2PeZqpuiFG9HIVMTk=";
+    vendorHash = "sha256-Hnq1aq1DGM7IJwjU38yEk6yXmQQLyisMeaktNZNysy8=";
     modRoot = "anvil/extras";
     # Include dependency on anvil api
     postPatch = ''


### PR DESCRIPTION
Tested functionality

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
