### PR TITLE
inkscape: 1.4.2 -> 1.4.3

### DIFF
--- a/pkgs/applications/graphics/inkscape/default.nix
+++ b/pkgs/applications/graphics/inkscape/default.nix
@@ -74,7 +74,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "inkscape";
-  version = "1.4.2";
+  version = "1.4.3";
   outputs = [
     "out"
     "man"
@@ -82,7 +82,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "https://inkscape.org/release/inkscape-${finalAttrs.version}/source/archive/xz/dl/inkscape-${finalAttrs.version}.tar.xz";
-    sha256 = "sha256-IABTDHkX5SYMnoV1pxVP9pJmQ9IAZIfXFOMEqWPwx4I=";
+    sha256 = "sha256-6DosPbVwtsWh/w/M/nCYg3s/a9dLEzVnk3yKkXEO0dE=";
   };
 
   # Inkscape hits the ARGMAX when linking on macOS. It appears to be
@@ -100,26 +100,6 @@ stdenv.mkDerivation (finalAttrs: {
     (replaceVars ./fix-ps2pdf-path.patch {
       # Fix path to ps2pdf binary
       inherit ghostscript;
-    })
-    (fetchpatch {
-      name = "fix-build-poppler-25.06.0.patch";
-      url = "https://gitlab.com/inkscape/inkscape/-/commit/40f5b15b7e29908b79c54e81db6f340936102e08.patch";
-      hash = "sha256-bYRd/KUh/7qFb7x0EuUgQYA9P8abcTf5XS67gzaAiXA=";
-    })
-    (fetchpatch {
-      name = "fix-build-poppler-25.07.0.patch";
-      url = "https://gitlab.com/inkscape/inkscape/-/commit/8ae83ca81bbaebcc0ff0abe82300d56d2c94e6f9.patch";
-      hash = "sha256-s7UMnv1pAiQA/HL5CEdBwCn4v/tsphc0MSnBJAoqolY=";
-    })
-    (fetchpatch {
-      name = "fix-build-poppler-25.09.0.patch";
-      url = "https://gitlab.com/inkscape/inkscape/-/commit/f48b429827dca510b41a5671d467e574ef348625.patch";
-      hash = "sha256-9CfmkTGMVHjZiiE3zvi4YOrytcir8a7O2z3PrhjcohI=";
-    })
-    (fetchpatch {
-      name = "fix-build-poppler-25.10.0.patch";
-      url = "https://gitlab.com/inkscape/inkscape/-/commit/4dba481fe898c6317696d50b109f5aed8f269c19.patch";
-      hash = "sha256-FFCkMU+Ec2qobG4ru89NPcM9Gxw8ZyFV+6jpW8ZwgE4=";
     })
   ];
 


### PR DESCRIPTION
I removed the poppler patches because they failed building and honstly don't know what they were for. Package builds & runs successfully, pdf rendering also works (which seems to be what poppler is about). 

https://inkscape.org/news/2025/12/26/bugs-banished-inkscape-143-is-out/
https://inkscape.org/doc/release_notes/1.4.3/Inkscape_1.4.3.html
https://gitlab.com/inkscape/inkscape/-/compare/INKSCAPE_1_4_2...INKSCAPE_1_4_3

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc


