### PR TITLE
nixos/stash: Fix default auth config + add tests

### DIFF
--- a/nixos/modules/services/web-apps/stash.nix
+++ b/nixos/modules/services/web-apps/stash.nix
@@ -116,8 +116,8 @@ let
           {
             stash = [
               {
-                Path = "/media/drive/videos";
-                ExcludeImage = true;
+                path = "/media/drive/videos";
+                excludeImage = true;
               }
             ];
           }
@@ -514,7 +514,7 @@ in
               install -d ${cfg.settings.generated}
               if [[ -z "${toString cfg.mutableSettings}" || ! -f ${cfg.dataDir}/config.yml ]]; then
                 env \
-                  password=$(< ${cfg.passwordFile}) \
+                  ${optionalString (cfg.passwordFile != null) "password=$(< ${cfg.passwordFile}) \\"}
                   jwtSecretKeyFile=$(< ${cfg.jwtSecretKeyFile}) \
                   sessionStoreKeyFile=$(< ${cfg.sessionStoreKeyFile}) \
                   ${lib.getExe pkgs.yq-go} '


### PR DESCRIPTION
The default configuration has both username and passwordFile being defined to null. However if you try and use this you run into the following error:

```
error: cannot coerce null to a string: null
```

from the `password=$(< ${cfg.passwordFile})` line.

If I try to write an empty file using pkgs.writeFile then I run into the error here:
https://github.com/NixOS/nixpkgs/blob/f560ccec6b1116b22e6ed15f4c510997d99d5852/nixos/modules/services/web-apps/stash.nix#L472

I have also added a test by trying to copy what caddy.nix is doing via this comment:
https://discourse.nixos.org/t/test-configuration-change-with-vm-test/69511/2

I also updated an example for one of the options as it uses lowercase attributes not uppercase.

I assume the tests work as I do not get an error when running nix-build, but if I revert my change to the ExecStartPre section the coerce error gets raised.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
