### PR TITLE
fresh-editor: init at 0.1.67

### DIFF
--- a/pkgs/by-name/fr/fresh-editor/package.nix
+++ b/pkgs/by-name/fr/fresh-editor/package.nix
@@ -1,0 +1,79 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  openssl,
+  gzip,
+  gitMinimal,
+  deno,
+  nix-update-script,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "fresh";
+  version = "0.1.67";
+
+  src = fetchFromGitHub {
+    owner = "sinelaw";
+    repo = "fresh";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-OA5foQEAs01bAi78c6tEaLKaQHcRhRVtNkwpOjbPgEQ=";
+  };
+
+  cargoHash = "sha256-/sJ956ZqtI1xV0JW3RwRd0b5pYW2W/vQhb9ApF61eF0=";
+
+  passthru.updateScript = nix-update-script { };
+
+  nativeBuildInputs = [
+    pkg-config
+    gzip
+  ];
+
+  nativeCheckInputs = [
+    gitMinimal
+  ];
+
+  buildInputs = [
+    openssl
+  ];
+
+  # Tests create a local http server to check update functionality
+  __darwinAllowLocalNetworking = true;
+
+  # Due to issues with incorrect import paths with the actual app, I have disabled the checks below. Need to report upstream.
+  checkFlags = [
+    "--skip=e2e::"
+  ];
+  cargoTestFlags = [
+    "--lib"
+    "--bins"
+  ];
+
+  # The v8 package will try to download a `librusty_v8.a` release at build time to our read-only filesystem
+  # To avoid this we pre-download the file and export it via RUSTY_V8_ARCHIVE
+  env.RUSTY_V8_ARCHIVE = deno.librusty_v8;
+  preBuild = ''
+    mkdir -p $out/share/fresh-editor/plugins/
+  '';
+
+  postInstall = ''
+    rm -rf $out/bin/fresh.dSYM
+  '';
+
+  meta = {
+    description = "Terminal-based text editor with LSP support and TypeScript plugins";
+    homepage = "https://github.com/sinelaw/fresh";
+    changelog = "https://github.com/sinelaw/fresh/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [
+      chillcicada
+      dwt
+    ];
+    mainProgram = "fresh";
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    sourceProvenance = with lib.sourceTypes; [
+      fromSource
+      binaryNativeCode # librusty_v8.a
+    ];
+  };
+})


### PR DESCRIPTION
## Things done

This is a continuation of the work at #472278, resolving the feedback that was given there.

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
