### PR TITLE
puae2021: init at 0-unstable-2025-11-02

### DIFF
--- a/pkgs/applications/emulators/libretro/cores/puae2021.nix
+++ b/pkgs/applications/emulators/libretro/cores/puae2021.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkLibretroCore,
+}:
+mkLibretroCore {
+  core = "puae2021";
+  version = "0-unstable-2025-11-02";
+
+  src = fetchFromGitHub {
+    owner = "libretro";
+    repo = "libretro-uae";
+    rev = "58527ce9e8cc5f19faae9e6010d2f06fc70b10de";
+    hash = "sha256-wHzjpTh/zuV5KXaMsv7A/7xqYfzLgIUusjwg8LOUzMY=";
+  };
+
+  makefile = "Makefile";
+
+  meta = {
+    description = "Amiga emulator based on WinUAE (Version 2021)";
+    homepage = "https://github.com/libretro/libretro-uae";
+    license = lib.licenses.gpl2Only;
+    platforms = [
+      "aarch64-linux"
+      "x86_64-linux"
+    ];
+  };
+}

--- a/pkgs/applications/emulators/libretro/default.nix
+++ b/pkgs/applications/emulators/libretro/default.nix
@@ -149,6 +149,8 @@ lib.makeScope newScope (self: {
 
   puae = self.callPackage ./cores/puae.nix { };
 
+  puae2021 = self.callPackage ./cores/puae2021.nix { };
+
   quicknes = self.callPackage ./cores/quicknes.nix { };
 
   same_cdi = self.callPackage ./cores/same_cdi.nix { }; # the name is not a typo


### PR DESCRIPTION
This PR adds puae2021 to the libretro cores.
Puae2021 is an Amiga emulator based on WinUAE version 2.6.1 from 2021.
It trades speed for accuracy and achieves acceptable frame rates on
low end devices like the R36S (Rockchip RK3326). 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
