### PR TITLE
cc-wrapper: increase FD_SETSIZE on darwin to 4096

### DIFF
--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -916,6 +916,11 @@ stdenvNoCC.mkDerivation {
       echo "-D__ANDROID_API__=${targetPlatform.androidSdkVersion}" >> $out/nix-support/cc-cflags
     ''
 
+    # Increase FD_SETSIZE on Darwin from default 1024 to 4096.
+    + optionalString targetPlatform.isDarwin ''
+      echo "-D_DARWIN_UNLIMITED_SELECT -DFD_SETSIZE=4096" >> $out/nix-support/cc-cflags
+    ''
+
     # There are a few tools (to name one libstdcxx5) which do not work
     # well with multi line flags, so make the flags single line again
     + ''


### PR DESCRIPTION
    Some software could benefit from more fds supported by select(). For
    example, this should help with nixpkgs VMs hanging on darwin due to
    overflow in opened /nix/store/ files when running beefy VMs with lots of
    processes / services. (See: [1] for some details.)

    In the case of qemu, we can apply the macro override narrowly to glib
    [2], but considering there's no practical reason to limit FD_SETSIZE to
    1024 entries (except the need to pass POSIX certification), and since
    alternative interfaces (poll or kqueue) have their own limitations (e.g.
    no support for device files), this patch applies higher limit value
    across the board for all nixpkgs packages.

    The exact value - 4096 - is picked to serve the nixpkgs qemu VM use case
    (based on my observations). If we ever believe 4096 is still not enough,
    we can bump it further as needed (while understanding that increasing
    the limit necessarily increases memory taken by fd set structures used
    by select API).

    [1] https://gitlab.gnome.org/GNOME/glib/-/merge_requests/4953
    [2] https://github.com/NixOS/nixpkgs/pull/474904



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
