### PR TITLE
nixos/zfs: update /etc/zfs/zed.d symlinks

### DIFF
--- a/nixos/modules/tasks/filesystems/zfs.nix
+++ b/nixos/modules/tasks/filesystems/zfs.nix
@@ -846,19 +846,33 @@ in
 
       environment.etc =
         lib.genAttrs
-          (map (file: "zfs/zed.d/${file}") [
-            "all-syslog.sh"
-            "pool_import-led.sh"
-            "resilver_finish-start-scrub.sh"
-            "statechange-led.sh"
-            "vdev_attach-led.sh"
-            "zed-functions.sh"
-            "data-notify.sh"
-            "resilver_finish-notify.sh"
-            "scrub_finish-notify.sh"
-            "statechange-notify.sh"
-            "vdev_clear-led.sh"
-          ])
+          (map (file: "zfs/zed.d/${file}") (
+            [
+              "all-syslog.sh"
+              "data-notify.sh"
+              "history_event-zfs-list-cacher.sh"
+              "resilver_finish-notify.sh"
+              "resilver_finish-start-scrub.sh"
+              "scrub_finish-notify.sh"
+              "statechange-notify.sh"
+            ]
+            ++ lib.optionals (lib.versionOlder cfgZfs.package.version "2.4") [
+              "deadman-slot_off.sh"
+              "pool_import-led.sh"
+              "statechange-led.sh"
+              "statechange-slot_off.sh"
+              "vdev_attach-led.sh"
+              "vdev_clear-led.sh"
+            ]
+            ++ lib.optionals (lib.versionAtLeast cfgZfs.package.version "2.4") [
+              "deadman-sync-slot_off.sh"
+              "pool_import-sync-led.sh"
+              "statechange-sync-led.sh"
+              "statechange-sync-slot_off.sh"
+              "vdev_attach-sync-led.sh"
+              "vdev_clear-sync-led.sh"
+            ]
+          ))
           (file: {
             source = "${cfgZfs.package}/etc/${file}";
           })


### PR DESCRIPTION
2.4 renamed some of these, and we were missing a couple in 2.3 as well.

We should probably find a less fragile way of managing these, but this

Fixes #474855


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
