### PR TITLE
gol: fix fetchedMavenDeps hash

### DIFF
--- a/pkgs/by-name/go/gol/package.nix
+++ b/pkgs/by-name/go/gol/package.nix
@@ -17,7 +17,7 @@ maven.buildMavenPackage rec {
     hash = "sha256-AnPm5Mooww9kAMWLnM36z8DVRGfIIEiqUE65tgNuKm8=";
   };
 
-  mvnHash = "sha256-YD28YX0RKuxOEWuK12ToOnFFrUPqA9xZ+EmsCt1fDPI=";
+  mvnHash = "sha256-0FxPSrEJqonxti0whkJeFMmWdG0ydLLUvM8b8txCwJA=";
   mvnParameters = "compile assembly:single -Dmaven.test.skip=true";
 
   nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
Fixes hash mismatch for `gol.fetchedMavenDeps`.

Pretty big diff. I don't see anything immediately wrong with it. I'm also not sure *why* it changed.

Build logs:
- [before (5830d8d)](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/gol/fetchedMavenDeps.before.log)
- [after (047f1e1)](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/gol/fetchedMavenDeps.after.log)
- [source diff](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/gol/fetchedMavenDeps.diff.log)

Source directories:
- [old source](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/gol/fetchedMavenDeps.src.before/)
- [new source](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/gol/fetchedMavenDeps.src.after/)

<details>
<summary>Source diff (first 100 lines)</summary>

```
.m2/org/codehaus/mojo/maven-metadata-central.xml.sha1 --- Text
1 76afcd4b1623558ca679eebeec8d74784c2090b5
2 

.m2/org/ow2/asm/asm/9.9/asm-9.9.jar --- Binary
Binary file removed (123.2 KiB).

.m2/org/ow2/asm/asm/9.9.1/asm-9.9.1.jar --- Binary
Binary file added (123.3 KiB).

.m2/org/ow2/asm/asm/9.9/asm-9.9.jar.sha1 --- Text
1 c29635c8a7afa03d74b33c1884df8abb2b3f3dcc
2 

.m2/org/ow2/asm/asm/9.9.1/asm-9.9.1.jar.sha1 --- Text
1 2ceea6ab43bcae1979b2a6d85fc0ca429877e5ab
2 

.m2/org/ow2/asm/asm/9.9/asm-9.9.pom --- Text
 1 <?xml version="1.0" encoding="UTF-8"?>
 2 <project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 3   <modelVersion>4.0.0</modelVersion>
 4   <groupId>org.ow2.asm</groupId>
 5   <artifactId>asm</artifactId>
 6   <version>9.9</version>
 7   <name>asm</name>
 8   <description>ASM, a very small and fast Java bytecode manipulation framework</description>
 9   <url>http://asm.ow2.io/</url>
10   <inceptionYear>2000</inceptionYear>
11   <organization>
12     <name>OW2</name>
13     <url>http://www.ow2.org/</url>
14   </organization>
15   <licenses>
16     <license>
17       <name>BSD-3-Clause</name>
18       <url>https://asm.ow2.io/license.html</url>
19     </license>
20   </licenses>
21   <developers>
22     <developer>
23       <id>ebruneton</id>
24       <name>Eric Bruneton</name>
25       <email>ebruneton@free.fr</email>
26       <roles>
27         <role>Creator</role>
28         <role>Java Developer</role>
29       </roles>
30     </developer>
31     <developer>
32       <id>eu</id>
33       <name>Eugene Kuleshov</name>
34       <email>eu@javatx.org</email>
35       <roles>
36         <role>Java Developer</role>
37       </roles>
38     </developer>
39     <developer>
40       <id>forax</id>
41       <name>Remi Forax</name>
42       <email>forax@univ-mlv.fr</email>
43       <roles>
44         <role>Java Developer</role>
45       </roles>
46     </developer>
47   </developers>
48   <mailingLists>
49     <mailingList>
50       <name>ASM Users List</name>
51       <subscribe>https://mail.ow2.org/wws/subscribe/asm</subscribe>
52       <post>asm@objectweb.org</post>
53       <archive>https://mail.ow2.org/wws/arc/asm/</archive>
54     </mailingList>
55     <mailingList>
56       <name>ASM Team List</name>
57       <subscribe>https://mail.ow2.org/wws/subscribe/asm-team</subscribe>
58       <post>asm-team@objectweb.org</post>
59       <archive>https://mail.ow2.org/wws/arc/asm-team/</archive>
60     </mailingList>
61   </mailingLists>
62   <scm>
63     <connection>scm:git:https://gitlab.ow2.org/asm/asm/</connection>
64     <developerConnection>scm:git:https://gitlab.ow2.org/asm/asm/</developerConnection>
65     <url>https://gitlab.ow2.org/asm/asm/</url>
66   </scm>
67   <issueManagement>
68     <url>https://gitlab.ow2.org/asm/asm/issues</url>
69   </issueManagement>
70   <parent>
71     <groupId>org.ow2</groupId>
72     <artifactId>ow2</artifactId>
73     <version>1.5.1</version>
74   </parent>
75 </project>
76 

.m2/org/ow2/asm/asm/9.9.1/asm-9.9.1.pom --- XML
 1 <?xml version="1.0" encoding="UTF-8"?>
 2 <project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 3   <modelVersion>4.0.0</modelVersion>
```
</details>

<details>
<summary>Build before (first 100 lines)</summary>

```
this derivation will be built:
  /nix/store/zr5xhrdcs8w1vajzjcijvd2rnd4xzhhs-maven-deps-gol-1.2.0.drv
building '/nix/store/zr5xhrdcs8w1vajzjcijvd2rnd4xzhhs-maven-deps-gol-1.2.0.drv'...
Running phase: unpackPhase
unpacking source archive /nix/store/vf881083w7qzx51c68ia86zfm0xgsgx5-source
source root is source
Running phase: patchPhase
Running phase: updateAutotoolsGnuConfigScriptsPhase
Running phase: configurePhase
no configure script, doing nothing
Running phase: buildPhase
[INFO] Scanning for projects...
Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/mojo/maven-metadata.xml
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-metadata.xml
Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/mojo/maven-metadata.xml (20 kB at 61 kB/s)
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-metadata.xml (14 kB at 43 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-assembly-plugin/3.3.0/maven-assembly-plugin-3.3.0.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-assembly-plugin/3.3.0/maven-assembly-plugin-3.3.0.pom (16 kB at 297 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-plugins/34/maven-plugins-34.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-plugins/34/maven-plugins-34.pom (11 kB at 218 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/34/maven-parent-34.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/34/maven-parent-34.pom (43 kB at 911 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/apache/23/apache-23.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/apache/23/apache-23.pom (18 kB at 384 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-assembly-plugin/3.3.0/maven-assembly-plugin-3.3.0.jar
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-assembly-plugin/3.3.0/maven-assembly-plugin-3.3.0.jar (242 kB at 2.8 MB/s)
[INFO] 
[INFO] ------------------------< com.geodesk:gol-tool >------------------------
[INFO] Building GeoDesk GOL Tool 1.2.0
[INFO]   from pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-resources-plugin/3.3.1/maven-resources-plugin-3.3.1.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-resources-plugin/3.3.1/maven-resources-plugin-3.3.1.pom (8.2 kB at 170 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-plugins/39/maven-plugins-39.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-plugins/39/maven-plugins-39.pom (8.1 kB at 156 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/39/maven-parent-39.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/39/maven-parent-39.pom (48 kB at 716 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/apache/29/apache-29.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/apache/29/apache-29.pom (21 kB at 450 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-resources-plugin/3.3.1/maven-resources-plugin-3.3.1.jar
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-resources-plugin/3.3.1/maven-resources-plugin-3.3.1.jar (31 kB at 619 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-compiler-plugin/3.10.1/maven-compiler-plugin-3.10.1.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-compiler-plugin/3.10.1/maven-compiler-plugin-3.10.1.pom (13 kB at 280 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-compiler-plugin/3.10.1/maven-compiler-plugin-3.10.1.jar
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-compiler-plugin/3.10.1/maven-compiler-plugin-3.10.1.jar (62 kB at 1.2 MB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-surefire-plugin/3.2.5/maven-surefire-plugin-3.2.5.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-surefire-plugin/3.2.5/maven-surefire-plugin-3.2.5.pom (5.3 kB at 100 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire/3.2.5/surefire-3.2.5.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire/3.2.5/surefire-3.2.5.pom (22 kB at 379 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/41/maven-parent-41.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/41/maven-parent-41.pom (50 kB at 924 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/apache/31/apache-31.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/apache/31/apache-31.pom (24 kB at 392 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.9.3/junit-bom-5.9.3.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.9.3/junit-bom-5.9.3.pom (5.6 kB at 115 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-surefire-plugin/3.2.5/maven-surefire-plugin-3.2.5.jar
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-surefire-plugin/3.2.5/maven-surefire-plugin-3.2.5.jar (45 kB at 910 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-jar-plugin/3.4.1/maven-jar-plugin-3.4.1.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-jar-plugin/3.4.1/maven-jar-plugin-3.4.1.pom (7.8 kB at 166 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-plugins/42/maven-plugins-42.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-plugins/42/maven-plugins-42.pom (7.7 kB at 142 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/42/maven-parent-42.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/42/maven-parent-42.pom (50 kB at 1.2 MB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/apache/32/apache-32.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/apache/32/apache-32.pom (24 kB at 465 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.10.2/junit-bom-5.10.2.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.10.2/junit-bom-5.10.2.pom (5.6 kB at 120 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-jar-plugin/3.4.1/maven-jar-plugin-3.4.1.jar
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-jar-plugin/3.4.1/maven-jar-plugin-3.4.1.jar (34 kB at 704 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/com/geodesk/geodesk/1.1.2/geodesk-1.1.2.pom
Downloaded from central: https://repo.maven.apache.org/maven2/com/geodesk/geodesk/1.1.2/geodesk-1.1.2.pom (6.1 kB at 128 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/eclipse/collections/eclipse-collections/maven-metadata.xml
Downloaded from central: https://repo.maven.apache.org/maven2/org/eclipse/collections/eclipse-collections/maven-metadata.xml (2.2 kB at 48 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/eclipse/collections/eclipse-collections/13.0.0/eclipse-collections-13.0.0.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/eclipse/collections/eclipse-collections/13.0.0/eclipse-collections-13.0.0.pom (5.7 kB at 125 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/eclipse/collections/eclipse-collections-parent/13.0.0/eclipse-collections-parent-13.0.0.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/eclipse/collections/eclipse-collections-parent/13.0.0/eclipse-collections-parent-13.0.0.pom (52 kB at 768 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/eclipse/collections/eclipse-collections-api/13.0.0/eclipse-collections-api-13.0.0.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/eclipse/collections/eclipse-collections-api/13.0.0/eclipse-collections-api-13.0.0.pom (5.5 kB at 132 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/locationtech/jts/jts-core/maven-metadata.xml
Downloaded from central: https://repo.maven.apache.org/maven2/org/locationtech/jts/jts-core/maven-metadata.xml (694 B at 12 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/locationtech/jts/jts-core/1.20.0/jts-core-1.20.0.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/locationtech/jts/jts-core/1.20.0/jts-core-1.20.0.pom (2.5 kB at 53 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/locationtech/jts/jts-modules/1.20.0/jts-modules-1.20.0.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/locationtech/jts/jts-modules/1.20.0/jts-modules-1.20.0.pom (1.3 kB at 26 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/locationtech/jts/jts/1.20.0/jts-1.20.0.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/locationtech/jts/jts/1.20.0/jts-1.20.0.pom (20 kB at 441 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/ow2/asm/asm/maven-metadata.xml
Downloaded from central: https://repo.maven.apache.org/maven2/org/ow2/asm/asm/maven-metadata.xml (1.6 kB at 24 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/ow2/asm/asm/9.9.1/asm-9.9.1.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/ow2/asm/asm/9.9.1/asm-9.9.1.pom (2.4 kB at 40 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/ow2/ow2/1.5.1/ow2-1.5.1.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/ow2/ow2/1.5.1/ow2-1.5.1.pom (11 kB at 205 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/junit/junit/4.13.2/junit-4.13.2.pom
Downloaded from central: https://repo.maven.apache.org/maven2/junit/junit/4.13.2/junit-4.13.2.pom (27 kB at 206 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.pom (766 B at 15 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-parent/1.3/hamcrest-parent-1.3.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-parent/1.3/hamcrest-parent-1.3.pom (2.0 kB at 39 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/com/geodesk/geodesk/1.1.2/geodesk-1.1.2.jar
```
</details>

<details>
<summary>Build after (first 100 lines)</summary>

```
checking outputs of '/nix/store/fa32620rn6jwwvs38xnhxapragakjvqz-maven-deps-gol-1.2.0.drv'...
Running phase: unpackPhase
unpacking source archive /nix/store/vf881083w7qzx51c68ia86zfm0xgsgx5-source
source root is source
Running phase: patchPhase
Running phase: updateAutotoolsGnuConfigScriptsPhase
Running phase: configurePhase
no configure script, doing nothing
Running phase: buildPhase
[INFO] Scanning for projects...
Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/mojo/maven-metadata.xml
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-metadata.xml
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-metadata.xml (14 kB at 42 kB/s)
Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/mojo/maven-metadata.xml (20 kB at 58 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-assembly-plugin/3.3.0/maven-assembly-plugin-3.3.0.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-assembly-plugin/3.3.0/maven-assembly-plugin-3.3.0.pom (16 kB at 292 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-plugins/34/maven-plugins-34.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-plugins/34/maven-plugins-34.pom (11 kB at 206 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/34/maven-parent-34.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/34/maven-parent-34.pom (43 kB at 752 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/apache/23/apache-23.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/apache/23/apache-23.pom (18 kB at 409 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-assembly-plugin/3.3.0/maven-assembly-plugin-3.3.0.jar
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-assembly-plugin/3.3.0/maven-assembly-plugin-3.3.0.jar (242 kB at 2.4 MB/s)
[INFO] 
[INFO] ------------------------< com.geodesk:gol-tool >------------------------
[INFO] Building GeoDesk GOL Tool 1.2.0
[INFO]   from pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-resources-plugin/3.3.1/maven-resources-plugin-3.3.1.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-resources-plugin/3.3.1/maven-resources-plugin-3.3.1.pom (8.2 kB at 181 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-plugins/39/maven-plugins-39.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-plugins/39/maven-plugins-39.pom (8.1 kB at 184 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/39/maven-parent-39.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/39/maven-parent-39.pom (48 kB at 999 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/apache/29/apache-29.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/apache/29/apache-29.pom (21 kB at 482 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-resources-plugin/3.3.1/maven-resources-plugin-3.3.1.jar
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-resources-plugin/3.3.1/maven-resources-plugin-3.3.1.jar (31 kB at 688 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-compiler-plugin/3.10.1/maven-compiler-plugin-3.10.1.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-compiler-plugin/3.10.1/maven-compiler-plugin-3.10.1.pom (13 kB at 268 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-compiler-plugin/3.10.1/maven-compiler-plugin-3.10.1.jar
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-compiler-plugin/3.10.1/maven-compiler-plugin-3.10.1.jar (62 kB at 1.1 MB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-surefire-plugin/3.2.5/maven-surefire-plugin-3.2.5.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-surefire-plugin/3.2.5/maven-surefire-plugin-3.2.5.pom (5.3 kB at 124 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire/3.2.5/surefire-3.2.5.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire/3.2.5/surefire-3.2.5.pom (22 kB at 439 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/41/maven-parent-41.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/41/maven-parent-41.pom (50 kB at 1.0 MB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/apache/31/apache-31.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/apache/31/apache-31.pom (24 kB at 436 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.9.3/junit-bom-5.9.3.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.9.3/junit-bom-5.9.3.pom (5.6 kB at 94 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-surefire-plugin/3.2.5/maven-surefire-plugin-3.2.5.jar
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-surefire-plugin/3.2.5/maven-surefire-plugin-3.2.5.jar (45 kB at 782 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-jar-plugin/3.4.1/maven-jar-plugin-3.4.1.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-jar-plugin/3.4.1/maven-jar-plugin-3.4.1.pom (7.8 kB at 153 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-plugins/42/maven-plugins-42.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-plugins/42/maven-plugins-42.pom (7.7 kB at 164 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/42/maven-parent-42.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/42/maven-parent-42.pom (50 kB at 1.1 MB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/apache/32/apache-32.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/apache/32/apache-32.pom (24 kB at 526 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.10.2/junit-bom-5.10.2.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.10.2/junit-bom-5.10.2.pom (5.6 kB at 113 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-jar-plugin/3.4.1/maven-jar-plugin-3.4.1.jar
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-jar-plugin/3.4.1/maven-jar-plugin-3.4.1.jar (34 kB at 662 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/com/geodesk/geodesk/1.1.2/geodesk-1.1.2.pom
Downloaded from central: https://repo.maven.apache.org/maven2/com/geodesk/geodesk/1.1.2/geodesk-1.1.2.pom (6.1 kB at 131 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/eclipse/collections/eclipse-collections/maven-metadata.xml
Downloaded from central: https://repo.maven.apache.org/maven2/org/eclipse/collections/eclipse-collections/maven-metadata.xml (2.2 kB at 47 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/eclipse/collections/eclipse-collections/13.0.0/eclipse-collections-13.0.0.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/eclipse/collections/eclipse-collections/13.0.0/eclipse-collections-13.0.0.pom (5.7 kB at 115 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/eclipse/collections/eclipse-collections-parent/13.0.0/eclipse-collections-parent-13.0.0.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/eclipse/collections/eclipse-collections-parent/13.0.0/eclipse-collections-parent-13.0.0.pom (52 kB at 1.1 MB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/eclipse/collections/eclipse-collections-api/13.0.0/eclipse-collections-api-13.0.0.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/eclipse/collections/eclipse-collections-api/13.0.0/eclipse-collections-api-13.0.0.pom (5.5 kB at 113 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/locationtech/jts/jts-core/maven-metadata.xml
Downloaded from central: https://repo.maven.apache.org/maven2/org/locationtech/jts/jts-core/maven-metadata.xml (694 B at 15 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/locationtech/jts/jts-core/1.20.0/jts-core-1.20.0.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/locationtech/jts/jts-core/1.20.0/jts-core-1.20.0.pom (2.5 kB at 55 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/locationtech/jts/jts-modules/1.20.0/jts-modules-1.20.0.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/locationtech/jts/jts-modules/1.20.0/jts-modules-1.20.0.pom (1.3 kB at 28 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/locationtech/jts/jts/1.20.0/jts-1.20.0.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/locationtech/jts/jts/1.20.0/jts-1.20.0.pom (20 kB at 413 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/ow2/asm/asm/maven-metadata.xml
Downloaded from central: https://repo.maven.apache.org/maven2/org/ow2/asm/asm/maven-metadata.xml (1.6 kB at 33 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/ow2/asm/asm/9.9.1/asm-9.9.1.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/ow2/asm/asm/9.9.1/asm-9.9.1.pom (2.4 kB at 47 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/ow2/ow2/1.5.1/ow2-1.5.1.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/ow2/ow2/1.5.1/ow2-1.5.1.pom (11 kB at 179 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/junit/junit/4.13.2/junit-4.13.2.pom
Downloaded from central: https://repo.maven.apache.org/maven2/junit/junit/4.13.2/junit-4.13.2.pom (27 kB at 563 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.pom (766 B at 19 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-parent/1.3/hamcrest-parent-1.3.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-parent/1.3/hamcrest-parent-1.3.pom (2.0 kB at 45 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/com/geodesk/geodesk/1.1.2/geodesk-1.1.2.jar
Downloading from central: https://repo.maven.apache.org/maven2/org/eclipse/collections/eclipse-collections/13.0.0/eclipse-collections-13.0.0.jar
Downloading from central: https://repo.maven.apache.org/maven2/org/eclipse/collections/eclipse-collections-api/13.0.0/eclipse-collections-api-13.0.0.jar
```
</details>


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
