### PR TITLE
python313Packages.sqlmodel: 0.0.24 -> 0.0.31

### DIFF
--- a/pkgs/development/python-modules/sqlmodel/default.nix
+++ b/pkgs/development/python-modules/sqlmodel/default.nix
@@ -49,8 +49,8 @@ buildPythonPackage rec {
 
   meta = {
     description = "Module to work with SQL databases";
-    homepage = "https://github.com/tiangolo/sqlmodel";
-    changelog = "https://github.com/tiangolo/sqlmodel/releases/tag/${version}";
+    homepage = "https://github.com/fastapi/sqlmodel";
+    changelog = "https://github.com/fastapi/sqlmodel/releases/tag/${src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
   };

--- a/pkgs/development/python-modules/sqlmodel/default.nix
+++ b/pkgs/development/python-modules/sqlmodel/default.nix
@@ -6,37 +6,23 @@
   dirty-equals,
   fastapi,
   fetchFromGitHub,
-  fetchpatch,
   pdm-backend,
   pydantic,
-  pytest-asyncio,
   pytestCheckHook,
-  pythonOlder,
   sqlalchemy,
 }:
 
 buildPythonPackage rec {
   pname = "sqlmodel";
-  version = "0.0.24";
+  version = "0.0.31";
   pyproject = true;
-
-  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "tiangolo";
     repo = "sqlmodel";
     tag = version;
-    hash = "sha256-RKihR3UJLuBYSHK79pcxIx/hT0nCkqQO8zBrq4AWaYM=";
+    hash = "sha256-HJ8we0gYySagUvs7NEKcwe9l7KEcqmJ8+CTW/rjBdME=";
   };
-
-  patches = [
-    (fetchpatch {
-      # https://github.com/tiangolo/sqlmodel/pull/969
-      name = "passthru-environ-variables.patch";
-      url = "https://github.com/tiangolo/sqlmodel/pull/969/commits/42d33049e9e4182b78914ad41d1e3d30125126ba.patch";
-      hash = "sha256-dPuFCFUnmTpduxn45tE8XUP0Jlwjwmwe+zFaKSganOg=";
-    })
-  ];
 
   build-system = [ pdm-backend ];
 
@@ -50,16 +36,10 @@ buildPythonPackage rec {
     jinja2
     dirty-equals
     fastapi
-    pytest-asyncio
     pytestCheckHook
   ];
 
   pythonImportsCheck = [ "sqlmodel" ];
-
-  disabledTests = [
-    # AssertionError: assert 'enum_field VARCHAR(1)
-    "test_sqlite_ddl_sql"
-  ];
 
   disabledTestPaths = [
     # Coverage


### PR DESCRIPTION
Changelog: https://github.com/fastapi/sqlmodel/releases
Diff: https://github.com/fastapi/sqlmodel/compare/0.0.24...0.0.31

This fixes the build of `python314Packages.sqlmodel`.

Hydra: https://hydra.nixos.org/build/317371769/nixlog/2
Tracking: #475732

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
