### PR TITLE
evtest: source from gitlab instead of anongit

### DIFF
--- a/pkgs/by-name/ev/evtest/package.nix
+++ b/pkgs/by-name/ev/evtest/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchgit,
+  fetchFromGitLab,
   autoreconfHook,
   pkg-config,
   libxml2,
@@ -17,9 +17,11 @@ stdenv.mkDerivation rec {
   ];
   buildInputs = [ libxml2 ];
 
-  src = fetchgit {
-    url = "git://anongit.freedesktop.org/${pname}";
-    rev = "refs/tags/${pname}-${version}";
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    owner = "libevdev";
+    repo = "evtest";
+    tag = "evtest-${version}";
     sha256 = "sha256-M7AGcHklErfRIOu64+OU397OFuqkAn4dqZxx7sDfklc=";
   };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Because the anongit URL doesn't work anymore:

```
exporting git://anongit.freedesktop.org/evtest (rev refs/tags/evtest-1.36) into /nix/store/nmhiz1cifr66q92xf6ccw964rdkl6qdj-evtest
Initialized empty Git repository in /nix/store/nmhiz1cifr66q92xf6ccw964rdkl6qdj-evtest/.git/
fatal: unable to connect to anongit.freedesktop.org:
anongit.freedesktop.org[0: 131.252.210.161]: errno=Connection refused
anongit.freedesktop.org[1: 2610:10:20:722:a800:0:83fc:d2a1]: errno=Network is unreachable
```

Replace it with the gitlab URL that is mentioned in README.md.

Fixes https://github.com/NixOS/nixpkgs/issues/475231.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
