### PR TITLE
python3Packages.coverage: 7.13.0 -> 7.13.1

### DIFF
--- a/pkgs/development/python-modules/coverage/default.nix
+++ b/pkgs/development/python-modules/coverage/default.nix
@@ -4,7 +4,6 @@
   buildPythonPackage,
   isPy312,
   fetchFromGitHub,
-  fetchpatch,
   flaky,
   hypothesis,
   pytest-xdist,
@@ -16,26 +15,15 @@
 
 buildPythonPackage rec {
   pname = "coverage";
-  version = "7.13.0";
+  version = "7.13.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "coveragepy";
     repo = "coveragepy";
     tag = version;
-    hash = "sha256-2i01Jlk4oj/0WhoYE1BgeKKjZK3YpEOrGHEgNhTruR4=";
+    hash = "sha256-xdbgHUE+vbSiqLRDhd5G5u90VU5+TxLehAuwdhdGzBQ=";
   };
-
-  patches = [
-    # test: correctly default the core being tested
-    # This fixes test_coverage_stop_in_threads
-    # https://github.com/coveragepy/coveragepy/issues/2109
-    (fetchpatch {
-      url = "https://github.com/coveragepy/coveragepy/commit/2f2e540709371f6184c2731f6d076bc782d37a3d.patch";
-      hash = "sha256-lwQ8OM9OWZAwrjExuPeGKSLEF+pYhgDHyAlgXzHiQ0M=";
-      excludes = [ "CHANGES.rst" ];
-    })
-  ];
 
   build-system = [ setuptools ];
 
@@ -59,25 +47,9 @@ buildPythonPackage rec {
   '';
 
   disabledTests = [
-    "test_doctest"
-    "test_files_up_one_level"
-    "test_get_encoded_zip_files"
-    "test_multi"
-    "test_no_duplicate_packages"
-    "test_zipfile"
     # tests expect coverage source to be there
     "test_all_our_source_files"
-    "test_metadata"
-    "test_more_metadata"
     "test_real_code_regions"
-  ];
-
-  disabledTestPaths = [
-    "tests/test_debug.py"
-    "tests/test_plugins.py"
-    "tests/test_process.py"
-    "tests/test_report.py"
-    "tests/test_venv.py"
   ];
 
   meta = {


### PR DESCRIPTION
Diff: https://github.com/coveragepy/coveragepy/compare/7.13.0...7.13.1

Changelog: https://github.com/coveragepy/coveragepy/blob/7.13.1/CHANGES.rst


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
