### PR TITLE
treewide: prepare Rust packages for structuredAttrs by putting RUSTFLAGS in env

### DIFF
--- a/pkgs/applications/virtualization/rust-hypervisor-firmware/default.nix
+++ b/pkgs/applications/virtualization/rust-hypervisor-firmware/default.nix
@@ -44,13 +44,14 @@ rustPlatform.buildRustPackage rec {
   # https://github.com/cloud-hypervisor/rust-hypervisor-firmware/issues/249
   auditable = false;
 
-  RUSTC_BOOTSTRAP = 1;
+  env = {
+    RUSTC_BOOTSTRAP = 1;
+    RUSTFLAGS = "-C linker=lld -C linker-flavor=ld.lld";
+  };
 
   nativeBuildInputs = [
     lld
   ];
-
-  RUSTFLAGS = "-C linker=lld -C linker-flavor=ld.lld";
 
   # Tests don't work for `no_std`. See https://os.phil-opp.com/testing/
   doCheck = false;

--- a/pkgs/by-name/al/alvr/package.nix
+++ b/pkgs/by-name/al/alvr/package.nix
@@ -78,18 +78,19 @@ rustPlatform.buildRustPackage rec {
       "-lpng"
       "-lssl"
     ];
+    RUSTFLAGS = toString (
+      map (a: "-C link-arg=${a}") [
+        "-Wl,--push-state,--no-as-needed"
+        "-lEGL"
+        "-lwayland-client"
+        "-lxkbcommon"
+        "-Wl,--pop-state"
+      ]
+    );
   };
 
-  RUSTFLAGS = map (a: "-C link-arg=${a}") [
-    "-Wl,--push-state,--no-as-needed"
-    "-lEGL"
-    "-lwayland-client"
-    "-lxkbcommon"
-    "-Wl,--pop-state"
-  ];
-
   cargoBuildFlags = [
-    "--exclude alvr_xtask"
+    "--exclude=alvr_xtask"
     "--workspace"
   ];
 

--- a/pkgs/by-name/as/asusctl/package.nix
+++ b/pkgs/by-name/as/asusctl/package.nix
@@ -77,14 +77,18 @@ rustPlatform.buildRustPackage rec {
     wayland
   ];
 
-  # force linking to all the dlopen()ed dependencies
-  RUSTFLAGS = map (a: "-C link-arg=${a}") [
-    "-Wl,--push-state,--no-as-needed"
-    "-lEGL"
-    "-lfontconfig"
-    "-lwayland-client"
-    "-Wl,--pop-state"
-  ];
+  env = {
+    # force linking to all the dlopen()ed dependencies
+    RUSTFLAGS = toString (
+      map (a: "-C link-arg=${a}") [
+        "-Wl,--push-state,--no-as-needed"
+        "-lEGL"
+        "-lfontconfig"
+        "-lwayland-client"
+        "-Wl,--pop-state"
+      ]
+    );
+  };
 
   # upstream has minimal tests, so don't rebuild twice
   doCheck = false;

--- a/pkgs/by-name/ca/caligula/package.nix
+++ b/pkgs/by-name/ca/caligula/package.nix
@@ -21,7 +21,7 @@ rustPlatform.buildRustPackage rec {
     rustPlatform.bindgenHook
   ];
 
-  RUSTFLAGS = "--cfg tracing_unstable";
+  env.RUSTFLAGS = "--cfg tracing_unstable";
 
   meta = {
     description = "User-friendly, lightweight TUI for disk imaging";

--- a/pkgs/by-name/fi/firezone-gateway/package.nix
+++ b/pkgs/by-name/fi/firezone-gateway/package.nix
@@ -17,7 +17,7 @@ rustPlatform.buildRustPackage rec {
   cargoHash = "sha256-8YftVt72JpmxWB/WvOPpduE0/QgYvQhSuFRmsFth2iU=";
   sourceRoot = "${src.name}/rust";
   buildAndTestSubdir = "gateway";
-  RUSTFLAGS = "--cfg system_certs";
+  env.RUSTFLAGS = "--cfg system_certs";
 
   # Required to remove profiling arguments which conflict with this builder
   postPatch = ''

--- a/pkgs/by-name/fi/firezone-gui-client/package.nix
+++ b/pkgs/by-name/fi/firezone-gui-client/package.nix
@@ -82,7 +82,7 @@ rustPlatform.buildRustPackage rec {
   cargoHash = "sha256-TDP1Z4MeQaSER8MGnCEQfIhRsakaSCeJ7boUMBYkkI0=";
   sourceRoot = "${src.name}/rust";
   buildAndTestSubdir = "gui-client";
-  RUSTFLAGS = "--cfg system_certs";
+  env.RUSTFLAGS = "--cfg system_certs";
 
   nativeBuildInputs = [
     cargo-tauri.hook

--- a/pkgs/by-name/fi/firezone-headless-client/package.nix
+++ b/pkgs/by-name/fi/firezone-headless-client/package.nix
@@ -17,7 +17,7 @@ rustPlatform.buildRustPackage rec {
   cargoHash = "sha256-J2IqqFBuoTkbO0nMJbY680G2HTAtC1To/nMra2PCopY=";
   sourceRoot = "${src.name}/rust";
   buildAndTestSubdir = "headless-client";
-  RUSTFLAGS = "--cfg system_certs";
+  env.RUSTFLAGS = "--cfg system_certs";
 
   # Required to remove profiling arguments which conflict with this builder
   postPatch = ''

--- a/pkgs/by-name/fi/firezone-relay/package.nix
+++ b/pkgs/by-name/fi/firezone-relay/package.nix
@@ -16,7 +16,7 @@ rustPlatform.buildRustPackage rec {
   cargoHash = "sha256-uqy4GgYaSX2kM4a37093lHmhvOtNUhkEs6/ZS1bjuYo=";
   sourceRoot = "${src.name}/rust";
   buildAndTestSubdir = "relay";
-  RUSTFLAGS = "--cfg system_certs";
+  env.RUSTFLAGS = "--cfg system_certs";
 
   # Required to remove profiling arguments which conflict with this builder
   postPatch = ''

--- a/pkgs/by-name/go/gossip/package.nix
+++ b/pkgs/by-name/go/gossip/package.nix
@@ -38,7 +38,7 @@ rustPlatform.buildRustPackage rec {
   cargoHash = "sha256-rE7SErOhl2fcmvLairq+mvdnbDIk1aPo3eYqwRx5kkA=";
 
   # See https://github.com/mikedilger/gossip/blob/0.9/README.md.
-  RUSTFLAGS = "--cfg tokio_unstable";
+  env.RUSTFLAGS = "--cfg tokio_unstable";
 
   # Some users might want to add "rustls-tls(-native)" for Rust TLS instead of OpenSSL.
   buildFeatures = [

--- a/pkgs/by-name/id/idmail/package.nix
+++ b/pkgs/by-name/id/idmail/package.nix
@@ -34,8 +34,10 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-UcS2gAoa2fzPu6hh8I5sXSHHbAmzsecT44Ju2CVsK0Q=";
 
-  RUSTC_BOOTSTRAP = 1;
-  RUSTFLAGS = "--cfg=web_sys_unstable_apis";
+  env = {
+    RUSTC_BOOTSTRAP = 1;
+    RUSTFLAGS = "--cfg=web_sys_unstable_apis";
+  };
 
   nativeBuildInputs = [
     wasm-bindgen-cli_0_2_100

--- a/pkgs/by-name/ki/kime/package.nix
+++ b/pkgs/by-name/ki/kime/package.nix
@@ -128,9 +128,11 @@ stdenv.mkDerivation (finalAttrs: {
     cargo
   ];
 
-  RUST_BACKTRACE = 1;
-  # https://github.com/Riey/kime/issues/688
-  RUSTFLAGS = "-Clink-args=-L./target/release";
+  env = {
+    RUST_BACKTRACE = 1;
+    # https://github.com/Riey/kime/issues/688
+    RUSTFLAGS = "-Clink-args=-L./target/release";
+  };
 
   meta = {
     homepage = "https://github.com/Riey/kime";

--- a/pkgs/by-name/la/lact/package.nix
+++ b/pkgs/by-name/la/lact/package.nix
@@ -53,7 +53,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   ];
 
   # we do this here so that the binary is usable during integration tests
-  RUSTFLAGS = lib.optionalString stdenv.targetPlatform.isElf (
+  env.RUSTFLAGS = lib.optionalString stdenv.targetPlatform.isElf (
     lib.concatStringsSep " " [
       "-C link-arg=-Wl,-rpath,${
         lib.makeLibraryPath [

--- a/pkgs/by-name/mi/miro/package.nix
+++ b/pkgs/by-name/mi/miro/package.nix
@@ -36,13 +36,15 @@ rustPlatform.buildRustPackage (finalAttrs: {
     libglvnd
   ];
 
-  RUSTFLAGS = map (a: "-C link-arg=${a}") [
-    "-Wl,--push-state,--no-as-needed"
-    "-lEGL"
-    "-lwayland-client"
-    "-lxkbcommon"
-    "-Wl,--pop-state"
-  ];
+  env.RUSTFLAGS = toString (
+    map (a: "-C link-arg=${a}") [
+      "-Wl,--push-state,--no-as-needed"
+      "-lEGL"
+      "-lwayland-client"
+      "-lxkbcommon"
+      "-Wl,--pop-state"
+    ]
+  );
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];

--- a/pkgs/by-name/mi/mitra/package.nix
+++ b/pkgs/by-name/mi/mitra/package.nix
@@ -21,7 +21,7 @@ rustPlatform.buildRustPackage rec {
   # require running database
   doCheck = false;
 
-  RUSTFLAGS = [
+  env.RUSTFLAGS = toString [
     # MEMO: mitra use ammonia crate with unstable rustc flag
     "--cfg=ammonia_unstable"
   ];

--- a/pkgs/by-name/pr/proxmox-backup-client/package.nix
+++ b/pkgs/by-name/pr/proxmox-backup-client/package.nix
@@ -124,12 +124,13 @@ rustPlatform.buildRustPackage {
     "--bin=pxar"
   ];
 
-  RUSTFLAGS = [ "-L.dep-stubs" ];
+  env = {
+    RUSTFLAGS = toString [ "-L.dep-stubs" ];
+    # pbs-buildcfg requires this set, would be the git commit id
+    REPOID = "";
+  };
 
   doCheck = false;
-
-  # pbs-buildcfg requires this set, would be the git commit id
-  REPOID = "";
 
   nativeBuildInputs = [
     pkgconf

--- a/pkgs/by-name/rc/rcp/package.nix
+++ b/pkgs/by-name/rc/rcp/package.nix
@@ -18,7 +18,7 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-AcH5V5hapVQgGrwWAEN6Xpj00RRNqZiCSn+/onpmd50=";
 
-  RUSTFLAGS = "--cfg tokio_unstable";
+  env.RUSTFLAGS = "--cfg tokio_unstable";
 
   checkFlags = [
     # these tests set setuid permissions on a test file (3oXXX) which doesn't work in a sandbox

--- a/pkgs/by-name/re/restate/package.nix
+++ b/pkgs/by-name/re/restate/package.nix
@@ -100,13 +100,14 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   checkFlags = [
     # Error: deadline has elapsed
-    "--skip replicated_loglet"
-
+    "--skip"
+    "replicated_loglet"
     # TIMEOUT [ 180.006s]
-    "--skip fast_forward_over_trim_gap"
-
-    # TIMEOUT (could be related to https://github.com/restatedev/restate/issues/3043)
-    "--skip restatectl_smoke_test"
+    "--skip"
+    "fast_forward_over_trim_gap"
+    # TIMEOUT (could be related to https://github.com/resytatedev/restate/issues/3043)
+    "--skip"
+    "restatectl_smoke_test"
   ];
 
   __darwinAllowLocalNetworking = true;

--- a/pkgs/by-name/ri/ripgrep-all/package.nix
+++ b/pkgs/by-name/ri/ripgrep-all/package.nix
@@ -35,7 +35,7 @@ rustPlatform.buildRustPackage rec {
   cargoHash = "sha256-v+lLCI2ti/xL8hcGkm/xDDN9qk0G9MgtijE8xYnhC68=";
 
   # override debug=true set in Cargo.toml upstream
-  RUSTFLAGS = "-C debuginfo=none";
+  env.RUSTFLAGS = "-C debuginfo=none";
 
   nativeBuildInputs = [
     makeWrapper

--- a/pkgs/by-name/sq/sqld/package.nix
+++ b/pkgs/by-name/sq/sqld/package.nix
@@ -55,10 +55,12 @@ rustPlatform.buildRustPackage rec {
     zstd
   ];
 
-  env.ZSTD_SYS_USE_PKG_CONFIG = true;
+  env = {
+    ZSTD_SYS_USE_PKG_CONFIG = true;
 
-  # error[E0425]: cannot find function `consume_budget` in module `tokio::task`
-  env.RUSTFLAGS = "--cfg tokio_unstable";
+    # error[E0425]: cannot find function `consume_budget` in module `tokio::task`
+    RUSTFLAGS = "--cfg tokio_unstable";
+  };
 
   # requires a complex setup with podman for the end-to-end tests
   doCheck = false;

--- a/pkgs/by-name/su/surrealdb/package.nix
+++ b/pkgs/by-name/su/surrealdb/package.nix
@@ -26,13 +26,15 @@ rustPlatform.buildRustPackage (finalAttrs: {
     rm .cargo/config.toml
   '';
 
-  PROTOC = "${protobuf}/bin/protoc";
-  PROTOC_INCLUDE = "${protobuf}/include";
+  env = {
+    PROTOC = "${protobuf}/bin/protoc";
+    PROTOC_INCLUDE = "${protobuf}/include";
 
-  ROCKSDB_INCLUDE_DIR = "${rocksdb}/include";
-  ROCKSDB_LIB_DIR = "${rocksdb}/lib";
+    ROCKSDB_INCLUDE_DIR = "${rocksdb}/include";
+    ROCKSDB_LIB_DIR = "${rocksdb}/lib";
 
-  RUSTFLAGS = "--cfg surrealdb_unstable";
+    RUSTFLAGS = "--cfg surrealdb_unstable";
+  };
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/by-name/to/tokio-console/package.nix
+++ b/pkgs/by-name/to/tokio-console/package.nix
@@ -28,13 +28,13 @@ rustPlatform.buildRustPackage rec {
   ];
 
   # uses currently unstable tokio features
-  RUSTFLAGS = "--cfg tokio_unstable";
+  env.RUSTFLAGS = "--cfg tokio_unstable";
 
   checkFlags = [
     # tests depend upon git repository at test execution time
-    "--skip bootstrap"
-    "--skip config::tests::args_example_changed"
-    "--skip config::tests::toml_example_changed"
+    "--skip=bootstrap"
+    "--skip=config::tests::args_example_changed"
+    "--skip=config::tests::toml_example_changed"
   ];
 
   postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''

--- a/pkgs/by-name/tr/trojan-rs/package.nix
+++ b/pkgs/by-name/tr/trojan-rs/package.nix
@@ -21,8 +21,10 @@ rustPlatform.buildRustPackage {
   nativeBuildInputs = [ rustPlatform.bindgenHook ];
   buildInputs = [ ipset ];
 
-  env.RUSTC_BOOTSTRAP = true;
-  env.RUSTFLAGS = "--cfg tokio_unstable";
+  env = {
+    RUSTC_BOOTSTRAP = true;
+    RUSTFLAGS = "--cfg tokio_unstable";
+  };
 
   meta = {
     homepage = "https://github.com/lazytiger/trojan-rs";

--- a/pkgs/by-name/ve/veilid/package.nix
+++ b/pkgs/by-name/ve/veilid/package.nix
@@ -33,7 +33,7 @@ rustPlatform.buildRustPackage rec {
     "--workspace"
   ];
 
-  RUSTFLAGS = "--cfg tokio_unstable";
+  env.RUSTFLAGS = "--cfg tokio_unstable";
 
   doCheck = false;
 

--- a/pkgs/by-name/wa/warpgate/package.nix
+++ b/pkgs/by-name/wa/warpgate/package.nix
@@ -50,7 +50,7 @@ rustPlatform.buildRustPackage (
       (replaceVars ./hardcode-version.patch { inherit (finalAttrs) version; })
     ];
 
-    RUSTFLAGS = "--cfg tokio_unstable";
+    env.RUSTFLAGS = "--cfg tokio_unstable";
 
     buildFeatures = [
       "postgres"

--- a/pkgs/by-name/wa/way-edges/package.nix
+++ b/pkgs/by-name/wa/way-edges/package.nix
@@ -30,7 +30,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     libpulseaudio
   ];
 
-  RUSTFLAGS = [
+  env.RUSTFLAGS = toString [
     "--cfg tokio_unstable"
     "--cfg tokio_uring"
   ];

--- a/pkgs/by-name/wp/wprs/package.nix
+++ b/pkgs/by-name/wp/wprs/package.nix
@@ -30,7 +30,7 @@ rustPlatform.buildRustPackage {
 
   cargoHash = "sha256-krrVgdoCcW3voSiQAoWsG+rPf1HYKbuGhplhn21as2c=";
 
-  RUSTFLAGS = "-C target-feature=+avx2"; # only works on x86 systems supporting AVX2
+  env.RUSTFLAGS = "-C target-feature=+avx2"; # only works on x86 systems supporting AVX2
 
   preFixup = ''
     cp  wprs "$out/bin/wprs"

--- a/pkgs/by-name/ze/zed-editor/package.nix
+++ b/pkgs/by-name/ze/zed-editor/package.nix
@@ -208,9 +208,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
     # Used by `zed --version`
     RELEASE_VERSION = finalAttrs.version;
     LK_CUSTOM_WEBRTC = livekit-libwebrtc;
+    RUSTFLAGS = lib.optionalString withGLES "--cfg gles";
   };
-
-  RUSTFLAGS = lib.optionalString withGLES "--cfg gles";
 
   preBuild = ''
     bash script/generate-licenses

--- a/pkgs/development/python-modules/mitmproxy-linux/default.nix
+++ b/pkgs/development/python-modules/mitmproxy-linux/default.nix
@@ -26,8 +26,10 @@ buildPythonPackage {
     patch -p1 < tmp.diff
   '';
 
-  RUSTFLAGS = "-C target-feature=";
-  RUSTC_BOOTSTRAP = 1;
+  env = {
+    RUSTFLAGS = "-C target-feature=";
+    RUSTC_BOOTSTRAP = 1;
+  };
 
   buildAndTestSubdir = "mitmproxy-linux";
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
