### PR TITLE
tika: fix fetchedMavenDeps hash

### DIFF
--- a/pkgs/by-name/ti/tika/package.nix
+++ b/pkgs/by-name/ti/tika/package.nix
@@ -17,7 +17,7 @@
 
 let
   mvnDepsHashes = {
-    "x86_64-linux" = "sha256-ZlGOxVXU63AKzfWeOLGPa2l8v+Rv8Bzr4H/Er62cxk8=";
+    "x86_64-linux" = "sha256-KplVoVM7KpOE/xFxcnW6QCGFOKLYlc6xehBuZBk7J6s=";
     "aarch64-linux" = "sha256-CrOYBEnp8cVpdF2PrpGQjmdYH8ZKupm9Jf1LVyNoObk=";
     "x86_64-darwin" = "sha256-D1QkCTYep9RbNUaZPrnbgkR94cvQkX3xxxUxwyLIqx8=";
     "aarch64-darwin" = "sha256-zvvko6wSJoc2cgMLl7XVmypq0vVTirrIpJiEdypPlrU=";


### PR DESCRIPTION
Fixes hash mismatch for `tika.fetchedMavenDeps` on x86_64-linux. I don't have the hardware to test the other platforms unfortunately.

Diff (just like others, see #475443 for a bunch of them ) looks like it's codehaus and apache changes.

Build logs:
- [before (b63bcab)](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/tika/fetchedMavenDeps.before.log)
- [after (32092cb)](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/tika/fetchedMavenDeps.after.log)
- [source diff](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/tika/fetchedMavenDeps.diff.log)

Source directories:
- [old source](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/tika/fetchedMavenDeps.src.before/)
- [new source](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/tika/fetchedMavenDeps.src.after/)

<details>
<summary>Source diff (first 100 lines)</summary>

```
.m2/org/apache/maven/plugins/maven-metadata-apache.snapshots.xml --- XML
  1 <?xml version="1.0" encoding="UTF-8"?>
  2 <metadata>
  3   <plugins>
  4     <plugin>
  5       <name>Apache Maven ACR Plugin</name>
  6       <prefix>acr</prefix>
  7       <artifactId>maven-acr-plugin</artifactId>
  8     </plugin>
  9     <plugin>
 10       <name>Apache Maven AntRun Plugin</name>
 11       <prefix>antrun</prefix>
 12       <artifactId>maven-antrun-plugin</artifactId>
 13     </plugin>
 14     <plugin>
 15       <name>Maven Archetype Plugin</name>
 16       <prefix>archetype</prefix>
 17       <artifactId>maven-archetype-plugin</artifactId>
 18     </plugin>
 19     <plugin>
 20       <name>Apache Maven Artifact Plugin</name>
 21       <prefix>artifact</prefix>
 22       <artifactId>maven-artifact-plugin</artifactId>
 23     </plugin>
 24     <plugin>
 25       <name>Apache Maven Assembly Plugin</name>
 26       <prefix>assembly</prefix>
 27       <artifactId>maven-assembly-plugin</artifactId>
 28     </plugin>
 29     <plugin>
 30       <name>Apache Maven Buildinfo Plugin</name>
 31       <prefix>buildinfo</prefix>
 32       <artifactId>maven-buildinfo-plugin</artifactId>
 33     </plugin>
 34     <plugin>
 35       <name>Apache Maven Changelog Plugin</name>
 36       <prefix>changelog</prefix>
 37       <artifactId>maven-changelog-plugin</artifactId>
 38     </plugin>
 39     <plugin>
 40       <name>Apache Maven Changes Plugin</name>
 41       <prefix>changes</prefix>
 42       <artifactId>maven-changes-plugin</artifactId>
 43     </plugin>
 44     <plugin>
 45       <name>Apache Maven Checkstyle Plugin</name>
 46       <prefix>checkstyle</prefix>
 47       <artifactId>maven-checkstyle-plugin</artifactId>
 48     </plugin>
 49     <plugin>
 50       <name>Apache Maven Clean Plugin</name>
 51       <prefix>clean</prefix>
 52       <artifactId>maven-clean-plugin</artifactId>
 53     </plugin>
 54     <plugin>
 55       <name>Apache Maven Compiler Plugin</name>
 56       <prefix>compiler</prefix>
 57       <artifactId>maven-compiler-plugin</artifactId>
 58     </plugin>
 59     <plugin>
 60       <name>Apache Maven Dependency Plugin</name>
 61       <prefix>dependency</prefix>
 62       <artifactId>maven-dependency-plugin</artifactId>
 63     </plugin>
 64     <plugin>
 65       <name>Apache Maven Deploy Plugin</name>
 66       <prefix>deploy</prefix>
 67       <artifactId>maven-deploy-plugin</artifactId>
 68     </plugin>
 69     <plugin>
 70       <name>Apache Maven DOAP Plugin</name>
 71       <prefix>doap</prefix>
 72       <artifactId>maven-doap-plugin</artifactId>
 73     </plugin>
 74     <plugin>
 75       <name>(RETIRED) Apache Maven Documentation Checker Plugin</name>
 76       <prefix>docck</prefix>
 77       <artifactId>maven-docck-plugin</artifactId>
 78     </plugin>
 79     <plugin>
 80       <name>Apache Maven EAR Plugin</name>
 81       <prefix>ear</prefix>
 82       <artifactId>maven-ear-plugin</artifactId>
 83     </plugin>
 84     <plugin>
 85       <name>Apache Maven EJB Plugin</name>
 86       <prefix>ejb</prefix>
 87       <artifactId>maven-ejb-plugin</artifactId>
 88     </plugin>
 89     <plugin>
 90       <name>Apache Maven Enforcer Plugin</name>
 91       <prefix>enforcer</prefix>
 92       <artifactId>maven-enforcer-plugin</artifactId>
 93     </plugin>
 94     <plugin>
 95       <name>Maven Failsafe Plugin</name>
 96       <prefix>failsafe</prefix>
 97       <artifactId>maven-failsafe-plugin</artifactId>
 98     </plugin>
 99     <plugin>
```
</details>

<details>
<summary>Build before (first 100 lines)</summary>

```
these 3 derivations will be built:
  /nix/store/pwn3k6glkjgv5w0vaw0kip27gja7wb81-temurin-bin-17.0.16.drv
  /nix/store/w65fj818ha97ajd1yfrxambi4jl36zgp-openjdk-17.0.17+10.drv
  /nix/store/bj0sadrmc2cb3ca21zwdhzcsviq461nf-maven-deps-tika-2.9.3.drv
building '/nix/store/pwn3k6glkjgv5w0vaw0kip27gja7wb81-temurin-bin-17.0.16.drv'...
Running phase: unpackPhase
unpacking source archive /nix/store/ldcr2izbhsy7jzvywl1jrb1vwmp8kqqv-OpenJDK17U-jdk_x64_linux_hotspot_17.0.16_8.tar.gz
source root is jdk-17.0.16+8
setting SOURCE_DATE_EPOCH to timestamp 1752614864 of file "jdk-17.0.16+8/NOTICE"
Running phase: patchPhase
Running phase: updateAutotoolsGnuConfigScriptsPhase
Running phase: configurePhase
no configure script, doing nothing
Running phase: buildPhase
no Makefile or custom buildPhase, doing nothing
Running phase: installPhase
Running phase: fixupPhase
moving /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/man to /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/share/man
shrinking RPATHs of ELF executables and libraries in /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/lib/libawt_xawt.so
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/lib/server/libjvm.so
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/lib/server/libjsig.so
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/lib/libjaas.so
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/lib/libinstrument.so
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/lib/libprefs.so
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/lib/libverify.so
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/lib/libjimage.so
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/lib/libjavajpeg.so
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/lib/libextnet.so
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/lib/libfontmanager.so
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/lib/libsctp.so
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/lib/libj2gss.so
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/lib/libdt_socket.so
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/lib/libattach.so
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/lib/libjsvml.so
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/lib/libawt_headless.so
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/lib/libjawt.so
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/lib/libsplashscreen.so
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/lib/liblcms.so
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/lib/librmi.so
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/lib/libsyslookup.so
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/lib/libj2pkcs11.so
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/lib/libmanagement_ext.so
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/lib/jspawnhelper
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/lib/libjava.so
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/lib/libjli.so
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/lib/libawt.so
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/lib/libmanagement.so
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/lib/libmlib_image.so
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/lib/libzip.so
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/lib/libmanagement_agent.so
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/lib/libjsig.so
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/lib/libnet.so
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/lib/libnio.so
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/lib/libjdwp.so
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/lib/libjsound.so
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/lib/libj2pcsc.so
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/lib/libsaproc.so
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/lib/.jexec-wrapped
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/bin/.jdeps-wrapped
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/bin/.jar-wrapped
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/bin/.jstack-wrapped
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/bin/.jlink-wrapped
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/bin/.serialver-wrapped
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/bin/.jpackage-wrapped
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/bin/.jconsole-wrapped
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/bin/.jstatd-wrapped
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/bin/.jstat-wrapped
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/bin/.javap-wrapped
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/bin/.jrunscript-wrapped
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/bin/.jdb-wrapped
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/bin/.keytool-wrapped
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/bin/.javac-wrapped
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/bin/.jps-wrapped
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/bin/.jdeprscan-wrapped
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/bin/.jshell-wrapped
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/bin/.jarsigner-wrapped
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/bin/.jfr-wrapped
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/bin/.jhsdb-wrapped
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/bin/.jinfo-wrapped
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/bin/.rmiregistry-wrapped
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/bin/.jimage-wrapped
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/bin/.jmod-wrapped
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/bin/.jcmd-wrapped
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/bin/.java-wrapped
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/bin/.javadoc-wrapped
shrinking /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/bin/.jmap-wrapped
checking for references to /build/ in /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16...
gzipping man pages under /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16/share/man/
patching script interpreter paths in /nix/store/pni3v0x3xdvhbvbf7plb4fg0hdhxlj9n-temurin-bin-17.0.16
automatically fixing dependencies for ELF files
{'add_existing': True,
 'append_rpaths': [],
 'extra_args': [],
 'ignore_missing': [],
 'keep_libc': False,
 'libs': [PosixPath('/nix/store/x9d8b6arxs2yvhbv5dq3mj7g7ar6pl0b-auto-patchelf-hook/lib'),
          PosixPath('/nix/store/iblzqnqm712rm600czliwq3x6g5fn82f-auto-patchelf-0-unstable-2024-08-14/lib'),
          PosixPath('/nix/store/n21wcnpiydy3fd6kqxkwnzvwvaibmg11-binutils-wrapper-2.44/lib'),
          PosixPath('/nix/store/48zc854y65q0jvsa2na6liawgqvh69cq-make-shell-wrapper-hook/lib'),
```
</details>

<details>
<summary>Build after (first 100 lines)</summary>

```
checking outputs of '/nix/store/bcv22qz09g2k23mbdx5xpbdyfixdad0l-maven-deps-tika-2.9.3.drv'...
Running phase: unpackPhase
unpacking source archive /nix/store/zi2k4ma0xgbp39m6hbw6qsp9y6q159b1-source
source root is source
Running phase: patchPhase
applying patch /nix/store/nm5isg7vg3inrm5rkk5y9n6ljsfksgfd-CVE-2025-54988.patch
patching file tika-core/src/main/java/org/apache/tika/utils/XMLReaderUtils.java
Hunk #1 succeeded at 295 (offset -13 lines).
Running phase: updateAutotoolsGnuConfigScriptsPhase
Running phase: configurePhase
no configure script, doing nothing
Running phase: buildPhase
[INFO] Scanning for projects...
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/apache/32/apache-32.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/apache/32/apache-32.pom (24 kB at 22 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/jackson-bom/2.18.2/jackson-bom-2.18.2.pom
Downloaded from central: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/jackson-bom/2.18.2/jackson-bom-2.18.2.pom (19 kB at 249 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/jackson-parent/2.18.1/jackson-parent-2.18.1.pom
Downloaded from central: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/jackson-parent/2.18.1/jackson-parent-2.18.1.pom (6.7 kB at 101 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/com/fasterxml/oss-parent/61/oss-parent-61.pom
Downloaded from central: https://repo.maven.apache.org/maven2/com/fasterxml/oss-parent/61/oss-parent-61.pom (23 kB at 279 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/io/netty/netty-bom/4.1.117.Final/netty-bom-4.1.117.Final.pom
Downloaded from central: https://repo.maven.apache.org/maven2/io/netty/netty-bom/4.1.117.Final/netty-bom-4.1.117.Final.pom (14 kB at 188 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/oss/oss-parent/7/oss-parent-7.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/oss/oss-parent/7/oss-parent-7.pom (4.8 kB at 67 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/cxf/cxf-bom/3.5.10/cxf-bom-3.5.10.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/cxf/cxf-bom/3.5.10/cxf-bom-3.5.10.pom (26 kB at 372 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/cxf/cxf/3.5.10/cxf-3.5.10.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/cxf/cxf/3.5.10/cxf-3.5.10.pom (40 kB at 512 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/logging/log4j/log4j-bom/2.24.3/log4j-bom-2.24.3.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/logging/log4j/log4j-bom/2.24.3/log4j-bom-2.24.3.pom (12 kB at 115 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/logging/logging-parent/11.3.0/logging-parent-11.3.0.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/logging/logging-parent/11.3.0/logging-parent-11.3.0.pom (53 kB at 413 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/apache/33/apache-33.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/apache/33/apache-33.pom (24 kB at 350 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/eclipse/jetty/jetty-bom/9.4.57.v20241219/jetty-bom-9.4.57.v20241219.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/eclipse/jetty/jetty-bom/9.4.57.v20241219/jetty-bom-9.4.57.v20241219.pom (18 kB at 210 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.11.4/junit-bom-5.11.4.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.11.4/junit-bom-5.11.4.pom (5.6 kB at 90 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/testcontainers/testcontainers-bom/1.20.4/testcontainers-bom-1.20.4.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/testcontainers/testcontainers-bom/1.20.4/testcontainers-bom-1.20.4.pom (11 kB at 165 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/felix/maven-bundle-plugin/5.1.9/maven-bundle-plugin-5.1.9.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/felix/maven-bundle-plugin/5.1.9/maven-bundle-plugin-5.1.9.pom (11 kB at 172 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/felix/felix-parent/7/felix-parent-7.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/felix/felix-parent/7/felix-parent-7.pom (21 kB at 324 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/apache/23/apache-23.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/apache/23/apache-23.pom (18 kB at 288 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/osgi/org.osgi.core/6.0.0/org.osgi.core-6.0.0.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/osgi/org.osgi.core/6.0.0/org.osgi.core-6.0.0.pom (1.1 kB at 14 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/biz/aQute/bnd/biz.aQute.bndlib/6.3.1/biz.aQute.bndlib-6.3.1.pom
Downloaded from central: https://repo.maven.apache.org/maven2/biz/aQute/bnd/biz.aQute.bndlib/6.3.1/biz.aQute.bndlib-6.3.1.pom (5.2 kB at 76 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/osgi/org.osgi.dto/1.0.0/org.osgi.dto-1.0.0.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/osgi/org.osgi.dto/1.0.0/org.osgi.dto-1.0.0.pom (1.3 kB at 23 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/osgi/org.osgi.resource/1.0.0/org.osgi.resource-1.0.0.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/osgi/org.osgi.resource/1.0.0/org.osgi.resource-1.0.0.pom (1.3 kB at 23 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/osgi/org.osgi.framework/1.8.0/org.osgi.framework-1.8.0.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/osgi/org.osgi.framework/1.8.0/org.osgi.framework-1.8.0.pom (1.3 kB at 21 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/osgi/org.osgi.util.tracker/1.5.4/org.osgi.util.tracker-1.5.4.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/osgi/org.osgi.util.tracker/1.5.4/org.osgi.util.tracker-1.5.4.pom (1.9 kB at 29 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/osgi/osgi.annotation/8.0.1/osgi.annotation-8.0.1.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/osgi/osgi.annotation/8.0.1/osgi.annotation-8.0.1.pom (1.5 kB at 19 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/osgi/org.osgi.service.log/1.3.0/org.osgi.service.log-1.3.0.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/osgi/org.osgi.service.log/1.3.0/org.osgi.service.log-1.3.0.pom (1.3 kB at 24 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/osgi/org.osgi.service.repository/1.1.0/org.osgi.service.repository-1.1.0.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/osgi/org.osgi.service.repository/1.1.0/org.osgi.service.repository-1.1.0.pom (1.3 kB at 19 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/osgi/org.osgi.util.function/1.2.0/org.osgi.util.function-1.2.0.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/osgi/org.osgi.util.function/1.2.0/org.osgi.util.function-1.2.0.pom (1.7 kB at 26 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/osgi/org.osgi.util.promise/1.2.0/org.osgi.util.promise-1.2.0.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/osgi/org.osgi.util.promise/1.2.0/org.osgi.util.promise-1.2.0.pom (1.9 kB at 24 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/osgi/org.osgi.util.function/1.1.0/org.osgi.util.function-1.1.0.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/osgi/org.osgi.util.function/1.1.0/org.osgi.util.function-1.1.0.pom (1.4 kB at 20 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/biz/aQute/bnd/biz.aQute.bnd.util/6.3.1/biz.aQute.bnd.util-6.3.1.pom
Downloaded from central: https://repo.maven.apache.org/maven2/biz/aQute/bnd/biz.aQute.bnd.util/6.3.1/biz.aQute.bnd.util-6.3.1.pom (2.7 kB at 36 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25.pom (3.8 kB at 50 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-parent/1.7.25/slf4j-parent-1.7.25.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-parent/1.7.25/slf4j-parent-1.7.25.pom (14 kB at 202 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/felix/org.apache.felix.bundlerepository/1.6.6/org.apache.felix.bundlerepository-1.6.6.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/felix/org.apache.felix.bundlerepository/1.6.6/org.apache.felix.bundlerepository-1.6.6.pom (5.9 kB at 85 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/felix/felix-parent/2.1/felix-parent-2.1.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/felix/felix-parent/2.1/felix-parent-2.1.pom (9.7 kB at 149 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/apache/9/apache-9.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/apache/9/apache-9.pom (15 kB at 237 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/osgi/org.osgi.core/4.1.0/org.osgi.core-4.1.0.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/osgi/org.osgi.core/4.1.0/org.osgi.core-4.1.0.pom (193 B at 3.3 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/easymock/easymock/2.4/easymock-2.4.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/easymock/easymock/2.4/easymock-2.4.pom (5.3 kB at 93 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/felix/org.apache.felix.utils/1.6.0/org.apache.felix.utils-1.6.0.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/felix/org.apache.felix.utils/1.6.0/org.apache.felix.utils-1.6.0.pom (3.3 kB at 62 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/osgi/org.osgi.compendium/4.2.0/org.osgi.compendium-4.2.0.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/osgi/org.osgi.compendium/4.2.0/org.osgi.compendium-4.2.0.pom (463 B at 5.0 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/reporting/maven-reporting-api/3.0/maven-reporting-api-3.0.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/reporting/maven-reporting-api/3.0/maven-reporting-api-3.0.pom (2.4 kB at 34 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/15/maven-shared-components-15.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/15/maven-shared-components-15.pom (9.3 kB at 164 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/16/maven-parent-16.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/16/maven-parent-16.pom (23 kB at 388 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/apache/7/apache-7.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/apache/7/apache-7.pom (14 kB at 253 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-sink-api/1.0/doxia-sink-api-1.0.pom
```
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
