### PR TITLE
neovimUtils.makeVimPackageInfo: to help deal with plugin dependencies

### DIFF
--- a/pkgs/applications/editors/neovim/wrapper.nix
+++ b/pkgs/applications/editors/neovim/wrapper.nix
@@ -81,9 +81,6 @@ let
     stdenv.mkDerivation (
       finalAttrs:
       let
-        pluginsNormalized = neovimUtils.normalizePlugins finalAttrs.plugins;
-
-        myVimPackage = neovimUtils.normalizedPluginsToVimPackage pluginsNormalized;
 
         rubyEnv = bundlerEnv {
           name = "neovim-ruby-env";
@@ -93,30 +90,19 @@ let
           '';
         };
 
-        pluginRC = lib.foldl (
-          acc: p: if p.config != null then acc ++ [ p.config ] else acc
-        ) [ ] pluginsNormalized;
-
         # a limited RC script used only to generate the manifest for remote plugins
         manifestRc = "";
+
+        # plugin-related information
+        vimPackageInfo = neovimUtils.makeVimPackageInfo finalAttrs.plugins;
+
         # we call vimrcContent without 'packages' to avoid the init.vim generation
         neovimRcContent' = lib.concatStringsSep "\n" (
-          pluginRC ++ lib.optional (neovimRcContent != null) neovimRcContent
+          vimPackageInfo.userPluginLua ++ lib.optional (neovimRcContent != null) neovimRcContent
         );
 
-        packpathDirs.myNeovimPackages = myVimPackage;
+        packpathDirs.myNeovimPackages = vimPackageInfo.vimPackage;
         finalPackdir = neovimUtils.packDir packpathDirs;
-
-        luaPluginRC =
-          let
-            op =
-              acc: normalizedPlugin:
-              acc
-              ++ lib.optional (
-                finalAttrs.autoconfigure && normalizedPlugin.plugin.passthru ? initLua
-              ) normalizedPlugin.plugin.passthru.initLua;
-          in
-          lib.foldl' op [ ] pluginsNormalized;
 
         rcContent = ''
           ${luaRcContent}
@@ -124,18 +110,18 @@ let
         + lib.optionalString (neovimRcContent' != "") ''
           vim.cmd.source "${writeText "init.vim" neovimRcContent'}"
         ''
-        + lib.concatStringsSep "\n" luaPluginRC;
-
-        getDeps = attrname: map (plugin: plugin.${attrname} or (_: [ ]));
-
-        requiredPlugins = vimUtils.requiredPluginsForPackage myVimPackage;
-        pluginPython3Packages = getDeps "python3Dependencies" requiredPlugins;
+        + lib.optionalString autoconfigure (lib.concatStringsSep "\n" vimPackageInfo.pluginAdvisedLua);
 
         python3Env =
           lib.warnIf (attrs ? python3Env)
             "Pass your python packages via the `extraPython3Packages`, e.g., `extraPython3Packages = ps: [ ps.pandas ]`"
             python3.pkgs.python.withPackages
-            (ps: [ ps.pynvim ] ++ (extraPython3Packages ps) ++ (lib.concatMap (f: f ps) pluginPython3Packages));
+            (
+              ps:
+              [ ps.pynvim ]
+              ++ (extraPython3Packages ps)
+              ++ (lib.concatMap (f: f ps) vimPackageInfo.pluginPython3Packages)
+            );
 
         wrapperArgsStr = if lib.isString wrapperArgs then wrapperArgs else lib.escapeShellArgs wrapperArgs;
 
@@ -234,14 +220,10 @@ let
         inherit wrapperArgs generatedWrapperArgs;
 
         runtimeDeps =
-          let
-            op = acc: normalizedPlugin: acc ++ normalizedPlugin.plugin.runtimeDeps or [ ];
-            runtimeDeps = lib.foldl' op [ ] pluginsNormalized;
-          in
           lib.optionals finalAttrs.waylandSupport [ wl-clipboard ]
           ++ lib.optional finalAttrs.withRuby rubyEnv
           ++ lib.optional finalAttrs.withNodeJs nodejs
-          ++ lib.optionals finalAttrs.autowrapRuntimeDeps runtimeDeps;
+          ++ lib.optionals finalAttrs.autowrapRuntimeDeps vimPackageInfo.runtimeDeps;
 
         luaRcContent = rcContent;
         # Remove the symlinks created by symlinkJoin which we need to perform
@@ -342,8 +324,7 @@ let
           lndir
         ];
 
-        # A Vim "package", see ':h packages'
-        vimPackage = myVimPackage;
+        vimPackage = vimPackageInfo.vimPackage;
 
         checkPhase = ''
           runHook preCheck


### PR DESCRIPTION

## Things done

Add utility to generate an attrset containing information about vim package that can be used in various ways by users to build their neovim configuration.

The initial motivation is for usage in home-manager, to skip nixpkgs wrapper and give more control to home-manager on how to install the package and the user control their config.

Might be useful for other projects such as nixvim.


Putting as draft until:
- I've tested it with my home-manager changes

feedback from possible consumers such as nixvim could be interesting. We may want to deprecate some of the simpler functions from neovimUtils once this is merged.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
