### PR TITLE
maintainers: drop grburst

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9860,13 +9860,6 @@
     githubId = 6179496;
     name = "Grayson Head";
   };
-  grburst = {
-    email = "GRBurst@protonmail.com";
-    github = "GRBurst";
-    githubId = 4647221;
-    name = "GRBurst";
-    keys = [ { fingerprint = "7FC7 98AB 390E 1646 ED4D  8F1F 797F 6238 68CD 00C2"; } ];
-  };
   greaka = {
     email = "git@greaka.de";
     github = "greaka";

--- a/pkgs/by-name/br/bront_fonts/package.nix
+++ b/pkgs/by-name/br/bront_fonts/package.nix
@@ -28,6 +28,6 @@ stdenvNoCC.mkDerivation {
       ufl
     ];
     platforms = lib.platforms.all;
-    maintainers = [ lib.maintainers.grburst ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/ka/kafkactl/package.nix
+++ b/pkgs/by-name/ka/kafkactl/package.nix
@@ -33,6 +33,6 @@ buildGoModule rec {
       - directly access kafka clusters inside your kubernetes cluster
     '';
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ grburst ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/ru/runescape/package.nix
+++ b/pkgs/by-name/ru/runescape/package.nix
@@ -99,7 +99,7 @@ let
       homepage = "https://www.runescape.com/";
       sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
       license = lib.licenses.unfree;
-      maintainers = with lib.maintainers; [ grburst ];
+      maintainers = [ ];
       platforms = [ "x86_64-linux" ];
     };
   };
@@ -149,7 +149,7 @@ buildFHSEnv {
     description = "RuneScape Game Client (NXT) - Launcher for RuneScape 3";
     homepage = "https://www.runescape.com/";
     license = lib.licenses.unfree;
-    maintainers = with lib.maintainers; [ grburst ];
+    maintainers = [ ];
     platforms = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/by-name/xc/xcwd/package.nix
+++ b/pkgs/by-name/xc/xcwd/package.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/schischi/xcwd";
     license = lib.licenses.bsd3;
     mainProgram = "xcwd";
-    maintainers = [ lib.maintainers.grburst ];
+    maintainers = [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/development/compilers/dart/default.nix
+++ b/pkgs/development/compilers/dart/default.nix
@@ -81,7 +81,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     homepage = "https://dart.dev";
-    maintainers = with lib.maintainers; [ grburst ];
+    maintainers = [ ];
     description = "Scalable programming language, with robust libraries and runtimes, for building web, server, and mobile apps";
     longDescription = ''
       Dart is a class-based, single inheritance, object-oriented language


### PR DESCRIPTION
## Reasons

- Last commented in [November of 2023](https://github.com/NixOS/nixpkgs/issues?q=commenter%3AGRBurst)
- Hasn't created any PRs / Issues since [January of 2023](https://github.com/NixOS/nixpkgs/issues?q=author%3AGRBurst)
- About 86 [unanswered](https://github.com/NixOS/nixpkgs/issues?q=involves%3AGRBurst%20-commenter%3AGRBurst%20-author%3AGRBurst%20-reviewed-by%3AGRBurst) PRs / Issues

See [losing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs. You have one week to respond to this.

## Packages 

Those packages only have them as their only maintainer and would need at least one new maintainer.

- [ ] bront_fonts
- [ ] dart
- [ ] kafkactl
- [ ] runescape
- [ ] xcwd

The packages `xcwd` seems to bee deprecated upstream, so it could also be removed.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
