### PR TITLE
nvrhi: init at 0-unstable-2025-12-16

### DIFF
--- a/pkgs/by-name/nv/nvrhi/package.nix
+++ b/pkgs/by-name/nv/nvrhi/package.nix
@@ -1,0 +1,60 @@
+{
+  cmake,
+  directx-headers,
+  fetchFromGitHub,
+  lib,
+  stdenv,
+  vulkan-headers,
+  d3d11 ? stdenv.hostPlatform.isWindows,
+  d3d12 ? stdenv.hostPlatform.isWindows,
+  validation ? true,
+  vulkan ? stdenv.hostPlatform.isLinux,
+}:
+
+stdenv.mkDerivation {
+  pname = "nvrhi";
+  version = "0-unstable-2025-12-16";
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  src = fetchFromGitHub {
+    owner = "NVIDIA-RTX";
+    repo = "NVRHI";
+    rev = "92a13688a5186ca76612517234490cfe72f3e7d1";
+    hash = "sha256-8WzGgXOcYTXNSJyRYtMl/dIbe7Qrq33/MJz6MeoonWs=";
+  };
+
+  patches = [
+    # Required; upstream hardcodes the expectation that Vulkan/DirectX headers be included as a submodule.
+    ./patches/0001-Fix-CMakeLists.patch
+  ];
+
+  nativeBuildInputs = [
+    cmake
+  ]
+  ++ lib.optionals vulkan [
+    vulkan-headers
+  ]
+  ++ lib.optionals (d3d11 || d3d12) [
+    directx-headers
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "NVRHI_BUILD_SHARED" (!stdenv.hostPlatform.isStatic))
+    (lib.cmakeBool "NVRHI_WITH_VALIDATION" validation)
+    (lib.cmakeBool "NVRHI_WITH_VULKAN" vulkan)
+    (lib.cmakeBool "NVRHI_WITH_DX11" d3d11)
+    (lib.cmakeBool "NVRHI_WITH_DX12" d3d12)
+  ];
+
+  meta = {
+    description = "NVIDIA Hardware Rendering Interface";
+    homepage = "https://github.com/NVIDIA-RTX/NVRHI";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ bearfm ];
+    platforms = lib.platforms.linux ++ lib.platforms.windows;
+  };
+}

--- a/pkgs/by-name/nv/nvrhi/patches/0001-Fix-CMakeLists.patch
+++ b/pkgs/by-name/nv/nvrhi/patches/0001-Fix-CMakeLists.patch
@@ -1,0 +1,37 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 5d1797e..3f9300a 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -61,20 +61,8 @@ endif()
+ 
+ set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+ 
+-if (NVRHI_WITH_VULKAN AND NOT TARGET Vulkan-Headers AND NOT TARGET Vulkan::Headers)
+-    add_subdirectory(thirdparty/Vulkan-Headers)
+-endif()
+-
+-if(NVRHI_WITH_DX12 AND NOT TARGET DirectX-Headers AND NOT TARGET Microsoft::DirectX-Headers)
+-    add_subdirectory(thirdparty/DirectX-Headers)
+-endif()
+ 
+ if (NVRHI_WITH_RTXMU)
+-    if (TARGET Vulkan-Headers)
+-        get_target_property(RTXMU_VULKAN_INCLUDE_DIR Vulkan-Headers INTERFACE_INCLUDE_DIRECTORIES)
+-    elseif (TARGET Vulkan::Headers)
+-        get_target_property(RTXMU_VULKAN_INCLUDE_DIR Vulkan::Headers INTERFACE_INCLUDE_DIRECTORIES)
+-    endif()
+ 
+     option(RTXMU_WITH_VULKAN "" ${NVRHI_WITH_VULKAN})
+     option(RTXMU_WITH_D3D12 "" ${NVRHI_WITH_DX12})
+@@ -325,11 +313,6 @@ if (NVRHI_WITH_VULKAN)
+         target_link_libraries(${nvrhi_vulkan_target} PUBLIC rtxmu)
+     endif()
+ 
+-    if (TARGET Vulkan-Headers)
+-        target_link_libraries(${nvrhi_vulkan_target} PRIVATE Vulkan-Headers)
+-    elseif (TARGET Vulkan::Headers)
+-        target_link_libraries(${nvrhi_vulkan_target} PRIVATE Vulkan::Headers)
+-    endif()
+ 
+     if (NVRHI_WITH_AFTERMATH)
+         target_link_libraries(${nvrhi_vulkan_target} PUBLIC aftermath)


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
NVRHI is a library from Nvidia serving a similar purpose to WebGPU. It provides an abstraction layer over Vulkan and DirectX.

Upstream hasn't published any releases or tags, so the package version is unstable for the time being.

Regardless of the lack of releases, the library doesn't seem like it's going anywhere anytime soon. It's been in development for over 4 years and is backed by Nvidia (who use it in multiple of their SDKs).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
