### PR TITLE
nixos/podman: fix starting unprivileged containers with sdnotify=conmon

### DIFF
--- a/nixos/modules/virtualisation/oci-containers.nix
+++ b/nixos/modules/virtualisation/oci-containers.nix
@@ -542,7 +542,7 @@ let
         Environment = "PODMAN_SYSTEMD_UNIT=%n";
         Type = "notify";
         NotifyAccess = "all";
-        Delegate = mkIf (container.podman.sdnotify == "healthy") true;
+        Delegate = true;
         User = effectiveUser;
         RuntimeDirectory = escapedName;
       };
@@ -630,13 +630,9 @@ in
               inherit (config.users.users.${podman.user}) linger;
             in
             warnings
-            ++ lib.optional (podman.user != "root" && linger && podman.sdnotify == "conmon") ''
-              Podman container ${name} is configured as rootless (user ${podman.user})
-              with `--sdnotify=conmon`, but lingering for this user is turned on.
-            ''
-            ++ lib.optional (podman.user != "root" && !linger && podman.sdnotify == "healthy") ''
-              Podman container ${name} is configured as rootless (user ${podman.user})
-              with `--sdnotify=healthy`, but lingering for this user is turned off.
+            ++ lib.optional (podman.user != "root" && !linger) ''
+              Podman container ${name} is configured as rootless (user ${podman.user}),
+              but lingering for this user is turned off.
             ''
           ) [ ] cfg.containers
         );

--- a/nixos/tests/oci-containers.nix
+++ b/nixos/tests/oci-containers.nix
@@ -84,7 +84,7 @@ let
               isSystemUser = true;
               group = "redis";
               home = "/var/lib/redis";
-              linger = type == "healthy";
+              linger = true;
               createHome = true;
               uid = 2342;
               subUidRanges = [

--- a/pkgs/by-name/po/podman/package.nix
+++ b/pkgs/by-name/po/podman/package.nix
@@ -158,6 +158,8 @@ buildGoModule (finalAttrs: {
         podman-tls-ghostunnel
         ;
       oci-containers-podman = nixosTests.oci-containers.podman;
+      oci-containers-podman-rootless-conmon = nixosTests.oci-containers.podman-rootless-conmon;
+      oci-containers-podman-rootless-healthy = nixosTests.oci-containers.podman-rootless-healthy;
     };
     # do not add qemu to this wrapper, store paths get written to the podman vm config and break when GCed
     binPath = lib.makeBinPath (


### PR DESCRIPTION
Closes #410857

Back when I researched the correct combinations of settings, containers would hang indefinitely with `--sdnotify=conmon` when using lingering and Delegate=yes.

Apparently, this changed now this is needed to get these containers to start.

cc @d-goldin @kromtar @piwicode @frlan 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
