### PR TITLE
t2sz: init at 1.1.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10261,6 +10261,12 @@
     githubId = 79340822;
     keys = [ { fingerprint = "3582 5B85 66C8 4F36 45C7  EC42 809F 7938 9CB1 8650"; } ];
   };
+  hawkrives = {
+    email = "honk@eml.cc";
+    github = "hawkrives";
+    githubId = 464441;
+    name = "Hawken Rives";
+  };
   hawkw = {
     email = "eliza@elizas.website";
     github = "hawkw";

--- a/pkgs/by-name/t2/t2sz/package.nix
+++ b/pkgs/by-name/t2/t2sz/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  zstd,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "t2sz";
+  version = "1.1.2";
+
+  src = fetchFromGitHub {
+    owner = "martinellimarco";
+    repo = "t2sz";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-RX652UNmPJog2n8onkPDD/uXfNASur/dD2F1lPHj1vE=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    zstd
+  ];
+
+  meta = {
+    description = "Compress files into seekable zstd, with special handling for tar archives";
+    longDescription = ''
+      t2sz compresses files into seekable zstd format by splitting them into multiple frames.
+      For tar archives, it compresses each file in the archive into an independent frame,
+      enabling fast seeking and extraction of individual files without decompressing the entire archive.
+    '';
+    homepage = "https://github.com/martinellimarco/t2sz";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ hawkrives ];
+    mainProgram = "t2sz";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
I added a package definition for [t2sz](https://github.com/martinellimarco/t2sz), which can "compress a file into a seekable zstd [archive, by] splitting the file into multiple frames. If the file is a tar archive, it compresses each file in the archive into an independent frame, hence the name: tar 2 seekable zstd."

Homepage (well, repository): <https://github.com/martinellimarco/t2sz>

I also added myself as a maintainer of the package, because I'd feel bad throwing a package into the repo with no maintainer.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
