### PR TITLE
haskell.compiler.ghc94: Backport PPC64 ELFv2 support

### DIFF
--- a/pkgs/development/compilers/ghc/common-make-native-bignum.nix
+++ b/pkgs/development/compilers/ghc/common-make-native-bignum.nix
@@ -378,6 +378,16 @@ stdenv.mkDerivation (
       })
     ]
 
+    # Support for ELFv2 powerpc64-linux
+    ++ [
+      ./ghc-9.4-PPC-Support-ELF-v2-on-powerpc64-big-endian.patch
+      (fetchpatch {
+        name = "ghc-rts-Fix-compile-on-powerpc64-elf-v1.patch";
+        url = "https://gitlab.haskell.org/ghc/ghc/-/commit/05e5785a3157c71e327a8e9bdc80fa7082918739.patch";
+        hash = "sha256-xP5v3cKhXeTRSFvRiKEn9hPxGXgVgykjTILKjh/pdDU=";
+      })
+    ]
+
     ++ lib.optionals (stdenv.targetPlatform.isDarwin && stdenv.targetPlatform.isAarch64) [
       # Prevent the paths module from emitting symbols that we don't use
       # when building with separate outputs.

--- a/pkgs/development/compilers/ghc/ghc-9.4-PPC-Support-ELF-v2-on-powerpc64-big-endian.patch
+++ b/pkgs/development/compilers/ghc/ghc-9.4-PPC-Support-ELF-v2-on-powerpc64-big-endian.patch
@@ -1,0 +1,222 @@
+From 10ed6b3a5c1df4d7e0a58b384ac473e56aaf53cb Mon Sep 17 00:00:00 2001
+From: Peter Trommler <ptrommler@acm.org>
+Date: Thu, 6 Jan 2022 10:52:24 +0100
+Subject: [PATCH] PPC: Support ELF v2 on powerpc64 big-endian
+
+Detect ELF v2 on PowerPC 64-bit systems. Check for `_CALL_ELF`
+preprocessor macro.
+
+Fixes #21191
+
+(Backported onto GHC 9.4)
+---
+ compiler/GHC/CmmToAsm/PPC/CodeGen.hs      | 11 +++++++++--
+ libraries/ghc-boot/GHC/Platform/ArchOS.hs |  3 +--
+ m4/fptools_set_haskell_platform_vars.m4   |  8 +++-----
+ m4/ghc_get_power_abi.m4                   | 19 +++++++++++++++++++
+ rts/AdjustorAsm.S                         | 12 +++++-------
+ rts/StgCRun.c                             |  2 +-
+ rts/StgCRunAsm.S                          | 12 ++++++------
+ rts/adjustor/NativePowerPC.c              |  6 ++----
+ 8 files changed, 46 insertions(+), 27 deletions(-)
+ create mode 100644 m4/ghc_get_power_abi.m4
+
+diff --git a/compiler/GHC/CmmToAsm/PPC/CodeGen.hs b/compiler/GHC/CmmToAsm/PPC/CodeGen.hs
+index 7329b8c4b1..630ffc4081 100644
+--- a/compiler/GHC/CmmToAsm/PPC/CodeGen.hs
++++ b/compiler/GHC/CmmToAsm/PPC/CodeGen.hs
+@@ -1895,8 +1895,15 @@ genCCall' config gcp target dest_regs args
+                          -- "Single precision floating point values
+                          -- are mapped to the second word in a single
+                          -- doubleword"
+-                         GCP64ELF 1      -> stackOffset' + 4
+-                         _               -> stackOffset'
++                         GCP64ELF 1 -> stackOffset' + 4
++                         -- ELF v2 ABI Revision 1.5 Section 2.2.3.3. requires
++                         -- a single-precision floating-point value
++                         -- to be mapped to the least-significant
++                         -- word in a single doubleword.
++                         GCP64ELF 2 -> case platformByteOrder platform of
++                                       BigEndian    -> stackOffset' + 4
++                                       LittleEndian -> stackOffset'
++                         _          -> stackOffset'
+                      | otherwise = stackOffset'
+ 
+                 stackSlot = AddrRegImm sp (ImmInt stackOffset'')
+diff --git a/libraries/ghc-boot/GHC/Platform/ArchOS.hs b/libraries/ghc-boot/GHC/Platform/ArchOS.hs
+index c46371fac0..d43bd76bd9 100644
+--- a/libraries/ghc-boot/GHC/Platform/ArchOS.hs
++++ b/libraries/ghc-boot/GHC/Platform/ArchOS.hs
+@@ -121,8 +121,7 @@ stringEncodeArch = \case
+   ArchX86           -> "i386"
+   ArchX86_64        -> "x86_64"
+   ArchPPC           -> "powerpc"
+-  ArchPPC_64 ELF_V1 -> "powerpc64"
+-  ArchPPC_64 ELF_V2 -> "powerpc64le"
++  ArchPPC_64 _      -> "powerpc64"
+   ArchS390X         -> "s390x"
+   ArchARM ARMv5 _ _ -> "armv5"
+   ArchARM ARMv6 _ _ -> "armv6"
+diff --git a/m4/fptools_set_haskell_platform_vars.m4 b/m4/fptools_set_haskell_platform_vars.m4
+index d067f971cd..2e3e4ae14a 100644
+--- a/m4/fptools_set_haskell_platform_vars.m4
++++ b/m4/fptools_set_haskell_platform_vars.m4
+@@ -14,11 +14,9 @@ AC_DEFUN([FPTOOLS_SET_HASKELL_PLATFORM_VARS_SHELL_FUNCTIONS],
+         powerpc)
+             test -z "[$]2" || eval "[$]2=ArchPPC"
+             ;;
+-        powerpc64)
+-            test -z "[$]2" || eval "[$]2=\"ArchPPC_64 ELF_V1\""
+-            ;;
+-        powerpc64le)
+-            test -z "[$]2" || eval "[$]2=\"ArchPPC_64 ELF_V2\""
++        powerpc64*)
++            GHC_GET_POWER_ABI()
++            test -z "[$]2" || eval "[$]2=\"ArchPPC_64 $POWER_ABI\""
+             ;;
+         s390x)
+             test -z "[$]2" || eval "[$]2=ArchS390X"
+diff --git a/m4/ghc_get_power_abi.m4 b/m4/ghc_get_power_abi.m4
+new file mode 100644
+index 0000000000..f8741a4fa8
+--- /dev/null
++++ b/m4/ghc_get_power_abi.m4
+@@ -0,0 +1,19 @@
++# GHC_GET_POWER_ABI
++# ----------------------------------
++# Get version of the PowerPC ABI
++AC_DEFUN([GHC_GET_POWER_ABI],
++[
++    AC_COMPILE_IFELSE([
++        AC_LANG_PROGRAM(
++            [],
++            [#if defined(_CALL_ELF) && _CALL_ELF == 2
++                 return 0;
++             #else
++                 not ELF v2
++             #endif]
++        )],
++        [POWER_ABI=ELF_V2],
++        [POWER_ABI=ELF_V1])
++
++        AC_SUBST(POWER_ABI)
++])
+diff --git a/rts/AdjustorAsm.S b/rts/AdjustorAsm.S
+index cc2f99df62..d4f875ebad 100644
+--- a/rts/AdjustorAsm.S
++++ b/rts/AdjustorAsm.S
+@@ -2,8 +2,7 @@
+ 
+ /* ******************************** PowerPC ******************************** */
+ 
+-#if defined(powerpc_HOST_ARCH) || defined(powerpc64_HOST_ARCH)
+-#if !(defined(powerpc_HOST_ARCH) && defined(linux_HOST_OS))
++#if defined(powerpc_HOST_ARCH) && defined(aix_HOST_OS) || defined(powerpc64_HOST_ARCH) && defined(__ELF__) && (!defined(_CALL_ELF) || _CALL_ELF == 1)
+     /* The following code applies, with some differences,
+        to all powerpc platforms except for powerpc32-linux,
+        whose calling convention is annoyingly complex.
+@@ -60,12 +59,12 @@ adjustorCode:
+         /* save the link */
+     mflr    0
+     STORE   0, LINK_SLOT(1)
+-    
++
+         /* set up stack frame */
+     LOAD    12, FRAMESIZE_OFF(2)
+ #if defined(powerpc64_HOST_ARCH)
+     stdux   1, 1, 12
+-#else   
++#else
+     stwux   1, 1, 12
+ #endif /* defined(powerpc64_HOST_ARCH) */
+ 
+@@ -108,7 +107,7 @@ L2:
+     LOAD    12, WPTR_OFF(2)
+     LOAD    0, 0(12)
+         /* The function we're calling will never be a nested function,
+-           so we don't load r11. 
++           so we don't load r11.
+         */
+     mtctr   0
+     LOAD    2, WS(12)
+@@ -118,8 +117,7 @@ L2:
+     LOAD    0, LINK_SLOT(1)
+     mtlr    0
+     blr
+-#endif /* !(defined(powerpc_HOST_ARCH) && defined(linux_HOST_OS)) */
+-#endif /* defined(powerpc_HOST_ARCH) || defined(powerpc64_HOST_ARCH) */
++#endif
+ 
+ /* mark stack as nonexecutable */
+ #if defined(__linux__) && defined(__ELF__)
+diff --git a/rts/StgCRun.c b/rts/StgCRun.c
+index 4fefc326e5..e05d6b71f8 100644
+--- a/rts/StgCRun.c
++++ b/rts/StgCRun.c
+@@ -670,7 +670,7 @@ StgRunIsImplementedInAssembler(void)
+    Everything is in assembler, so we don't have to deal with GCC...
+    -------------------------------------------------------------------------- */
+ 
+-#if defined(powerpc64_HOST_ARCH)
++#if defined(powerpc64_HOST_ARCH) && (!defined _CALL_ELF || _CALL_ELF == 1)
+ /* 64-bit PowerPC ELF ABI 1.9
+  *
+  * Stack frame organization (see Figure 3-17, ELF ABI 1.9, p 14)
+diff --git a/rts/StgCRunAsm.S b/rts/StgCRunAsm.S
+index aed3241d12..784c42e773 100644
+--- a/rts/StgCRunAsm.S
++++ b/rts/StgCRunAsm.S
+@@ -5,11 +5,11 @@
+  * then functions StgRun/StgReturn are implemented in file StgCRun.c */
+ #if !defined(USE_MINIINTERPRETER)
+ 
+-#if defined(powerpc64le_HOST_ARCH)
+-# if defined(linux_HOST_OS)
+-/* 64-bit PowerPC ELF V2 ABI Revision 1.4
++#if defined(powerpc64le_HOST_ARCH) || defined(powerpc64_HOST_ARCH)
++# if defined(_CALL_ELF) && _CALL_ELF == 2
++/* 64-bit PowerPC ELF V2 ABI Revision 1.5
+  *
+- * Stack frame organization (see Figure 2.18, ELF V2 ABI Revision 1.4, p 31)
++ * Stack frame organization (see Figure 2.18, ELF V2 ABI Revision 1.5, p 34)
+  *
+  * +-> Back Chain (points to the prevoius stack frame)
+  * |   Floating point register save area (f14-f31)
+@@ -68,8 +68,8 @@ StgReturn:
+         b _restfpr_14
+ 
+ 	.section	.note.GNU-stack,"",@progbits
+-# else // linux_HOST_OS
+-# error Only Linux support for power64 little endian right now.
++# else // Not ELF v2
++# error Only ELF v2 supported.
+ # endif
+ 
+ #elif defined(powerpc_HOST_ARCH)
+diff --git a/rts/adjustor/NativePowerPC.c b/rts/adjustor/NativePowerPC.c
+index 6cc4093d63..7ad32fb760 100644
+--- a/rts/adjustor/NativePowerPC.c
++++ b/rts/adjustor/NativePowerPC.c
+@@ -29,8 +29,7 @@ __asm__("obscure_ccall_ret_code:\n\t"
+ extern void obscure_ccall_ret_code(void);
+ #endif /* defined(linux_HOST_OS) */
+ 
+-#if defined(powerpc_HOST_ARCH) || defined(powerpc64_HOST_ARCH)
+-#if !(defined(powerpc_HOST_ARCH) && defined(linux_HOST_OS))
++#if defined(powerpc_HOST_ARCH) && defined(aix_HOST_OS) || defined(powerpc64_HOST_ARCH) && defined(__ELF__) && (!defined(_CALL_ELF) || _CALL_ELF == 1)
+ 
+ /* !!! !!! WARNING: !!! !!!
+  * This structure is accessed from AdjustorAsm.s
+@@ -50,8 +49,7 @@ typedef struct AdjustorStub {
+     StgInt          extrawords_plus_one;
+ } AdjustorStub;
+ 
+-#endif /* !(defined(powerpc_HOST_ARCH) && defined(linux_HOST_OS)) */
+-#endif /* defined(powerpc_HOST_ARCH) || defined(powerpc64_HOST_ARCH) */
++#endif
+ 
+ void initAdjustors(void) { }
+ 
+-- 
+2.51.2
+


### PR DESCRIPTION
Extracted from #462247

> `ghc94`s build, but don't run.
> 
> ```
> puna@Yubel ~> /nix/store/dhv857lm0ahyfbg7np9jprg5j0b9nkz1-ghc-powerpc64-unknown-linux-gnuabielfv1-9.4.8/bin/ghci
> fish: Job 1, '/nix/store/dhv857lm0ahyfbg7np9j…' terminated by signal SIGSEGV (Address boundary error)
> puna@Yubel ~ [SIGSEGV]> /nix/store/p5s6ai4z34m72qr30174vwbdcq6qhc26-ghc-powerpc64-unknown-linux-gnuabielfv2-9.4.8/bin/ghci
> fish: Job 1, '/nix/store/p5s6ai4z34m72qr30174…' terminated by signal SIGSEGV (Address boundary error)
> puna@Yubel ~ [SIGSEGV]> /nix/store/lfqpkyr81rld6sb25z8h8lzhisssh88m-ghc-musl-powerpc64-unknown-linux-musl-9.4.8/bin/ghci
> fish: Job 1, '/nix/store/lfqpkyr81rld6sb25z8h…' terminated by signal SIGSEGV (Address boundary error)
> ```
> 
> Identical to current behaviour of `ppc64-elfv1` on master. I'm not gonna try it, but flipping `enableUnregisterised` to `true` might fix them. Noted in https://github.com/NixOS/nixpkgs/pull/439258#issuecomment-3560760300, I think the suitability of cross-compiled `ghc94` is still getting looked into though?

> I'm unsure about the patch for GHC 9.4, if we can't verify that it works. Should we postpone that until these run in the first place?

> Seems like ppc64le has similar issues with cross-compiled registerised GHC segfaulting. Maybe a general issue on (64-bit) POWER? https://github.com/NixOS/nixpkgs/pull/439258#issuecomment-3695118416
> 
> I'm fine with pulling the GHC 9.4 changes out for now until they're actually needed (bootstrapping off of cross-compiled GHC).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
