### PR TITLE
dependency-track: fix fetchedMavenDeps hash

### DIFF
--- a/pkgs/by-name/de/dependency-track/package.nix
+++ b/pkgs/by-name/de/dependency-track/package.nix
@@ -65,7 +65,7 @@ maven.buildMavenPackage rec {
   '';
 
   mvnJdk = jre_headless;
-  mvnHash = "sha256-HZK/o/RMbMj7OUfucizO5/LpJhwNhHfwbyvUOcO13dA=";
+  mvnHash = "sha256-Y4imt+eB9KrLN6f1X5CqYoj0FiGU/6ST79R5tK4rWw4=";
   manualMvnArtifacts = [ "com.coderplus.maven.plugins:copy-rename-maven-plugin:1.0.1" ];
   buildOffline = true;
 


### PR DESCRIPTION
Fixes hash mismatch for `dependency-track.fetchedMavenDeps`.

Seems similar to #475443. Codehaus and apache both changed. Changes in the diff are still substantial, unfortunately.

Build logs:
- [before (f2bd99d)](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/dependency-track/fetchedMavenDeps.before.log)
- [after (6fbf418)](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/dependency-track/fetchedMavenDeps.after.log)
- [source diff](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/dependency-track/fetchedMavenDeps.diff.log)

Source directories:
- [old source](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/dependency-track/fetchedMavenDeps.src.before/)
- [new source](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/dependency-track/fetchedMavenDeps.src.after/)

<details>
<summary>Source diff (first 100 lines)</summary>

```
.m2/org/apache/maven/plugins/maven-assembly-plugin/3.7.1/maven-assembly-plugin-3.7.1.pom.sha1 --- Text
1 da815fead86f0d7b8e2fe4a0cc1c2cfe49616229
2 

.m2/org/apache/maven/plugins/maven-antrun-plugin/3.1.0/maven-antrun-plugin-3.1.0.jar --- Binary
Binary file removed (40.2 KiB).

.m2/org/apache/maven/plugins/maven-antrun-plugin/3.1.0/maven-antrun-plugin-3.1.0.pom --- Text
  1 <?xml version='1.0' encoding='UTF-8'?>
  2 
  3 <!--
  4 Licensed to the Apache Software Foundation (ASF) under one
  5 or more contributor license agreements.  See the NOTICE file
  6 distributed with this work for additional information
  7 regarding copyright ownership.  The ASF licenses this file
  8 to you under the Apache License, Version 2.0 (the
  9 "License"); you may not use this file except in compliance
 10 with the License.  You may obtain a copy of the License at
 11 
 12   http://www.apache.org/licenses/LICENSE-2.0
 13 
 14 Unless required by applicable law or agreed to in writing,
 15 software distributed under the License is distributed on an
 16 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 17 KIND, either express or implied.  See the License for the
 18 specific language governing permissions and limitations
 19 under the License.
 20 -->
 21 
 22 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 23   <modelVersion>4.0.0</modelVersion>
 24 
 25   <parent>
 26     <artifactId>maven-plugins</artifactId>
 27     <groupId>org.apache.maven.plugins</groupId>
 28     <version>34</version>
 29     <relativePath />
 30   </parent>
 31 
 32   <artifactId>maven-antrun-plugin</artifactId>
 33   <version>3.1.0</version>
 34   <packaging>maven-plugin</packaging>
 35 
 36   <name>Apache Maven AntRun Plugin</name>
 37   <description>Runs Ant scripts embedded in the POM</description>
 38 
 39   <prerequisites>
 40     <maven>${mavenVersion}</maven>
 41   </prerequisites>
 42 
 43   <scm>
 44     <connection>scm:git:https://gitbox.apache.org/repos/asf/maven-antrun-plugin.git</connection>
 45     <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/maven-antrun-plugin.git</developerConnection>
 46     <url>https://github.com/apache/maven-antrun-plugin/tree/${project.scm.tag}</url>
 47     <tag>maven-antrun-plugin-3.1.0</tag>
 48   </scm>
 49   <issueManagement>
 50     <system>jira</system>
 51     <url>https://issues.apache.org/jira/browse/MANTRUN</url>
 52   </issueManagement>
 53   <ciManagement>
 54     <system>Jenkins</system>
 55     <url>https://ci-maven.apache.org/job/Maven/job/maven-box/job/maven-antrun-plugin/</url>
 56   </ciManagement>
 57   <distributionManagement>
 58     <site>
 59       <id>apache.website</id>
 60       <url>scm:svn:https://svn.apache.org/repos/asf/maven/website/components/${maven.site.path}</url>
 61     </site>
 62   </distributionManagement>
 63 
 64   <properties>
 65     <mavenVersion>3.2.5</mavenVersion>
 66     <javaVersion>8</javaVersion>
 67     <surefire.version>2.22.2</surefire.version>
 68     <mavenPluginToolsVersion>3.6.4</mavenPluginToolsVersion>
 69     <project.build.outputTimestamp>2022-04-18T19:39:44Z</project.build.outputTimestamp>
 70   </properties>
 71 
 72   <dependencies>
 73     <dependency>
 74       <groupId>org.apache.maven</groupId>
 75       <artifactId>maven-plugin-api</artifactId>
 76       <version>${mavenVersion}</version>
 77       <scope>provided</scope>
 78     </dependency>
 79     <dependency>
 80       <groupId>org.apache.maven</groupId>
 81       <artifactId>maven-core</artifactId>
 82       <version>${mavenVersion}</version>
 83       <scope>provided</scope>
 84     </dependency>
 85     <dependency>
 86       <groupId>org.apache.maven</groupId>
 87       <artifactId>maven-artifact</artifactId>
 88       <version>${mavenVersion}</version>
 89       <scope>provided</scope>
 90     </dependency>
 91     <dependency>
 92       <groupId>org.apache.maven.plugin-tools</groupId>
```
</details>

<details>
<summary>Build before (first 100 lines)</summary>

```
these 2 derivations will be built:
  /nix/store/jlh6c7lc4kxm6lfxypvvjl7rjhsylqx4-protobuf-30.2.drv
  /nix/store/nqbv824yak6mnbmp60ary1idyrlp1xb3-maven-deps-dependency-track-4.13.6.drv
building '/nix/store/jlh6c7lc4kxm6lfxypvvjl7rjhsylqx4-protobuf-30.2.drv'...
Using versionCheckHook
Running phase: unpackPhase
unpacking source archive /nix/store/zwz18jwmdxd32axzba8c8ylm7lcrzaxf-source
source root is source
Running phase: patchPhase
Running phase: updateAutotoolsGnuConfigScriptsPhase
Running phase: configurePhase
cmake flags: -DCMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY=OFF -DCMAKE_FIND_USE_PACKAGE_REGISTRY=OFF -DCMAKE_EXPORT_NO_PACKAGE_REGISTRY=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_LOCALEDIR=/nix/store/0wl4gw4j8330jzr09cd431wnf2j6bzcs-protobuf-30.2/share/locale -DCMAKE_INSTALL_LIBEXECDIR=/nix/store/0wl4gw4j8330jzr09cd431wnf2j6bzcs-protobuf-30.2/libexec -DCMAKE_INSTALL_LIBDIR=/nix/store/0wl4gw4j8330jzr09cd431wnf2j6bzcs-protobuf-30.2/lib -DCMAKE_INSTALL_DOCDIR=/nix/store/0wl4gw4j8330jzr09cd431wnf2j6bzcs-protobuf-30.2/share/doc/protobuf -DCMAKE_INSTALL_INFODIR=/nix/store/0wl4gw4j8330jzr09cd431wnf2j6bzcs-protobuf-30.2/share/info -DCMAKE_INSTALL_MANDIR=/nix/store/0wl4gw4j8330jzr09cd431wnf2j6bzcs-protobuf-30.2/share/man -DCMAKE_INSTALL_INCLUDEDIR=/nix/store/0wl4gw4j8330jzr09cd431wnf2j6bzcs-protobuf-30.2/include -DCMAKE_INSTALL_SBINDIR=/nix/store/0wl4gw4j8330jzr09cd431wnf2j6bzcs-protobuf-30.2/sbin -DCMAKE_INSTALL_BINDIR=/nix/store/0wl4gw4j8330jzr09cd431wnf2j6bzcs-protobuf-30.2/bin -DCMAKE_INSTALL_NAME_DIR=/nix/store/0wl4gw4j8330jzr09cd431wnf2j6bzcs-protobuf-30.2/lib -DCMAKE_STRIP=/nix/store/r9wbjib6xxjkyb9yvjvrkl4sq61i2lyn-gcc-wrapper-15.2.0/bin/strip -DCMAKE_RANLIB=/nix/store/r9wbjib6xxjkyb9yvjvrkl4sq61i2lyn-gcc-wrapper-15.2.0/bin/ranlib -DCMAKE_AR=/nix/store/r9wbjib6xxjkyb9yvjvrkl4sq61i2lyn-gcc-wrapper-15.2.0/bin/ar -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_INSTALL_PREFIX=/nix/store/0wl4gw4j8330jzr09cd431wnf2j6bzcs-protobuf-30.2 -Dprotobuf_USE_EXTERNAL_GTEST=ON -Dprotobuf_ABSL_PROVIDER=package -Dprotobuf_BUILD_SHARED_LIBS=ON
CMake Deprecation Warning at CMakeLists.txt:7 (cmake_policy):
  The OLD behavior for policy CMP0141 will be removed from a future version
  of CMake.

  The cmake-policies(7) manual explains that the OLD behaviors of all
  policies are deprecated and that a policy should be set to OLD only under
  specific short-term circumstances.  Projects should be ported to the NEW
  behavior and not rely on setting a policy to OLD.


-- The C compiler identification is GNU 15.2.0
-- The CXX compiler identification is GNU 15.2.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /nix/store/r9wbjib6xxjkyb9yvjvrkl4sq61i2lyn-gcc-wrapper-15.2.0/bin/gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /nix/store/r9wbjib6xxjkyb9yvjvrkl4sq61i2lyn-gcc-wrapper-15.2.0/bin/g++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- protobuf version: 30.2.0
-- Performing Test protobuf_HAVE_LD_VERSION_SCRIPT
-- Performing Test protobuf_HAVE_LD_VERSION_SCRIPT - Success
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE
-- Found ZLIB: /nix/store/c2qsgf2832zi4n29gfkqgkjpvmbmxam6-zlib-1.3.1/lib/libz.so (found version "1.3.1")
-- Performing Test protobuf_HAVE_BUILTIN_ATOMICS
-- Performing Test protobuf_HAVE_BUILTIN_ATOMICS - Success
-- Configuring done (2.1s)
-- Generating done (0.5s)
CMake Warning:
  Manually-specified variables were not used by the project:

    CMAKE_EXPORT_NO_PACKAGE_REGISTRY
    protobuf_ABSL_PROVIDER
    protobuf_USE_EXTERNAL_GTEST


-- Build files have been written to: /build/source/build
cmake: enabled parallel building
cmake: enabled parallel installing
Running phase: buildPhase
build flags: -j24 SHELL=/nix/store/lw117lsr8d585xs63kx5k233impyrq7q-bash-5.3p3/bin/bash
[  0%] Building CXX object third_party/utf8_range/CMakeFiles/utf8_validity.dir/utf8_validity.cc.o
[  0%] Building C object third_party/utf8_range/CMakeFiles/utf8_validity.dir/utf8_range.c.o
[  0%] Building C object third_party/utf8_range/CMakeFiles/utf8_range.dir/utf8_range.c.o
[  0%] Linking C shared library libutf8_range.so
[  0%] Built target utf8_range
[  0%] Building C object CMakeFiles/libupb.dir/upb/base/status.c.o
[  0%] Building C object CMakeFiles/libupb.dir/upb/hash/common.c.o
[  0%] Building C object CMakeFiles/libupb.dir/upb/json/decode.c.o
[  0%] Building C object CMakeFiles/libupb.dir/upb/lex/atoi.c.o
[  0%] Building C object CMakeFiles/libupb.dir/upb/json/encode.c.o
[  0%] Building C object CMakeFiles/libupb.dir/upb/lex/unicode.c.o
[  0%] Building C object CMakeFiles/libupb.dir/upb/mem/alloc.c.o
[  0%] Building C object CMakeFiles/libupb.dir/upb/lex/strtod.c.o
[  0%] Building C object CMakeFiles/libupb.dir/upb/mem/arena.c.o
[  1%] Building C object CMakeFiles/libupb.dir/upb/lex/round_trip.c.o
[  1%] Building C object CMakeFiles/libupb.dir/upb/message/array.c.o
[  1%] Building C object CMakeFiles/libupb.dir/upb/message/compat.c.o
[  1%] Building C object CMakeFiles/libupb.dir/upb/message/compare.c.o
[  1%] Building C object CMakeFiles/libupb.dir/upb/message/accessors.c.o
[  2%] Building C object CMakeFiles/libupb.dir/upb/message/internal/compare_unknown.c.o
[  2%] Building C object CMakeFiles/libupb.dir/upb/message/copy.c.o
[  2%] Building C object CMakeFiles/libupb.dir/upb/message/merge.c.o
[  2%] Building C object CMakeFiles/libupb.dir/upb/message/internal/extension.c.o
[  2%] Building C object CMakeFiles/libupb.dir/upb/message/map.c.o
[  2%] Building C object CMakeFiles/libupb.dir/upb/message/internal/iterator.c.o
[  2%] Building C object CMakeFiles/libupb.dir/upb/message/internal/message.c.o
[  2%] Building C object CMakeFiles/libupb.dir/upb/message/message.c.o
[  2%] Building C object CMakeFiles/libupb.dir/upb/message/map_sorter.c.o
[  2%] Building C object CMakeFiles/libupb.dir/upb/mini_descriptor/build_enum.c.o
[  3%] Building C object CMakeFiles/libupb.dir/upb/mini_descriptor/decode.c.o
[  3%] Building C object CMakeFiles/libupb.dir/upb/mini_descriptor/internal/base92.c.o
[  3%] Building C object CMakeFiles/libupb.dir/upb/mini_descriptor/internal/encode.c.o
[  3%] Building C object CMakeFiles/libupb.dir/upb/mini_descriptor/link.c.o
[  3%] Building C object CMakeFiles/libupb.dir/upb/mini_table/extension_registry.c.o
[  4%] Linking CXX shared library libutf8_validity.so
[  4%] Building C object CMakeFiles/libupb.dir/upb/mini_table/internal/message.c.o
[  4%] Building C object CMakeFiles/libupb.dir/upb/mini_table/message.c.o
/build/source/upb/mini_table/extension_registry.c:85:1: warning: 'no_sanitize' attribute ignored [-Wattributes]
   85 | UPB_LINKARR_DECLARE(upb_AllExts, upb_MiniTableExtension);
      | ^~~~~~~~~~~~~~~~~~~
[  4%] Building C object CMakeFiles/libupb.dir/upb/reflection/def_type.c.o
[  4%] Building C object CMakeFiles/libupb.dir/upb/reflection/def_pool.c.o
```
</details>

<details>
<summary>Build after (first 100 lines)</summary>

```
checking outputs of '/nix/store/47r3v32y1fwxnrqvykrr9lknyr1nq0z5-maven-deps-dependency-track-4.13.6.drv'...
Running phase: unpackPhase
unpacking source archive /nix/store/cwbvv82wnlh996p62nm26pb2aim5xb8n-source
source root is source
Running phase: patchPhase
applying patch /nix/store/mxjab5mnmmvg8x6cpyiqadckrip10x35-0000-remove-frontend-download.patch
patching file pom.xml
Hunk #1 succeeded at 824 with fuzz 2 (offset 164 lines).
applying patch /nix/store/9h25xnsr9ik7rzh2zpvc2m1n95sq7pk7-0001-add-junixsocket.patch
patching file pom.xml
Hunk #1 succeeded at 486 (offset 29 lines).
Running phase: updateAutotoolsGnuConfigScriptsPhase
Running phase: configurePhase
no configure script, doing nothing
Running phase: buildPhase
[INFO] Scanning for projects...
Downloading from central: https://repo.maven.apache.org/maven2/us/springett/alpine-parent/3.4.0/alpine-parent-3.4.0.pom
Downloaded from central: https://repo.maven.apache.org/maven2/us/springett/alpine-parent/3.4.0/alpine-parent-3.4.0.pom (53 kB at 43 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/central/central-publishing-maven-plugin/0.9.0/central-publishing-maven-plugin-0.9.0.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/central/central-publishing-maven-plugin/0.9.0/central-publishing-maven-plugin-0.9.0.pom (17 kB at 204 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/buildsupport/buildsupport/32/buildsupport-32.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/buildsupport/buildsupport/32/buildsupport-32.pom (36 kB at 365 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/3.5.1/plexus-utils-3.5.1.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/3.5.1/plexus-utils-3.5.1.pom (8.8 kB at 99 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/10/plexus-10.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/10/plexus-10.pom (25 kB at 374 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/com/github/package-url/packageurl-java/1.4.1/packageurl-java-1.4.1.pom
Downloaded from central: https://repo.maven.apache.org/maven2/com/github/package-url/packageurl-java/1.4.1/packageurl-java-1.4.1.pom (12 kB at 183 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/com/google/guava/guava/32.1.0-jre/guava-32.1.0-jre.pom
Downloaded from central: https://repo.maven.apache.org/maven2/com/google/guava/guava/32.1.0-jre/guava-32.1.0-jre.pom (13 kB at 217 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/com/google/guava/guava-parent/32.1.0-jre/guava-parent-32.1.0-jre.pom
Downloaded from central: https://repo.maven.apache.org/maven2/com/google/guava/guava-parent/32.1.0-jre/guava-parent-32.1.0-jre.pom (22 kB at 323 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1.pom
Downloaded from central: https://repo.maven.apache.org/maven2/com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1.pom (2.4 kB at 32 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/com/google/guava/guava-parent/26.0-android/guava-parent-26.0-android.pom
Downloaded from central: https://repo.maven.apache.org/maven2/com/google/guava/guava-parent/26.0-android/guava-parent-26.0-android.pom (10 kB at 141 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/oss/oss-parent/9/oss-parent-9.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/oss/oss-parent/9/oss-parent-9.pom (6.6 kB at 113 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.pom
Downloaded from central: https://repo.maven.apache.org/maven2/com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.pom (2.3 kB at 34 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.pom
Downloaded from central: https://repo.maven.apache.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.pom (4.3 kB at 64 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/oss/oss-parent/7/oss-parent-7.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/oss/oss-parent/7/oss-parent-7.pom (4.8 kB at 71 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/checkerframework/checker-qual/3.33.0/checker-qual-3.33.0.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/checkerframework/checker-qual/3.33.0/checker-qual-3.33.0.pom (2.1 kB at 40 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_annotations/2.18.0/error_prone_annotations-2.18.0.pom
Downloaded from central: https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_annotations/2.18.0/error_prone_annotations-2.18.0.pom (2.2 kB at 42 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_parent/2.18.0/error_prone_parent-2.18.0.pom
Downloaded from central: https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_parent/2.18.0/error_prone_parent-2.18.0.pom (11 kB at 185 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/com/google/j2objc/j2objc-annotations/2.8/j2objc-annotations-2.8.pom
Downloaded from central: https://repo.maven.apache.org/maven2/com/google/j2objc/j2objc-annotations/2.8/j2objc-annotations-2.8.pom (2.9 kB at 46 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/commons-io/commons-io/2.15.1/commons-io-2.15.1.pom
Downloaded from central: https://repo.maven.apache.org/maven2/commons-io/commons-io/2.15.1/commons-io-2.15.1.pom (20 kB at 307 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/commons/commons-parent/65/commons-parent-65.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/commons/commons-parent/65/commons-parent-65.pom (78 kB at 1.2 MB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/apache/31/apache-31.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/apache/31/apache-31.pom (24 kB at 420 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.10.1/junit-bom-5.10.1.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.10.1/junit-bom-5.10.1.pom (5.6 kB at 120 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.18.0/commons-lang3-3.18.0.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.18.0/commons-lang3-3.18.0.pom (32 kB at 572 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/commons/commons-parent/85/commons-parent-85.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/commons/commons-parent/85/commons-parent-85.pom (78 kB at 1.2 MB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/apache/35/apache-35.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/apache/35/apache-35.pom (24 kB at 425 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.13.1/junit-bom-5.13.1.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.13.1/junit-bom-5.13.1.pom (5.6 kB at 111 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.16.1/jackson-databind-2.16.1.pom
Downloaded from central: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.16.1/jackson-databind-2.16.1.pom (21 kB at 388 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/jackson-base/2.16.1/jackson-base-2.16.1.pom
Downloaded from central: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/jackson-base/2.16.1/jackson-base-2.16.1.pom (11 kB at 134 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/jackson-bom/2.16.1/jackson-bom-2.16.1.pom
Downloaded from central: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/jackson-bom/2.16.1/jackson-bom-2.16.1.pom (18 kB at 338 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/jackson-parent/2.16/jackson-parent-2.16.pom
Downloaded from central: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/jackson-parent/2.16/jackson-parent-2.16.pom (6.5 kB at 125 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/com/fasterxml/oss-parent/56/oss-parent-56.pom
Downloaded from central: https://repo.maven.apache.org/maven2/com/fasterxml/oss-parent/56/oss-parent-56.pom (24 kB at 362 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.9.2/junit-bom-5.9.2.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.9.2/junit-bom-5.9.2.pom (5.6 kB at 110 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.16.1/jackson-annotations-2.16.1.pom
Downloaded from central: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.16.1/jackson-annotations-2.16.1.pom (7.1 kB at 109 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-core/2.16.1/jackson-core-2.16.1.pom
Downloaded from central: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-core/2.16.1/jackson-core-2.16.1.pom (9.9 kB at 144 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.9.3/junit-bom-5.9.3.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.9.3/junit-bom-5.9.3.pom (5.6 kB at 110 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/httpcomponents/client5/httpclient5/5.3.1/httpclient5-5.3.1.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/httpcomponents/client5/httpclient5/5.3.1/httpclient5-5.3.1.pom (6.0 kB at 119 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/httpcomponents/client5/httpclient5-parent/5.3.1/httpclient5-parent-5.3.1.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/httpcomponents/client5/httpclient5-parent/5.3.1/httpclient5-parent-5.3.1.pom (17 kB at 340 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcomponents-parent/13/httpcomponents-parent-13.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcomponents-parent/13/httpcomponents-parent-13.pom (30 kB at 472 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/apache/27/apache-27.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/apache/27/apache-27.pom (20 kB at 407 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/httpcomponents/core5/httpcore5/5.2.4/httpcore5-5.2.4.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/httpcomponents/core5/httpcore5/5.2.4/httpcore5-5.2.4.pom (3.9 kB at 77 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/httpcomponents/core5/httpcore5-parent/5.2.4/httpcore5-parent-5.2.4.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/httpcomponents/core5/httpcore5-parent/5.2.4/httpcore5-parent-5.2.4.pom (14 kB at 269 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/httpcomponents/core5/httpcore5-h2/5.2.4/httpcore5-h2-5.2.4.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/httpcomponents/core5/httpcore5-h2/5.2.4/httpcore5-h2-5.2.4.pom (3.6 kB at 63 kB/s)
```
</details>


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
