### PR TITLE
python3Packages.morecantile: fix build

### DIFF
--- a/pkgs/development/python-modules/morecantile/default.nix
+++ b/pkgs/development/python-modules/morecantile/default.nix
@@ -1,11 +1,10 @@
 {
   lib,
-  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
 
   # build-system
-  flit,
+  hatchling,
 
   # dependencies
   attrs,
@@ -32,7 +31,7 @@ buildPythonPackage rec {
     hash = "sha256-VDe39J4z5aSmdARaYknon4BK7OpovEzni0OVCxKRAkE=";
   };
 
-  build-system = [ flit ];
+  build-system = [ hatchling ];
 
   dependencies = [
     attrs
@@ -46,26 +45,6 @@ buildPythonPackage rec {
     pytestCheckHook
     rasterio
     versionCheckHook
-  ];
-
-  disabledTests = [
-    # AssertionError CLI exists with non-zero error code
-    # This is a regression introduced by https://github.com/NixOS/nixpkgs/pull/448189
-    "test_cli_shapes"
-    "test_cli_shapesWGS84"
-    "test_cli_strict_overlap_contain"
-    "test_cli_tiles_bad_bounds"
-    "test_cli_tiles_geosjon"
-    "test_cli_tiles_implicit_stdin"
-    "test_cli_tiles_multi_bounds"
-    "test_cli_tiles_multi_bounds_seq"
-    "test_cli_tiles_ok"
-    "test_cli_tiles_points"
-    "test_cli_tiles_seq"
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    # https://github.com/developmentseed/morecantile/issues/156
-    "test_tiles_when_tms_bounds_and_provided_bounds_cross_antimeridian"
   ];
 
   pythonImportsCheck = [ "morecantile" ];


### PR DESCRIPTION
Fix https://hydra.nixos.org/build/323011258

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
