### PR TITLE
sandhole: init at 0.8.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7895,6 +7895,12 @@
     githubId = 5085029;
     name = "Emanuele Peruffo";
   };
+  EpicEric = {
+    email = "eric@eric.dev.br";
+    github = "EpicEric";
+    githubId = 3129194;
+    name = "Eric Rodrigues Pires";
+  };
   epireyn = {
     github = "epireyn";
     githubId = 48213068;

--- a/pkgs/by-name/sa/sandhole/package.nix
+++ b/pkgs/by-name/sa/sandhole/package.nix
@@ -1,0 +1,53 @@
+{
+  cmake,
+  fetchFromGitHub,
+  lib,
+  perl,
+  rustPlatform,
+  versionCheckHook,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "sandhole";
+  version = "0.8.6";
+
+  src = fetchFromGitHub {
+    owner = "EpicEric";
+    repo = "sandhole";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-30ltOQLobRy/M1v+0jFpBmH5ZkTmkZ+mQP7BX5RKo2s=";
+  };
+
+  cargoHash = "sha256-BE7y4VlvINWdJM4/36CDn4YxPWUQnT22YJtcvjup0Ec=";
+
+  # All integration tests require networking.
+  postPatch = ''
+    echo "fn main() {}" > tests/integration/main.rs
+  '';
+
+  buildInputs = [ cmake ];
+  nativeBuildInputs = [ perl ];
+
+  useNextest = true;
+  checkFlags = [
+    # Some unit tests require networking.
+    "--skip"
+    "login"
+  ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  meta = {
+    description = "Expose HTTP/SSH/TCP services through SSH port forwarding";
+    longDescription = ''
+      A reverse proxy that just works with an OpenSSH client.
+      No extra software required to beat NAT!
+    '';
+    homepage = "https://sandhole.com.br";
+    changelog = "https://github.com/EpicEric/sandhole/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    mainProgram = "sandhole";
+    maintainers = with lib.maintainers; [ EpicEric ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+})


### PR DESCRIPTION
Sandhole is a reverse proxy that lets users expose HTTP/SSH/TCP services through SSH port forwarding. It's mostly feature-complete, but still receives occasional updates and fixes.

Link to homepage: https://sandhole.com.br/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
