### PR TITLE
nixos/udev: Copy dmi_memory_id only if installed

### DIFF
--- a/nixos/modules/services/hardware/udev.nix
+++ b/nixos/modules/services/hardware/udev.nix
@@ -462,10 +462,17 @@ in
       "${config.boot.initrd.systemd.package}/lib/systemd/systemd-udevd"
       "${config.boot.initrd.systemd.package}/lib/udev/ata_id"
       "${config.boot.initrd.systemd.package}/lib/udev/cdrom_id"
-      "${config.boot.initrd.systemd.package}/lib/udev/dmi_memory_id"
       "${config.boot.initrd.systemd.package}/lib/udev/scsi_id"
       "${config.boot.initrd.systemd.package}/lib/udev/rules.d"
     ]
+    ++ lib.optional (
+      # https://github.com/systemd/systemd/blob/v259/meson.build#L1529-L1530
+      pkgs.stdenv.hostPlatform.isx86
+      || pkgs.stdenv.hostPlatform.isAarch
+      || pkgs.stdenv.hostPlatform.isLoongArch64
+      || pkgs.stdenv.hostPlatform.isMips
+      || pkgs.stdenv.hostPlatform.isRiscV64
+    ) "${config.boot.initrd.systemd.package}/lib/udev/dmi_memory_id"
     ++ map (x: "${x}/bin") config.boot.initrd.services.udev.binPackages;
 
     # Generate the udev rules for the initrd


### PR DESCRIPTION
This tool is only built on certain architectures that systemd [enumerates as supporting DMI][1]. Notably, this excludes POWER.

[1]: https://github.com/systemd/systemd/blob/v259/meson.build#L1529-L1530

This resolves the following error when building the initrd on a POWER system:
```
Error: failed to get symlink metadata for "/nix/store/4ns9ypfiryqjxxwdzkycb1j5vz3bs1fw-systemd-258.2/lib/udev/dmi_memory_id"

Caused by:
    No such file or directory (os error 2)

Location:
    src/main.rs:244:22
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [x] powerpc64le-linux-musl
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
