### PR TITLE
calamares-nixos-extensions: add filesystem type chooser with btrfs support

### DIFF
--- a/pkgs/by-name/ca/calamares-nixos-extensions/src/config/modules/mount.conf
+++ b/pkgs/by-name/ca/calamares-nixos-extensions/src/config/modules/mount.conf
@@ -20,8 +20,20 @@ extraMounts:
       mountPoint: /sys/firmware/efi/efivars
       efi: true
 
-# Ensure the right fmask/dmask is set on the ESP, as it will be
-# picked up by nixos-generate-config later
+# Btrfs subvolume layout for NixOS
+# Empty subvolume for / means no subvolume (top-level) for GRUB compatibility
+btrfsSubvolumes:
+    - mountPoint: /
+      subvolume: ""
+    - mountPoint: /home
+      subvolume: /home
+    - mountPoint: /nix
+      subvolume: /nix
+
+# Mount options by filesystem type
+# nixos-generate-config picks these up for hardware-configuration.nix
 mountOptions:
     - filesystem: efi
       options: [ fmask=0077, dmask=0077 ]
+    - filesystem: btrfs
+      options: [ compress=zstd, noatime ]

--- a/pkgs/by-name/ca/calamares-nixos-extensions/src/config/modules/partition.conf
+++ b/pkgs/by-name/ca/calamares-nixos-extensions/src/config/modules/partition.conf
@@ -12,11 +12,29 @@ userSwapChoices:
 
 luksGeneration: luks2
 
+defaultFileSystemType: "ext4"
+
+availableFileSystemTypes:
+    - ext4
+    - btrfs
+    - xfs
+    - f2fs
+
 showNotEncryptedBootMessage: false
 
+bios:
+    mountPoint: "/boot"
+    minimumSize: 512MiB
+    recommendedSize: 1GiB
+    label: "BOOT"
+
 partitionLayout:
-    - name: "root"
+    - name: "boot"
       filesystem: "ext4"
+      mountPoint: "/boot"
+      size: 1GiB
+    - name: "root"
+      filesystem: "unknown"
       noEncrypt: false
       mountPoint: "/"
       size: 100%


### PR DESCRIPTION
Adds a filesystem type chooser to the NixOS Calamares installer allowing users to select between ext4, btrfs, xfs and f2fs during
  installation.

  **Changes:**

  - partition.conf: Added filesystem type chooser with ext4, btrfs, xfs and f2fs options. Added separate /boot partition (1GB ext4) for reliable GRUB boot on all filesystem types.
  - mount.conf: Added btrfs subvolume layout (root, /home, /nix) and mount options (compress=zstd, noatime).
  - main.py: Addeded `fix_btrfs_subvolumes()` to correct subvol options in hardware-configuration.nix. Added btrfs-specific GRUB config with`fsIdentifier = "provided"` to avoid blkid issues. Fix root mount point permissions.

  **Testing:**

  Manually tested in QEMU with both BIOS (SeaBIOS) and UEFI (OVMF) firmware:
  - BIOS/GRUB with ext4, xfs and f2fs 
  - BIOS/GRUB with btrfs (subvolumes + compression)
  - EFI/systemd-boot with ext4, xfs and f2fs
  - EFI/systemd-boot with btrfs (subvolumes + compression)
 
 **How to test:**

To test these changes, build the Calamares GNOME ISO:

  `nix-build '<nixpkgs/nixos>' -A config.system.build.isoImage -I`

  `nixos-config=nixos/modules/installer/cd-dvd/installation-cd-graphical-calamares-gnome.nix -I nixpkgs=.`

  Create a virtual disk for installation:

  `qemu-img create -f qcow2 test-disk.qcow2 20G`

  Test BIOS/GRUB install:

  `qemu-system-x86_64 -enable-kvm -m 4G -drive file=test-disk.qcow2,format=qcow2 -cdrom result/iso/*.iso -boot d`

  Test EFI/systemd-boot install:

```bash
  cp /run/libvirt/nix-ovmf/edk2-i386-vars.fd edk2-vars.fd
  qemu-system-x86_64 -enable-kvm -m 4G \
    -drive if=pflash,format=raw,readonly=on,file=/run/libvirt/nix-ovmf/edk2-x86_64-code.fd \
    -drive if=pflash,format=raw,file=edk2-vars.fd \
    -drive file=test-disk-efi.qcow2,format=qcow2 \
    -cdrom result/iso/*.iso -boot d
```

 Boot from installed disk (remove -cdrom and -boot d):

  `qemu-system-x86_64 -enable-kvm -m 4G -drive file=test-disk.qcow2,format=qcow2`

  After install run `df -hT`to verify partition layout. For btrfs you should see separate /boot (ext4) and btrfs subvolumes for `/` `/home` and `/nix` with compress=zstd in mount options.

  ## Things done

  <!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

  - Built on platform:
    - [x] x86_64-linux
    - [ ] aarch64-linux
    - [ ] x86_64-darwin
    - [ ] aarch64-darwin
  - Tested, as applicable:
    - [ ] [NixOS tests] in [nixos/tests].
    - [ ] [Package tests] at `passthru.tests`.
    - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
  - [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
  - [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - Nixpkgs Release Notes
    - [ ] Package update: when the change is major or breaking.
  - NixOS Release Notes
    - [ ] Module addition: when adding a new NixOS module.
    - [ ] Module update: when the change is significant.
  - [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

  [NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
  [Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
  [nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

  [CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
  [lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
  [maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
  [nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
  [pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
  [pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

  Add a :+1: [reaction] to [pull requests you find important].

  [reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
  [pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc