### PR TITLE
lato: fix URL

### DIFF
--- a/pkgs/by-name/la/lato/package.nix
+++ b/pkgs/by-name/la/lato/package.nix
@@ -10,38 +10,36 @@ stdenvNoCC.mkDerivation {
 
   src = fetchzip {
     url = "https://www.latofonts.com/files/Lato2OFL.zip";
-    stripRoot = false;
     hash = "sha256-n1TsqigCQIGqyGLGTjLtjHuBf/iCwRlnqh21IHfAuXI=";
+    stripRoot = false;
   };
 
   installPhase = ''
     runHook preInstall
 
-    install -Dm644 Lato2OFL/*.ttf -t $out/share/fonts/lato
+    install -Dm644 Lato2OFL/*.ttf \
+      --target-directory=$out/share/fonts/lato
 
     runHook postInstall
   '';
 
   meta = {
-    homepage = "https://www.latofonts.com/";
-
-    description = ''
-      Sans-serif typeface family designed in Summer 2010 by Łukasz Dziedzic
-    '';
-
+    homepage = "https://www.latofonts.com";
+    description = "Sans-serif typeface family designed in Summer 2010 by Łukasz Dziedzic";
     longDescription = ''
-      Lato is a sans-serif typeface family designed in the Summer 2010 by
-      Warsaw-based designer Łukasz Dziedzic ("Lato" means "Summer" in Polish).
-      In December 2010 the Lato family was published under the open-source Open
-      Font License by his foundry tyPoland, with support from Google.
+      Lato is a sans-serif typeface family designed in the Summer 2010
+      by Warsaw-based designer Łukasz Dziedzic ("Lato" means "Summer"
+      in Polish).  In December 2010 the Lato family was published
+      under the open-source Open Font License by his foundry tyPoland,
+      with support from Google.
 
-      In 2013-2014, the family was greatly extended to cover 3000+ glyphs per
-      style. The Lato 2.010 family now supports 100+ Latin-based languages, 50+
-      Cyrillic-based languages as well as Greek and IPA phonetics. In the
-      process, the metrics and kerning of the family have been revised and four
-      additional weights were created.
+      In 2013-2014, the family was greatly extended to cover 3000+
+      glyphs per style. The Lato 2.010 family now supports 100+
+      Latin-based languages, 50+ Cyrillic-based languages as well as
+      Greek and IPA phonetics. In the process, the metrics and kerning
+      of the family have been revised and four additional weights were
+      created.
     '';
-
     license = lib.licenses.ofl;
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [ chris-martin ];

--- a/pkgs/by-name/la/lato/package.nix
+++ b/pkgs/by-name/la/lato/package.nix
@@ -9,7 +9,7 @@ stdenvNoCC.mkDerivation {
   version = "2.0";
 
   src = fetchzip {
-    url = "https://www.latofonts.com/download/Lato2OFL.zip";
+    url = "https://www.latofonts.com/files/Lato2OFL.zip";
     stripRoot = false;
     hash = "sha256-n1TsqigCQIGqyGLGTjLtjHuBf/iCwRlnqh21IHfAuXI=";
   };


### PR DESCRIPTION
Resolves #473007
The upstream has changed the download URL from https://www.latofonts.com/download/Lato2OFL.zip to https://www.latofonts.com/files/Lato2OFL.zip.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
