### PR TITLE
python3Packages.datalad: fix src hash

### DIFF
--- a/pkgs/development/python-modules/datalad/default.nix
+++ b/pkgs/development/python-modules/datalad/default.nix
@@ -58,7 +58,7 @@ buildPythonPackage rec {
     owner = "datalad";
     repo = "datalad";
     tag = version;
-    hash = "sha256-VkHTX0j963N2HMwHoJv8M314SykXFB9u4eqIUDeJ+tw=";
+    hash = "sha256-C3e9k4RDFfDMaimZ/7TtAJNzdlfVrKoTHVl0zKL9EjI=";
   };
 
   postPatch = ''


### PR DESCRIPTION
Fixes hash mismatch for `python3Packages.datalad.src`.

Build logs:
- [before (46869a7)](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/python3Packages_datalad/src.before.log)
- [after (46869a7)](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/python3Packages_datalad/src.after.log)
- [source diff](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/python3Packages_datalad/src.diff.log)

Source directories:
- [old source](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/python3Packages_datalad/src.src.before/)
- [new source](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/python3Packages_datalad/src.src.after/)

<details>
<summary>Source diff</summary>

```
datalad/_version.py --- Python
28     # setup.py/versioneer.py will grep for the variable names, so they must   28     # setup.py/versioneer.py will grep for the variable names, so they must
29     # each be defined on a line of their own. _version.py will just call      29     # each be defined on a line of their own. _version.py will just call
30     # get_keywords().                                                         30     # get_keywords().
31     git_refnames = " (HEAD -> maint, tag: 1.2.3)"                             31     git_refnames = " (tag: 1.2.3)"
32     git_full = "14f7558bab20e612f332de79db5f03531feb03e2"                     32     git_full = "14f7558bab20e612f332de79db5f03531feb03e2"
33     git_date = "2025-10-30 12:00:57 +0000"                                    33     git_date = "2025-10-30 12:00:57 +0000"
34     keywords = {"refnames": git_refnames, "full": git_full, "date": git_date} 34     keywords = {"refnames": git_refnames, "full": git_full, "date": git_date}

```
</details>

<details>
<summary>Build before</summary>

```
this derivation will be built:
  /nix/store/r3prlqw08rzxzmv635mxzr6yyc8wx96y-source.drv
building '/nix/store/r3prlqw08rzxzmv635mxzr6yyc8wx96y-source.drv'...
structuredAttrs is enabled

trying https://github.com/datalad/datalad/archive/refs/tags/1.2.3.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0   0     0   0     0     0     0  --:--:-- --:--:-- --:--:--     0
100  1401k   0  1401k   0     0  1531k     0  --:--:-- --:--:-- --:--:-- 24965k
unpacking source archive /build/download.tar.gz
error: hash mismatch in fixed-output derivation '/nix/store/r3prlqw08rzxzmv635mxzr6yyc8wx96y-source.drv':
         specified: sha256-VkHTX0j963N2HMwHoJv8M314SykXFB9u4eqIUDeJ+tw=
            got:    sha256-C3e9k4RDFfDMaimZ/7TtAJNzdlfVrKoTHVl0zKL9EjI=
```
</details>

<details>
<summary>Build after</summary>

```
checking outputs of '/nix/store/chgbq806d2bz8pgxawjb7lyj2wx33v6f-source.drv'...
structuredAttrs is enabled

trying https://github.com/datalad/datalad/archive/refs/tags/1.2.3.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0   0     0   0     0     0     0  --:--:-- --:--:-- --:--:--     0
100  1401k   0  1401k   0     0  2910k     0  --:--:-- --:--:-- --:--:--  2910k
unpacking source archive /build/download.tar.gz
/nix/store/b2y3h1qsi6jgmz23bxx14nq79jyzl1r5-source
```
</details>

Again, it's _version.py that's different. I don't see much in nixpkgs that is modifying in postFetch the _version.py, so I will leave it alone.

Partially addresses #471498

Partially supercedes #471221



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
