### PR TITLE
runtimeShellPackage: drop

### DIFF
--- a/pkgs/by-name/ap/apparmor-utils/package.nix
+++ b/pkgs/by-name/ap/apparmor-utils/package.nix
@@ -3,7 +3,7 @@
   makeWrapper,
   gawk,
   perl,
-  runtimeShellPackage,
+  bashNonInteractive,
   stdenv,
   which,
   linuxHeaders ? stdenv.cc.libc.linuxHeaders,
@@ -49,7 +49,7 @@ python3Packages.buildPythonApplication {
 
   buildInputs = [
     perl
-    runtimeShellPackage
+    bashNonInteractive
   ];
 
   pythonPath = [

--- a/pkgs/by-name/dh/dhcpcd/package.nix
+++ b/pkgs/by-name/dh/dhcpcd/package.nix
@@ -5,8 +5,7 @@
   pkg-config,
   udev,
   freebsd,
-  runtimeShellPackage,
-  runtimeShell,
+  bashNonInteractive,
   nixosTests,
   # Always tries to do dynamic linking for udev.
   withUdev ? stdenv.hostPlatform.isLinux && !stdenv.hostPlatform.isStatic,
@@ -26,7 +25,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [
-    runtimeShellPackage # So patchShebangs finds a bash suitable for the installed scripts
+    bashNonInteractive # So patchShebangs finds a bash suitable for the installed scripts
   ]
   ++ lib.optionals withUdev [
     udev
@@ -37,7 +36,7 @@ stdenv.mkDerivation rec {
   ];
 
   postPatch = ''
-    substituteInPlace hooks/dhcpcd-run-hooks.in --replace /bin/sh ${runtimeShell}
+    substituteInPlace hooks/dhcpcd-run-hooks.in --replace /bin/sh ${bashNonInteractive}
   '';
 
   configureFlags = [

--- a/pkgs/by-name/ed/ed/package.nix
+++ b/pkgs/by-name/ed/ed/package.nix
@@ -2,7 +2,7 @@
   lib,
   fetchurl,
   lzip,
-  runtimeShellPackage,
+  bashNonInteractive,
   stdenv,
   testers,
 }:
@@ -23,7 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ lzip ];
 
-  buildInputs = [ runtimeShellPackage ];
+  buildInputs = [ bashNonInteractive ];
 
   configureFlags = [
     "CC=${stdenv.cc.targetPrefix}cc"

--- a/pkgs/tools/compression/gzip/default.nix
+++ b/pkgs/tools/compression/gzip/default.nix
@@ -4,7 +4,7 @@
   fetchurl,
   makeShellWrapper,
   updateAutotoolsGnuConfigScriptsHook,
-  runtimeShellPackage,
+  bashNonInteractive,
 }:
 
 # Note: this package is used for bootstrapping fetchurl, and thus
@@ -33,7 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
     updateAutotoolsGnuConfigScriptsHook
     makeShellWrapper
   ];
-  buildInputs = [ runtimeShellPackage ];
+  buildInputs = [ bashNonInteractive ];
 
   makeFlags = [
     "SHELL=/bin/sh"

--- a/pkgs/tools/text/gawk/default.nix
+++ b/pkgs/tools/text/gawk/default.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchurl,
   removeReferencesTo,
-  runtimeShellPackage,
+  bashNonInteractive,
   texinfo,
   interactive ? false,
   readline,
@@ -55,7 +55,7 @@ stdenv.mkDerivation rec {
 
   buildInputs =
     lib.optionals interactive [
-      runtimeShellPackage
+      bashNonInteractive
       readline
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [

--- a/pkgs/tools/text/gnugrep/default.nix
+++ b/pkgs/tools/text/gnugrep/default.nix
@@ -7,7 +7,7 @@
   pcre2,
   libiconv,
   perl,
-  runtimeShellPackage,
+  bashNonInteractive,
 }:
 
 # Note: this package is used for bootstrapping fetchurl, and thus
@@ -61,7 +61,7 @@ stdenv.mkDerivation {
     pcre2
     libiconv
   ]
-  ++ lib.optional (!stdenv.hostPlatform.isWindows) runtimeShellPackage;
+  ++ lib.optional (!stdenv.hostPlatform.isWindows) bashNonInteractive;
 
   # cygwin: FAIL: multibyte-white-space
   # freebsd: FAIL mb-non-UTF8-performance

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1488,6 +1488,7 @@ mapAliases {
   rucksack = throw "rucksack was removed due to numerous vulnerabilities in freeimage"; # Added 2025-10-23
   runCommandNoCC = warnAlias "'runCommandNoCC' has been renamed to/replaced by 'runCommand'" runCommand; # Converted to warning 2025-10-28
   runCommandNoCCLocal = warnAlias "'runCommandNoCCLocal' has been renamed to/replaced by 'runCommandLocal'" runCommandLocal; # Converted to warning 2025-10-28
+  runtimeShellPackage = throw "'runtimeShellPackage' has been removed as pointless. Use 'bashNonInteractive' or 'bash' instead."; # Added 2025-12-29
   rust-synapse-state-compress = throw "'rust-synapse-state-compress' has been renamed to/replaced by 'rust-synapse-compress-state'"; # Converted to throw 2025-10-27
   rustc-wasm32 = throw "'rustc-wasm32' has been renamed to/replaced by 'rustc'"; # Converted to throw 2025-10-27
   rustic-rs = throw "'rustic-rs' has been renamed to/replaced by 'rustic'"; # Converted to throw 2025-10-27

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4063,8 +4063,7 @@ with pkgs;
 
   ### SHELLS
 
-  runtimeShell = "${runtimeShellPackage}${runtimeShellPackage.shellPath}";
-  runtimeShellPackage = bashNonInteractive;
+  runtimeShell = "${bashNonInteractive}${bashNonInteractive.shellPath}";
 
   bash = callPackage ../shells/bash/5.nix { };
   bashNonInteractive = lowPrio (


### PR DESCRIPTION
It was effectively an alias cause our shell is bash anyways


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
