### PR TITLE
vatprism: fix fetchedMavenDeps hash

### DIFF
--- a/pkgs/by-name/va/vatprism/package.nix
+++ b/pkgs/by-name/va/vatprism/package.nix
@@ -73,7 +73,7 @@ maven.buildMavenPackage rec {
     if (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) then
       "sha256-gerjxTj8UQEVthMO3unWPEG7SPseMt5JPPureC/wUsw="
     else
-      "sha256-QH14GJ8JUYuu5XWnSKPYsamFeP0o+5Sobl+a0FUOIzs=";
+      "sha256-LoOiLisqc99gIGClpVe8tq5/2prmyyOzLDkpmuSgwVo=";
 
   installPhase = ''
     runHook preInstall


### PR DESCRIPTION
Fixes hash mismatch for `vatprism.fetchedMavenDeps` on x86_64-linux. It might be wrong on aarch64-linux still after this. Don't have any way to test that arch.

Build logs:
- [before (e72a42d)](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/vatprism/fetchedMavenDeps.before.log)
- [after (9fb42f4)](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/vatprism/fetchedMavenDeps.after.log)
- [source diff](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/vatprism/fetchedMavenDeps.diff.log)

Source directories:
- [old source](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/vatprism/fetchedMavenDeps.src.before/)
- [new source](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/vatprism/fetchedMavenDeps.src.after/)

<details>
<summary>Source diff (first 100 lines)</summary>

```
.m2/org/apache/maven/plugins/maven-plugins/18/maven-plugins-18.pom --- Text
  1 <?xml version='1.0' encoding='UTF-8'?>
  2 <!--
  3 Licensed to the Apache Software Foundation (ASF) under one
  4 or more contributor license agreements.  See the NOTICE file
  5 distributed with this work for additional information
  6 regarding copyright ownership.  The ASF licenses this file
  7 to you under the Apache License, Version 2.0 (the
  8 "License"); you may not use this file except in compliance
  9 with the License.  You may obtain a copy of the License at
 10 
 11   http://www.apache.org/licenses/LICENSE-2.0
 12 
 13 Unless required by applicable law or agreed to in writing,
 14 software distributed under the License is distributed on an
 15 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 16 KIND, either express or implied.  See the License for the
 17 specific language governing permissions and limitations
 18 under the License.
 19 -->
 20 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 21   <modelVersion>4.0.0</modelVersion>
 22 
 23   <parent>
 24     <groupId>org.apache.maven</groupId>
 25     <artifactId>maven-parent</artifactId>
 26     <version>16</version>
 27     <relativePath>../pom/maven/pom.xml</relativePath>
 28   </parent>
 29 
 30   <groupId>org.apache.maven.plugins</groupId>
 31   <artifactId>maven-plugins</artifactId>
 32   <version>18</version>
 33   <packaging>pom</packaging>
 34 
 35   <name>Maven Plugins</name>
 36   <description>Maven Plugins</description>
 37   <url>http://maven.apache.org/plugins/</url>
 38 
 39   <mailingLists>
 40     <!-- duplication from components - temporary until the site layout is clearer -->
 41     <mailingList>
 42       <name>Maven User List</name>
 43       <subscribe>users-subscribe@maven.apache.org</subscribe>
 44       <unsubscribe>users-unsubscribe@maven.apache.org</unsubscribe>
 45       <post>users@maven.apache.org</post>
 46       <archive>http://mail-archives.apache.org/mod_mbox/maven-users</archive>
 47       <otherArchives>
 48         <otherArchive>http://www.mail-archive.com/users@maven.apache.org/</otherArchive>
 49         <otherArchive>http://old.nabble.com/Maven---Users-f178.html</otherArchive>
 50         <otherArchive>http://maven.users.markmail.org/</otherArchive>
 51       </otherArchives>
 52     </mailingList>
 53     <mailingList>
 54       <name>Maven Developer List</name>
 55       <subscribe>dev-subscribe@maven.apache.org</subscribe>
 56       <unsubscribe>dev-unsubscribe@maven.apache.org</unsubscribe>
 57       <post>dev@maven.apache.org</post>
 58       <archive>http://mail-archives.apache.org/mod_mbox/maven-dev</archive>
 59       <otherArchives>
 60         <otherArchive>http://www.mail-archive.com/dev@maven.apache.org/</otherArchive>
 61         <otherArchive>http://old.nabble.com/Maven-Developers-f179.html</otherArchive>
 62         <otherArchive>http://maven.dev.markmail.org/</otherArchive>
 63       </otherArchives>
 64     </mailingList>
 65     <mailingList>
 66       <name>Maven Issues List</name>
 67       <subscribe>issues-subscribe@maven.apache.org</subscribe>
 68       <unsubscribe>issues-unsubscribe@maven.apache.org</unsubscribe>
 69       <archive>http://mail-archives.apache.org/mod_mbox/maven-issues/</archive>
 70       <otherArchives>
 71         <otherArchive>http://www.mail-archive.com/issues@maven.apache.org</otherArchive>
 72         <otherArchive>http://old.nabble.com/Maven---Issues-f15573.html</otherArchive>
 73         <otherArchive>http://maven.issues.markmail.org/</otherArchive>
 74       </otherArchives>
 75     </mailingList>
 76     <mailingList>
 77       <name>Maven Commits List</name>
 78       <subscribe>commits-subscribe@maven.apache.org</subscribe>
 79       <unsubscribe>commits-unsubscribe@maven.apache.org</unsubscribe>
 80       <archive>http://mail-archives.apache.org/mod_mbox/maven-dev</archive>
 81       <otherArchives>
 82         <otherArchive>http://www.mail-archive.com/commits@maven.apache.org</otherArchive>
 83         <otherArchive>http://old.nabble.com/Maven---Commits-f15575.html</otherArchive>
 84         <otherArchive>http://maven.commits.markmail.org/</otherArchive>
 85       </otherArchives>
 86     </mailingList>
 87     <!-- duplication from parent pom - temporary until they inherit properly -->
 88     <mailingList>
 89       <name>Maven Announcements List</name>
 90       <post>announce@maven.apache.org</post>
 91       <subscribe>announce-subscribe@maven.apache.org</subscribe>
 92       <unsubscribe>announce-unsubscribe@maven.apache.org</unsubscribe>
 93       <archive>http://mail-archives.apache.org/mod_mbox/maven-announce/</archive>
 94       <otherArchives>
 95         <otherArchive>http://www.mail-archive.com/announce@maven.apache.org</otherArchive>
 96         <otherArchive>http://old.nabble.com/Maven-Announcements-f15617.html</otherArchive>
 97         <otherArchive>http://maven.announce.markmail.org/</otherArchive>
 98       </otherArchives>
 99     </mailingList>
```
</details>

<details>
<summary>Build before (first 100 lines)</summary>

```
these 28 derivations will be built:
  /nix/store/dwz8a904hhxq67l3q6g1f8sg7qwrzxbq-python3.13-pyflakes-3.4.0.drv
  /nix/store/lfq2iilq90h4nr923x5hq18yfljjkacn-python3.13-pycodestyle-2.14.0.drv
  /nix/store/jdq2q86kmivrwkc6khrv03x4fiyrhgkb-setuptools-build-hook.drv
  /nix/store/n4mv8c1vy8rd8mbciyad256b2fciwlwb-python3.13-mccabe-0.7.0.drv
  /nix/store/05dga9zvim6fm8bf6xn99pcn3qg71ab3-python3.13-flake8-7.3.0.drv
  /nix/store/0zad7m4p20g372n84dgbh455fbnpf4pj-zip-3.0.drv
  /nix/store/34y6skni0gr5m6pn03b9h3fmwrlm8mrl-libedit-20251016-3.1.drv
  /nix/store/8gspilix33r28kbd7l2lr1jgkain53yj-dash-0.5.13.1.drv
  /nix/store/2bwg08y561nn2c2smr1a2hqf629hdwgg-pythoncheck.sh.drv
  /nix/store/65cz55ivzfwvg3gp7mq596a23dq33dwv-alsa-lib-1.2.14.drv
  /nix/store/an7kqxgxnpi13y0lhkvzd2p44dzgqj5p-set-java-classpath-hook.drv
  /nix/store/mr3ak5p12hd0g8jpny0yklvz4yw1mz6p-temurin-bin-21.0.8.drv
  /nix/store/nhspbrp6mlymdrw2lfs8xjhvkbsk9vb5-lcms2-2.17.drv
  /nix/store/y97idgaivay72x0dlnwi64655c0095p8-cpio-2.15.drv
  /nix/store/8yyhkqq1l1z9ij8dip54ppzgzqx5jfkd-openjdk-21.0.9+10.drv
  /nix/store/hvxxm22ddlig6lvn8pifxa7kpb67acq6-builder.pl.drv
  /nix/store/jfjma0kawk1x67aqk3i1kqzickq8n2p6-perl-5.42.0.drv
  /nix/store/9qlf339fdp06rg616rfd3wn8bdi0h906-perl-5.42.0-env.drv
  /nix/store/daqq1h1l1zwg75f2bzp02az6r4g92nd9-copy-desktop-items-hook.drv
  /nix/store/yiz7zbmlr48xh8am1s5s6bh6agiwipsi-pythoncheck.sh.drv
  /nix/store/dqa77x6yhka4qbs0ilz7ydlzls1p4mb1-write-proxy-settings.drv
  /nix/store/h7w93pihw2yyb6jgpwiqs17hj4h8qv8v-write-proxy-settings.drv
  /nix/store/wk0s4qr74kn0zx22dgzb2bcpwsn9h8bz-temurin-bin-21.0.8.drv
  /nix/store/jnfyr3nlclc0q17xwx5i8g0k8wd9rh0q-openjdk-headless-21.0.9+10.drv
  /nix/store/nvabvwx7nmr6s0y0xc6j2zys9mrp7axl-maven-3.9.12.drv
  /nix/store/r8ijmahll125j8f22pjpv0k93sdszv94-jre-generate-cacerts.drv
  /nix/store/v5z7i2hx8b3wqa9ncphsr0yw7z8qgkq8-jre-generate-cacerts.drv
  /nix/store/gcsmy269dnlzjp7v9lfx0wsg11x5gdb3-maven-deps-vatprism-0.3.6.drv
building '/nix/store/daqq1h1l1zwg75f2bzp02az6r4g92nd9-copy-desktop-items-hook.drv'...
building '/nix/store/an7kqxgxnpi13y0lhkvzd2p44dzgqj5p-set-java-classpath-hook.drv'...
building '/nix/store/65cz55ivzfwvg3gp7mq596a23dq33dwv-alsa-lib-1.2.14.drv'...
building '/nix/store/y97idgaivay72x0dlnwi64655c0095p8-cpio-2.15.drv'...
building '/nix/store/hvxxm22ddlig6lvn8pifxa7kpb67acq6-builder.pl.drv'...
building '/nix/store/nhspbrp6mlymdrw2lfs8xjhvkbsk9vb5-lcms2-2.17.drv'...
Running phase: unpackPhase
unpacking source archive /nix/store/2mi5ycx8zl4yl408z49vansnwxh8gd9k-alsa-lib-1.2.14.tar.bz2
Running phase: patchPhase
Running phase: updateAutotoolsGnuConfigScriptsPhase
Running phase: configurePhase
Running phase: unpackPhase
unpacking source archive /nix/store/gvbhdrrj1ggw2f66bbkzyz77zlnx3wp0-cpio-2.15.tar.bz2
no configure script, doing nothing
Running phase: buildPhase
Running phase: checkPhase
Running phase: installPhase
no Makefile or custom installPhase, doing nothing
Running phase: fixupPhase
shrinking RPATHs of ELF executables and libraries in /nix/store/119wcss8hpblzq13acpgivaiy5vg3hv8-builder.pl
Running phase: unpackPhase
checking for references to /build/ in /nix/store/119wcss8hpblzq13acpgivaiy5vg3hv8-builder.pl...
unpacking source archive /nix/store/ggy8llzbjhmdyqlgw0ycinwpi6g9cgjx-lcms2-2.17.tar.gz
patching script interpreter paths in /nix/store/119wcss8hpblzq13acpgivaiy5vg3hv8-builder.pl
building '/nix/store/34y6skni0gr5m6pn03b9h3fmwrlm8mrl-libedit-20251016-3.1.drv'...
source root is lcms2-2.17
setting SOURCE_DATE_EPOCH to timestamp 1739127899 of file "lcms2-2.17/utils/transicc/transicc.c"
Running phase: patchPhase
Running phase: updateAutotoolsGnuConfigScriptsPhase
Updating Autotools / GNU config script to a newer upstream version: ./config.sub
source root is alsa-lib-1.2.14
Updating Autotools / GNU config script to a newer upstream version: ./config.guess
Running phase: configurePhase
setting SOURCE_DATE_EPOCH to timestamp 1744649154 of file "alsa-lib-1.2.14/libtool"
Running phase: patchPhase
applying patch /nix/store/ilsa6dxdcjdpxmpsz7cvflrhcs98czfd-alsa-plugin-conf-multilib.patch
patching file src/control/control.c
Hunk #1 succeeded at 1456 (offset 618 lines).
Hunk #2 succeeded at 1502 (offset 619 lines).
Hunk #3 succeeded at 1539 (offset 619 lines).
Hunk #4 succeeded at 1610 with fuzz 2 (offset 619 lines).
patching file src/pcm/pcm.c
Hunk #1 succeeded at 2576 (offset 460 lines).
Hunk #2 succeeded at 2625 (offset 461 lines).
Hunk #3 succeeded at 2662 (offset 461 lines).
Hunk #4 succeeded at 2733 with fuzz 2 (offset 461 lines).
fixing libtool script ./ltmain.sh
Running phase: updateAutotoolsGnuConfigScriptsPhase
Updating Autotools / GNU config script to a newer upstream version: ./config.sub
./configure
Updating Autotools / GNU config script to a newer upstream version: ./config.guess
Running phase: configurePhase
patching script interpreter paths in ./configure
fixing libtool script ./ltmain.sh
./configure: interpreter directive changed from "#! /bin/sh" to "/nix/store/lw117lsr8d585xs63kx5k233impyrq7q-bash-5.3p3/bin/sh"
Running phase: unpackPhase
./configure
unpacking source archive /nix/store/4f5r16c8974czm23arn0g22vh8lb7hhp-libedit-20251016-3.1.tar.gz
configure flags: --disable-static --disable-dependency-tracking --prefix=/nix/store/b8vsara78lvpyqz25n03qljh0587fqv5-lcms2-2.17 --bindir=/nix/store/a6q5zzy75h8k8wa7mnzqcpvnnr1wj8jy-lcms2-2.17-bin/bin --sbindir=/nix/store/a6q5zzy75h8k8wa7mnzqcpvnnr1wj8jy-lcms2-2.17-bin/sbin --includedir=/nix/store/lb33y3zdr3dzc948mf9v8n6sznc5b9bf-lcms2-2.17-dev/include --mandir=/nix/store/a6q5zzy75h8k8wa7mnzqcpvnnr1wj8jy-lcms2-2.17-bin/share/man --infodir=/nix/store/a6q5zzy75h8k8wa7mnzqcpvnnr1wj8jy-lcms2-2.17-bin/share/info --docdir=/nix/store/b8vsara78lvpyqz25n03qljh0587fqv5-lcms2-2.17/share/doc/lcms2 --libdir=/nix/store/b8vsara78lvpyqz25n03qljh0587fqv5-lcms2-2.17/lib --libexecdir=/nix/store/b8vsara78lvpyqz25n03qljh0587fqv5-lcms2-2.17/libexec --localedir=/nix/store/b8vsara78lvpyqz25n03qljh0587fqv5-lcms2-2.17/share/locale
source root is libedit-20251016-3.1
patching script interpreter paths in ./configure
setting SOURCE_DATE_EPOCH to timestamp 1760636523 of file "libedit-20251016-3.1/src/Makefile.in"
./configure: interpreter directive changed from "#! /bin/sh" to "/nix/store/lw117lsr8d585xs63kx5k233impyrq7q-bash-5.3p3/bin/sh"
Running phase: patchPhase
applying patch /nix/store/d89cp7008x3hr6wjvil8szhz3nlsxrda-01-cygwin.patch
patching file src/editline/readline.h
Hunk #1 succeeded at 78 (offset 3 lines).
patching file src/read.c
Running phase: autoreconfPhase
configure flags: --disable-static --disable-dependency-tracking --prefix=/nix/store/f0mf3rlv29ql40qx36kqd2jzabd1m0s0-alsa-lib-1.2.14 --bindir=/nix/store/f0mf3rlv29ql40qx36kqd2jzabd1m0s0-alsa-lib-1.2.14/bin --sbindir=/nix/store/f0mf3rlv29ql40qx36kqd2jzabd1m0s0-alsa-lib-1.2.14/sbin --includedir=/nix/store/7s5yml5zzmcs11brgbrjj47npr0nw8mw-alsa-lib-1.2.14-dev/include --mandir=/nix/store/f0mf3rlv29ql40qx36kqd2jzabd1m0s0-alsa-lib-1.2.14/share/man --infodir=/nix/store/f0mf3rlv29ql40qx36kqd2jzabd1m0s0-alsa-lib-1.2.14/share/info --docdir=/nix/store/f0mf3rlv29ql40qx36kqd2jzabd1m0s0-alsa-lib-1.2.14/share/doc/alsa-lib --libdir=/nix/store/f0mf3rlv29ql40qx36kqd2jzabd1m0s0-alsa-lib-1.2.14/lib --libexecdir=/nix/store/f0mf3rlv29ql40qx36kqd2jzabd1m0s0-alsa-lib-1.2.14/libexec --localedir=/nix/store/f0mf3rlv29ql40qx36kqd2jzabd1m0s0-alsa-lib-1.2.14/share/locale
source root is cpio-2.15
```
</details>

<details>
<summary>Build after (first 100 lines)</summary>

```
checking outputs of '/nix/store/bw8rsx0122xnyv1xyms24bpkpjqml45s-maven-deps-vatprism-0.3.6.drv'...
Running phase: unpackPhase
unpacking source archive /nix/store/mb68kg79qcsa8n0jk9r4lig90dzsf638-source
source root is source
Running phase: patchPhase
applying patch /nix/store/28c401xqxi1javg8k1m8rx4r8vy2a6w9-0001-Fix-build-on-JDK-21.patch
patching file pom.xml
Running phase: updateAutotoolsGnuConfigScriptsPhase
Running phase: configurePhase
no configure script, doing nothing
Running phase: buildPhase
[INFO] Scanning for projects...
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for net.marvk.fs:vatsim-map:jar:0.3.6
[WARNING] 'version' contains an expression but should be a constant. @ net.marvk.fs:vatsim-map:${versionName}, /build/source/pom.xml, line 9, column 14
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
[INFO] 
[INFO] ----------------------< net.marvk.fs:vatsim-map >-----------------------
[INFO] Building VATprism 0.3.6
[INFO]   from pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/mojo/license-maven-plugin/2.0.0/license-maven-plugin-2.0.0.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/mojo/license-maven-plugin/2.0.0/license-maven-plugin-2.0.0.pom (24 kB at 40 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/mojo/mojo-parent/50/mojo-parent-50.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/mojo/mojo-parent/50/mojo-parent-50.pom (34 kB at 550 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/mojo/license-maven-plugin/2.0.0/license-maven-plugin-2.0.0.jar
Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/mojo/license-maven-plugin/2.0.0/license-maven-plugin-2.0.0.jar (515 kB at 4.2 MB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-resources-plugin/3.3.1/maven-resources-plugin-3.3.1.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-resources-plugin/3.3.1/maven-resources-plugin-3.3.1.pom (8.2 kB at 157 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-plugins/39/maven-plugins-39.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-plugins/39/maven-plugins-39.pom (8.1 kB at 159 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/39/maven-parent-39.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/39/maven-parent-39.pom (48 kB at 842 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/apache/29/apache-29.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/apache/29/apache-29.pom (21 kB at 391 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-resources-plugin/3.3.1/maven-resources-plugin-3.3.1.jar
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-resources-plugin/3.3.1/maven-resources-plugin-3.3.1.jar (31 kB at 525 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-compiler-plugin/3.3/maven-compiler-plugin-3.3.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-compiler-plugin/3.3/maven-compiler-plugin-3.3.pom (11 kB at 162 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-plugins/27/maven-plugins-27.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-plugins/27/maven-plugins-27.pom (11 kB at 180 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/26/maven-parent-26.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/26/maven-parent-26.pom (40 kB at 846 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/apache/16/apache-16.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/apache/16/apache-16.pom (15 kB at 237 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-compiler-plugin/3.3/maven-compiler-plugin-3.3.jar
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-compiler-plugin/3.3/maven-compiler-plugin-3.3.jar (46 kB at 799 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-help-plugin/3.2.0/maven-help-plugin-3.2.0.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-help-plugin/3.2.0/maven-help-plugin-3.2.0.pom (11 kB at 230 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-plugins/33/maven-plugins-33.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-plugins/33/maven-plugins-33.pom (11 kB at 198 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/33/maven-parent-33.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/33/maven-parent-33.pom (44 kB at 803 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/apache/21/apache-21.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/apache/21/apache-21.pom (17 kB at 295 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-help-plugin/3.2.0/maven-help-plugin-3.2.0.jar
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-help-plugin/3.2.0/maven-help-plugin-3.2.0.jar (86 kB at 1.7 MB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-surefire-plugin/2.22.1/maven-surefire-plugin-2.22.1.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-surefire-plugin/2.22.1/maven-surefire-plugin-2.22.1.pom (5.0 kB at 100 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire/2.22.1/surefire-2.22.1.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire/2.22.1/surefire-2.22.1.pom (26 kB at 369 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-surefire-plugin/2.22.1/maven-surefire-plugin-2.22.1.jar
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-surefire-plugin/2.22.1/maven-surefire-plugin-2.22.1.jar (41 kB at 739 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-jar-plugin/3.2.0/maven-jar-plugin-3.2.0.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-jar-plugin/3.2.0/maven-jar-plugin-3.2.0.pom (7.3 kB at 113 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-jar-plugin/3.2.0/maven-jar-plugin-3.2.0.jar
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-jar-plugin/3.2.0/maven-jar-plugin-3.2.0.jar (29 kB at 500 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-shade-plugin/2.3/maven-shade-plugin-2.3.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-shade-plugin/2.3/maven-shade-plugin-2.3.pom (7.3 kB at 133 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-plugins/25/maven-plugins-25.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-plugins/25/maven-plugins-25.pom (9.6 kB at 203 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/24/maven-parent-24.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/24/maven-parent-24.pom (37 kB at 499 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/apache/14/apache-14.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/apache/14/apache-14.pom (15 kB at 233 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-shade-plugin/2.3/maven-shade-plugin-2.3.jar
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-shade-plugin/2.3/maven-shade-plugin-2.3.jar (101 kB at 1.6 MB/s)
Downloading from Maven Central: https://repo.maven.apache.org/maven2/org/kordamp/ikonli/ikonli-octicons-pack/12.2.0/ikonli-octicons-pack-12.2.0.pom
Downloaded from Maven Central: https://repo.maven.apache.org/maven2/org/kordamp/ikonli/ikonli-octicons-pack/12.2.0/ikonli-octicons-pack-12.2.0.pom (1.5 kB at 28 kB/s)
Downloading from Maven Central: https://repo.maven.apache.org/maven2/org/kordamp/ikonli/ikonli-core/12.2.0/ikonli-core-12.2.0.pom
Downloaded from Maven Central: https://repo.maven.apache.org/maven2/org/kordamp/ikonli/ikonli-core/12.2.0/ikonli-core-12.2.0.pom (1.4 kB at 28 kB/s)
Downloading from Maven Central: https://repo.maven.apache.org/maven2/org/kordamp/ikonli/ikonli-javafx/12.2.0/ikonli-javafx-12.2.0.pom
Downloaded from Maven Central: https://repo.maven.apache.org/maven2/org/kordamp/ikonli/ikonli-javafx/12.2.0/ikonli-javafx-12.2.0.pom (1.5 kB at 36 kB/s)
Downloading from Maven Central: https://repo.maven.apache.org/maven2/org/kordamp/ikonli/ikonli-ionicons4-pack/12.2.0/ikonli-ionicons4-pack-12.2.0.pom
Downloaded from Maven Central: https://repo.maven.apache.org/maven2/org/kordamp/ikonli/ikonli-ionicons4-pack/12.2.0/ikonli-ionicons4-pack-12.2.0.pom (1.5 kB at 28 kB/s)
Downloading from Maven Central: https://repo.maven.apache.org/maven2/org/kordamp/ikonli/ikonli-fileicons-pack/12.2.0/ikonli-fileicons-pack-12.2.0.pom
Downloaded from Maven Central: https://repo.maven.apache.org/maven2/org/kordamp/ikonli/ikonli-fileicons-pack/12.2.0/ikonli-fileicons-pack-12.2.0.pom (1.5 kB at 29 kB/s)
Downloading from Maven Central: https://repo.maven.apache.org/maven2/org/projectlombok/lombok/1.18.30/lombok-1.18.30.pom
Downloaded from Maven Central: https://repo.maven.apache.org/maven2/org/projectlombok/lombok/1.18.30/lombok-1.18.30.pom (1.5 kB at 27 kB/s)
Downloading from Maven Central: https://repo.maven.apache.org/maven2/net/marvk/fs/vatsim-api/1.2.0/vatsim-api-1.2.0.pom
Downloaded from Maven Central: https://repo.maven.apache.org/maven2/net/marvk/fs/vatsim-api/1.2.0/vatsim-api-1.2.0.pom (5.4 kB at 112 kB/s)
Downloading from Maven Central: https://repo.maven.apache.org/maven2/com/google/code/gson/gson/2.8.6/gson-2.8.6.pom
Downloaded from Maven Central: https://repo.maven.apache.org/maven2/com/google/code/gson/gson/2.8.6/gson-2.8.6.pom (2.5 kB at 46 kB/s)
Downloading from Maven Central: https://repo.maven.apache.org/maven2/com/google/code/gson/gson-parent/2.8.6/gson-parent-2.8.6.pom
Downloaded from Maven Central: https://repo.maven.apache.org/maven2/com/google/code/gson/gson-parent/2.8.6/gson-parent-2.8.6.pom (4.4 kB at 111 kB/s)
Downloading from Maven Central: https://repo.maven.apache.org/maven2/org/sonatype/oss/oss-parent/7/oss-parent-7.pom
```
</details>

It looks like apache, openjfx, and codehaus changed with some slight build instruction modifications. I don't see anything super crazy in the diff. Mostly looks like different artifacts are referred to. No binaries are different.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
