### PR TITLE
efitools: fix build with gcc15

### DIFF
--- a/pkgs/by-name/ef/efitools/package.nix
+++ b/pkgs/by-name/ef/efitools/package.nix
@@ -30,9 +30,12 @@ stdenv.mkDerivation rec {
     sha256 = "0jabgl2pxvfl780yvghq131ylpf82k7banjz0ksjhlm66ik8gb1i";
   };
 
-  # https://github.com/ncroxon/gnu-efi/issues/7#issuecomment-2122741592
   patches = [
+    # https://github.com/ncroxon/gnu-efi/issues/7#issuecomment-2122741592
     ./aarch64.patch
+
+    # Fix build with gcc15
+    ./remove-redundant-bool.patch
   ];
 
   postPatch = ''

--- a/pkgs/by-name/ef/efitools/remove-redundant-bool.patch
+++ b/pkgs/by-name/ef/efitools/remove-redundant-bool.patch
@@ -1,0 +1,24 @@
+From 7698d2e2fdde341677907fbbec7197c8bb3a687a Mon Sep 17 00:00:00 2001
+From: Moraxyc <i@qaq.li>
+Date: Wed, 31 Dec 2025 22:12:04 +0800
+Subject: [PATCH] remove-redundant-bool
+
+---
+ lib/asn1/typedefs.h | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/lib/asn1/typedefs.h b/lib/asn1/typedefs.h
+index 756a629..45db045 100644
+--- a/lib/asn1/typedefs.h
++++ b/lib/asn1/typedefs.h
+@@ -52,7 +52,6 @@ typedef unsigned char u_char;
+ 
+ #endif
+ 
+-typedef unsigned char bool;
+ typedef unsigned int u_int;
+ 
+ #define DBG1(s...)
+-- 
+2.51.2
+


### PR DESCRIPTION
https://hydra.nixos.org/build/317988750

https://github.com/NixOS/nixpkgs/issues/475479
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
