### PR TITLE
packmol: init at 20.15.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -29040,6 +29040,11 @@
     githubId = 38934577;
     keys = [ { fingerprint = "8F5E 6C1A F909 76CA 7102 917A 8656 58ED 1FE6 1EC3"; } ];
   };
+  Youwes09 = {
+    name = "Youwes Shozikan";
+    github = "Youwes09";
+    githubId = 142514207;
+  };
   yrashk = {
     email = "yrashk@gmail.com";
     github = "yrashk";

--- a/pkgs/by-name/pa/packmol/package.nix
+++ b/pkgs/by-name/pa/packmol/package.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  gfortran,
+  which,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "packmol";
+  version = "20.15.2";
+
+  src = fetchFromGitHub {
+    owner = "m3g";
+    repo = "packmol";
+    rev = "v${version}";
+    hash = "sha256-insp8OOQCqyzTYAND0SxBSTA2rYWFgNHKHR+Ws5VStE=";
+  };
+
+  nativeBuildInputs = [
+    gfortran
+    which
+  ];
+
+  # This fixes the "/bin/bash: bad interpreter" error
+  postPatch = ''
+    patchShebangs configure
+  '';
+
+  configurePhase = ''
+    runHook preConfigure
+    # In Nix, since gfortran is in nativeBuildInputs, it is already in your $PATH.
+    # We just pass the name 'gfortran' instead of the full store path.
+    ./configure gfortran
+    runHook postConfigure
+  '';
+
+  # Packmol's Makefile uses the FC variable for the Fortran compiler.
+  # Explicitly setting it here ensures 'make' knows what to use.
+  makeFlags = [ "FC=gfortran" ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 packmol -t $out/bin
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Packing optimization for molecular dynamics simulations";
+    longDescription = ''
+      Packmol creates initial configurations for molecular dynamics simulations
+      by packing molecules in defined regions of space. The packing guarantees
+      that short range repulsive interactions do not disrupt the simulations.
+    '';
+    homepage = "https://m3g.github.io/packmol/";
+    license = licenses.mit;
+    maintainers = with lib.maintainers; [ Youwes09 ];
+    platforms = platforms.linux;
+    mainProgram = "packmol";
+  };
+}


### PR DESCRIPTION
Adds packmol, a tool for creating initial configurations for molecular dynamics simulations by packing optimization.
- Homepage: https://m3g.github.io/packmol/
- Source: https://github.com/m3g/packmol
- License: MIT

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
