### PR TITLE
vulkanscenegraph: init at 1.1.12

### DIFF
--- a/pkgs/by-name/vu/vulkanscenegraph/package.nix
+++ b/pkgs/by-name/vu/vulkanscenegraph/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchpatch,
+  cmake,
+  pkg-config,
+  glslang,
+  libxcb,
+  vulkan-headers,
+  vulkan-loader,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "vulkanscenegraph";
+  version = "1.1.12";
+
+  src = fetchFromGitHub {
+    owner = "vsg-dev";
+    repo = "VulkanSceneGraph";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-DdTfn8URLJkF5Nhkl8ZCq+brKK/T+9FipaeTON4Dsfw=";
+  };
+
+  patches = [
+    # make it compatible with glslang 16.x
+    (fetchpatch {
+      url = "https://github.com/vsg-dev/VulkanSceneGraph/commit/313865d420bba7bb3327460c367c7526f566a74e.patch";
+      hash = "sha256-hytv79AE70S/yBiI+n9RHGbHmYZW5388BiFh9l1auzU=";
+    })
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    glslang
+    libxcb
+    vulkan-headers
+    vulkan-loader
+  ];
+
+  meta = {
+    description = "Vulkan & C++17 based Scene Graph Project";
+    homepage = "http://www.vulkanscenegraph.org";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ sikmir ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/vu/vulkanscenegraph/package.nix
+++ b/pkgs/by-name/vu/vulkanscenegraph/package.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Vulkan & C++17 based Scene Graph Project";
-    homepage = "http://www.vulkanscenegraph.org";
+    homepage = "https://www.vulkanscenegraph.org";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ sikmir ];
     platforms = lib.platforms.unix;


### PR DESCRIPTION
Vulkan & C++17 based Scene Graph Project:
- http://www.vulkanscenegraph.org/
- https://github.com/vsg-dev/VulkanSceneGraph

[![Packaging status](https://repology.org/badge/tiny-repos/vulkanscenegraph.svg)](https://repology.org/project/vulkanscenegraph/versions)

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
