### PR TITLE
python3Packages.blis: fix src hash

### DIFF
--- a/pkgs/development/python-modules/blis/default.nix
+++ b/pkgs/development/python-modules/blis/default.nix
@@ -28,7 +28,7 @@ buildPythonPackage rec {
     owner = "explosion";
     repo = "cython-blis";
     tag = "release-v${version}";
-    hash = "sha256-mSIfFjnLhPLqSNLHMS5gTeAmqmNfXpcbyH7ejv4YgQU=";
+    hash = "sha256-TEvdhxQqCFRpckq3WUHCF0+OtQhexO3GlWLPd+TkaaA=";
   };
 
   build-system = [


### PR DESCRIPTION
Fixes hash mismatch for `python3Packages.blis.src`.

Build logs:
- [before (4506266)](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/python3Packages_blis/src.before.log)
- [after (d2fc772)](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/python3Packages_blis/src.after.log)
- [source diff](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/python3Packages_blis/src.diff.log)

Source directories:
- [old source](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/python3Packages_blis/src.src.before/)
- [new source](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/python3Packages_blis/src.src.after/)

<details>
<summary>Source diff (first 100 lines)</summary>

```
.github/workflows/cibuildwheel.yml --- 1/2 --- YAML
14     strategy:                                                                     14     strategy:
15       matrix:                                                                     15       matrix:
16         # macos-13 is an intel runner, macos-14 is apple silicon                  16         # macos-13 is an intel runner, macos-14 is apple silicon
17         os: [ubuntu-latest, windows-2022, macos-13, macos-14, ubuntu-24.04-arm]   17         os: [ubuntu-latest, macos-13, macos-14, ubuntu-24.04-arm, windows-latest]
18                                                                                   18 
19     steps:                                                                        19     steps:
20       # See https://cibuildwheel.pypa.io/en/1.x/cpp_standards/                    20       # See https://cibuildwheel.pypa.io/en/1.x/cpp_standards/
21       - uses: ilammy/msvc-dev-cmd@v1                                              21       - uses: ilammy/msvc-dev-cmd@v1
22       - uses: actions/checkout@v4                                                 22       - uses: actions/checkout@v4
..                                                                                   23       
..                                                                                   24       # Install LLVM 18 on Windows
..                                                                                   25       - name: Install LLVM 18 on Windows
..                                                                                   26         if: runner.os == 'Windows'
..                                                                                   27         run: |
..                                                                                   28           choco install llvm --version=18.1.8 -y --force
..                                                                                   29           echo "C:\Program Files\LLVM\bin" >> $env:GITHUB_PATH
23       # This is crazy slow. We'll need to wait for arm Linux                      30       # This is crazy slow. We'll need to wait for arm Linux
24       # runners.                                                                  31       # runners.
25       # aarch64 (arm) is built via qemu emulation on Linux                        32       # aarch64 (arm) is built via qemu emulation on Linux

.github/workflows/cibuildwheel.yml --- 2/2 --- YAML
31       - name: Debug env                                                           38       - name: Debug env
32         run: env                                                                  39         run: env
33       - name: Build wheels                                                        40       - name: Build wheels
34         uses: pypa/cibuildwheel@v2.21.3                                           41         uses: pypa/cibuildwheel@v3.2.1
35         env:                                                                      42         env:
36           CIBW_ARCHS_LINUX: auto                                                  43           CIBW_ARCHS_LINUX: auto
37           DISTUTILS_USE_SDK: 1                                                    44           DISTUTILS_USE_SDK: 1

.github/workflows/tests.yml --- 1/2 --- YAML
22     strategy:                                                  22     strategy:
23       fail-fast: true                                          23       fail-fast: true
24       matrix:                                                  24       matrix:
25         os: [ubuntu-latest, windows-2019]                      25         os: [ubuntu-latest, windows-2022]
26         python_version: ["3.9", "3.10", "3.11", "3.12"]        26         python_version: ["3.9", "3.10", "3.11", "3.12"]
27     runs-on: ${{ matrix.os }}                                  27     runs-on: ${{ matrix.os }}
28                                                                28 

.github/workflows/tests.yml --- 2/2 --- YAML
36           python-version: ${{ matrix.python_version }}         36           python-version: ${{ matrix.python_version }}
37           architecture: x64                                    37           architecture: x64
38                                                                38 
..                                                                39       # Install LLVM 18 on Windows
39       - name: Preinstall (Windows)                             40       - name: Install LLVM 18 on Windows
40         shell: bash                                            .. 
41         if: startsWith(matrix.os, 'windows')                   41         if: runner.os == 'Windows'
42         run: |                                                 42         run: |
43           choco install llvm                                   43           choco install llvm --version=18.1.8 -y --force
44                                                                44           echo "C:\Program Files\LLVM\bin" >> $env:GITHUB_PATH
..                                                                45  
45       - name: Install dependencies                             46       - name: Install dependencies
46         run: |                                                 47         run: |

blis/_src/include/linux-power9/blis.h --- Text (1.2 MiB exceeded DFT_BYTE_LIMIT)
    1 
    2 
    3 #ifndef BLIS_H
    4 #define BLIS_H
    5 
    6 
    7 // Allow C++ users to include this header file in their source code. However,
    8 // we make the extern "C" conditional on whether we're using a C++ compiler,
    9 // since regular C compilers don't understand the extern "C" construct.
   10 #ifdef __cplusplus
   11 extern "C" {
   12 #endif
   13 
   14 // NOTE: PLEASE DON'T CHANGE THE ORDER IN WHICH HEADERS ARE INCLUDED UNLESS
   15 // YOU ARE SURE THAT IT DOESN'T BREAK INTER-HEADER MACRO DEPENDENCIES.
   16 
   17 // -- System headers --
   18 // NOTE: This header must be included before bli_config_macro_defs.h.
   19 
   20 // begin bli_system.h
   21 
   22 
   23 #ifndef BLIS_SYSTEM_H
   24 #define BLIS_SYSTEM_H
   25 
   26 // NOTE: If not yet defined, we define _POSIX_C_SOURCE to make sure that
   27 // various parts of POSIX are defined and made available.
   28 #ifndef _POSIX_C_SOURCE
   29 #define _POSIX_C_SOURCE 200809L
   30 #endif
   31 
   32 #include <stdio.h> // skipped
   33 #include <stdlib.h> // skipped
   34 #include <math.h> // skipped
   35 #include <string.h> // skipped
   36 #include <stdarg.h> // skipped
   37 #include <float.h> // skipped
   38 #include <errno.h> // skipped
   39 #include <ctype.h> // skipped
   40 
   41 // Determine the compiler (hopefully) and define conveniently named macros
   42 // accordingly.
   43 #if   defined(__ICC) || defined(__INTEL_COMPILER)
   44   #define BLIS_ICC
   45 #elif defined(__clang__)
```
</details>

<details>
<summary>Build before</summary>

```
checking outputs of '/nix/store/z938zx1ipxh4lvfvqp4g7h71pfalvc2k-source.drv'...
structuredAttrs is enabled

trying https://github.com/explosion/cython-blis/archive/refs/tags/release-v1.3.0.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0   0     0   0     0     0     0  --:--:-- --:--:-- --:--:--     0
100  2890k   0  2890k   0     0  2750k     0  --:--:--  0:00:01 --:--:--  2750k
unpacking source archive /build/download.tar.gz
error: hash mismatch in fixed-output derivation '/nix/store/z938zx1ipxh4lvfvqp4g7h71pfalvc2k-source.drv':
         specified: sha256-mSIfFjnLhPLqSNLHMS5gTeAmqmNfXpcbyH7ejv4YgQU=
            got:    sha256-TEvdhxQqCFRpckq3WUHCF0+OtQhexO3GlWLPd+TkaaA=
```
</details>

<details>
<summary>Build after</summary>

```
this derivation will be built:
  /nix/store/nzxibjvnzg8fmnn4naif8h37qnv0s20d-source.drv
building '/nix/store/nzxibjvnzg8fmnn4naif8h37qnv0s20d-source.drv'...
structuredAttrs is enabled

trying https://github.com/explosion/cython-blis/archive/refs/tags/release-v1.3.0.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0   0     0   0     0     0     0  --:--:-- --:--:-- --:--:--     0
100  2890k   0  2890k   0     0  1176k     0  --:--:--  0:00:02 --:--:--  1373k
unpacking source archive /build/download.tar.gz
/nix/store/n688c2fn1pv4wkndg9zzi6xccfwag1ap-source
```
</details>

I'm not sure why the src changed, but beyond that it looks okay. Mostly CI changes.

Partially addresses #471498

Partially supercedes #471221

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
