### PR TITLE
prometheus-node-cert-exporter: 1.1.7-unstable-2024-12-26 -> 1.1.7-unstable-2025-03-10

### DIFF
--- a/pkgs/by-name/pr/prometheus-node-cert-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-node-cert-exporter/package.nix
@@ -1,32 +1,51 @@
 {
   lib,
-  buildGoModule,
   fetchFromGitHub,
+
+  go,
+  buildGoModule,
+
+  versionCheckHook,
+  nix-update-script,
 }:
 
-buildGoModule {
+buildGoModule (finalAttrs: {
   pname = "node-cert-exporter";
-  version = "1.1.7-unstable-2024-12-26";
+  version = "1.1.7-unstable-2025-03-10";
 
   src = fetchFromGitHub {
     owner = "amimof";
     repo = "node-cert-exporter";
-    rev = "v1.1.7";
-    sha256 = "sha256-VYJPgNVsfEs/zh/SEdOrFn0FK6S+hNFGDhonj2syutQ=";
+    rev = "eef1b8207b5fdb4d6690fcfa543caf823cff0754";
+    hash = "sha256-/z2wQmcCEsPKEMKj7OunD0e+9OvXv6NV6Bn8myW6HLk=";
   };
-
-  vendorHash = "sha256-31MHX3YntogvoJmbOytl0rXS6qtdBSBJe8ejKyu6gqM=";
 
   # Required otherwise we get a few:
   # vendor/github.com/golang/glog/internal/logsink/logsink.go:129:41:
   # predeclared any requires go1.18 or later (-lang was set to go1.16; check go.mod)
   patches = [ ./gomod.patch ];
 
+  vendorHash = "sha256-Y/JgjWb2eFe4aCTU/v05rB5xH9TgZgZt2WITalj1nwc=";
+
+  ldflags = [
+    "-s"
+    "-X main.VERSION=${finalAttrs.version}"
+    "-X main.COMMIT=${finalAttrs.src.rev}"
+    "-X main.BRANCH=master"
+    "-X main.GOVERSION=${go.version}"
+  ];
+
+  doInstallCheck = true;
+  versionCheckProgramArg = "--version";
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
+
   meta = {
     description = "Prometheus exporter for SSL certificate";
-    mainProgram = "node-cert-exporter";
     homepage = "https://github.com/amimof/node-cert-exporter";
     license = lib.licenses.asl20;
+    mainProgram = "node-cert-exporter";
     maintainers = with lib.maintainers; [ ibizaman ];
   };
-}
+})


### PR DESCRIPTION

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
