### PR TITLE
gridix: init at 2.0.1

### DIFF
--- a/pkgs/by-name/gr/gridix/package.nix
+++ b/pkgs/by-name/gr/gridix/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  gtk3,
+  xdotool,
+  openssl,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "gridix";
+  version = "2.0.1";
+
+  src = fetchFromGitHub {
+    owner = "MCB-SMART-BOY";
+    repo = "Gridix";
+    rev = "v${version}";
+    hash = "sha256-RVOD6PdneFjA/CXsWyRpbx7/oICKXYov5Dm0aimdCTY=";
+  };
+
+  cargoHash = "sha256-VFgLpZHHqcH2mwhoPlBtgNX/5SahLcBXQUWGWnN2Xhs=";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    gtk3
+    xdotool
+    openssl
+  ];
+
+  meta = {
+    description = "Fast, secure, cross-platform database management tool with Helix/Vim keybindings";
+    homepage = "https://github.com/MCB-SMART-BOY/Gridix";
+    license = lib.licenses.asl20;
+    maintainers = [ ];
+    mainProgram = "gridix";
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description

Add gridix, a fast, secure, cross-platform database management tool with Helix/Vim keybindings.

### Features
- Support for SQLite, MySQL, and PostgreSQL
- Helix/Vim-style keyboard navigation
- SSH tunnel support for remote databases
- Data import/export (CSV, JSON)
- SQL syntax highlighting

### Metadata
- Homepage: https://github.com/MCB-SMART-BOY/Gridix
- License: Apache-2.0

### Things done

- [x] Built on x86_64-linux
- [x] Tested locally with `nix-build -A gridix`
- [x] All 79 tests pass