### PR TITLE
ykush: 1.2.5 -> 1.4.0

### DIFF
--- a/pkgs/by-name/yk/ykush/package.nix
+++ b/pkgs/by-name/yk/ykush/package.nix
@@ -8,15 +8,15 @@
 }:
 stdenv.mkDerivation (final: {
   pname = "ykushcmd";
-  version = "1.2.5";
+  version = "1.4.0";
 
   buildInputs = [ libusb1 ];
 
   src = fetchFromGitHub {
     owner = "yepkit";
     repo = "ykush";
-    tag = "${final.version}";
-    hash = "sha256-FbqlXh8A5hzpthBE3jZ1LLOMs4WcEGke3sOZi9vmZF8=";
+    tag = "v${final.version}";
+    hash = "sha256-+ssr1QHKjEdK8pFkmyHYwG9tY7YHaYcIIJUqaEXixOg=";
   };
 
   installPhase = ''


### PR DESCRIPTION
Adds new commands for the latest functionalities brought by YKUSHXS firmware version 1.1.0.

The version tag changed to a leading `v`.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - ~[NixOS tests] in [nixos/tests].~
  - ~[Package tests] at `passthru.tests`.~
  - ~Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.~
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - ~Package update: when the change is major or breaking.~ is not breaking
- NixOS Release Notes
  - ~Module addition: when adding a new NixOS module.~
  - ~Module update: when the change is significant.~
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
