### PR TITLE
ocamlPackages: fixes related to GCC 15

### DIFF
--- a/pkgs/by-name/fr/framac/package.nix
+++ b/pkgs/by-name/fr/framac/package.nix
@@ -138,5 +138,6 @@ stdenv.mkDerivation rec {
       amiddelk
     ];
     platforms = lib.platforms.unix;
+    broken = !lib.versionAtLeast ocamlPackages.ocaml.version "4.14";
   };
 }

--- a/pkgs/development/compilers/ocaml/generic.nix
+++ b/pkgs/development/compilers/ocaml/generic.nix
@@ -118,9 +118,11 @@ stdenv.mkDerivation (
       ++ optional noNakedPointers (flags "--disable-naked-pointers" "-no-naked-pointers");
     dontAddStaticConfigureFlags = lib.versionOlder version "4.08";
 
-    env = lib.optionalAttrs (lib.versionOlder version "4.14") {
-      NIX_CFLAGS_COMPILE = "-std=gnu11";
-    };
+    env =
+      lib.optionalAttrs (lib.versionOlder version "4.14" || lib.versions.majorMinor version == "5.0")
+        {
+          NIX_CFLAGS_COMPILE = "-std=gnu11";
+        };
 
     # on aarch64-darwin using --host and --target causes the build to invoke
     # `aarch64-apple-darwin-clang` while using assembler. However, such binary

--- a/pkgs/development/ocaml-modules/colors/default.nix
+++ b/pkgs/development/ocaml-modules/colors/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  ocaml,
   buildDunePackage,
   fetchurl,
   mdx,
@@ -16,7 +17,7 @@ buildDunePackage rec {
     hash = "sha256-fY1j9FODVnifwsI8qkKm0QSmssgWqYFXJ7y8o7/KmEY=";
   };
 
-  doCheck = true;
+  doCheck = lib.versionAtLeast ocaml.version "5.1";
 
   checkInputs = [
     mdx

--- a/pkgs/development/ocaml-modules/dolmen/loop.nix
+++ b/pkgs/development/ocaml-modules/dolmen/loop.nix
@@ -1,4 +1,6 @@
 {
+  lib,
+  ocaml,
   buildDunePackage,
   dolmen,
   dolmen_type,
@@ -10,6 +12,17 @@
 buildDunePackage {
   pname = "dolmen_loop";
   inherit (dolmen) src version;
+
+  env =
+    # Fix build with gcc15
+    lib.optionalAttrs
+      (
+        lib.versionAtLeast ocaml.version "4.10" && lib.versionOlder ocaml.version "4.14"
+        || lib.versions.majorMinor ocaml.version == "5.0"
+      )
+      {
+        NIX_CFLAGS_COMPILE = "-std=gnu11";
+      };
 
   propagatedBuildInputs = [
     dolmen

--- a/pkgs/development/ocaml-modules/domain-local-await/default.nix
+++ b/pkgs/development/ocaml-modules/domain-local-await/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  ocaml,
   buildDunePackage,
   fetchurl,
   alcotest,
@@ -13,6 +14,11 @@ buildDunePackage rec {
   version = "1.0.1";
 
   minimalOCamlVersion = "5.0";
+
+  # Fix build with gcc15
+  env = lib.optionalAttrs (lib.versions.majorMinor ocaml.version == "5.0") {
+    NIX_CFLAGS_COMPILE = "-std=gnu11";
+  };
 
   src = fetchurl {
     url = "https://github.com/ocaml-multicore/${pname}/releases/download/${version}/${pname}-${version}.tbz";

--- a/pkgs/development/ocaml-modules/domain-local-timeout/default.nix
+++ b/pkgs/development/ocaml-modules/domain-local-timeout/default.nix
@@ -28,7 +28,7 @@ buildDunePackage rec {
     thread-table
   ];
 
-  doCheck = lib.versionAtLeast ocaml.version "5.0";
+  doCheck = lib.versionAtLeast ocaml.version "5.1";
   nativeCheckInputs = [ mdx.bin ];
   checkInputs = [
     alcotest

--- a/pkgs/development/ocaml-modules/kcas/default.nix
+++ b/pkgs/development/ocaml-modules/kcas/default.nix
@@ -16,8 +16,6 @@ buildDunePackage rec {
   pname = "kcas";
   version = "0.7.0";
 
-  minimalOCamlVersion = "4.13.0";
-
   src = fetchurl {
     url = "https://github.com/ocaml-multicore/kcas/releases/download/${version}/kcas-${version}.tbz";
     hash = "sha256-mo/otnkB79QdyVgLw1sZFfkR/Z/l15cRVfEYPPd6H5E=";
@@ -30,7 +28,7 @@ buildDunePackage rec {
     backoff
   ];
 
-  doCheck = !lib.versionAtLeast ocaml.version "5.4";
+  doCheck = lib.versionAtLeast ocaml.version "5.1" && !lib.versionAtLeast ocaml.version "5.4";
   nativeCheckInputs = [ mdx.bin ];
   checkInputs = [
     alcotest

--- a/pkgs/development/ocaml-modules/mdx/default.nix
+++ b/pkgs/development/ocaml-modules/mdx/default.nix
@@ -24,12 +24,21 @@ buildDunePackage (finalAttrs: {
   pname = "mdx";
   version = "2.5.1";
 
-  minimalOCamlVersion = "4.08";
-
   src = fetchurl {
     url = "https://github.com/realworldocaml/mdx/releases/download/${finalAttrs.version}/mdx-${finalAttrs.version}.tbz";
     hash = "sha256-3YKYDdERpIBv+akdnS7Xwmrvsdp9zL0V5zw6j2boY/U=";
   };
+
+  env =
+    # Fix build with gcc15
+    lib.optionalAttrs
+      (
+        lib.versionAtLeast ocaml.version "4.10" && lib.versionOlder ocaml.version "4.14"
+        || lib.versions.majorMinor ocaml.version == "5.0"
+      )
+      {
+        NIX_CFLAGS_COMPILE = "-std=gnu11";
+      };
 
   nativeBuildInputs = [ cppo ];
   propagatedBuildInputs = [

--- a/pkgs/development/ocaml-modules/patricia-tree/default.nix
+++ b/pkgs/development/ocaml-modules/patricia-tree/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  ocaml,
   buildDunePackage,
   fetchFromGitHub,
   findlib,
@@ -13,6 +14,11 @@ buildDunePackage rec {
   version = "0.11.0";
 
   minimalOCamlVersion = "4.14";
+
+  # Fix build with gcc15
+  env = lib.optionalAttrs (lib.versions.majorMinor ocaml.version == "5.0") {
+    NIX_CFLAGS_COMPILE = "-std=gnu11";
+  };
 
   src = fetchFromGitHub {
     owner = "codex-semantics-library";

--- a/pkgs/development/ocaml-modules/ppx_cstubs/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_cstubs/default.nix
@@ -18,7 +18,16 @@ buildDunePackage rec {
   pname = "ppx_cstubs";
   version = "0.7.0";
 
-  minimalOCamlVersion = "4.08";
+  env =
+    # Fix build with gcc15
+    lib.optionalAttrs
+      (
+        lib.versionAtLeast ocaml.version "4.10" && lib.versionOlder ocaml.version "4.14"
+        || lib.versions.majorMinor ocaml.version == "5.0"
+      )
+      {
+        NIX_CFLAGS_COMPILE = "-std=gnu11";
+      };
 
   src = fetchFromGitHub {
     owner = "fdopen";

--- a/pkgs/development/ocaml-modules/ppx_deriving_yaml/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_deriving_yaml/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   buildDunePackage,
+  ocaml,
   fetchurl,
   ppxlib,
   alcotest,
@@ -27,7 +28,13 @@ buildDunePackage rec {
   pname = "ppx_deriving_yaml";
   inherit (param) version;
 
-  minimalOCamlVersion = "4.08";
+  env =
+    # Fix build with gcc15
+    lib.optionalAttrs
+      (lib.versions.majorMinor ocaml.version == "4.13" || lib.versions.majorMinor ocaml.version == "5.0")
+      {
+        NIX_CFLAGS_COMPILE = "-std=gnu11";
+      };
 
   src = fetchurl {
     url = "https://github.com/patricoferris/ppx_deriving_yaml/releases/download/v${version}/ppx_deriving_yaml-${version}.tbz";

--- a/pkgs/development/ocaml-modules/rdbg/default.nix
+++ b/pkgs/development/ocaml-modules/rdbg/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  ocaml,
   buildDunePackage,
   fetchurl,
   num,
@@ -11,7 +12,16 @@ buildDunePackage rec {
   pname = "rdbg";
   version = "1.199.0";
 
-  minimalOCamlVersion = "4.08";
+  env =
+    # Fix build with gcc15
+    lib.optionalAttrs
+      (
+        lib.versionAtLeast ocaml.version "4.10" && lib.versionOlder ocaml.version "4.14"
+        || lib.versions.majorMinor ocaml.version == "5.0"
+      )
+      {
+        NIX_CFLAGS_COMPILE = "-std=gnu11";
+      };
 
   src = fetchurl {
     url = "http://www-verimag.imag.fr/DIST-TOOLS/SYNCHRONE/pool/rdbg.v${version}.tgz";

--- a/pkgs/development/ocaml-modules/tls/eio.nix
+++ b/pkgs/development/ocaml-modules/tls/eio.nix
@@ -1,4 +1,6 @@
 {
+  lib,
+  ocaml,
   buildDunePackage,
   crowbar,
   eio,
@@ -19,7 +21,7 @@ buildDunePackage {
 
   __darwinAllowLocalNetworking = true;
 
-  doCheck = true;
+  doCheck = lib.versionAtLeast ocaml.version "5.1";
   nativeCheckInputs = [
     mdx.bin
   ];

--- a/pkgs/development/ocaml-modules/zelus/default.nix
+++ b/pkgs/development/ocaml-modules/zelus/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  ocaml,
   buildDunePackage,
   fetchFromGitHub,
   menhir,
@@ -11,7 +12,16 @@ buildDunePackage rec {
   pname = "zelus";
   version = "2.2";
 
-  minimalOCamlVersion = "4.08.1";
+  env =
+    # Fix build with gcc15
+    lib.optionalAttrs
+      (
+        lib.versionAtLeast ocaml.version "4.10" && lib.versionOlder ocaml.version "4.14"
+        || lib.versions.majorMinor ocaml.version == "5.0"
+      )
+      {
+        NIX_CFLAGS_COMPILE = "-std=gnu11";
+      };
 
   src = fetchFromGitHub {
     owner = "INRIA";


### PR DESCRIPTION
Changes inspired by #474970

A few OCaml packages have been (partially) broken by the recent GCC update. This PR fixes some of the regressions.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
