### PR TITLE
morse_cli: init at 1.16.4

### DIFF
--- a/pkgs/by-name/mo/morse_cli/package.nix
+++ b/pkgs/by-name/mo/morse_cli/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  openssl,
+  libnl,
+  zstd,
+  libusb1,
+  pkg-config,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "morse-cli";
+  version = "1.16.4";
+
+  src = fetchFromGitHub {
+    owner = "MorseMicro";
+    repo = "morse_cli";
+    tag = version;
+    hash = "sha256-EhrKMMbWJ6gweAt2EudyO7vHZ9ITjRYagE4k+QuUnOo=";
+  };
+
+  buildInputs = [
+    openssl
+    libnl
+    libusb1
+    zstd
+  ];
+
+  nativeBuildInputs = [ pkg-config ];
+
+  env.NIX_CFLAGS_COMPILE = toString [
+    "-I${libnl.dev}/include/libnl3"
+    "-I${libusb1.dev}/include/libusb-1.0"
+    "-Wno-error"
+  ];
+
+  makeFlags = [ "CONFIG_MORSE_TRANS_NL80211=1" ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D -m755 morse_cli "$out/bin/morse_cli"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "MorseMicro cli";
+    homepage = "https://github.com/MorseMicro";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ govindsi ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
Add Morse Micro userspace control utility package version 1.16.4.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
