### PR TITLE
nixos/redlib: Make into modular service

### DIFF
--- a/lib/options.nix
+++ b/lib/options.nix
@@ -313,9 +313,8 @@ rec {
       example ? null,
       extraDescription ? "",
       pkgsText ? "pkgs",
-    }:
+    }@attrs:
     let
-      name' = if isList name then last name else name;
       default' = toList default;
       defaultText = showAttrPath default';
       defaultValue = attrByPath default' (throw "${defaultText} cannot be found in ${pkgsText}") pkgs;
@@ -330,8 +329,22 @@ rec {
             default = null;
           };
     in
+    mkModularPackageOption name ({ extra = defaults; } // lib.removeAttrs attrs [ "default" ]);
+
+  mkModularPackageOption =
+    name:
+    {
+      nullable ? false,
+      example ? null,
+      extraDescription ? "",
+      pkgsText ? "pkgs",
+      extra ? { },
+    }:
+    let
+      name' = if isList name then last name else name;
+    in
     mkOption (
-      defaults
+      extra
       // {
         description =
           "The ${name'} package to use." + (if extraDescription == "" then "" else " ") + extraDescription;

--- a/nixos/modules/misc/documentation/modular-services.nix
+++ b/nixos/modules/misc/documentation/modular-services.nix
@@ -22,6 +22,7 @@ let
     options = {
       "<imports = [ pkgs.ghostunnel.services.default ]>" = fakeSubmodule pkgs.ghostunnel.services.default;
       "<imports = [ pkgs.php.services.default ]>" = fakeSubmodule pkgs.php.services.default;
+      "<imports = [ pkgs.redlib.services.default ]>" = fakeSubmodule pkgs.redlib.services.default;
     };
   };
 in

--- a/nixos/modules/services/misc/redlib.nix
+++ b/nixos/modules/services/misc/redlib.nix
@@ -7,25 +7,15 @@
 
 let
   inherit (lib)
-    concatStringsSep
-    isBool
-    mapAttrs
+    mkAliasOptionModule
     mkEnableOption
     mkIf
     mkOption
-    mkPackageOption
     mkRenamedOptionModule
     types
     ;
 
   cfg = config.services.redlib;
-
-  args = concatStringsSep " " [
-    "--port ${toString cfg.port}"
-    "--address ${cfg.address}"
-  ];
-
-  boolToString' = b: if b then "on" else "off";
 in
 {
   imports = [
@@ -39,121 +29,47 @@ in
         "redlib"
       ]
     )
-  ];
+  ]
+  ++
+    map
+      (
+        opt:
+        mkAliasOptionModule
+          [
+            "services"
+            "redlib"
+            opt
+          ]
+          [
+            "system"
+            "services"
+            "redlib"
+            "redlib"
+            opt
+          ]
+      )
+      [
+        "package"
+        "address"
+        "port"
+        "settings"
+      ];
 
   options = {
     services.redlib = {
       enable = mkEnableOption "Private front-end for Reddit";
-
-      package = mkPackageOption pkgs "redlib" { };
-
-      address = mkOption {
-        default = "0.0.0.0";
-        example = "127.0.0.1";
-        type = types.str;
-        description = "The address to listen on";
-      };
-
-      port = mkOption {
-        default = 8080;
-        example = 8000;
-        type = types.port;
-        description = "The port to listen on";
-      };
 
       openFirewall = mkOption {
         type = types.bool;
         default = false;
         description = "Open ports in the firewall for the redlib web interface";
       };
-
-      settings = lib.mkOption {
-        type = lib.types.submodule {
-          freeformType =
-            with types;
-            attrsOf (
-              nullOr (oneOf [
-                bool
-                int
-                str
-              ])
-            );
-          options = { };
-        };
-        default = { };
-        description = ''
-          See [GitHub](https://github.com/redlib-org/redlib/tree/main?tab=readme-ov-file#configuration) for available settings.
-        '';
-      };
     };
   };
 
   config = mkIf cfg.enable {
-    systemd.packages = [ cfg.package ];
-    systemd.services.redlib = {
-      wantedBy = [ "default.target" ];
-      environment = mapAttrs (_: v: if isBool v then boolToString' v else toString v) cfg.settings;
-      serviceConfig = {
-        # Hardening
-        LockPersonality = true;
-        MemoryDenyWriteExecute = true;
-        NoNewPrivileges = true;
-        PrivateDevices = true;
-        PrivateIPC = true;
-        PrivateTmp = true;
-        ProcSubset = "pid";
-        ProtectClock = true;
-        ProtectControlGroups = true;
-        ProtectHome = true;
-        ProtectHostname = true;
-        ProtectKernelLogs = true;
-        ProtectKernelModules = true;
-        ProtectKernelTunables = true;
-        ProtectProc = "invisible";
-        ProtectSystem = "full";
-        RemoveIPC = true;
-        RestrictAddressFamilies = [
-          "AF_INET"
-          "AF_INET6"
-        ];
-        RestrictNamespaces = true;
-        RestrictRealtime = true;
-        RestrictSUIDSGID = true;
-        SystemCallArchitectures = "native";
-        SystemCallFilter = [
-          "~@mount"
-          "~@swap"
-          "~@resources"
-          "~@reboot"
-          "~@raw-io"
-          "~@obsolete"
-          "~@module"
-          "~@debug"
-          "~@cpu-emulation"
-          "~@clock"
-          "~@privileged"
-        ];
-        UMask = "0027";
-
-        ExecStart = [
-          ""
-          "${lib.getExe cfg.package} ${args}"
-        ];
-      }
-      // (
-        if (cfg.port < 1024) then
-          {
-            AmbientCapabilities = [ "CAP_NET_BIND_SERVICE" ];
-            CapabilityBoundingSet = [ "CAP_NET_BIND_SERVICE" ];
-          }
-        else
-          {
-            # A private user cannot have process capabilities on the host's user
-            # namespace and thus CAP_NET_BIND_SERVICE has no effect.
-            PrivateUsers = true;
-            CapabilityBoundingSet = false;
-          }
-      );
+    system.services.redlib = {
+      imports = [ pkgs.redlib.services.default ];
     };
 
     networking.firewall = mkIf cfg.openFirewall {

--- a/pkgs/by-name/re/redlib/package.nix
+++ b/pkgs/by-name/re/redlib/package.nix
@@ -7,7 +7,7 @@
   nix-update-script,
 }:
 
-rustPlatform.buildRustPackage {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "redlib";
   version = "0.36.0-unstable-2025-12-16";
 
@@ -65,6 +65,10 @@ rustPlatform.buildRustPackage {
   };
 
   passthru = {
+    services.default = {
+      imports = [ ./service.nix ];
+      redlib.package = lib.mkDefault finalAttrs.finalPackage;
+    };
     tests = nixosTests.redlib;
     updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
   };
@@ -79,4 +83,4 @@ rustPlatform.buildRustPackage {
       Guanran928
     ];
   };
-}
+})

--- a/pkgs/by-name/re/redlib/service.nix
+++ b/pkgs/by-name/re/redlib/service.nix
@@ -1,0 +1,140 @@
+{
+  config,
+  options,
+  lib,
+  ...
+}:
+
+let
+  inherit (lib)
+    isBool
+    mapAttrs
+    mkOption
+    types
+    ;
+
+  cfg = config.redlib;
+
+  boolToString' = b: if b then "on" else "off";
+in
+{
+  _class = "service";
+
+  options = {
+    redlib = {
+      package = lib.options.mkModularPackageOption "redlib" { };
+
+      address = mkOption {
+        default = "0.0.0.0";
+        example = "127.0.0.1";
+        type = types.str;
+        description = "The address to listen on";
+      };
+
+      port = mkOption {
+        default = 8080;
+        example = 8000;
+        type = types.port;
+        description = "The port to listen on";
+      };
+
+      settings = lib.mkOption {
+        type = lib.types.submodule {
+          freeformType =
+            with types;
+            attrsOf (
+              nullOr (oneOf [
+                bool
+                int
+                str
+              ])
+            );
+          options = { };
+        };
+        default = { };
+        description = ''
+          See [GitHub](https://github.com/redlib-org/redlib/tree/main?tab=readme-ov-file#configuration) for available settings.
+        '';
+      };
+    };
+  };
+
+  config = {
+    process.argv = [
+      (lib.getExe cfg.package)
+      "--port"
+      (toString cfg.port)
+      "--address"
+      cfg.address
+    ];
+  }
+  // lib.optionalAttrs (options ? systemd) {
+    #systemd.packages = [ cfg.package ];
+    systemd.service = {
+      wantedBy = [ "default.target" ];
+      environment = mapAttrs (_: v: if isBool v then boolToString' v else toString v) cfg.settings;
+      serviceConfig = {
+        # Reset the ExecStart from the portable service interface
+        ExecStart = lib.mkBefore [ "" ];
+        # Hardening
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        PrivateIPC = true;
+        PrivateTmp = true;
+        ProcSubset = "pid";
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        ProtectSystem = "full";
+        RemoveIPC = true;
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+        ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "~@mount"
+          "~@swap"
+          "~@resources"
+          "~@reboot"
+          "~@raw-io"
+          "~@obsolete"
+          "~@module"
+          "~@debug"
+          "~@cpu-emulation"
+          "~@clock"
+          "~@privileged"
+        ];
+        UMask = "0027";
+      }
+      // (
+        if (cfg.port < 1024) then
+          {
+            AmbientCapabilities = [ "CAP_NET_BIND_SERVICE" ];
+            CapabilityBoundingSet = [ "CAP_NET_BIND_SERVICE" ];
+          }
+        else
+          {
+            # A private user cannot have process capabilities on the host's user
+            # namespace and thus CAP_NET_BIND_SERVICE has no effect.
+            PrivateUsers = true;
+            CapabilityBoundingSet = false;
+          }
+      );
+    };
+  };
+
+  meta = {
+    maintainers = with lib.maintainers; [ Guanran928 ];
+  };
+}


### PR DESCRIPTION
Trying to understand what is needed to backwards-compatibly retrofit and existing NixOS module.

(I don't know anything about `redlib` in particular, I picked it basically at random.)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
