### PR TITLE
json-tui: init at 1.4.1

### DIFF
--- a/pkgs/by-name/ft/ftxui/package.nix
+++ b/pkgs/by-name/ft/ftxui/package.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
     changelog = "https://github.com/ArthurSonzogni/FTXUI/blob/v${version}/CHANGELOG.md";
     description = "Functional Terminal User Interface library for C++";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ phanirithvij ];
     platforms = lib.platforms.all;
   };
 }

--- a/pkgs/by-name/ft/ftxui/package.nix
+++ b/pkgs/by-name/ft/ftxui/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+
   cmake,
   doxygen,
   gbenchmark,
@@ -9,14 +10,14 @@
   gtest,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "ftxui";
   version = "6.1.9";
 
   src = fetchFromGitHub {
     owner = "ArthurSonzogni";
     repo = "ftxui";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-plJxTLhOhUyuay5uYv4KLK9UTmM2vsoda+iDXVa4b+k=";
   };
 
@@ -33,20 +34,20 @@ stdenv.mkDerivation rec {
     gbenchmark
   ];
 
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
   cmakeFlags = [
     (lib.cmakeBool "FTXUI_BUILD_EXAMPLES" false)
     (lib.cmakeBool "FTXUI_BUILD_DOCS" true)
-    (lib.cmakeBool "FTXUI_BUILD_TESTS" doCheck)
+    (lib.cmakeBool "FTXUI_BUILD_TESTS" finalAttrs.doCheck)
   ];
-
-  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
 
   meta = {
     homepage = "https://github.com/ArthurSonzogni/FTXUI";
-    changelog = "https://github.com/ArthurSonzogni/FTXUI/blob/v${version}/CHANGELOG.md";
+    changelog = "https://github.com/ArthurSonzogni/FTXUI/blob/v${finalAttrs.version}/CHANGELOG.md";
     description = "Functional Terminal User Interface library for C++";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ phanirithvij ];
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/by-name/js/json-tui/package.nix
+++ b/pkgs/by-name/js/json-tui/package.nix
@@ -1,0 +1,69 @@
+{
+  lib,
+  stdenv,
+  fetchpatch2,
+  fetchFromGitHub,
+
+  cmake,
+  ftxui,
+  libargs,
+  nlohmann_json,
+  gtest,
+  gbenchmark,
+
+  versionCheckHook,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "json-tui";
+  version = "1.4.1";
+
+  src = fetchFromGitHub {
+    owner = "ArthurSonzogni";
+    repo = "json-tui";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-qS2EbCxH8sUUJMu5hwm1+Nu6SsJRfLReX56YSd1RZU4=";
+  };
+
+  patches = [
+    # fixes tests - https://github.com/ArthurSonzogni/json-tui/pull/37
+    (fetchpatch2 {
+      url = "https://github.com/ArthurSonzogni/json-tui/commit/645060a016c1e1ca84b9e1dc638a926415aaa5fe.patch?full_index=1";
+      hash = "sha256-8AZEZgU8HHyaasb/7LegSwRAMo1iyonv3XUY284nYKg=";
+    })
+  ];
+
+  strictDeps = true;
+
+  buildInputs = [
+    ftxui
+    libargs
+    nlohmann_json
+  ];
+
+  nativeBuildInputs = [ cmake ];
+
+  checkInputs = [ gbenchmark ];
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  cmakeFlags = [
+    "-Wno-dev" # suppress cmake warning about deprecated usage
+    (lib.cmakeBool "JSON_TUI_BUILD_TESTS" finalAttrs.doCheck)
+    (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_GOOGLETEST" "${gtest.src}")
+  ];
+
+  doInstallCheck = true;
+  versionCheckProgramArg = "--version";
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  meta = {
+    homepage = "https://github.com/ArthurSonzogni/json-tui";
+    changelog = "https://github.com/ArthurSonzogni/json-tui/blob/v${finalAttrs.version}/CHANGELOG.md";
+    description = "JSON terminal UI made in C++";
+    license = lib.licenses.mit;
+    mainProgram = "json-tui";
+    maintainers = with lib.maintainers; [ phanirithvij ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
Also adopting dependency ftxui which has no maintainers.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
