### PR TITLE
postgresql: use rev instead of tag

### DIFF
--- a/pkgs/servers/sql/postgresql/14.nix
+++ b/pkgs/servers/sql/postgresql/14.nix
@@ -1,6 +1,6 @@
 import ./generic.nix {
   version = "14.20";
-  rev = "refs/tags/REL_14_20";
+  rev = "REL_14_20";
   hash = "sha256-5wWuS78yn1p+ZjlUy5jCf1mLq78D3iI7mWPBVTd1Ufk=";
   muslPatches = {
     disable-test-collate-icu-utf8 = {

--- a/pkgs/servers/sql/postgresql/15.nix
+++ b/pkgs/servers/sql/postgresql/15.nix
@@ -1,6 +1,6 @@
 import ./generic.nix {
   version = "15.15";
-  rev = "refs/tags/REL_15_15";
+  rev = "REL_15_15";
   hash = "sha256-veGKXAvK+dNofBuSXsmCsPdXDJOC04+QV3HEr0XaE68=";
   muslPatches = {
     dont-use-locale-a = {

--- a/pkgs/servers/sql/postgresql/16.nix
+++ b/pkgs/servers/sql/postgresql/16.nix
@@ -1,6 +1,6 @@
 import ./generic.nix {
   version = "16.11";
-  rev = "refs/tags/REL_16_11";
+  rev = "REL_16_11";
   hash = "sha256-hxv+N+OWqiXmFmsB+SSYGKQLBbHtNMnneHFvOtUz8z4=";
   muslPatches = {
     dont-use-locale-a = {

--- a/pkgs/servers/sql/postgresql/17.nix
+++ b/pkgs/servers/sql/postgresql/17.nix
@@ -1,6 +1,6 @@
 import ./generic.nix {
   version = "17.7";
-  rev = "refs/tags/REL_17_7";
+  rev = "REL_17_7";
   hash = "sha256-W+505LAeiO5ln7wBhxZLv/p3GxiJp8MFfCGVDyvHREg=";
   muslPatches = {
     dont-use-locale-a = {

--- a/pkgs/servers/sql/postgresql/18.nix
+++ b/pkgs/servers/sql/postgresql/18.nix
@@ -1,6 +1,6 @@
 import ./generic.nix {
   version = "18.1";
-  rev = "refs/tags/REL_18_1";
+  rev = "REL_18_1";
   hash = "sha256-cZA2hWtr5RwsUrRWkvl/yvUzFPSfdtpyAKGXfrVUr0g=";
   muslPatches = {
     dont-use-locale-a = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

As [mentioned here](https://github.com/NixOS/nixpkgs/pull/473846#issuecomment-3696598166), [this code comment](https://github.com/NixOS/nixpkgs/blob/master/pkgs/servers/sql/postgresql/generic.nix#L192) is misleading.

```nix
src = fetchFromGitHub {
  owner = "postgres";
  repo = "postgres";
  # rev, not tag, on purpose: allows updating when new versions
  # are "stamped" a few days before release (tag).
  inherit hash rev;
};
```

I suspect that the intention is to download `https://github.com/postgres/postgres/archive/REL_18_1.tar.gz` rather than `https://github.com/postgres/postgres/archive/refs/tags/REL_18_1.tar.gz`.

The updated download link works:

```
 wget https://github.com/postgres/postgres/archive/REL_18_1.tar.gz
--2025-12-29 15:29:54--  https://github.com/postgres/postgres/archive/REL_18_1.tar.gz
Resolving github.com (github.com)... 140.82.121.3
Connecting to github.com (github.com)|140.82.121.3|:443... connected.
HTTP request sent, awaiting response... 302 Found
Location: https://codeload.github.com/postgres/postgres/tar.gz/refs/tags/REL_18_1 [following]
--2025-12-29 15:29:54--  https://codeload.github.com/postgres/postgres/tar.gz/refs/tags/REL_18_1
Resolving codeload.github.com (codeload.github.com)... 140.82.121.10
Connecting to codeload.github.com (codeload.github.com)|140.82.121.10|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: unspecified [application/x-gzip]
Saving to: ‘REL_18_1.tar.gz’

REL_18_1.tar.gz                                [                   <=>                                                                   ]  28,31M  7,28MB/s    in 3,9s    

2025-12-29 15:29:59 (7,27 MB/s) - ‘REL_18_1.tar.gz’ saved [29690303]


 ls REL_18_1.tar.gz
 REL_18_1.tar.gz
```

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
