### PR TITLE
[25.05] weaviate: 1.30.2 -> 1.30.23

### DIFF
--- a/pkgs/by-name/we/weaviate/package.nix
+++ b/pkgs/by-name/we/weaviate/package.nix
@@ -6,16 +6,16 @@
 
 buildGoModule rec {
   pname = "weaviate";
-  version = "1.30.2";
+  version = "1.30.3";
 
   src = fetchFromGitHub {
     owner = "weaviate";
     repo = "weaviate";
     rev = "v${version}";
-    hash = "sha256-/jaBELPSxmGY4atPxpGEZcLN6Xezesez9UBD/uQNkNg=";
+    hash = "sha256-kZxXpC2pnfKT2uVPDbrH3hG8zCtUcsPszr5BFrcDlYc=";
   };
 
-  vendorHash = "sha256-jXfVPdORMBOAl3Od3GknGo7Qtfb4H3RqGYdI6Jx1/5I=";
+  vendorHash = "sha256-TOmY7Caxi+TGguHFK9Blylf6AhhYVHDD23KS9EoE8vw=";
 
   subPackages = [ "cmd/weaviate-server" ];
 

--- a/pkgs/by-name/we/weaviate/package.nix
+++ b/pkgs/by-name/we/weaviate/package.nix
@@ -6,16 +6,16 @@
 
 buildGoModule rec {
   pname = "weaviate";
-  version = "1.30.3";
+  version = "1.30.5";
 
   src = fetchFromGitHub {
     owner = "weaviate";
     repo = "weaviate";
     rev = "v${version}";
-    hash = "sha256-kZxXpC2pnfKT2uVPDbrH3hG8zCtUcsPszr5BFrcDlYc=";
+    hash = "sha256-35wvIAt9VeF5poVYwOen+WAhO1uQusMH7/V9Czz8s+A=";
   };
 
-  vendorHash = "sha256-TOmY7Caxi+TGguHFK9Blylf6AhhYVHDD23KS9EoE8vw=";
+  vendorHash = "sha256-W2n9qET1D1xuNrmBAyjTPljouhVPtld4z9Xcar0EfWY=";
 
   subPackages = [ "cmd/weaviate-server" ];
 

--- a/pkgs/by-name/we/weaviate/package.nix
+++ b/pkgs/by-name/we/weaviate/package.nix
@@ -6,16 +6,16 @@
 
 buildGoModule rec {
   pname = "weaviate";
-  version = "1.30.5";
+  version = "1.30.23";
 
   src = fetchFromGitHub {
     owner = "weaviate";
     repo = "weaviate";
     rev = "v${version}";
-    hash = "sha256-35wvIAt9VeF5poVYwOen+WAhO1uQusMH7/V9Czz8s+A=";
+    hash = "sha256-WFppKjGz0OOX4fxubtbSh5GqMey5sY1SEnPRuWa/sEI=";
   };
 
-  vendorHash = "sha256-W2n9qET1D1xuNrmBAyjTPljouhVPtld4z9Xcar0EfWY=";
+  vendorHash = "sha256-sILHOIqHZmpn+HA0YJxTz3nlTwburyl6t48AxfLJ+eg=";
 
   subPackages = [ "cmd/weaviate-server" ];
 


### PR DESCRIPTION
Fixes CVE-2025-67819 and CVE-2025-67818.
https://weaviate.io/blog/weaviate-security-release-november-2025

Changes:
https://github.com/weaviate/weaviate/releases/tag/v1.30.23
https://github.com/weaviate/weaviate/releases/tag/v1.30.22
https://github.com/weaviate/weaviate/releases/tag/v1.30.21
https://github.com/weaviate/weaviate/releases/tag/v1.30.20
https://github.com/weaviate/weaviate/releases/tag/v1.30.19
https://github.com/weaviate/weaviate/releases/tag/v1.30.18
https://github.com/weaviate/weaviate/releases/tag/v1.30.17
https://github.com/weaviate/weaviate/releases/tag/v1.30.16
https://github.com/weaviate/weaviate/releases/tag/v1.30.15
https://github.com/weaviate/weaviate/releases/tag/v1.30.14
https://github.com/weaviate/weaviate/releases/tag/v1.30.13
https://github.com/weaviate/weaviate/releases/tag/v1.30.12
https://github.com/weaviate/weaviate/releases/tag/v1.30.11
https://github.com/weaviate/weaviate/releases/tag/v1.30.10
https://github.com/weaviate/weaviate/releases/tag/v1.30.9
https://github.com/weaviate/weaviate/releases/tag/v1.30.8
https://github.com/weaviate/weaviate/releases/tag/v1.30.7
https://github.com/weaviate/weaviate/releases/tag/v1.30.6

Not-cherry-picked-because: unstable is using the 1.33.x branch

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 475054`
Commit: `c1504089516cae7029b196f3cf560db2399e96cc`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>weaviate</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
