### PR TITLE
rakudo: fix wrapper

### DIFF
--- a/pkgs/development/interpreters/rakudo/default.nix
+++ b/pkgs/development/interpreters/rakudo/default.nix
@@ -20,6 +20,15 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-rCLlLxFexk2fzuuSMrJjbwhgU+HgJNX6Ect6uCsuJmo=";
   };
 
+  postPatch = ''
+    substituteInPlace src/core.c/CompUnit/Repository/Installation.rakumod \
+      --subst-var out
+  '';
+
+  patches = [
+    ./rakudo-plain-wrapper.patch
+  ];
+
   configureScript = "${lib.getExe perl} ./Configure.pl";
   configureFlags = [
     "--backends=moar"

--- a/pkgs/development/interpreters/rakudo/rakudo-plain-wrapper.patch
+++ b/pkgs/development/interpreters/rakudo/rakudo-plain-wrapper.patch
@@ -1,0 +1,13 @@
+--- a/src/core.c/CompUnit/Repository/Installation.rakumod
++++ b/src/core.c/CompUnit/Repository/Installation.rakumod
+@@ -848,6 +848,10 @@
+                 my $val = $1.Str;
+                 given $op {
+                     when "plain" | "plat-sep" {
++                        # use rakudo from our store path and avoid PATH lookups
++                        if $val ~~ / ^ "rakudo" / {
++                            return '"@out@/bin/' ~ sh-escape($val) ~ '"';
++                        }
+                         return '"' ~ sh-escape($val) ~ '"';
+                     }
+                     when "cmd-args" {


### PR DESCRIPTION
This should resolve issues related to the wrapper scripts created by Rakudo, which include, but are not limited to, zef.

Supersedes and closes https://github.com/NixOS/nixpkgs/pull/474773.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
