### PR TITLE
lvm2: fix lvresize with filesystem

### DIFF
--- a/nixos/modules/tasks/lvm.nix
+++ b/nixos/modules/tasks/lvm.nix
@@ -51,7 +51,7 @@ in
   config = mkMerge [
     {
       # minimal configuration file to make lvmconfig/lvm2-activation-generator happy
-      environment.etc."lvm/lvm.conf".text = "config {}";
+      environment.etc."lvm/lvm.conf".text = lib.mkBefore "config {}";
     }
     (mkIf cfg.enable {
       systemd.tmpfiles.packages = [ cfg.package.out ];
@@ -59,6 +59,8 @@ in
       systemd.packages = [ cfg.package ];
 
       services.udev.packages = [ cfg.package.out ];
+      environment.etc."lvm/lvm.conf".text =
+        "global/lvresize_fs_helper_executable = ${pkgs.lvm2.scripts}/libexec/lvresize_fs_helper";
     })
     (mkIf config.boot.initrd.services.lvm.enable {
       # We need lvm2 for the device-mapper rules
@@ -71,9 +73,7 @@ in
       systemd.sockets."dm-event".wantedBy = [ "sockets.target" ];
       systemd.services."lvm2-monitor".wantedBy = [ "sysinit.target" ];
 
-      environment.etc."lvm/lvm.conf".text = ''
-        dmeventd/executable = "${cfg.package}/bin/dmeventd"
-      '';
+      environment.etc."lvm/lvm.conf".text = "dmeventd/executable = ${cfg.package}/bin/dmeventd";
       services.lvm.package = mkDefault pkgs.lvm2_dmeventd;
     })
     (mkIf cfg.boot.thin.enable {

--- a/pkgs/os-specific/linux/lvm2/common.nix
+++ b/pkgs/os-specific/linux/lvm2/common.nix
@@ -202,7 +202,7 @@ stdenv.mkDerivation rec {
       moveToOutput bin/lvmdump $scripts
       moveToOutput bin/lvm_import_vdo $scripts
       moveToOutput bin/lvmpersist $scripts
-      moveToOutput libexec/lvresize_fs_helper $scripts/lib
+      moveToOutput libexec/lvresize_fs_helper $scripts
     ''
     + lib.optionalString (!enableCmdlib) ''
       moveToOutput lib/libdevmapper.so $lib


### PR DESCRIPTION
## Things done
- move to libexec from lib/libexec
- add path to config, if services.lvm.enable is set

Fixes https://github.com/NixOS/nixpkgs/issues/465633

untested

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
