### PR TITLE
nixos/yazi: refactor settings

### DIFF
--- a/nixos/modules/programs/yazi.nix
+++ b/nixos/modules/programs/yazi.nix
@@ -26,23 +26,17 @@ in
       type =
         with lib.types;
         submodule {
-          options = (
-            lib.listToAttrs (
-              map (
-                name:
-                lib.nameValuePair name (
-                  lib.mkOption {
-                    inherit (settingsFormat) type;
-                    default = { };
-                    description = ''
-                      Configuration included in `${name}.toml`.
+          options = lib.genAttrs files (
+            name:
+            lib.mkOption {
+              inherit (settingsFormat) type;
+              default = { };
+              description = ''
+                Configuration included in `${name}.toml`.
 
-                      See <https://yazi-rs.github.io/docs/configuration/${name}/> for documentation.
-                    '';
-                  }
-                )
-              ) files
-            )
+                See <https://yazi-rs.github.io/docs/configuration/${name}/> for documentation.
+              '';
+            }
           );
         };
       default = { };


### PR DESCRIPTION
Simply generate the settings submodule's attrset as opposed to mapping and then converting a list to an attrset.

<details><summary>Test</summary>
<p>

```nix
# test.nix
{
  nixpkgs ? import <nixpkgs> { },
  lib ? nixpkgs.lib,
  pkgs ? nixpkgs.pkgs,
  ...
}:
let
  settingsFormat = pkgs.formats.toml { };

  files = [
    "yazi"
    "theme"
    "keymap"
  ];
in
{
  settings = lib.mkOption {
    type =
      with lib.types;
      submodule {
        options = lib.genAttrs files (
          name:
          lib.mkOption {
            inherit (settingsFormat) type;
            default = { };
            description = ''
              Configuration included in `${name}.toml`.

              See <https://yazi-rs.github.io/docs/configuration/${name}/> for documentation.
            '';
          }
        );
      };
    default = { };
    description = ''
      Configuration included in `$YAZI_CONFIG_HOME`.
    '';
  };
}
```

```shellSession
$ nix repl
Nix 2.32.4
Type :? for help.
nix-repl> :l test.nix
Added 1 variables.
settings

nix-repl> settings.type.getSubOptions {}
{
  _module = { ... };
  keymap = { ... };
  theme = { ... };
  yazi = { ... };
}
```

</p>
</details> 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
