### PR TITLE
lichess-bot: init at 2025.12.23.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17873,6 +17873,11 @@
     githubId = 30654959;
     name = "Michele Sciabarra";
   };
+  mse63 = {
+    name = "Mahmoud Elsharawy";
+    github = "mse63";
+    githubId = 81396550;
+  };
   msgilligan = {
     email = "sean@msgilligan.com";
     github = "msgilligan";

--- a/pkgs/by-name/li/lichess-bot/package.nix
+++ b/pkgs/by-name/li/lichess-bot/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+}:
+
+python3Packages.buildPythonApplication {
+  pname = "lichess-bot";
+  version = "2025.12.23.1";
+  format = "other";
+
+  src = fetchFromGitHub {
+    owner = "lichess-bot-devs";
+    repo = "lichess-bot";
+    rev = "6ea42dfaffa65efea0da09d94b058853d724a989";
+    hash = "sha256-G8DiW96mRnvmmmRALRcYDnjLilQIRqH5m6+aTluhohI=";
+  };
+
+  propagatedBuildInputs = with python3Packages; [
+    chess
+    pyyaml
+    requests
+    backoff
+    rich
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    substituteInPlace "lib/lichess_bot.py" \
+      --replace 'open("lib/versioning.yml")' \
+                'open("'$out'/share/lichess-bot/lib/versioning.yml")'
+
+
+    mkdir -p "$out"/{bin,share/lichess-bot}
+    cp -R . $out/share/lichess-bot
+
+    makeWrapper ${python3Packages.python.interpreter} $out/bin/lichess-bot \
+      --set PYTHONPATH "$PYTHONPATH:$out/share/lichess-bot" \
+      --add-flags "$out/share/lichess-bot/lichess-bot.py"
+    echo $out > $out/my_dir.txt
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Bridge between lichess.org and bots";
+    homepage = "https://github.com/lichess-bot-devs/lichess-bot";
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [ mse63 ];
+    platforms = lib.platforms.unix;
+    mainProgram = "lichess-bot";
+  };
+
+}


### PR DESCRIPTION
Added a new package, lichess-bot, a bridge between chess engines and the lichess.org API
Homepage: https://github.com/lichess-bot-devs/lichess-bot
This is useful for people creating their own chess engine that they want to interact with the lichess API
Added myself as a maintainer.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
