### PR TITLE
hqplayer-desktop: 5.13.0-35 -> 5.16.2-43

### DIFF
--- a/pkgs/by-name/hq/hqplayer-desktop/package.nix
+++ b/pkgs/by-name/hq/hqplayer-desktop/package.nix
@@ -17,15 +17,15 @@
 }:
 
 let
-  version = "5.13.0-35";
+  version = "5.16.2-43";
   srcs = {
     aarch64-linux = fetchurl {
-      url = "https://signalyst.com/bins/bookworm/hqplayer5desktop_${version}_arm64.deb";
-      hash = "sha256-ofS+EDNHKv94GSi9DrZPUhosAZsjSuP8rQghldKZmkU=";
+      url = "https://signalyst.com/bins/trixie/hqplayer5desktop_${version}_arm64.deb";
+      hash = "sha256-dmnDbFf1obuBvKSMIGFiI7fXi/5YRP23625Y+UEj+Wo=";
     };
     x86_64-linux = fetchurl {
       url = "https://signalyst.com/bins/noble/hqplayer5desktop_${version}_amd64.deb";
-      hash = "sha256-ej4H7SuDMkihlJsHcvPIFSGghyqCvVY/7LbCdq6lky4=";
+      hash = "sha256-WUqfMUQSVb+MSc0GyhuEMM9H6fJP/NcmpFAX46BCiPI=";
     };
   };
 in


### PR DESCRIPTION
Resolves #472997

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
