### PR TITLE
nixos/cgit: add gitHttpBackend options

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -63,6 +63,8 @@ of pulling the upstream container image from Docker Hub. If you want the old beh
 
 - Ethercalc and its associated module have been removed, as the package is unmaintained and cannot be installed from source with npm now.
 
+- `services.cgit` before always had the git-http-backend and its "export all" setting enabled, which sidestepped any access control configured in cgit's settings. Now you have to make a decision and either enable or disable `services.cgit.gitHttpBackend.checkExportOkFiles` (or disable the git-http-backend).
+
 - The Bash implementation of the `nixos-rebuild` program is removed. All switchable systems now use the Python rewrite. Any prior usage of `system.rebuild.enableNg` must now be removed. If you have any outstanding issues with the new implementation, please open an issue on GitHub.
 
 - The `networking.wireless` module has been security hardened: the `wpa_supplicant` daemon now runs under an unprivileged user with restricted access to the system.

--- a/nixos/modules/services/networking/cgit.nix
+++ b/nixos/modules/services/networking/cgit.nix
@@ -193,6 +193,32 @@ in
                 type = lib.types.str;
                 default = "cgit";
               };
+
+              gitHttpBackend.enable = lib.mkOption {
+                description = ''
+                  Whether to bypass cgit and use git-http-backend for HTTP clones.
+                  While this enables HTTP clones to use the more efficient smart protocol,
+                  it does not support access control via cgit's settings (e.g. the `ignore` repository setting).
+
+                  If you want to disallow access to some repositories with this backend,
+                  enable `checkExportOkFiles` and set `strict-export = "git-daemon-export-ok"` in `settings`.
+                '';
+                type = lib.types.bool;
+                default = true;
+              };
+
+              gitHttpBackend.checkExportOkFiles = lib.mkOption {
+                description = ''
+                  Whether git-http-backend should only export repositories that contain a `git-daemon-export-ok` file.
+
+                  When the backend is enabled and the check is disabled all repositories can be cloned
+                  irrespective of cgit's settings (e.g. the `ignore` repository setting).
+
+                  When enabled you must also configure `strict-export = "git-daemon-export-ok"`
+                  in `settings` to make cgit check for the same files.
+                '';
+                type = lib.types.bool;
+              };
             };
           }
         )
@@ -201,10 +227,30 @@ in
   };
 
   config = lib.mkIf (lib.any (cfg: cfg.enable) (lib.attrValues cfgs)) {
-    assertions = lib.mapAttrsToList (vhost: cfg: {
-      assertion = !cfg.enable || (cfg.scanPath == null) != (cfg.repos == { });
-      message = "Exactly one of services.cgit.${vhost}.scanPath or services.cgit.${vhost}.repos must be set.";
-    }) cfgs;
+    assertions = lib.flatten (
+      lib.mapAttrsToList (vhost: cfg: [
+        {
+          assertion = !cfg.enable || (cfg.scanPath == null) != (cfg.repos == { });
+          message = "Misconfigured services.cgit.${vhost}: Exactly one of scanPath or repos must be set.";
+        }
+        {
+          assertion =
+            !cfg.enable
+            || !cfg.gitHttpBackend.enable
+            || !cfg.gitHttpBackend.checkExportOkFiles
+            || cfg.settings.strict-export == "git-daemon-export-ok";
+          message = "Misconfigured services.cgit.${vhost}: When gitHttpBackend.checkExportOkFiles is true then settings.strict-export must be \"git-daemon-export-ok\".";
+        }
+        {
+          assertion =
+            !cfg.enable
+            || !cfg.gitHttpBackend.enable
+            || cfg.settings.strict-export == null
+            || cfg.gitHttpBackend.checkExportOkFiles;
+          message = "Misconfigured services.cgit.${vhost}: settings.strict-export is set but the gitHttpBackend is enabled and checkExportOkFiles is false.";
+        }
+      ]) cfgs
+    );
 
     users = lib.mkMerge (
       lib.flip lib.mapAttrsToList cfgs (
@@ -259,16 +305,20 @@ in
                 alias = lib.mkDefault "${cfg.package}/cgit/${fileName}";
               }
             ))
-            // {
+            // lib.optionalAttrs cfg.gitHttpBackend.enable {
               "~ ${regexLocation cfg}/.+/(info/refs|git-upload-pack)" = {
                 fastcgiParams = rec {
                   SCRIPT_FILENAME = "${pkgs.git}/libexec/git-core/git-http-backend";
-                  GIT_HTTP_EXPORT_ALL = "1";
                   GIT_PROJECT_ROOT = gitProjectRoot name cfg;
                   HOME = GIT_PROJECT_ROOT;
+                }
+                // lib.optionalAttrs (!cfg.gitHttpBackend.checkExportOkFiles) {
+                  GIT_HTTP_EXPORT_ALL = "1";
                 };
                 extraConfig = mkFastcgiPass name cfg;
               };
+            }
+            // {
               "${stripLocation cfg}/" = {
                 fastcgiParams = {
                   SCRIPT_FILENAME = "${cfg.package}/cgit/cgit.cgi";


### PR DESCRIPTION
`services.cgit` before always had the git-http-backend and its "export all" setting enabled, which sidestepped any access control configured in cgit's settings (such as the `ignore` repository setting). Now you have to make a decision and either enable or disable `services.cgit.gitHttpBackend.checkExportOkFiles` (or disable the backend).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested manually.
- NixOS Release Notes
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
