### PR TITLE
azure-artifacts-credprovider: add multi-platform support

### DIFF
--- a/pkgs/by-name/az/azure-artifacts-credprovider/package.nix
+++ b/pkgs/by-name/az/azure-artifacts-credprovider/package.nix
@@ -29,6 +29,6 @@ buildDotnetModule rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ anpin ];
     mainProgram = "CredentialProvider.Microsoft";
-    platforms = [ "x86_64-linux" ];
+    platforms = lib.platforms.unix;
   };
 }


### PR DESCRIPTION
## Summary
Extend platform support from `x86_64-linux` only to all Unix platforms (`lib.platforms.unix`), enabling use on aarch64-linux, x86_64-darwin, and aarch64-darwin.

## Motivation
macOS users currently cannot use this package from nixpkgs. The underlying .NET code is platform-agnostic and `buildDotnetModule` handles cross-platform builds correctly.

## Things done
- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

## Testing Details
On aarch64-darwin:
- Build completed successfully
- Binary runs and responds to credential provider protocol requests
- Verified with: `./result/bin/CredentialProvider.Microsoft -h`

@anpin I guess I should make you aware of this change.