### PR TITLE
texlab: 5.24.0 -> 5.25.0

### DIFF
--- a/pkgs/by-name/te/texlab/package.nix
+++ b/pkgs/by-name/te/texlab/package.nix
@@ -12,14 +12,14 @@
 let
   isCross = stdenv.hostPlatform != stdenv.buildPlatform;
 in
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "texlab";
   version = "5.25.0";
 
   src = fetchFromGitHub {
     owner = "latex-lsp";
     repo = "texlab";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-UI88DQjLRJRPgKX3A+PoLNzgm/9uJeNERTrzh5mnAEk=";
   };
 
@@ -47,7 +47,7 @@ rustPlatform.buildRustPackage rec {
   meta = {
     description = "Implementation of the Language Server Protocol for LaTeX";
     homepage = "https://github.com/latex-lsp/texlab";
-    changelog = "https://github.com/latex-lsp/texlab/blob/v${version}/CHANGELOG.md";
+    changelog = "https://github.com/latex-lsp/texlab/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       doronbehar
@@ -56,4 +56,4 @@ rustPlatform.buildRustPackage rec {
     platforms = lib.platforms.all;
     mainProgram = "texlab";
   };
-}
+})

--- a/pkgs/by-name/te/texlab/package.nix
+++ b/pkgs/by-name/te/texlab/package.nix
@@ -14,16 +14,16 @@ let
 in
 rustPlatform.buildRustPackage rec {
   pname = "texlab";
-  version = "5.24.0";
+  version = "5.25.0";
 
   src = fetchFromGitHub {
     owner = "latex-lsp";
     repo = "texlab";
     tag = "v${version}";
-    hash = "sha256-gwF4cBlS43u2PfOQBxD7iq2JL9tUo8TPJqR0tWNdW9k=";
+    hash = "sha256-UI88DQjLRJRPgKX3A+PoLNzgm/9uJeNERTrzh5mnAEk=";
   };
 
-  cargoHash = "sha256-9sAurVJSpLNgQvJOG7kSXHIr38MHsw3BhGAaxi9xjUE=";
+  cargoHash = "sha256-xDLKuAfLyo3V++OKb+anw9oHxehwUxqfnDCuT2GSDWw=";
 
   outputs = [ "out" ] ++ lib.optional (!isCross) "man";
 
@@ -37,7 +37,7 @@ rustPlatform.buildRustPackage rec {
   # generate the man page
   postInstall = lib.optionalString (!isCross) ''
     # TexLab builds man page separately in CI:
-    # https://github.com/latex-lsp/texlab/blob/v5.24.0/.github/workflows/publish.yml#L110-L114
+    # https://github.com/latex-lsp/texlab/blob/v5.25.0/.github/workflows/publish.yml#L110-L114
     help2man --no-info "$out/bin/texlab" > texlab.1
     installManPage texlab.1
   '';


### PR DESCRIPTION
https://github.com/latex-lsp/texlab/blob/v5.25.0/CHANGELOG.md

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
