### PR TITLE
accesskit-c: init at 0.18.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18438,6 +18438,12 @@
     githubId = 364510;
     name = "Tobias Geerinckx-Rice";
   };
+  ndarilek = {
+    email = "nolan@thewordnerd.info";
+    github = "ndarilek";
+    githubId = 1172;
+    name = "Nolan Darilek";
+  };
   ndl = {
     email = "ndl@endl.ch";
     github = "ndl";

--- a/pkgs/by-name/ac/accesskit-c/package.nix
+++ b/pkgs/by-name/ac/accesskit-c/package.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  corrosion,
+  rustPlatform,
+  cargo,
+  rustc,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "accesskit-c";
+  version = "0.18.0";
+
+  src = fetchFromGitHub {
+    owner = "AccessKit";
+    repo = "accesskit-c";
+    tag = finalAttrs.version;
+    hash = "sha256-fIzGY8PkQV0Xen0kdBHHNEEczBdLRY9TL5aOY7oz4V4=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) src;
+    hash = "sha256-P0MRRhVg13cmPJFSK+WA05sT0Mpy9Kzyyr/vxFjZTX0=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    rustPlatform.cargoSetupHook
+    cargo
+    rustc
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_CORROSION" "${corrosion.src}")
+  ];
+
+  preConfigure = ''
+    substituteInPlace accesskit.cmake \
+      --replace-fail 'set(ACCESSKIT_INCLUDE_DIR' 'set(ACCESSKIT_INCLUDE_DIR "''${CMAKE_INSTALL_PREFIX}/include" CACHE PATH "")  #' \
+      --replace-fail 'set(ACCESSKIT_LIBRARIES_DIR' 'set(ACCESSKIT_LIBRARIES_DIR "''${CMAKE_INSTALL_PREFIX}/lib" CACHE PATH "")  #'
+  '';
+
+  postInstall = ''
+    install -Dm644 $src/include/accesskit.h $out/include/accesskit.h
+    mv $out/lib/static/* $out/lib/
+    mv $out/lib/shared/* $out/lib/
+    rmdir $out/lib/static $out/lib/shared
+  '';
+
+  meta = {
+    description = "C bindings for the AccessKit accessibility toolkit";
+    homepage = "https://github.com/AccessKit/accesskit-c";
+    license = with lib.licenses; [
+      mit
+      asl20
+    ];
+    maintainers = with lib.maintainers; [ ndarilek ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
Packaged [accesskit-c](https://github.com/AccessKit/accesskit-c/), C bindings for the [AccessKit](https://github.com/accesskit/accesskit) cross-platform accessibility toolkit.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
