### PR TITLE
bitcoin: Remove libsodium and libz transistive dependencies from bitcoin

### DIFF
--- a/pkgs/by-name/ze/zeromq/package.nix
+++ b/pkgs/by-name/ze/zeromq/package.nix
@@ -4,11 +4,13 @@
   fetchFromGitHub,
   cmake,
   pkg-config,
-  libsodium,
+  libsodium ? null,
   asciidoc,
   xmlto,
+  enableCurve ? true,
   enableDrafts ? false,
   fetchpatch,
+  withLibsodium ? libsodium != null,
   # for passthru.tests
   azmq,
   cppzmq,
@@ -61,13 +63,13 @@ stdenv.mkDerivation (finalAttrs: {
     xmlto
   ];
 
-  buildInputs = [ libsodium ];
+  buildInputs = lib.optionals withLibsodium [ libsodium ];
 
   cmakeFlags = [
     (lib.cmakeBool "BUILD_SHARED" (!stdenv.hostPlatform.isStatic))
-    (lib.cmakeBool "ENABLE_CURVE" true)
+    (lib.cmakeBool "ENABLE_CURVE" enableCurve)
     (lib.cmakeBool "ENABLE_DRAFTS" enableDrafts)
-    (lib.cmakeBool "WITH_LIBSODIUM" true)
+    (lib.cmakeBool "WITH_LIBSODIUM" withLibsodium)
   ];
 
   postPatch = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12546,6 +12546,9 @@ with pkgs;
 
   bitcoin = qt6Packages.callPackage ../applications/blockchains/bitcoin {
     withGui = true;
+    sqlite = sqlite.override {
+      zlib = null;
+    };
     zeromq = zeromq.override {
       enableCurve = false;
       enableDrafts = false;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12546,12 +12546,16 @@ with pkgs;
 
   bitcoin = qt6Packages.callPackage ../applications/blockchains/bitcoin {
     withGui = true;
+    zeromq = zeromq.override {
+      enableCurve = false;
+      enableDrafts = false;
+      libsodium = null;
+    };
     inherit (darwin) autoSignDarwinBinariesHook;
   };
 
-  bitcoind = callPackage ../applications/blockchains/bitcoin {
+  bitcoind = bitcoin.override {
     withGui = false;
-    inherit (darwin) autoSignDarwinBinariesHook;
   };
 
   bitcoin-knots = libsForQt5.callPackage ../applications/blockchains/bitcoin-knots {


### PR DESCRIPTION
The official binaries for bitcoin-core explicitly configure their dependencies to minimize them.  In particular, [their configuration](https://github.com/bitcoin/bitcoin/blob/94ddc2dced5736612e358a3b80f2bc718fbd8161/depends/README.md) minimizes unused transitive dependencies.

Since dynamically loaded libraries can pretty much do anything they want, it is useful to minimize them to reduce the attack surface, particularly against sensitive applications, such as bitcoin.

This PR eliminates `libsodium`, `libz` (and `libpthread`) from the loaded libraries of `bitcoind`.

Before this PR:
```
$ ldd /nix/store/1svm0gkiqbh6vaja5b1kwz61hqn3369z-bitcoind-30.0/bin/bitcoind
        linux-vdso.so.1 (0x00007f22e8c55000)
        libzmq.so.5 => /nix/store/137kvclqwjk2fskzchic4b1jjx5wcvnf-zeromq-4.3.5/lib/libzmq.so.5 (0x00007f22e7f0d000)
        libsodium.so.26 => /nix/store/3d0pz2rax1v3b05lwjqlm4zi6dklnhs5-libsodium-1.0.20/lib/libsodium.so.26 (0x00007f22e7e96000)
        librt.so.1 => /nix/store/xx7cm72qy2c0643cm1ipngd87aqwkcdp-glibc-2.40-66/lib/librt.so.1 (0x00007f22e8c4a000)
        libevent_core-2.1.so.7 => /nix/store/58lnfa43dm43r4wy8mppqxh6n5xgwqpc-libevent-2.1.12/lib/libevent_core-2.1.so.7 (0x00007f22e7e5e000)
        libevent_extra-2.1.so.7 => /nix/store/58lnfa43dm43r4wy8mppqxh6n5xgwqpc-libevent-2.1.12/lib/libevent_extra-2.1.so.7 (0x00007f22e7e38000)
        libevent_pthreads-2.1.so.7 => /nix/store/58lnfa43dm43r4wy8mppqxh6n5xgwqpc-libevent-2.1.12/lib/libevent_pthreads-2.1.so.7 (0x00007f22e8c43000)
        libevent-2.1.so.7 => /nix/store/58lnfa43dm43r4wy8mppqxh6n5xgwqpc-libevent-2.1.12/lib/libevent-2.1.so.7 (0x00007f22e7ddf000)
        /nix/store/l30c488dws7z5mazacqsmj25izb9jlp2-sqlite-3.50.4/lib/libsqlite3.so (0x00007f22e7c49000)
        libstdc++.so.6 => /nix/store/xm08aqdd7pxcdhm0ak6aqb1v7hw5q6ri-gcc-14.3.0-lib/lib/libstdc++.so.6 (0x00007f22e7800000)
        libm.so.6 => /nix/store/xx7cm72qy2c0643cm1ipngd87aqwkcdp-glibc-2.40-66/lib/libm.so.6 (0x00007f22e7b61000)
        libgcc_s.so.1 => /nix/store/xm08aqdd7pxcdhm0ak6aqb1v7hw5q6ri-gcc-14.3.0-lib/lib/libgcc_s.so.1 (0x00007f22e7b33000)
        libc.so.6 => /nix/store/xx7cm72qy2c0643cm1ipngd87aqwkcdp-glibc-2.40-66/lib/libc.so.6 (0x00007f22e7400000)
        /nix/store/xx7cm72qy2c0643cm1ipngd87aqwkcdp-glibc-2.40-66/lib/ld-linux-x86-64.so.2 => /nix/store/qhw0sp183mqd04x5jp75981kwya64npv-glibc-2.40-66/lib64/ld-linux-x86-64.so.2 (0x00007f22e8c57000)
        libpthread.so.0 => /nix/store/xx7cm72qy2c0643cm1ipngd87aqwkcdp-glibc-2.40-66/lib/libpthread.so.0 (0x00007f22e8c3c000)
        libz.so.1 => /nix/store/l7xwm1f6f3zj2x8jwdbi8gdyfbx07sh7-zlib-1.3.1/lib/libz.so.1 (0x00007f22e7b15000)
```
After this PR:

```
$ ldd /nix/store/h446nxq6zrsdxahxq691d4qrim8dqbx7-bitcoind-30.0/bin/bitcoind
        linux-vdso.so.1 (0x00007f9dff405000)
        libzmq.so.5 => /nix/store/nmc9cbvnih8wmd5xblqgchvjkds18lb5-zeromq-4.3.5/lib/libzmq.so.5 (0x00007f9dff315000)
        librt.so.1 => /nix/store/xx7cm72qy2c0643cm1ipngd87aqwkcdp-glibc-2.40-66/lib/librt.so.1 (0x00007f9dff310000)
        libevent_core-2.1.so.7 => /nix/store/58lnfa43dm43r4wy8mppqxh6n5xgwqpc-libevent-2.1.12/lib/libevent_core-2.1.so.7 (0x00007f9dff2d8000)
        libevent_extra-2.1.so.7 => /nix/store/58lnfa43dm43r4wy8mppqxh6n5xgwqpc-libevent-2.1.12/lib/libevent_extra-2.1.so.7 (0x00007f9dff2b2000)
        libevent_pthreads-2.1.so.7 => /nix/store/58lnfa43dm43r4wy8mppqxh6n5xgwqpc-libevent-2.1.12/lib/libevent_pthreads-2.1.so.7 (0x00007f9dff2ab000)
        libevent-2.1.so.7 => /nix/store/58lnfa43dm43r4wy8mppqxh6n5xgwqpc-libevent-2.1.12/lib/libevent-2.1.so.7 (0x00007f9dff252000)
        /nix/store/gwrvg5yzxmvqk7kvzvgvsjknfw31dsrf-sqlite-3.50.4/lib/libsqlite3.so (0x00007f9dfe46a000)
        libstdc++.so.6 => /nix/store/xm08aqdd7pxcdhm0ak6aqb1v7hw5q6ri-gcc-14.3.0-lib/lib/libstdc++.so.6 (0x00007f9dfe000000)
        libm.so.6 => /nix/store/xx7cm72qy2c0643cm1ipngd87aqwkcdp-glibc-2.40-66/lib/libm.so.6 (0x00007f9dfe382000)
        libgcc_s.so.1 => /nix/store/xm08aqdd7pxcdhm0ak6aqb1v7hw5q6ri-gcc-14.3.0-lib/lib/libgcc_s.so.1 (0x00007f9dfe354000)
        libc.so.6 => /nix/store/xx7cm72qy2c0643cm1ipngd87aqwkcdp-glibc-2.40-66/lib/libc.so.6 (0x00007f9dfdc00000)
        /nix/store/xx7cm72qy2c0643cm1ipngd87aqwkcdp-glibc-2.40-66/lib/ld-linux-x86-64.so.2 => /nix/store/qhw0sp183mqd04x5jp75981kwya64npv-glibc-2.40-66/lib64/ld-linux-x86-64.so.2 (0x00007f9dff407000)
```

The libraries in the official bitcoin-core binaries are statically linked, so a direct comparison of run-time dependencies isn't easy.

Thus far I've been focusing on `bitcoind`, but `bitcoin-qt` probably also deserves the same treatment.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
