### PR TITLE
python3Packages.bayespy: fix src hash

### DIFF
--- a/pkgs/development/python-modules/bayespy/default.nix
+++ b/pkgs/development/python-modules/bayespy/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     owner = "bayespy";
     repo = "bayespy";
     tag = version;
-    hash = "sha256-X7CwJBrKHlU1jqMkt/7XEzaiwul1Yzkb/V64lXG4Aqo=";
+    hash = "sha256-kx87XY4GCL1PQIeZyovEbrPyCC/EVA6Hdvt+3P/D6VI=";
   };
 
   postPatch = ''


### PR DESCRIPTION
Fixes hash mismatch for `python3Packages.bayespy.src`.

Build logs:
- [before (5d65a61)](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/python3Packages_bayespy/src.before.log)
- [after (5d65a61)](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/python3Packages_bayespy/src.after.log)
- [source diff](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/python3Packages_bayespy/src.diff.log)

Source directories:
- [old source](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/python3Packages_bayespy/src.src.before/)
- [new source](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/python3Packages_bayespy/src.src.after/)

<details>
<summary>Source diff</summary>

```
bayespy/_version.py --- Python
23     # setup.py/versioneer.py will grep for the variable names, so they must 23     # setup.py/versioneer.py will grep for the variable names, so they must
24     # each be defined on a line of their own. _version.py will just call    24     # each be defined on a line of their own. _version.py will just call
25     # get_keywords().                                                       25     # get_keywords().
26     git_refnames = " (HEAD -> develop, tag: 0.6.1)"                         26     git_refnames = " (tag: 0.6.1)"
27     git_full = "95fdd91a22e6eb4c35aa9ccb53d7d656f65374f7"                   27     git_full = "95fdd91a22e6eb4c35aa9ccb53d7d656f65374f7"
28     keywords = {"refnames": git_refnames, "full": git_full}                 28     keywords = {"refnames": git_refnames, "full": git_full}
29     return keywords                                                         29     return keywords

```
</details>

<details>
<summary>Build before</summary>

```
checking outputs of '/nix/store/pbggx11v4n1kf1r1n84784iyq0sfm3sm-source.drv'...
structuredAttrs is enabled

trying https://github.com/bayespy/bayespy/archive/refs/tags/0.6.1.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0   0     0   0     0     0     0  --:--:-- --:--:-- --:--:--     0
100 495904   0 495904   0     0 816786     0  --:--:-- --:--:-- --:--:--  1192k
unpacking source archive /build/download.tar.gz
error: hash mismatch in fixed-output derivation '/nix/store/pbggx11v4n1kf1r1n84784iyq0sfm3sm-source.drv':
         specified: sha256-X7CwJBrKHlU1jqMkt/7XEzaiwul1Yzkb/V64lXG4Aqo=
            got:    sha256-kx87XY4GCL1PQIeZyovEbrPyCC/EVA6Hdvt+3P/D6VI=
```
</details>

<details>
<summary>Build after</summary>

```
checking outputs of '/nix/store/prj65filw6q0fnyxfv4icc92bcdlq700-source.drv'...
structuredAttrs is enabled

trying https://github.com/bayespy/bayespy/archive/refs/tags/0.6.1.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0   0     0   0     0     0     0  --:--:-- --:--:-- --:--:--     0
100 495904 100 495904   0     0  1187k     0  --:--:-- --:--:-- --:--:--  2295k
unpacking source archive /build/download.tar.gz
/nix/store/76fayk0sb5rzaxfq6jf5dvmcif1jqrpr-source
```
</details>

I'm not sure if it's a good idea to in the postFetch to rm `$out/_version.py`. Not sure if that hurts anything at runtime... 

Diff is small so this is a safe merge.

Partially addresses #471498

Partially supercedes #471221


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
