### PR TITLE
python3Packages.cymem: fix src hash

### DIFF
--- a/pkgs/development/python-modules/cymem/default.nix
+++ b/pkgs/development/python-modules/cymem/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     owner = "explosion";
     repo = "cymem";
     tag = "release-v${version}";
-    hash = "sha256-4srwdQS06KeBAIaJm6XxmsHEZto0eiXBznrCHgT/BAc=";
+    hash = "sha256-kZHnfUNbDyw+LD/7GgtXa6ZssTkJG2PkcM+6YLFK5RQ=";
   };
 
   build-system = [


### PR DESCRIPTION
Fixes hash mismatch for `python3Packages.cymem.src`.

Build logs:
- [before (46869a7)](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/python3Packages_cymem/src.before.log)
- [after (7026f69)](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/python3Packages_cymem/src.after.log)
- [source diff](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/python3Packages_cymem/src.diff.log)

Source directories:
- [old source](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/python3Packages_cymem/src.src.before/)
- [new source](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/python3Packages_cymem/src.src.after/)

<details>
<summary>Source diff (first 100 lines)</summary>

```
.github/workflows/tests.yml --- YAML
24       fail-fast: false                                                          24       fail-fast: false
25       matrix:                                                                   25       matrix:
26         os: [ubuntu-latest, windows-latest, macos-latest]                       26         os: [ubuntu-latest, windows-latest, macos-latest]
27         python_version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]           27         python_version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
28         include:                                                                28         exclude:
..                                                                                 29           # The 3.9/3.10 arm64 Python binaries that `setup-python` tries to use
..                                                                                 30           # don't work on macOS 15 anymore, so skip those.
29           - os: windows-2019                                                    31           - os: macos-latest
30             python_version: "3.6"                                               32             python_version: "3.9"
31           - os: ubuntu-20.04                                                    33           - os: macos-latest
32             python_version: "3.6"                                               34             python_version: "3.10"
33     runs-on: ${{ matrix.os }}                                                   35     runs-on: ${{ matrix.os }}
34                                                                                 36 
35     steps:                                                                      37     steps:
36       - name: Check out repo                                                    38       - name: Check out repo
37         uses: actions/checkout@v3                                               39         uses: actions/checkout@v4
38                                                                                 40 
39       - name: Configure Python version                                          41       - name: Configure Python version
40         uses: actions/setup-python@v4                                           42         uses: actions/setup-python@v5
41         with:                                                                   43         with:
42           python-version: ${{ matrix.python_version }}                          44           python-version: ${{ matrix.python_version }}
43           architecture: x64                                                     45           architecture: x64

setup.py --- Python
111                 "Operating System :: MacOS :: MacOS X",     111                 "Operating System :: MacOS :: MacOS X",
112                 "Operating System :: Microsoft :: Windows", 112                 "Operating System :: Microsoft :: Windows",
113                 "Programming Language :: Cython",           113                 "Programming Language :: Cython",
114                 "Programming Language :: Python :: 2.6",    ... 
115                 "Programming Language :: Python :: 2.7",    ... 
116                 "Programming Language :: Python :: 3.3",    ... 
117                 "Programming Language :: Python :: 3.4",    ... 
118                 "Programming Language :: Python :: 3.5",    ... 
119                 "Programming Language :: Python :: 3.6",    ... 
120                 "Programming Language :: Python :: 3.7",    ... 
121                 "Programming Language :: Python :: 3.8",    ... 
122                 "Programming Language :: Python :: 3.9",    114                 "Programming Language :: Python :: 3.9",
123                 "Programming Language :: Python :: 3.10",   115                 "Programming Language :: Python :: 3.10",
124                 "Programming Language :: Python :: 3.11",   116                 "Programming Language :: Python :: 3.11",
125                 "Programming Language :: Python :: 3.12",   117                 "Programming Language :: Python :: 3.12",
...                                                             118                 "Programming Language :: Python :: 3.13",
126                 "Topic :: Scientific/Engineering",          119                 "Topic :: Scientific/Engineering",
127             ],                                              120             ],
128             cmdclass={"build_ext": build_ext_subclass},     121             cmdclass={"build_ext": build_ext_subclass},

.github/workflows/cibuildwheel.yml --- YAML
 9       - 'prerelease-v[0-9]+.[0-9]+.[0-9]+**'                                       9       - 'prerelease-v[0-9]+.[0-9]+.[0-9]+**'
10 jobs:                                                                             10 jobs:
11   build_wheels:                                                                   11   build_wheels:
12     name: Build wheels on ${{ matrix.os }}                                        .. 
13     runs-on: ${{ matrix.os }}                                                     .. 
14     strategy:                                                                     .. 
15       matrix:                                                                     .. 
16         # macos-13 is an intel runner, macos-14 is apple silicon                  .. 
17         os: [ubuntu-latest, windows-latest, macos-13, macos-14, ubuntu-24.04-arm] .. 
18                                                                                   .. 
19     steps:                                                                        .. 
20       - uses: actions/checkout@v4                                                 .. 
21       - name: Build wheels                                                        .. 
22         uses: pypa/cibuildwheel@v2.21.3                                           .. 
23         env:                                                                      .. 
24           CIBW_SOME_OPTION: value                                                 .. 
25         with:                                                                     .. 
26           package-dir: .                                                          .. 
27           output-dir: wheelhouse                                                  .. 
28           config-file: "{package}/pyproject.toml"                                 .. 
29       - uses: actions/upload-artifact@v4                                          .. 
30         with:                                                                     .. 
31           name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}            .. 
32           path: ./wheelhouse/*.whl                                                .. 
33                                                                                   .. 
34   build_sdist:                                                                    .. 
35     name: Build source distribution                                               .. 
36     runs-on: ubuntu-latest                                                        .. 
37     steps:                                                                        .. 
38       - uses: actions/checkout@v4                                                 .. 
39                                                                                   .. 
40       - name: Build sdist                                                         .. 
41         run: pipx run build --sdist                                               .. 
42       - uses: actions/upload-artifact@v4                                          .. 
43         with:                                                                     .. 
44           name: cibw-sdist                                                        .. 
45           path: dist/*.tar.gz                                                     .. 
46   create_release:                                                                 .. 
47     needs: [build_wheels, build_sdist]                                            12     uses: explosion/gha-cibuildwheel/.github/workflows/cibuildwheel.yml@main
48     runs-on: ubuntu-latest                                                        .. 
49     permissions:                                                                  13     permissions:
50       contents: write                                                             14       contents: write
51       checks: write                                                               .. 
52       actions: read                                                               15       actions: read
53       issues: read                                                                .. 
54       packages: write                                                             .. 
55       pull-requests: read                                                         .. 
56       repository-projects: read                                                   .. 
57       statuses: read                                                              .. 
58     steps:                                                                        .. 
59       - name: Get the tag name and determine if it's a prerelease                 .. 
60         id: get_tag_info                                                          .. 
61         run: |                                                                    .. 
62           FULL_TAG=${GITHUB_REF#refs/tags/}                                       .. 
```
</details>

<details>
<summary>Build before</summary>

```
this derivation will be built:
  /nix/store/8afyhhf28kav9f4bk2hp9phr3am5chff-source.drv
building '/nix/store/8afyhhf28kav9f4bk2hp9phr3am5chff-source.drv'...
structuredAttrs is enabled

trying https://github.com/explosion/cymem/archive/refs/tags/release-v2.0.11.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0   0     0   0     0     0     0  --:--:-- --:--:-- --:--:--     0
100  9430   0  9430   0     0 19700     0  --:--:-- --:--:-- --:--:-- 19700
unpacking source archive /build/download.tar.gz
error: hash mismatch in fixed-output derivation '/nix/store/8afyhhf28kav9f4bk2hp9phr3am5chff-source.drv':
         specified: sha256-4srwdQS06KeBAIaJm6XxmsHEZto0eiXBznrCHgT/BAc=
            got:    sha256-kZHnfUNbDyw+LD/7GgtXa6ZssTkJG2PkcM+6YLFK5RQ=
```
</details>

<details>
<summary>Build after</summary>

```
checking outputs of '/nix/store/idxdxcsp2pv4qxlmivpgwqhkzvm47zly-source.drv'...
structuredAttrs is enabled

trying https://github.com/explosion/cymem/archive/refs/tags/release-v2.0.11.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0   0     0   0     0     0     0  --:--:-- --:--:-- --:--:--     0
100  9430   0  9430   0     0 32175     0  --:--:-- --:--:-- --:--:-- 32175
unpacking source archive /build/download.tar.gz
/nix/store/p5iwhdzlz56cl0fyi484z3cvyfvirrg3-source
```
</details>

Partially addresses #471498

Partially supercedes #471221


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->


Looks like some relatively minor changes to ci, wheel build instructions, and supported versions of python in the setup.py. Nothing major. Should be a frictionless merge, though perhaps we should just get rid of .github directory. Not sure if that makes sense.

## Things done


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
