### PR TITLE
python3Packages.fipy: fix src hash

### DIFF
--- a/pkgs/development/python-modules/fipy/default.nix
+++ b/pkgs/development/python-modules/fipy/default.nix
@@ -32,7 +32,7 @@ buildPythonPackage rec {
     owner = "usnistgov";
     repo = "fipy";
     rev = "refs/tags/${version}";
-    hash = "sha256-345YrGQgHNq0FULjJjLqHksyfm/EHl+KyGfxwS6xK9U=";
+    hash = "sha256-usuAj+bIzbCSxYuKeUDxEESbjxPCwYwdD/opaBbgl1w=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
Fixes hash mismatch for `python3Packages.fipy.src`.

Build logs:
- [before (d4a8d2b)](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/python3Packages_fipy/src.before.log)
- [after (d4a8d2b)](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/python3Packages_fipy/src.after.log)
- [source diff](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/python3Packages_fipy/src.diff.log)

Source directories:
- [old source](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/python3Packages_fipy/src.src.before/)
- [new source](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/python3Packages_fipy/src.src.after/)

<details>
<summary>Source diff</summary>

```
fipy/_version.py --- Python
29     # setup.py/versioneer.py will grep for the variable names, so they must   29     # setup.py/versioneer.py will grep for the variable names, so they must
30     # each be defined on a line of their own. _version.py will just call      30     # each be defined on a line of their own. _version.py will just call
31     # get_keywords().                                                         31     # get_keywords().
32     git_refnames = " (HEAD -> master, tag: 3.4.5)"                            32     git_refnames = " (tag: 3.4.5)"
33     git_full = "3c7c8c1921b415a7d5a45f7a9b5a7c191514aa10"                     33     git_full = "3c7c8c1921b415a7d5a45f7a9b5a7c191514aa10"
34     git_date = "2024-06-25 20:11:57 -0400"                                    34     git_date = "2024-06-25 20:11:57 -0400"
35     keywords = {"refnames": git_refnames, "full": git_full, "date": git_date} 35     keywords = {"refnames": git_refnames, "full": git_full, "date": git_date}

```
</details>

<details>
<summary>Build before</summary>

```
this derivation will be built:
  /nix/store/2h4wj0h65hx4jsybj2lr7dvsnisj4nxy-source.drv
building '/nix/store/2h4wj0h65hx4jsybj2lr7dvsnisj4nxy-source.drv'...
structuredAttrs is enabled

trying https://github.com/usnistgov/fipy/archive/refs/tags/3.4.5.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0   0     0   0     0     0     0  --:--:-- --:--:-- --:--:--     0
100 10523k   0 10523k   0     0  9964k     0  --:--:--  0:00:01 --:--:-- 12212k
unpacking source archive /build/download.tar.gz
error: hash mismatch in fixed-output derivation '/nix/store/2h4wj0h65hx4jsybj2lr7dvsnisj4nxy-source.drv':
         specified: sha256-345YrGQgHNq0FULjJjLqHksyfm/EHl+KyGfxwS6xK9U=
            got:    sha256-usuAj+bIzbCSxYuKeUDxEESbjxPCwYwdD/opaBbgl1w=
```
</details>

<details>
<summary>Build after</summary>

```
checking outputs of '/nix/store/4mvvakx8f40aziszfmi668gj39980m91-source.drv'...
structuredAttrs is enabled

trying https://github.com/usnistgov/fipy/archive/refs/tags/3.4.5.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0   0     0   0     0     0     0  --:--:-- --:--:-- --:--:--     0
100 10523k   0 10523k   0     0  2322k     0  --:--:--  0:00:04 --:--:--  2758k
unpacking source archive /build/download.tar.gz
/nix/store/pfnsyw3nnm7ar7ggq64xlhjp15vj84iv-source
```
</details>

This seems to be another `_version.py` difference.

Partially addresses #471498

Partially supercedes #471221


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
