### PR TITLE
voicevox: patch to ignore node version

### DIFF
--- a/pkgs/by-name/vo/voicevox/package.nix
+++ b/pkgs/by-name/vo/voicevox/package.nix
@@ -40,6 +40,10 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   postPatch = ''
+    # don't fail if node version doesn't fit the constraint
+    substituteInPlace .npmrc \
+      --replace-fail "engine-strict=true" ""
+
     # unlock the overly specific pnpm package version pin
     # and also set version to a proper value
     jq "del(.packageManager) | .version = \"$version\"" package.json | sponge package.json


### PR DESCRIPTION
Voicevox does not build currently. I think the solution is to drop the nodejs version. I found a few other packages that do this (by grepping pnpm').  The changes build for me (srcbot incoming), but IDK if it is idiomatic since this is my first time touching a pnpm package. Let me know if this needs changes!

Also: my linux box is headless, so I can't test the changes.

Here are the failing logs

```
$ nix-build --no-out-link --substituters  --expr with import /tmp/nix-shell.izAIxn/.tmpeRPZSX/nixpkgs { system = "x86_64-linux"; config = { allowUnfree = true; }; }; voicevox.pnpmDeps
this derivation will be built:
  /nix/store/wwph74vavg38nk4s15gvkn39ibwha0m0-voicevox-pnpm-deps.drv
building '/nix/store/wwph74vavg38nk4s15gvkn39ibwha0m0-voicevox-pnpm-deps.drv'...
Running phase: unpackPhase
unpacking source archive /nix/store/bjp3b8mx1ys83dhpy571hiwbkhbxxgak-source
source root is source
Running phase: patchPhase
applying patch /nix/store/ybvdjp6iv1r3qxlj38swzf1lx2r9dj60-hardcode-paths.patch
patching file .env.production
patching file build/electronBuilderConfig.ts
patching file src/backend/electron/vvppFile.ts
patching file vite.config.ts
Running phase: updateAutotoolsGnuConfigScriptsPhase
Running phase: installPhase
/build /build/source
/build/source
 ERR_PNPM_UNSUPPORTED_ENGINE  Unsupported environment (bad pnpm and/or Node.js version)

Your Node version is incompatible with "/build/source".

Expected version: >=22.14.0 <23
Got: v24.12.0

This is happening because the package's manifest has an engines.node field specified.
To fix this issue, install the required Node version.
error: Cannot build '/nix/store/wwph74vavg38nk4s15gvkn39ibwha0m0-voicevox-pnpm-deps.drv'.
       Reason: builder failed with exit code 1.
       Output paths:
         /nix/store/3pyq9yill079zgp6cga9x09d2cr2k05z-voicevox-pnpm-deps
       Last 22 log lines:
       > Running phase: unpackPhase
       > unpacking source archive /nix/store/bjp3b8mx1ys83dhpy571hiwbkhbxxgak-source
       > source root is source
       > Running phase: patchPhase
       > applying patch /nix/store/ybvdjp6iv1r3qxlj38swzf1lx2r9dj60-hardcode-paths.patch
       > patching file .env.production
       > patching file build/electronBuilderConfig.ts
       > patching file src/backend/electron/vvppFile.ts
       > patching file vite.config.ts
       > Running phase: updateAutotoolsGnuConfigScriptsPhase
       > Running phase: installPhase
       > /build /build/source
       > /build/source
       >  ERR_PNPM_UNSUPPORTED_ENGINE  Unsupported environment (bad pnpm and/or Node.js version)
       >
       > Your Node version is incompatible with "/build/source".
       >
       > Expected version: >=22.14.0 <23
       > Got: v24.12.0
       >
       > This is happening because the package's manifest has an engines.node field specified.
       > To fix this issue, install the required Node version.
       For full logs, run:
         nix log /nix/store/wwph74vavg38nk4s15gvkn39ibwha0m0-voicevox-pnpm-deps.drv
```



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
