### PR TITLE
tuxguitar: 1.6.6 -> 2.0.1

### DIFF
--- a/pkgs/by-name/sw/swt/disable-werror.patch
+++ b/pkgs/by-name/sw/swt/disable-werror.patch
@@ -1,0 +1,6 @@
+diff --git a/library/make_linux.mak b/library/make_linux.mak
+--- a/library/make_linux.mak
++++ b/library/make_linux.mak
+@@ -114,0 +115,1 @@
++CFLAGS += -Wno-error=deprecated-declarations
+

--- a/pkgs/by-name/sw/swt/package.nix
+++ b/pkgs/by-name/sw/swt/package.nix
@@ -60,6 +60,10 @@ stdenv.mkDerivation (finalAttrs: {
       '';
     };
 
+  patches = [
+    ./disable-werror.patch
+  ];
+
   nativeBuildInputs = [
     jdk
     stripJavaArchivesHook

--- a/pkgs/by-name/tu/tuxguitar/package.nix
+++ b/pkgs/by-name/tu/tuxguitar/package.nix
@@ -16,12 +16,12 @@
 }:
 
 stdenv.mkDerivation (finalAttrs: {
-  version = "1.6.6";
+  version = "2.0.1";
   pname = "tuxguitar";
 
   src = fetchurl {
     url = "https://github.com/helge17/tuxguitar/releases/download/${finalAttrs.version}/tuxguitar-${finalAttrs.version}-linux-swt-amd64.tar.gz";
-    hash = "sha256-kfPk+IIg5Q4Fc9HMS0kxxCarlbJjVKluIvz8KpDjJLM=";
+    hash = "sha256-psWt/gzFc5JeFed/2xzNpMAagmYebAOOKSedABt/bqM=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Update `tuxguitar` from 1.6.6 (which is almost a year old at this point) to 2.0.1. SWT fails to build with recent `gdk-pixbuf` due to deprecated GTK APIs being treated as errors, so I also had to relax `-Werror` for deprecated declarations.

After making these changes, I was able to successfully build `swt` and then `tuxguitar` for x86_64-linux.