### PR TITLE
librenms: fix composerVendor hash

### DIFF
--- a/pkgs/by-name/li/librenms/package.nix
+++ b/pkgs/by-name/li/librenms/package.nix
@@ -36,7 +36,7 @@ phpPackage.buildComposerProject2 rec {
     hash = "sha256-SzDSeWTnsXy274H2mkGIHOsW26EoL7aony7Xcb+e+h4=";
   };
 
-  vendorHash = "sha256-OYQsgwbxsXsOM+sn0mJcABtyXVQAKBa6/ghfbZR1jX4=";
+  vendorHash = "sha256-lCDBz0+VUTlvH371WRCPBh8NFWn6BTVS6BPMQM621dE=";
 
   php = phpPackage;
 


### PR DESCRIPTION
Fixes hash mismatch for `librenms.composerVendor`.

The diff is enormous but it looks like the same sort of stuff got changed as in the other PHP PRs like #475448

Build logs:
- [before (0c947b9)](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/librenms/composerVendor.before.log)
- [after (2cd3a81)](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/librenms/composerVendor.after.log)
- [source diff](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/librenms/composerVendor.diff.log)

Source directories:
- [old source](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/librenms/composerVendor.src.before/)
- [new source](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/librenms/composerVendor.src.after/)

<details>
<summary>Source diff (first 100 lines)</summary>

```
vendor/autoload.php --- PHP
 1 <?php
 2 
 3 // autoload.php @generated by Composer
 4 
 5 if (PHP_VERSION_ID < 50600) {
 6     if (!headers_sent()) {
 7         header('HTTP/1.1 500 Internal Server Error');
 8     }
 9     $err = 'Composer 2.3.0 dropped support for autoloading on PHP <5.6 and you are running '.PHP_VERSION.', please upgrade PHP or use Composer 2.2 LTS via "composer self-update --2.2". Aborting.'.PHP_EOL;
10     if (!ini_get('display_errors')) {
11         if (PHP_SAPI === 'cli' || PHP_SAPI === 'phpdbg') {
12             fwrite(STDERR, $err);
13         } elseif (!headers_sent()) {
14             echo $err;
15         }
16     }
17     throw new RuntimeException($err);
18 }
19 
20 require_once __DIR__ . '/composer/autoload_real.php';
21 
22 return ComposerAutoloaderInit8dd9c512f9205d42bffd7f95790b8781::getLoader();
23 

vendor/bin/carbon --- Text
  1 #!/usr/bin/env php
  2 <?php
  3 
  4 /**
  5  * Proxy PHP file generated by Composer
  6  *
  7  * This file includes the referenced bin path (../nesbot/carbon/bin/carbon)
  8  * using a stream wrapper to prevent the shebang from being output on PHP<8
  9  *
 10  * @generated
 11  */
 12 
 13 namespace Composer;
 14 
 15 $GLOBALS['_composer_bin_dir'] = __DIR__;
 16 $GLOBALS['_composer_autoload_path'] = __DIR__ . '/..'.'/autoload.php';
 17 
 18 if (PHP_VERSION_ID < 80000) {
 19     if (!class_exists('Composer\BinProxyWrapper')) {
 20         /**
 21          * @internal
 22          */
 23         final class BinProxyWrapper
 24         {
 25             private $handle;
 26             private $position;
 27             private $realpath;
 28 
 29             public function stream_open($path, $mode, $options, &$opened_path)
 30             {
 31                 // get rid of phpvfscomposer:// prefix for __FILE__ & __DIR__ resolution
 32                 $opened_path = substr($path, 17);
 33                 $this->realpath = realpath($opened_path) ?: $opened_path;
 34                 $opened_path = $this->realpath;
 35                 $this->handle = fopen($this->realpath, $mode);
 36                 $this->position = 0;
 37 
 38                 return (bool) $this->handle;
 39             }
 40 
 41             public function stream_read($count)
 42             {
 43                 $data = fread($this->handle, $count);
 44 
 45                 if ($this->position === 0) {
 46                     $data = preg_replace('{^#!.*\r?\n}', '', $data);
 47                 }
 48 
 49                 $this->position += strlen($data);
 50 
 51                 return $data;
 52             }
 53 
 54             public function stream_cast($castAs)
 55             {
 56                 return $this->handle;
 57             }
 58 
 59             public function stream_close()
 60             {
 61                 fclose($this->handle);
 62             }
 63 
 64             public function stream_lock($operation)
 65             {
 66                 return $operation ? flock($this->handle, $operation) : true;
 67             }
 68 
 69             public function stream_seek($offset, $whence)
 70             {
 71                 if (0 === fseek($this->handle, $offset, $whence)) {
 72                     $this->position = ftell($this->handle);
 73                     return true;
 74                 }
```
</details>

<details>
<summary>Build before (first 100 lines)</summary>

```
these 7 derivations will be built:
  /nix/store/c6bdwr94bqf0a9hm3xvbdc100xkn53h4-libmemcached-1.0.18.drv
  /nix/store/cyb8dxi1zs2vss3k5841724agsmvq62d-php-memcached-3.4.0.drv
  /nix/store/iwlw0ail1c4pxij3097797cz4casfmb5-php-extra-init-8.4.16.ini.drv
  /nix/store/hj77r435wl1flimhnda7wdklvy8k2ch7-php-with-extensions-8.4.16.drv
  /nix/store/v6hibyi9ccdr5ibyf1iins79xacrzlf5-composer-phar-2.9.2.drv
  /nix/store/5rlla370hvla5bld59b81kr3kri4d968-composer-2.9.2.drv
  /nix/store/0vajjxfxp03lsz804wr5yz5wvvbvvg68-librenms-composer-vendor-25.10.0.drv
building '/nix/store/c6bdwr94bqf0a9hm3xvbdc100xkn53h4-libmemcached-1.0.18.drv'...
Running phase: unpackPhase
unpacking source archive /nix/store/knvkr629x4d3fmp1xdli01803r7ixbnh-libmemcached-1.0.18.tar.gz
source root is libmemcached-1.0.18
setting SOURCE_DATE_EPOCH to timestamp 1391947052 of file "libmemcached-1.0.18/support/libmemcached.spec"
Running phase: patchPhase
applying patch /nix/store/1wp8vhlmis96f87kkqwh8d7h6lxilsd1-libmemcached-fix-linking-with-libpthread.patch
patching file build-aux/ltmain.sh
Running phase: updateAutotoolsGnuConfigScriptsPhase
Updating Autotools / GNU config script to a newer upstream version: ./build-aux/config.sub
Updating Autotools / GNU config script to a newer upstream version: ./build-aux/config.guess
Running phase: configurePhase
fixing libtool script ./build-aux/ltmain.sh
patching script interpreter paths in ./configure
./configure: interpreter directive changed from "#! /bin/sh" to "/nix/store/lw117lsr8d585xs63kx5k233impyrq7q-bash-5.3p3/bin/sh"
configure flags: --disable-static --disable-dependency-tracking --prefix=/nix/store/2ridzv43c774zgvgixlq7rknwjlb33yv-libmemcached-1.0.18
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables... 
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether we are using the GNU C compiler... yes
checking whether gcc accepts -g... yes
checking for gcc option to accept ISO C89... none needed
checking whether we are using the GNU C++ compiler... yes
checking whether g++ accepts -g... yes
checking build system type... x86_64-pc-linux-gnu
checking host system type... x86_64-pc-linux-gnu
checking how to run the C preprocessor... gcc -E
checking for grep that handles long lines and -e... /nix/store/qfmq7p42ak5yn389qvx7zpxkan5i4xiy-gnugrep-3.12/bin/grep
checking for egrep... /nix/store/qfmq7p42ak5yn389qvx7zpxkan5i4xiy-gnugrep-3.12/bin/grep -E
checking for ANSI C header files... yes
checking for sys/types.h... yes
checking for sys/stat.h... yes
checking for stdlib.h... yes
checking for string.h... yes
checking for memory.h... yes
checking for strings.h... yes
checking for inttypes.h... yes
checking for stdint.h... yes
checking for unistd.h... yes
checking minix/config.h usability... no
checking minix/config.h presence... no
checking for minix/config.h... no
checking whether it is safe to define __EXTENSIONS__... yes
checking for a BSD-compatible install... /nix/store/d75200gb22v7p0703h5jrkgg8bqydk5q-coreutils-9.8/bin/install -c
checking whether build environment is sane... yes
checking for a thread-safe mkdir -p... /nix/store/d75200gb22v7p0703h5jrkgg8bqydk5q-coreutils-9.8/bin/mkdir -p
checking for gawk... gawk
checking whether make sets $(MAKE)... yes
checking for style of include used by make... GNU
checking whether make supports nested variables... yes
checking whether UID '1000' is supported by ustar format... yes
checking whether GID '100' is supported by ustar format... yes
checking how to create a ustar tar archive... gnutar
checking dependency style of gcc... none
checking dependency style of g++... none
checking how to print strings... printf
checking for a sed that does not truncate output... /nix/store/k06ssckzrzn9jjvvs4n62m6567zmbx6x-gnused-4.9/bin/sed
checking for fgrep... /nix/store/qfmq7p42ak5yn389qvx7zpxkan5i4xiy-gnugrep-3.12/bin/grep -F
checking for ld used by gcc... ld
checking if the linker (ld) is GNU ld... yes
checking for BSD- or MS-compatible name lister (nm)... nm
checking the name lister (nm) interface... BSD nm
checking whether ln -s works... yes
checking the maximum length of command line arguments... 1572864
checking whether the shell understands some XSI constructs... yes
checking whether the shell understands "+="... yes
checking how to convert x86_64-pc-linux-gnu file names to x86_64-pc-linux-gnu format... func_convert_file_noop
checking how to convert x86_64-pc-linux-gnu file names to toolchain format... func_convert_file_noop
checking for ld option to reload object files... -r
checking for objdump... objdump
checking how to recognize dependent libraries... (cached) pass_all
checking for dlltool... no
checking how to associate runtime and link libraries... printf %s\n
checking for archiver @FILE support... @
checking for strip... strip
checking for ranlib... ranlib
checking command to parse nm output from gcc object... ok
checking for sysroot... no
./configure: line 7502: /usr/bin/file: No such file or directory
checking for mt... no
checking if : is a manifest tool... no
checking for dlfcn.h... yes
checking for objdir... .libs
checking if gcc supports -fno-rtti -fno-exceptions... no
checking for gcc option to produce PIC... -fPIC -DPIC
checking if gcc PIC flag -fPIC -DPIC works... yes
checking if gcc static flag -static works... no
checking if gcc supports -c -o file.o... yes
checking if gcc supports -c -o file.o... (cached) yes
checking whether the gcc linker (ld) supports shared libraries... yes
```
</details>

<details>
<summary>Build after (first 100 lines)</summary>

```
checking outputs of '/nix/store/k2c0v8ssqwjz4yarijhcnmd32ir1y1m5-librenms-composer-vendor-25.10.0.drv'...
Running phase: unpackPhase
unpacking source archive /nix/store/fpr4r0231mjaib2ghf93p5y444qagskw-source
source root is source
Running phase: patchPhase
Running phase: updateAutotoolsGnuConfigScriptsPhase
Running phase: configurePhase
Running phase: composerVendorConfigureHook
Setting COMPOSER_ROOT_VERSION to 25.10.0
Found 'composer.lock' in source root.
Finished phase: composerVendorConfigureHook
Running phase: buildPhase
Running phase: composerVendorBuildHook
Setting some required environment variables for Composer...
Installing Composer dependencies to 'vendor'...
Installing dependencies from lock file
Verifying lock file contents can be installed on current platform.
Package operations: 128 installs, 0 updates, 0 removals
  - Downloading php-http/discovery (1.20.0)
  - Downloading amenadiel/jpgraph (v4.1.1)
  - Downloading clue/socket-raw (v1.6.0)
  - Downloading dapphp/radius (v3.0.0)
  - Downloading doctrine/inflector (2.1.0)
  - Downloading doctrine/lexer (3.0.1)
  - Downloading symfony/polyfill-ctype (v1.33.0)
  - Downloading webmozart/assert (1.11.0)
  - Downloading dragonmantank/cron-expression (v3.4.0)
  - Downloading easybook/geshi (v1.0.8.19)
  - Downloading enshrined/svg-sanitize (0.22.0)
  - Downloading voku/portable-ascii (2.0.3)
  - Downloading symfony/polyfill-php80 (v1.33.0)
  - Downloading symfony/polyfill-mbstring (v1.33.0)
  - Downloading phpoption/phpoption (1.9.4)
  - Downloading graham-campbell/result-type (v1.1.3)
  - Downloading vlucas/phpdotenv (v5.6.2)
  - Downloading symfony/css-selector (v7.3.0)
  - Downloading tijsverkoyen/css-to-inline-styles (v2.3.0)
  - Downloading symfony/deprecation-contracts (v3.6.0)
  - Downloading symfony/var-dumper (v7.3.3)
  - Downloading symfony/polyfill-uuid (v1.33.0)
  - Downloading symfony/uid (v7.3.1)
  - Downloading symfony/routing (v7.3.2)
  - Downloading symfony/process (v7.3.3)
  - Downloading symfony/polyfill-php85 (v1.33.0)
  - Downloading symfony/polyfill-php84 (v1.33.0)
  - Downloading symfony/polyfill-php83 (v1.33.0)
  - Downloading symfony/polyfill-intl-normalizer (v1.33.0)
  - Downloading symfony/polyfill-intl-idn (v1.33.0)
  - Downloading symfony/mime (v7.3.2)
  - Downloading psr/container (2.0.2)
  - Downloading symfony/service-contracts (v3.6.0)
  - Downloading psr/event-dispatcher (1.0.0)
  - Downloading symfony/event-dispatcher-contracts (v3.6.0)
  - Downloading symfony/event-dispatcher (v7.3.3)
  - Downloading psr/log (3.0.2)
  - Downloading egulias/email-validator (4.0.4)
  - Downloading symfony/mailer (v7.3.3)
  - Downloading symfony/http-foundation (v7.3.3)
  - Downloading symfony/error-handler (v7.3.2)
  - Downloading symfony/http-kernel (v7.3.3)
  - Downloading symfony/finder (v7.3.2)
  - Downloading symfony/polyfill-intl-grapheme (v1.33.0)
  - Downloading symfony/string (v7.3.3)
  - Downloading symfony/console (v7.3.3)
  - Downloading ramsey/collection (2.1.1)
  - Downloading brick/math (0.13.1)
  - Downloading ramsey/uuid (4.9.0)
  - Downloading psr/simple-cache (3.0.0)
  - Downloading nunomaduro/termwind (v2.3.1)
  - Downloading symfony/translation-contracts (v3.6.0)
  - Downloading symfony/translation (v7.3.3)
  - Downloading psr/clock (1.0.0)
  - Downloading symfony/clock (v7.3.0)
  - Downloading carbonphp/carbon-doctrine-types (3.2.0)
  - Downloading nesbot/carbon (3.10.2)
  - Downloading monolog/monolog (3.9.0)
  - Downloading psr/http-message (2.0)
  - Downloading psr/http-factory (1.1.0)
  - Downloading league/uri-interfaces (7.5.0)
  - Downloading league/uri (7.5.1)
  - Downloading league/mime-type-detection (1.16.0)
  - Downloading league/flysystem-local (3.30.0)
  - Downloading league/flysystem (3.30.0)
  - Downloading nette/utils (v4.0.8)
  - Downloading nette/schema (v1.3.2)
  - Downloading dflydev/dot-access-data (v3.0.3)
  - Downloading league/config (v1.2.0)
  - Downloading league/commonmark (2.7.1)
  - Downloading laravel/serializable-closure (v2.0.4)
  - Downloading laravel/prompts (v0.3.6)
  - Downloading guzzlehttp/uri-template (v1.0.5)
  - Downloading psr/http-client (1.0.3)
  - Downloading ralouphie/getallheaders (3.0.3)
  - Downloading guzzlehttp/psr7 (2.8.0)
  - Downloading guzzlehttp/promises (2.3.0)
  - Downloading guzzlehttp/guzzle (7.10.0)
  - Downloading fruitcake/php-cors (v1.3.0)
  - Downloading laravel/framework (v12.28.0)
  - Downloading fico7489/laravel-pivot (3.0.13)
  - Downloading firebase/php-jwt (v6.11.1)
```
</details>



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
