### PR TITLE
gurk-rs: fix NIX_LDFLAGS type error, cleanup

### DIFF
--- a/pkgs/by-name/gu/gurk-rs/package.nix
+++ b/pkgs/by-name/gu/gurk-rs/package.nix
@@ -38,10 +38,9 @@ rustPlatform.buildRustPackage rec {
   buildInputs = [ openssl ];
 
   env = {
-    NIX_LDFLAGS = lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) [
-      "-framework"
-      "AppKit"
-    ];
+    NIX_LDFLAGS = lib.optionalString (
+      stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64
+    ) "-framework AppKit";
     OPENSSL_NO_VENDOR = true;
   };
 

--- a/pkgs/by-name/gu/gurk-rs/package.nix
+++ b/pkgs/by-name/gu/gurk-rs/package.nix
@@ -1,5 +1,5 @@
 {
-  stdenv,
+  stdenvNoCC,
   lib,
   protobuf,
   rustPlatform,
@@ -10,17 +10,16 @@
   writableTmpDirAsHomeHook,
   versionCheckHook,
   nix-update-script,
-  gurk-rs,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "gurk-rs";
   version = "0.6.4";
 
   src = fetchFromGitHub {
     owner = "boxdot";
     repo = "gurk-rs";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-1vnyzKissOciLopWzWN2kmraFevYW/w32KVmP8qgUM4=";
   };
 
@@ -39,22 +38,18 @@ rustPlatform.buildRustPackage rec {
 
   env = {
     NIX_LDFLAGS = lib.optionalString (
-      stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64
+      with stdenvNoCC.hostPlatform; (isDarwin && isx86_64)
     ) "-framework AppKit";
     OPENSSL_NO_VENDOR = true;
+    PROTOC = "${lib.getExe pkgsBuildHost.protobuf}";
   };
-
-  PROTOC = "${pkgsBuildHost.protobuf}/bin/protoc";
 
   useNextest = true;
 
   nativeCheckInputs = [ writableTmpDirAsHomeHook ];
 
-  nativeInstallCheckInputs = [
-    versionCheckHook
-  ];
+  nativeInstallCheckInputs = [ versionCheckHook ];
   doInstallCheck = true;
-  versionCheckProgram = "${placeholder "out"}/bin/${meta.mainProgram}";
 
   passthru.updateScript = nix-update-script { };
 
@@ -65,4 +60,4 @@ rustPlatform.buildRustPackage rec {
     license = lib.licenses.agpl3Only;
     maintainers = with lib.maintainers; [ devhell ];
   };
-}
+})


### PR DESCRIPTION
Fix type error:

```
$ nix-build -A gurk-rs --show-trace
error:
       … while evaluating an expression to select 'drvPath' on it
         at «internal»:1:552:
       … while evaluating strict
         at «internal»:1:552:
       … while calling the 'derivationStrict' builtin
         at «internal»:1:208:
       … while evaluating derivation 'gurk-rs-0.6.4'
         whose name attribute is located at /home/yiyu/projects/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:541:13

       … while evaluating attribute 'NIX_LDFLAGS' of derivation 'gurk-rs-0.6.4'

       … while calling anonymous lambda
         at /home/yiyu/projects/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:853:14:
          852|         mapAttrs (
          853|           n: v:
             |              ^
          854|           assert assertMsg (isString v || isBool v || isInt v || isDerivation v)

       … from call site
         at /home/yiyu/projects/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:854:18:
          853|           n: v:
          854|           assert assertMsg (isString v || isBool v || isInt v || isDerivation v)
             |                  ^
          855|             "The `env` attribute set can only contain derivation, string, boolean or integer attributes. The `${n}` attribute is of type ${builtins.typeOf v}.";

       … while calling 'assertMsg'
         at /home/yiyu/projects/nixpkgs/lib/asserts.nix:50:21:
           49|   # TODO(Profpatsch): add tests that check stderr
           50|   assertMsg = pred: msg: pred || throw msg;
             |                     ^
           51|

       … caused by explicit throw
         at /home/yiyu/projects/nixpkgs/lib/asserts.nix:50:34:
           49|   # TODO(Profpatsch): add tests that check stderr
           50|   assertMsg = pred: msg: pred || throw msg;
             |                                  ^
           51|

       error: The `env` attribute set can only contain derivation, string, boolean or integer attributes. The `NIX_LDFLAGS` attribute is of type list.
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
