### PR TITLE
gnomeExtensions.forge: 49.2 -> 49.3

### DIFF
--- a/pkgs/desktops/gnome/extensions/forge/default.nix
+++ b/pkgs/desktops/gnome/extensions/forge/default.nix
@@ -10,13 +10,13 @@ let
 in
 stdenv.mkDerivation {
   pname = "gnome-shell-extension-forge";
-  version = "49.2-development";
+  version = "49.3-development";
 
   src = fetchFromGitHub {
     owner = "forge-ext";
     repo = "forge";
-    rev = "701e7587e88fd51cc10e0f2fc5124ac61c82cf1c";
-    hash = "sha256-yKBH4Hv4b0CUVubsfs8a8fg3nIuogvGp5DJT/HjBcns=";
+    rev = "a2fabeb5102d3b96661cde0e332c288bea21a1a5";
+    hash = "sha256-nk2olkhNX7dIKO9xYR1yWaaKHjxtMv7mPvmUf2sCDD8=";
   };
 
   nativeBuildInputs = [ glib ];


### PR DESCRIPTION
There is a bug in the current gnome forge extension which does't toggle floating windows correctly. There is already a fix present in the forge repo [here](https://github.com/forge-ext/forge/commit/a2fabeb5102d3b96661cde0e332c288bea21a1a5)

Updating the gnome forge version to incorporate the fix


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
