### PR TITLE
[release-25.05] treewide: fix broken-string-escape

### DIFF
--- a/nixos/modules/services/web-apps/baikal.nix
+++ b/nixos/modules/services/web-apps/baikal.nix
@@ -98,11 +98,11 @@ in
             rewrite ^/.well-known/caldav  /dav.php redirect;
             rewrite ^/.well-known/carddav /dav.php redirect;
           '';
-          "~ /(\.ht|Core|Specific|config)".extraConfig = ''
+          "~ /(\\.ht|Core|Specific|config)".extraConfig = ''
             deny all;
             return 404;
           '';
-          "~ ^(.+\.php)(.*)$".extraConfig = ''
+          "~ ^(.+\\.php)(.*)$".extraConfig = ''
             try_files $fastcgi_script_name =404;
             include                   ${config.services.nginx.package}/conf/fastcgi.conf;
             fastcgi_split_path_info   ^(.+\.php)(.*)$;

--- a/nixos/modules/services/web-apps/part-db.nix
+++ b/nixos/modules/services/web-apps/part-db.nix
@@ -179,7 +179,7 @@ in
                 sendfile off;
               '';
             };
-            "~ \.php$" = {
+            "~ \\.php$" = {
               extraConfig = ''
                 include ${config.services.nginx.package}/conf/fastcgi_params ;
                 fastcgi_param SCRIPT_FILENAME $request_filename;

--- a/nixos/tests/web-apps/netbox/default.nix
+++ b/nixos/tests/web-apps/netbox/default.nix
@@ -157,7 +157,7 @@ import ../../make-test-python.nix (
         '';
       in
       builtins.replaceStrings
-        [ "$\{changePassword}" "$\{testUser}" "$\{testPassword}" "$\{testGroup}" ]
+        [ "\${changePassword}" "\${testUser}" "\${testPassword}" "\${testGroup}" ]
         [ "${changePassword}" "${testUser}" "${testPassword}" "${testGroup}" ]
         (lib.readFile "${./testScript.py}");
   }

--- a/pkgs/by-name/be/beedii/package.nix
+++ b/pkgs/by-name/be/beedii/package.nix
@@ -29,7 +29,7 @@ stdenvNoCC.mkDerivation rec {
 
     # This version does not include font files in the released assets.
     # https://github.com/webkul/beedii/issues/1
-    ignoredVersions = "^1\.2\.0$";
+    ignoredVersions = "^1\\.2\\.0$";
   };
 
   meta = {

--- a/pkgs/by-name/bl/bloaty/package.nix
+++ b/pkgs/by-name/bl/bloaty/package.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation {
     substituteInPlace CMakeLists.txt \
       --replace "find_package(Python COMPONENTS Interpreter)" "" \
       --replace "if(Python_FOUND AND LIT_EXECUTABLE" "if(LIT_EXECUTABLE" \
-      --replace "COMMAND \''\${Python_EXECUTABLE} \''\${LIT_EXECUTABLE}" "COMMAND \''\${LIT_EXECUTABLE}"
+      --replace "COMMAND \''${Python_EXECUTABLE} \''${LIT_EXECUTABLE}" "COMMAND \''${LIT_EXECUTABLE}"
     # wasm test fail. Possibly due to LLVM version < 17. See https://github.com/google/bloaty/pull/354
     rm -rf tests/wasm
   '';

--- a/pkgs/by-name/bl/blst/package.nix
+++ b/pkgs/by-name/bl/blst/package.nix
@@ -44,17 +44,17 @@ stdenv.mkDerivation (finalAttrs: {
     mkdir -p $out/lib/pkgconfig
     cat <<EOF > $out/lib/pkgconfig/libblst.pc
     prefix=$out
-    exec_prefix=''\\''${prefix}
-    libdir=''\\''${exec_prefix}/lib
-    includedir=''\\''${prefix}/include
+    exec_prefix=\''${prefix}
+    libdir=\''${exec_prefix}/lib
+    includedir=\''${prefix}/include
 
     Name: libblst
     Description: ${finalAttrs.meta.description}
     URL: ${finalAttrs.meta.homepage}
     Version: ${finalAttrs.version}
 
-    Cflags: -I''\\''${includedir}
-    Libs: -L''\\''${libdir} -lblst
+    Cflags: -I \''${includedir}
+    Libs: -L \''${libdir} -lblst
     Libs.private:
     EOF
 

--- a/pkgs/by-name/ed/edgetx/package.nix
+++ b/pkgs/by-name/ed/edgetx/package.nix
@@ -125,7 +125,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildPhase = ''
     runHook preBuild
 
-    cmakeCommonFlags="$''\{cmakeFlags[@]}"
+    cmakeCommonFlags="''${cmakeFlags[@]}"
     # This is the most sensible way to convert target name -> cmake options
     # aside from manually extracting bash variables from upstream's CI scripts
     # and converting that to nix expressions. Let's hope upstream doesn't break
@@ -134,7 +134,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     # Yes, this is really how upstream expects packaging to look like ¯\_(ツ)_/¯.
     # https://github.com/EdgeTX/edgetx/wiki/Build-Instructions-under-Ubuntu-20.04#building-companion-simulator-and-radio-simulator-libraries
-    for plugin in "$''\{targetsToBuild[@]''\}"
+    for plugin in "''${targetsToBuild[@]}"
     do
       # Variable modified by `get_target_build_options` from build-common.sh.
       local BUILD_OPTIONS=""

--- a/pkgs/by-name/eq/equicord/package.nix
+++ b/pkgs/by-name/eq/equicord/package.nix
@@ -60,7 +60,7 @@ stdenv.mkDerivation (finalAttrs: {
   passthru.updateScript = nix-update-script {
     extraArgs = [
       "--version-regex"
-      "^\d{4}-\d{2}-\d{2}$"
+      "^(\\d{4}-\\d{2}-\\d{2})$"
     ];
   };
 

--- a/pkgs/by-name/fi/filebeat8/package.nix
+++ b/pkgs/by-name/fi/filebeat8/package.nix
@@ -29,7 +29,7 @@ buildGoModule rec {
   doInstallCheck = true;
 
   passthru = {
-    updateScript = nix-update-script { extraArgs = [ "--version-regex=v(8\..*)" ]; };
+    updateScript = nix-update-script { extraArgs = [ "--version-regex=v(8\\..*)" ]; };
   };
 
   meta = {

--- a/pkgs/by-name/fs/fstar/package.nix
+++ b/pkgs/by-name/fs/fstar/package.nix
@@ -107,7 +107,7 @@ ocamlPackages.buildDunePackage rec {
     updateScript = nix-update-script {
       extraArgs = [
         "--version-regex"
-        "v(\d{4}\.\d{2}\.\d{2})$"
+        "v(\\d{4}\\.\\d{2}\\.\\d{2})$"
       ];
     };
     z3 = fstarZ3;

--- a/pkgs/by-name/li/libcupsfilters/package.nix
+++ b/pkgs/by-name/li/libcupsfilters/package.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation {
       name = "CVE-2025-64503.patch";
       url = "https://github.com/OpenPrinting/libcupsfilters/commit/fd01543f372ca3ba1f1c27bd3427110fa0094e3f.patch";
       # File has been renamed before the fix
-      decode = "sed -e 's/pdftoraster\.c/pdftoraster\.cxx/g'";
+      decode = "sed -e 's/pdftoraster\\.c/pdftoraster\\.cxx/g'";
       hash = "sha256-cKbDHZEc/A51M+ce3kVsRxjRUWA96ynGv/avpq4iUHU=";
     })
     (fetchpatch {

--- a/pkgs/by-name/lm/lmath/package.nix
+++ b/pkgs/by-name/lm/lmath/package.nix
@@ -39,7 +39,7 @@ appimageTools.wrapType2 {
   passthru.updateScript = nix-update-script {
     extraArgs = [
       "--version-regex"
-      "^r([0-9\.]*)"
+      "^r([0-9\\.]*)"
     ];
   };
 

--- a/pkgs/by-name/ze/zed-editor/package.nix
+++ b/pkgs/by-name/ze/zed-editor/package.nix
@@ -312,7 +312,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     updateScript = nix-update-script {
       extraArgs = [
         "--version-regex"
-        "^v(?!.*(?:-pre|0\.999999\.0|0\.9999-temporary)$)(.+)$"
+        "^v(?!.*(?:-pre|0\\.999999\\.0|0\\.9999-temporary)$)(.+)$"
       ];
     };
     fhs = fhs { zed-editor = finalAttrs.finalPackage; };

--- a/pkgs/by-name/zi/zizmor/package.nix
+++ b/pkgs/by-name/zi/zizmor/package.nix
@@ -37,7 +37,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   doInstallCheck = true;
 
   passthru.updateScript = nix-update-script {
-    extraArgs = [ "--version-regex=^v([0-9.]+\.[0-9.]+\.[0-9.])+$" ];
+    extraArgs = [ "--version-regex=^v([0-9.]+\\.[0-9.]+\\.[0-9.])+$" ];
   };
 
   meta = {

--- a/pkgs/development/python-modules/ipydatawidgets/default.nix
+++ b/pkgs/development/python-modules/ipydatawidgets/default.nix
@@ -48,7 +48,7 @@ buildPythonPackage rec {
     "--deselect=ipydatawidgets/tests/test_ndarray_trait.py::test_dtype_coerce"
 
     # https://github.com/vidartf/ipydatawidgets/issues/63
-    "--deselect=examples/test.ipynb::Cell\\\ 3"
+    "--deselect=examples/test.ipynb::Cell\\ 3"
   ];
 
   meta = {

--- a/pkgs/games/quake2/yquake2/default.nix
+++ b/pkgs/games/quake2/yquake2/default.nix
@@ -60,7 +60,7 @@ let
     makeFlags = [
       "WITH_OPENAL=${mkFlag openalSupport}"
       "WITH_SYSTEMWIDE=yes"
-      "WITH_SYSTEMDIR=$\{out}/share/games/quake2"
+      "WITH_SYSTEMDIR=\${out}/share/games/quake2"
     ];
 
     nativeBuildInputs = [ copyDesktopItems ];


### PR DESCRIPTION
See #473065:

> Lix is going to warn, and in the future, error on broken string escape.
> After a flaker run, the following escape were flagged as broken, so this
> commit fix them to make sure Lix is still able to build nixpkgs once the
> patch deprecating the broken escapes land.

@piegamesde you'll want to also review this one. @CommentatorForAll you might also be interested.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
