### PR TITLE
notesnook: add update script

### DIFF
--- a/pkgs/by-name/no/notesnook/hashes.nix
+++ b/pkgs/by-name/no/notesnook/hashes.nix
@@ -1,0 +1,6 @@
+{
+  x86_64-linux = "sha256-jvQph74dMQgino3K1ZFLT/fsJVdTHVqMQaW0RQhfci0=";
+  aarch64-linux = "sha256-jrKmZmdx1T1wrlM0y195Z2MsI1XpFn0gyFyf7N/aUzo=";
+  x86_64-darwin = "sha256-bJ+sq6/lZcLcM7R2KAigemdpRDqSiExfcSunNQ7cGw0=";
+  aarch64-darwin = "sha256-DTY0gq62aXOanZvYletyXl5xmcs30vWTKE4nZujRCq0=";
+}

--- a/pkgs/by-name/no/notesnook/package.nix
+++ b/pkgs/by-name/no/notesnook/package.nix
@@ -25,18 +25,15 @@ let
 
   src = fetchurl {
     url = "https://github.com/streetwriters/notesnook/releases/download/v${version}/notesnook_${suffix}";
-    hash =
-      {
-        x86_64-linux = "sha256-jvQph74dMQgino3K1ZFLT/fsJVdTHVqMQaW0RQhfci0=";
-        aarch64-linux = "sha256-jrKmZmdx1T1wrlM0y195Z2MsI1XpFn0gyFyf7N/aUzo=";
-        x86_64-darwin = "sha256-bJ+sq6/lZcLcM7R2KAigemdpRDqSiExfcSunNQ7cGw0=";
-        aarch64-darwin = "sha256-DTY0gq62aXOanZvYletyXl5xmcs30vWTKE4nZujRCq0=";
-      }
-      .${system} or throwSystem;
+    hash = (import ./hashes.nix).${system} or throwSystem;
   };
 
   appimageContents = appimageTools.extractType2 {
     inherit pname version src;
+  };
+
+  passthru = {
+    updateScript = ./update.sh;
   };
 
   meta = {
@@ -67,6 +64,7 @@ let
       version
       src
       meta
+      passthru
       ;
 
     nativeBuildInputs = [ makeWrapper ];
@@ -91,6 +89,7 @@ let
       version
       src
       meta
+      passthru
       ;
 
     nativeBuildInputs = [ _7zz ];

--- a/pkgs/by-name/no/notesnook/update.sh
+++ b/pkgs/by-name/no/notesnook/update.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p bash curl jq
+
+set -xe
+
+fetch() {
+  platform=$1
+  suffix=$2
+  hash=$(nix-hash --to-sri --type sha256 "$(nix-prefetch-url "https://github.com/streetwriters/notesnook/releases/download/v$latestVersion/notesnook_$suffix")")
+  printf '  %s = "%s";\n' "$platform" "$hash" >> "$dirname/hashes.nix"
+}
+
+dirname="$(dirname "$0")"
+
+latestTag=$(curl ${GITHUB_TOKEN:+-u":$GITHUB_TOKEN"} https://api.github.com/repos/streetwriters/notesnook/releases/latest | jq -r ".tag_name")
+latestVersion="$(expr "$latestTag" : 'v\(.*\)')"
+
+sed -i "s/version = \"$UPDATE_NIX_OLD_VERSION\";/version = \"$latestVersion\";/" "$dirname/package.nix"
+
+printf '{\n' > "$dirname/hashes.nix"
+fetch x86_64-linux linux_x86_64.AppImage
+fetch aarch64-linux linux_arm64.AppImage
+fetch x86_64-darwin mac_x64.dmg
+fetch aarch64-darwin mac_arm64.dmg
+printf '}\n' >> "$dirname/hashes.nix"


### PR DESCRIPTION
frankly this kind of sucks. I'm fairly sure it works, though. (conveniently, there's an update available currently, so testing this should be easy.)

closes #474269 (to get r-ryantm to run again)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
