### PR TITLE
ieda: add update script for r-ryantm

### DIFF
--- a/pkgs/by-name/ie/ieda/package.nix
+++ b/pkgs/by-name/ie/ieda/package.nix
@@ -28,7 +28,7 @@
 let
   rootSrc = stdenv.mkDerivation {
     pname = "iEDA-src";
-    version = "2025-12-16";
+    version = "0.1.0-unstable-2025-12-16";
     src = fetchgit {
       url = "https://gitee.com/oscc-project/iEDA";
       rev = "b73be0f1909294b56b2dbb27dba04b6cd9e0070d";
@@ -57,7 +57,7 @@ let
 in
 stdenv.mkDerivation {
   pname = "iEDA";
-  version = "0.1.0-unstable-2025-12-16";
+  version = rootSrc.version;
 
   src = rootSrc;
 
@@ -125,6 +125,8 @@ stdenv.mkDerivation {
   doInstallCheck = !stdenv.hostPlatform.isAarch64; # Tests will fail on aarch64-linux, wait for upstream fix: https://github.com/microsoft/onnxruntime/issues/10038
 
   enableParallelBuild = true;
+
+  passthru.updateScript = ./update.sh;
 
   meta = {
     description = "Open-source EDA infracstructure and tools from Netlist to GDS for ASIC design";

--- a/pkgs/by-name/ie/ieda/update.sh
+++ b/pkgs/by-name/ie/ieda/update.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq common-updater-scripts
+
+set -eu -o pipefail
+
+latestCommit="$(curl -fs https://gitee.com/api/v5/repos/oscc-project/iEDA/commits?sha=master | jq -r '.[0].sha')"
+commitDate="$(curl -fs https://gitee.com/api/v5/repos/oscc-project/iEDA/commits/"$latestCommit" | jq -r '.commit.committer.date[:10]')"
+latestReleaseTag="$(curl -fs https://gitee.com/api/v5/repos/oscc-project/iEDA/releases/latest | jq -r '.tag_name | ltrimstr("v")')"
+
+[ "$latestCommit" != "null" ] && [ -n "$latestCommit" ] || { echo "Failed to fetch latest commit"; exit 1; }
+[ "$commitDate" != "null" ] && [ -n "$commitDate" ] || { echo "Failed to fetch commit date"; exit 1; }
+[ "$latestReleaseTag" != "null" ] && [ -n "$latestReleaseTag" ] || { echo "Failed to fetch release tag"; exit 1; }
+
+newVersion="$latestReleaseTag-unstable-$commitDate"
+
+update-source-version \
+  "$UPDATE_NIX_ATTR_PATH" \
+  "$newVersion" \
+  --rev="$latestCommit" \
+  --source-key="src.src"


### PR DESCRIPTION
- Added update.sh that tracks the latest commit from the upstream Gitee repository

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
