### PR TITLE
php83Packages.phing: fix composerVendor hash

### DIFF
--- a/pkgs/development/php-packages/phing/default.nix
+++ b/pkgs/development/php-packages/phing/default.nix
@@ -17,7 +17,7 @@
       hash = "sha256-gY6ocmkd7eJIMaBrewfxYL7gTr+1qNHTkuAp+w9ApUU=";
     };
 
-    vendorHash = "sha256-zrHOw7Uyq8H7AyxrfCo5VthX1EeoSB44ynrRt38u3Sk=";
+    vendorHash = "sha256-yfGfMAQGlXnCoww4rtynknL7qDjcQFEM8p8FbsIqJZU=";
 
     nativeInstallCheckInputs = [
       versionCheckHook


### PR DESCRIPTION
Fixes hash mismatch for `php83Packages.phing.composerVendor`

Very similar to #475449 or #475448 in terms of diff.

Build logs:
- [before (fe707b4)](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/php83Packages_phing/composerVendor.before.log)
- [after (aef176e)](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/php83Packages_phing/composerVendor.after.log)
- [source diff](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/php83Packages_phing/composerVendor.diff.log)

Source directories:
- [old source](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/php83Packages_phing/composerVendor.src.before/)
- [new source](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/php83Packages_phing/composerVendor.src.after/)

<details>
<summary>Source diff (first 100 lines)</summary>

```
vendor/composer/LICENSE --- Text
 1 Copyright (c) Nils Adermann, Jordi Boggiano
 2 
 3 Permission is hereby granted, free of charge, to any person obtaining a copy
 4 of this software and associated documentation files (the "Software"), to deal
 5 in the Software without restriction, including without limitation the rights
 6 to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 7 copies of the Software, and to permit persons to whom the Software is furnished
 8 to do so, subject to the following conditions:
 9 
10 The above copyright notice and this permission notice shall be included in all
11 copies or substantial portions of the Software.
12 
13 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
14 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
15 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
16 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
17 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
18 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
19 THE SOFTWARE.
20 

vendor/bin/yaml-lint --- Text
  1 #!/usr/bin/env php
  2 <?php
  3 
  4 /**
  5  * Proxy PHP file generated by Composer
  6  *
  7  * This file includes the referenced bin path (../symfony/yaml/Resources/bin/yaml-lint)
  8  * using a stream wrapper to prevent the shebang from being output on PHP<8
  9  *
 10  * @generated
 11  */
 12 
 13 namespace Composer;
 14 
 15 $GLOBALS['_composer_bin_dir'] = __DIR__;
 16 $GLOBALS['_composer_autoload_path'] = __DIR__ . '/..'.'/autoload.php';
 17 
 18 if (PHP_VERSION_ID < 80000) {
 19     if (!class_exists('Composer\BinProxyWrapper')) {
 20         /**
 21          * @internal
 22          */
 23         final class BinProxyWrapper
 24         {
 25             private $handle;
 26             private $position;
 27             private $realpath;
 28 
 29             public function stream_open($path, $mode, $options, &$opened_path)
 30             {
 31                 // get rid of phpvfscomposer:// prefix for __FILE__ & __DIR__ resolution
 32                 $opened_path = substr($path, 17);
 33                 $this->realpath = realpath($opened_path) ?: $opened_path;
 34                 $opened_path = $this->realpath;
 35                 $this->handle = fopen($this->realpath, $mode);
 36                 $this->position = 0;
 37 
 38                 return (bool) $this->handle;
 39             }
 40 
 41             public function stream_read($count)
 42             {
 43                 $data = fread($this->handle, $count);
 44 
 45                 if ($this->position === 0) {
 46                     $data = preg_replace('{^#!.*\r?\n}', '', $data);
 47                 }
 48 
 49                 $this->position += strlen($data);
 50 
 51                 return $data;
 52             }
 53 
 54             public function stream_cast($castAs)
 55             {
 56                 return $this->handle;
 57             }
 58 
 59             public function stream_close()
 60             {
 61                 fclose($this->handle);
 62             }
 63 
 64             public function stream_lock($operation)
 65             {
 66                 return $operation ? flock($this->handle, $operation) : true;
 67             }
 68 
 69             public function stream_seek($offset, $whence)
 70             {
 71                 if (0 === fseek($this->handle, $offset, $whence)) {
 72                     $this->position = ftell($this->handle);
 73                     return true;
 74                 }
 75 
 76                 return false;
 77             }
```
</details>

<details>
<summary>Build before (first 100 lines)</summary>

```
these 52 derivations will be built:
  /nix/store/4ns1vsah40vlcm99m9rb1s3qk13bf2gw-php-8.3.29.tar.bz2.drv
  /nix/store/cicqzg33dw39f3vqnswba3w8a7fd645l-php-8.3.29.drv
  /nix/store/177yzr1bqa2lhgg59yynisvbg3lm6nzq-php-pgsql-8.3.29.drv
  /nix/store/19fzmq95sjx267cm5q6w7d7c3r6dbkqb-php-intl-8.3.29.drv
  /nix/store/19q14gy6nyri7krzbylc5ibkgj379qmr-php-sodium-8.3.29.drv
  /nix/store/1lfd848qj8dkak6fjdw1prx7jch79rx9-php-iconv-8.3.29.drv
  /nix/store/1xqam9qv6ayml5mdr1q4wa8yii7v1k1c-php-session-8.3.29.drv
  /nix/store/4rjq3zzqby2ca73hmvl7v85b7a82n4yk-php-sqlite3-8.3.29.drv
  /nix/store/5bjxhvdhjw6whxbrr4bgspk35bap99gh-php-dom-8.3.29.drv
  /nix/store/6fqgahb9xciilx77dg046r02y0fp233d-php-openssl-8.3.29.drv
  /nix/store/8ayfa5af47d54217ms2iyhn552w2wfqv-php-calendar-8.3.29.drv
  /nix/store/8cqb9a9bsjap8nxpg4scka29wc78yhwp-php-zlib-8.3.29.drv
  /nix/store/8iaicm77z9zpk5c4azd0dmwz4333i1il-php-pcntl-8.3.29.drv
  /nix/store/8nplfzgkzf3mak426clbw8bk2jnkckx2-php-gmp-8.3.29.drv
  /nix/store/9hg5c0mbshh8za745dzk1kb8cgrb2f2z-php-ldap-8.3.29.drv
  /nix/store/an0h79a4vc0ynj20y77n0m2m2m2rgsyi-php-pdo-8.3.29.drv
  /nix/store/andmbmm1lgi3m0yq9nl34gqivxxjw6ch-php-sysvsem-8.3.29.drv
  /nix/store/bzwhk24xhs58hljcdih5q7ay8ca2sq2p-php-zip-8.3.29.drv
  /nix/store/ci29k1xp8iiif033zz36i9wp0zzv7yg4-php-pdo_pgsql-8.3.29.drv
  /nix/store/fm7k80av73aa4v9khbs0w9g3v50bfp9p-php-tokenizer-8.3.29.drv
  /nix/store/g9dipf6jbmy26q5p5izc9hidb7va4xkp-php-sockets-8.3.29.drv
  /nix/store/gqih1lx7qhz5xndk2l946dz8cdnz5rg7-php-gettext-8.3.29.drv
  /nix/store/gv3jhbik155j200c04i9mif8wx3nqywh-php-imap-1.0.2.drv
  /nix/store/h04f2mkgdpx4an6wl0wr2ih1w8chjbma-php-soap-8.3.29.drv
  /nix/store/hcf6jnamrfw97rbsg5vckzq1a335vhsk-php-pdo_odbc-8.3.29.drv
  /nix/store/hgxqaagbkc7rpvdv5k9b5jd2pccfnlxj-php-opcache-8.3.29.drv
  /nix/store/5kjphasir645kv08ih1hy26z7dag7ql6-libxslt-1.1.45.tar.xz.drv
  /nix/store/as550acnjd5y3gqyd43d69zx1pi0npnz-libxslt-1.1.45.drv
  /nix/store/hzxa4rq0r2vn2j4kx6ch4dy339ssr4n6-php-xsl-8.3.29.drv
  /nix/store/phjiasaz3x0ymgqwyfx1i8rafnx8s35c-php-mysqlnd-8.3.29.drv
  /nix/store/jl608nym5gr5vdcwz2yzaz4cgfhpiicr-php-pdo_mysql-8.3.29.drv
  /nix/store/kpc4hzsyw0n6mqc5clanyxb248ir2b9y-php-exif-8.3.29.drv
  /nix/store/l4qb9prh09n1shj75nbbkfxa9fv7vrsq-php-xmlreader-8.3.29.drv
  /nix/store/miqgy2r246jlb6vy5b6xndmww1rkp66j-php-filter-8.3.29.drv
  /nix/store/p04vns7zp38gjfhl18apq2lrfigak40h-php-ctype-8.3.29.drv
  /nix/store/rnmrjy8gm4r3fhl47hcxp6sgnk28cawd-php-mysqli-8.3.29.drv
  /nix/store/vqaxn0r7mhmahpxg5jimnrps3iqrhlpl-php-curl-8.3.29.drv
  /nix/store/vvbjrdrdi6n32vjlarjs4vk3p8srycbd-php-posix-8.3.29.drv
  /nix/store/vysns29hl2xspk160klfh17bg9qvcc0x-php-ftp-8.3.29.drv
  /nix/store/w70znbfbiw0wcayfcaw2a3l5h58n6l9y-php-pdo_sqlite-8.3.29.drv
  /nix/store/wdyzqva661g8a5dg6gzzsy7vrkmpv986-php-xmlwriter-8.3.29.drv
  /nix/store/xgfr34k84r4pz6pxph0z6svi1jb9dzwv-php-gd-8.3.29.drv
  /nix/store/xz5i25hc8vswi4k44qcfdzjg7p7y5ihn-php-bcmath-8.3.29.drv
  /nix/store/yag7yg5iprwydnvv9ayhr5ww76v0d9v6-php-mbstring-8.3.29.drv
  /nix/store/yyqz9ldp9rd3mwaw7w71mjnrxha69sjr-php-fileinfo-8.3.29.drv
  /nix/store/zs9ir391c74qjda87m5kbrmcxlv6ym2b-php-simplexml-8.3.29.drv
  /nix/store/zwyyqyyrzayd4x5fyfdsf13f6cy5n9dw-php-readline-8.3.29.drv
  /nix/store/nnpcn3fxvgds2zg159a9kyb8bgf1marz-php-extra-init-8.3.29.ini.drv
  /nix/store/mk72passa8ml5ad3mmc2y3vkq7skmqwm-php-with-extensions-8.3.29.drv
  /nix/store/3dd8nahxjmbm1c10r75v2ikjgh8n53wq-composer-phar-2.9.2.drv
  /nix/store/hzs66myhrppy1afwqmzyr04zl830j8vw-composer-2.9.2.drv
  /nix/store/yickq922xgjdsai4rr9wyd8sx2vkmk8w-phing-composer-vendor-3.1.0.drv
building '/nix/store/4ns1vsah40vlcm99m9rb1s3qk13bf2gw-php-8.3.29.tar.bz2.drv'...
building '/nix/store/5kjphasir645kv08ih1hy26z7dag7ql6-libxslt-1.1.45.tar.xz.drv'...
structuredAttrs is enabled
structuredAttrs is enabled

trying https://www.php.net/distributions/php-8.3.29.tar.bz2
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

trying https://download.gnome.org/sources/libxslt/1.1/libxslt-1.1.45.tar.xz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1484k 100  1484k   0     0  3949k     0  --:--:-- --:--:-- --:--:--  3958k
building '/nix/store/as550acnjd5y3gqyd43d69zx1pi0npnz-libxslt-1.1.45.drv'...
Running phase: unpackPhase
unpacking source archive /nix/store/wgfnwj03869aypv2r5xylq7b7vqvvaz7-libxslt-1.1.45.tar.xz
source root is libxslt-1.1.45
setting SOURCE_DATE_EPOCH to timestamp 1764486005 of file "libxslt-1.1.45/libxslt/libxslt.syms"
Running phase: patchPhase
applying patch /nix/store/id4ng0365zcsav1lx4zh7q3bdqgw0vnh-77-Use-a-dedicated-node-type-to-maintain-the-list-of-cached-rv-ts.patch
patching file libxslt/transform.c
Hunk #1 succeeded at 519 (offset 1 line).
Hunk #2 succeeded at 2265 (offset 1 line).
Hunk #3 succeeded at 2322 (offset 1 line).
Hunk #4 succeeded at 2368 (offset 1 line).
Hunk #5 succeeded at 2602 (offset 1 line).
Hunk #6 succeeded at 2697 (offset 1 line).
Hunk #7 succeeded at 2763 (offset 1 line).
Hunk #8 succeeded at 2893 (offset 1 line).
Hunk #9 succeeded at 3072 (offset 1 line).
Hunk #10 succeeded at 3120 (offset 1 line).
Hunk #11 succeeded at 3232 (offset 1 line).
Hunk #12 succeeded at 5319 (offset 1 line).
Hunk #13 succeeded at 5327 (offset 1 line).
patching file libxslt/variables.c
Hunk #17 succeeded at 2435 (offset 11 lines).
patching file libxslt/xsltInternals.h
Running phase: autoreconfPhase
autoreconf: export WARNINGS=
autoreconf: Entering directory '.'
autoreconf: configure.ac: not using Gettext
autoreconf: running: aclocal --force -I m4
autoreconf: configure.ac: tracing
autoreconf: running: libtoolize --copy --force
libtoolize: putting auxiliary files in '.'.
libtoolize: copying file './ltmain.sh'
libtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'm4'.
```
</details>

<details>
<summary>Build after</summary>

```
checking outputs of '/nix/store/c142c0wj5shsh8sk7l1lhkz8l0afaspp-phing-composer-vendor-3.1.0.drv'...
Running phase: unpackPhase
unpacking source archive /nix/store/w1zbw95g3p19vjv545rm5778w1f369mc-phing
source root is phing
Running phase: patchPhase
Running phase: updateAutotoolsGnuConfigScriptsPhase
Running phase: configurePhase
Running phase: composerVendorConfigureHook
Setting COMPOSER_ROOT_VERSION to 3.1.0
Found 'composer.lock' in source root.
Finished phase: composerVendorConfigureHook
Running phase: buildPhase
Running phase: composerVendorBuildHook
Setting some required environment variables for Composer...
Installing Composer dependencies to 'vendor'...
Installing dependencies from lock file
Verifying lock file contents can be installed on current platform.
Package operations: 12 installs, 0 updates, 0 removals
  - Downloading sebastian/version (3.0.2)
  - Downloading symfony/polyfill-mbstring (v1.32.0)
  - Downloading symfony/polyfill-intl-normalizer (v1.32.0)
  - Downloading symfony/polyfill-intl-grapheme (v1.32.0)
  - Downloading symfony/polyfill-ctype (v1.32.0)
  - Downloading symfony/string (v6.4.21)
  - Downloading symfony/deprecation-contracts (v3.6.0)
  - Downloading psr/container (2.0.2)
  - Downloading symfony/service-contracts (v3.6.0)
  - Downloading symfony/console (v6.4.23)
  - Downloading symfony/filesystem (v6.4.13)
  - Downloading symfony/yaml (v6.4.23)
  - Installing sebastian/version (3.0.2): Extracting archive
  - Installing symfony/polyfill-mbstring (v1.32.0): Extracting archive
  - Installing symfony/polyfill-intl-normalizer (v1.32.0): Extracting archive
  - Installing symfony/polyfill-intl-grapheme (v1.32.0): Extracting archive
  - Installing symfony/polyfill-ctype (v1.32.0): Extracting archive
  - Installing symfony/string (v6.4.21): Extracting archive
  - Installing symfony/deprecation-contracts (v3.6.0): Extracting archive
  - Installing psr/container (2.0.2): Extracting archive
  - Installing symfony/service-contracts (v3.6.0): Extracting archive
  - Installing symfony/console (v6.4.23): Extracting archive
  - Installing symfony/filesystem (v6.4.13): Extracting archive
  - Installing symfony/yaml (v6.4.23): Extracting archive
Cleaning up Composer 'bin' directory (will be regenerated during install).
Finished phase: composerVendorBuildHook
Running phase: checkPhase
Running phase: composerVendorCheckHook
Finished phase: composerVendorCheckHook
Running phase: installPhase
Running phase: composerVendorInstallHook
Preserving Composer vendor directory from 'vendor'...
Finished phase: composerVendorInstallHook
Running phase: fixupPhase
shrinking RPATHs of ELF executables and libraries in /nix/store/33ww5s2pa4llqd6kyfnmsm7nj90a9yir-phing-composer-vendor-3.1.0
checking for references to /build/ in /nix/store/33ww5s2pa4llqd6kyfnmsm7nj90a9yir-phing-composer-vendor-3.1.0...
/nix/store/33ww5s2pa4llqd6kyfnmsm7nj90a9yir-phing-composer-vendor-3.1.0
```
</details>


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
