### PR TITLE
linux/hardening: miscellaneous config updates

### DIFF
--- a/pkgs/os-specific/linux/kernel/hardened/config.nix
+++ b/pkgs/os-specific/linux/kernel/hardened/config.nix
@@ -1,5 +1,5 @@
 # Based on recommendations from:
-# http://kernsec.org/wiki/index.php/Kernel_Self_Protection_Project#Recommended_settings
+# https://kspp.github.io/Recommended_Settings
 # https://wiki.gentoo.org/wiki/Hardened/Hardened_Kernel_Project
 #
 # Dangerous features that can be permanently (for the boot session) disabled at
@@ -56,6 +56,9 @@ assert (lib.versionAtLeast version "4.9");
   # Enable init_on_free by default
   INIT_ON_FREE_DEFAULT_ON = whenAtLeast "5.3" yes;
 
+  # Initialize all stack variables on function entry
+  INIT_STACK_ALL_ZERO = yes;
+
   # Wipe all caller-used registers on exit from a function
   ZERO_CALL_USED_REGS = whenAtLeast "5.15" yes;
 
@@ -67,8 +70,6 @@ assert (lib.versionAtLeast version "4.9");
 
   GCC_PLUGINS = yes; # Enable gcc plugin options
 
-  GCC_PLUGIN_STRUCTLEAK = option yes; # A port of the PaX structleak plugin
-  GCC_PLUGIN_STRUCTLEAK_BYREF_ALL = option yes; # Also cover structs passed by address
   GCC_PLUGIN_STACKLEAK = whenAtLeast "4.20" yes; # A port of the PaX stackleak plugin
   GCC_PLUGIN_RANDSTRUCT = whenOlder "5.19" yes; # A port of the PaX randstruct plugin
   GCC_PLUGIN_RANDSTRUCT_PERFORMANCE = whenOlder "5.19" yes;

--- a/pkgs/os-specific/linux/kernel/hardened/config.nix
+++ b/pkgs/os-specific/linux/kernel/hardened/config.nix
@@ -29,7 +29,7 @@ assert (lib.versionAtLeast version "4.9");
   # We set SECURITY_WRITABLE_HOOKS n primarily for documentation purposes; the
   # config builder fails to detect that it has indeed been unset.
   SECURITY_SELINUX_DISABLE = whenOlder "6.4" no; # On 6.4: error: unused option: SECURITY_SELINUX_DISABLE
-  SECURITY_WRITABLE_HOOKS = option no;
+  SECURITY_WRITABLE_HOOKS = whenOlder "6.4" no;
 
   # Perform additional validation of commonly targeted structures.
   DEBUG_CREDENTIALS = whenOlder "6.6" yes;


### PR DESCRIPTION
Linux 5.9 added a config option ([`INIT_STACK_ALL_ZERO`][1]) to zero initialize stack variables by default with `-ftrivial-auto-var-init=zero` on supported compilers (GCC 12+ and Clang 15+). This is similar to the zero initialization done by the GCC structleak plugin, but it also works with Clang. [The Kernel Self Protection Project recommends using `INIT_STACK_ALL_ZERO` over `GCC_PLUGIN_STRUCTLEAK_BYREF_ALL` on supported
kernel versions and toolchains][2]. [Kernel 6.16 also dropped support for the GCC structleak plugin][3], with `INIT_STACK_ALL_ZERO` being recommended as a replacement.

Update the hardened kernel config to use INIT_STACK_ALL_ZERO instead of GCC_PLUGIN_STRUCTLEAK_BYREF_ALL (as kernel 5.10 is the minimum supported version in Nixpkgs). This matches other distros, such as [Arch Linux][4] and [Fedora][5].

While we're here, limit `SECURITY_WRITABLE_HOOKS` to kernel 6.3 and older, as [Linux 6.4 dropped support for disabling SELinux at runtime][6].

[1]: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=f0fe00d4972a8cd4b98cc2c29758615e4d51cdfe
[2]: https://kspp.github.io/Recommended_Settings
[3]: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=8530ea3c9b9747faba46ed3a59ad103b894f1189
[4]: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/commit/231862cf72a926e62d5a02efd2b833f368b293b0
[5]: https://src.fedoraproject.org/rpms/kernel/blob/8ca58d5eff5c5c56e54e3ba64ffa887ead00a934/f/kernel-x86_64-fedora.config#_3189
[6]: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=f22f9aaf6c3d92ebd5ad9e67acc03afebaaeb289

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
