### PR TITLE
n98-magerun2: fix composerVendor hash

### DIFF
--- a/pkgs/by-name/n9/n98-magerun2/package.nix
+++ b/pkgs/by-name/n9/n98-magerun2/package.nix
@@ -16,7 +16,7 @@ php83.buildComposerProject2 (finalAttrs: {
     hash = "sha256-kjT72pLKuN166Edm8+8vUIfhFdMnZkeTagl0ECL20b8=";
   };
 
-  vendorHash = "sha256-0Bk01aU3vicwk9swkv+8VZxcPdaEMOOtp9niNfPfQyA=";
+  vendorHash = "sha256-wqaePPMC1OiXwtdhMJzg4AvcYDmJg2Uo2LV7TbZ00ec=";
 
   nativeInstallCheckInputs = [ versionCheckHook ];
   doInstallCheck = true;


### PR DESCRIPTION
Fixes hash mismatch for `n98-magerun2.composerVendor`.

I will say that this fetcher seems to be nondeterministic. This second run I had success curling from github, and I guess that gives a "morally correct" vendor hash.

But, the first time I built the attribute, I got:

```
    Failed to download laminas/laminas-servicemanager from dist: curl error 28 while downloading https://api.github.com/repos/laminas/laminas-servicemanager/zipball/a8640182b892b99767d54404d19c5c3b3699f79b: Failed to connect to api.github.com port 443 after 281 ms: Could not connect to server
# unrelated stuff
  - Installing laminas/laminas-servicemanager (3.23.0): Cloning a8640182b8
```

And this resulted in:

```
sha256-wrmGSeFnGx90AJ1umdgJJwzotFgHFOfZR0KsE1znJ60=
```

when I missed the curl and had to do the github fetch. But when I hit the curl (in a different run), I got `sha256-wqaePPMC1OiXwtdhMJzg4AvcYDmJg2Uo2LV7TbZ00ec=`. This seems not good? I'm not sure how the source could possibly be different. The rev fetched is the same! maybe the fetcher isn't stripping out the git stuff?.

Anyway, if we get a run of the happy path where curl is not failing, here are some logs and a diff below. I am still not sure I understand why this is happening. The diff is enormous. I don't think there's anything glaringly wrong.

Build logs:
- [before (5830d8d)](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/n98-magerun2/composerVendor.before.log)
- [after (6fcdc51)](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/n98-magerun2/composerVendor.after.log)
- [source diff](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/n98-magerun2/composerVendor.diff.log)

Source directories:
- [old source](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/n98-magerun2/composerVendor.src.before/)
- [new source](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/n98-magerun2/composerVendor.src.after/)

<details>
<summary>Source diff (first 100 lines)</summary>


```
vendor/bin/php-parse --- Text
  1 #!/usr/bin/env php
  2 <?php
  3 
  4 /**
  5  * Proxy PHP file generated by Composer
  6  *
  7  * This file includes the referenced bin path (../nikic/php-parser/bin/php-parse)
  8  * using a stream wrapper to prevent the shebang from being output on PHP<8
  9  *
 10  * @generated
 11  */
 12 
 13 namespace Composer;
 14 
 15 $GLOBALS['_composer_bin_dir'] = __DIR__;
 16 $GLOBALS['_composer_autoload_path'] = __DIR__ . '/..'.'/autoload.php';
 17 
 18 if (PHP_VERSION_ID < 80000) {
 19     if (!class_exists('Composer\BinProxyWrapper')) {
 20         /**
 21          * @internal
 22          */
 23         final class BinProxyWrapper
 24         {
 25             private $handle;
 26             private $position;
 27             private $realpath;
 28 
 29             public function stream_open($path, $mode, $options, &$opened_path)
 30             {
 31                 // get rid of phpvfscomposer:// prefix for __FILE__ & __DIR__ resolution
 32                 $opened_path = substr($path, 17);
 33                 $this->realpath = realpath($opened_path) ?: $opened_path;
 34                 $opened_path = $this->realpath;
 35                 $this->handle = fopen($this->realpath, $mode);
 36                 $this->position = 0;
 37 
 38                 return (bool) $this->handle;
 39             }
 40 
 41             public function stream_read($count)
 42             {
 43                 $data = fread($this->handle, $count);
 44 
 45                 if ($this->position === 0) {
 46                     $data = preg_replace('{^#!.*\r?\n}', '', $data);
 47                 }
 48 
 49                 $this->position += strlen($data);
 50 
 51                 return $data;
 52             }
 53 
 54             public function stream_cast($castAs)
 55             {
 56                 return $this->handle;
 57             }
 58 
 59             public function stream_close()
 60             {
 61                 fclose($this->handle);
 62             }
 63 
 64             public function stream_lock($operation)
 65             {
 66                 return $operation ? flock($this->handle, $operation) : true;
 67             }
 68 
 69             public function stream_seek($offset, $whence)
 70             {
 71                 if (0 === fseek($this->handle, $offset, $whence)) {
 72                     $this->position = ftell($this->handle);
 73                     return true;
 74                 }
 75 
 76                 return false;
 77             }
 78 
 79             public function stream_tell()
 80             {
 81                 return $this->position;
 82             }
 83 
 84             public function stream_eof()
 85             {
 86                 return feof($this->handle);
 87             }
 88 
 89             public function stream_stat()
 90             {
 91                 return array();
 92             }
 93 
 94             public function stream_set_option($option, $arg1, $arg2)
 95             {
 96                 return true;
 97             }
 98 
 99             public function url_stat($path, $flags)
```
</details>

<details>
<summary>Build before</summary>

```
checking outputs of '/nix/store/c12psiijb1j051z0jp1vijm4xnsby1m7-n98-magerun2-composer-vendor-9.1.0.drv'...
Running phase: unpackPhase
unpacking source archive /nix/store/xff9gsi41a6i6dh9076dmxx4b8gqck1f-source
source root is source
Running phase: patchPhase
Running phase: updateAutotoolsGnuConfigScriptsPhase
Running phase: configurePhase
Running phase: composerVendorConfigureHook
Setting COMPOSER_ROOT_VERSION to 9.1.0
Found 'composer.lock' in source root.
Finished phase: composerVendorConfigureHook
Running phase: buildPhase
Running phase: composerVendorBuildHook
Setting some required environment variables for Composer...
Installing Composer dependencies to 'vendor'...
Installing dependencies from lock file
Verifying lock file contents can be installed on current platform.
Package operations: 30 installs, 0 updates, 0 removals
  - Downloading dflydev/dot-access-data (v3.0.3)
  - Downloading symfony/deprecation-contracts (v3.6.0)
  - Downloading psr/container (1.1.2)
  - Downloading fakerphp/faker (v1.24.1)
  - Downloading laminas/laminas-stdlib (3.20.0)
  - Downloading laminas/laminas-servicemanager (3.23.0)
  - Downloading symfony/polyfill-mbstring (v1.33.0)
  - Downloading laminas/laminas-filter (2.41.0)
  - Downloading n98/junit-xml (1.1.0)
  - Downloading psr/log (2.0.0)
  - Downloading symfony/var-dumper (v6.4.24)
  - Downloading symfony/polyfill-intl-normalizer (v1.33.0)
  - Downloading symfony/polyfill-intl-grapheme (v1.33.0)
  - Downloading symfony/polyfill-ctype (v1.33.0)
  - Downloading symfony/string (v6.4.25)
  - Downloading symfony/service-contracts (v3.6.0)
  - Downloading symfony/console (v6.4.25)
  - Downloading nikic/php-parser (v5.6.0)
  - Downloading psy/psysh (v0.12.10)
  - Downloading rmccue/requests (v2.0.15)
  - Downloading psr/event-dispatcher (1.0.0)
  - Downloading symfony/event-dispatcher-contracts (v3.6.0)
  - Downloading symfony/event-dispatcher (v6.4.25)
  - Downloading symfony/finder (v6.4.24)
  - Downloading symfony/process (v6.4.25)
  - Downloading symfony/translation-contracts (v3.6.0)
  - Downloading symfony/polyfill-php83 (v1.32.0)
  - Downloading symfony/validator (v6.4.22)
  - Downloading symfony/yaml (v6.4.21)
  - Downloading twig/twig (v3.21.1)
  - Installing dflydev/dot-access-data (v3.0.3): Extracting archive
  - Installing symfony/deprecation-contracts (v3.6.0): Extracting archive
  - Installing psr/container (1.1.2): Extracting archive
  - Installing fakerphp/faker (v1.24.1): Extracting archive
  - Installing laminas/laminas-stdlib (3.20.0): Extracting archive
  - Installing laminas/laminas-servicemanager (3.23.0): Extracting archive
  - Installing symfony/polyfill-mbstring (v1.33.0): Extracting archive
  - Installing laminas/laminas-filter (2.41.0): Extracting archive
  - Installing n98/junit-xml (1.1.0): Extracting archive
  - Installing psr/log (2.0.0): Extracting archive
  - Installing symfony/var-dumper (v6.4.24): Extracting archive
  - Installing symfony/polyfill-intl-normalizer (v1.33.0): Extracting archive
  - Installing symfony/polyfill-intl-grapheme (v1.33.0): Extracting archive
  - Installing symfony/polyfill-ctype (v1.33.0): Extracting archive
  - Installing symfony/string (v6.4.25): Extracting archive
  - Installing symfony/service-contracts (v3.6.0): Extracting archive
  - Installing symfony/console (v6.4.25): Extracting archive
  - Installing nikic/php-parser (v5.6.0): Extracting archive
  - Installing psy/psysh (v0.12.10): Extracting archive
  - Installing rmccue/requests (v2.0.15): Extracting archive
  - Installing psr/event-dispatcher (1.0.0): Extracting archive
  - Installing symfony/event-dispatcher-contracts (v3.6.0): Extracting archive
  - Installing symfony/event-dispatcher (v6.4.25): Extracting archive
  - Installing symfony/finder (v6.4.24): Extracting archive
  - Installing symfony/process (v6.4.25): Extracting archive
  - Installing symfony/translation-contracts (v3.6.0): Extracting archive
  - Installing symfony/polyfill-php83 (v1.32.0): Extracting archive
  - Installing symfony/validator (v6.4.22): Extracting archive
  - Installing symfony/yaml (v6.4.21): Extracting archive
  - Installing twig/twig (v3.21.1): Extracting archive
Cleaning up Composer 'bin' directory (will be regenerated during install).
Finished phase: composerVendorBuildHook
Running phase: checkPhase
Running phase: composerVendorCheckHook
Finished phase: composerVendorCheckHook
Running phase: installPhase
Running phase: composerVendorInstallHook
Preserving Composer vendor directory from 'vendor'...
Finished phase: composerVendorInstallHook
Running phase: fixupPhase
shrinking RPATHs of ELF executables and libraries in /nix/store/0ngv8wfsfj7i7rlz40zynyk7kv5n2a24-n98-magerun2-composer-vendor-9.1.0
checking for references to /build/ in /nix/store/0ngv8wfsfj7i7rlz40zynyk7kv5n2a24-n98-magerun2-composer-vendor-9.1.0...
error: hash mismatch in fixed-output derivation '/nix/store/c12psiijb1j051z0jp1vijm4xnsby1m7-n98-magerun2-composer-vendor-9.1.0.drv':
         specified: sha256-0Bk01aU3vicwk9swkv+8VZxcPdaEMOOtp9niNfPfQyA=
            got:    sha256-wqaePPMC1OiXwtdhMJzg4AvcYDmJg2Uo2LV7TbZ00ec=
```
</details>

<details>
<summary>Build after</summary>

```
checking outputs of '/nix/store/4nw2jp3lza7jj6kdiw2iv400sgkbdpf4-n98-magerun2-composer-vendor-9.1.0.drv'...
Running phase: unpackPhase
unpacking source archive /nix/store/xff9gsi41a6i6dh9076dmxx4b8gqck1f-source
source root is source
Running phase: patchPhase
Running phase: updateAutotoolsGnuConfigScriptsPhase
Running phase: configurePhase
Running phase: composerVendorConfigureHook
Setting COMPOSER_ROOT_VERSION to 9.1.0
Found 'composer.lock' in source root.
Finished phase: composerVendorConfigureHook
Running phase: buildPhase
Running phase: composerVendorBuildHook
Setting some required environment variables for Composer...
Installing Composer dependencies to 'vendor'...
Installing dependencies from lock file
Verifying lock file contents can be installed on current platform.
Package operations: 30 installs, 0 updates, 0 removals
  - Downloading dflydev/dot-access-data (v3.0.3)
  - Downloading symfony/deprecation-contracts (v3.6.0)
  - Downloading psr/container (1.1.2)
  - Downloading fakerphp/faker (v1.24.1)
  - Downloading laminas/laminas-stdlib (3.20.0)
  - Downloading laminas/laminas-servicemanager (3.23.0)
  - Downloading symfony/polyfill-mbstring (v1.33.0)
  - Downloading laminas/laminas-filter (2.41.0)
  - Downloading n98/junit-xml (1.1.0)
  - Downloading psr/log (2.0.0)
  - Downloading symfony/var-dumper (v6.4.24)
  - Downloading symfony/polyfill-intl-normalizer (v1.33.0)
  - Downloading symfony/polyfill-intl-grapheme (v1.33.0)
  - Downloading symfony/polyfill-ctype (v1.33.0)
  - Downloading symfony/string (v6.4.25)
  - Downloading symfony/service-contracts (v3.6.0)
  - Downloading symfony/console (v6.4.25)
  - Downloading nikic/php-parser (v5.6.0)
  - Downloading psy/psysh (v0.12.10)
  - Downloading rmccue/requests (v2.0.15)
  - Downloading psr/event-dispatcher (1.0.0)
  - Downloading symfony/event-dispatcher-contracts (v3.6.0)
  - Downloading symfony/event-dispatcher (v6.4.25)
  - Downloading symfony/finder (v6.4.24)
  - Downloading symfony/process (v6.4.25)
  - Downloading symfony/translation-contracts (v3.6.0)
  - Downloading symfony/polyfill-php83 (v1.32.0)
  - Downloading symfony/validator (v6.4.22)
  - Downloading symfony/yaml (v6.4.21)
  - Downloading twig/twig (v3.21.1)
  - Installing dflydev/dot-access-data (v3.0.3): Extracting archive
  - Installing symfony/deprecation-contracts (v3.6.0): Extracting archive
  - Installing psr/container (1.1.2): Extracting archive
  - Installing fakerphp/faker (v1.24.1): Extracting archive
  - Installing laminas/laminas-stdlib (3.20.0): Extracting archive
  - Installing laminas/laminas-servicemanager (3.23.0): Extracting archive
  - Installing symfony/polyfill-mbstring (v1.33.0): Extracting archive
  - Installing laminas/laminas-filter (2.41.0): Extracting archive
  - Installing n98/junit-xml (1.1.0): Extracting archive
  - Installing psr/log (2.0.0): Extracting archive
  - Installing symfony/var-dumper (v6.4.24): Extracting archive
  - Installing symfony/polyfill-intl-normalizer (v1.33.0): Extracting archive
  - Installing symfony/polyfill-intl-grapheme (v1.33.0): Extracting archive
  - Installing symfony/polyfill-ctype (v1.33.0): Extracting archive
  - Installing symfony/string (v6.4.25): Extracting archive
  - Installing symfony/service-contracts (v3.6.0): Extracting archive
  - Installing symfony/console (v6.4.25): Extracting archive
  - Installing nikic/php-parser (v5.6.0): Extracting archive
  - Installing psy/psysh (v0.12.10): Extracting archive
  - Installing rmccue/requests (v2.0.15): Extracting archive
  - Installing psr/event-dispatcher (1.0.0): Extracting archive
  - Installing symfony/event-dispatcher-contracts (v3.6.0): Extracting archive
  - Installing symfony/event-dispatcher (v6.4.25): Extracting archive
  - Installing symfony/finder (v6.4.24): Extracting archive
  - Installing symfony/process (v6.4.25): Extracting archive
  - Installing symfony/translation-contracts (v3.6.0): Extracting archive
  - Installing symfony/polyfill-php83 (v1.32.0): Extracting archive
  - Installing symfony/validator (v6.4.22): Extracting archive
  - Installing symfony/yaml (v6.4.21): Extracting archive
  - Installing twig/twig (v3.21.1): Extracting archive
Cleaning up Composer 'bin' directory (will be regenerated during install).
Finished phase: composerVendorBuildHook
Running phase: checkPhase
Running phase: composerVendorCheckHook
Finished phase: composerVendorCheckHook
Running phase: installPhase
Running phase: composerVendorInstallHook
Preserving Composer vendor directory from 'vendor'...
Finished phase: composerVendorInstallHook
Running phase: fixupPhase
shrinking RPATHs of ELF executables and libraries in /nix/store/mzdmz32ppz0lfi36wcr87d1gpx4bwdbp-n98-magerun2-composer-vendor-9.1.0
checking for references to /build/ in /nix/store/mzdmz32ppz0lfi36wcr87d1gpx4bwdbp-n98-magerun2-composer-vendor-9.1.0...
/nix/store/mzdmz32ppz0lfi36wcr87d1gpx4bwdbp-n98-magerun2-composer-vendor-9.1.0
```
</details>


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
