### PR TITLE
apl387: init at 0-unstable-2025-12-13

### DIFF
--- a/pkgs/by-name/ap/apl387/package.nix
+++ b/pkgs/by-name/ap/apl387/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  installFonts,
+  python3,
+  fontforge,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "apl387";
+  version = "0-unstable-2025-12-13";
+
+  src = fetchFromGitHub {
+    owner = "dyalog";
+    repo = "APL387";
+    rev = "60ff47a728ee043f878dc2ed801d53e29fcebe9d";
+    hash = "sha256-VyO+7PUYcmmhbFVAW37yvWQLUpt0K/ihA/JGmbt+4Uk=";
+  };
+
+  nativeBuildInputs = [
+    python3
+    fontforge
+    installFonts
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+    ${python3.executable} script.py . "${finalAttrs.src.rev}"
+    runHook postBuild
+  '';
+
+  outputs = [
+    "out"
+    "webfont"
+  ];
+
+  postInstall = ''
+    installFont svg $out/share/fonts/svg
+  '';
+
+  meta = {
+    homepage = "https://dyalog.github.io/APL387";
+    description = "Redrawn and extended version of Adrian Smith's classic APL385 font with clean rounded look";
+    license = lib.licenses.unlicense;
+    maintainers = [
+      lib.maintainers.sternenseemann
+      lib.maintainers.sigmanificient
+    ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Btw, #435714 has another interesting APL related font.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
