### PR TITLE
kustomize-lint: init at 1.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16291,6 +16291,17 @@
     githubId = 36074738;
     name = "MasterEvarior";
   };
+  matanyall = {
+    email = "matanya@loewenthal.net";
+    github = "matanyall";
+    githubId = 28307422;
+    name = "Matanya Loewenthal";
+    keys = [
+      {
+        fingerprint = "50E3 E2DF 756A 1C25 9AAF  C1B8 1B48 7B28 582B 9C51";
+      }
+    ];
+  };
   matdibu = {
     email = "contact@mateidibu.dev";
     github = "matdibu";

--- a/pkgs/by-name/ku/kustomize-lint/package.nix
+++ b/pkgs/by-name/ku/kustomize-lint/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  kustomize-lint,
+  testers,
+}:
+
+buildGoModule rec {
+  pname = "kustomize-lint";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "groq";
+    repo = "kustomize-lint";
+    tag = "v${version}";
+    hash = "sha256-zVtF66A7w0RtEzZ9MNA4dqgxQUtpiUqcmnjslm4NxaE=";
+  };
+
+  vendorHash = "sha256-hCj3fmtt2lyD9ieGVPI1UXY1eDwBXEywOumzGJ+trXE=";
+
+  subPackages = [ "cmd/kustomize-lint" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  passthru.tests.version = testers.testVersion {
+    package = kustomize-lint;
+    command = "kustomize-lint --version";
+  };
+
+  meta = {
+    description = "Linter for Kustomize configuration files";
+    homepage = "https://github.com/groq/kustomize-lint";
+    changelog = "https://github.com/groq/kustomize-lint/releases/tag/v${version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ matanyall ];
+    mainProgram = "kustomize-lint";
+  };
+}


### PR DESCRIPTION
A linter for Kustomize configuration files that detects unreferenced files and validates that all referenced files exist.

Homepage: https://github.com/groq/kustomize-lint

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR.
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.