### PR TITLE
prefer-remote-fetch: Fix evaluation for all fetchers and export additional attributes

### DIFF
--- a/pkgs/build-support/prefer-remote-fetch/default.nix
+++ b/pkgs/build-support/prefer-remote-fetch/default.nix
@@ -10,24 +10,38 @@
 # $ mkdir ~/.config/nixpkgs/overlays/
 # $ echo 'self: super: super.prefer-remote-fetch self super' > ~/.config/nixpkgs/overlays/prefer-remote-fetch.nix
 #
-self: super: {
-  binary-cache = args: super.binary-cache ({ preferLocalBuild = false; } // args);
-  buildenv = args: super.buildenv ({ preferLocalBuild = false; } // args);
-  fetchfossil = args: super.fetchfossil ({ preferLocalBuild = false; } // args);
-  fetchdocker = args: super.fetchdocker ({ preferLocalBuild = false; } // args);
-  fetchgit = args: super.fetchgit ({ preferLocalBuild = false; } // args);
-  fetchgx = args: super.fetchgx ({ preferLocalBuild = false; } // args);
-  fetchhg = args: super.fetchhg ({ preferLocalBuild = false; } // args);
-  fetchipfs = args: super.fetchipfs ({ preferLocalBuild = false; } // args);
-  fetchrepoproject = args: super.fetchrepoproject ({ preferLocalBuild = false; } // args);
-  fetchs3 = args: super.fetchs3 ({ preferLocalBuild = false; } // args);
-  fetchsvn = args: super.fetchsvn ({ preferLocalBuild = false; } // args);
-  fetchurl =
-    fpArgs:
-    super.fetchurl (
-      super.lib.extends (finalAttrs: args: { preferLocalBuild = args.preferLocalBuild or false; }) (
-        super.lib.toFunction fpArgs
-      )
-    );
-  mkNugetSource = args: super.mkNugetSource ({ preferLocalBuild = false; } // args);
+self: super:
+let
+  preferLocal =
+    orig:
+    self.lib.extendMkDerivation {
+      constructDrv = orig;
+      extendDrvArgs =
+        finalAttrs:
+        {
+          preferLocalBuild ? false,
+          ...
+        }:
+        {
+          inherit preferLocalBuild;
+        };
+    };
+
+in
+{
+  binary-cache = preferLocal super.binary-cache;
+  buildenv = preferLocal super.buildenv;
+  fetchfossil = preferLocal super.fetchfossil;
+  fetchdocker = preferLocal super.fetchdocker;
+  fetchgit = (preferLocal super.fetchgit) // {
+    inherit (super.fetchgit) getRevWithTag;
+  };
+  fetchgx = preferLocal super.fetchgx;
+  fetchhg = preferLocal super.fetchhg;
+  fetchipfs = preferLocal super.fetchipfs;
+  fetchrepoproject = preferLocal super.fetchrepoproject;
+  fetchs3 = preferLocal super.fetchs3;
+  fetchsvn = preferLocal super.fetchsvn;
+  fetchurl = preferLocal super.fetchurl;
+  mkNugetSource = preferLocal super.mkNugetSource;
 }

--- a/pkgs/build-support/prefer-remote-fetch/tests.nix
+++ b/pkgs/build-support/prefer-remote-fetch/tests.nix
@@ -1,0 +1,49 @@
+{ pkgs, ... }:
+
+let
+  pkgs' = pkgs.extend (self: super: super.prefer-remote-fetch self super);
+
+  check =
+    fn: args:
+    let
+      drv = pkgs'.testers.invalidateFetcherByDrvHash fn args;
+    in
+    if drv.preferLocalBuild then throw "Fetcher must not prefer local builds" else drv;
+
+in
+pkgs'.callPackage (
+  {
+    testers,
+    fetchgit,
+    fetchFromGitHub,
+    fetchurl,
+    fetchzip,
+    ...
+  }:
+  {
+    fetchgit = check fetchgit {
+      name = "simple-nix-source";
+      url = "https://github.com/NixOS/nix";
+      rev = "9d9dbe6ed05854e03811c361a3380e09183f4f4a";
+      sha256 = "sha256-7DszvbCNTjpzGRmpIVAWXk20P0/XTrWZ79KSOGLrUWY=";
+    };
+
+    fetchFromGitHub = check fetchFromGitHub {
+      name = "simple-nix-source";
+      owner = "NixOS";
+      repo = "nix";
+      rev = "9d9dbe6ed05854e03811c361a3380e09183f4f4a";
+      hash = "sha256-7DszvbCNTjpzGRmpIVAWXk20P0/XTrWZ79KSOGLrUWY=";
+    };
+
+    fetchurl = check fetchurl {
+      url = "https://gist.github.com/glandium/01d54cefdb70561b5f6675e08f2990f2/archive/2f430f0c136a69b0886281d0c76708997d8878af.zip";
+      sha256 = "sha256-J/ZWC23GmFfew/56NQvPqKzqkWgjOaPvbMicFJnuJxI=";
+    };
+
+    fetchzip = check fetchzip {
+      url = "https://gist.github.com/glandium/01d54cefdb70561b5f6675e08f2990f2/archive/2f430f0c136a69b0886281d0c76708997d8878af.zip";
+      sha256 = "sha256-0ecwgL8qUavSj1+WkaxpmRBmu7cvj53V5eXQV71fddU=";
+    };
+  }
+) { }

--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -246,4 +246,8 @@ in
   build-environment-info = callPackage ./build-environment-info { };
 
   rust-hooks = recurseIntoAttrs (callPackages ../build-support/rust/hooks/test { });
+
+  prefer-remote-fetch = recurseIntoAttrs (
+    callPackages ../build-support/prefer-remote-fetch/tests.nix { }
+  );
 }


### PR DESCRIPTION
This fixes valuation error with enabled prefer-remote-fetch overlay.

Fixes #467200.

## Things done
- Use `extendMkDerivation` to override default for `preferLocalBuild` on fetchers.
- Expose additional attributes on `fetchgit`
- Add some tests

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
