### PR TITLE
revert bad updateScripts

### DIFF
--- a/pkgs/development/tools/build-managers/gnumake/default.nix
+++ b/pkgs/development/tools/build-managers/gnumake/default.nix
@@ -9,7 +9,6 @@
   inBootstrap ? false,
   pkg-config,
   gnumake,
-  directoryListingUpdater,
 }:
 
 let
@@ -53,15 +52,9 @@ stdenv.mkDerivation (finalAttrs: {
   ];
   separateDebugInfo = true;
 
-  passthru = {
-    tests = {
-      # make sure that the override doesn't break bootstrapping
-      gnumakeWithGuile = gnumake.override { guileSupport = true; };
-    };
-    updateScript = directoryListingUpdater {
-      inherit (finalAttrs) pname version;
-      url = "https://ftp.gnu.org/gnu/make/";
-    };
+  passthru.tests = {
+    # make sure that the override doesn't break bootstrapping
+    gnumakeWithGuile = gnumake.override { guileSupport = true; };
   };
 
   meta = {

--- a/pkgs/tools/compression/gzip/default.nix
+++ b/pkgs/tools/compression/gzip/default.nix
@@ -5,7 +5,6 @@
   makeShellWrapper,
   updateAutotoolsGnuConfigScriptsHook,
   runtimeShellPackage,
-  directoryListingUpdater,
 }:
 
 # Note: this package is used for bootstrapping fetchurl, and thus
@@ -60,13 +59,6 @@ stdenv.mkDerivation (finalAttrs: {
     wrapProgram $out/bin/gzip \
       --add-flags "\''${GZIP_NO_TIMESTAMPS:+-n}"
   '';
-
-  passthru = {
-    updateScript = directoryListingUpdater {
-      inherit (finalAttrs) pname version;
-      url = "https://ftp.gnu.org/gnu/gzip/";
-    };
-  };
 
   meta = {
     homepage = "https://www.gnu.org/software/gzip/";

--- a/pkgs/tools/misc/findutils/default.nix
+++ b/pkgs/tools/misc/findutils/default.nix
@@ -4,7 +4,6 @@
   fetchurl,
   updateAutotoolsGnuConfigScriptsHook,
   coreutils,
-  directoryListingUpdater,
 }:
 
 # Note: this package is used for bootstrapping fetchurl, and thus
@@ -75,11 +74,6 @@ stdenv.mkDerivation (finalAttrs: {
   # https://github.com/NixOS/nixpkgs/pull/192630#discussion_r978985593
   # or you can check libc/include/sys/cdefs.h in bionic source code
   hardeningDisable = lib.optional (stdenv.hostPlatform.libc == "bionic") "fortify";
-
-  passthru.updateScript = directoryListingUpdater {
-    inherit (finalAttrs) pname version;
-    url = "https://ftp.gnu.org/gnu/findutils/";
-  };
 
   meta = {
     homepage = "https://www.gnu.org/software/findutils/";


### PR DESCRIPTION
- **Revert "gzip: set passthru.updateScript"**
- **Revert "findutils: set passthru.updateScript"**
- **Revert "gnumake: set passthru.updateScript"**

Addresses https://github.com/NixOS/nixpkgs/pull/474210#issuecomment-3698308437.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
