### PR TITLE
fresh-editor: init at 0.1.65

### DIFF
--- a/pkgs/by-name/fr/fresh-editor/fetchers.nix
+++ b/pkgs/by-name/fr/fresh-editor/fetchers.nix
@@ -1,0 +1,21 @@
+# not a stable interface, do not reference outside the deno package but make a
+# copy if you need
+{
+  lib,
+  stdenv,
+  fetchurl,
+}:
+
+{
+  fetchLibrustyV8 =
+    args:
+    fetchurl {
+      name = "librusty_v8-${args.version}";
+      url = "https://github.com/denoland/rusty_v8/releases/download/v${args.version}/librusty_v8_release_${stdenv.hostPlatform.rust.rustcTarget}.a.gz";
+      sha256 = args.shas.${stdenv.hostPlatform.system};
+      meta = {
+        inherit (args) version;
+        sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+      };
+    };
+}

--- a/pkgs/by-name/fr/fresh-editor/librusty_v8.nix
+++ b/pkgs/by-name/fr/fresh-editor/librusty_v8.nix
@@ -1,0 +1,12 @@
+# auto-generated file -- DO NOT EDIT!
+{ fetchLibrustyV8 }:
+
+fetchLibrustyV8 {
+  version = "142.2.0";
+  shas = {
+    x86_64-linux = "sha256-xHmofo8wTNg88/TuC2pX2OHDRYtHncoSvSBnTV65o+0=";
+    aarch64-linux = "sha256-24q6wX8RTRX1tMGqgcz9/wN3Y+hWxM2SEuVrYhECyS8=";
+    x86_64-darwin = "sha256-u7fImeadycU1gS5m+m35WZA/G2SOdPrLOMafY54JwY4=";
+    aarch64-darwin = "sha256-XvJ7M5XxOzmevv+nPpy/mvEDD1MfHr986bImvDG0o4U=";
+  };
+}

--- a/pkgs/by-name/fr/fresh-editor/package.nix
+++ b/pkgs/by-name/fr/fresh-editor/package.nix
@@ -1,0 +1,71 @@
+{
+  lib,
+  callPackage,
+  rustPlatform,
+  stdenv,
+  fetchFromGitHub,
+  pkg-config,
+  openssl,
+  gzip,
+  gitMinimal,
+  writableTmpDirAsHomeHook,
+  versionCheckHook,
+  librusty_v8 ? callPackage ./librusty_v8.nix {
+    inherit (callPackage ./fetchers.nix { }) fetchLibrustyV8;
+  },
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "fresh";
+  version = "0.1.65";
+
+  src = fetchFromGitHub {
+    owner = "sinelaw";
+    repo = "fresh";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-eSpu95r5v28wP1l6GuNFT9h+NpiS2AAbZ+d6mK9JTCM=";
+  };
+
+  cargoHash = "sha256-P2o8rJVrw+g8M3iiK1fY9/+Sxse1SSChwJ+NJwRI0Io=";
+
+  nativeBuildInputs = [
+    pkg-config
+    gzip
+    writableTmpDirAsHomeHook
+  ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [ openssl ];
+
+  nativeCheckInputs = [ gitMinimal ];
+
+  # Permission denied errors
+  checkFlags = lib.optionals stdenv.hostPlatform.isDarwin [
+    "--skip=services::release_checker::tests::"
+  ];
+
+  cargoTestFlags = [
+    "--lib"
+    "--bins"
+  ];
+
+  env = {
+    RUSTY_V8_ARCHIVE = librusty_v8;
+    OPENSSL_NO_VENDOR = true;
+  };
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Terminal-based text editor with LSP support and TypeScript plugins";
+    homepage = "https://github.com/sinelaw/fresh";
+    changelog = "https://github.com/sinelaw/fresh/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.gpl2Only;
+    mainProgram = "fresh";
+    maintainers = with lib.maintainers; [ chillcicada ];
+  };
+})


### PR DESCRIPTION
succeed #472278

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
