### PR TITLE
firezone-server: fix mua adapter patch

### DIFF
--- a/pkgs/by-name/fi/firezone-server/0000-add-mua.patch
+++ b/pkgs/by-name/fi/firezone-server/0000-add-mua.patch
@@ -14,7 +14,7 @@ diff --git a/elixir/mix.exs b/elixir/mix.exs
 index df90739df..5c53e4383 100644
 --- a/elixir/mix.exs
 +++ b/elixir/mix.exs
-@@ -50,7 +50,9 @@ defmodule Firezone.MixProject do
+@@ -50,6 +50,8 @@ defmodule Firezone.MixProject do
        # Formatter doesn't track dependencies of children applications
        {:phoenix, "~> 1.7.0"},
        {:phoenix_live_view, "~> 1.0.0-rc.0"},
@@ -24,7 +24,26 @@ index df90739df..5c53e4383 100644
 +      {:mail, "~> 0.3.0"}
      ]
    end
- 
+diff --git a/elixir/config/runtime.exs b/elixir/config/runtime.exs
+index abb3171bf77..f9d903e040f 100644
+--- a/elixir/config/runtime.exs
++++ b/elixir/config/runtime.exs
+@@ -324,5 +324,12 @@ if config_env() == :prod do
+          Domain.Mailer,
+          [
+            adapter: env_var_to_config!(:outbound_email_adapter),
+-           from_email: env_var_to_config!(:outbound_email_from)
++           from_email: env_var_to_config!(:outbound_email_from),
++           protocol: String.to_atom(System.get_env("OUTBOUND_EMAIL_SMTP_PROTOCOL")),
++           relay: System.get_env("OUTBOUND_EMAIL_SMTP_HOST"),
++           port: String.to_integer(System.get_env("OUTBOUND_EMAIL_SMTP_PORT")),
++           auth: [
++             username: System.get_env("OUTBOUND_EMAIL_SMTP_USERNAME"),
++             password: System.get_env("OUTBOUND_EMAIL_SMTP_PASSWORD")
++           ]
+          ] ++ env_var_to_config!(:outbound_email_adapter_opts)
+
+   config :workos, WorkOS.Client,
 diff --git a/elixir/mix.lock b/elixir/mix.lock
 index 0b03b58d0..eefb202f4 100644
 --- a/elixir/mix.lock
@@ -43,4 +62,3 @@ index 0b03b58d0..eefb202f4 100644
    "multipart": {:hex, :multipart, "0.4.0", "634880a2148d4555d050963373d0e3bbb44a55b2badd87fa8623166172e9cda0", [:mix], [{:mime, "~> 1.2 or ~> 2.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm", "3c5604bc2fb17b3137e5d2abdf5dacc2647e60c5cc6634b102cf1aef75a06f0a"},
    "nimble_csv": {:hex, :nimble_csv, "1.3.0", "b7f998dc62b222bce9596e46f028c7a5af04cb5dde6df2ea197c583227c54971", [:mix], [], "hexpm", "41ccdc18f7c8f8bb06e84164fc51635321e80d5a3b450761c4997d620925d619"},
    "nimble_options": {:hex, :nimble_options, "1.1.1", "e3a492d54d85fc3fd7c5baf411d9d2852922f66e69476317787a7b2bb000a61b", [:mix], [], "hexpm", "821b2470ca9442c4b6984882fe9bb0389371b8ddec4d45a9504f00a66f650b44"},
-

--- a/pkgs/by-name/fi/firezone-server/package.nix
+++ b/pkgs/by-name/fi/firezone-server/package.nix
@@ -22,7 +22,7 @@ beamPackages.mixRelease rec {
       owner = "firezone";
       repo = "firezone";
       rev = "f86719db19b848ab757995361032c1f2b7927d13";
-      hash = "sha256-YvPxLEE6pdILrABWCZs7ebf6i3Inm1k/YkotZgI7A2k=";
+      hash = "sha256-MrW+mnVMi3mOwkcWDsY84rVBaX1qJPmqkecdH8I2ng0=";
 
       # This is necessary to allow sending mails via SMTP, as the default
       # SMTP adapter is current broken: https://github.com/swoosh/swoosh/issues/785


### PR DESCRIPTION
We use a custom patch to provide compatibility for the [Mua adapter](https://hexdocs.pm/swoosh/Swoosh.Adapters.Mua.html). In a536b2a the part that is configuring the adapter was removed, rendering the `services.firezone.server.smtp` module options useless (as the module defaults to the Mua adapter) unless `services.firezone.server.configureManually` is set.

This adds back in the missing part.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
