### PR TITLE
corosync: 3.1.9 -> 3.1.10

### DIFF
--- a/pkgs/by-name/co/corosync/package.nix
+++ b/pkgs/by-name/co/corosync/package.nix
@@ -1,8 +1,8 @@
 {
   lib,
   stdenv,
-  fetchurl,
-  fetchpatch2,
+  fetchFromGitHub,
+  autoreconfHook,
   makeWrapper,
   pkg-config,
   kronosnet,
@@ -24,24 +24,19 @@
 let
   inherit (lib) optional;
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "corosync";
-  version = "3.1.9";
+  version = "3.1.10";
 
-  src = fetchurl {
-    url = "http://build.clusterlabs.org/corosync/releases/${pname}-${version}.tar.gz";
-    sha256 = "sha256-IDNUu93uGpezxQoHbq6JxjX0Bt1nTMrvyUu5CSrNlTU=";
+  src = fetchFromGitHub {
+    owner = "corosync";
+    repo = "corosync";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-9x19et+SEH+6Ufwx2MunQxX9wGfZgHCabd1IABTB8rk=";
   };
 
-  patches = [
-    (fetchpatch2 {
-      name = "CVE-2025-30472.patch";
-      url = "https://github.com/corosync/corosync/commit/7839990f9cdf34e55435ed90109e82709032466a.patch??full_index=1";
-      hash = "sha256-EgGTfOM9chjLnb1QWNGp6IQQKQGdetNkztdddXlN/uo=";
-    })
-  ];
-
   nativeBuildInputs = [
+    autoreconfHook
     makeWrapper
     pkg-config
   ];
@@ -112,4 +107,4 @@ stdenv.mkDerivation rec {
       ryantm
     ];
   };
-}
+})


### PR DESCRIPTION
https://github.com/corosync/corosync/releases/tag/v3.1.10

The derivation is now built directly from the source repository, the existing tarballs source was not mentioned in the recent changelogs.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
