### PR TITLE
nixos/vaultwarden: refactor

### DIFF
--- a/nixos/modules/services/security/vaultwarden/default.nix
+++ b/nixos/modules/services/security/vaultwarden/default.nix
@@ -270,7 +270,7 @@ in
         after = [ "network-online.target" ] ++ lib.optional cfg.configurePostgres "postgresql.target";
         requires = lib.mkIf cfg.configurePostgres [ "postgresql.target" ];
         wants = [ "network-online.target" ];
-        path = with pkgs; [ openssl ];
+        path = [ pkgs.openssl ];
         serviceConfig = {
           User = user;
           Group = group;
@@ -326,7 +326,7 @@ in
           DATA_FOLDER = dataDir;
           BACKUP_FOLDER = cfg.backupDir;
         };
-        path = with pkgs; [ sqlite ];
+        path = [ pkgs.sqlite ];
         # if both services are started at the same time, vaultwarden fails with "database is locked"
         before = [ "vaultwarden.service" ];
         serviceConfig = {


### PR DESCRIPTION
Remove unnecessary `with pkgs` in systemd service definition

This is 276b1608545a0ae0cda1cf5622fa372e3e443a4b cherry picked from #457241 

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
