### PR TITLE
python3Packages.awslambdaric: fix src hash

### DIFF
--- a/pkgs/development/python-modules/awslambdaric/default.nix
+++ b/pkgs/development/python-modules/awslambdaric/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
     owner = "aws";
     repo = "aws-lambda-python-runtime-interface-client";
     tag = version;
-    sha256 = "sha256-pUVWd4zpmTygndPIy76uVk7+sLCmwQqulLaUI7B0fQc=";
+    sha256 = "sha256-gwbEDo/LewCb0wTtkw/bF3XSAiSu1ITYHAnuvpNsfs0=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
Fixes hash mismatch for `python3Packages.awslambdaric.src`.

Build logs:
- [before (bb90a6f)](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/python3Packages_awslambdaric/src.before.log)
- [after (7edf252)](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/python3Packages_awslambdaric/src.after.log)
- [source diff](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/python3Packages_awslambdaric/src.diff.log)

Source directories:
- [old source](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/python3Packages_awslambdaric/src.src.before/)
- [new source](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/python3Packages_awslambdaric/src.src.after/)

<details>
<summary>Source diff (last 100 lines)</summary>

```
 ...  635                 import invalid_module  # noqa: F401
 ...  636             except ImportError:
 ...  637                 raise bootstrap.FaultException("FaultExceptionType", None, None)
 ...  638 
 ...  639         logging_handler = logging.StreamHandler(mock_stdout)
 ...  640         logging_handler.setFormatter(JsonFormatter())
 ...  641         logging.getLogger().addHandler(logging_handler)
 ...  642 
 ...  643         bootstrap.handle_event_request(
 ...  644             self.lambda_runtime,
 ...  645             raise_exception_handler,
 ...  646             "invoke_id",
 ...  647             self.event_body,
 ...  648             "application/json",
 ...  649             {},
 ...  650             {},
 ...  651             "invoked_function_arn",
 ...  652             0,
 ...  653             "tenant_id",
 ...  654             bootstrap.StandardLogSink(),
 ...  655         )
 ...  656 
 ...  657         stdout_value = mock_stdout.getvalue()
 ...  658 
 ...  659         # this line is not in json because of the way the test runtime is bootstrapped
 ...  660         error_logs = "[ERROR] FaultExceptionType\rTraceback (most recent call last):\n"
 ...  661 
 ...  662         self.assertEqual(stdout_value, error_logs)
 606  663 
 607  664 
 608  665 class TestXrayFault(unittest.TestCase):

tests/test_bootstrap.py --- 23/27 --- Python
 800  857             cognito_identity_json=None,
 801  858             invoked_function_arn="invocation-arn",
 802  859             epoch_deadline_time_in_ms=1415836801003,
 ...  860             tenant_id=None,
 803  861             log_sink=bootstrap.StandardLogSink(),
 804  862         )
 805  863 

tests/test_bootstrap.py --- 24/27 --- Python
 819  877             cognito_identity_json=None,
 820  878             invoked_function_arn="invocation-arn",
 821  879             epoch_deadline_time_in_ms=1415836801003,
 ...  880             tenant_id=None,
 822  881             log_sink=bootstrap.StandardLogSink(),
 823  882         )
 824  883 

tests/test_bootstrap.py --- 25/27 --- Python
 838  897             cognito_identity_json=None,
 839  898             invoked_function_arn="invocation-arn",
 840  899             epoch_deadline_time_in_ms=1415836801003,
 ...  900             tenant_id=None,
 841  901             log_sink=bootstrap.StandardLogSink(),
 842  902         )
 843  903 

tests/test_bootstrap.py --- 26/27 --- Python
 856  916             cognito_identity_json=None,
 857  917             invoked_function_arn="invocation-arn",
 858  918             epoch_deadline_time_in_ms=1415836801003,
 ...  919             tenant_id=None,
 859  920             log_sink=bootstrap.StandardLogSink(),
 860  921         )
 861  922 

tests/test_bootstrap.py --- 27/27 --- Python
1289 1350                     )
1290 1351         self.assertEqual(mock_stderr.getvalue(), "")
.... 1352 
.... 1353     @patch("awslambdaric.bootstrap._GLOBAL_TENANT_ID", "test-tenant-id")
.... 1354     @patch("sys.stderr", new_callable=StringIO)
.... 1355     def test_json_formatter_with_tenant_id(self, mock_stderr):
.... 1356         logger = logging.getLogger("a.b")
.... 1357         level = logging.INFO
.... 1358         message = "Test json formatting with tenant id"
.... 1359         expected = {
.... 1360             "level": "INFO",
.... 1361             "logger": "a.b",
.... 1362             "message": message,
.... 1363             "requestId": "",
.... 1364             "tenantId": "test-tenant-id",
.... 1365         }
.... 1366 
.... 1367         with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
.... 1368             logger.log(level, message)
.... 1369 
.... 1370             data = json.loads(mock_stdout.getvalue())
.... 1371             data.pop("timestamp")
.... 1372             self.assertEqual(
.... 1373                 data,
.... 1374                 expected,
.... 1375             )
.... 1376         self.assertEqual(mock_stderr.getvalue(), "")
1291 1377 
1292 1378     @patch("sys.stdout", new_callable=StringIO)
1293 1379     @patch("sys.stderr", new_callable=StringIO)

```
</details>

<details>
<summary>Build before</summary>

```
checking outputs of '/nix/store/zrccr01n63rq6chdyskgrdidvlf13sx3-source.drv'...
structuredAttrs is enabled

trying https://github.com/aws/aws-lambda-python-runtime-interface-client/archive/refs/tags/3.1.1.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0   0     0   0     0     0     0  --:--:-- --:--:-- --:--:--     0
100  9577k 100  9577k   0     0  8894k     0   0:00:01  0:00:01 --:--:-- 30398k
unpacking source archive /build/download.tar.gz
error: hash mismatch in fixed-output derivation '/nix/store/zrccr01n63rq6chdyskgrdidvlf13sx3-source.drv':
         specified: sha256-pUVWd4zpmTygndPIy76uVk7+sLCmwQqulLaUI7B0fQc=
            got:    sha256-gwbEDo/LewCb0wTtkw/bF3XSAiSu1ITYHAnuvpNsfs0=
```
</details>

<details>
<summary>Build after</summary>

```
checking outputs of '/nix/store/xdjc30d40w0x6s2ha3aqy2kvc4fa20q8-source.drv'...
structuredAttrs is enabled

trying https://github.com/aws/aws-lambda-python-runtime-interface-client/archive/refs/tags/3.1.1.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0   0     0   0     0     0     0  --:--:-- --:--:-- --:--:--     0
100  9577k 100  9577k   0     0 17635k     0  --:--:-- --:--:-- --:--:-- 17635k
unpacking source archive /build/download.tar.gz
/nix/store/27f5k4yinm675zqdyxwh46kvwigpdxak-source
```
</details>

There's a surprisingly large amount of changes, but they're mostly in tests and I don't see anything outright malicious. I think it's more likely the tag changed due to a force push for some reason.

Partially addresses #471498

Partially supercedes #471221 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
