### PR TITLE
xray-tun: init at 0.0.8

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14533,6 +14533,13 @@
       }
     ];
   };
+  lalala = {
+    email = "l@lalala.ing";
+    matrix = "@l:lalala.ing";
+    github = "l4l4l4l4";
+    githubId = 25174105;
+    name = "Habibi";
+  };
   lamarios = {
     matrix = "@lamarios:matrix.org";
     github = "lamarios";

--- a/pkgs/by-name/xr/xray-tun/package.nix
+++ b/pkgs/by-name/xr/xray-tun/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+buildGoModule {
+  pname = "xray-tun";
+  version = "0.0.8-unstable-2025-12-29";
+
+  src = fetchFromGitHub {
+    owner = "goxray";
+    repo = "tun";
+    rev = "0d07c6bbe69cc5c73f6a0e82cdf78be8f85d9738";
+    hash = "sha256-cy/0/OEt4mbMhwpinjFmZfkIMXhWy5JmhNQLvSjULGs=";
+  };
+
+  vendorHash = "sha256-jNGjpXjuaFU/WbedE87sUGo1pq+MLaMIFqeIOp8m1wk=";
+
+  postInstall = ''
+    mv $out/bin/tun $out/bin/xray-tun
+  '';
+
+  meta = {
+    description = "CLI Xray VPN client";
+    homepage = "https://github.com/goxray/tun";
+    license = lib.licenses.mit;
+    mainProgram = "xray-tun";
+    maintainers = with lib.maintainers; [ lalala ];
+  };
+}


### PR DESCRIPTION
Init a new package, a CLI TUN client for xray VPN.

inb4 I used ref instead of a tag, because it contains fixes to tests, not present in any tag.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
