### PR TITLE
vaultwarden: 1.34.3 -> 1.35.0; vaultwarden.webvault: 2025.7.0.0 -> 2025.12.0

### DIFF
--- a/pkgs/by-name/va/vaultwarden/package.nix
+++ b/pkgs/by-name/va/vaultwarden/package.nix
@@ -19,16 +19,16 @@ in
 
 rustPlatform.buildRustPackage rec {
   pname = "vaultwarden";
-  version = "1.34.3";
+  version = "1.35.0";
 
   src = fetchFromGitHub {
     owner = "dani-garcia";
     repo = "vaultwarden";
-    rev = version;
-    hash = "sha256-Dj0ySVRvBZ/57+UHas3VI8bi/0JBRqn0IW1Dq+405J0=";
+    tag = version;
+    hash = "sha256-Thj/I9eLngErUskKxnJ5Bd2Q9Hgp1e/6hWiiEyJ7lOQ=";
   };
 
-  cargoHash = "sha256-4sDagd2XGamBz1XvDj4ycRVJ0F+4iwHOPlj/RglNDqE=";
+  cargoHash = "sha256-/sKUAADlxzMOyThvYhFLK52oOePFQC1V8hF9Ay5Atis=";
 
   # used for "Server Installed" version in admin panel
   env.VW_VERSION = version;

--- a/pkgs/by-name/va/vaultwarden/update.nix
+++ b/pkgs/by-name/va/vaultwarden/update.nix
@@ -30,12 +30,12 @@ lib.getExe (writeShellApplication {
     VAULTWARDEN_VERSION=$(curl --silent https://api.github.com/repos/dani-garcia/vaultwarden/releases/latest | jq -r '.tag_name')
     nix-update "vaultwarden" --version "$VAULTWARDEN_VERSION"
 
-    URL="https://raw.githubusercontent.com/dani-garcia/vaultwarden/''${VAULTWARDEN_VERSION}/docker/DockerSettings.yaml"
-    WEBVAULT_VERSION="$(curl --silent "$URL" | yq -r ".vault_version" | sed s/^v//)"
-    old_hash="$(nix --extra-experimental-features nix-command eval -f default.nix --raw vaultwarden.webvault.bw_web_builds.outputHash)"
-    new_hash="$(nix-prefetch-git https://github.com/dani-garcia/bw_web_builds.git --rev "v$WEBVAULT_VERSION" | jq --raw-output ".sha256")"
-    new_hash_sri="$(nix --extra-experimental-features nix-command hash to-sri --type sha256 "$new_hash")"
-    sed -e "s#$old_hash#$new_hash_sri#" -i pkgs/tools/security/vaultwarden/webvault.nix
-    nix-update "vaultwarden.webvault" --version "$WEBVAULT_VERSION"
+    URL_VAULTWARDEN_DOCKER_SETTINGS="https://raw.githubusercontent.com/dani-garcia/vaultwarden/''${VAULTWARDEN_VERSION}/docker/DockerSettings.yaml"
+    WEBVAULT_VERSION="$(curl --silent "$URL_VAULTWARDEN_DOCKER_SETTINGS" | yq -r ".vault_version")"
+    URL_BW_WEBVAULT_DOCKERFILE="https://raw.githubusercontent.com/dani-garcia/bw_web_builds/refs/tags/''${WEBVAULT_VERSION}/Dockerfile"
+    WEBVAULT_REV="$(curl --silent "$URL_BW_WEBVAULT_DOCKERFILE" | grep -m1 "^ARG VAULT_VERSION=" | cut -d'=' -f2)"
+    URL_VW_WEBVAULT_TAGS="https://api.github.com/repos/vaultwarden/vw_web_builds/tags"
+    WEBVAULT_TAG="$(curl --silent "$URL_VW_WEBVAULT_TAGS" | jq -r --arg rev "''${WEBVAULT_REV}" '.[] | select(.commit.sha == $rev) | .name')"
+    nix-update "vaultwarden.webvault" --version "$WEBVAULT_TAG"
   '';
 })

--- a/pkgs/by-name/va/vaultwarden/webvault.nix
+++ b/pkgs/by-name/va/vaultwarden/webvault.nix
@@ -4,24 +4,26 @@
   fetchFromGitHub,
   nixosTests,
   python3,
+  dart-sass,
   vaultwarden,
 }:
 
 buildNpmPackage rec {
   pname = "vaultwarden-webvault";
-  version = "2025.7.0.0";
+  version = "2025.12.0.0";
 
   src = fetchFromGitHub {
     owner = "vaultwarden";
     repo = "vw_web_builds";
     tag = "v${version}";
-    hash = "sha256-CnVOi4xE0+VFTm0yI4++MBv8w0vgtsRE5E2RwsLojMI=";
+    hash = "sha256-j31wroJKBa6pQFDTGtZBBljXVvpt8233G2oTj8oz3fo=";
   };
 
-  npmDepsHash = "sha256-QoZtiZpS8jVIaGKHcfKbtBrrn+RcMRvm1/oF23nPPQw=";
+  npmDepsHash = "sha256-OT9Ll+F4e/yOJVpay/zwfEHcBqRvSFOM2mtlrJ8E6fs=";
 
   nativeBuildInputs = [
     python3
+    dart-sass
   ];
 
   makeCacheWritable = true;
@@ -30,6 +32,10 @@ buildNpmPackage rec {
     ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
     npm_config_build_from_source = "true";
   };
+
+  preBuild = ''
+    echo "export const compilerCommand = ['dart-sass'];" > node_modules/sass-embedded/dist/lib/src/compiler-path.js
+  '';
 
   npmRebuildFlags = [
     # FIXME one of the esbuild versions fails to download @esbuild/linux-x64


### PR DESCRIPTION
## Things done
- Updated vaultwarden
- Removed potentially unneeded code from `update.nix`
- Changed webvault to use rev instead of tag, as that's what we pull from the docker settings file
- Fixed build on newest webvault version.

---

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
