### PR TITLE
php: 8.4.15 -> 8.4.16, 8.3.28 -> 8.3.29, 8.2.29 -> 8.2.30, fixes CVE-2025-14177, CVE-2025-14178, CVE-2025-14180, GHSA-www2-q4fc-65wf

### DIFF
--- a/pkgs/development/interpreters/php/8.2.nix
+++ b/pkgs/development/interpreters/php/8.2.nix
@@ -4,8 +4,8 @@ let
   base = callPackage ./generic.nix (
     _args
     // {
-      version = "8.2.29";
-      hash = "sha256-UZeejRmMut4qrU/+n1PdPwT5YC0wieWXmYXgWK3kJnw=";
+      version = "8.2.30";
+      hash = "sha256-EEggtsj8lZ3eSzNCE19CvavyRuhpGKFjgaF9hEfIZvo=";
     }
   );
 in

--- a/pkgs/development/interpreters/php/8.3.nix
+++ b/pkgs/development/interpreters/php/8.3.nix
@@ -4,8 +4,8 @@ let
   base = callPackage ./generic.nix (
     _args
     // {
-      version = "8.3.28";
-      hash = "sha256-1bOF7jUexGPIXUfutTtRFW80g+rz/0OnrVCAwrbUxVc=";
+      version = "8.3.29";
+      hash = "sha256-xzNyEuZVMl1JnqgQj6dvad3eL/98sPrTaqY+7VQMuKU=";
     }
   );
 in

--- a/pkgs/development/interpreters/php/8.4.nix
+++ b/pkgs/development/interpreters/php/8.4.nix
@@ -4,8 +4,8 @@ let
   base = callPackage ./generic.nix (
     _args
     // {
-      version = "8.4.15";
-      hash = "sha256-txVb3UmNYNY+S8Mg3CJIY5dtMbW9kzlplybJYSVaMZc=";
+      version = "8.4.16";
+      hash = "sha256-bEjGXrpqL3oQKSXQh3Ijmx9FEQrtIYf92BuTPtQ5xpI=";
     }
   );
 in

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -447,16 +447,6 @@ lib.makeScope pkgs.newScope (
               configureFlags = [
                 "--enable-dom"
               ];
-              patches = lib.optionals (lib.versionOlder php.version "8.3") [
-                # Fix gh10234 test with libxml 2.15.0
-                (fetchpatch {
-                  url = "https://github.com/php/php-src/commit/d6e70e705323a50b616ffee9402245ab97de3e4e.patch";
-                  hash = "sha256-Axu09l3uQ83qe30aDsR+Bt29cJiF4mLknwDyQf94vic=";
-                  includes = [
-                    "ext/dom/tests/gh10234.phpt"
-                  ];
-                })
-              ];
             }
             {
               name = "enchant";


### PR DESCRIPTION
Changes:
* https://www.php.net/ChangeLog-8.php#8.4.16
* https://www.php.net/ChangeLog-8.php#8.3.29
* https://www.php.net/ChangeLog-8.php#8.2.30

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
