### PR TITLE
Revert "carapace: 1.5.5 -> 1.5.7"

### DIFF
--- a/pkgs/by-name/ca/carapace/package.nix
+++ b/pkgs/by-name/ca/carapace/package.nix
@@ -9,16 +9,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "carapace";
-  version = "1.5.7";
+  version = "1.5.5";
 
   src = fetchFromGitHub {
     owner = "carapace-sh";
     repo = "carapace-bin";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-gYgROZAmhgU/H4XsFXdIHRrS72EVRHxAalx8K7hmnDE=";
+    hash = "sha256-q7G7odkRwh4/w8H09exXYSC7n4CUeoG2iKb/k2D/gek=";
   };
 
-  vendorHash = "sha256-4k9iX47PjEEsJO1lB7xOwCnakhkd+OelaAr/zv3A1l8=";
+  vendorHash = "sha256-eADiOSLqouH9saTgbbQY18wc3DxCBvqdVKI32I7sTWQ=";
 
   ldflags = [
     "-s"


### PR DESCRIPTION
Reverts NixOS/nixpkgs#470187

Doesn't actually build.