### PR TITLE
python3Packages.ansible-compat: fix src hash

### DIFF
--- a/pkgs/development/python-modules/ansible-compat/default.nix
+++ b/pkgs/development/python-modules/ansible-compat/default.nix
@@ -30,7 +30,11 @@ buildPythonPackage rec {
     owner = "ansible";
     repo = "ansible-compat";
     tag = "v${version}";
-    hash = "sha256-nn0NKX6rqNKrSZd+p/oq/LmESAgvTkSOA08wq1xLY2I=";
+    # this resulted in a mismatched hash, so remove it
+    postFetch = ''
+      rm -f $out/.git_archival.txt
+    '';
+    hash = "sha256-qknFdICK+gtFmlRPL7AzIwGDOpMxmX6DzMsIsPC6JY8=";
   };
 
   build-system = [


### PR DESCRIPTION
Fixes hash mismatch for `python3Packages.ansible-compat.src`.

Build logs:
- [before (0145e9c)](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/python3Packages_ansible-compat/src.before.log)
- [after (54d3e27)](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/python3Packages_ansible-compat/src.after.log)
- [source diff](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/python3Packages_ansible-compat/src.diff.log)

Source directories:
- [old source](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/python3Packages_ansible-compat/src.src.before/)
- [new source](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/python3Packages_ansible-compat/src.src.after/)

Partially addresses https://github.com/NixOS/nixpkgs/issues/471498

Partially supercedes https://github.com/NixOS/nixpkgs/pull/471221


Given that the directory diff only has

```
 .git_archival.txt --- Text
1 node: 601b6905c7c7819efb1f2c820a853827b835ec4f 1 node: 601b6905c7c7819efb1f2c820a853827b835ec4f
2 node-date: 2025-12-02T07:14:27-08:00           2 node-date: 2025-12-02T07:14:27-08:00
3 describe-name: v25.12.0                        3 describe-name: v25.12.0
4 ref-names: HEAD -> main, tag: v25.12.0         4 ref-names: tag: v25.12.0
```

in it, I think we should probably ignore this? maybe? I'm not sure how to do this.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
