### PR TITLE
phpExtensions.pcov: drop patch

### DIFF
--- a/pkgs/development/php-packages/pcov/default.nix
+++ b/pkgs/development/php-packages/pcov/default.nix
@@ -17,18 +17,10 @@ buildPecl {
     owner = "krakjoe";
     repo = "pcov";
     tag = "v${version}";
-    hash = "sha256-lyY17Y9chpTO8oeWmDGSh0YSnipYqCuy1qmn9su5Eu8=";
+    hash = "sha256-yz+c1FrjGJAUgnu+azvebqoAN3I/GXLeAlKobNdDiHI=";
   };
 
   buildInputs = [ pcre2 ];
-
-  patches = [
-    # Allow building for PHP 8.4
-    (fetchpatch {
-      url = "https://github.com/krakjoe/pcov/commit/7d764c7c2555e8287351961d72be3ebec4d8743f.patch";
-      hash = "sha256-5wIHrrCwUXQpPdUg+3Kwyop5yvOzQQ3qc4pQXU8q2OM=";
-    })
-  ];
 
   meta = {
     changelog = "https://github.com/krakjoe/pcov/releases/tag/v${version}";


### PR DESCRIPTION
For a more detailed explanation see https://github.com/NixOS/nixpkgs/pull/475115#issuecomment-3702391777

TLDR seems like a recent update to nixpkgs (I didn't track down which but within 1-2 days ago) results in the hunk not being able to be applied because the patch is already in the source code.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
