### PR TITLE
python3Packages.coveralls: fix src hash

### DIFF
--- a/pkgs/development/python-modules/coveralls/default.nix
+++ b/pkgs/development/python-modules/coveralls/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
     owner = "TheKevJames";
     repo = "coveralls-python";
     tag = version;
-    hash = "sha256-c7YV1SAbxmqfVI/wGtfdr+S4T7G2q7tf0FhuyCJaPDg=";
+    hash = "sha256-sr3pR3t21nMZczwugFNAioSry/RxIWAzGdGG070YXGw=";
   };
 
   build-system = [ poetry-core ];


### PR DESCRIPTION
Fixes hash mismatch for `python3Packages.coveralls.src`.

Build logs:
- [before (4506266)](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/python3Packages_coveralls/src.before.log)
- [after (3a7f84d)](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/python3Packages_coveralls/src.after.log)
- [source diff](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/python3Packages_coveralls/src.diff.log)

Source directories:
- [old source](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/python3Packages_coveralls/src.src.before/)
- [new source](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/python3Packages_coveralls/src.src.after/)

<details>
<summary>Source diff (first 100 lines)</summary>

```
poetry.lock --- 1/31 --- TOML
  1 # This file is automatically @generated by Poetry 1.8.2 and should not be changed by hand.                       1 # This file is automatically @generated by Poetry 2.1.4 and should not be changed by hand.
  2                                                                                                                  2 
  3 [[package]]                                                                                                      3 [[package]]
  4 name = "alabaster"                                                                                               4 name = "alabaster"
  5 version = "0.7.16"                                                                                               5 version = "0.7.16"
  6 description = "A light, configurable Sphinx theme"                                                               6 description = "A light, configurable Sphinx theme"
  7 optional = false                                                                                                 7 optional = false
  8 python-versions = ">=3.9"                                                                                        8 python-versions = ">=3.9"
  .                                                                                                                  9 groups = ["docs"]
  9 files = [                                                                                                       10 files = [
 10     {file = "alabaster-0.7.16-py3-none-any.whl", hash = "sha256:b46733c07dce03ae4e150330b975c75737fa60f0a7c591  11     {file = "alabaster-0.7.16-py3-none-any.whl", hash = "sha256:b46733c07dce03ae4e150330b975c75737fa60f0a7c591
 .. b6c8bf4928a28e2c92"},                                                                                           .. b6c8bf4928a28e2c92"},
 11     {file = "alabaster-0.7.16.tar.gz", hash = "sha256:75a8b99c28a5dad50dd7f8ccdd447a121ddb3892da9e53d1ca5cca31  12     {file = "alabaster-0.7.16.tar.gz", hash = "sha256:75a8b99c28a5dad50dd7f8ccdd447a121ddb3892da9e53d1ca5cca31
 .. 06d58d65"},                                                                                                     .. 06d58d65"},

poetry.lock --- 2/31 --- TOML
 17 description = "Internationalization utilities"                                                                  18 description = "Internationalization utilities"
 18 optional = false                                                                                                19 optional = false
 19 python-versions = ">=3.8"                                                                                       20 python-versions = ">=3.8"
 ..                                                                                                                 21 groups = ["docs"]
 20 files = [                                                                                                       22 files = [
 21     {file = "babel-2.17.0-py3-none-any.whl", hash = "sha256:4d0b53093fdfb4b21c92b5213dba5a1b23885afa8383709427  23     {file = "babel-2.17.0-py3-none-any.whl", hash = "sha256:4d0b53093fdfb4b21c92b5213dba5a1b23885afa8383709427
 .. 046b21c366e5f2"},                                                                                               .. 046b21c366e5f2"},
 22     {file = "babel-2.17.0.tar.gz", hash = "sha256:0c54cffb19f690cdcc52a3b50bcbf71e07a808d1c80d549f2459b9d2cf0a  24     {file = "babel-2.17.0.tar.gz", hash = "sha256:0c54cffb19f690cdcc52a3b50bcbf71e07a808d1c80d549f2459b9d2cf0a
 .. fb9d"},                                                                                                         .. fb9d"},
 23 ]                                                                                                               25 ]
 24                                                                                                                 26 
 25 [package.extras]                                                                                                27 [package.extras]
 26 dev = ["backports.zoneinfo", "freezegun (>=1.0,<2.0)", "jinja2 (>=3.0)", "pytest (>=6.0)", "pytest-cov", "pytz  28 dev = ["backports.zoneinfo ; python_version < \"3.9\"", "freezegun (>=1.0,<2.0)", "jinja2 (>=3.0)", "pytest (>
 .. ", "setuptools", "tzdata"]                                                                                      .. =6.0)", "pytest-cov", "pytz", "setuptools", "tzdata ; sys_platform == \"win32\""]
 27                                                                                                                 29 
 28 [[package]]                                                                                                     30 [[package]]
 29 name = "certifi"                                                                                                31 name = "certifi"
 30 version = "2025.10.5"                                                                                           32 version = "2025.10.5"
 31 description = "Python package for providing Mozilla's CA Bundle."                                               33 description = "Python package for providing Mozilla's CA Bundle."
 32 optional = false                                                                                                34 optional = false
 33 python-versions = ">=3.7"                                                                                       35 python-versions = ">=3.7"
 ..                                                                                                                 36 groups = ["main", "dev", "docs"]
 34 files = [                                                                                                       37 files = [
 35     {file = "certifi-2025.10.5-py3-none-any.whl", hash = "sha256:0f212c2744a9bb6de0c56639a6f68afe01ecd92d91f14  38     {file = "certifi-2025.10.5-py3-none-any.whl", hash = "sha256:0f212c2744a9bb6de0c56639a6f68afe01ecd92d91f14
 .. ae897c4fe7bbeeef0de"},                                                                                          .. ae897c4fe7bbeeef0de"},
 36     {file = "certifi-2025.10.5.tar.gz", hash = "sha256:47c09d31ccf2acf0be3f701ea53595ee7e0b8fa08801c6624be771d  39     {file = "certifi-2025.10.5.tar.gz", hash = "sha256:47c09d31ccf2acf0be3f701ea53595ee7e0b8fa08801c6624be771d
 .. f09ae7b43"},                                                                                                    .. f09ae7b43"},

poetry.lock --- 3/31 --- TOML
 42  45 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 43  46 optional = false
 44  47 python-versions = ">=3.7"
 ..  48 groups = ["main", "dev", "docs"]
 45  49 files = [
 46  50     {file = "charset_normalizer-3.4.4-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:e824f1492727fa856dd6eda4f7cee25f8518a12f3c4a56a74e8095695089cf6d"},
 47  51     {file = "charset_normalizer-3.4.4-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4bd5d4137d500351a30687c2d3971758aac9a19208fc110ccb9d7188fbe709e8"},

poetry.lock --- 4/31 --- TOML
164 168 description = "Cross-platform colored terminal text."
165 169 optional = false
166 170 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
... 171 groups = ["dev", "docs"]
... 172 markers = "sys_platform == \"win32\""
167 173 files = [
168 174     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
169 175     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},

poetry.lock --- 5/31 --- TOML
175 181 description = "Code coverage measurement for Python"
176 182 optional = false
177 183 python-versions = ">=3.8"
... 184 groups = ["main"]
178 185 files = [
179 186     {file = "coverage-7.6.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b06079abebbc0e89e6163b8e8f0e16270124c154dc6e4a47b413dd538859af16"},
180 187     {file = "coverage-7.6.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:cf4b19715bccd7ee27b6b120e7e9dd56037b9c0681dcc1adc9ba9db3d417fa36"},

poetry.lock --- 6/31 --- TOML
254 tomli = {version = "*", optional = true, markers = "python_full_version <= \"3.11.0a6\" and extra == \"toml\"" 261 tomli = {version = "*", optional = true, markers = "python_full_version <= \"3.11.0a6\" and extra == \"toml\""
... }                                                                                                              ... }
255                                                                                                                262 
256 [package.extras]                                                                                               263 [package.extras]
257 toml = ["tomli"]                                                                                               264 toml = ["tomli ; python_full_version <= \"3.11.0a6\""]
258                                                                                                                265 
259 [[package]]                                                                                                    266 [[package]]
260 name = "docopt"                                                                                                267 name = "docopt"
261 version = "0.6.2"                                                                                              268 version = "0.6.2"
262 description = "Pythonic argument parser, that will make you smile"                                             269 description = "Pythonic argument parser, that will make you smile"
263 optional = false                                                                                               270 optional = false
264 python-versions = "*"                                                                                          271 python-versions = "*"
...                                                                                                                272 groups = ["main"]
265 files = [                                                                                                      273 files = [
266     {file = "docopt-0.6.2.tar.gz", hash = "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85 274     {file = "docopt-0.6.2.tar.gz", hash = "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85
... c491"},                                                                                                        ... c491"},
267 ]                                                                                                              275 ]

poetry.lock --- 7/31 --- TOML
272 280 description = "Docutils -- Python Documentation Utilities"
273 281 optional = false
274 282 python-versions = ">=3.9"
... 283 groups = ["docs"]
275 284 files = [
276 285     {file = "docutils-0.21.2-py3-none-any.whl", hash = "sha256:dafca5b9e384f0e419294eb4d2ff9fa826435bf15f15b7bd45723e8ad76811b2"},
277 286     {file = "docutils-0.21.2.tar.gz", hash = "sha256:3a6b18732edf182daa3cd12775bbb338cf5691468f91eeeb109deff6ebfa986f"},
```
</details>

<details>
<summary>Build before</summary>

```
checking outputs of '/nix/store/nrlzh1z1cf0zcjv9lhdbgfkkjldspfv8-source.drv'...
structuredAttrs is enabled

trying https://github.com/TheKevJames/coveralls-python/archive/refs/tags/4.0.2.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0   0     0   0     0     0     0  --:--:-- --:--:-- --:--:--     0
100 62555   0 62555   0     0 124831     0  --:--:-- --:--:-- --:--:-- 124831
unpacking source archive /build/download.tar.gz
error: hash mismatch in fixed-output derivation '/nix/store/nrlzh1z1cf0zcjv9lhdbgfkkjldspfv8-source.drv':
         specified: sha256-c7YV1SAbxmqfVI/wGtfdr+S4T7G2q7tf0FhuyCJaPDg=
            got:    sha256-sr3pR3t21nMZczwugFNAioSry/RxIWAzGdGG070YXGw=
```
</details>

<details>
<summary>Build after</summary>

```
this derivation will be built:
  /nix/store/m79rjh3ak5208zj9fprxzbilkywl85i1-source.drv
building '/nix/store/m79rjh3ak5208zj9fprxzbilkywl85i1-source.drv'...
structuredAttrs is enabled

trying https://github.com/TheKevJames/coveralls-python/archive/refs/tags/4.0.2.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0   0     0   0     0     0     0  --:--:-- --:--:-- --:--:--     0
100 62555   0 62555   0     0 78614     0  --:--:-- --:--:-- --:--:-- 115628
unpacking source archive /build/download.tar.gz
/nix/store/n1dyy2yh87z5dinabldw3mk65n80q53r-source
```
</details>

Strangely this one is just lockfile changes. Seems okay? Don't see anything incredibly off about it.

Partially addresses #471498

Partially supercedes #471221




## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
