### PR TITLE
bevy_cli: init at 0.1.0-alpha.2

### DIFF
--- a/pkgs/by-name/be/bevy_cli/package.nix
+++ b/pkgs/by-name/be/bevy_cli/package.nix
@@ -1,0 +1,80 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  makeWrapper,
+  installShellFiles,
+  nix-update-script,
+  versionCheckHook,
+  pkg-config,
+  openssl,
+  cargo-generate,
+  binaryen,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "bevy_cli";
+  version = "0.1.0-alpha.2";
+
+  src = fetchFromGitHub {
+    owner = "TheBevyFlock";
+    repo = "bevy_cli";
+    tag = "cli-v${finalAttrs.version}";
+    hash = "sha256-FGUmUPWgrAKTijKBiFqh6AfFPHONWCd80SzF/t1g4go=";
+  };
+
+  cargoHash = "sha256-rOaJzU48/C4hqygQFYKPiYXKzxBa+SrGNpOZVYCEGOE=";
+
+  nativeBuildInputs = [
+    pkg-config
+    makeWrapper
+    installShellFiles
+  ];
+
+  buildInputs = [ openssl ];
+
+  checkFlags = [
+    # This unit tests rely on specific environment
+    "--skip=config::tests::merge_rustflags::merge_empty_native_cli_config"
+    "--skip=config::tests::merge_rustflags::merge_native_cli_config"
+
+    # Integration tests require access to dependencies
+    "--skip=should_build_native_dev"
+    "--skip=should_build_native_release"
+    "--skip=should_build_web_dev"
+    "--skip=should_build_web_release"
+  ];
+
+  postInstall = ''
+    wrapProgram $out/bin/bevy --suffix PATH : ${
+      lib.makeBinPath [
+        cargo-generate
+        binaryen
+      ]
+    }
+  ''
+  + (lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd bevy \
+      --bash <($out/bin/bevy completions bash) \
+      --fish <($out/bin/bevy completions fish) \
+      --zsh <($out/bin/bevy completions zsh)
+  '');
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "A Bevy CLI tool and linter";
+    mainProgram = "bevy";
+    homepage = "https://thebevyflock.github.io/bevy_cli/";
+    changelog = "https://github.com/TheBevyFlock/bevy_cli/releases/tag/cli-v${finalAttrs.version}";
+    license = with lib.licenses; [
+      mit # or
+      asl20
+    ];
+    maintainers = [ lib.maintainers.progrm_jarvis ];
+  };
+})


### PR DESCRIPTION
Initialized `bevy_cli` at version `0.1.0-alpha.2`

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
