### PR TITLE
mistral-vibe: init at 1.3.3

### DIFF
--- a/pkgs/by-name/mi/mistral-vibe/package.nix
+++ b/pkgs/by-name/mi/mistral-vibe/package.nix
@@ -1,0 +1,104 @@
+{
+  lib,
+  stdenv,
+  python3Packages,
+  fetchFromGitHub,
+
+  # tests
+  uv,
+  versionCheckHook,
+  writableTmpDirAsHomeHook,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "mistral-vibe";
+  version = "1.3.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "mistralai";
+    repo = "mistral-vibe";
+    tag = "v${version}";
+    hash = "sha256-nW7pRSyv+t/7yatx84PMgxsHRTfRqqpy6rz+dQfLluU=";
+  };
+
+  build-system = with python3Packages; [
+    editables
+    hatch-vcs
+    hatchling
+  ];
+
+  pythonRelaxDeps = [
+    "agent-client-protocol"
+    "mistralai"
+    "pydantic"
+    "pydantic-settings"
+    "watchfiles"
+  ];
+  dependencies = with python3Packages; [
+    agent-client-protocol
+    aiofiles
+    httpx
+    mcp
+    mistralai
+    packaging
+    pexpect
+    pydantic
+    pydantic-settings
+    pyperclip
+    python-dotenv
+    pyyaml
+    rich
+    textual
+    textual-speedups
+    tomli-w
+    watchfiles
+  ];
+
+  pythonImportsCheck = [ "vibe" ];
+
+  nativeCheckInputs = [
+    python3Packages.pytest-asyncio
+    python3Packages.pytest-textual-snapshot
+    python3Packages.pytest-xdist
+    python3Packages.pytestCheckHook
+    python3Packages.respx
+    uv
+    versionCheckHook
+    writableTmpDirAsHomeHook
+  ];
+  versionCheckProgramArg = "--version";
+  versionCheckKeepEnvironment = [ "HOME" ];
+  pytestFlags = [ "tests/cli/test_clipboard.py" ];
+
+  disabledTests = [
+    # AssertionError: assert '/nix/store/rlq03x4cwf8zn73hxaxnx0zn5q9kifls-bash-5.3p3/bin/sh:
+    # warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8): No such file or directory\n' == ''
+    "test_decodes_non_utf8_bytes"
+    "test_runs_echo_successfully"
+    "test_truncates_output_to_max_bytes"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # AssertionError: assert 3 == 4
+    "test_get_copy_fns_with_wl_copy"
+    "test_get_copy_fns_with_both_system_tools"
+    "test_get_copy_fns_with_xclip"
+  ];
+
+  disabledTestPaths = [
+    # All snapshot tests fail with AssertionError
+    "tests/snapshots/"
+
+    # ACP tests require network access
+    "tests/acp/test_acp.py"
+  ];
+
+  meta = {
+    description = "Minimal CLI coding agent by Mistral";
+    homepage = "https://github.com/mistralai/mistral-vibe";
+    changelog = "https://github.com/mistralai/mistral-vibe/blob/${src.tag}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+    mainProgram = "vibe";
+  };
+}

--- a/pkgs/by-name/mi/mistral-vibe/package.nix
+++ b/pkgs/by-name/mi/mistral-vibe/package.nix
@@ -98,7 +98,10 @@ python3Packages.buildPythonApplication rec {
     homepage = "https://github.com/mistralai/mistral-vibe";
     changelog = "https://github.com/mistralai/mistral-vibe/blob/${src.tag}/CHANGELOG.md";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ GaetanLepage ];
+    maintainers = with lib.maintainers; [
+      GaetanLepage
+      shikanime
+    ];
     mainProgram = "vibe";
   };
 }

--- a/pkgs/development/python-modules/agent-client-protocol/default.nix
+++ b/pkgs/development/python-modules/agent-client-protocol/default.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  pdm-backend,
+
+  # dependencies
+  pydantic,
+
+  # optional-dependencies
+  opentelemetry-sdk,
+
+  # tests
+  pytest-asyncio,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "agent-client-protocol";
+  version = "0.7.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "agentclientprotocol";
+    repo = "python-sdk";
+    tag = version;
+    hash = "sha256-pUOs6TUc0qmY+/AWTtm5kKouHKL8cLMhJ+nZT4r+6sI=";
+  };
+
+  build-system = [
+    pdm-backend
+  ];
+
+  dependencies = [
+    pydantic
+  ];
+
+  optional-dependencies = {
+    logfire = [
+      # logfire (unpackaged)
+      opentelemetry-sdk
+    ];
+  };
+
+  pythonImportsCheck = [ "acp" ];
+
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    # Hangs forever
+    "test_spawn_agent_process_roundtrip"
+  ];
+
+  meta = {
+    description = "Python SDK for ACP clients and agents";
+    homepage = "https://github.com/agentclientprotocol/python-sdk";
+    changelog = "https://github.com/agentclientprotocol/python-sdk/releases/tag/${src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+}

--- a/pkgs/development/python-modules/textual-speedups/default.nix
+++ b/pkgs/development/python-modules/textual-speedups/default.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  rustPlatform,
+}:
+
+buildPythonPackage rec {
+  pname = "textual-speedups";
+  version = "0.2.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "willmcgugan";
+    repo = "textual-speedups";
+    tag = "v${version}";
+    hash = "sha256-zsDA8qPpeiOlmL18p4pItEgXQjgrQEBVRJazrGJT9Bw=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit pname version src;
+    hash = "sha256-Bz4ocEziOlOX4z5F9EDry99YofeGyxL/6OTIf/WEgK4=";
+  };
+
+  nativeBuildInputs = [
+    rustPlatform.cargoSetupHook
+    rustPlatform.maturinBuildHook
+  ];
+
+  pythonImportsCheck = [ "textual_speedups" ];
+
+  # No tests
+  doCheck = false;
+
+  meta = {
+    description = "Optional Rust speedups for Textual";
+    homepage = "https://github.com/willmcgugan/textual-speedups";
+    # No license (yet?)
+    # https://github.com/willmcgugan/textual-speedups/issues/2
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -138,6 +138,8 @@ self: super: with self; {
 
   agate-sql = callPackage ../development/python-modules/agate-sql { };
 
+  agent-client-protocol = callPackage ../development/python-modules/agent-client-protocol { };
+
   agent-py = callPackage ../development/python-modules/agent-py { };
 
   aggdraw = callPackage ../development/python-modules/aggdraw { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18784,6 +18784,8 @@ self: super: with self; {
 
   textual-slider = callPackage ../development/python-modules/textual-slider { };
 
+  textual-speedups = callPackage ../development/python-modules/textual-speedups { };
+
   textual-textarea = callPackage ../development/python-modules/textual-textarea { };
 
   textual-universal-directorytree =


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Add [mistral-vibe](https://github.com/mistralai/mistral-vibe), a minimal CLI coding agent by Mistral.

- **python3Packages.agent-client-protocol: init at 0.7.1**
- **python3Packages.textual-speedups: init at 0.2.1**
- **mistral-vibe: init at 1.3.3**

---

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
