### PR TITLE
Speechd: Fix broken Generic Synth with upstream changes

### DIFF
--- a/pkgs/by-name/sp/speechd/fix-shell.patch
+++ b/pkgs/by-name/sp/speechd/fix-shell.patch
@@ -1,0 +1,17 @@
+diff --git a/src/modules/generic.c b/src/modules/generic.c
+index 8f1672c..9ab8c94 100644
+--- a/src/modules/generic.c
++++ b/src/modules/generic.c
+@@ -648,9 +650,9 @@ void _generic_child(TModuleDoublePipe dpipe, const size_t maxlen)
+ 					exit(EXIT_FAILURE);
+ 				} else if (pid == 0) {
+ 					// child, execute command
+-					ret = execl("/bin/bash", "bash", "-c", command, (char *) NULL);
+-					// catch missing bash
+-					DBG("Missing /bin/bash? (ret=%d error=%d) %s", ret, errno, strerror(errno));
++					ret = execl("/bin/sh", "sh", "-c", command, (char *) NULL);
++					// catch missing sh
++					DBG("Missing /bin/sh? (ret=%d error=%d) %s", ret, errno, strerror(errno));
+ 					exit(EXIT_FAILURE);
+ 				} else {
+ 					int status;

--- a/pkgs/by-name/sp/speechd/package.nix
+++ b/pkgs/by-name/sp/speechd/package.nix
@@ -52,6 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
       # patch context
       bindir = null;
     })
+    ./fix-shell.patch
   ]
   ++ lib.optionals (withEspeak && espeak.mbrolaSupport) [
     # Replace FHS paths.


### PR DESCRIPTION
Adds a patch file generated from upstream changes to fix hardcoded /bin/bash file since it's not yet in a packaged release. This fixes #409229, which currently requires users to create an overlay or enable envfs for generic synths to work correctly.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
