### PR TITLE
nixos/test/nominatim: replace activation script by ExecStartPre

### DIFF
--- a/nixos/tests/nominatim.nix
+++ b/nixos/tests/nominatim.nix
@@ -59,14 +59,34 @@ in
       { config, pkgs, ... }:
       {
         # Database password
-        system.activationScripts = {
-          passwordFile.text = with config.services.nominatim.database; ''
-            mkdir -p /run/secrets
-            echo "${host}:${toString port}:${dbname}:${apiUser}:password" \
-              > /run/secrets/pgpass
-            chown nominatim-api:nominatim-api /run/secrets/pgpass
-            chmod 0600 /run/secrets/pgpass
-          '';
+        systemd.services.nominatim = {
+          serviceConfig.ExecStartPre =
+            let
+              createPasswordFile = lib.getExe (
+                pkgs.writeShellApplication {
+                  name = "nominatim-pre-start";
+                  text =
+                    let
+                      inherit (config.services.nominatim.database)
+                        host
+                        port
+                        dbname
+                        apiUser
+                        ;
+                    in
+                    ''
+                      mkdir -p /run/secrets
+                      echo "${host}:${toString port}:${dbname}:${apiUser}:password" \
+                        > /run/secrets/pgpass
+                      chown nominatim-api:nominatim-api /run/secrets/pgpass
+                      chmod 0600 /run/secrets/pgpass
+                    '';
+                }
+              );
+            in
+            [
+              "+${createPasswordFile}"
+            ];
         };
 
         # Nominatim


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
See https://github.com/NixOS/nixpkgs/issues/475305

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
