### PR TITLE
nixos/alsa: add bluetooth support

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -128,6 +128,8 @@ See <https://github.com/NixOS/nixpkgs/issues/481673>.
 
 - [services.resolved](#opt-services.resolved.enable) module was converted to RFC42-style settings. The moved options have also been renamed to match the upstream names. Aliases mean current configs will continue to function, but users should move to the new options as convenient.
 
+- Support for Bluetooth audio based on `bluez-alsa` has been added to the `hardware.alsa` module. It can be enabled with the new [enableBluetooth](#opt-hardware.alsa.enableBluetooth) option.
+
 - `services.openssh` now supports generating host SSH keys by setting `services.openssh.generateHostKeys = true` while leaving `services.openssh.enable` disabled.  This is particularly useful for systems that have no need of an SSH daemon but want SSH host keys for other purposes such as using agenix or sops-nix.
 
 - `services.slurm` now supports slurmrestd usage through the `services.slurm.rest` NixOS options.

--- a/pkgs/by-name/bl/bluez-alsa/package.nix
+++ b/pkgs/by-name/bl/bluez-alsa/package.nix
@@ -16,6 +16,8 @@
   readline,
   sbc,
   python3,
+  systemdSupport ? true,
+  systemdLibs,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -37,7 +39,8 @@ stdenv.mkDerivation (finalAttrs: {
     autoreconfHook
     pkg-config
     python3
-  ];
+  ]
+  ++ lib.optional systemdSupport systemdLibs;
 
   buildInputs = [
     alsa-lib
@@ -49,9 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
     libbsd
     ncurses
   ]
-  ++ lib.optionals aacSupport [
-    fdk_aac
-  ];
+  ++ lib.optional aacSupport fdk_aac;
 
   configureFlags = [
     (lib.enableFeature aacSupport "aac")
@@ -59,6 +60,10 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.enableFeature true "rfcomm")
     (lib.withFeatureAs true "alsaplugindir" "${placeholder "out"}/lib/alsa-lib")
     (lib.withFeatureAs true "dbusconfdir" "${placeholder "out"}/share/dbus-1/system.d")
+    (lib.enableFeature systemdSupport "systemd")
+    (lib.withFeatureAs systemdSupport "systemdsystemunitdir" "${placeholder "out"}/lib/systemd/system")
+    (lib.withFeatureAs systemdSupport "bluealsauser" "bluealsa")
+    (lib.withFeatureAs systemdSupport "bluealsaaplayuser" "bluealsa")
   ];
 
   passthru.updateScript = gitUpdater { };


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested
  - [x] `nixosTests.firefox`
  - [x] `aplay -D bluealsa` with a bluetooth speaker
  - [x] adjusting volume using `alsamixer -D bluealsa`
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
