### PR TITLE
newlib: Fix i386 libgloss support

### DIFF
--- a/pkgs/by-name/ne/newlib/package.nix
+++ b/pkgs/by-name/ne/newlib/package.nix
@@ -26,6 +26,11 @@ stdenvNoLibc.mkDerivation (finalAttrs: {
       url = "https://sourceware.org/git/?p=newlib-cygwin.git;a=patch;h=8a8fb570d7c5310a03a34b3dd6f9f8bb35ee9f40";
       hash = "sha256-hWS/X0jf/ZFXIR39NvNDVhkR8F81k9UWpsqDhZFxO5o=";
     })
+    (fetchpatch {
+      name = "0002-newlib-Fix-i386-libgloss-support.patch";
+      url = "https://sourceware.org/git/?p=newlib-cygwin.git;a=patch;h=351842d55ee50fab672818b72f2c6bf3be1772bd;hp=4a1144dc540423b422dbec27eb433bc7dc725ae8";
+      hash = "sha256-GMx9nQKJEnXbA5HFczp3xjrrU94j1oXq4lIjEf0um9Y=";
+    })
   ]
   ++ lib.optionals nanoizeNewlib [
     # https://bugs.gentoo.org/723756


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixes #424403
Fixes #404741

This PR adds a patch of upstream commits that fix the build with gcc-14.

In addition to `nixpkgs-review` (result posted below), I also successfully built `pkgsCross.i686-embedded.buildPackages.binutils`, `pkgsCross.i686-embedded.buildPackages.gcc` and `pkgsCross.i686-embedded.newlib`.

I also added the auto backport to 25.11 label as this build failure also affects the current stable branch.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
