### PR TITLE
mdbook-rss-feed: init at 1.3.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23475,6 +23475,12 @@
     githubId = 11632726;
     name = "Arijit Basu";
   };
+  saylesss88 = {
+    email = "saylesss87@proton.me";
+    github = "saylesss88";
+    githubId = 209646716;
+    name = "T. Sawyer";
+  };
   sb0 = {
     email = "sb@m-labs.hk";
     github = "sbourdeauducq";

--- a/pkgs/by-name/md/mdbook-rss-feed/package.nix
+++ b/pkgs/by-name/md/mdbook-rss-feed/package.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  rustPlatform,
+  fetchCrate,
+  versionCheckHook,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "mdbook-rss-feed";
+  version = "1.3.0";
+
+  src = fetchCrate {
+    inherit pname version;
+    hash = "sha256-zeI5O4qdQEhh3qmOhT4s3Jdw2GLuWsNjwimchEM1wCU=";
+  };
+
+  cargoHash = "sha256-0+Fe/NJZby0ygSRJLz1WWoG9B5dZmluoXVqzQPtBXSc=";
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
+
+  meta = {
+    description = "mdBook preprocessor that generates RSS, Atom, and JSON feeds with rich HTML previews, optional full-content entries, and pagination support";
+    mainProgram = "mdbook-rss-feed";
+    homepage = "https://crates.io/crates/mdbook-rss-feed";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.saylesss88 ];
+  };
+}


### PR DESCRIPTION
mdbook-rss-feed: init at 1.3.0

mdBook preprocessor that generates RSS, Atom, and JSON feeds with rich HTML
previews, optional full-content entries, and pagination support.

https://crates.io/crates/mdbook-rss-feed

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) in [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests).
  - [ ] [Package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests) at `passthru.tests`.
  - [ ] Tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test) for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage).
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - `./result/bin/mdbook-rss-feed --version` reports `mdbook-rss-feed 1.3.0`
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other READMEs.
