### PR TITLE
[Backport release-25.11] ocamlPackages.ezgzip: init at 0.2.3 #474699

### DIFF
--- a/pkgs/development/ocaml-modules/ezgzip/default.nix
+++ b/pkgs/development/ocaml-modules/ezgzip/default.nix
@@ -1,0 +1,37 @@
+{
+  alcotest,
+  astring,
+  buildDunePackage,
+  camlzip,
+  fetchurl,
+  lib,
+  ocplib-endian,
+  qcheck,
+  rresult,
+}:
+
+buildDunePackage (finalAttrs: {
+  pname = "ezgzip";
+  version = "0.2.3";
+  src = fetchurl {
+    url = "https://github.com/hcarty/ezgzip/releases/download/v${finalAttrs.version}/ezgzip-v${finalAttrs.version}.tbz";
+    hash = "sha256-iGju25j4Oy1T8JGoJ9ubeltOm6U4u8CAyRtKxLr2edQ=";
+  };
+  propagatedBuildInputs = [
+    astring
+    camlzip
+    ocplib-endian
+    rresult
+  ];
+  checkInputs = [
+    alcotest
+    qcheck
+  ];
+  doCheck = true;
+  meta = {
+    description = "Simple gzip (de)compression library";
+    homepage = "https://github.com/hcarty/ezgzip";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.vog ];
+  };
+})

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -570,6 +570,8 @@ let
 
         extlib-1-7-7 = callPackage ../development/ocaml-modules/extlib/1.7.7.nix { };
 
+        ezgzip = callPackage ../development/ocaml-modules/ezgzip { };
+
         ezjsonm = callPackage ../development/ocaml-modules/ezjsonm { };
 
         ezjsonm-encoding = callPackage ../development/ocaml-modules/ezjsonm-encoding { };


### PR DESCRIPTION
(cherry picked from commit 647c096395e1db9a11c34eaf75977e883cd14bba)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
