### PR TITLE
relibc: init

### DIFF
--- a/pkgs/by-name/re/relibc/package.nix
+++ b/pkgs/by-name/re/relibc/package.nix
@@ -1,0 +1,88 @@
+{
+  lib,
+  rustPlatform,
+  rust-cbindgen,
+  expect,
+  stdenv,
+  fetchFromGitLab,
+  nix-update-script,
+  fetchpatch,
+}:
+rustPlatform.buildRustPackage {
+  pname = "relibc";
+  version = "0.2.5-unstable-2026-04-17";
+
+  src = fetchFromGitLab {
+    owner = "redox-os";
+    repo = "relibc";
+    rev = "24a481364fd3cd2a2a186204ef929ef37e0e5137";
+    hash = "sha256-Qt6kk/7WT18T31839FkiSy8fm2PtSoYvIC2RL+QjQns=";
+    fetchSubmodules = true;
+    domain = "gitlab.redox-os.org";
+  };
+
+  cargoHash = "sha256-0F+RW9/zz6b2HUaOADBaJq0hVyJEe+djtBN4LwoKUYA=";
+
+  env = {
+    RUSTC_BOOTSTRAP = 1;
+    TARGET = stdenv.hostPlatform.rust.rustcTargetSpec;
+  };
+
+  # error: Usage of `RUSTC_WORKSPACE_WRAPPER` requires `-Z unstable-options`
+  auditable = false;
+
+  doCheck = false;
+  postPatch = ''
+    patchShebangs --build renamesyms.sh stripcore.sh
+  '';
+
+  patches = [
+    # Fixes the issues with stable rust 1.94
+    # https://gitlab.redox-os.org/redox-os/relibc/-/merge_requests/1204
+    (fetchpatch {
+      url = "https://gitlab.redox-os.org/eveeifyeve/relibc/-/commit/fa171808ee01995f6b33cfb48b8dc37bc2439caf.patch";
+      hash = "sha256-QVSoMt2ZugoDyyK33FqX2nEHQH1ZqsqLMgNHfaUZajw=";
+    })
+  ];
+
+  # relibc expects target-triple-prefixed GNU binutils (e.g. `x86_64-linux-gnu-ar`), which Nixpkgs doesn't expose natively; this makes it so unprefixed tools are used instead.
+  # See https://gitlab.redox-os.org/redox-os/relibc/-/blob/master/README.md#im-building-for-my-own-platform-which-i-run-and-am-getting-x86_64-linux-gnu-ar-command-not-found-or-similar for more info.
+  makeFlags = [
+    "CC=gcc"
+    "AR=ar"
+    "LD=ld"
+    "NM=nm"
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    make $makeFlags CARGO_COMMON_FLAGS="" all
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    DESTDIR=$out make $makeFlagsinstall
+
+    runHook postInstall
+  '';
+
+  nativeBuildInputs = [
+    rust-cbindgen
+    expect
+  ];
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
+
+  meta = {
+    homepage = "https://gitlab.redox-os.org/redox-os/relibc";
+    description = "C Library in Rust for Redox and Linux";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.redox ++ lib.platforms.linux;
+    teams = [ lib.teams.redox ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Redone relibc pr. A lot of issues that involved fetchFromGitLab, cargoLock defined instead we can use cargoHash(vendored), some werid changes to aliases to deprecated packages, staleness, merge conflicts and more.

Closes: https://github.com/NixOS/nixpkgs/pull/453786
Fixes: https://github.com/NixOS/nixpkgs/issues/93661

Waiting on https://github.com/NixOS/nixpkgs/pull/475235 to be merged first before we rebase and merge this one.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
