### PR TITLE
perlPackages.YAMLSyck: 1.34 -> 1.36

### DIFF
--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -39171,10 +39171,10 @@ with self;
 
   YAMLSyck = buildPerlPackage {
     pname = "YAML-Syck";
-    version = "1.34";
+    version = "1.36";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TO/TODDR/YAML-Syck-1.34.tar.gz";
-      hash = "sha256-zJFWzK69p5jr/i8xthnoBld/hg7RcEJi8X/608bjQVk=";
+      url = "mirror://cpan/authors/id/T/TO/TODDR/YAML-Syck-1.36.tar.gz";
+      hash = "sha256-Tc2dmzsM48ZaL/K5tMb/+LZJ/fJDv9fhiJVDvs25GlI=";
     };
     meta = {
       description = "Fast, lightweight YAML loader and dumper";


### PR DESCRIPTION
Fixes CVE-2025-11683.

```
1.36 Oct 10 2025
- Address memory corruption leading to 'str' value being set on empty keys
  Thanks @timlegge
1.35 Oct 9 2025
- Address parsing error related to string detection on read for empty strings.
```

Fixes #475110


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test


## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 475119`
Commit: `68535984e661cd041de91066b3118768fbb4d69f`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 25 packages built:</summary>
  <ul>
    <li>perl538Packages.BeanstalkClient</li>
    <li>perl538Packages.BeanstalkClient.devdoc</li>
    <li>perl538Packages.CPAN</li>
    <li>perl538Packages.CPAN.devdoc</li>
    <li>perl538Packages.GraphicsColor</li>
    <li>perl538Packages.GraphicsColor.devdoc</li>
    <li>perl538Packages.MooseXStorage</li>
    <li>perl538Packages.MooseXStorage.devdoc</li>
    <li>perl538Packages.MooseXStorageFormatJSONpm</li>
    <li>perl538Packages.MooseXStorageFormatJSONpm.devdoc</li>
    <li>perl538Packages.YAMLSyck</li>
    <li>perl538Packages.YAMLSyck.devdoc</li>
    <li>perlPackages.BeanstalkClient (perl540Packages.BeanstalkClient)</li>
    <li>perlPackages.BeanstalkClient.devdoc (perl540Packages.BeanstalkClient.devdoc)</li>
    <li>perlPackages.CPAN (perl540Packages.CPAN)</li>
    <li>perlPackages.CPAN.devdoc (perl540Packages.CPAN.devdoc)</li>
    <li>perlPackages.GraphicsColor (perl540Packages.GraphicsColor)</li>
    <li>perlPackages.GraphicsColor.devdoc (perl540Packages.GraphicsColor.devdoc)</li>
    <li>perlPackages.MooseXStorage (perl540Packages.MooseXStorage)</li>
    <li>perlPackages.MooseXStorage.devdoc (perl540Packages.MooseXStorage.devdoc)</li>
    <li>perlPackages.MooseXStorageFormatJSONpm (perl540Packages.MooseXStorageFormatJSONpm)</li>
    <li>perlPackages.MooseXStorageFormatJSONpm.devdoc (perl540Packages.MooseXStorageFormatJSONpm.devdoc)</li>
    <li>perlPackages.YAMLSyck (perl540Packages.YAMLSyck)</li>
    <li>perlPackages.YAMLSyck.devdoc (perl540Packages.YAMLSyck.devdoc)</li>
    <li>shelldap</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
