### PR TITLE
bstone: 1.2.16 -> 1.3.2

### DIFF
--- a/pkgs/by-name/bs/bstone/package.nix
+++ b/pkgs/by-name/bs/bstone/package.nix
@@ -3,32 +3,39 @@
   stdenv,
   fetchFromGitHub,
   cmake,
+  makeWrapper,
   sdl2-compat,
+  vulkan-loader,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "bstone";
-  version = "1.2.16";
+  version = "1.3.2";
 
   src = fetchFromGitHub {
     owner = "bibendovsky";
     repo = "bstone";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-6BNIMBbLBcQoVx5lnUz14viAvBcFjoZLY8c30EgcvKQ=";
+    hash = "sha256-D0f4DmVv2Bo3cwCUuo3LsXNWFR16rirpvSnAS2C6YEY=";
   };
 
   nativeBuildInputs = [
     cmake
+    makeWrapper
   ];
 
   buildInputs = [
     sdl2-compat
+    vulkan-loader
   ];
 
   postInstall = ''
     mkdir -p $out/{bin,share/bibendovsky/bstone}
     mv $out/bstone $out/bin
     mv $out/*.txt $out/share/bibendovsky/bstone
+
+    wrapProgram $out/bin/bstone \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ vulkan-loader ]}
   '';
 
   meta = {


### PR DESCRIPTION
- Bump to 1.3.2
- Add `vulkan-loader` for new Vulkan support, wrap executable.

Release: https://github.com/bibendovsky/bstone/releases/tag/v1.3.2
Diff: https://github.com/bibendovsky/bstone/compare/v1.2.16...v1.3.2

Notes: 
- ~Currently doesn't work well with Vulkan and `SDL_VIDEODRIVER=wayland`. Issue upstream: https://github.com/bibendovsky/bstone/issues/524~
- Darwin support should be added eventually. Will need assistance on testing that.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
