### PR TITLE
finamp: fix pubcache hash

### DIFF
--- a/pkgs/by-name/fi/finamp/package.nix
+++ b/pkgs/by-name/fi/finamp/package.nix
@@ -29,7 +29,7 @@ flutter338.buildFlutterApplication {
   buildInputs = [ mpv-unwrapped ];
 
   gitHashes = {
-    balanced_text = "sha256-lSDR5dDjZ4garRbBPI+wSxC5iScg8wVSD5kymmLbYbk=";
+    balanced_text = "sha256-U+gtC9AaUFp3gVkUzYMWAUSuUV7kYB8ZE2BsclnxwkA=";
     isar_generator = "sha256-EthUFM+YI3bnM0U0sECoNOCRXpo4qjP71VXYBuO/u+I=";
     isar_flutter_libs = "sha256-Z5IdfiaZ7348XwYSQb81z0YZEoIHWmsSZr6mYqqz4Oo=";
     media_kit_libs_windows_audio = "sha256-p3hRq79whLFJLNUgL9atXyTGvOIqCbTRKVk1ie0Euqs=";


### PR DESCRIPTION
Fixes hash mismatch for `finamp.pubcache` attribute.

It seems that the source hash for pub-balanced_text-0.0.3 changed. Here's the diff for the pub-balanced_text-0.0.3: https://gist.github.com/DieracDelta/e078167b2fbdff2d64ec9391ca2051ff . It seems okay to me given how minor of a change it is. I'm guessing upstream force pushed to this 0.0.3 tag.

Build logs:
- [before (0c947b9)](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/finamp/pubcache.before.log)
- [after (9eb4aea)](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/finamp/pubcache.after.log)
- [source diff (only of pubcache. See above for the pub-balanced_text) ](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/finamp/pubcache.diff.log)

Source directories:
- [old source](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/finamp/pubcache.src.before/)
- [new source](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/finamp/pubcache.src.after/)

<details>
<summary>Source diff</summary>

```
package_config.json --- JSON
1426     },                                              1426     },
1427     {                                               1427     {
1428       "name": "balanced_text",                      1428       "name": "balanced_text",
1429       "rootUri": "file:///nix/store/1p83y7z33r1jpjv 1429       "rootUri": "file:///nix/store/0ljmwi36ycq0qpc
.... bbhn7x4pkfbikc5wn-pub-balanced_text-0.0.3/.",       .... 2n6ia59xbxx3bd9cr-pub-balanced_text-0.0.3/.",
1430       "packageUri": "lib/",                         1430       "packageUri": "lib/",
1431       "languageVersion": "2.17"                     1431       "languageVersion": "2.17"
1432     },                                              1432     },

```
</details>

<details>
<summary>Build before (first 100 lines)</summary>

```
these 507 derivations will be built:
  /nix/store/00mxin3cgiljn62nrfj2zm80y9jsvy5c-pub-flutter_rust_bridge-2.11.1.drv
  /nix/store/0170z7pzpahqqvjpmfqmh30ryb0y5xrs-pub-value_layout_builder-0.5.0.tar.gz.drv
  /nix/store/01immwv529ba2njkr3qkyn1033cqf422-plotters-backend-0.3.6.drv
  /nix/store/01xr5j6xzkcw7bm8xg7073fdj0kv6qj0-pub-device_info_plus-12.3.0.drv
  /nix/store/020c7w20phbzaz46828yzf8bhcw61z9v-lerc-4.0.0.drv
  /nix/store/n01gwh4kz0yx79q01p549ziyw0181aq9-pub-threshold-1.0.5.tar.gz.drv
  /nix/store/02zzf61jcpzwc2apkq56ngb2lbcqdrp2-pub-threshold-1.0.5.drv
  /nix/store/03a47nx48mznb2m93q1bgx8vi98khj2x-python3-3.13.11-env.drv
  /nix/store/03ajacpr5r0a9x4sljahy5z9yqckd7bw-crc-catalog-2.4.0.drv
  /nix/store/0a7rni150v1s68jajh5bwxq1h472hpii-pub-args-2.7.0.drv
  /nix/store/0a89viy39r47whfj95v3dawy8235gka2-pub-hive_ce_generator-1.9.2.tar.gz.drv
  /nix/store/0cgcvhba3zngiv9bd3gd7z35g5fk0l14-pub-vector_graphics-1.1.19.drv
  /nix/store/0dyg8lrna9514k4441chzm6dvlvw1rrr-pub-equatable-2.0.7.drv
  /nix/store/0iwa2ip0bpari7clx9n2n8ln9i9rb37s-db-4.8.30.drv
  /nix/store/0kk9flvxni90a020i4khw1iqrj6550ma-pub-shared_preferences_platform_interface-2.4.1.drv
  /nix/store/0ma6fm1whi1pglsgh3d54fa13zwilyqd-pub-split_view-3.2.1.drv
  /nix/store/0mm0d5k6sfwsps65xr4b1y6n6svlc44p-libxcb-cursor-0.1.6.drv
  /nix/store/23fzzk7mfispg5v4zcldxxwrkj4yxnqv-pub-media_kit-1.2.6.tar.gz.drv
  /nix/store/0ms77wlhwl2y92mryhzl96ya3955z3l2-pub-media_kit-1.2.6.drv
  /nix/store/0nv604kv28aiirq537xfw6hhvpv8qm1p-windows-targets-0.52.6.drv
  /nix/store/0q5z2yka4b2rvn82lwaj8bw1z392baa0-pub-shared_preferences_android-2.4.18.drv
  /nix/store/0sga1bikinx4d2hpsvpc9xrihfddlr3k-pub-permission_handler_apple-9.4.7.drv
  /nix/store/0ybba6k2cnxw1zq6923hh5ilg1bbblnv-dart-install-hook.drv
  /nix/store/0zhma443zyh6nghcqsxpyyn6hr20bdqh-windows_x86_64_msvc-0.52.6.drv
  /nix/store/0zkr52n1kcksd8if0najjjmk45xzkyjv-c-ares-1.34.5.drv
  /nix/store/0zp38bnsfvncklwv9mq9ar76j4l7wvaj-pub-ci-0.1.0.drv
  /nix/store/10kxxms9rx2yrk3yjfj98jw49s8y0hhf-dart-build-hook.drv
  /nix/store/nm0rwi4jhhmqbk3w0q2lmjsmxi9jy7yy-mimalloc-3.1.5.drv
  /nix/store/qmzqhszq1fkmgz98zgvb3pl78zb2fs4a-pub-media_kit_libs_linux-1.2.1.drv
  /nix/store/1171cxvmmqm1ifpw273rjpiqx2dqbzm4-media_kit_libs_linux-1.2.1.drv
  /nix/store/123p77snas7yxjy2lqxhqk29jw4lb81q-pub-watcher-1.1.4.drv
  /nix/store/12ya6g95dhv5k7ihv5g54vgj90zbsayx-pub-riverpod_generator-2.6.5.drv
  /nix/store/1bbngb7jxfcj0k714j032japf0gy7qnp-pub-glob-2.1.3.drv
  /nix/store/1crjdgzchz7qq4qhq2v2917n032kjnn3-pub-nested-1.0.0.drv
  /nix/store/1gbrfnffdi3kykc20djlb62mnlqi216i-pub-marquee-2.3.0.drv
  /nix/store/1if2c3974zl125x26z6rw1hnads5sx7q-pub-gtk-2.1.0.drv
  /nix/store/1m33f77jc7v4mlj119xxvhvbp9722caf-pub-riverpod_annotation-2.6.1.drv
  /nix/store/1na56nn65d5ikdlzwwwp8k3a4p4xxa7y-pub-just_audio_platform_interface-4.6.0.drv
  /nix/store/1sa6x04n62yvwvzazdndavfivrjcxl1g-pub-yaml_edit-2.2.2.drv
  /nix/store/1x88jwv7s4ra3bs1ayadyn7z6k0hjha5-pub-dwds-25.1.0+2.drv
  /nix/store/1xfc4g9p52xnv0wxpbvz0kb7pbnka2b5-windows_aarch64_msvc-0.52.6.drv
  /nix/store/1yfxwyvidpxddkhc3jz2wv9dfhj4akmz-pub-path_provider_foundation-2.5.1.drv
  /nix/store/l4dfngwb00mcqlbbv2pw8p5bk9f93424-pub-clipboard-2.0.2.tar.gz.drv
  /nix/store/20qwm1cw1hf4xyrf01j39wcxb939z62s-pub-clipboard-2.0.2.drv
  /nix/store/21k7d49nz19bmw9gdr5a1nhk6c2il4wm-regex-automata-0.4.7.drv
  /nix/store/21snixrqlq43lk300rd45l9i7x87a7xb-pub-sqflite-2.4.2.drv
  /nix/store/cq9j1jk5572bm9jk5fi198nrqhim2cq1-pub-chopper-8.4.0.tar.gz.drv
  /nix/store/241q17158madgppbj579y0znyypcx5p5-pub-chopper-8.4.0.drv
  /nix/store/5aijh5pw15agyz8fxwr8clmz8c5xsi54-pub-flutter_discord_rpc-1.1.0.drv
  /nix/store/775c4yxm8cxqs17n1z3fzsl4d80ngz90-flutter_discord_rpc-rs-1.1.0-vendor.drv
  /nix/store/a0n6x0ysax71r0c29spnmd4wphvv9paw-flutter_discord_rpc-rs-1.1.0.drv
  /nix/store/2cpf9mp56vn7n9pnpqhnrgx2k7icqhq0-cargokit.patch.drv
  /nix/store/2fbfkp38gmf5lxl7cxq7mkzhpjli8wxw-python3.13-glad2-2.0.8.drv
  /nix/store/2fbnnp8bl19k6bxgrcp4zgh18r2k6v4b-pub-balanced_text-0.0.3.drv
  /nix/store/2hkk2w5nhy6iz1kc9ynaspicq8a1kjwy-pub-shelf_proxy-1.0.4.drv
  /nix/store/2jganlsw9g3v2gvch2xv7aa46s6025n4-pub-source_maps-0.10.13.drv
  /nix/store/2mz7rn5clrxyj23pk8kkxqdb3p8lizf4-pub-flutter_riverpod-2.6.1.drv
  /nix/store/2w48hyakqwqczxxnyam2kwj6a2akf6y3-pub-state_notifier-1.0.0.drv
  /nix/store/2w8901scd866vb5r719nsi0an8z9ihgs-ciborium-io-0.2.2.drv
  /nix/store/2wfjdac5qhjghinsx9h4izrrlz65aph6-pub-js-0.6.7.drv
  /nix/store/2xq8jk2jnhaz1bdv7njr4fqwalkj9bix-pub-completion-1.0.2.drv
  /nix/store/2zi71yss77pm48zh2vx9m1zs6js6yqs2-keyutils-1.6.3.drv
  /nix/store/2zyb6q1n655rhyc9zirxvk36c8159ksq-pub-path-1.9.1.drv
  /nix/store/30lrwh3hxq90hqvqvghljfrap5wskk2m-pub-audio_service_web-0.1.4.drv
  /nix/store/352a8sxzii6hvk0jzlzrf64m4x44q0hf-pub-locale_names-1.1.1.drv
  /nix/store/3776yxd6w1g9chhlbl9ya82p04r59fhf-pub-synchronized-3.4.0.drv
  /nix/store/3d9xb52zckbxsgk584vxafd29bqq5n2h-pub-audio_service_platform_interface-0.1.3.drv
  /nix/store/3nmf5wbi19zq8nv8xv68i5cacw11kh5j-pub-battery_plus_platform_interface-2.0.1.drv
  /nix/store/4sgpvr03qsnqlpgfw4h8y4glzdpgd6y1-rb-dialogs-link-labsfolderlistmodel-into-quickdialogs2quickimpl.patch.drv
  /nix/store/c01dspdb6lf1irn7nlkm8593x92l362h-dont-cache-nix-store-paths.patch.drv
  /nix/store/bp3s384r8y5v2srrnwgx0qw7gan02yrk-rav1e-0.8.1.drv
  /nix/store/ixzpi69fzksckbg6dfbxwgpdphf9ncwd-libheif-1.20.2.drv
  /nix/store/kndq31m3ps5r8hv7h103f2nxc3z3vl45-jasper-4.2.8.drv
  /nix/store/rzlxshs4jz3g0qg33sdvxy0f8fs0vwca-libmng-2.0.3.drv
  /nix/store/fqqcc5gq5ddxwlnn4nzrgxayn64mfx9s-sqlite-connector-odbc-fix-incompatible-pointer-compilation-error.patch.drv
  /nix/store/nqiyj9gywjf3k2xzmlyb9whn3xw7a2m5-sqliteodbc-0.99991.tar.gz.drv
  /nix/store/afwkk2c4kjwi6m30fwlqds9ldms8qqjl-sqlite-connector-odbc-0.99991.drv
  /nix/store/d9y0r4c58cgnqr5v3cdd0mqwy53lzvp6-md4c-0.5.2.drv
  /nix/store/ql8v20bdscsg33php51vqvk2qbkzksvf-mariadb-connector-odbc-add-include-cstdint-gcc15.patch.drv
  /nix/store/dccc2r33y2q5qpzsh45kmcqyxnxqwpjj-mariadb-connector-odbc-3.2.6.drv
  /nix/store/pyljdia2axq8rls0gf8y11qfacb4jcwv-libdatrie-2019-12-20.drv
  /nix/store/i2kvqnk123f9p1snflas4lj1yw12lhg6-libthai-0.1.29.drv
  /nix/store/mi3qgkki49gj22r9wsssr029j8298v6k-hardcode-gsettings.patch.drv
  /nix/store/prr4xf5wh9nnw0bwf6fsl1mzqid9agdd-libproxy-0.5.11.drv
  /nix/store/gd0cgn9xbpjhwqr54xds57db9vkal7zp-source.drv
  /nix/store/smg18l2k51zklizl8lf1af6n1dm3354p-psqlodbc-17.00.0007.drv
  /nix/store/y69mshiy2zakikfswkx2dp9ipi50qr54-lksctp-tools-1.0.21.drv
  /nix/store/zp9r3146y6pv1hrf4slah570bz206w3a-qtbase-6.10.1.drv
  /nix/store/cnwc19d21vqhrc3bb875dwaxiasasq4m-qtsvg-6.10.1.drv
  /nix/store/gp7kmzcx04xh7pgmq7v7vbca1w0lwr6y-9c6b2b78e9076f1c2676aa0c41573db9ca480654.diff.drv
  /nix/store/hzsm3y6anvyls30s4bp5akk8sv7fcrzw-rb-quickcontrols-fix-controls-styles-linkage.patch.drv
  /nix/store/mnzgmaw8r1qg3qx3dprhwnggp16lprxp-qtshadertools-6.10.1.drv
  /nix/store/xmzviapg6f6a8h1wdikijzrsghpvc4fc-qtlanguageserver-6.10.1.drv
  /nix/store/3nqxrp7mjpvh6npivyd1bzy060vvg3nh-qtdeclarative-6.10.1.drv
  /nix/store/3pcf1s65vqnby7i3nlmxa96yy4s1gc8n-pub-analyzer_plugin-0.13.0.tar.gz.drv
  /nix/store/3pjqs7wvs1rkdyazkma3mx68mpdny6xf-anes-0.1.6.drv
  /nix/store/3qkrbwwkkmq8xznb4gippcclary5sapf-pub-custom_lint_visitor-1.0.0+7.3.0.tar.gz.drv
  /nix/store/3s7svarn6s9v5147mrz39yxrd3phbqa0-indexmap-2.3.0.drv
  /nix/store/a228rhb9dqks9qsvky2cz4s6hlfja3pm-utils.sh.drv
```
</details>

<details>
<summary>Build after (first 100 lines)</summary>

```
these 75 derivations will be built:
  /nix/store/03a47nx48mznb2m93q1bgx8vi98khj2x-python3-3.13.11-env.drv
  /nix/store/0nv604kv28aiirq537xfw6hhvpv8qm1p-windows-targets-0.52.6.drv
  /nix/store/0zhma443zyh6nghcqsxpyyn6hr20bdqh-windows_x86_64_msvc-0.52.6.drv
  /nix/store/83kxd5b12h4kcsdvmzsrnwk1rncm9s20-source.drv
  /nix/store/zzwf4lim5v5b0zhb23fjr9yk0mnifjsw-finamp-0.9.21-beta-package-config.json.drv
  /nix/store/1m2d3v1967zql0jpqm86fs1yabwdyijf-finamp-0.9.21-beta-package-config-with-root.json.drv
  /nix/store/1xfc4g9p52xnv0wxpbvz0kb7pbnka2b5-windows_aarch64_msvc-0.52.6.drv
  /nix/store/21k7d49nz19bmw9gdr5a1nhk6c2il4wm-regex-automata-0.4.7.drv
  /nix/store/2fbfkp38gmf5lxl7cxq7mkzhpjli8wxw-python3.13-glad2-2.0.8.drv
  /nix/store/4sgpvr03qsnqlpgfw4h8y4glzdpgd6y1-rb-dialogs-link-labsfolderlistmodel-into-quickdialogs2quickimpl.patch.drv
  /nix/store/bp3s384r8y5v2srrnwgx0qw7gan02yrk-rav1e-0.8.1.drv
  /nix/store/ixzpi69fzksckbg6dfbxwgpdphf9ncwd-libheif-1.20.2.drv
  /nix/store/kndq31m3ps5r8hv7h103f2nxc3z3vl45-jasper-4.2.8.drv
  /nix/store/fqqcc5gq5ddxwlnn4nzrgxayn64mfx9s-sqlite-connector-odbc-fix-incompatible-pointer-compilation-error.patch.drv
  /nix/store/nqiyj9gywjf3k2xzmlyb9whn3xw7a2m5-sqliteodbc-0.99991.tar.gz.drv
  /nix/store/afwkk2c4kjwi6m30fwlqds9ldms8qqjl-sqlite-connector-odbc-0.99991.drv
  /nix/store/gd0cgn9xbpjhwqr54xds57db9vkal7zp-source.drv
  /nix/store/smg18l2k51zklizl8lf1af6n1dm3354p-psqlodbc-17.00.0007.drv
  /nix/store/zp9r3146y6pv1hrf4slah570bz206w3a-qtbase-6.10.1.drv
  /nix/store/cnwc19d21vqhrc3bb875dwaxiasasq4m-qtsvg-6.10.1.drv
  /nix/store/hzsm3y6anvyls30s4bp5akk8sv7fcrzw-rb-quickcontrols-fix-controls-styles-linkage.patch.drv
  /nix/store/mnzgmaw8r1qg3qx3dprhwnggp16lprxp-qtshadertools-6.10.1.drv
  /nix/store/xmzviapg6f6a8h1wdikijzrsghpvc4fc-qtlanguageserver-6.10.1.drv
  /nix/store/3nqxrp7mjpvh6npivyd1bzy060vvg3nh-qtdeclarative-6.10.1.drv
  /nix/store/a228rhb9dqks9qsvky2cz4s6hlfja3pm-utils.sh.drv
  /nix/store/mif5lk7crdw9fx5nwivwlxr57i377s4a-lua-5.2.4.drv
  /nix/store/gvfvkh3qrwab8i4zz2m1q3cmlfhrqw7y-luarocks_bootstrap-3.12.2.drv
  /nix/store/vjx5fijp9bdydd6g0pbxn6jj6ndnf70v-wrap-lua-hook.drv
  /nix/store/hs4ifa546w47vxmx528abv6rv4f566pj-luasocket-luarocks-config.lua.drv
  /nix/store/5ig9hcv8lmyy3yc36xv9ngcjjaq9fwcw-lua5.2-luasocket-3.1.0-1.drv
  /nix/store/3v5qp1c8607mr2flp9k5vipplj90lgln-lua-5.2.4-env.drv
  /nix/store/43gc6wachpdpxcp5q928hivhknbi1rpf-wasm-bindgen-macro-support-0.2.92.drv
  /nix/store/43sciwpjch39mk993zgjsj0bfdj933ir-syn-2.0.72.drv
  /nix/store/5b329pp7135ippl864nlm3k9hbdqabhb-regex-syntax-0.8.4.drv
  /nix/store/6x4ycrikmb7i7flkksk6l94bys414ivh-flutter-cache-dir.drv
  /nix/store/7kk9sjd5qs251grghl9y5s5xvbjvrwsd-serde-1.0.204.drv
  /nix/store/9j3dji9l0bk8xm3mcbih219qkh3xp8gf-wasm-bindgen-backend-0.2.92.drv
  /nix/store/9mcm15saainpvxh8gvzrf22zrf4n1kzv-wasm-bindgen-macro-0.2.92.drv
  /nix/store/b01qy7lgvh8dvzdxaa9m7qpvqh0qs3xy-ryu-1.0.18.drv
  /nix/store/dhv3x6lxxw5cz2pyalzzlmmz2a8pn2pv-winapi-util-0.1.9.drv
  /nix/store/fbmy1jzd442vvlmndjphhc71rk69j6k5-wasm-bindgen-shared-0.2.92.drv
  /nix/store/fls9syxwpcsz9gqpj40qcklgp0wjgr4w-tinyvec-1.8.0.drv
  /nix/store/fqsnjsxycg2yv8mmpbwb6m9sy799p92s-windows_aarch64_gnullvm-0.52.6.drv
  /nix/store/h2ssmzrwhbhdk134wnimkk0fa5n4c628-wasm-bindgen-0.2.92.drv
  /nix/store/hs6cdcszyqn8r3k8v67i52jwdgdi3rcj-windows_x86_64_gnullvm-0.52.6.drv
  /nix/store/il2pl9z9kcm01rplyl960qmzsf9b71hj-windows_i686_msvc-0.52.6.drv
  /nix/store/in2yif16999pa1af0yvlkn8d2mrbvxgn-web-sys-0.3.69.drv
  /nix/store/l70hygjifl8wj5gl2kyxjsh16vmf11q2-windows_x86_64_gnu-0.52.6.drv
  /nix/store/lqhqqk9i5mdsv548ws6w45xz77mc4wlz-windows_i686_gnu-0.52.6.drv
  /nix/store/m8b3fv7dvngpjx273hd40ks8s8vrwqn8-tinytemplate-1.2.1.drv
  /nix/store/mwivw18gjb21rfqdvm4shqshf9csigi0-serde_json-1.0.122.drv
  /nix/store/njgsfssnqdkardds3h7bj3fcq9arbpm3-serde_derive-1.0.204.drv
  /nix/store/pwm89ybs25xdim2mb7bkjldqdn18r2dd-windows_i686_gnullvm-0.52.6.drv
  /nix/store/rayw6cg3mq8mmvrrbqphbdlnp57xww75-radium-0.7.0.drv
  /nix/store/rq87qxl46sqbq9nsvq6f6z4s1k7f78qa-wyz-0.5.1.drv
  /nix/store/sdpi9967crr9lv2w3zp3yc8jaxk1k2a0-roxmltree-0.20.0.drv
  /nix/store/smdyjp8aarmbd09w7iajl2rb7hm4j0yr-tap-1.0.1.drv
  /nix/store/vmzg7xm80867s857h7nbkm5d7kyr20ad-regex-1.10.6.drv
  /nix/store/x9hp80bb0apwa3vggqgyzrdck1c92w82-windows-sys-0.59.0.drv
  /nix/store/9mpzylppl4b4gy9s5bpvmblc86cc0fzr-cargo-vendor-dir.drv
  /nix/store/6xl5s0g10yjxxbr0kbhx1zwsc9zvvm0v-libdovi-3.3.1.drv
  /nix/store/9pmgqr1lhmbrpnk9ni7bvyj83fjrf34f-flutter-wrapped-3.38.5-sdk-links.drv
  /nix/store/b7diq63bgn4981aqsjhd5qczj0ncdvzx-libcaca-0.99.beta20.drv
  /nix/store/d04xqhrqwr04q7y5idb5xj6h5jhx7pfk-qt5compat-6.10.1.drv
  /nix/store/rln451rp7mxd32vbr2ynpjf86vmr2dk8-wrap-qt6-apps-hook.drv
  /nix/store/kavvcw30qkqkys70zabbaw3prkl2z4wz-v4l-utils-1.32.0.drv
  /nix/store/dvc90sb798xk1g77wazbszb43b96mz27-libdisplay-info-0.3.0.drv
  /nix/store/f9nl5a4p0732mglna4gvf4kwlkff9hn1-libplacebo-7.351.0.drv
  /nix/store/fyhglsmgn8xklzyxdwa9vd50xvjw30b8-vamp-plugin-sdk-2.10.drv
  /nix/store/gwjmd1avig9zkrhx1ddq6yqsj518125z-dart-config-hook.drv
  /nix/store/mv724rlky0fpy3g7cpc1h4npx6fms29b-mujs-1.3.6.drv
  /nix/store/nkn705znwmply45k0b6bi6sf0r2j760d-rubberband-4.0.0.drv
  /nix/store/sx0y1avvqz6kkxrb7a0ipm11ssfsgra5-uchardet-0.0.8.drv
  /nix/store/n80j8qw4k3390j4j02cr67nkh4p2dpnc-mpv-0.41.0.drv
  /nix/store/y1q1a3rbily6h4b24qk1r9k58110xyy7-finamp-0.9.21-beta.drv
building '/nix/store/83kxd5b12h4kcsdvmzsrnwk1rncm9s20-source.drv'...
building '/nix/store/6x4ycrikmb7i7flkksk6l94bys414ivh-flutter-cache-dir.drv'...
building '/nix/store/03a47nx48mznb2m93q1bgx8vi98khj2x-python3-3.13.11-env.drv'...
building '/nix/store/zzwf4lim5v5b0zhb23fjr9yk0mnifjsw-finamp-0.9.21-beta-package-config.json.drv'...
waiting for lock on '/nix/store/nf5pbw72n6zg8h1iiz4zl8p0k58gxr7k-rav1e-0.8.1'...
structuredAttrs is enabled
/nix/store/aidw9n2qknal33yp5npra7kcanq4z1wr-flutter-artifacts-universal-x86_64-linux/bin/cache:
engine.stamp: Keeping existing link to /nix/store/ncq0cdm6j3pk4kyn7y1zcmrxkk8fdq01-flutter-artifacts-linux-x86_64-linux/bin/cache/engine.stamp
/nix/store/aidw9n2qknal33yp5npra7kcanq4z1wr-flutter-artifacts-universal-x86_64-linux/bin/cache/artifacts/engine/linux-x64:
gen_snapshot: Keeping existing link to /nix/store/ncq0cdm6j3pk4kyn7y1zcmrxkk8fdq01-flutter-artifacts-linux-x86_64-linux/bin/cache/artifacts/engine/linux-x64/gen_snapshot
created 218 symlinks in user environment
structuredAttrs is enabled

trying https://github.com/jmshrv/finamp/archive/0.9.21-beta.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0   0     0   0     0     0     0  --:--:-- --:--:-- --:--:--     0
100 18407k   0 18407k   0     0 12309k     0  --:--:--  0:00:01 --:--:-- 18937k
unpacking source archive /build/download.tar.gz
building '/nix/store/b7diq63bgn4981aqsjhd5qczj0ncdvzx-libcaca-0.99.beta20.drv'...
Running phase: unpackPhase
unpacking source archive /nix/store/ic29kbmw8hqhzrvyb16i578nw21f1c3s-source
source root is source
Running phase: patchPhase
```
</details>


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
