### PR TITLE
foldersync-desktop: init at 2.8.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15568,6 +15568,18 @@
     githubId = 4969294;
     name = "Louis Tim Larsen";
   };
+  LouisJalouzot = {
+    email = "louis.jalouzot.public@gmail.com";
+    github = "LouisJalouzot";
+    githubId = 86967472;
+    name = "Louis Jalouzot";
+  };
+  lovek323 = {
+    email = "jason@oconal.id.au";
+    github = "lovek323";
+    githubId = 265084;
+    name = "Jason O'Conal";
+  };
   lovesegfault = {
     email = "meurerbernardo@gmail.com";
     matrix = "@lovesegfault:matrix.org";

--- a/pkgs/by-name/fo/foldersync-desktop/package.nix
+++ b/pkgs/by-name/fo/foldersync-desktop/package.nix
@@ -1,0 +1,205 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  makeWrapper,
+  copyDesktopItems,
+  makeDesktopItem,
+  alsa-lib,
+  fontconfig,
+  freetype,
+  glib,
+  gtk3,
+  libGL,
+  libx11,
+  libxi,
+  libxrender,
+  libxtst,
+  libxkbcommon,
+  wayland,
+  zlib,
+  undmg,
+  unzip,
+}:
+
+let
+  pname = "foldersync-desktop";
+  version = "2.8.5";
+
+  sources = {
+    x86_64-linux = {
+      arch = "linux-amd64";
+      hash = "sha256-HCmdGA1gK5ZuyEGMsJ2NIgIFERZMmbk4wA9pUK4QP7g=";
+    };
+    aarch64-linux = {
+      arch = "linux-aarch64";
+      hash = "sha256-w+E9DQSvioh7JjfZKzwBK3OexAijAeZVrbN0hiAOEOE=";
+    };
+    x86_64-darwin = {
+      arch = "mac-amd64";
+      hash = "sha256-VIjFFkfB1sknMJcio5OTCuqyys6P9reIrB72lFnRrDg=";
+    };
+    aarch64-darwin = {
+      arch = "mac-aarch64";
+      hash = "sha256-140xkPV+N/DPxFTZit0xO1IVgykQQToHSmy1noXzwyM=";
+    };
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
+  inherit pname version;
+
+  src =
+    let
+      inherit
+        (sources.${stdenv.hostPlatform.system}
+          or (throw "Unsupported system: ${stdenv.hostPlatform.system}")
+        )
+        arch
+        hash
+        ;
+      ext = if stdenv.hostPlatform.isDarwin then "zip" else "tar.gz";
+    in
+    fetchurl {
+      url = "https://github.com/tacitdynamics/foldersync-desktop-production/releases/download/${finalAttrs.version}/foldersync-desktop-${finalAttrs.version}-${arch}.${ext}";
+      inherit hash;
+    };
+
+  nativeBuildInputs = [
+    makeWrapper
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    autoPatchelfHook
+    copyDesktopItems
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    undmg
+    unzip
+  ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    alsa-lib
+    fontconfig
+    freetype
+    glib
+    gtk3
+    libGL
+    libx11
+    libxi
+    libxrender
+    libxtst
+    libxkbcommon
+    wayland
+    zlib
+    stdenv.cc.cc.lib
+  ];
+
+  runtimeDependencies = lib.optionals stdenv.hostPlatform.isLinux [
+    fontconfig
+    freetype
+    glib
+    libx11
+    libxrender
+    libxtst
+    libxkbcommon
+    wayland
+  ];
+
+  sourceRoot =
+    if stdenv.hostPlatform.isDarwin then "." else "foldersync-desktop-${finalAttrs.version}";
+
+  dontBuild = true;
+  dontConfigure = true;
+
+  desktopItems = lib.optionals stdenv.hostPlatform.isLinux [
+    (makeDesktopItem {
+      name = "foldersync-desktop";
+      desktopName = "FolderSync Desktop";
+      comment = "File syncing and backup application";
+      exec = "foldersync-desktop %U";
+      icon = "foldersync-desktop";
+      terminal = false;
+      mimeTypes = [ "x-scheme-handler/foldersync-desktop" ];
+      categories = [
+        "Utility"
+        "FileTools"
+        "Filesystem"
+        "System"
+      ];
+      startupWMClass = "dk-tacit-desktop-foldersync-MainKt";
+    })
+  ];
+
+  installPhase =
+    if stdenv.hostPlatform.isDarwin then
+      ''
+        runHook preInstall
+
+        mkdir -p "$out/Applications" "$out/bin"
+        cp -r *.app "$out/Applications/" || cp -r "FolderSync Desktop.app" "$out/Applications/"
+
+        appPath=$(find "$out/Applications" -name "*.app" -maxdepth 1 | head -1)
+        if [ -n "$appPath" ]; then
+          makeWrapper "$appPath/Contents/MacOS/"* "$out/bin/foldersync-desktop" || true
+        fi
+
+        runHook postInstall
+      ''
+    else
+      ''
+        runHook preInstall
+
+        mkdir -p $out/{bin,lib/foldersync-desktop,share}
+        cp -r lib $out/lib/foldersync-desktop/
+        cp -r bin $out/lib/foldersync-desktop/
+        cp -r share/icons $out/share/
+
+        for size in 16x16 32x32 44x44 64x64 128x128 150x150 256x256 512x512 1024x1024; do
+          if [ -d "$out/share/icons/hicolor/$size/apps" ]; then
+            for icon in $out/share/icons/hicolor/$size/apps/*; do
+              mv "$icon" "$out/share/icons/hicolor/$size/apps/foldersync-desktop.png"
+            done
+          fi
+        done
+
+        makeWrapper $out/lib/foldersync-desktop/bin/foldersync-desktop $out/bin/foldersync-desktop \
+          --set LD_LIBRARY_PATH "${
+            lib.makeLibraryPath [
+              alsa-lib
+              fontconfig
+              freetype
+              glib
+              gtk3
+              libGL
+              libx11
+              libxi
+              libxrender
+              libxtst
+              libxkbcommon
+              wayland
+            ]
+          }"
+
+        runHook postInstall
+      '';
+
+  passthru.updateScript = ./update.sh;
+
+  meta = {
+    description = "File syncing and backup application for desktop";
+    longDescription = ''
+      FolderSync is a file synchronization and backup application that supports
+      syncing folders between your computer and various cloud storage providers.
+      It features automatic file synchronization, support for 20+ cloud storage
+      providers, secure file transfer with encryption, flexible scheduling options,
+      two-way and one-way synchronization, and detailed sync logs.
+    '';
+    homepage = "https://foldersync.io/";
+    downloadPage = "https://github.com/tacitdynamics/foldersync-desktop-production/releases";
+    license = lib.licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with lib.maintainers; [ LouisJalouzot ];
+    mainProgram = "foldersync-desktop";
+    platforms = lib.attrNames sources;
+  };
+})

--- a/pkgs/by-name/fo/foldersync-desktop/update.sh
+++ b/pkgs/by-name/fo/foldersync-desktop/update.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p bash curl coreutils jq
+
+set -eu -o pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+latestVersion=$(curl -sSfL ${GITHUB_TOKEN:+" -u \":$GITHUB_TOKEN\""} https://api.github.com/repos/tacitdynamics/foldersync-desktop-production/releases/latest | jq -r '.tag_name')
+currentVersion=$(nix-instantiate --eval -E "with import ../../../.. {}; foldersync-desktop.version" | tr -d '"')
+
+if [[ "$latestVersion" == "$currentVersion" ]]; then
+    echo "foldersync-desktop is up-to-date"
+    exit 0
+fi
+
+echo "Updating foldersync-desktop from $currentVersion to $latestVersion"
+
+# Update the hashes of the sources
+for platform in x86_64-linux:linux-amd64:tar.gz aarch64-linux:linux-aarch64:tar.gz x86_64-darwin:mac-amd64:zip aarch64-darwin:mac-aarch64:zip; do
+    nixPlatform="${platform%%:*}"
+    rest="${platform#*:}"
+    fileSuffix="${rest%%:*}"
+    ext="${rest##*:}"
+
+    url="https://github.com/tacitdynamics/foldersync-desktop-production/releases/download/${latestVersion}/foldersync-desktop-${latestVersion}-${fileSuffix}.${ext}"
+    prefetch=$(nix-prefetch-url "$url")
+    hash=$(nix-hash --type sha256 --to-sri "$prefetch")
+
+    sed -i "/${nixPlatform} = {/,/};/ s|hash = \"[^\"]*\";|hash = \"${hash}\";|" ./package.nix
+done
+
+# Update the version of the package once the hashes are updated
+sed -i "s|version = \"$currentVersion\";|version = \"$latestVersion\";|" ./package.nix
+
+echo "Done"


### PR DESCRIPTION
Add FolderSync Desktop, a file synchronization and backup application supporting 20+ cloud storage providers.

- Homepage: https://foldersync.io/
- License: Proprietary (unfree)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
