### PR TITLE
ankiAddons.advanced-browser: init at 4.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19222,6 +19222,18 @@
     githubId = 61601147;
     name = "basti n00b0ss";
   };
+  n0emis = {
+    email = "nixpkgs@n0emis.network";
+    github = "n0emis";
+    githubId = 22817873;
+    name = "Ember Keske";
+  };
+  n0pl4c3 = {
+    email = "mail@n0pl4c3.net";
+    github = "n0pl4c3";
+    githubId = 69087176;
+    name = "n0pl4c3";
+  };
   n3oney = {
     name = "Michał Minarowski";
     email = "nixpkgs@neoney.dev";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19222,12 +19222,6 @@
     githubId = 61601147;
     name = "basti n00b0ss";
   };
-  n0emis = {
-    email = "nixpkgs@n0emis.network";
-    github = "n0emis";
-    githubId = 22817873;
-    name = "Ember Keske";
-  };
   n0pl4c3 = {
     email = "mail@n0pl4c3.net";
     github = "n0pl4c3";

--- a/pkgs/by-name/an/anki/addons/advanced-browser/default.nix
+++ b/pkgs/by-name/an/anki/addons/advanced-browser/default.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  anki-utils,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+anki-utils.buildAnkiAddon (finalAttrs: {
+  pname = "advanced-browser";
+  version = "4.5";
+  src = fetchFromGitHub {
+    owner = "AnKing-VIP";
+    repo = "advanced-browser";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-oVL+Y96/d+uD8s6yjz6L7zWV2G6PgP7ZfIiEAAZR2T4=";
+  };
+  passthru.updateScript = nix-update-script { };
+  meta = {
+    description = "Adds more sorting options to the browser";
+    longDescription = ''
+      A general overview of the functionality can be found [here](https://ankiweb.net/shared/info/874215009).
+      The options to configure this add-on can be found [here](https://github.com/AnKing-VIP/advanced-browser/blob/v${finalAttrs.version}/advancedbrowser/config.md).
+    '';
+    homepage = "https://ankiweb.net/shared/info/874215009";
+    downloadPage = "https://github.com/AnKing-VIP/advanced-browser";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ n0pl4c3 ];
+  };
+})

--- a/pkgs/by-name/an/anki/addons/default.nix
+++ b/pkgs/by-name/an/anki/addons/default.nix
@@ -4,6 +4,8 @@
 {
   adjust-sound-volume = callPackage ./adjust-sound-volume { };
 
+  advanced-browser = callPackage ./advanced-browser { };
+
   ajt-card-management = callPackage ./ajt-card-management { };
 
   anki-connect = callPackage ./anki-connect { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- Added ankiAddons.advanced-browser [Anki Addon](https://ankiweb.net/shared/info/874215009)
- Added self (n0pl4c3) to maintainers

As there was discussion in an issue on home-manager about packaging more Anki addons, I decided to try packaging some of the addons I use. I have some others prepared, but since this is my first time contributing here I think it makes sense to wait if I did something massively wrong first :sweat_smile:

Tested with `nix-build -E 'with import ./. {}; anki.withAddons [ ankiAddons.advanced-browser ]' && ./result/bin/anki`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
