### PR TITLE
[staging-next] aseprite, skia-aseprite: fix build with GCC 15

### DIFF
--- a/pkgs/by-name/as/aseprite/package.nix
+++ b/pkgs/by-name/as/aseprite/package.nix
@@ -105,6 +105,11 @@ clangStdenv.mkDerivation (finalAttrs: {
   postPatch = ''
     substituteInPlace src/ver/CMakeLists.txt \
       --replace-fail '"1.x-dev"' '"${finalAttrs.version}"'
+
+    # Using substituteInPlace because no upstream patch for GCC 15 was found for this bundled library.
+    substituteInPlace third_party/json11/json11.cpp \
+      --replace-fail "#include <cmath>" "#include <cmath>
+    #include <cstdint>"
   '';
 
   cmakeFlags = [

--- a/pkgs/by-name/sk/skia-aseprite/package.nix
+++ b/pkgs/by-name/sk/skia-aseprite/package.nix
@@ -41,6 +41,16 @@ clangStdenv.mkDerivation (finalAttrs: {
     python3
   ];
 
+  # Using substituteInPlace because no clean upstream backport for GCC 15 exists for this version of Skia, newer versions fix this with large refactorings.
+  postPatch = ''
+    substituteInPlace include/private/SkSLProgramKind.h \
+      --replace-fail "#include <cinttypes>" "#include <cinttypes>
+    #include <cstdint>"
+    substituteInPlace src/sksl/transform/SkSLTransform.h \
+      --replace-fail "#include <vector>" "#include <vector>
+    #include <cstdint>"
+  '';
+
   preConfigure = with depSrcs; ''
     mkdir -p third_party/externals
     ln -s ${angle2} third_party/externals/angle2


### PR DESCRIPTION
closes https://github.com/NixOS/nixpkgs/issues/474677

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
