### PR TITLE
idris2Packages.pack: 2025-11-06 -> 2025-12-27

### DIFF
--- a/pkgs/development/compilers/idris2/pack.nix
+++ b/pkgs/development/compilers/idris2/pack.nix
@@ -169,12 +169,12 @@ let
 
   packPkg = buildIdris {
     ipkgName = "pack";
-    version = "2025-11-06";
+    version = "2025-12-27";
     src = fetchFromGitHub {
       owner = "stefan-hoeck";
       repo = "idris2-pack";
-      rev = "37787fa16550ef761d3242bf8ccb8ab672d9f2d1";
-      hash = "sha256-pvunaZSXj5Ee0utBFZfagxRKFuoSBxeU0IN7VTc56rY=";
+      rev = "cd512a0bf61a6effacc24060bb04106a849df0fe";
+      hash = "sha256-309k3ALAnCno8C09Fy7zz/oiSCzKI2ZbH5WFn6QIwF0=";
     };
     idrisLibraries = [
       idris2Api


### PR DESCRIPTION
Update pack to get a fix for an issue that affected Nix installs. The issue is described by- and fixed by the following PR against the pack project: https://github.com/stefan-hoeck/idris2-pack/pull/372

In short, pack required its own binary to be found at `~/.local/bin/pack` which is, of course, not in the Nix store.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
