### PR TITLE
packmol: init at 20.15.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -29039,6 +29039,12 @@
     githubId = 38934577;
     keys = [ { fingerprint = "8F5E 6C1A F909 76CA 7102 917A 8656 58ED 1FE6 1EC3"; } ];
   };
+  Youwes09 = {
+    name = "Youwes Shozikan";
+    email = "yuvi.shen@outlook.com";
+    github = "Youwes09";
+    githubId = 142514207;
+  };
   yrashk = {
     email = "yrashk@gmail.com";
     github = "yrashk";

--- a/pkgs/by-name/pa/packmol/package.nix
+++ b/pkgs/by-name/pa/packmol/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  gfortran,
+  which,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "packmol";
+  version = "20.15.2";
+
+  src = fetchFromGitHub {
+    owner = "m3g";
+    repo = "packmol";
+    rev = "v${version}";
+    hash = "sha256-insp8OOQCqyzTYAND0SxBSTA2rYWFgNHKHR+Ws5VStE=";
+  };
+
+  nativeBuildInputs = [
+    gfortran
+    which
+  ];
+
+  postPatch = ''
+    patchShebangs configure
+  '';
+
+  configurePhase = ''
+    runHook preConfigure
+    ./configure gfortran
+    runHook postConfigure
+  '';
+
+  makeFlags = [ "FC=gfortran" ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 packmol -t $out/bin
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Packing optimization for molecular dynamics simulations";
+    longDescription = ''
+      Packmol creates initial configurations for molecular dynamics simulations
+      by packing molecules in defined regions of space. The packing guarantees
+      that short range repulsive interactions do not disrupt the simulations.
+    '';
+    homepage = "https://m3g.github.io/packmol/";
+    license = licenses.mit;
+    maintainers = [ Youwes09 ];
+    platforms = platforms.unix;
+    mainProgram = "packmol";
+  };
+}

--- a/pkgs/by-name/pa/packmol/package.nix
+++ b/pkgs/by-name/pa/packmol/package.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
     homepage = "https://m3g.github.io/packmol/";
     license = licenses.mit;
     maintainers = [ Youwes09 ];
-    platforms = platforms.unix;
+    platforms = platforms.linux;
     mainProgram = "packmol";
   };
 }


### PR DESCRIPTION
## Description

Adds Packmol, a molecular packing optimization tool for molecular dynamics simulations. 
[https://m3g.github.io/packmol/](url)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
