### PR TITLE
python3Packages.dulwich: rationalize test exclusions, adopt

### DIFF
--- a/pkgs/development/python-modules/dulwich/default.nix
+++ b/pkgs/development/python-modules/dulwich/default.nix
@@ -110,6 +110,9 @@ buildPythonPackage rec {
       asl20
       gpl2Plus
     ];
-    maintainers = with lib.maintainers; [ koral ];
+    maintainers = with lib.maintainers; [
+      koral
+      sarahec
+    ];
   };
 }

--- a/pkgs/development/python-modules/dulwich/default.nix
+++ b/pkgs/development/python-modules/dulwich/default.nix
@@ -13,13 +13,11 @@
   merge3,
   paramiko,
   pytestCheckHook,
-  pythonOlder,
   rich,
   rustPlatform,
   rustc,
   setuptools,
   setuptools-rust,
-  typing-extensions,
   urllib3,
 }:
 
@@ -27,8 +25,6 @@ buildPythonPackage rec {
   pname = "dulwich";
   version = "0.24.1";
   pyproject = true;
-
-  disabled = pythonOlder "3.9";
 
   src = fetchFromGitHub {
     owner = "jelmer";
@@ -55,9 +51,6 @@ buildPythonPackage rec {
 
   dependencies = [
     urllib3
-  ]
-  ++ lib.optionals (pythonOlder "3.11") [
-    typing-extensions
   ];
 
   optional-dependencies = {

--- a/pkgs/development/python-modules/dulwich/default.nix
+++ b/pkgs/development/python-modules/dulwich/default.nix
@@ -81,17 +81,17 @@ buildPythonPackage rec {
     "test_file_win"
     # dulwich.errors.NotGitRepository: No git repository was found at .
     "WorktreeCliTests"
-    # 'SwiftPackData' object has no attribute '_file'
-    "test_iterobjects_subset_all_present"
-    "test_iterobjects_subset_missing_allowed"
-    "test_iterobjects_subset_missing_not_allowed"
     # Adding a symlink to a directory outside the repo doesn't raise
     "test_add_symlink_absolute_to_system"
+    # Depends on setuid which is not available in sandboxed environments
+    "SharedRepositoryTests"
+    # TypeError: pack index v1 only supports SHA-1 names
+    "test_pack_index_v1_with_sha256"
   ];
 
   disabledTestPaths = [
-    # requires swift config file
-    "tests/contrib/test_swift_smoke.py"
+    # "Code [in contrib] is not an official part of Dulwich, and may no longer work"
+    "tests/contrib"
   ];
 
   __darwinAllowLocalNetworking = true;


### PR DESCRIPTION
1. Disable tests that break on darwin and linux; drop `contrib` tests (not guaranteed to be maintained, and one breaks on Darwin already). Simplify `disabledTests` accordingly.
2. Add self as maintainer.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
