### PR TITLE
libretro.melondsds: init at 1.2.0

### DIFF
--- a/pkgs/applications/emulators/libretro/cores/melondsds.nix
+++ b/pkgs/applications/emulators/libretro/cores/melondsds.nix
@@ -1,0 +1,109 @@
+{
+  lib,
+  fetchFromGitHub,
+  glm,
+  libslirp,
+  fmt_11,
+  span-lite,
+  howard-hinnant-date,
+  libGL,
+  libGLU,
+  cmake,
+  mkLibretroCore,
+}:
+let
+  # https://github.com/JesseTG/melonds-ds/blob/33c48260402865ef77667487528efd5ca7ce1233/cmake/FetchDependencies.cmake#L44
+  melonDS-src = fetchFromGitHub {
+    owner = "JesseTG";
+    repo = "melonDS";
+    rev = "f6692dff8c0c53f77639a08e5e746a286312bb41";
+    hash = "sha256-+bMqpjspQzyRci3u0PEpR9oX3S9LBqP223y6VfI2j14=";
+  };
+  libretro-common-src = fetchFromGitHub {
+    owner = "JesseTG";
+    repo = "libretro-common";
+    rev = "8e2b884db16711a999a0e46a02a3dc0be294b048";
+    hash = "sha256-NYxi1BADUgMAtLfmYcOIhTAnmJ/LYd0OyfPKx6lorw4=";
+  };
+  embed-binaries-src = fetchFromGitHub {
+    owner = "andoalon";
+    repo = "embed-binaries";
+    rev = "21f28cabbba02cd657578c70b7aedd0f141467ff";
+    hash = "sha256-iW3DBGdp/ykE3EoGcuirq5V5lKV0vemzIjDFrINzQPM=";
+  };
+  pntr-src = fetchFromGitHub {
+    owner = "robloach";
+    repo = "pntr";
+    rev = "650237a524ea4fc953de7223a1587c83f2696794";
+    hash = "sha256-qGWPlHkcW/wavxRN76SHiEKCl2b1VZR+O9YrZOFZL0I=";
+  };
+  yamc-src = fetchFromGitHub {
+    owner = "yohhoy";
+    repo = "yamc";
+    rev = "4e015a7e8eb0d61c34e6928676c8c78881a72d73";
+    hash = "sha256-J5wAqF5yQ5KYArJJyKzaqscWsXq+KAPKXybYfVgasXs=";
+  };
+  # using nixpkgs zlib gives a linking error
+  zlib-src = fetchFromGitHub {
+    owner = "madler";
+    repo = "zlib";
+    rev = "570720b0c24f9686c33f35a1b3165c1f568b96be";
+    hash = "sha256-5g/Jo8M/jvkgV0NofSAV4JdwJSk5Lyv9iGRb2Kz/CC0=";
+  };
+in
+mkLibretroCore rec {
+  core = "melondsds";
+  version = "1.2.0";
+
+  src = fetchFromGitHub {
+    owner = "JesseTG";
+    repo = "melonds-ds";
+    rev = "33c48260402865ef77667487528efd5ca7ce1233";
+    hash = "sha256-n5MZ6BWUWRi+jz34EbL+SeSkjFZeqQNXE3hS6JzS424=";
+  };
+
+  patches = [ ./patches/melondsds-noslirpcopy.patch ];
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail "find_package(Git REQUIRED)" ""
+
+    substituteInPlace src/libretro/CMakeLists.txt \
+      --replace-fail "include(embed-binaries)" "include(${embed-binaries-src}/cmake/embed-binaries.cmake)"
+
+    substituteInPlace cmake/FetchDependencies.cmake \
+      --replace-fail "set_target_properties(example" "set_target_properties(zlib_example" \
+      --replace-fail "set_target_properties(zlib_example64 minigzip64" "set_target_properties(zlib_example64"
+  '';
+
+  makefile = "";
+  extraBuildInputs = [
+    libGL
+    libGLU
+  ];
+  extraNativeBuildInputs = [ cmake ];
+  cmakeFlags = [
+    (lib.cmakeBool "ENABLE_LTO_RELEASE" false) # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=121831
+    (lib.cmakeFeature "CMAKE_POLICY_VERSION_MINIMUM" "3.5") # required by yamc
+
+    (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_MELONDS" "${melonDS-src}")
+    (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_LIBRETRO-COMMON" "${libretro-common-src}")
+    (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_EMBED-BINARIES" "${embed-binaries-src}")
+    (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_GLM" "${glm.src}")
+    (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_ZLIB" "${zlib-src}")
+    (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_LIBSLIRP" "${libslirp.src}")
+    (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_PNTR" "${pntr-src}")
+    (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_FMT" "${fmt_11.src}")
+    (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_YAMC" "${yamc-src}")
+    (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_SPAN-LITE" "${span-lite.src}")
+    (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_DATE" "${howard-hinnant-date.src}")
+  ];
+
+  postBuild = "cd src/libretro";
+
+  meta = {
+    description = "A remake of the libretro MelonDS core";
+    homepage = "https://github.com/JesseTG/melonds-ds";
+    changelog = "https://github.com/JesseTG/melonds-ds/releases/tag/v${version}";
+    license = lib.licenses.gpl3Only;
+  };
+}

--- a/pkgs/applications/emulators/libretro/cores/patches/melondsds-noslirpcopy.patch
+++ b/pkgs/applications/emulators/libretro/cores/patches/melondsds-noslirpcopy.patch
@@ -1,0 +1,17 @@
+diff --git a/cmake/libslirp.cmake b/cmake/libslirp.cmake
+index 1cb6758..bef1793 100644
+--- a/cmake/libslirp.cmake
++++ b/cmake/libslirp.cmake
+@@ -2,12 +2,6 @@ add_library(slirp STATIC
+         src/glib-stub/glib.c
+ )
+ 
+-# Copy libslirp's files to another directory so that we can include it as <slirp/libslirp.h>
+-file(MAKE_DIRECTORY "${libslirp_BINARY_DIR}/include")
+-file(REMOVE_RECURSE "${libslirp_BINARY_DIR}/include/slirp")
+-file(COPY "${libslirp_SOURCE_DIR}/src" DESTINATION "${libslirp_BINARY_DIR}/include")
+-file(RENAME "${libslirp_BINARY_DIR}/include/src" "${libslirp_BINARY_DIR}/include/slirp")
+-
+ target_include_directories(slirp PUBLIC
+     "${libslirp_BINARY_DIR}/include"
+     "${libslirp_SOURCE_DIR}/src"

--- a/pkgs/applications/emulators/libretro/default.nix
+++ b/pkgs/applications/emulators/libretro/default.nix
@@ -106,6 +106,8 @@ lib.makeScope newScope (self: {
 
   melonds = self.callPackage ./cores/melonds.nix { };
 
+  melondsds = self.callPackage ./cores/melondsds.nix { };
+
   mesen = self.callPackage ./cores/mesen.nix { };
 
   mesen-s = self.callPackage ./cores/mesen-s.nix { };


### PR DESCRIPTION
docs.libretro.com [recommends this core](https://docs.libretro.com/library/melonds/) over the melonDS core. I was able to launch and play a game with the built core.

It relies heavily on FetchContent and there are some exotic libraries as well. I've tried to handle them but I'm not familiar with packaging for Nix so I apologize if there are better ways.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
