### PR TITLE
maptool: Bump openjfx to openjfx21

### DIFF
--- a/pkgs/by-name/ma/maptool/package.nix
+++ b/pkgs/by-name/ma/maptool/package.nix
@@ -7,7 +7,7 @@
   jre,
   libarchive,
   makeDesktopItem,
-  openjfx,
+  openjfx21,
   stdenvNoCC,
   wrapGAppsHook3,
 }:
@@ -47,9 +47,9 @@ let
 
   classpath =
     lib.concatMap (mod: [
-      "${openjfx}/modules_src/javafx.${mod}/module-info.java"
-      "${openjfx}/modules/javafx.${mod}"
-      "${openjfx}/modules_libs/javafx.${mod}"
+      "${openjfx21}/modules_src/javafx.${mod}/module-info.java"
+      "${openjfx21}/modules/javafx.${mod}"
+      "${openjfx21}/modules_libs/javafx.${mod}"
     ]) javafxModules
     ++ [ "$out/${appClasspath}/*" ];
 


### PR DESCRIPTION
openjfx by default is resolved to openjfx17, which builds using gradle 7, which is EOL.
Currently you can't even install maptool without allowing gradle 7 in permittedInsecurePackages.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
