### PR TITLE
jellyhaj: init at version 0.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22582,6 +22582,12 @@
     keys = [ { fingerprint = "EC7E F0F9 B681 4C24 6236  3842 B755 6972 702A FD45"; } ];
     name = "Robin Krahl";
   };
+  RobinMarchart = {
+    email = "robin.marchart@gmail.com";
+    github = "RobinMarchart";
+    githubId = 33575791;
+    name = "Robin Marchart";
+  };
   roblabla = {
     email = "robinlambertz+dev@gmail.com";
     github = "roblabla";

--- a/pkgs/by-name/je/jellyhaj/package.nix
+++ b/pkgs/by-name/je/jellyhaj/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  rustPlatform,
+  pkg-config,
+  mpv-unwrapped,
+  sqlite,
+  versionCheckHook,
+  mpris ? stdenv.isLinux,
+}:
+
+rustPlatform.buildRustPackage {
+  pname = "jellyhaj";
+  version = "0.2.0";
+  src = fetchFromGitHub {
+    owner = "owo-uwu-nyaa";
+    repo = "jellyhaj";
+    tag = "v0.2.0";
+    hash = "sha256-eZrCw0237tnYu9s/5s0QyX2CaIqW6rnMeYrLH2Wch9w=";
+  };
+  cargoHash = "sha256-ehzgNaDg3dNZzb5Qe8vk/ZDVglynm+wjVpafFS53iGk=";
+  nativeBuildInputs = [
+    rustPlatform.bindgenHook
+    pkg-config
+  ];
+  buildInputs = [
+    sqlite
+    mpv-unwrapped
+  ];
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
+  checkFlags = [
+    #some tests need internet access
+    "--skip=tests::properties"
+    "--skip=tests::node_map"
+    "--skip=tests::events"
+  ];
+  cargoTestFlags = [ "--workspace" ];
+  buildFeatures = lib.optional mpris "mpris";
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Terminal client for Jellyfin trying to reimplement parts of the web ui";
+    license = lib.licenses.mit;
+    sourceProvenance = [ lib.sourceTypes.fromSource ];
+    mainProgram = "jellyhaj";
+    homepage = "https://github.com/owo-uwu-nyaa/jellyhaj";
+    maintainers = with lib.maintainers; [ RobinMarchart ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

added jellyhaj (and myself as a new maintainer)

jellyhaj is a terminal based client for Jellyfin that is modeled after the offical web client. It is focused on video media and can play them through libmpv.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
