### PR TITLE
phpPackages.composer-local-repo-plugin: fix vendor hash

### DIFF
--- a/pkgs/development/php-packages/composer-local-repo-plugin/default.nix
+++ b/pkgs/development/php-packages/composer-local-repo-plugin/default.nix
@@ -19,7 +19,7 @@ php.buildComposerWithPlugin {
   };
 
   composerLock = ./composer.lock;
-  vendorHash = "sha256-SL3HiYTVaUwcEfnRO932MWgOP1VRkxTl3lxLbW0qiTY=";
+  vendorHash = "sha256-cup8maS9NkhdqTHoKJaH7r7AJQdkflWTvM6uIuxMPX0=";
 
   meta = {
     changelog = "https://github.com/nix-community/composer-local-repo-plugin/releases/tag/${version}";


### PR DESCRIPTION
# Things done

Fixes hash mismatch for `phpPackages.composer-local-repo-plugin.vendor` mentioned in #473846

Build logs: 
- [before](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/phpPackages_composer-local-repo-plugin/vendor.before.log) 
- [after](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/phpPackages_composer-local-repo-plugin/vendor.after.log)

I'm not really sure why this changed. I don't think the underlying source changed....

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc