### PR TITLE
[staging] gnupg: 2.4.8 -> 2.4.9, update freepg patches

### DIFF
--- a/pkgs/tools/security/gnupg/24.nix
+++ b/pkgs/tools/security/gnupg/24.nix
@@ -36,11 +36,11 @@ assert guiSupport -> !enableMinimal;
 
 stdenv.mkDerivation rec {
   pname = "gnupg";
-  version = "2.4.8";
+  version = "2.4.9";
 
   src = fetchurl {
     url = "mirror://gnupg/gnupg/${pname}-${version}.tar.bz2";
-    hash = "sha256-tYyA15sE0yQ/9JwcP8a1+DE46zeEaJVjvN0GBZUxhhY=";
+    hash = "sha256-3RerLpoE/XnTnYU/WZy8hSBi3bmrUqTd60F2/YswKWQ=";
   };
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
@@ -87,8 +87,8 @@ stdenv.mkDerivation rec {
     domain = "gitlab.com";
     owner = "freepg";
     repo = "gnupg";
-    rev = "361c223eb00ca372fbf9506f5150ddbec193936f";
-    hash = "sha256-hRuwrB6G2vjp7Md6m+cwoi7g4GtW0sazAEN5RC+AKdg=";
+    tag = "source-2.4.9-freepg";
+    hash = "sha256-wF+iR0OgnU8VI90NlFOXtN5aCRC0YY/X7sPiDXjJm5M=";
   };
 
   patches = [
@@ -128,6 +128,7 @@ stdenv.mkDerivation rec {
     "0029-Add-keyboxd-systemd-support.patch"
     "0033-Support-large-RSA-keygen-in-non-batch-mode.patch"
     "0034-gpg-Verify-Text-mode-Signatures-over-binary-Literal-.patch"
+    "0039-gpg-Do-not-use-a-default-when-asking-for-another-out.patch"
   ];
 
   postPatch =
@@ -139,7 +140,10 @@ stdenv.mkDerivation rec {
     # A significant difference between the two seems to be that keys.openpgp.org is verifying keys, while keyserver.ubuntu.com isn't: https://unix.stackexchange.com/a/694528
     # The keys.openpgp.org also has a great FAQ: https://keys.openpgp.org/about/faq
     ''
-      sed -i 's,\(hkps\|https\)://keyserver.ubuntu.com,hkps://keys.openpgp.org,g' configure configure.ac doc/dirmngr.texi doc/gnupg.info-1
+      substituteInPlace configure configure.ac \
+        --replace-fail "hkps://keyserver.ubuntu.com"  "hkps://keys.openpgp.org"
+      substituteInPlace doc/gnupg.info-1 doc/dirmngr.texi \
+        --replace-fail "https://keyserver.ubuntu.com" "https://keys.openpgp.org"
     ''
     + lib.optionalString (stdenv.hostPlatform.isLinux && withPcsc) ''
       sed -i 's,"libpcsclite\.so[^"]*","${lib.getLib pcsclite}/lib/libpcsclite.so",g' scd/scdaemon.c

--- a/pkgs/tools/security/gnupg/static.patch
+++ b/pkgs/tools/security/gnupg/static.patch
@@ -1,4 +1,4 @@
-From 6a426b8093cf6633425d08a2d33ed24d200473a0 Mon Sep 17 00:00:00 2001
+From 5eec11089067947bd850e069651cfa9bf4c48d07 Mon Sep 17 00:00:00 2001
 From: Alyssa Ross <hi@alyssa.is>
 Date: Sun, 9 Feb 2025 08:51:32 +0100
 Subject: [PATCH] build: use pkg-config to find tss2-esys
@@ -8,15 +8,15 @@ won't be linked when tss2-esys is a static library.
 ---
 Link: https://dev.gnupg.org/D606
 
- configure    | 131 +++++++++++++++++++++++++++++----------------------
+ configure    | 132 ++++++++++++++++++++++++++++-----------------------
  configure.ac |   5 +-
- 2 files changed, 76 insertions(+), 60 deletions(-)
+ 2 files changed, 75 insertions(+), 62 deletions(-)
 
 diff --git a/configure b/configure
-index 59f027d..f53c99d 100755
+index f5d8bef90..e7f4fb175 100755
 --- a/configure
 +++ b/configure
-@@ -669,12 +669,12 @@ TEST_LIBTSS_FALSE
+@@ -696,12 +696,12 @@ TEST_LIBTSS_FALSE
  TEST_LIBTSS_TRUE
  HAVE_LIBTSS_FALSE
  HAVE_LIBTSS_TRUE
@@ -31,7 +31,7 @@ index 59f027d..f53c99d 100755
  W32SOCKLIBS
  NETLIBS
  CROSS_COMPILING_FALSE
-@@ -1005,7 +1005,9 @@ PKG_CONFIG_LIBDIR
+@@ -1030,7 +1030,9 @@ PKG_CONFIG_LIBDIR
  SQLITE3_CFLAGS
  SQLITE3_LIBS
  LIBGNUTLS_CFLAGS
@@ -42,7 +42,7 @@ index 59f027d..f53c99d 100755
  
  
  # Initialize some variables set by options.
-@@ -1771,6 +1773,9 @@ Some influential environment variables:
+@@ -1805,6 +1807,9 @@ Some influential environment variables:
                C compiler flags for LIBGNUTLS, overriding pkg-config
    LIBGNUTLS_LIBS
                linker flags for LIBGNUTLS, overriding pkg-config
@@ -52,15 +52,16 @@ index 59f027d..f53c99d 100755
  
  Use these variables to override the choices made by `configure' or to help
  it to find libraries and programs with nonstandard names/locations.
-@@ -15465,64 +15470,77 @@ else
+@@ -16616,67 +16621,77 @@ else $as_nop
  fi
  
    elif test "$with_tss" = intel; then
--    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing Esys_Initialize" >&5
--$as_echo_n "checking for library containing Esys_Initialize... " >&6; }
--if ${ac_cv_search_Esys_Initialize+:} false; then :
--  $as_echo_n "(cached) " >&6
--else
+-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for library containing Esys_Initialize" >&5
+-printf %s "checking for library containing Esys_Initialize... " >&6; }
+-if test ${ac_cv_search_Esys_Initialize+y}
+-then :
+-  printf %s "(cached) " >&6
+-else $as_nop
 -  ac_func_search_save_LIBS=$LIBS
 -cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 -/* end confdefs.h.  */
@@ -68,52 +69,54 @@ index 59f027d..f53c99d 100755
 -/* Override any GCC internal prototype to avoid an error.
 -   Use char because int might match the return type of a GCC
 -   builtin and then its argument prototype would still apply.  */
--#ifdef __cplusplus
--extern "C"
--#endif
 -char Esys_Initialize ();
 -int
--main ()
+-main (void)
 -{
 -return Esys_Initialize ();
 -  ;
 -  return 0;
 -}
 -_ACEOF
--for ac_lib in '' tss2-esys; do
+-for ac_lib in '' tss2-esys
+-do
 -  if test -z "$ac_lib"; then
 -    ac_res="none required"
 -  else
 -    ac_res=-l$ac_lib
 -    LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
 -  fi
--  if ac_fn_c_try_link "$LINENO"; then :
+-  if ac_fn_c_try_link "$LINENO"
+-then :
 -  ac_cv_search_Esys_Initialize=$ac_res
 -fi
--rm -f core conftest.err conftest.$ac_objext \
+-rm -f core conftest.err conftest.$ac_objext conftest.beam \
 -    conftest$ac_exeext
--  if ${ac_cv_search_Esys_Initialize+:} false; then :
+-  if test ${ac_cv_search_Esys_Initialize+y}
+-then :
 -  break
 -fi
 -done
--if ${ac_cv_search_Esys_Initialize+:} false; then :
+-if test ${ac_cv_search_Esys_Initialize+y}
+-then :
 +pkg_failed=no
-+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for LIBTSS" >&5
-+$as_echo_n "checking for LIBTSS... " >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for LIBTSS" >&5
++printf %s "checking for LIBTSS... " >&6; }
  
+-else $as_nop
+-  ac_cv_search_Esys_Initialize=no
 +if test -n "$LIBTSS_CFLAGS"; then
 +    pkg_cv_LIBTSS_CFLAGS="$LIBTSS_CFLAGS"
 + elif test -n "$PKG_CONFIG"; then
 +    if test -n "$PKG_CONFIG" && \
-+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"tss2-esys tss2-mu tss2-rc tss2-tctildr\""; } >&5
++    { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"tss2-esys tss2-mu tss2-rc tss2-tctildr\""; } >&5
 +  ($PKG_CONFIG --exists --print-errors "tss2-esys tss2-mu tss2-rc tss2-tctildr") 2>&5
 +  ac_status=$?
-+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
++  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
 +  test $ac_status = 0; }; then
 +  pkg_cv_LIBTSS_CFLAGS=`$PKG_CONFIG --cflags "tss2-esys tss2-mu tss2-rc tss2-tctildr" 2>/dev/null`
 +		      test "x$?" != "x0" && pkg_failed=yes
- else
--  ac_cv_search_Esys_Initialize=no
++else
 +  pkg_failed=yes
  fi
 -rm conftest.$ac_ext
@@ -121,25 +124,27 @@ index 59f027d..f53c99d 100755
 + else
 +    pkg_failed=untried
  fi
--{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_Esys_Initialize" >&5
--$as_echo "$ac_cv_search_Esys_Initialize" >&6; }
+-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_Esys_Initialize" >&5
+-printf "%s\n" "$ac_cv_search_Esys_Initialize" >&6; }
 -ac_res=$ac_cv_search_Esys_Initialize
--if test "$ac_res" != no; then :
+-if test "$ac_res" != no
+-then :
 -  test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
 -  have_libtss=Intel
+-else $as_nop
+-  as_fn_error $? "Intel TPM Software Stack requested but not found" "$LINENO" 5
 +if test -n "$LIBTSS_LIBS"; then
 +    pkg_cv_LIBTSS_LIBS="$LIBTSS_LIBS"
 + elif test -n "$PKG_CONFIG"; then
 +    if test -n "$PKG_CONFIG" && \
-+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"tss2-esys tss2-mu tss2-rc tss2-tctildr\""; } >&5
++    { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"tss2-esys tss2-mu tss2-rc tss2-tctildr\""; } >&5
 +  ($PKG_CONFIG --exists --print-errors "tss2-esys tss2-mu tss2-rc tss2-tctildr") 2>&5
 +  ac_status=$?
-+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
++  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
 +  test $ac_status = 0; }; then
 +  pkg_cv_LIBTSS_LIBS=`$PKG_CONFIG --libs "tss2-esys tss2-mu tss2-rc tss2-tctildr" 2>/dev/null`
 +		      test "x$?" != "x0" && pkg_failed=yes
- else
--  as_fn_error $? "Intel TPM Software Stack requested but not found" "$LINENO" 5
++else
 +  pkg_failed=yes
 +fi
 + else
@@ -149,8 +154,8 @@ index 59f027d..f53c99d 100755
 +
 +
 +if test $pkg_failed = yes; then
-+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-+$as_echo "no" >&6; }
++        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
++printf "%s\n" "no" >&6; }
 +
 +if $PKG_CONFIG --atleast-pkgconfig-version 0.20; then
 +        _pkg_short_errors_supported=yes
@@ -167,29 +172,29 @@ index 59f027d..f53c99d 100755
 +
 +	as_fn_error $? "Intel TPM Software Stack requested but not found" "$LINENO" 5
 +elif test $pkg_failed = untried; then
-+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-+$as_echo "no" >&6; }
++        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
++printf "%s\n" "no" >&6; }
 +	as_fn_error $? "Intel TPM Software Stack requested but not found" "$LINENO" 5
 +else
 +	LIBTSS_CFLAGS=$pkg_cv_LIBTSS_CFLAGS
 +	LIBTSS_LIBS=$pkg_cv_LIBTSS_LIBS
-+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-+$as_echo "yes" >&6; }
++        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
++printf "%s\n" "yes" >&6; }
 +	have_libtss=Intel
 +fi
    else
      as_fn_error $? "Invalid TPM Software Stack requested: $with_tss" "$LINENO" 5
    fi
-@@ -15616,7 +15634,6 @@ $as_echo "$as_me: WARNING: Need Esys_TR_GetTpmHandle API (usually requires Intel
+@@ -16768,7 +16783,6 @@ printf "%s\n" "$as_me: WARNING: Need Esys_TR_GetTpmHandle API (usually requires
  
  fi
  
 -    LIBTSS_LIBS="$LIBS -ltss2-mu -ltss2-rc -ltss2-tctildr"
  
- $as_echo "#define HAVE_INTEL_TSS 1" >>confdefs.h
+ printf "%s\n" "#define HAVE_INTEL_TSS 1" >>confdefs.h
  
 diff --git a/configure.ac b/configure.ac
-index dc44465..92880e6 100644
+index 94bc80583..e88d0f650 100644
 --- a/configure.ac
 +++ b/configure.ac
 @@ -1574,8 +1574,8 @@ if test "$build_tpm2d" = "yes"; then
@@ -212,5 +217,5 @@ index dc44465..92880e6 100644
    fi
    LIBS="$_save_libs"
 -- 
-2.47.2
+2.51.0
 


### PR DESCRIPTION
- Updates gnupg 2.4.8 to 2.4.9

- Update freepg patches to source-2.4.9-freepg

- Use `substituteInPlace` with `--replace-fail` to make keyserver change more robust.

- Update `static.patch` to generated `configure` (Thanks @alyssais)
