### PR TITLE
canon-cups-ufr2: Link with libxml2_13

### DIFF
--- a/pkgs/by-name/ca/canon-cups-ufr2/package.nix
+++ b/pkgs/by-name/ca/canon-cups-ufr2/package.nix
@@ -20,7 +20,7 @@
   cairo,
   atk,
   pkg-config,
-  libxml2,
+  libxml2_13,
   libredirect,
   ghostscript,
   pkgs,
@@ -57,7 +57,7 @@ let
     libgcrypt
     glib
     gtk3
-    libxml2
+    libxml2_13
     gdk-pixbuf
     pango
     cairo
@@ -123,7 +123,7 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace $(find cnrdrvcups-lb-${version}/cngplp -name Makefile.am) \
-      --replace-quiet /usr/include/libxml2/ ${libxml2.dev}/include/libxml2/
+      --replace-quiet /usr/include/libxml2/ ${libxml2_13.dev}/include/libxml2/
 
     substituteInPlace \
       cnrdrvcups-common-${version}/{{backend,cngplp/src,rasterfilter}/Makefile.am,rasterfilter/cnrasterproc.h} \


### PR DESCRIPTION
Some pre-built binaries in the package might expect the old libxml2 version.

Fixes #440634


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
