### PR TITLE
agorakit: fix composerVendor hash

### DIFF
--- a/pkgs/by-name/ag/agorakit/package.nix
+++ b/pkgs/by-name/ag/agorakit/package.nix
@@ -27,7 +27,7 @@ php82.buildComposerProject2 (finalAttrs: {
     runHook postInstall
   '';
 
-  vendorHash = "sha256-cg9OIBvWX69yU6U6Ag/T3jScG2OUdpTqc+KwP6VyUHo=";
+  vendorHash = "sha256-3Kxuvmb3eZN3ChW59b5rITgCe4NqPHIBHau1PBmxPis=";
   composerStrictValidation = false;
 
   passthru.updateScript = nix-update-script { };


### PR DESCRIPTION
Fixes hash mismatch for `agorakit.composerVendor`.

A *lot* of stuff seems to have changed here. Seems like nothing obviously malicious. But, I'm still not really sure *why* it changed beyond maybe "somebody force pushed to the dependencies and now they resolve differently". At least we can inspect the changes thanks to cache.nixos.org.

Build logs:
- [before (48e7e6f)](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/agorakit/composerVendor.before.log)
- [after (48e7e6f)](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/agorakit/composerVendor.after.log)
- [source diff](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/agorakit/composerVendor.diff.log)

Source directories:
- [old source](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/agorakit/composerVendor.src.before/)
- [new source](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/agorakit/composerVendor.src.after/)

<details>
<summary>Source diff (first 100 lines)</summary>

```
vendor/autoload.php --- PHP
 1 <?php
 2 
 3 // autoload.php @generated by Composer
 4 
 5 if (PHP_VERSION_ID < 50600) {
 6     if (!headers_sent()) {
 7         header('HTTP/1.1 500 Internal Server Error');
 8     }
 9     $err = 'Composer 2.3.0 dropped support for autoloading on PHP <5.6 and you are running '.PHP_VERSION.', please upgrade PHP or use Composer 2.2 LTS via "composer self-update --2.2". Aborting.'.PHP_EOL;
10     if (!ini_get('display_errors')) {
11         if (PHP_SAPI === 'cli' || PHP_SAPI === 'phpdbg') {
12             fwrite(STDERR, $err);
13         } elseif (!headers_sent()) {
14             echo $err;
15         }
16     }
17     throw new RuntimeException($err);
18 }
19 
20 require_once __DIR__ . '/composer/autoload_real.php';
21 
22 return ComposerAutoloaderInitdc64c4251818dfd0c32599b4f33cd5b0::getLoader();
23 

vendor/bin/carbon --- Text
  1 #!/usr/bin/env php
  2 <?php
  3 
  4 /**
  5  * Proxy PHP file generated by Composer
  6  *
  7  * This file includes the referenced bin path (../nesbot/carbon/bin/carbon)
  8  * using a stream wrapper to prevent the shebang from being output on PHP<8
  9  *
 10  * @generated
 11  */
 12 
 13 namespace Composer;
 14 
 15 $GLOBALS['_composer_bin_dir'] = __DIR__;
 16 $GLOBALS['_composer_autoload_path'] = __DIR__ . '/..'.'/autoload.php';
 17 
 18 if (PHP_VERSION_ID < 80000) {
 19     if (!class_exists('Composer\BinProxyWrapper')) {
 20         /**
 21          * @internal
 22          */
 23         final class BinProxyWrapper
 24         {
 25             private $handle;
 26             private $position;
 27             private $realpath;
 28 
 29             public function stream_open($path, $mode, $options, &$opened_path)
 30             {
 31                 // get rid of phpvfscomposer:// prefix for __FILE__ & __DIR__ resolution
 32                 $opened_path = substr($path, 17);
 33                 $this->realpath = realpath($opened_path) ?: $opened_path;
 34                 $opened_path = $this->realpath;
 35                 $this->handle = fopen($this->realpath, $mode);
 36                 $this->position = 0;
 37 
 38                 return (bool) $this->handle;
 39             }
 40 
 41             public function stream_read($count)
 42             {
 43                 $data = fread($this->handle, $count);
 44 
 45                 if ($this->position === 0) {
 46                     $data = preg_replace('{^#!.*\r?\n}', '', $data);
 47                 }
 48 
 49                 $this->position += strlen($data);
 50 
 51                 return $data;
 52             }
 53 
 54             public function stream_cast($castAs)
 55             {
 56                 return $this->handle;
 57             }
 58 
 59             public function stream_close()
 60             {
 61                 fclose($this->handle);
 62             }
 63 
 64             public function stream_lock($operation)
 65             {
 66                 return $operation ? flock($this->handle, $operation) : true;
 67             }
 68 
 69             public function stream_seek($offset, $whence)
 70             {
 71                 if (0 === fseek($this->handle, $offset, $whence)) {
 72                     $this->position = ftell($this->handle);
 73                     return true;
 74                 }
```
</details>

<details>
<summary>Build before (first 100 lines)</summary>

```
these 51 derivations will be built:
  /nix/store/6bv35zq8k0xzs5hzzhydrdkiyap3p8ri-php-8.2.30.tar.bz2.drv
  /nix/store/xf6f9xj9kr760yvqpr32g8qgbhvx2gyx-php-8.2.30.drv
  /nix/store/q5dgnalrm9bpm3gjivbij2f0p68zx886-php-session-8.2.30.drv
  /nix/store/022qqmfw3mr36ns4ij1wmd2gprm44kcf-php-soap-8.2.30.drv
  /nix/store/1dkp9bacn12w11ch03vv5xl8jn0xds2p-php-filter-8.2.30.drv
  /nix/store/w40ak4rddabsy099syrqapc9k5gkzjz0-php-pdo-8.2.30.drv
  /nix/store/1n6hak6cdg563a043ivscrs5qzkza0qx-php-pdo_pgsql-8.2.30.drv
  /nix/store/2gwnrc2770n5md7skgs21b8zhi6jlaf8-php-calendar-8.2.30.drv
  /nix/store/40bz2vkp4prsjw9saj08d8iazjl4vqs7-php-pdo_sqlite-8.2.30.drv
  /nix/store/4lfsxb8vlh7cr7mvy8a32xjka12vbbaj-php-mbstring-8.2.30.drv
  /nix/store/5sjq09ckqhr8hc4bx0a7vv13245mw3cp-php-sodium-8.2.30.drv
  /nix/store/60mjvhw9whl5vkbf2dkw46dz8y6z0i9a-php-pcntl-8.2.30.drv
  /nix/store/6yzyri5kprllrx5fvg65rxfdwcdv8xjz-php-opcache-8.2.30.drv
  /nix/store/6z5kvkc3rmgib2q6z5kfw8k6p16igakn-php-simplexml-8.2.30.drv
  /nix/store/80ywzamwi0yxfgivw05dnw1m1fqxw9sx-php-dom-8.2.30.drv
  /nix/store/89kpx75gljhizql7y3ap2nqr667i36wg-php-sockets-8.2.30.drv
  /nix/store/afcvvysr987sq4i8qms27ww7p7fpwkx0-php-mysqlnd-8.2.30.drv
  /nix/store/8wrxn5dxw4jadkgabqykani0q40qv9zs-php-mysqli-8.2.30.drv
  /nix/store/93vglm43rxrk4j67q80nj6a32wa7vwfj-php-intl-8.2.30.drv
  /nix/store/aw3b3plk9s1n5375vw67f7m4m9rxzjs3-php-openssl-8.2.30.drv
  /nix/store/b6v6bi6sx4n77i99rlfx7dywbwli17qj-php-readline-8.2.30.drv
  /nix/store/bkqi2bdw4xvhwbaisndrmd0465mxvg5l-php-zlib-8.2.30.drv
  /nix/store/c7kcxc2bi23njld7ga9s44p9qwr50ipr-php-xmlreader-8.2.30.drv
  /nix/store/ccn4l4c4q4armsl353b3lsa2lbncsm9l-php-pdo_odbc-8.2.30.drv
  /nix/store/cvd0w5mqrwalki5gnfvjv5qgyck3hjzw-php-gettext-8.2.30.drv
  /nix/store/d4317yq8qrdmcyh5kish6z5nxj0aqlbk-php-sysvsem-8.2.30.drv
  /nix/store/fqvn2abbclmd55iaxkm027f3l39r8kyb-php-curl-8.2.30.drv
  /nix/store/g9jchhn0xlkll5gjc4y0vmsd4ci56109-php-pgsql-8.2.30.drv
  /nix/store/gxdikz41h6lh0dqhd1pajlgb8vxv9vz4-php-sqlite3-8.2.30.drv
  /nix/store/iksi4vzq3agrh99fx4bnd1s9csmv5j9y-php-ldap-8.2.30.drv
  /nix/store/j61l30gziq7zbwyfr5yi7zsj46h8zpb6-php-fileinfo-8.2.30.drv
  /nix/store/j7iv73rnpznv4y0w0xy5sdlb7xchvdcw-php-zip-8.2.30.drv
  /nix/store/k41f3crlmjhs7pinxa78nm9nj9mmfanb-php-gmp-8.2.30.drv
  /nix/store/kh4lbc3pcxryy4yhicy3zzn2q6sjdz0z-php-xmlwriter-8.2.30.drv
  /nix/store/ls59l8np7xv6gdxkb4klr2cbgm7rwq8j-uw-imap-2007f.drv
  /nix/store/knslm6m1n5wqj356rcgpbqjm1sfn1s18-php-imap-8.2.30.drv
  /nix/store/kxgpkjzc8a6bizs9mpi84bqar1qlqk49-php-pdo_mysql-8.2.30.drv
  /nix/store/p5zdfqkwj971qsqphqssym023f48p2gw-php-ftp-8.2.30.drv
  /nix/store/pbnzpzks218517g4wpd42rrzkkv4haxa-php-bcmath-8.2.30.drv
  /nix/store/r30r2q9rp7b0drgnrihya0cnaiwgn21m-php-gd-8.2.30.drv
  /nix/store/rg5805y81a8nkg3p6q2xfva1c7c5axh5-php-tokenizer-8.2.30.drv
  /nix/store/vymvhm585kkjmx00m1hc0dnmvs62zs7j-php-posix-8.2.30.drv
  /nix/store/w9hfrww9d0l4hsi332ccikaar37kcpnx-php-ctype-8.2.30.drv
  /nix/store/w9kypiy9s7w8db459lh8xwzwxsydmd3g-php-iconv-8.2.30.drv
  /nix/store/zwpf732jywbx5g4c3v7yng0mb981hy35-php-exif-8.2.30.drv
  /nix/store/8kc55319w6maccd3rclp74h9dzx2lyia-php-extra-init-8.2.30.ini.drv
  /nix/store/qjaafzsin41y8jkx7hzf8ycjyv0dchhr-php-with-extensions-8.2.30.drv
  /nix/store/84dw9csyaa6fv50gqzd1zl4zv3czyyjr-composer-phar-2.9.2.drv
  /nix/store/gzh0xzvf29vjxkg6grd5ybizfhgp64p5-composer-2.9.2.drv
  /nix/store/wwlqp1sf3axmhk53w89b5zpa0nryj0j5-composer-vendor-hook.sh.drv
  /nix/store/6pfx4wp6c6d0j8irdfy89fyjvzwyjpd9-agorakit-composer-vendor-1.11.drv
building '/nix/store/wwlqp1sf3axmhk53w89b5zpa0nryj0j5-composer-vendor-hook.sh.drv'...
building '/nix/store/6bv35zq8k0xzs5hzzhydrdkiyap3p8ri-php-8.2.30.tar.bz2.drv'...
building '/nix/store/ls59l8np7xv6gdxkb4klr2cbgm7rwq8j-uw-imap-2007f.drv'...
structuredAttrs is enabled

trying https://www.php.net/distributions/php-8.2.30.tar.bz2
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
Running phase: unpackPhase
unpacking source archive /nix/store/8v3nv3ndxpq42h10z49a4wmjzy27blbc-imap-2007f.tar.gz
source root is imap-2007f
setting SOURCE_DATE_EPOCH to timestamp 1311380421 of file "imap-2007f/makefile.wce"
Running phase: patchPhase
applying patch /nix/store/hyd0vdzwbaim2q42gsg8zww3yl0k4gbg-1006_openssl1.1_autoverify.patch
patching file src/osdep/unix/ssl_unix.c
applying patch /nix/store/23ki7l6j069w9hzfhidn1zgf3m3ansvb-clang-fix.patch
patching file src/c-client/netmsg.c
patching file src/c-client/nntp.c
patching file src/dmail/dmail.c
patching file src/mlock/mlock.c
patching file src/osdep/unix/dummy.c
patching file src/osdep/unix/mbx.c
patching file src/osdep/unix/mh.c
patching file src/osdep/unix/mix.c
patching file src/osdep/unix/mmdf.c
patching file src/osdep/unix/mtx.c
patching file src/osdep/unix/mx.c
patching file src/osdep/unix/news.c
patching file src/osdep/unix/tenex.c
patching file src/osdep/unix/unix.c
patching file src/tmail/tmail.c
applying patch /nix/store/xxk2ran6wjrhgy6j1m1j90caxmmd121p-gcc-14-fix.diff
patching file src/mtest/mtest.c
patching file src/osdep/unix/flocklnx.c
patching file src/osdep/unix/flocklnx.h
patching file src/osdep/unix/os_lnx.h
patching file src/osdep/unix/os_slx.h
Running phase: updateAutotoolsGnuConfigScriptsPhase
Running phase: configurePhase
no configure script, doing nothing
Running phase: buildPhase
build flags: SHELL=/nix/store/lw117lsr8d585xs63kx5k233impyrq7q-bash-5.3p3/bin/bash CC=cc RANLIB=ranlib lnp EXTRACFLAGS=-fPIC ARRC=ar\ rc
make[1]: Entering directory '/build/imap-2007f'
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ Building in full compliance with RFC 3501 security
+ requirements:
++ TLS/SSL encryption is supported
++ Unencrypted plaintext passwords are prohibited
```
</details>

<details>
<summary>Build after (first 100 lines)</summary>

```
checking outputs of '/nix/store/ccwkqkpdvw7lgnbcl2i7543pj72svam7-agorakit-composer-vendor-1.11.drv'...
Running phase: unpackPhase
unpacking source archive /nix/store/1h13ya4cpapb3bmxlbra1j1yyh57vdyv-source
source root is source
Running phase: patchPhase
Running phase: updateAutotoolsGnuConfigScriptsPhase
Running phase: configurePhase
Running phase: composerVendorConfigureHook
Setting COMPOSER_ROOT_VERSION to 1.11
Found 'composer.lock' in source root.
Finished phase: composerVendorConfigureHook
Running phase: buildPhase
Running phase: composerVendorBuildHook
Setting some required environment variables for Composer...
Installing Composer dependencies to 'vendor'...
Installing dependencies from lock file
Verifying lock file contents can be installed on current platform.
Package operations: 139 installs, 0 updates, 0 removals
  - Downloading php-http/discovery (1.20.0)
  - Downloading carbonphp/carbon-doctrine-types (2.1.0)
  - Downloading voku/portable-ascii (2.0.3)
  - Downloading symfony/polyfill-php80 (v1.31.0)
  - Downloading symfony/polyfill-mbstring (v1.31.0)
  - Downloading symfony/polyfill-ctype (v1.31.0)
  - Downloading phpoption/phpoption (1.9.3)
  - Downloading graham-campbell/result-type (v1.1.3)
  - Downloading vlucas/phpdotenv (v5.6.1)
  - Downloading symfony/css-selector (v7.2.0)
  - Downloading tijsverkoyen/css-to-inline-styles (v2.3.0)
  - Downloading symfony/var-dumper (v7.2.3)
  - Downloading symfony/polyfill-uuid (v1.31.0)
  - Downloading symfony/uid (v7.2.0)
  - Downloading symfony/deprecation-contracts (v3.5.1)
  - Downloading symfony/routing (v7.2.3)
  - Downloading symfony/process (v7.2.5)
  - Downloading symfony/polyfill-php83 (v1.31.0)
  - Downloading symfony/polyfill-intl-normalizer (v1.31.0)
  - Downloading symfony/polyfill-intl-idn (v1.31.0)
  - Downloading symfony/mime (v7.2.4)
  - Downloading psr/container (2.0.2)
  - Downloading symfony/service-contracts (v3.5.1)
  - Downloading psr/event-dispatcher (1.0.0)
  - Downloading symfony/event-dispatcher-contracts (v3.5.1)
  - Downloading symfony/event-dispatcher (v7.2.0)
  - Downloading psr/log (3.0.2)
  - Downloading doctrine/lexer (3.0.1)
  - Downloading egulias/email-validator (4.0.4)
  - Downloading symfony/mailer (v7.2.3)
  - Downloading symfony/http-foundation (v7.2.5)
  - Downloading symfony/error-handler (v7.2.5)
  - Downloading symfony/http-kernel (v7.2.5)
  - Downloading symfony/finder (v7.2.2)
  - Downloading symfony/polyfill-intl-grapheme (v1.31.0)
  - Downloading symfony/string (v7.2.0)
  - Downloading symfony/console (v7.2.5)
  - Downloading ramsey/collection (2.1.1)
  - Downloading brick/math (0.12.3)
  - Downloading ramsey/uuid (4.7.6)
  - Downloading psr/simple-cache (3.0.0)
  - Downloading nunomaduro/termwind (v2.3.0)
  - Downloading symfony/translation-contracts (v3.5.1)
  - Downloading symfony/translation (v7.2.4)
  - Downloading psr/clock (1.0.0)
  - Downloading symfony/clock (v7.2.0)
  - Downloading nesbot/carbon (3.9.0)
  - Downloading monolog/monolog (3.9.0)
  - Downloading psr/http-message (2.0)
  - Downloading psr/http-factory (1.1.0)
  - Downloading league/uri-interfaces (7.5.0)
  - Downloading league/uri (7.5.1)
  - Downloading league/mime-type-detection (1.16.0)
  - Downloading league/flysystem-local (3.29.0)
  - Downloading league/flysystem (3.29.1)
  - Downloading nette/utils (v4.0.6)
  - Downloading nette/schema (v1.3.2)
  - Downloading dflydev/dot-access-data (v3.0.3)
  - Downloading league/config (v1.2.0)
  - Downloading league/commonmark (2.6.1)
  - Downloading laravel/serializable-closure (v2.0.4)
  - Downloading laravel/prompts (v0.3.5)
  - Downloading guzzlehttp/uri-template (v1.0.4)
  - Downloading psr/http-client (1.0.3)
  - Downloading ralouphie/getallheaders (3.0.3)
  - Downloading guzzlehttp/psr7 (2.7.1)
  - Downloading guzzlehttp/promises (2.2.0)
  - Downloading guzzlehttp/guzzle (7.9.3)
  - Downloading fruitcake/php-cors (v1.3.0)
  - Downloading webmozart/assert (1.11.0)
  - Downloading dragonmantank/cron-expression (v3.4.0)
  - Downloading doctrine/inflector (2.0.10)
  - Downloading laravel/framework (v11.44.2)
  - Downloading balping/json-raw-encoder (v1.0.2)
  - Downloading consoletvs/charts (6.8.0)
  - Downloading cocur/slugify (v4.6.0)
  - Downloading cviebrock/eloquent-sluggable (11.0.1)
  - Downloading cviebrock/eloquent-taggable (11.0.2)
  - Downloading symfony/polyfill-iconv (v1.31.0)
  - Downloading ddeboer/imap (1.19.0)
  - Downloading psr/cache (3.0.0)
  - Downloading doctrine/event-manager (2.0.1)
```
</details>


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
