### PR TITLE
jedit: use git sources instead of removed svn sources

### DIFF
--- a/pkgs/by-name/je/jedit/package.nix
+++ b/pkgs/by-name/je/jedit/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchsvn,
+  fetchgit,
   ant,
   jdk,
   jre,
@@ -14,14 +14,11 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "jedit";
   version = "5.7.0";
 
-  src =
-    let
-      versionWithDashes = lib.replaceStrings [ "." ] [ "-" ] finalAttrs.version;
-    in
-    fetchsvn {
-      url = "https://svn.code.sf.net/p/jedit/svn/jEdit/tags/jedit-${versionWithDashes}";
-      hash = "sha256-XfYK2C0QZrg4b//1eQcUNViRthBbXV+cbcYetzw2RG8=";
-    };
+  src = fetchgit {
+    url = "https://git.code.sf.net/p/jedit/jEdit";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Q2uarFMWXTWuJ0brw1PNS/vKWUa9gOTpD6Fumn0wMoI=";
+  };
 
   ivyDeps = stdenv.mkDerivation {
     name = "${finalAttrs.pname}-${finalAttrs.version}-ivy-deps";
@@ -107,7 +104,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    changelog = "${finalAttrs.src.url}/doc/CHANGES.txt";
+    changelog = "https://sourceforge.net/p/jedit/jEdit/ci/v${finalAttrs.version}/tree/doc/CHANGES.txt";
     description = "Programmer's text editor written in Java";
     homepage = "https://www.jedit.org";
     license = lib.licenses.gpl2Only;


### PR DESCRIPTION
Closes https://github.com/NixOS/nixpkgs/issues/475228

As the svn repo states, they have moved over to using git primarily
https://svn.code.sf.net/p/jedit/svn/jEdit/trunk/moved_to_git.txt

Comparing the cached svn source and the new git source, the only differences are:
- `$Id$` and `$Revision$` used in the javadoc comments are not expanded in the git sources
- `.gitignore` files are present in the git sources

There should be no behavioural changes to the app even if it the sources aren't exactly matching.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
