### PR TITLE
fish: 4.2.1 -> 4.3.1

### DIFF
--- a/pkgs/by-name/fi/fish/package.nix
+++ b/pkgs/by-name/fi/fish/package.nix
@@ -151,13 +151,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "fish";
-  version = "4.2.1";
+  version = "4.3.1";
 
   src = fetchFromGitHub {
     owner = "fish-shell";
     repo = "fish-shell";
     tag = finalAttrs.version;
-    hash = "sha256-BUtHMx44efWTiS6heCUqONxngLwUCBOoDQqxoCj189U=";
+    hash = "sha256-M1/jgIbFY0VSQrHwT9/gcfA0HJ0r2cL1eJ3Y7lmmYVE=";
   };
 
   env = {
@@ -168,7 +168,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) src patches;
-    hash = "sha256-00Ch1EcX4cxMwvuDQLzTUIY7XkE3WX8bXBUA3yMRAMI=";
+    hash = "sha256-j+V4/oxKDg4oQ+7eg34sefIMJLelOSUKXTXasQK2Z1g=";
   };
 
   patches = [
@@ -220,6 +220,17 @@ stdenv.mkDerivation (finalAttrs: {
 
     substituteInPlace tests/checks/complete.fish \
       --replace-fail '/bin/ls' '${lib.getExe' coreutils "ls"}'
+
+    substituteInPlace tests/checks/output-buffering.fish \
+      --replace-fail '/bin/echo' '${lib.getExe' coreutils "echo"}'
+
+    substituteInPlace tests/pexpects/wait.py \
+      --replace-fail 'expect_prompt("Job ' 'expect_prompt("fish: Job ' \
+      --replace-fail 'expect_str("Job ' 'expect_str("fish: Job '
+
+    substituteInPlace share/tools/web_config/webconfig.py \
+      --replace-fail 'os.environ["__fish_terminal_color_theme"]' \
+        'os.environ.get("__fish_terminal_color_theme", "default")'
 
     # Several pexpect tests are flaky
     # See https://github.com/fish-shell/fish-shell/issues/8789


### PR DESCRIPTION
Changelog: https://github.com/fish-shell/fish-shell/releases/tag/4.3.1
Diff: https://github.com/fish-shell/fish-shell/compare/4.2.1...4.3.1

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
