### PR TITLE
python3Packages.wagtail-localize: add missing assets

### DIFF
--- a/pkgs/development/python-modules/wagtail-localize/default.nix
+++ b/pkgs/development/python-modules/wagtail-localize/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   buildPythonPackage,
+  buildNpmPackage,
 
   # build-system
   flit-core,
@@ -22,11 +23,10 @@
   freezegun,
   python,
 }:
-
-buildPythonPackage rec {
+let
   pname = "wagtail-localize";
+
   version = "1.13.1";
-  pyproject = true;
 
   src = fetchFromGitHub {
     repo = "wagtail-localize";
@@ -34,6 +34,33 @@ buildPythonPackage rec {
     tag = "v${version}";
     hash = "sha256-iJwX/N8/aaAjinU1htVasp88fuuZCOomVPgJ1Ymxre4=";
   };
+
+  assets = buildNpmPackage {
+    pname = "${pname}-assets";
+    npmDepsHash = "sha256-mLZaa3BBvbbgaSgZhsdUVPRXR6X5xy/sWRiOXnzV2cQ=";
+
+    NODE_OPTIONS = "--openssl-legacy-provider";
+
+    inherit version src;
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir $out
+
+      for static_dir in wagtail_localize/static; do
+        cp --parents -r $static_dir $out
+      done
+
+      runHook postInstall
+    '';
+  };
+in
+
+buildPythonPackage rec {
+  inherit pname version src;
+
+  pyproject = true;
 
   build-system = [ flit-core ];
 
@@ -55,6 +82,10 @@ buildPythonPackage rec {
     freezegun
     google-cloud-translate
   ];
+
+  preBuild = ''
+    cp -r ${assets}/wagtail_localize .
+  '';
 
   # See https://github.com/wagtail/wagtail-localize/issues/922
   patches = [ ./failing-test.patch ];


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/470142

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `6f80188d8934b3a41b6d7dcdf5dc1809a4db1f6c`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 4 packages built:</summary>
  <ul>
    <li>python312Packages.wagtail-localize</li>
    <li>python312Packages.wagtail-localize.dist</li>
    <li>python313Packages.wagtail-localize</li>
    <li>python313Packages.wagtail-localize.dist</li>
  </ul>
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
