### PR TITLE
zxing: fix fetchedMavenDeps hash

### DIFF
--- a/pkgs/by-name/zx/zxing/package.nix
+++ b/pkgs/by-name/zx/zxing/package.nix
@@ -18,7 +18,7 @@ maven.buildMavenPackage rec {
     hash = "sha256-D+ZKfDa406RIaTRhH9yXxgP8EpGe0iQU9CqkOMC4UdE=";
   };
 
-  mvnHash = "sha256-wVkWbhi5b/rZ0EF5zlQr2BMVOm5nZ1DhI6SGksZO5Vg=";
+  mvnHash = "sha256-G21YIzAuc4LZhVqPmd2i/N42anUzmfqyciYR5XclzKk=";
 
   sourceRoot = "${src.name}/javase";
 


### PR DESCRIPTION
Fixes hash mismatch for `zxing.fetchedMavenDeps`.

A bunch of vendored dependencies look like they changed:

- simpligility
- apache, codehaus (as usual)
- jacoco

The diff is big again. I did a cursory read and it seems okay. But, grain of salt since I don't know how maven works.

Build logs:
- [before (ec401e4)](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/zxing/fetchedMavenDeps.before.log)
- [after (e68003f)](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/zxing/fetchedMavenDeps.after.log)
- [source diff](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/zxing/fetchedMavenDeps.diff.log)

Source directories:
- [old source](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/zxing/fetchedMavenDeps.src.before/)
- [new source](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/zxing/fetchedMavenDeps.src.after/)

<details>
<summary>Source diff (first 100 lines)</summary>

```
.m2/com/simpligility/maven/plugins/maven-metadata-central.xml.sha1 --- Text
1 888fe0e44573f8b14177cdcdae13dd52bb089b8d
2 

.m2/com/github/wvengen/maven-metadata-central.xml.sha1 --- Text
1 54eb1bef8a4b71d7e14a9187bf45dd1f4208c68b
2 

.m2/com/simpligility/maven/plugins/maven-metadata-central.xml --- XML
 1 <?xml version="1.0" encoding="UTF-8"?>
 2 <metadata>
 3   <plugins>
 4     <plugin>
 5       <name>Android Maven Plugin - android-maven-plugin</name>
 6       <prefix>android</prefix>
 7       <artifactId>android-maven-plugin</artifactId>
 8     </plugin>
 9     <plugin>
10       <name>Android NDK Maven Plugin - android-ndk-maven-plugin</name>
11       <prefix>android-ndk</prefix>
12       <artifactId>android-ndk-maven-plugin</artifactId>
13     </plugin>
14   </plugins>
15 </metadata>
16 

.m2/com/simpligility/maven/plugins/maven-metadata-google-maven-central.xml --- XML
 1 <?xml version="1.0" encoding="UTF-8"?>
 2 <metadata>
 3   <plugins>
 4     <plugin>
 5       <name>Android Maven Plugin - android-maven-plugin</name>
 6       <prefix>android</prefix>
 7       <artifactId>android-maven-plugin</artifactId>
 8     </plugin>
 9     <plugin>
10       <name>Android NDK Maven Plugin - android-ndk-maven-plugin</name>
11       <prefix>android-ndk</prefix>
12       <artifactId>android-ndk-maven-plugin</artifactId>
13     </plugin>
14   </plugins>
15 </metadata>
16 

.m2/com/simpligility/maven/plugins/maven-metadata-google-maven-central.xml.sha1 --- Text
1 888fe0e44573f8b14177cdcdae13dd52bb089b8d
2 

.m2/com/github/wvengen/maven-metadata-google-maven-central.xml --- XML
 1 <?xml version="1.0" encoding="UTF-8"?>
 2 <metadata>
 3   <plugins>
 4     <plugin>
 5       <name>ProGuard Maven Plugin</name>
 6       <prefix>proguard</prefix>
 7       <artifactId>proguard-maven-plugin</artifactId>
 8     </plugin>
 9   </plugins>
10 </metadata>
11 

.m2/com/github/wvengen/maven-metadata-google-maven-central.xml.sha1 --- Text
1 54eb1bef8a4b71d7e14a9187bf45dd1f4208c68b
2 

.m2/com/github/wvengen/maven-metadata-central.xml --- XML
 1 <?xml version="1.0" encoding="UTF-8"?>
 2 <metadata>
 3   <plugins>
 4     <plugin>
 5       <name>ProGuard Maven Plugin</name>
 6       <prefix>proguard</prefix>
 7       <artifactId>proguard-maven-plugin</artifactId>
 8     </plugin>
 9   </plugins>
10 </metadata>
11 

.m2/org/apache/maven/release/maven-release/3.1.1/maven-release-3.1.1.pom --- Text
  1 <?xml version="1.0" encoding="UTF-8"?>
  2 <!--
  3   ~ Licensed to the Apache Software Foundation (ASF) under one
  4   ~ or more contributor license agreements.  See the NOTICE file
  5   ~ distributed with this work for additional information
  6   ~ regarding copyright ownership.  The ASF licenses this file
  7   ~ to you under the Apache License, Version 2.0 (the
  8   ~ "License"); you may not use this file except in compliance
  9   ~ with the License.  You may obtain a copy of the License at
 10   ~
 11   ~   http://www.apache.org/licenses/LICENSE-2.0
 12   ~
 13   ~ Unless required by applicable law or agreed to in writing,
 14   ~ software distributed under the License is distributed on an
 15   ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 16   ~ KIND, either express or implied.  See the License for the
 17   ~ specific language governing permissions and limitations
 18   ~ under the License.
 19   -->
 20 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 21   <modelVersion>4.0.0</modelVersion>
```
</details>

<details>
<summary>Build before (first 100 lines)</summary>

```
this derivation will be built:
  /nix/store/j73xjkc462n2si1kji12yysi1va2skza-maven-deps-zxing-3.5.4.drv
building '/nix/store/j73xjkc462n2si1kji12yysi1va2skza-maven-deps-zxing-3.5.4.drv'...
Running phase: unpackPhase
unpacking source archive /nix/store/xl8yzza03357rvapbc3b0073nfy20c2a-source
source root is source/javase
Running phase: patchPhase
Running phase: updateAutotoolsGnuConfigScriptsPhase
Running phase: configurePhase
no configure script, doing nothing
Running phase: buildPhase
[INFO] Scanning for projects...
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/rat/maven-metadata.xml
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/rat/maven-metadata.xml
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/com/simpligility/maven/plugins/maven-metadata.xml
Downloading from central: https://repo.maven.apache.org/maven2/com/simpligility/maven/plugins/maven-metadata.xml
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/rat/maven-metadata.xml (558 B at 616 B/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/com/github/wvengen/maven-metadata.xml
Downloaded from central: https://repo.maven.apache.org/maven2/com/simpligility/maven/plugins/maven-metadata.xml (449 B at 437 B/s)
Downloading from central: https://repo.maven.apache.org/maven2/com/github/wvengen/maven-metadata.xml
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/com/github/wvengen/maven-metadata.xml (240 B at 1.4 kB/s)
Downloaded from central: https://repo.maven.apache.org/maven2/com/github/wvengen/maven-metadata.xml (240 B at 4.2 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/jacoco/maven-metadata.xml
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/jacoco/maven-metadata.xml
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/rat/maven-metadata.xml (558 B at 502 B/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-metadata.xml
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/com/simpligility/maven/plugins/maven-metadata.xml (449 B at 403 B/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-metadata.xml
Downloaded from central: https://repo.maven.apache.org/maven2/org/jacoco/maven-metadata.xml (237 B at 3.1 kB/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/codehaus/mojo/maven-metadata.xml
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-metadata.xml (14 kB at 213 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/mojo/maven-metadata.xml
Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/mojo/maven-metadata.xml (20 kB at 337 kB/s)
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-metadata.xml (14 kB at 92 kB/s)
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/codehaus/mojo/maven-metadata.xml (20 kB at 170 kB/s)
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/jacoco/maven-metadata.xml (237 B at 901 B/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-assembly-plugin/3.7.1/maven-assembly-plugin-3.7.1.pom
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-assembly-plugin/3.7.1/maven-assembly-plugin-3.7.1.pom (15 kB at 220 kB/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-plugins/41/maven-plugins-41.pom
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-plugins/41/maven-plugins-41.pom (7.4 kB at 88 kB/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/maven-parent/41/maven-parent-41.pom
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/maven-parent/41/maven-parent-41.pom (50 kB at 426 kB/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/apache/31/apache-31.pom
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/apache/31/apache-31.pom (24 kB at 341 kB/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-assembly-plugin/3.7.1/maven-assembly-plugin-3.7.1.jar
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-assembly-plugin/3.7.1/maven-assembly-plugin-3.7.1.jar (240 kB at 2.1 MB/s)
[INFO] 
[INFO] ----------------------< com.google.zxing:javase >-----------------------
[INFO] Building ZXing Java SE extensions 3.5.4
[INFO]   from pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-javadoc-plugin/3.12.0/maven-javadoc-plugin-3.12.0.pom
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-javadoc-plugin/3.12.0/maven-javadoc-plugin-3.12.0.pom (21 kB at 251 kB/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-plugins/45/maven-plugins-45.pom
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-plugins/45/maven-plugins-45.pom (8.4 kB at 97 kB/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/maven-parent/45/maven-parent-45.pom
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/maven-parent/45/maven-parent-45.pom (53 kB at 534 kB/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/apache/35/apache-35.pom
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/apache/35/apache-35.pom (24 kB at 391 kB/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/junit/junit-bom/5.13.1/junit-bom-5.13.1.pom
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/junit/junit-bom/5.13.1/junit-bom-5.13.1.pom (5.6 kB at 115 kB/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-javadoc-plugin/3.12.0/maven-javadoc-plugin-3.12.0.jar
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-javadoc-plugin/3.12.0/maven-javadoc-plugin-3.12.0.jar (493 kB at 2.8 MB/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-source-plugin/3.3.1/maven-source-plugin-3.3.1.pom
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-source-plugin/3.3.1/maven-source-plugin-3.3.1.pom (6.7 kB at 120 kB/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-source-plugin/3.3.1/maven-source-plugin-3.3.1.jar
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-source-plugin/3.3.1/maven-source-plugin-3.3.1.jar (32 kB at 657 kB/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-enforcer-plugin/3.6.2/maven-enforcer-plugin-3.6.2.pom
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-enforcer-plugin/3.6.2/maven-enforcer-plugin-3.6.2.pom (8.2 kB at 94 kB/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/enforcer/enforcer/3.6.2/enforcer-3.6.2.pom
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/enforcer/enforcer/3.6.2/enforcer-3.6.2.pom (9.2 kB at 109 kB/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-enforcer-plugin/3.6.2/maven-enforcer-plugin-3.6.2.jar
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-enforcer-plugin/3.6.2/maven-enforcer-plugin-3.6.2.jar (40 kB at 421 kB/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-checkstyle-plugin/3.6.0/maven-checkstyle-plugin-3.6.0.pom
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-checkstyle-plugin/3.6.0/maven-checkstyle-plugin-3.6.0.pom (15 kB at 154 kB/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-plugins/43/maven-plugins-43.pom
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-plugins/43/maven-plugins-43.pom (7.5 kB at 92 kB/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/maven-parent/43/maven-parent-43.pom
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/maven-parent/43/maven-parent-43.pom (50 kB at 509 kB/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/apache/33/apache-33.pom
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/apache/33/apache-33.pom (24 kB at 484 kB/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/junit/junit-bom/5.10.3/junit-bom-5.10.3.pom
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/junit/junit-bom/5.10.3/junit-bom-5.10.3.pom (5.6 kB at 113 kB/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-checkstyle-plugin/3.6.0/maven-checkstyle-plugin-3.6.0.jar
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-checkstyle-plugin/3.6.0/maven-checkstyle-plugin-3.6.0.jar (100 kB at 903 kB/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-resources-plugin/3.3.1/maven-resources-plugin-3.3.1.pom
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-resources-plugin/3.3.1/maven-resources-plugin-3.3.1.pom (8.2 kB at 138 kB/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-plugins/39/maven-plugins-39.pom
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-plugins/39/maven-plugins-39.pom (8.1 kB at 172 kB/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/maven-parent/39/maven-parent-39.pom
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/maven-parent/39/maven-parent-39.pom (48 kB at 716 kB/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/apache/29/apache-29.pom
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/apache/29/apache-29.pom (21 kB at 545 kB/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-resources-plugin/3.3.1/maven-resources-plugin-3.3.1.jar
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-resources-plugin/3.3.1/maven-resources-plugin-3.3.1.jar (31 kB at 476 kB/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-compiler-plugin/3.14.1/maven-compiler-plugin-3.14.1.pom
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-compiler-plugin/3.14.1/maven-compiler-plugin-3.14.1.pom (9.9 kB at 84 kB/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-compiler-plugin/3.14.1/maven-compiler-plugin-3.14.1.jar
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-compiler-plugin/3.14.1/maven-compiler-plugin-3.14.1.jar (84 kB at 804 kB/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-surefire-plugin/3.5.4/maven-surefire-plugin-3.5.4.pom
```
</details>

<details>
<summary>Build after (first 100 lines)</summary>

```
checking outputs of '/nix/store/imi7s5sdsfpyqx3vr5k14hdrxsaakfqp-maven-deps-zxing-3.5.4.drv'...
Running phase: unpackPhase
unpacking source archive /nix/store/xl8yzza03357rvapbc3b0073nfy20c2a-source
source root is source/javase
Running phase: patchPhase
Running phase: updateAutotoolsGnuConfigScriptsPhase
Running phase: configurePhase
no configure script, doing nothing
Running phase: buildPhase
[INFO] Scanning for projects...
Downloading from central: https://repo.maven.apache.org/maven2/com/simpligility/maven/plugins/maven-metadata.xml
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/rat/maven-metadata.xml
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/com/simpligility/maven/plugins/maven-metadata.xml
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/rat/maven-metadata.xml
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/rat/maven-metadata.xml (558 B at 844 B/s)
Downloaded from central: https://repo.maven.apache.org/maven2/com/simpligility/maven/plugins/maven-metadata.xml (449 B at 678 B/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/com/github/wvengen/maven-metadata.xml
Downloading from central: https://repo.maven.apache.org/maven2/com/github/wvengen/maven-metadata.xml
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/rat/maven-metadata.xml (558 B at 814 B/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/jacoco/maven-metadata.xml
Downloaded from central: https://repo.maven.apache.org/maven2/com/github/wvengen/maven-metadata.xml (240 B at 4.8 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/jacoco/maven-metadata.xml
Downloaded from central: https://repo.maven.apache.org/maven2/org/jacoco/maven-metadata.xml (237 B at 4.8 kB/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-metadata.xml
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/com/simpligility/maven/plugins/maven-metadata.xml (449 B at 571 B/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-metadata.xml
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/com/github/wvengen/maven-metadata.xml (240 B at 1.6 kB/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/codehaus/mojo/maven-metadata.xml
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-metadata.xml (14 kB at 255 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/mojo/maven-metadata.xml
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/jacoco/maven-metadata.xml (237 B at 1.4 kB/s)
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/codehaus/mojo/maven-metadata.xml (20 kB at 200 kB/s)
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-metadata.xml (14 kB at 94 kB/s)
Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/mojo/maven-metadata.xml (20 kB at 289 kB/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-assembly-plugin/3.7.1/maven-assembly-plugin-3.7.1.pom
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-assembly-plugin/3.7.1/maven-assembly-plugin-3.7.1.pom (15 kB at 245 kB/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-plugins/41/maven-plugins-41.pom
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-plugins/41/maven-plugins-41.pom (7.4 kB at 125 kB/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/maven-parent/41/maven-parent-41.pom
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/maven-parent/41/maven-parent-41.pom (50 kB at 712 kB/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/apache/31/apache-31.pom
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/apache/31/apache-31.pom (24 kB at 453 kB/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-assembly-plugin/3.7.1/maven-assembly-plugin-3.7.1.jar
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-assembly-plugin/3.7.1/maven-assembly-plugin-3.7.1.jar (240 kB at 2.3 MB/s)
[INFO] 
[INFO] ----------------------< com.google.zxing:javase >-----------------------
[INFO] Building ZXing Java SE extensions 3.5.4
[INFO]   from pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-javadoc-plugin/3.12.0/maven-javadoc-plugin-3.12.0.pom
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-javadoc-plugin/3.12.0/maven-javadoc-plugin-3.12.0.pom (21 kB at 270 kB/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-plugins/45/maven-plugins-45.pom
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-plugins/45/maven-plugins-45.pom (8.4 kB at 86 kB/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/maven-parent/45/maven-parent-45.pom
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/maven-parent/45/maven-parent-45.pom (53 kB at 608 kB/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/apache/35/apache-35.pom
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/apache/35/apache-35.pom (24 kB at 495 kB/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/junit/junit-bom/5.13.1/junit-bom-5.13.1.pom
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/junit/junit-bom/5.13.1/junit-bom-5.13.1.pom (5.6 kB at 113 kB/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-javadoc-plugin/3.12.0/maven-javadoc-plugin-3.12.0.jar
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-javadoc-plugin/3.12.0/maven-javadoc-plugin-3.12.0.jar (493 kB at 4.2 MB/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-source-plugin/3.3.1/maven-source-plugin-3.3.1.pom
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-source-plugin/3.3.1/maven-source-plugin-3.3.1.pom (6.7 kB at 84 kB/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-source-plugin/3.3.1/maven-source-plugin-3.3.1.jar
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-source-plugin/3.3.1/maven-source-plugin-3.3.1.jar (32 kB at 424 kB/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-enforcer-plugin/3.6.2/maven-enforcer-plugin-3.6.2.pom
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-enforcer-plugin/3.6.2/maven-enforcer-plugin-3.6.2.pom (8.2 kB at 120 kB/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/enforcer/enforcer/3.6.2/enforcer-3.6.2.pom
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/enforcer/enforcer/3.6.2/enforcer-3.6.2.pom (9.2 kB at 109 kB/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-enforcer-plugin/3.6.2/maven-enforcer-plugin-3.6.2.jar
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-enforcer-plugin/3.6.2/maven-enforcer-plugin-3.6.2.jar (40 kB at 533 kB/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-checkstyle-plugin/3.6.0/maven-checkstyle-plugin-3.6.0.pom
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-checkstyle-plugin/3.6.0/maven-checkstyle-plugin-3.6.0.pom (15 kB at 198 kB/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-plugins/43/maven-plugins-43.pom
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-plugins/43/maven-plugins-43.pom (7.5 kB at 101 kB/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/maven-parent/43/maven-parent-43.pom
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/maven-parent/43/maven-parent-43.pom (50 kB at 690 kB/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/apache/33/apache-33.pom
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/apache/33/apache-33.pom (24 kB at 562 kB/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/junit/junit-bom/5.10.3/junit-bom-5.10.3.pom
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/junit/junit-bom/5.10.3/junit-bom-5.10.3.pom (5.6 kB at 66 kB/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-checkstyle-plugin/3.6.0/maven-checkstyle-plugin-3.6.0.jar
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-checkstyle-plugin/3.6.0/maven-checkstyle-plugin-3.6.0.jar (100 kB at 1.3 MB/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-resources-plugin/3.3.1/maven-resources-plugin-3.3.1.pom
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-resources-plugin/3.3.1/maven-resources-plugin-3.3.1.pom (8.2 kB at 170 kB/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-plugins/39/maven-plugins-39.pom
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-plugins/39/maven-plugins-39.pom (8.1 kB at 176 kB/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/maven-parent/39/maven-parent-39.pom
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/maven-parent/39/maven-parent-39.pom (48 kB at 905 kB/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/apache/29/apache-29.pom
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/apache/29/apache-29.pom (21 kB at 460 kB/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-resources-plugin/3.3.1/maven-resources-plugin-3.3.1.jar
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-resources-plugin/3.3.1/maven-resources-plugin-3.3.1.jar (31 kB at 619 kB/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-compiler-plugin/3.14.1/maven-compiler-plugin-3.14.1.pom
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-compiler-plugin/3.14.1/maven-compiler-plugin-3.14.1.pom (9.9 kB at 139 kB/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-compiler-plugin/3.14.1/maven-compiler-plugin-3.14.1.jar
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-compiler-plugin/3.14.1/maven-compiler-plugin-3.14.1.jar (84 kB at 950 kB/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-surefire-plugin/3.5.4/maven-surefire-plugin-3.5.4.pom
Downloaded from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/plugins/maven-surefire-plugin/3.5.4/maven-surefire-plugin-3.5.4.pom (4.9 kB at 61 kB/s)
Downloading from google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/surefire/surefire/3.5.4/surefire-3.5.4.pom
```
</details>


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
