### PR TITLE
smuxi: fix build

### DIFF
--- a/pkgs/by-name/sm/smuxi/package.nix
+++ b/pkgs/by-name/sm/smuxi/package.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
     ];
 
   preConfigure = ''
-    NOCONFIGURE=1 NOGIT=1 ./autogen.sh
+    NOCONFIGURE=1 NOGIT=1 ACLOCAL_FLAGS="-I ${gettext}/share/gettext/m4" ./autogen.sh
   '';
 
   configureFlags = [


### PR DESCRIPTION
This fixes the build error:

    Running aclocal -I m4  ...
    configure.ac:117: warning: macro 'AM_GNU_GETTEXT' not found in library
    configure.ac:118: warning: macro 'AM_GNU_GETTEXT_VERSION' not found in library
    ...
    configure.ac:762: the top level
    configure.ac:117: error: possibly undefined macro: AM_GNU_GETTEXT
    	  If this token and others are legitimate, please use m4_pattern_allow.
    	  See the Autoconf documentation.
    configure.ac:118: error: possibly undefined macro: AM_GNU_GETTEXT_VERSION
    ...
    checking for XML::Parser... ok
    ./configure: line 3892: syntax error near unexpected token `external'
    ./configure: line 3892: `AM_GNU_GETTEXT(external)'
    error: Cannot build '/nix/store/y3jqbgi6415mbkjh0102ip693hhxgy0l-smuxi-unstable-2024-04-14.drv'.
    	   Reason: builder failed with exit code 2.

Which is caused by the gettext package to no longer automatically include the macro that smuxi requires during aclocal. Thus we simply pass the gettext macro path to autogen.sh


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
