### PR TITLE
waterfox: init at 6.7.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2723,6 +2723,12 @@
     githubId = 574938;
     name = "Jonathan Glines";
   };
+  aurelivia = {
+    name = "Olivia Taliesin";
+    email = "olivia@taliesin.dev";
+    github = "aurelivia";
+    githubId = 154032262;
+  };
   auscyber = {
     email = "ivyp@outlook.com.au";
     github = "auscyber";

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1861,6 +1861,10 @@ in
   wasabibackend = runTest ./wasabibackend.nix;
   wastebin = runTest ./wastebin.nix;
   watchdogd = runTest ./watchdogd.nix;
+  waterfox = runTest {
+    imports = [ ./firefox.nix ];
+    _module.args.firefoxPackage = pkgs.waterfox;
+  };
   watt = runTest ./watt.nix;
   webhook = runTest ./webhook.nix;
   weblate = runTest ./web-apps/weblate.nix;

--- a/pkgs/by-name/wa/waterfox-unwrapped/package.nix
+++ b/pkgs/by-name/wa/waterfox-unwrapped/package.nix
@@ -1,0 +1,67 @@
+{
+  buildMozillaMach,
+  fetchFromGitHub,
+  lib,
+  nixosTests,
+  stdenv,
+}:
+
+(buildMozillaMach rec {
+  pname = "waterfox";
+  version = "140.13.0";
+  packageVersion = "6.6.17";
+  applicationName = "Waterfox";
+  binaryName = "waterfox";
+  branding = "waterfox/browser/branding";
+  requireSigning = false;
+  src = fetchFromGitHub {
+    owner = "BrowserWorks";
+    repo = "Waterfox";
+    tag = packageVersion;
+    hash = "sha256-bFYRdEImKTwD456yc9lN+Dx83q70WZXjwD3Qo2SRpnQ=";
+    fetchSubmodules = true;
+    # We can't clone the submodules with SSH.
+    preFetch = ''
+      export GIT_CONFIG_COUNT=1
+      export GIT_CONFIG_KEY_0=url.https://github.com/.insteadOf
+      export GIT_CONFIG_VALUE_0=git@github.com:
+    '';
+  };
+
+  extraPatches = [
+    # Some of the icons are missing and cause the build to crash. Removing them fixes the issue.
+    ./remove-missing-icons.patch
+  ];
+
+  extraPostPatch = ''
+    # `buildMozillaMach` will take care of the build.
+    rm .mozconfig .mozconfig-*
+
+    # Override the default Firefox version.
+    for fn in browser/config/version.txt browser/config/version_display.txt; do
+      echo "${packageVersion}" > "$fn"
+    done
+  '';
+
+  meta = {
+    broken = stdenv.buildPlatform.is32bit;
+    # since Firefox 60, build on 32-bit platforms fails with "out of memory".
+    # not in `badPlatforms` because cross-compilation on 64-bit machine might work.
+    changelog = "https://github.com/BrowserWorks/waterfox/releases/tag/${src.tag}";
+    description = "Privacy-focused Firefox Fork";
+    homepage = "https://www.waterfox.com";
+    license = lib.licenses.mpl20;
+    mainProgram = "waterfox";
+    maintainers = with lib.maintainers; [
+      aurelivia
+      defelo
+      ethancedwards8
+      hythera
+    ];
+    maxSilent = 14400; # 4h, double the default of 7200s (c.f. #129212, #129115)
+    platforms = lib.platforms.unix;
+  };
+  tests = { inherit (nixosTests) waterfox; };
+  updateScript = ./update.sh;
+}).override
+  { crashreporterSupport = false; }

--- a/pkgs/by-name/wa/waterfox-unwrapped/remove-missing-icons.patch
+++ b/pkgs/by-name/wa/waterfox-unwrapped/remove-missing-icons.patch
@@ -1,0 +1,18 @@
+diff --git a/browser/installer/package-manifest.in b/browser/installer/package-manifest.in
+index 64d9993530c3..8f107b65c5be 100644
+--- a/browser/installer/package-manifest.in
++++ b/browser/installer/package-manifest.in
+@@ -222,13 +222,10 @@
+ @RESPATH@/chrome/toolkit.manifest
+ #ifdef MOZ_GTK
+ @RESPATH@/browser/chrome/icons/default/default16.png
+-@RESPATH@/browser/chrome/icons/default/default22.png
+-@RESPATH@/browser/chrome/icons/default/default24.png
+ @RESPATH@/browser/chrome/icons/default/default32.png
+ @RESPATH@/browser/chrome/icons/default/default48.png
+ @RESPATH@/browser/chrome/icons/default/default64.png
+ @RESPATH@/browser/chrome/icons/default/default128.png
+-@RESPATH@/browser/chrome/icons/default/default256.png
+ #endif
+ 
+ ; [DevTools Startup Files]

--- a/pkgs/by-name/wa/waterfox-unwrapped/update.sh
+++ b/pkgs/by-name/wa/waterfox-unwrapped/update.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p nix-update gnused
+
+set -euo pipefail
+
+pkgdir="pkgs/by-name/wa/waterfox-unwrapped"
+
+nix-update waterfox-unwrapped --src-only --override-filename "$pkgdir/package.nix"
+
+src="$(nix-build --no-out-link -A waterfox-unwrapped.src)"
+
+firefoxVersion=$(<"$src/browser/config/version.txt")
+sed -i -E "s|\bversion = \".*\";|version = \"$firefoxVersion\";|" "$pkgdir/package.nix"

--- a/pkgs/by-name/wa/waterfox/package.nix
+++ b/pkgs/by-name/wa/waterfox/package.nix
@@ -1,0 +1,3 @@
+{ waterfox-unwrapped, wrapFirefox }:
+
+wrapFirefox waterfox-unwrapped { }


### PR DESCRIPTION
## Things done

This PR introduce a new browser to `nixpkgs` called [Waterfox](https://www.waterfox.com/), a privacy focused browser based on Firefox. This has been attempted already in #388679 but this implementation is a lot simpler, as it uses the newer `buildMozillaMach` builder for building the package (this also means this is a from-source build, rather than using the precompiled code). The basic functionaly seems to be there tho this needs some tweaking to get everything to work as intended.

### Testing

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

## Nixpkgs-review

I'm going to put an up-to-date [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review) result here, until this PR is done.

### `x86_64-linux`
<details>
  <summary>:white_check_mark: 5 packages built:</summary>
  <ul>
    <li>nixpkgs-manual</li>
    <li>waterfox</li>
    <li>waterfox-unwrapped</li>
    <li>waterfox-unwrapped.debug</li>
    <li>waterfox-unwrapped.symbols</li>
  </ul>
</details>

## Todo
- [x] Fix official branding (right now it uses the default Firefox branding)
- [x] Fix audio
- [x] Add desktop entry and rename binary if necessary
- [x] Add potential tests for this package
- [x] Test build on Darwin (it would also be good to have a maintainer who can test and build the package on Darwin)
- [x] Have at least one maintainer with committer access as it is required as of recently (see [adding a package](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#quick-start-to-adding-a-package))

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
