### PR TITLE
python3Packages.pyvips: 3.0.0 -> 3.1.1

### DIFF
--- a/pkgs/development/python-modules/pyvips/default.nix
+++ b/pkgs/development/python-modules/pyvips/default.nix
@@ -8,23 +8,20 @@
   pkg-config, # from pkgs
   pkgconfig, # from pythonPackages
   pytestCheckHook,
-  pythonOlder,
   setuptools,
   vips,
 }:
 
 buildPythonPackage rec {
   pname = "pyvips";
-  version = "3.0.0";
+  version = "3.1.1";
   pyproject = true;
-
-  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "libvips";
     repo = "pyvips";
     tag = "v${version}";
-    hash = "sha256-dyous0EahUR7pkr2siBBJwzcoC4TOsnsbRo+rVE8/QQ=";
+    hash = "sha256-BPQFndikPSsKU4HPauTAewab32IumckG/y3lhUUNbMU=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/pyvips/default.nix
+++ b/pkgs/development/python-modules/pyvips/default.nix
@@ -63,6 +63,10 @@ buildPythonPackage rec {
     "test_progress"
   ];
 
+  disabledTestPaths = [
+    "tests/perf"
+  ];
+
   pythonImportsCheck = [ "pyvips" ];
 
   meta = {

--- a/pkgs/development/python-modules/pyvips/default.nix
+++ b/pkgs/development/python-modules/pyvips/default.nix
@@ -57,6 +57,12 @@ buildPythonPackage rec {
       --replace 'libgobject-2.0.dylib' '${glib.out}/lib/libgobject-2.0${stdenv.hostPlatform.extensions.sharedLibrary}' \
   '';
 
+  disabledTests = [
+    # flaky due to a race condition
+    # https://github.com/libvips/pyvips/issues/566
+    "test_progress"
+  ];
+
   pythonImportsCheck = [ "pyvips" ];
 
   meta = {


### PR DESCRIPTION
## Changes 
1. Disabled flaky `test_progress` and filed https://github.com/libvips/pyvips/issues/566; Hydra: https://hydra.nixos.org/build/317528888
2. Disabled benchmarks under tests
3. Upgraded to version 3.1.1

### Version 3.1.1 (released 9 December 2025)

fix get_gainmap arguments [jcupitt]
fix __array__ copy argument test [jcupitt]
add a test [jcupitt]

### Version 3.1.0 (released 8 December 2025)

fix glib DLL name with Conan [boussaffawalid]
update docs for libvips 8.18 [jcupitt]
add get_gainmap() [jcupitt]
remove redundant revalidate flags from docs [kleisauke]


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
