### PR TITLE
fcitx5-chinese-addons: patch CLOUDPINYIN build flag

### DIFF
--- a/nixos/tests/fcitx5/default.nix
+++ b/nixos/tests/fcitx5/default.nix
@@ -30,7 +30,7 @@
         enable = true;
         type = "fcitx5";
         fcitx5.addons = [
-          pkgs.fcitx5-chinese-addons
+          pkgs.qt6Packages.fcitx5-chinese-addons
           pkgs.fcitx5-hangul
           pkgs.fcitx5-m17n
           pkgs.fcitx5-mozc
@@ -81,7 +81,7 @@
       user = nodes.machine.users.users.alice;
       xauth = "${user.home}/.Xauthority";
     in
-    ''
+    /* python */ ''
       start_all()
 
       machine.wait_for_x()

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-chinese-addons.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-chinese-addons.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  fetchpatch,
   fetchFromGitHub,
   cmake,
   extra-cmake-modules,
@@ -48,6 +49,15 @@ stdenv.mkDerivation rec {
     extra-cmake-modules
     gettext
     fcitx5-lua
+  ];
+
+  patches = [
+    # Without this patch, setting ENABLE_CLOUDPINYIN to off would fail to build
+    (fetchpatch {
+      name = "cloudpinyin-disable-build";
+      url = "https://github.com/fcitx/fcitx5-chinese-addons/commit/024fff9c8587ca2fb01905e9a25df838e7d99da2.patch";
+      hash = "sha256-Mo5l8tsn1JQxTFHxOZfQRmbCeWZHLyxfn2Qwv/gQXGA=";
+    })
   ];
 
   prePatch = ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Related to https://github.com/fcitx/fcitx5-chinese-addons/issues/233
Without this patch, setting the flag ENABLE_CLOUDPINYIN to off will fail to build.
This is not yet contained in a tag or a release, so I added just the patch.

I also fixed the test. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
