### PR TITLE
tabula-java: fix fetchedMavenDeps hash

### DIFF
--- a/pkgs/by-name/ta/tabula-java/package.nix
+++ b/pkgs/by-name/ta/tabula-java/package.nix
@@ -17,7 +17,7 @@ maven.buildMavenPackage rec {
     hash = "sha256-lg8/diyGhfkUU0w7PEOlxb1WNpJZVDDllxMMsTIU/Cw=";
   };
 
-  mvnHash = "sha256-CXJm9YlYsYViChFcH9e2P9pxK0q/tLWODOzZPXZ8hK0=";
+  mvnHash = "sha256-YD8toy45PqeXXTvRv9ww8QeJfqG1nNz0q63AMgZayy4=";
   mvnParameters = "compile assembly:single -Dmaven.test.skip=true";
 
   nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
Fixes hash mismatch for `tabula-java.fetchedMavenDeps`. The diff is large, with changes to maven for:

- sonatype
- codehaus, apache (as usual)

I did a cursory read through, didn't see anything glaringly wrong...

Build logs:
- [before (af77653)](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/tabula-java/fetchedMavenDeps.before.log)
- [after (43e72c4)](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/tabula-java/fetchedMavenDeps.after.log)
- [source diff](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/tabula-java/fetchedMavenDeps.diff.log)

Source directories:
- [old source](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/tabula-java/fetchedMavenDeps.src.before/)
- [new source](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/tabula-java/fetchedMavenDeps.src.after/)

<details>
<summary>Source diff (first 100 lines)</summary>

```
.m2/org/codehaus/mojo/maven-metadata-central.xml.sha1 --- Text
1 76afcd4b1623558ca679eebeec8d74784c2090b5
2 

.m2/org/apache/maven/maven-parent/26/maven-parent-26.pom.sha1 --- Text
1 c33a248bd35b9d6b6fbcbe7061a30bb9d422dc42
2 

.m2/org/apache/maven/plugins/maven-gpg-plugin/1.6/maven-gpg-plugin-1.6.pom.sha1 --- Text
1 bcab9cbb621ccd3cc0f9bfb4b675133b465073b5
2 

.m2/org/sonatype/plugins/maven-metadata-central.xml.sha1 --- Text
1 f2e17f56d8c79c0373218f81bf73fc0647bd1cdd
2 

.m2/org/apache/maven/plugins/maven-plugins/27/maven-plugins-27.pom --- Text
  1 <?xml version='1.0' encoding='UTF-8'?>
  2 <!--
  3 Licensed to the Apache Software Foundation (ASF) under one
  4 or more contributor license agreements.  See the NOTICE file
  5 distributed with this work for additional information
  6 regarding copyright ownership.  The ASF licenses this file
  7 to you under the Apache License, Version 2.0 (the
  8 "License"); you may not use this file except in compliance
  9 with the License.  You may obtain a copy of the License at
 10 
 11   http://www.apache.org/licenses/LICENSE-2.0
 12 
 13 Unless required by applicable law or agreed to in writing,
 14 software distributed under the License is distributed on an
 15 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 16 KIND, either express or implied.  See the License for the
 17 specific language governing permissions and limitations
 18 under the License.
 19 -->
 20 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 21   <modelVersion>4.0.0</modelVersion>
 22 
 23   <parent>
 24     <groupId>org.apache.maven</groupId>
 25     <artifactId>maven-parent</artifactId>
 26     <version>26</version>
 27     <relativePath>../../pom/maven/pom.xml</relativePath>
 28   </parent>
 29 
 30   <groupId>org.apache.maven.plugins</groupId>
 31   <artifactId>maven-plugins</artifactId>
 32   <version>27</version>
 33   <packaging>pom</packaging>
 34 
 35   <name>Apache Maven Plugins</name>
 36   <description>Maven Plugins</description>
 37   <url>http://maven.apache.org/plugins/</url>
 38 
 39   <scm>
 40     <connection>scm:svn:http://svn.apache.org/repos/asf/maven/plugins/tags/maven-plugins-27</connection>
 41     <developerConnection>scm:svn:https://svn.apache.org/repos/asf/maven/plugins/tags/maven-plugins-27</developerConnection>
 42     <url>http://svn.apache.org/viewvc/maven/plugins/tags/maven-plugins-27</url>
 43   </scm>
 44   <ciManagement>
 45     <system>Jenkins</system>
 46     <url>https://builds.apache.org/job/maven-plugins/</url>
 47   </ciManagement>
 48 
 49   <distributionManagement>
 50     <site><!-- to be copied in every plugin pom, since inheritance adds unwanted artifactId -->
 51       <id>apache.website</id>
 52       <url>scm:svn:https://svn.apache.org/repos/infra/websites/production/maven/content/${maven.site.path}</url>
 53     </site>
 54   </distributionManagement>
 55 
 56   <properties>
 57     <maven.site.path>plugins-archives/${project.artifactId}-LATEST</maven.site.path>
 58   </properties>
 59 
 60   <repositories>
 61     <repository>
 62       <id>apache.snapshots</id>
 63       <name>Apache Snapshot Repository</name>
 64       <url>http://repository.apache.org/snapshots</url>
 65       <releases>
 66         <enabled>false</enabled>
 67       </releases>
 68     </repository>
 69   </repositories>
 70 
 71   <dependencies>
 72     <!-- dependencies to annotations -->
 73     <dependency>
 74       <groupId>org.apache.maven.plugin-tools</groupId>
 75       <artifactId>maven-plugin-annotations</artifactId>
 76     </dependency>
 77   </dependencies>
 78 
 79   <build>
 80     <pluginManagement>
 81       <plugins>
 82         <plugin>
 83           <groupId>org.apache.maven.plugins</groupId>
```
</details>

<details>
<summary>Build before (first 100 lines)</summary>

```
this derivation will be built:
  /nix/store/l70lj0n16aqh0y7i860jj52p6r2k9bi4-maven-deps-tabula-java-1.0.5.drv
building '/nix/store/l70lj0n16aqh0y7i860jj52p6r2k9bi4-maven-deps-tabula-java-1.0.5.drv'...
Running phase: unpackPhase
unpacking source archive /nix/store/a1hf72bjz7f972zyan07h234397h14gc-source
source root is source
Running phase: patchPhase
Running phase: updateAutotoolsGnuConfigScriptsPhase
Running phase: configurePhase
no configure script, doing nothing
Running phase: buildPhase
[INFO] Scanning for projects...
Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/plugins/nexus-staging-maven-plugin/1.6.8/nexus-staging-maven-plugin-1.6.8.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/plugins/nexus-staging-maven-plugin/1.6.8/nexus-staging-maven-plugin-1.6.8.pom (12 kB at 34 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/nexus/maven/nexus-staging/1.6.8/nexus-staging-1.6.8.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/nexus/maven/nexus-staging/1.6.8/nexus-staging-1.6.8.pom (2.8 kB at 58 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/nexus/maven/nexus-maven-plugins/1.6.8/nexus-maven-plugins-1.6.8.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/nexus/maven/nexus-maven-plugins/1.6.8/nexus-maven-plugins-1.6.8.pom (18 kB at 313 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/buildsupport/public-parent/6/public-parent-6.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/buildsupport/public-parent/6/public-parent-6.pom (760 B at 16 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/buildsupport/buildsupport/6/buildsupport-6.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/buildsupport/buildsupport/6/buildsupport-6.pom (23 kB at 79 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/nexus/maven/nexus-common/1.6.8/nexus-common-1.6.8.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/nexus/maven/nexus-common/1.6.8/nexus-common-1.6.8.pom (2.2 kB at 39 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-sec-dispatcher/1.4/plexus-sec-dispatcher-1.4.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-sec-dispatcher/1.4/plexus-sec-dispatcher-1.4.pom (3.0 kB at 67 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/spice/spice-parent/12/spice-parent-12.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/spice/spice-parent/12/spice-parent-12.pom (6.8 kB at 154 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/forge/forge-parent/4/forge-parent-4.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/forge/forge-parent/4/forge-parent-4.pom (8.4 kB at 171 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-cipher/1.7/plexus-cipher-1.7.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-cipher/1.7/plexus-cipher-1.7.pom (4.2 kB at 91 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/spice/spice-parent/15/spice-parent-15.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/spice/spice-parent/15/spice-parent-15.pom (8.4 kB at 178 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/forge/forge-parent/5/forge-parent-5.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/forge/forge-parent/5/forge-parent-5.pom (8.4 kB at 178 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/com/google/guava/guava/14.0.1/guava-14.0.1.pom
Downloaded from central: https://repo.maven.apache.org/maven2/com/google/guava/guava/14.0.1/guava-14.0.1.pom (5.4 kB at 114 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/com/google/guava/guava-parent/14.0.1/guava-parent-14.0.1.pom
Downloaded from central: https://repo.maven.apache.org/maven2/com/google/guava/guava-parent/14.0.1/guava-parent-14.0.1.pom (2.6 kB at 56 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/oss/oss-parent/7/oss-parent-7.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/oss/oss-parent/7/oss-parent-7.pom (4.8 kB at 105 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/nexus/nexus-client-core/2.14.3-02/nexus-client-core-2.14.3-02.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/nexus/nexus-client-core/2.14.3-02/nexus-client-core-2.14.3-02.pom (4.9 kB at 114 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/nexus/nexus-components/2.14.3-02/nexus-components-2.14.3-02.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/nexus/nexus-components/2.14.3-02/nexus-components-2.14.3-02.pom (2.6 kB at 50 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/nexus/nexus-parent/2.14.3-02/nexus-parent-2.14.3-02.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/nexus/nexus-parent/2.14.3-02/nexus-parent-2.14.3-02.pom (38 kB at 748 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/buildsupport/public-parent/9/public-parent-9.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/buildsupport/public-parent/9/public-parent-9.pom (760 B at 13 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/buildsupport/buildsupport/9/buildsupport-9.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/buildsupport/buildsupport/9/buildsupport-9.pom (24 kB at 436 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/nexus/buildsupport/nexus-buildsupport-all/2.14.3-02/nexus-buildsupport-all-2.14.3-02.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/nexus/buildsupport/nexus-buildsupport-all/2.14.3-02/nexus-buildsupport-all-2.14.3-02.pom (6.5 kB at 106 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/nexus/buildsupport/nexus-buildsupport/2.14.3-02/nexus-buildsupport-2.14.3-02.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/nexus/buildsupport/nexus-buildsupport/2.14.3-02/nexus-buildsupport-2.14.3-02.pom (2.2 kB at 44 kB/s)
Downloading from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-commons/2.14.3-02/nexus-buildsupport-commons-2.14.3-02.pom
Downloaded from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-commons/2.14.3-02/nexus-buildsupport-commons-2.14.3-02.pom (3.1 kB at 9.7 kB/s)
Downloading from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-db/2.14.3-02/nexus-buildsupport-db-2.14.3-02.pom
Downloaded from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-db/2.14.3-02/nexus-buildsupport-db-2.14.3-02.pom (3.2 kB at 92 kB/s)
Downloading from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-gwt/2.14.3-02/nexus-buildsupport-gwt-2.14.3-02.pom
Downloaded from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-gwt/2.14.3-02/nexus-buildsupport-gwt-2.14.3-02.pom (2.2 kB at 71 kB/s)
Downloading from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-httpclient/2.14.3-02/nexus-buildsupport-httpclient-2.14.3-02.pom
Downloaded from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-httpclient/2.14.3-02/nexus-buildsupport-httpclient-2.14.3-02.pom (2.1 kB at 61 kB/s)
Downloading from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-insight/2.14.3-02/nexus-buildsupport-insight-2.14.3-02.pom
Downloaded from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-insight/2.14.3-02/nexus-buildsupport-insight-2.14.3-02.pom (4.4 kB at 126 kB/s)
Downloading from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-maven/2.14.3-02/nexus-buildsupport-maven-2.14.3-02.pom
Downloaded from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-maven/2.14.3-02/nexus-buildsupport-maven-2.14.3-02.pom (7.1 kB at 153 kB/s)
Downloading from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-messaging/2.14.3-02/nexus-buildsupport-messaging-2.14.3-02.pom
Downloaded from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-messaging/2.14.3-02/nexus-buildsupport-messaging-2.14.3-02.pom (5.0 kB at 138 kB/s)
Downloading from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-shiro/2.14.3-02/nexus-buildsupport-shiro-2.14.3-02.pom
Downloaded from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-shiro/2.14.3-02/nexus-buildsupport-shiro-2.14.3-02.pom (3.4 kB at 101 kB/s)
Downloading from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-bouncycastle/2.14.3-02/nexus-buildsupport-bouncycastle-2.14.3-02.pom
Downloaded from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-bouncycastle/2.14.3-02/nexus-buildsupport-bouncycastle-2.14.3-02.pom (2.1 kB at 51 kB/s)
Downloading from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-jetty/2.14.3-02/nexus-buildsupport-jetty-2.14.3-02.pom
Downloaded from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-jetty/2.14.3-02/nexus-buildsupport-jetty-2.14.3-02.pom (4.5 kB at 131 kB/s)
Downloading from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-goodies/2.14.3-02/nexus-buildsupport-goodies-2.14.3-02.pom
Downloaded from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-goodies/2.14.3-02/nexus-buildsupport-goodies-2.14.3-02.pom (3.6 kB at 89 kB/s)
Downloading from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-groovy/2.14.3-02/nexus-buildsupport-groovy-2.14.3-02.pom
Downloaded from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-groovy/2.14.3-02/nexus-buildsupport-groovy-2.14.3-02.pom (3.1 kB at 98 kB/s)
Downloading from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-guice/2.14.3-02/nexus-buildsupport-guice-2.14.3-02.pom
Downloaded from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-guice/2.14.3-02/nexus-buildsupport-guice-2.14.3-02.pom (3.7 kB at 101 kB/s)
Downloading from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-logging/2.14.3-02/nexus-buildsupport-logging-2.14.3-02.pom
Downloaded from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-logging/2.14.3-02/nexus-buildsupport-logging-2.14.3-02.pom (3.3 kB at 100 kB/s)
Downloading from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-osgi/2.14.3-02/nexus-buildsupport-osgi-2.14.3-02.pom
Downloaded from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-osgi/2.14.3-02/nexus-buildsupport-osgi-2.14.3-02.pom (2.0 kB at 60 kB/s)
Downloading from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-other/2.14.3-02/nexus-buildsupport-other-2.14.3-02.pom
Downloaded from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-other/2.14.3-02/nexus-buildsupport-other-2.14.3-02.pom (7.0 kB at 189 kB/s)
Downloading from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-plexus/2.14.3-02/nexus-buildsupport-plexus-2.14.3-02.pom
Downloaded from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-plexus/2.14.3-02/nexus-buildsupport-plexus-2.14.3-02.pom (4.5 kB at 127 kB/s)
Downloading from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-rest/2.14.3-02/nexus-buildsupport-rest-2.14.3-02.pom
Downloaded from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-rest/2.14.3-02/nexus-buildsupport-rest-2.14.3-02.pom (5.1 kB at 138 kB/s)
Downloading from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-testing/2.14.3-02/nexus-buildsupport-testing-2.14.3-02.pom
Downloaded from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-testing/2.14.3-02/nexus-buildsupport-testing-2.14.3-02.pom (5.0 kB at 139 kB/s)
Downloading from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-metrics/2.14.3-02/nexus-buildsupport-metrics-2.14.3-02.pom
Downloaded from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-metrics/2.14.3-02/nexus-buildsupport-metrics-2.14.3-02.pom (3.0 kB at 82 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/nexus/plugins/nexus-restlet1x-model/2.14.3-02/nexus-restlet1x-model-2.14.3-02.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/nexus/plugins/nexus-restlet1x-model/2.14.3-02/nexus-restlet1x-model-2.14.3-02.pom (3.5 kB at 75 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/nexus/plugins/nexus-plugins-restlet1x/2.14.3-02/nexus-plugins-restlet1x-2.14.3-02.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/nexus/plugins/nexus-plugins-restlet1x/2.14.3-02/nexus-plugins-restlet1x-2.14.3-02.pom (6.0 kB at 69 kB/s)
```
</details>

<details>
<summary>Build after (first 100 lines)</summary>

```
checking outputs of '/nix/store/l9s8cb5a5rghpn6cpls83hm2qchdvv80-maven-deps-tabula-java-1.0.5.drv'...
Running phase: unpackPhase
unpacking source archive /nix/store/a1hf72bjz7f972zyan07h234397h14gc-source
source root is source
Running phase: patchPhase
Running phase: updateAutotoolsGnuConfigScriptsPhase
Running phase: configurePhase
no configure script, doing nothing
Running phase: buildPhase
[INFO] Scanning for projects...
Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/plugins/nexus-staging-maven-plugin/1.6.8/nexus-staging-maven-plugin-1.6.8.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/plugins/nexus-staging-maven-plugin/1.6.8/nexus-staging-maven-plugin-1.6.8.pom (12 kB at 39 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/nexus/maven/nexus-staging/1.6.8/nexus-staging-1.6.8.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/nexus/maven/nexus-staging/1.6.8/nexus-staging-1.6.8.pom (2.8 kB at 51 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/nexus/maven/nexus-maven-plugins/1.6.8/nexus-maven-plugins-1.6.8.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/nexus/maven/nexus-maven-plugins/1.6.8/nexus-maven-plugins-1.6.8.pom (18 kB at 358 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/buildsupport/public-parent/6/public-parent-6.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/buildsupport/public-parent/6/public-parent-6.pom (760 B at 16 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/buildsupport/buildsupport/6/buildsupport-6.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/buildsupport/buildsupport/6/buildsupport-6.pom (23 kB at 489 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/nexus/maven/nexus-common/1.6.8/nexus-common-1.6.8.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/nexus/maven/nexus-common/1.6.8/nexus-common-1.6.8.pom (2.2 kB at 48 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-sec-dispatcher/1.4/plexus-sec-dispatcher-1.4.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-sec-dispatcher/1.4/plexus-sec-dispatcher-1.4.pom (3.0 kB at 76 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/spice/spice-parent/12/spice-parent-12.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/spice/spice-parent/12/spice-parent-12.pom (6.8 kB at 174 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/forge/forge-parent/4/forge-parent-4.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/forge/forge-parent/4/forge-parent-4.pom (8.4 kB at 122 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-cipher/1.7/plexus-cipher-1.7.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-cipher/1.7/plexus-cipher-1.7.pom (4.2 kB at 110 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/spice/spice-parent/15/spice-parent-15.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/spice/spice-parent/15/spice-parent-15.pom (8.4 kB at 190 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/forge/forge-parent/5/forge-parent-5.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/forge/forge-parent/5/forge-parent-5.pom (8.4 kB at 144 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/com/google/guava/guava/14.0.1/guava-14.0.1.pom
Downloaded from central: https://repo.maven.apache.org/maven2/com/google/guava/guava/14.0.1/guava-14.0.1.pom (5.4 kB at 90 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/com/google/guava/guava-parent/14.0.1/guava-parent-14.0.1.pom
Downloaded from central: https://repo.maven.apache.org/maven2/com/google/guava/guava-parent/14.0.1/guava-parent-14.0.1.pom (2.6 kB at 43 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/oss/oss-parent/7/oss-parent-7.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/oss/oss-parent/7/oss-parent-7.pom (4.8 kB at 79 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/nexus/nexus-client-core/2.14.3-02/nexus-client-core-2.14.3-02.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/nexus/nexus-client-core/2.14.3-02/nexus-client-core-2.14.3-02.pom (4.9 kB at 86 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/nexus/nexus-components/2.14.3-02/nexus-components-2.14.3-02.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/nexus/nexus-components/2.14.3-02/nexus-components-2.14.3-02.pom (2.6 kB at 49 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/nexus/nexus-parent/2.14.3-02/nexus-parent-2.14.3-02.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/nexus/nexus-parent/2.14.3-02/nexus-parent-2.14.3-02.pom (38 kB at 706 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/buildsupport/public-parent/9/public-parent-9.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/buildsupport/public-parent/9/public-parent-9.pom (760 B at 18 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/buildsupport/buildsupport/9/buildsupport-9.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/buildsupport/buildsupport/9/buildsupport-9.pom (24 kB at 399 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/nexus/buildsupport/nexus-buildsupport-all/2.14.3-02/nexus-buildsupport-all-2.14.3-02.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/nexus/buildsupport/nexus-buildsupport-all/2.14.3-02/nexus-buildsupport-all-2.14.3-02.pom (6.5 kB at 115 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/nexus/buildsupport/nexus-buildsupport/2.14.3-02/nexus-buildsupport-2.14.3-02.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/nexus/buildsupport/nexus-buildsupport/2.14.3-02/nexus-buildsupport-2.14.3-02.pom (2.2 kB at 49 kB/s)
Downloading from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-commons/2.14.3-02/nexus-buildsupport-commons-2.14.3-02.pom
Downloaded from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-commons/2.14.3-02/nexus-buildsupport-commons-2.14.3-02.pom (3.1 kB at 12 kB/s)
Downloading from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-db/2.14.3-02/nexus-buildsupport-db-2.14.3-02.pom
Downloaded from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-db/2.14.3-02/nexus-buildsupport-db-2.14.3-02.pom (3.2 kB at 87 kB/s)
Downloading from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-gwt/2.14.3-02/nexus-buildsupport-gwt-2.14.3-02.pom
Downloaded from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-gwt/2.14.3-02/nexus-buildsupport-gwt-2.14.3-02.pom (2.2 kB at 65 kB/s)
Downloading from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-httpclient/2.14.3-02/nexus-buildsupport-httpclient-2.14.3-02.pom
Downloaded from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-httpclient/2.14.3-02/nexus-buildsupport-httpclient-2.14.3-02.pom (2.1 kB at 61 kB/s)
Downloading from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-insight/2.14.3-02/nexus-buildsupport-insight-2.14.3-02.pom
Downloaded from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-insight/2.14.3-02/nexus-buildsupport-insight-2.14.3-02.pom (4.4 kB at 119 kB/s)
Downloading from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-maven/2.14.3-02/nexus-buildsupport-maven-2.14.3-02.pom
Downloaded from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-maven/2.14.3-02/nexus-buildsupport-maven-2.14.3-02.pom (7.1 kB at 181 kB/s)
Downloading from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-messaging/2.14.3-02/nexus-buildsupport-messaging-2.14.3-02.pom
Downloaded from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-messaging/2.14.3-02/nexus-buildsupport-messaging-2.14.3-02.pom (5.0 kB at 141 kB/s)
Downloading from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-shiro/2.14.3-02/nexus-buildsupport-shiro-2.14.3-02.pom
Downloaded from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-shiro/2.14.3-02/nexus-buildsupport-shiro-2.14.3-02.pom (3.4 kB at 93 kB/s)
Downloading from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-bouncycastle/2.14.3-02/nexus-buildsupport-bouncycastle-2.14.3-02.pom
Downloaded from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-bouncycastle/2.14.3-02/nexus-buildsupport-bouncycastle-2.14.3-02.pom (2.1 kB at 58 kB/s)
Downloading from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-jetty/2.14.3-02/nexus-buildsupport-jetty-2.14.3-02.pom
Downloaded from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-jetty/2.14.3-02/nexus-buildsupport-jetty-2.14.3-02.pom (4.5 kB at 121 kB/s)
Downloading from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-goodies/2.14.3-02/nexus-buildsupport-goodies-2.14.3-02.pom
Downloaded from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-goodies/2.14.3-02/nexus-buildsupport-goodies-2.14.3-02.pom (3.6 kB at 105 kB/s)
Downloading from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-groovy/2.14.3-02/nexus-buildsupport-groovy-2.14.3-02.pom
Downloaded from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-groovy/2.14.3-02/nexus-buildsupport-groovy-2.14.3-02.pom (3.1 kB at 82 kB/s)
Downloading from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-guice/2.14.3-02/nexus-buildsupport-guice-2.14.3-02.pom
Downloaded from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-guice/2.14.3-02/nexus-buildsupport-guice-2.14.3-02.pom (3.7 kB at 107 kB/s)
Downloading from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-logging/2.14.3-02/nexus-buildsupport-logging-2.14.3-02.pom
Downloaded from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-logging/2.14.3-02/nexus-buildsupport-logging-2.14.3-02.pom (3.3 kB at 89 kB/s)
Downloading from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-osgi/2.14.3-02/nexus-buildsupport-osgi-2.14.3-02.pom
Downloaded from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-osgi/2.14.3-02/nexus-buildsupport-osgi-2.14.3-02.pom (2.0 kB at 60 kB/s)
Downloading from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-other/2.14.3-02/nexus-buildsupport-other-2.14.3-02.pom
Downloaded from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-other/2.14.3-02/nexus-buildsupport-other-2.14.3-02.pom (7.0 kB at 184 kB/s)
Downloading from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-plexus/2.14.3-02/nexus-buildsupport-plexus-2.14.3-02.pom
Downloaded from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-plexus/2.14.3-02/nexus-buildsupport-plexus-2.14.3-02.pom (4.5 kB at 101 kB/s)
Downloading from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-rest/2.14.3-02/nexus-buildsupport-rest-2.14.3-02.pom
Downloaded from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-rest/2.14.3-02/nexus-buildsupport-rest-2.14.3-02.pom (5.1 kB at 146 kB/s)
Downloading from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-testing/2.14.3-02/nexus-buildsupport-testing-2.14.3-02.pom
Downloaded from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-testing/2.14.3-02/nexus-buildsupport-testing-2.14.3-02.pom (5.0 kB at 143 kB/s)
Downloading from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-metrics/2.14.3-02/nexus-buildsupport-metrics-2.14.3-02.pom
Downloaded from rso-public-grid: https://repository.sonatype.org/content/groups/sonatype-public-grid/org/sonatype/nexus/buildsupport/nexus-buildsupport-metrics/2.14.3-02/nexus-buildsupport-metrics-2.14.3-02.pom (3.0 kB at 89 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/nexus/plugins/nexus-restlet1x-model/2.14.3-02/nexus-restlet1x-model-2.14.3-02.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/nexus/plugins/nexus-restlet1x-model/2.14.3-02/nexus-restlet1x-model-2.14.3-02.pom (3.5 kB at 80 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/nexus/plugins/nexus-plugins-restlet1x/2.14.3-02/nexus-plugins-restlet1x-2.14.3-02.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/nexus/plugins/nexus-plugins-restlet1x/2.14.3-02/nexus-plugins-restlet1x-2.14.3-02.pom (6.0 kB at 113 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/nexus/plugins/nexus-plugins/2.14.3-02/nexus-plugins-2.14.3-02.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/nexus/plugins/nexus-plugins/2.14.3-02/nexus-plugins-2.14.3-02.pom (32 kB at 685 kB/s)
```
</details>


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
