### PR TITLE
haskellPackages.buildFromCabalSdist: respect patches

### DIFF
--- a/pkgs/development/haskell-modules/lib/compose.nix
+++ b/pkgs/development/haskell-modules/lib/compose.nix
@@ -482,10 +482,11 @@ rec {
     overrideCabal (drv: {
       src = "${sdistTarball pkg}/${pkg.pname}-${pkg.version}.tar.gz";
 
-      # Revising and jailbreaking the cabal file has been handled in sdistTarball
+      # Revising, jailbreaking and patches have been handled in sdistTarball
       revision = null;
       editedCabalFile = null;
       jailbreak = false;
+      patches = [ ];
     }) pkg;
 
   /*

--- a/pkgs/development/haskell-modules/make-package-set.nix
+++ b/pkgs/development/haskell-modules/make-package-set.nix
@@ -696,7 +696,7 @@ package-set { inherit pkgs lib callPackage; } self
   buildFromCabalSdist =
     pkg:
     haskellLib.overrideSrc {
-      src = self.cabalSdist { inherit (pkg) src; };
+      src = self.cabalSdist { src = pkgs.srcOnly pkg; };
       version = pkg.version;
     } pkg;
 

--- a/pkgs/development/haskell-modules/make-package-set.nix
+++ b/pkgs/development/haskell-modules/make-package-set.nix
@@ -695,10 +695,18 @@ package-set { inherit pkgs lib callPackage; } self
   */
   buildFromCabalSdist =
     pkg:
-    haskellLib.overrideSrc {
-      src = self.cabalSdist { src = pkgs.srcOnly pkg; };
-      version = pkg.version;
-    } pkg;
+    haskellLib.overrideCabal
+      (_: {
+        # Patches are already applied by srcOnly above, so clear them
+        # to avoid double-application.
+        patches = [ ];
+      })
+      (
+        haskellLib.overrideSrc {
+          src = self.cabalSdist { src = pkgs.srcOnly pkg; };
+          version = pkg.version;
+        } pkg
+      );
 
   /*
     Modify a Haskell package to add shell completion scripts for the

--- a/pkgs/test/haskell/cabalSdist/change-greeting.patch
+++ b/pkgs/test/haskell/cabalSdist/change-greeting.patch
@@ -1,0 +1,8 @@
+--- a/app/Main.hs
++++ b/app/Main.hs
+@@ -1,4 +1,4 @@
+ module Main where
+
+ main :: IO ()
+-main = putStrLn "Hello, Haskell!"
++main = putStrLn "Hello, Patched Haskell!"

--- a/pkgs/test/haskell/cabalSdist/default.nix
+++ b/pkgs/test/haskell/cabalSdist/default.nix
@@ -57,4 +57,17 @@ lib.recurseIntoAttrs rec {
         ${lib.getExe localPatchedFromCabalSdist} | grep "Patched" >/dev/null
         touch $out
       '';
+
+  # Test that buildFromSdist (non-cabal-install variant) also respects patches.
+  localPatchedFromSdist = haskell.lib.buildFromSdist localPatched;
+
+  patchRespectedSdist =
+    runCommand "patchRespectedSdist"
+      {
+        nativeBuildInputs = [ localPatchedFromSdist ];
+      }
+      ''
+        ${lib.getExe localPatchedFromSdist} | grep "Patched" >/dev/null
+        touch $out
+      '';
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

(`buildFromSdist` does this as well afaict)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
