### PR TITLE
weaviate: 1.33.2 -> 1.33.11

### DIFF
--- a/pkgs/by-name/we/weaviate/package.nix
+++ b/pkgs/by-name/we/weaviate/package.nix
@@ -6,16 +6,16 @@
 
 buildGoModule rec {
   pname = "weaviate";
-  version = "1.33.2";
+  version = "1.33.11";
 
   src = fetchFromGitHub {
     owner = "weaviate";
     repo = "weaviate";
     rev = "v${version}";
-    hash = "sha256-+QchAvIBJcbrwveeGHXFC+96oD5Uy/+lqMV/vxRPzbk=";
+    hash = "sha256-v7RnWb3Lg++AasNY2LzvMRfatDzPecrV47gScep6opY=";
   };
 
-  vendorHash = "sha256-KiDU9fw/4vIhI0XbEzUfw+HhopJniVeGhFVJBbLkixU=";
+  vendorHash = "sha256-JG8UwPGij3F2zCMVNgPiRyPegL0aIsWy4rchKmWaAro=";
 
   subPackages = [ "cmd/weaviate-server" ];
 
@@ -31,7 +31,7 @@ buildGoModule rec {
 
   meta = {
     description = "ML-first vector search engine";
-    homepage = "https://github.com/semi-technologies/weaviate";
+    homepage = "https://github.com/weaviate/weaviate";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ dit7ya ];
   };


### PR DESCRIPTION
Fixes CVE-2025-67819 and CVE-2025-67818.
https://weaviate.io/blog/weaviate-security-release-november-2025

Changes:
https://github.com/weaviate/weaviate/releases/tag/v1.33.11
https://github.com/weaviate/weaviate/releases/tag/v1.33.10
https://github.com/weaviate/weaviate/releases/tag/v1.33.9
https://github.com/weaviate/weaviate/releases/tag/v1.33.8
https://github.com/weaviate/weaviate/releases/tag/v1.33.7
https://github.com/weaviate/weaviate/releases/tag/v1.33.6
https://github.com/weaviate/weaviate/releases/tag/v1.33.5
https://github.com/weaviate/weaviate/releases/tag/v1.33.4
https://github.com/weaviate/weaviate/releases/tag/v1.33.3


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 475051`
Commit: `0b8618fa0d1ee29d4e93496b6a8fac4d6c37abf7`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>weaviate</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
