### PR TITLE
systemd: accept more symlink patterns for /etc/localtime

### DIFF
--- a/pkgs/os-specific/linux/systemd/0007-Change-usr-share-zoneinfo-to-etc-zoneinfo.patch
+++ b/pkgs/os-specific/linux/systemd/0007-Change-usr-share-zoneinfo-to-etc-zoneinfo.patch
@@ -70,7 +70,7 @@ index 55931a2546..2e00bd7539 100644
                  return r; /* Return EINVAL if not a symlink */
  
 -        const char *e = PATH_STARTSWITH_SET(t, "/usr/share/zoneinfo/", "../usr/share/zoneinfo/");
-+        const char *e = PATH_STARTSWITH_SET(t, "/etc/zoneinfo/", "../etc/zoneinfo/");
++        const char *e = PATH_STARTSWITH_SET(t, "/etc/zoneinfo/", "../etc/zoneinfo/", "zoneinfo/");
          if (!e)
                  return -EINVAL;
          if (!timezone_is_valid(e, LOG_DEBUG))
@@ -112,7 +112,7 @@ index 480a9c55c6..02c9ae6608 100644
                          path,
 -                        "../usr/share/zoneinfo/",
 -                        "/usr/share/zoneinfo/");
-+                        "../etc/zoneinfo/",
++                        "../etc/zoneinfo/", "zoneinfo/",
 +                        "/etc/zoneinfo/");
  }
  


### PR DESCRIPTION
Steps to trigger the related bug:

- build system with `config.time.timeZone = null;`
- `sudo timedatectl set-timezone [whatever]`
- wait a few minutes for systemd-timedated to deactivate
- `timedatectl`

This will show the current timezone as "n/a" and default to UTC time since in step 2 /etc/localtime was linked to `zoneinfo/[whatever]` , but this pattern is not on the list of acceptable patterns to recognize. You can observe a related error message in the logs for systemd-timedated: `/etc/localtime should be a symbolic link to a time zone data file in /etc/zoneinfo/.`

This patch fixes this by adding the right pattern.

## Things done

Tested by building and running a system with the following configuration:

```nix
  systemd.package = pkgs.systemd.overrideAttrs (prev: {
    postPatch = (prev.postPatch or "") + ''
      substituteInPlace src/nspawn/nspawn.c src/basic/time-util.c --replace-fail '"../etc/zoneinfo/"' '"../etc/zoneinfo/", "zoneinfo/"'
    '';
  });

```

I was not able to test a full system built from the submitted patch directly because the resulting mass rebuild was simply too big.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
