### PR TITLE
[release-25.11] backport treewide: fix broken-escape-string

### DIFF
--- a/nixos/modules/services/networking/llama-swap.nix
+++ b/nixos/modules/services/networking/llama-swap.nix
@@ -48,7 +48,7 @@ in
           healthCheckTimeout = 60;
           models = {
             "some-model" = {
-              cmd = "$\{llama-server\} --port ''\${PORT} -m /var/lib/llama-cpp/models/some-model.gguf -ngl 0 --no-webui";
+              cmd = "''\${llama-server} --port ''\${PORT} -m /var/lib/llama-cpp/models/some-model.gguf -ngl 0 --no-webui";
               aliases = [
                 "the-best"
               ];

--- a/nixos/modules/services/web-apps/baikal.nix
+++ b/nixos/modules/services/web-apps/baikal.nix
@@ -83,11 +83,11 @@ in
             rewrite ^/.well-known/caldav  /dav.php redirect;
             rewrite ^/.well-known/carddav /dav.php redirect;
           '';
-          "~ /(\.ht|Core|Specific|config)".extraConfig = ''
+          "~ /(\\.ht|Core|Specific|config)".extraConfig = ''
             deny all;
             return 404;
           '';
-          "~ ^(.+\.php)(.*)$".extraConfig = ''
+          "~ ^(.+\\.php)(.*)$".extraConfig = ''
             try_files $fastcgi_script_name =404;
             include                   ${config.services.nginx.package}/conf/fastcgi.conf;
             fastcgi_split_path_info   ^(.+\.php)(.*)$;

--- a/nixos/modules/services/web-apps/drupal.nix
+++ b/nixos/modules/services/web-apps/drupal.nix
@@ -439,7 +439,7 @@ in
             index index.php;
           '';
           locations = {
-            "~ '\.php$|^/update.php'" = {
+            "~ '\\.php$|^/update\\.php'" = {
               extraConfig = ''
                 fastcgi_split_path_info ^(.+\.php)(/.+)$;
                 fastcgi_pass unix:${config.services.phpfpm.pools."drupal-${hostName}".socket};
@@ -470,7 +470,7 @@ in
                 access_log off;
               '';
             };
-            "~ \..*/.*\.php$" = {
+            "~ \\..*/.*\\.php$" = {
               extraConfig = ''
                 return 403;
               '';
@@ -480,7 +480,7 @@ in
                 return 403;
               '';
             };
-            "~ ^/sites/[^/]+/files/.*\.php$" = {
+            "~ ^/sites/[^/]+/files/.*\\.php$" = {
               extraConfig = ''
                 deny all;
               '';
@@ -500,13 +500,13 @@ in
                 rewrite ^ /index.php;
               '';
             };
-            "~ /vendor/.*\.php$" = {
+            "~ /vendor/.*\\.php$" = {
               extraConfig = ''
                 deny all;
                 return 404;
               '';
             };
-            "~* \.(js|css|png|jpg|jpeg|gif|ico|svg)$" = {
+            "~* \\.(js|css|png|jpg|jpeg|gif|ico|svg)$" = {
               extraConfig = ''
                 try_files $uri @rewrite;
                 expires max;
@@ -518,7 +518,7 @@ in
                 try_files $uri @rewrite;
               '';
             };
-            "~ ^(/[a-z\-]+)?/system/files/" = {
+            "~ ^(/[a-z\\-]+)?/system/files/" = {
               extraConfig = ''
                 try_files $uri /index.php?$query_string;
               '';

--- a/nixos/modules/services/web-apps/limesurvey.nix
+++ b/nixos/modules/services/web-apps/limesurvey.nix
@@ -511,7 +511,7 @@ in
                 tryFiles = "$uri /index.php?$args";
               };
 
-              "~ \.php$".extraConfig = ''
+              "~ \\.php$".extraConfig = ''
                 fastcgi_pass unix:${config.services.phpfpm.pools."limesurvey".socket};
               '';
               "/tmp".root = "/var/lib/limesurvey";

--- a/nixos/modules/services/web-apps/part-db.nix
+++ b/nixos/modules/services/web-apps/part-db.nix
@@ -179,7 +179,7 @@ in
                 sendfile off;
               '';
             };
-            "~ \.php$" = {
+            "~ \\.php$" = {
               extraConfig = ''
                 include ${config.services.nginx.package}/conf/fastcgi_params ;
                 fastcgi_param SCRIPT_FILENAME $request_filename;

--- a/nixos/modules/services/web-apps/tuliprox.nix
+++ b/nixos/modules/services/web-apps/tuliprox.nix
@@ -60,7 +60,7 @@ in
           }
           {
             name = "not_low_resolution";
-            value = "NOT (Title ~ \"(?i).*\(360p|240p\).*\")";
+            value = "NOT (Title ~ \"(?i).*(360p|240p).*\")";
           }
           {
             name = "all_channels";

--- a/nixos/tests/web-apps/netbox/default.nix
+++ b/nixos/tests/web-apps/netbox/default.nix
@@ -157,7 +157,7 @@ import ../../make-test-python.nix (
         '';
       in
       builtins.replaceStrings
-        [ "$\{changePassword}" "$\{testUser}" "$\{testPassword}" "$\{testGroup}" ]
+        [ "\${changePassword}" "\${testUser}" "\${testPassword}" "\${testGroup}" ]
         [ "${changePassword}" "${testUser}" "${testPassword}" "${testGroup}" ]
         (lib.readFile "${./testScript.py}");
   }

--- a/pkgs/applications/editors/vscode/extensions/chenglou92.rescript-vscode/rescript-editor-analysis.nix
+++ b/pkgs/applications/editors/vscode/extensions/chenglou92.rescript-vscode/rescript-editor-analysis.nix
@@ -26,7 +26,7 @@ ocamlPackages.buildDunePackage rec {
   passthru.updateScript = nix-update-script {
     extraArgs = [
       "--version-regex"
-      "([0-9]+\.[0-9]+\.[0-9]+)"
+      "([0-9]+\\.[0-9]+\\.[0-9]+)"
     ];
   };
 

--- a/pkgs/by-name/be/beedii/package.nix
+++ b/pkgs/by-name/be/beedii/package.nix
@@ -29,7 +29,7 @@ stdenvNoCC.mkDerivation rec {
 
     # This version does not include font files in the released assets.
     # https://github.com/webkul/beedii/issues/1
-    ignoredVersions = "^1\.2\.0$";
+    ignoredVersions = "^1\\.2\\.0$";
   };
 
   meta = {

--- a/pkgs/by-name/bl/bloaty/package.nix
+++ b/pkgs/by-name/bl/bloaty/package.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation {
     substituteInPlace CMakeLists.txt \
       --replace "find_package(Python COMPONENTS Interpreter)" "" \
       --replace "if(Python_FOUND AND LIT_EXECUTABLE" "if(LIT_EXECUTABLE" \
-      --replace "COMMAND \''\${Python_EXECUTABLE} \''\${LIT_EXECUTABLE}" "COMMAND \''\${LIT_EXECUTABLE}"
+      --replace "COMMAND \''${Python_EXECUTABLE} \''${LIT_EXECUTABLE}" "COMMAND \''${LIT_EXECUTABLE}"
     # wasm test fail. Possibly due to LLVM version < 17. See https://github.com/google/bloaty/pull/354
     rm -rf tests/wasm
   '';

--- a/pkgs/by-name/bl/blst/package.nix
+++ b/pkgs/by-name/bl/blst/package.nix
@@ -44,17 +44,17 @@ stdenv.mkDerivation (finalAttrs: {
     mkdir -p $out/lib/pkgconfig
     cat <<EOF > $out/lib/pkgconfig/libblst.pc
     prefix=$out
-    exec_prefix=''\\''${prefix}
-    libdir=''\\''${exec_prefix}/lib
-    includedir=''\\''${prefix}/include
+    exec_prefix=\''${prefix}
+    libdir=\''${exec_prefix}/lib
+    includedir=\''${prefix}/include
 
     Name: libblst
     Description: ${finalAttrs.meta.description}
     URL: ${finalAttrs.meta.homepage}
     Version: ${finalAttrs.version}
 
-    Cflags: -I''\\''${includedir}
-    Libs: -L''\\''${libdir} -lblst
+    Cflags: -I \''${includedir}
+    Libs: -L \''${libdir} -lblst
     Libs.private:
     EOF
 

--- a/pkgs/by-name/dp/dput-ng/package.nix
+++ b/pkgs/by-name/dp/dput-ng/package.nix
@@ -58,7 +58,7 @@ python3.pkgs.buildPythonApplication {
     # Essentially: all tags from 1.40 onwards start with `debian/`,
     # then the version, and then an optional suffix (usually reserved for backports).
     # We want to ignore the backport versions, and strip the `debian/` prefix.
-    extraArgs = [ "--version-regex=(?:debian\/)?(\d+(?:\.\d+)*)(?:[_\+].*)?" ];
+    extraArgs = [ "--version-regex=(?:debian/)?(\\d+(?:\\.\\d+)*)(?:[_+].*)?" ];
   };
 
   meta = {

--- a/pkgs/by-name/ed/edgetx/package.nix
+++ b/pkgs/by-name/ed/edgetx/package.nix
@@ -133,7 +133,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildPhase = ''
     runHook preBuild
 
-    cmakeCommonFlags="$''\{cmakeFlags[@]}"
+    cmakeCommonFlags="''${cmakeFlags[@]}"
     # This is the most sensible way to convert target name -> cmake options
     # aside from manually extracting bash variables from upstream's CI scripts
     # and converting that to nix expressions. Let's hope upstream doesn't break

--- a/pkgs/by-name/fi/filebeat8/package.nix
+++ b/pkgs/by-name/fi/filebeat8/package.nix
@@ -31,7 +31,7 @@ buildGoModule rec {
   doInstallCheck = true;
 
   passthru = {
-    updateScript = nix-update-script { extraArgs = [ "--version-regex=v(8\..*)" ]; };
+    updateScript = nix-update-script { extraArgs = [ "--version-regex=v(8\\..*)" ]; };
   };
 
   meta = {

--- a/pkgs/by-name/fs/fstar/package.nix
+++ b/pkgs/by-name/fs/fstar/package.nix
@@ -105,7 +105,7 @@ ocamlPackages.buildDunePackage (finalAttrs: {
     updateScript = nix-update-script {
       extraArgs = [
         "--version-regex"
-        "v(\d{4}\.\d{2}\.\d{2})$"
+        "v(\\d{4}\\.\\d{2}\\.\\d{2})$"
       ];
     };
     z3 = fstarZ3;

--- a/pkgs/by-name/lm/lmath/package.nix
+++ b/pkgs/by-name/lm/lmath/package.nix
@@ -39,7 +39,7 @@ appimageTools.wrapType2 {
   passthru.updateScript = nix-update-script {
     extraArgs = [
       "--version-regex"
-      "^r([0-9\.]*)"
+      "^r([0-9.]*)"
     ];
   };
 

--- a/pkgs/by-name/re/rescript-language-server/package.nix
+++ b/pkgs/by-name/re/rescript-language-server/package.nix
@@ -60,7 +60,7 @@ buildNpmPackage (finalAttrs: {
   passthru.updateScript = nix-update-script {
     extraArgs = [
       "--version-regex"
-      "([0-9]+\.[0-9]+\.[0-9]+)"
+      "([0-9]+\\.[0-9]+\\.[0-9]+)"
     ];
   };
 

--- a/pkgs/by-name/ze/zed-editor/package.nix
+++ b/pkgs/by-name/ze/zed-editor/package.nix
@@ -318,7 +318,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     updateScript = nix-update-script {
       extraArgs = [
         "--version-regex"
-        "^v(?!.*(?:-pre|0\.999999\.0|0\.9999-temporary)$)(.+)$"
+        "^v(?!.*(?:-pre|0\\.999999\\.0|0\\.9999-temporary)$)(.+)$"
 
         # use github releases instead of git tags
         # zed sometimes moves git tags, making them unreliable

--- a/pkgs/by-name/zi/zizmor/package.nix
+++ b/pkgs/by-name/zi/zizmor/package.nix
@@ -42,7 +42,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   doInstallCheck = true;
 
   passthru.updateScript = nix-update-script {
-    extraArgs = [ "--version-regex=^v([0-9.]+\.[0-9.]+\.[0-9.])+$" ];
+    extraArgs = [ "--version-regex=^v([0-9.]+\\.[0-9.]+\\.[0-9.])+$" ];
   };
 
   meta = {

--- a/pkgs/games/quake2/yquake2/default.nix
+++ b/pkgs/games/quake2/yquake2/default.nix
@@ -58,7 +58,7 @@ let
     makeFlags = [
       "WITH_OPENAL=${lib.boolToYesNo openalSupport}"
       "WITH_SYSTEMWIDE=yes"
-      "WITH_SYSTEMDIR=$\{out}/share/games/quake2"
+      "WITH_SYSTEMDIR=\${out}/share/games/quake2"
     ];
 
     nativeBuildInputs = [ copyDesktopItems ];


### PR DESCRIPTION
See https://github.com/NixOS/nixpkgs/pull/473065:

Lix is going to warn, and in the future, error on broken string escape. After a flaker run, the following escape were flagged as broken, so this commit fix them to make sure Lix is still able to build nixpkgs once the patch deprecating the broken escapes land.

(cherry picked from commit 127761a0326594596bb351fce92741b66b8ab85b)

---

@piegamesde after this one, we should be done with the broken-escape-string.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
