### PR TITLE
nixos/netns: init module to manage network namespaces

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1287,6 +1287,7 @@
   ./services/networking/netbird.nix
   ./services/networking/netbird/server.nix
   ./services/networking/netclient.nix
+  ./services/networking/netns.nix
   ./services/networking/networkd-dispatcher.nix
   ./services/networking/networkmanager.nix
   ./services/networking/newt.nix

--- a/nixos/modules/services/networking/netns.nix
+++ b/nixos/modules/services/networking/netns.nix
@@ -1,0 +1,134 @@
+{
+  pkgs,
+  lib,
+  config,
+  options,
+  ...
+}:
+with lib;
+let
+  cfg = config.services.netns;
+  inherit (config) networking;
+  # Escape as required by: https://www.freedesktop.org/software/systemd/man/systemd.unit.html
+  escapeUnitName =
+    name:
+    lib.concatMapStrings (s: if lib.isList s then "-" else s) (
+      builtins.split "[^a-zA-Z0-9_.\\-]+" name
+    );
+in
+{
+  options.services.netns = {
+    namespaces = mkOption {
+      description = ''
+        Network namespaces to create.
+
+        Other services can join a network namespace named `netns` with:
+        ```
+        PrivateNetwork=true;
+        JoinsNamespaceOf="netns-''${netns}.service";
+        ```
+
+        So can `iproute2` with: `ip -n ''${netns}`
+
+        ::: {.warning}
+        You should usually create (or update via your VPN configuration's up script)
+        a file named `/etc/netns/''${netns}/resolv.conf`
+        that will be bind-mounted by `ip -n ''${netns}` onto `/etc/resolv.conf`,
+        which you'll also want to configure in the services joining this network namespace:
+        ```
+        BindReadOnlyPaths = ["/etc/netns/''${netns}/resolv.conf:/etc/resolv.conf"];
+        ```
+        :::
+      '';
+      default = { };
+      type = types.attrsOf (
+        types.submodule {
+          options.nftables = mkOption {
+            description = "Nftables ruleset within the network namespace.";
+            type = types.lines;
+            default = networking.nftables.ruleset;
+            defaultText = "config.networking.nftables.ruleset";
+          };
+          options.sysctl = options.boot.kernel.sysctl // {
+            description = "sysctl within the network namespace.";
+            default = config.boot.kernel.sysctl;
+            defaultText = literalMD "config.boot.kernel.sysctl";
+          };
+          options.service = mkOption {
+            description = "Systemd configuration specific to this netns service";
+            type = types.attrs;
+            default = { };
+          };
+        }
+      );
+    };
+  };
+  config = {
+    systemd.services = mapAttrs' (
+      name: c:
+      nameValuePair "netns-${escapeUnitName name}" (mkMerge [
+        {
+          description = "${name} network namespace";
+          before = [ "network.target" ];
+          serviceConfig = {
+            Type = "oneshot";
+            RemainAfterExit = true;
+            # Explanation: let systemd create the netns so that PrivateNetwork=true
+            # with JoinsNamespaceOf="netns-${name}.service" works.
+            PrivateNetwork = true;
+            # Explanation: PrivateNetwork=true implies PrivateMounts=true by default,
+            # which would prevent the persisting and sharing of /var/run/netns/$name
+            # causing `ip netns exec $name $SHELL` outside of this service to fail with:
+            # Error: Peer netns reference is invalid.
+            # As `stat -f -c %T /var/run/netns/$name` would not be "nsfs" in those mntns.
+            # See https://serverfault.com/questions/961504/cannot-create-nested-network-namespace
+            PrivateMounts = false;
+            ExecStart = [
+              # Explanation: register the netns with a binding mount
+              # to /var/run/netns/$name to keep it alive,
+              # and make sure resolv.conf can be used in BindReadOnlyPaths=
+              # For propagating changes in that file to the services bind mounting it,
+              # updating must not remove the file, but only truncate it.
+              (pkgs.writeShellScript "ip-netns-attach" ''
+                ${pkgs.iproute2}/bin/ip netns attach ${escapeShellArg name} $$
+                mkdir -p /etc/netns/${escapeShellArg name}
+                touch /etc/netns/${escapeShellArg name}/resolv.conf
+              '')
+
+              # Explanation: activating the loopback interface is almost always a good thing.
+              "${pkgs.iproute2}/bin/ip link set dev lo up"
+
+              # Explanation: use --ignore because some keys
+              # may no longer exist in that new namespace,
+              # like net.ipv6.conf.eth0.addr_gen_mode or net.core.rmem_max
+              ''
+                ${pkgs.procps}/bin/sysctl --ignore -p ${
+                  pkgs.writeScript "sysctl" (
+                    concatStrings (
+                      mapAttrsToList (
+                        n: v: optionalString (v != null) "${n}=${if v == false then "0" else toString v}\n"
+                      ) c.sysctl
+                    )
+                  )
+                }
+              ''
+            ]
+            ++
+              # Description: load the nftables ruleset of this netns.
+              optional networking.nftables.enable (
+                pkgs.writeScript "nftables-ruleset" ''
+                  #!${pkgs.nftables}/bin/nft -f
+                  flush ruleset
+                  ${c.nftables}
+                ''
+              );
+            # Description: unregister the netns from the tracking mecanism of iproute2.
+            ExecStop = "${pkgs.iproute2}/bin/ip netns delete ${escapeShellArg name}";
+          };
+        }
+        c.service
+      ])
+    ) cfg.namespaces;
+    meta.maintainers = with lib.maintainers; [ julm ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Initiate a service to create network namespaces.
Useful to sandbox VPN.

## Things done
- [X] Pull this from https://github.com/NixOS/nixpkgs/pull/109643 to dignify it with its own PR

## RoadMap
- [ ] NixOS test
- [ ] Release note

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
## Checks
- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
