### PR TITLE
python313Packages.numdifftools: 0.9.41 -> 0.9.42

### DIFF
--- a/pkgs/development/python-modules/numdifftools/default.nix
+++ b/pkgs/development/python-modules/numdifftools/default.nix
@@ -3,25 +3,25 @@
   buildPythonPackage,
   fetchFromGitHub,
   numpy,
-  pythonOlder,
   scipy,
+  pdm-backend,
 }:
 
 buildPythonPackage rec {
   pname = "numdifftools";
-  version = "0.9.41";
-  format = "setuptools";
-
-  disabled = pythonOlder "3.7";
+  version = "0.9.42";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pbrod";
     repo = "numdifftools";
-    rev = "v${version}";
-    hash = "sha256-HYacLaowSDdrwkxL1h3h+lw/8ahzaecpXEnwrCqMCWk=";
+    tag = "v${version}";
+    hash = "sha256-tNPv+KJuSmMHItHfRUjMIFtAFB+vC530sp+Am0VRG44=";
   };
 
-  propagatedBuildInputs = [
+  build-system = [ pdm-backend ];
+
+  dependencies = [
     numpy
     scipy
   ];
@@ -29,20 +29,12 @@ buildPythonPackage rec {
   # Tests requires algopy and other modules which are optional and/or not available
   doCheck = false;
 
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace '"pytest-runner"' ""
-    # Remove optional dependencies
-    substituteInPlace requirements.txt \
-      --replace "algopy>=0.4" "" \
-      --replace "statsmodels>=0.6" ""
-  '';
-
   pythonImportsCheck = [ "numdifftools" ];
 
   meta = {
     description = "Library to solve automatic numerical differentiation problems in one or more variables";
     homepage = "https://github.com/pbrod/numdifftools";
+    changelog = "https://github.com/pbrod/numdifftools/blob/${src.tag}/CHANGELOG.md";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ fab ];
   };


### PR DESCRIPTION
Changelog: https://github.com/pbrod/numdifftools/blob/v0.9.42/CHANGELOG.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
