### PR TITLE
build-support/php: fix regression in `buildComposerProject2`

### DIFF
--- a/pkgs/build-support/php/builders/v2/build-composer-project.nix
+++ b/pkgs/build-support/php/builders/v2/build-composer-project.nix
@@ -9,14 +9,14 @@ let
   buildComposerProjectOverride =
     finalAttrs:
     {
-      php ? finalAttrs.php or toplevel.php,
-      composer ? finalAttrs.php.packages.composer or toplevel.php.packages.composer,
-      composerLock ? finalAttrs.composerLock or null,
-      vendorHash ? finalAttrs.vendorHash or "",
-      composerNoDev ? finalAttrs.composerNoDev or true,
-      composerNoPlugins ? finalAttrs.composerNoPlugins or true,
-      composerNoScripts ? finalAttrs.composerNoScripts or true,
-      composerStrictValidation ? finalAttrs.composerStrictValidation or true,
+      php ? toplevel.php,
+      composer ? php.packages.composer,
+      composerLock ? null,
+      vendorHash ? "",
+      composerNoDev ? true,
+      composerNoPlugins ? true,
+      composerNoScripts ? true,
+      composerStrictValidation ? true,
       buildInputs ? [ ],
       nativeBuildInputs ? [ ],
       strictDeps ? true,
@@ -35,6 +35,9 @@ let
         doCheck
         doInstallCheck
         dontCheckForBrokenSymlinks
+        composerNoDev
+        composerNoPlugins
+        composerNoScripts
         ;
 
       nativeBuildInputs = nativeBuildInputs ++ [

--- a/pkgs/build-support/php/builders/v2/build-composer-vendor.nix
+++ b/pkgs/build-support/php/builders/v2/build-composer-vendor.nix
@@ -8,14 +8,14 @@ let
   mkComposerVendorOverride =
     finalAttrs:
     {
-      php ? finalAttrs.php or toplevel.php,
-      composer ? finalAttrs.php.packages.composer or toplevel.php.packages.composer,
-      composerLock ? finalAttrs.composerLock or null,
-      vendorHash ? finalAttrs.vendorHash or "",
-      composerNoDev ? finalAttrs.composerNoDev or true,
-      composerNoPlugins ? finalAttrs.composerNoPlugins or true,
-      composerNoScripts ? finalAttrs.composerNoScripts or true,
-      composerStrictValidation ? finalAttrs.composerStrictValidation or true,
+      php ? toplevel.php,
+      composer ? php.packages.composer,
+      composerLock ? null,
+      vendorHash ? "",
+      composerNoDev ? true,
+      composerNoPlugins ? true,
+      composerNoScripts ? true,
+      composerStrictValidation ? true,
       buildInputs ? [ ],
       nativeBuildInputs ? [ ],
       dontPatchShebangs ? true,

--- a/pkgs/build-support/php/builders/v2/hooks/composer-vendor-hook.sh
+++ b/pkgs/build-support/php/builders/v2/hooks/composer-vendor-hook.sh
@@ -10,9 +10,10 @@ declare -g composerNoPlugins
 declare -g composerNoScripts
 
 declare -ga composerFlags=()
-[[ 1 == "${composerNoDev:-1}" ]] && composerFlags+=(--no-dev)
-[[ 1 == "${composerNoPlugins:-1}" ]] && composerFlags+=(--no-plugins)
-[[ 1 == "${composerNoScripts:-1}" ]] && composerFlags+=(--no-scripts)
+
+[[ -n "${composerNoDev-1}" ]] && composerFlags+=(--no-dev)
+[[ -n "${composerNoPlugins-1}" ]] && composerFlags+=(--no-plugins)
+[[ -n "${composerNoScripts-1}" ]] && composerFlags+=(--no-scripts)
 
 preConfigureHooks+=(composerVendorConfigureHook)
 preBuildHooks+=(composerVendorBuildHook)

--- a/pkgs/by-name/dr/drupal/package.nix
+++ b/pkgs/by-name/dr/drupal/package.nix
@@ -19,7 +19,7 @@ php.buildComposerProject2 (finalAttrs: {
   };
 
   composerNoPlugins = false;
-  vendorHash = "sha256-CAntERLTmR9Gf/e+qBLJqqebdXZ0E9k8ifDh75ASoRo=";
+  vendorHash = "sha256-7FwwkPTKc/miStdHv1wfLoZhV4Gku1KwNgSlWdpPG8g=";
 
   passthru = {
     tests = {


### PR DESCRIPTION
Fix `composerFlags` regression in `buildComposerProject2`. Issue #475198

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
