### PR TITLE
php84Packages.box: fix composerVendor hash

### DIFF
--- a/pkgs/development/php-packages/box/default.nix
+++ b/pkgs/development/php-packages/box/default.nix
@@ -16,7 +16,7 @@ php82.buildComposerProject2 (finalAttrs: {
     hash = "sha256-giJAcH2R9hAlUTbwRi7rbmUP+WV8Nfb9XmoHHs4RcbI=";
   };
 
-  vendorHash = "sha256-A/hAw0J4Q3kun6soxI6h7kpyGef9q0EFg8HAQHHZUro=";
+  vendorHash = "sha256-K/mgYRp8vM+PC9AEJDZ9lW/XZkQ+YxHSnEY70VVX9FY=";
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];


### PR DESCRIPTION
Fixes hash mismatch for `php84Packages.box.composerVendor`.

Diff looks similarly enormous just like #475448 .  And, it seems like it changed in a similar way, so maybe the same thing happened?

Build logs:
- [before (6e60047)](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/php84Packages_box/composerVendor.before.log)
- [after (eaebe9c)](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/php84Packages_box/composerVendor.after.log)
- [source diff](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/php84Packages_box/composerVendor.diff.log)

Source directories:
- [old source](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/php84Packages_box/composerVendor.src.before/)
- [new source](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/php84Packages_box/composerVendor.src.after/)

<details>
<summary>Source diff (first 100 lines)</summary>

```
vendor/composer/autoload_classmap.php --- PHP
   1 <?php
   2 
   3 // autoload_classmap.php @generated by Composer
   4 
   5 $vendorDir = dirname(__DIR__);
   6 $baseDir = dirname($vendorDir);
   7 
   8 return array(
   9     'Amp\\ByteStream\\AsyncWriter' => $vendorDir . '/amphp/byte-stream/src/AsyncWriter.php',
  10     'Amp\\ByteStream\\Base64\\Base64DecodingReadableStream' => $vendorDir . '/amphp/byte-stream/src/Base64/Base64DecodingReadableStream.php',
  11     'Amp\\ByteStream\\Base64\\Base64DecodingWritableStream' => $vendorDir . '/amphp/byte-stream/src/Base64/Base64DecodingWritableStream.php',
  12     'Amp\\ByteStream\\Base64\\Base64EncodingReadableStream' => $vendorDir . '/amphp/byte-stream/src/Base64/Base64EncodingReadableStream.php',
  13     'Amp\\ByteStream\\Base64\\Base64EncodingWritableStream' => $vendorDir . '/amphp/byte-stream/src/Base64/Base64EncodingWritableStream.php',
  14     'Amp\\ByteStream\\BufferException' => $vendorDir . '/amphp/byte-stream/src/BufferException.php',
  15     'Amp\\ByteStream\\BufferedReader' => $vendorDir . '/amphp/byte-stream/src/BufferedReader.php',
  16     'Amp\\ByteStream\\ClosedException' => $vendorDir . '/amphp/byte-stream/src/ClosedException.php',
  17     'Amp\\ByteStream\\Compression\\CompressingReadableStream' => $vendorDir . '/amphp/byte-stream/src/Compression/CompressingReadableStream.php',
  18     'Amp\\ByteStream\\Compression\\CompressingWritableStream' => $vendorDir . '/amphp/byte-stream/src/Compression/CompressingWritableStream.php',
  19     'Amp\\ByteStream\\Compression\\DecompressingReadableStream' => $vendorDir . '/amphp/byte-stream/src/Compression/DecompressingReadableStream.php',
  20     'Amp\\ByteStream\\Compression\\DecompressingWritableStream' => $vendorDir . '/amphp/byte-stream/src/Compression/DecompressingWritableStream.php',
  21     'Amp\\ByteStream\\Internal\\ChannelParser' => $vendorDir . '/amphp/byte-stream/src/Internal/ChannelParser.php',
  22     'Amp\\ByteStream\\Payload' => $vendorDir . '/amphp/byte-stream/src/Payload.php',
  23     'Amp\\ByteStream\\PendingReadError' => $vendorDir . '/amphp/byte-stream/src/PendingReadError.php',
  24     'Amp\\ByteStream\\Pipe' => $vendorDir . '/amphp/byte-stream/src/Pipe.php',
  25     'Amp\\ByteStream\\ReadableBuffer' => $vendorDir . '/amphp/byte-stream/src/ReadableBuffer.php',
  26     'Amp\\ByteStream\\ReadableIterableStream' => $vendorDir . '/amphp/byte-stream/src/ReadableIterableStream.php',
  27     'Amp\\ByteStream\\ReadableResourceStream' => $vendorDir . '/amphp/byte-stream/src/ReadableResourceStream.php',
  28     'Amp\\ByteStream\\ReadableStream' => $vendorDir . '/amphp/byte-stream/src/ReadableStream.php',
  29     'Amp\\ByteStream\\ReadableStreamChain' => $vendorDir . '/amphp/byte-stream/src/ReadableStreamChain.php',
  30     'Amp\\ByteStream\\ReadableStreamIteratorAggregate' => $vendorDir . '/amphp/byte-stream/src/ReadableStreamIteratorAggregate.php',
  31     'Amp\\ByteStream\\ResourceStream' => $vendorDir . '/amphp/byte-stream/src/ResourceStream.php',
  32     'Amp\\ByteStream\\StreamChannel' => $vendorDir . '/amphp/byte-stream/src/StreamChannel.php',
  33     'Amp\\ByteStream\\StreamException' => $vendorDir . '/amphp/byte-stream/src/StreamException.php',
  34     'Amp\\ByteStream\\WritableBuffer' => $vendorDir . '/amphp/byte-stream/src/WritableBuffer.php',
  35     'Amp\\ByteStream\\WritableIterableStream' => $vendorDir . '/amphp/byte-stream/src/WritableIterableStream.php',
  36     'Amp\\ByteStream\\WritableResourceStream' => $vendorDir . '/amphp/byte-stream/src/WritableResourceStream.php',
  37     'Amp\\ByteStream\\WritableStream' => $vendorDir . '/amphp/byte-stream/src/WritableStream.php',
  38     'Amp\\Cache\\AtomicCache' => $vendorDir . '/amphp/cache/src/AtomicCache.php',
  39     'Amp\\Cache\\Cache' => $vendorDir . '/amphp/cache/src/Cache.php',
  40     'Amp\\Cache\\CacheException' => $vendorDir . '/amphp/cache/src/CacheException.php',
  41     'Amp\\Cache\\LocalCache' => $vendorDir . '/amphp/cache/src/LocalCache.php',
  42     'Amp\\Cache\\NullCache' => $vendorDir . '/amphp/cache/src/NullCache.php',
  43     'Amp\\Cache\\PrefixCache' => $vendorDir . '/amphp/cache/src/PrefixCache.php',
  44     'Amp\\Cache\\SerializedCache' => $vendorDir . '/amphp/cache/src/SerializedCache.php',
  45     'Amp\\Cache\\StringCache' => $vendorDir . '/amphp/cache/src/StringCache.php',
  46     'Amp\\Cache\\StringCacheAdapter' => $vendorDir . '/amphp/cache/src/StringCacheAdapter.php',
  47     'Amp\\Cancellation' => $vendorDir . '/amphp/amp/src/Cancellation.php',
  48     'Amp\\CancelledException' => $vendorDir . '/amphp/amp/src/CancelledException.php',
  49     'Amp\\Closable' => $vendorDir . '/amphp/amp/src/Closable.php',
  50     'Amp\\CompositeCancellation' => $vendorDir . '/amphp/amp/src/CompositeCancellation.php',
  51     'Amp\\CompositeException' => $vendorDir . '/amphp/amp/src/CompositeException.php',
  52     'Amp\\CompositeLengthException' => $vendorDir . '/amphp/amp/src/CompositeLengthException.php',
  53     'Amp\\DeferredCancellation' => $vendorDir . '/amphp/amp/src/DeferredCancellation.php',
  54     'Amp\\DeferredFuture' => $vendorDir . '/amphp/amp/src/DeferredFuture.php',
  55     'Amp\\Dns\\BlockingFallbackDnsResolver' => $vendorDir . '/amphp/dns/src/BlockingFallbackDnsResolver.php',
  56     'Amp\\Dns\\DnsConfig' => $vendorDir . '/amphp/dns/src/DnsConfig.php',
  57     'Amp\\Dns\\DnsConfigException' => $vendorDir . '/amphp/dns/src/DnsConfigException.php',
  58     'Amp\\Dns\\DnsConfigLoader' => $vendorDir . '/amphp/dns/src/DnsConfigLoader.php',
  59     'Amp\\Dns\\DnsException' => $vendorDir . '/amphp/dns/src/DnsException.php',
  60     'Amp\\Dns\\DnsRecord' => $vendorDir . '/amphp/dns/src/DnsRecord.php',
  61     'Amp\\Dns\\DnsResolver' => $vendorDir . '/amphp/dns/src/DnsResolver.php',
  62     'Amp\\Dns\\DnsTimeoutException' => $vendorDir . '/amphp/dns/src/DnsTimeoutException.php',
  63     'Amp\\Dns\\HostLoader' => $vendorDir . '/amphp/dns/src/HostLoader.php',
  64     'Amp\\Dns\\Internal\\Socket' => $vendorDir . '/amphp/dns/src/Internal/Socket.php',
  65     'Amp\\Dns\\Internal\\TcpSocket' => $vendorDir . '/amphp/dns/src/Internal/TcpSocket.php',
  66     'Amp\\Dns\\Internal\\UdpSocket' => $vendorDir . '/amphp/dns/src/Internal/UdpSocket.php',
  67     'Amp\\Dns\\InvalidNameException' => $vendorDir . '/amphp/dns/src/InvalidNameException.php',
  68     'Amp\\Dns\\MissingDnsRecordException' => $vendorDir . '/amphp/dns/src/MissingDnsRecordException.php',
  69     'Amp\\Dns\\Rfc1035StubDnsResolver' => $vendorDir . '/amphp/dns/src/Rfc1035StubDnsResolver.php',
  70     'Amp\\Dns\\StaticDnsConfigLoader' => $vendorDir . '/amphp/dns/src/StaticDnsConfigLoader.php',
  71     'Amp\\Dns\\UnixDnsConfigLoader' => $vendorDir . '/amphp/dns/src/UnixDnsConfigLoader.php',
  72     'Amp\\Dns\\WindowsDnsConfigLoader' => $vendorDir . '/amphp/dns/src/WindowsDnsConfigLoader.php',
  73     'Amp\\ForbidCloning' => $vendorDir . '/amphp/amp/src/ForbidCloning.php',
  74     'Amp\\ForbidSerialization' => $vendorDir . '/amphp/amp/src/ForbidSerialization.php',
  75     'Amp\\Future' => $vendorDir . '/amphp/amp/src/Future.php',
  76     'Amp\\Future\\UnhandledFutureError' => $vendorDir . '/amphp/amp/src/Future/UnhandledFutureError.php',
  77     'Amp\\Internal\\Cancellable' => $vendorDir . '/amphp/amp/src/Internal/Cancellable.php',
  78     'Amp\\Internal\\FutureIterator' => $vendorDir . '/amphp/amp/src/Internal/FutureIterator.php',
  79     'Amp\\Internal\\FutureIteratorQueue' => $vendorDir . '/amphp/amp/src/Internal/FutureIteratorQueue.php',
  80     'Amp\\Internal\\FutureState' => $vendorDir . '/amphp/amp/src/Internal/FutureState.php',
  81     'Amp\\Internal\\WrappedCancellation' => $vendorDir . '/amphp/amp/src/Internal/WrappedCancellation.php',
  82     'Amp\\Interval' => $vendorDir . '/amphp/amp/src/Interval.php',
  83     'Amp\\NullCancellation' => $vendorDir . '/amphp/amp/src/NullCancellation.php',
  84     'Amp\\Parallel\\Context\\Context' => $vendorDir . '/amphp/parallel/src/Context/Context.php',
  85     'Amp\\Parallel\\Context\\ContextException' => $vendorDir . '/amphp/parallel/src/Context/ContextException.php',
  86     'Amp\\Parallel\\Context\\ContextFactory' => $vendorDir . '/amphp/parallel/src/Context/ContextFactory.php',
  87     'Amp\\Parallel\\Context\\ContextPanicError' => $vendorDir . '/amphp/parallel/src/Context/ContextPanicError.php',
  88     'Amp\\Parallel\\Context\\DefaultContextFactory' => $vendorDir . '/amphp/parallel/src/Context/DefaultContextFactory.php',
  89     'Amp\\Parallel\\Context\\Internal\\AbstractContext' => $vendorDir . '/amphp/parallel/src/Context/Internal/AbstractContext.php',
  90     'Amp\\Parallel\\Context\\Internal\\ContextChannel' => $vendorDir . '/amphp/parallel/src/Context/Internal/ContextChannel.php',
  91     'Amp\\Parallel\\Context\\Internal\\ContextException' => $vendorDir . '/amphp/parallel/src/Context/Internal/ContextException.php',
  92     'Amp\\Parallel\\Context\\Internal\\ContextMessage' => $vendorDir . '/amphp/parallel/src/Context/Internal/ContextMessage.php',
  93     'Amp\\Parallel\\Context\\Internal\\ExitFailure' => $vendorDir . '/amphp/parallel/src/Context/Internal/ExitFailure.php',
  94     'Amp\\Parallel\\Context\\Internal\\ExitResult' => $vendorDir . '/amphp/parallel/src/Context/Internal/ExitResult.php',
  95     'Amp\\Parallel\\Context\\Internal\\ExitSuccess' => $vendorDir . '/amphp/parallel/src/Context/Internal/ExitSuccess.php',
  96     'Amp\\Parallel\\Context\\Internal\\ParallelHub' => $vendorDir . '/amphp/parallel/src/Context/Internal/ParallelHub.php',
  97     'Amp\\Parallel\\Context\\ProcessContext' => $vendorDir . '/amphp/parallel/src/Context/ProcessContext.php',
  98     'Amp\\Parallel\\Context\\ProcessContextFactory' => $vendorDir . '/amphp/parallel/src/Context/ProcessContextFactory.php',
  99     'Amp\\Parallel\\Context\\StatusError' => $vendorDir . '/amphp/parallel/src/Context/StatusError.php',
```
</details>

<details>
<summary>Build before (first 100 lines)</summary>

```
this derivation will be built:
  /nix/store/fy014lghvvf48rm93q8zs93bgr7kb04n-box-composer-vendor-4.6.6.drv
building '/nix/store/fy014lghvvf48rm93q8zs93bgr7kb04n-box-composer-vendor-4.6.6.drv'...
Running phase: unpackPhase
unpacking source archive /nix/store/xch1z7gfiw67d9dizv3vj1w1ml03fngp-source
source root is source
Running phase: patchPhase
Running phase: updateAutotoolsGnuConfigScriptsPhase
Running phase: configurePhase
Running phase: composerVendorConfigureHook
Setting COMPOSER_ROOT_VERSION to 4.6.6
Found 'composer.lock' in source root.
Finished phase: composerVendorConfigureHook
Running phase: buildPhase
Running phase: composerVendorBuildHook
Setting some required environment variables for Composer...
Installing Composer dependencies to 'vendor'...
Installing dependencies from lock file
Verifying lock file contents can be installed on current platform.
Package operations: 56 installs, 0 updates, 0 removals
  - Downloading revolt/event-loop (v1.0.7)
  - Downloading amphp/serialization (v1.0.0)
  - Downloading amphp/amp (v3.1.0)
  - Downloading amphp/pipeline (v1.2.2)
  - Downloading amphp/sync (v2.3.0)
  - Downloading psr/http-message (2.0)
  - Downloading psr/http-factory (1.1.0)
  - Downloading league/uri-interfaces (7.5.0)
  - Downloading league/uri (7.5.1)
  - Downloading kelunik/certificate (v1.1.3)
  - Downloading symfony/polyfill-ctype (v1.31.0)
  - Downloading daverandom/libdns (v2.1.0)
  - Downloading amphp/parser (v1.1.1)
  - Downloading amphp/byte-stream (v2.1.1)
  - Downloading amphp/process (v2.0.3)
  - Downloading amphp/cache (v2.0.1)
  - Downloading amphp/dns (v2.4.0)
  - Downloading amphp/socket (v2.3.1)
  - Downloading amphp/parallel (v2.3.1)
  - Downloading composer/semver (3.4.3)
  - Downloading psr/log (3.0.2)
  - Downloading composer/pcre (3.3.2)
  - Downloading composer/xdebug-handler (3.0.5)
  - Downloading thecodingmachine/safe (v3.0.2)
  - Downloading symfony/polyfill-mbstring (v1.31.0)
  - Downloading symfony/var-dumper (v7.2.3)
  - Downloading symfony/finder (v7.2.2)
  - Downloading symfony/filesystem (v7.2.0)
  - Downloading symfony/polyfill-intl-normalizer (v1.31.0)
  - Downloading symfony/polyfill-intl-grapheme (v1.31.0)
  - Downloading symfony/string (v7.2.0)
  - Downloading symfony/deprecation-contracts (v3.5.1)
  - Downloading psr/container (2.0.2)
  - Downloading symfony/service-contracts (v3.5.1)
  - Downloading symfony/console (v7.2.1)
  - Downloading nikic/php-parser (v5.4.0)
  - Downloading jetbrains/phpstorm-stubs (v2024.3)
  - Downloading fidry/filesystem (1.2.3)
  - Downloading webmozart/assert (1.11.0)
  - Downloading symfony/polyfill-php84 (v1.31.0)
  - Downloading psr/event-dispatcher (1.0.0)
  - Downloading symfony/event-dispatcher-contracts (v3.5.1)
  - Downloading fidry/console (0.6.11)
  - Downloading humbug/php-scoper (0.18.17)
  - Downloading justinrainbow/json-schema (5.3.0)
  - Downloading nikic/iter (v2.4.1)
  - Downloading phpstan/phpdoc-parser (2.1.0)
  - Downloading phpdocumentor/reflection-common (2.2.0)
  - Downloading doctrine/deprecations (1.1.4)
  - Downloading phpdocumentor/type-resolver (1.10.0)
  - Downloading phpdocumentor/reflection-docblock (5.6.1)
  - Downloading sebastian/diff (5.1.1)
  - Downloading seld/jsonlint (1.11.0)
  - Downloading seld/phar-utils (1.2.1)
  - Downloading symfony/polyfill-iconv (v1.31.0)
  - Downloading symfony/process (v7.2.4)
  - Installing revolt/event-loop (v1.0.7): Extracting archive
  - Installing amphp/serialization (v1.0.0): Extracting archive
  - Installing amphp/amp (v3.1.0): Extracting archive
  - Installing amphp/pipeline (v1.2.2): Extracting archive
  - Installing amphp/sync (v2.3.0): Extracting archive
  - Installing psr/http-message (2.0): Extracting archive
  - Installing psr/http-factory (1.1.0): Extracting archive
  - Installing league/uri-interfaces (7.5.0): Extracting archive
  - Installing league/uri (7.5.1): Extracting archive
  - Installing kelunik/certificate (v1.1.3): Extracting archive
  - Installing symfony/polyfill-ctype (v1.31.0): Extracting archive
  - Installing daverandom/libdns (v2.1.0): Extracting archive
  - Installing amphp/parser (v1.1.1): Extracting archive
  - Installing amphp/byte-stream (v2.1.1): Extracting archive
  - Installing amphp/process (v2.0.3): Extracting archive
  - Installing amphp/cache (v2.0.1): Extracting archive
  - Installing amphp/dns (v2.4.0): Extracting archive
  - Installing amphp/socket (v2.3.1): Extracting archive
  - Installing amphp/parallel (v2.3.1): Extracting archive
  - Installing composer/semver (3.4.3): Extracting archive
  - Installing psr/log (3.0.2): Extracting archive
  - Installing composer/pcre (3.3.2): Extracting archive
  - Installing composer/xdebug-handler (3.0.5): Extracting archive
  - Installing thecodingmachine/safe (v3.0.2): Extracting archive
```
</details>

<details>
<summary>Build after (first 100 lines)</summary>

```
checking outputs of '/nix/store/bcpqwc7gvbprr1vlvz2a63c0hhd100l7-box-composer-vendor-4.6.6.drv'...
Running phase: unpackPhase
unpacking source archive /nix/store/xch1z7gfiw67d9dizv3vj1w1ml03fngp-source
source root is source
Running phase: patchPhase
Running phase: updateAutotoolsGnuConfigScriptsPhase
Running phase: configurePhase
Running phase: composerVendorConfigureHook
Setting COMPOSER_ROOT_VERSION to 4.6.6
Found 'composer.lock' in source root.
Finished phase: composerVendorConfigureHook
Running phase: buildPhase
Running phase: composerVendorBuildHook
Setting some required environment variables for Composer...
Installing Composer dependencies to 'vendor'...
Installing dependencies from lock file
Verifying lock file contents can be installed on current platform.
Package operations: 56 installs, 0 updates, 0 removals
  - Downloading revolt/event-loop (v1.0.7)
  - Downloading amphp/serialization (v1.0.0)
  - Downloading amphp/amp (v3.1.0)
  - Downloading amphp/pipeline (v1.2.2)
  - Downloading amphp/sync (v2.3.0)
  - Downloading psr/http-message (2.0)
  - Downloading psr/http-factory (1.1.0)
  - Downloading league/uri-interfaces (7.5.0)
  - Downloading league/uri (7.5.1)
  - Downloading kelunik/certificate (v1.1.3)
  - Downloading symfony/polyfill-ctype (v1.31.0)
  - Downloading daverandom/libdns (v2.1.0)
  - Downloading amphp/parser (v1.1.1)
  - Downloading amphp/byte-stream (v2.1.1)
  - Downloading amphp/process (v2.0.3)
  - Downloading amphp/cache (v2.0.1)
  - Downloading amphp/dns (v2.4.0)
  - Downloading amphp/socket (v2.3.1)
  - Downloading amphp/parallel (v2.3.1)
  - Downloading composer/semver (3.4.3)
  - Downloading psr/log (3.0.2)
  - Downloading composer/pcre (3.3.2)
  - Downloading composer/xdebug-handler (3.0.5)
  - Downloading thecodingmachine/safe (v3.0.2)
  - Downloading symfony/polyfill-mbstring (v1.31.0)
  - Downloading symfony/var-dumper (v7.2.3)
  - Downloading symfony/finder (v7.2.2)
  - Downloading symfony/filesystem (v7.2.0)
  - Downloading symfony/polyfill-intl-normalizer (v1.31.0)
  - Downloading symfony/polyfill-intl-grapheme (v1.31.0)
  - Downloading symfony/string (v7.2.0)
  - Downloading symfony/deprecation-contracts (v3.5.1)
  - Downloading psr/container (2.0.2)
  - Downloading symfony/service-contracts (v3.5.1)
  - Downloading symfony/console (v7.2.1)
  - Downloading nikic/php-parser (v5.4.0)
  - Downloading jetbrains/phpstorm-stubs (v2024.3)
  - Downloading fidry/filesystem (1.2.3)
  - Downloading webmozart/assert (1.11.0)
  - Downloading symfony/polyfill-php84 (v1.31.0)
  - Downloading psr/event-dispatcher (1.0.0)
  - Downloading symfony/event-dispatcher-contracts (v3.5.1)
  - Downloading fidry/console (0.6.11)
  - Downloading humbug/php-scoper (0.18.17)
  - Downloading justinrainbow/json-schema (5.3.0)
  - Downloading nikic/iter (v2.4.1)
  - Downloading phpstan/phpdoc-parser (2.1.0)
  - Downloading phpdocumentor/reflection-common (2.2.0)
  - Downloading doctrine/deprecations (1.1.4)
  - Downloading phpdocumentor/type-resolver (1.10.0)
  - Downloading phpdocumentor/reflection-docblock (5.6.1)
  - Downloading sebastian/diff (5.1.1)
  - Downloading seld/jsonlint (1.11.0)
  - Downloading seld/phar-utils (1.2.1)
  - Downloading symfony/polyfill-iconv (v1.31.0)
  - Downloading symfony/process (v7.2.4)
  - Installing revolt/event-loop (v1.0.7): Extracting archive
  - Installing amphp/serialization (v1.0.0): Extracting archive
  - Installing amphp/amp (v3.1.0): Extracting archive
  - Installing amphp/pipeline (v1.2.2): Extracting archive
  - Installing amphp/sync (v2.3.0): Extracting archive
  - Installing psr/http-message (2.0): Extracting archive
  - Installing psr/http-factory (1.1.0): Extracting archive
  - Installing league/uri-interfaces (7.5.0): Extracting archive
  - Installing league/uri (7.5.1): Extracting archive
  - Installing kelunik/certificate (v1.1.3): Extracting archive
  - Installing symfony/polyfill-ctype (v1.31.0): Extracting archive
  - Installing daverandom/libdns (v2.1.0): Extracting archive
  - Installing amphp/parser (v1.1.1): Extracting archive
  - Installing amphp/byte-stream (v2.1.1): Extracting archive
  - Installing amphp/process (v2.0.3): Extracting archive
  - Installing amphp/cache (v2.0.1): Extracting archive
  - Installing amphp/dns (v2.4.0): Extracting archive
  - Installing amphp/socket (v2.3.1): Extracting archive
  - Installing amphp/parallel (v2.3.1): Extracting archive
  - Installing composer/semver (3.4.3): Extracting archive
  - Installing psr/log (3.0.2): Extracting archive
  - Installing composer/pcre (3.3.2): Extracting archive
  - Installing composer/xdebug-handler (3.0.5): Extracting archive
  - Installing thecodingmachine/safe (v3.0.2): Extracting archive
  - Installing symfony/polyfill-mbstring (v1.31.0): Extracting archive
  - Installing symfony/var-dumper (v7.2.3): Extracting archive
```
</details>


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
