### PR TITLE
nitrotpm-tools: init at 1.1.0

### DIFF
--- a/pkgs/by-name/ni/nitrotpm-tools/package.nix
+++ b/pkgs/by-name/ni/nitrotpm-tools/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  pkg-config,
+  openssl,
+  tpm2-tss,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "nitrotpm-tools";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "aws";
+    repo = "NitroTPM-Tools";
+    rev = "v${version}";
+    hash = "sha256-ZTASHHa+LQ/hNaM0qfsaGdNwkZQQZnR9+f05DHbviLw=";
+  };
+
+  cargoHash = "sha256-z0b0bLKrnLdMfGKp9aIg3DPW3MJnEhjy9GjCYy44TTQ=";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    openssl
+    tpm2-tss
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Collection of utilities for working with NitroTPM attestation";
+    longDescription = ''
+      A collection of utilities for working with NitroTPM attestation on AWS EC2.
+      Includes nitro-tpm-attest for requesting attestation documents and
+      nitro-tpm-pcr-compute for precomputing PCR values of UKIs (Unified Kernel Images).
+    '';
+    homepage = "https://github.com/aws/NitroTPM-Tools";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ arianvp ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
This is used for building NixOS EC2 Attestable AMIs [0]

Currently the packaging for that lives in a separate AWS repo but I want the tooling to be in nixpkgs instead ideally.

[0] - https://github.com/aws/nitrotpm-attestation-samples/tree/main/nix



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
