### PR TITLE
mir_2_15: Fix build on GCC15

### DIFF
--- a/pkgs/servers/mir/common.nix
+++ b/pkgs/servers/mir/common.nix
@@ -215,6 +215,13 @@ stdenv.mkDerivation (
       ))
     ];
 
+    env.NIX_CFLAGS_COMPILE = lib.optionalString (lib.strings.versionOlder version "2.20.0") (toString [
+      # std::wstring_convert<std::codecvt_utf8[...]> in src/server/shell/decoration/renderer.cpp is deprecated in C++17, removed in C++26
+      # Upstream just disabled the warning for now: https://github.com/canonical/mir/commit/e8d1a2255a48991f20889e5844b0d69f5f75d01f
+      # File got ripped apart and shuffled around between 2.15 and 2.20, so can't just add as patch
+      "-Wno-error=deprecated-declarations"
+    ]);
+
     doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
 
     disabledTests = lib.optionals (lib.strings.versionAtLeast version "2.25.0") [


### PR DESCRIPTION
```
/build/source/src/server/shell/decoration/renderer.cpp: In static member function 'static std::u32string mir::shell::decoration::Renderer::Text::Impl::utf8_to_utf32(const std::string&)':
/build/source/src/server/shell/decoration/renderer.cpp:429:10: error: 'template<class _Codecvt, class _Elem, class _Wide_alloc, class _Byte_alloc> class std::__cxx11::wstring_convert' is deprecated [-Wdeprecated-declarations]
  429 |     std::wstring_convert<std::codecvt_utf8<char32_t>, char32_t> converter;
      |          ^~~~~~~~~~~~~~~
In file included from /nix/store/rmv9ajkrzg19k0ax5kq3wq9xcibman7g-gcc-15.2.0/include/c++/15.2.0/locale:47,
                 from /nix/store/k0m9kall5vjhn60sqs8q9qfn31i4f31f-boost-1.87.0-dev/include/boost/filesystem/path.hpp:22,
                 from /nix/store/k0m9kall5vjhn60sqs8q9qfn31i4f31f-boost-1.87.0-dev/include/boost/filesystem.hpp:16,
                 from /build/source/src/server/shell/decoration/renderer.cpp:28:
/nix/store/rmv9ajkrzg19k0ax5kq3wq9xcibman7g-gcc-15.2.0/include/c++/15.2.0/bits/locale_conv.h:262:33: note: declared here
  262 |     class _GLIBCXX17_DEPRECATED wstring_convert
      |                                 ^~~~~~~~~~~~~~~
```

Upstream added diagnostic pragmas to just ignore the warning for now: https://github.com/canonical/mir/commit/e8d1a2255a48991f20889e5844b0d69f5f75d01f

Could backport & vendor this as a patch, but that feels overkill… `env.NIX_CFLAGS_COMPILE` it is ig.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
