### PR TITLE
robo: fix composerVendor hash

### DIFF
--- a/pkgs/by-name/ro/robo/package.nix
+++ b/pkgs/by-name/ro/robo/package.nix
@@ -16,7 +16,7 @@ php82.buildComposerProject2 (finalAttrs: {
     hash = "sha256-OYuP56KlS9onuYcy9xL0XrH9hqf/njwVUju1pDyRgKM=";
   };
 
-  vendorHash = "sha256-HGVeoy6duUfRLtx05mlZc3wCOeRTzNXJXxXurZDzZFs=";
+  vendorHash = "sha256-rOFY9TymSw8MatAR/yCpKaj0LupuhaIkk7QAnaKQUZ4=";
 
   nativeInstallCheckInputs = [
     versionCheckHook


### PR DESCRIPTION
Fixes hash mismatch for `robo.composerVendor`.

As in the other composerVendor PRs, the diff is enormous and seems autogenerated.... I don't know what caused the changes, but they seem ok?

Build logs:
- [before (4667e1d)](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/robo/composerVendor.before.log)
- [after (0aed65f)](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/robo/composerVendor.after.log)
- [source diff](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/robo/composerVendor.diff.log)

Source directories:
- [old source](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/robo/composerVendor.src.before/)
- [new source](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/robo/composerVendor.src.after/)

<details>
<summary>Source diff (first 100 lines)</summary>

```
vendor/composer/autoload_files.php --- PHP
 1 <?php
 2 
 3 // autoload_files.php @generated by Composer
 4 
 5 $vendorDir = dirname(__DIR__);
 6 $baseDir = dirname($vendorDir);
 7 
 8 return array(
 9     '0e6d7bf4a5811bfa5cf40c5ccd6fae6a' => $vendorDir . '/symfony/polyfill-mbstring/bootstrap.php',
10     '6e3fae29631ef280660b3cdad06f25a8' => $vendorDir . '/symfony/deprecation-contracts/function.php',
11     '320cde22f66dd4f5d3fd621d3e88b98f' => $vendorDir . '/symfony/polyfill-ctype/bootstrap.php',
12     '8825ede83f2f289127722d4e842cf7e8' => $vendorDir . '/symfony/polyfill-intl-grapheme/bootstrap.php',
13     'e69f7f6ee287b969198c3c9d6777bd38' => $vendorDir . '/symfony/polyfill-intl-normalizer/bootstrap.php',
14     'b6b991a57620e2fb6b2f66f03fe9ddc2' => $vendorDir . '/symfony/string/Resources/functions.php',
15     '23c18046f52bef3eea034657bafda50f' => $vendorDir . '/symfony/polyfill-php81/bootstrap.php',
16 );
17 

vendor/autoload.php --- PHP
 1 <?php
 2 
 3 // autoload.php @generated by Composer
 4 
 5 if (PHP_VERSION_ID < 50600) {
 6     if (!headers_sent()) {
 7         header('HTTP/1.1 500 Internal Server Error');
 8     }
 9     $err = 'Composer 2.3.0 dropped support for autoloading on PHP <5.6 and you are running '.PHP_VERSION.', please upgrade PHP or use Composer 2.2 LTS via "composer self-update --2.2". Aborting.'.PHP_EOL;
10     if (!ini_get('display_errors')) {
11         if (PHP_SAPI === 'cli' || PHP_SAPI === 'phpdbg') {
12             fwrite(STDERR, $err);
13         } elseif (!headers_sent()) {
14             echo $err;
15         }
16     }
17     throw new RuntimeException($err);
18 }
19 
20 require_once __DIR__ . '/composer/autoload_real.php';
21 
22 return ComposerAutoloaderInit356d965c2355967efaa4c71b48fe813e::getLoader();
23 

vendor/composer/autoload_namespaces.php --- PHP
 1 <?php
 2 
 3 // autoload_namespaces.php @generated by Composer
 4 
 5 $vendorDir = dirname(__DIR__);
 6 $baseDir = dirname($vendorDir);
 7 
 8 return array(
 9 );
10 

vendor/bin/yaml-lint --- Text
  1 #!/usr/bin/env php
  2 <?php
  3 
  4 /**
  5  * Proxy PHP file generated by Composer
  6  *
  7  * This file includes the referenced bin path (../symfony/yaml/Resources/bin/yaml-lint)
  8  * using a stream wrapper to prevent the shebang from being output on PHP<8
  9  *
 10  * @generated
 11  */
 12 
 13 namespace Composer;
 14 
 15 $GLOBALS['_composer_bin_dir'] = __DIR__;
 16 $GLOBALS['_composer_autoload_path'] = __DIR__ . '/..'.'/autoload.php';
 17 
 18 if (PHP_VERSION_ID < 80000) {
 19     if (!class_exists('Composer\BinProxyWrapper')) {
 20         /**
 21          * @internal
 22          */
 23         final class BinProxyWrapper
 24         {
 25             private $handle;
 26             private $position;
 27             private $realpath;
 28 
 29             public function stream_open($path, $mode, $options, &$opened_path)
 30             {
 31                 // get rid of phpvfscomposer:// prefix for __FILE__ & __DIR__ resolution
 32                 $opened_path = substr($path, 17);
 33                 $this->realpath = realpath($opened_path) ?: $opened_path;
 34                 $opened_path = $this->realpath;
 35                 $this->handle = fopen($this->realpath, $mode);
 36                 $this->position = 0;
 37 
 38                 return (bool) $this->handle;
 39             }
 40 
 41             public function stream_read($count)
 42             {
 43                 $data = fread($this->handle, $count);
```
</details>

<details>
<summary>Build before</summary>

```
this derivation will be built:
  /nix/store/br9wv89p4cndi7mzdpp1k6nc2ii3z37s-robo-composer-vendor-5.1.1.drv
building '/nix/store/br9wv89p4cndi7mzdpp1k6nc2ii3z37s-robo-composer-vendor-5.1.1.drv'...
Running phase: unpackPhase
unpacking source archive /nix/store/934ldh2vjdwm26gksqp2k2hval1943nb-source
source root is source
Running phase: patchPhase
Running phase: updateAutotoolsGnuConfigScriptsPhase
Running phase: configurePhase
Running phase: composerVendorConfigureHook
Setting COMPOSER_ROOT_VERSION to 5.1.1
Found 'composer.lock' in source root.
Finished phase: composerVendorConfigureHook
Running phase: buildPhase
Running phase: composerVendorBuildHook
Setting some required environment variables for Composer...
Installing Composer dependencies to 'vendor'...
Installing dependencies from lock file
Verifying lock file contents can be installed on current platform.
Package operations: 28 installs, 0 updates, 0 removals
  - Downloading symfony/finder (v7.3.5)
  - Downloading psr/event-dispatcher (1.0.0)
  - Downloading symfony/event-dispatcher-contracts (v3.6.0)
  - Downloading symfony/event-dispatcher (v7.3.3)
  - Downloading symfony/polyfill-mbstring (v1.33.0)
  - Downloading symfony/polyfill-intl-normalizer (v1.33.0)
  - Downloading symfony/polyfill-intl-grapheme (v1.33.0)
  - Downloading symfony/polyfill-ctype (v1.33.0)
  - Downloading symfony/string (v7.3.4)
  - Downloading symfony/deprecation-contracts (v3.6.0)
  - Downloading psr/container (2.0.2)
  - Downloading symfony/service-contracts (v3.6.1)
  - Downloading symfony/console (v7.3.6)
  - Downloading psr/log (3.0.2)
  - Downloading dflydev/dot-access-data (v3.0.3)
  - Downloading consolidation/output-formatters (4.7.0)
  - Downloading consolidation/annotated-command (4.10.4)
  - Downloading grasmash/expander (3.0.1)
  - Downloading consolidation/config (3.2.0)
  - Downloading consolidation/log (3.1.1)
  - Downloading league/container (4.2.5)
  - Downloading symfony/polyfill-php81 (v1.33.0)
  - Downloading phootwork/lang (v3.2.3)
  - Downloading phootwork/collection (v3.2.3)
  - Downloading phpowermove/docblock (v4.0)
  - Downloading symfony/filesystem (v7.3.6)
  - Downloading symfony/process (v7.3.4)
  - Downloading symfony/yaml (v7.3.5)
  - Installing symfony/finder (v7.3.5): Extracting archive
  - Installing psr/event-dispatcher (1.0.0): Extracting archive
  - Installing symfony/event-dispatcher-contracts (v3.6.0): Extracting archive
  - Installing symfony/event-dispatcher (v7.3.3): Extracting archive
  - Installing symfony/polyfill-mbstring (v1.33.0): Extracting archive
  - Installing symfony/polyfill-intl-normalizer (v1.33.0): Extracting archive
  - Installing symfony/polyfill-intl-grapheme (v1.33.0): Extracting archive
  - Installing symfony/polyfill-ctype (v1.33.0): Extracting archive
  - Installing symfony/string (v7.3.4): Extracting archive
  - Installing symfony/deprecation-contracts (v3.6.0): Extracting archive
  - Installing psr/container (2.0.2): Extracting archive
  - Installing symfony/service-contracts (v3.6.1): Extracting archive
  - Installing symfony/console (v7.3.6): Extracting archive
  - Installing psr/log (3.0.2): Extracting archive
  - Installing dflydev/dot-access-data (v3.0.3): Extracting archive
  - Installing consolidation/output-formatters (4.7.0): Extracting archive
  - Installing consolidation/annotated-command (4.10.4): Extracting archive
  - Installing grasmash/expander (3.0.1): Extracting archive
  - Installing consolidation/config (3.2.0): Extracting archive
  - Installing consolidation/log (3.1.1): Extracting archive
  - Installing league/container (4.2.5): Extracting archive
  - Installing symfony/polyfill-php81 (v1.33.0): Extracting archive
  - Installing phootwork/lang (v3.2.3): Extracting archive
  - Installing phootwork/collection (v3.2.3): Extracting archive
  - Installing phpowermove/docblock (v4.0): Extracting archive
  - Installing symfony/filesystem (v7.3.6): Extracting archive
  - Installing symfony/process (v7.3.4): Extracting archive
  - Installing symfony/yaml (v7.3.5): Extracting archive
Package patchwork/jsqueeze is abandoned, you should avoid using it. No replacement was suggested.
Cleaning up Composer 'bin' directory (will be regenerated during install).
Finished phase: composerVendorBuildHook
Running phase: checkPhase
Running phase: composerVendorCheckHook
Finished phase: composerVendorCheckHook
Running phase: installPhase
Running phase: composerVendorInstallHook
Preserving Composer vendor directory from 'vendor'...
Finished phase: composerVendorInstallHook
Running phase: fixupPhase
shrinking RPATHs of ELF executables and libraries in /nix/store/cvnf9jn5p89nsvv56q53l9jk40lhaxkf-robo-composer-vendor-5.1.1
checking for references to /build/ in /nix/store/cvnf9jn5p89nsvv56q53l9jk40lhaxkf-robo-composer-vendor-5.1.1...
error: hash mismatch in fixed-output derivation '/nix/store/br9wv89p4cndi7mzdpp1k6nc2ii3z37s-robo-composer-vendor-5.1.1.drv':
         specified: sha256-HGVeoy6duUfRLtx05mlZc3wCOeRTzNXJXxXurZDzZFs=
            got:    sha256-rOFY9TymSw8MatAR/yCpKaj0LupuhaIkk7QAnaKQUZ4=
```
</details>

<details>
<summary>Build after</summary>

```
checking outputs of '/nix/store/67v1p19kasd8w9f9k74z0v6isk3k0mj8-robo-composer-vendor-5.1.1.drv'...
Running phase: unpackPhase
unpacking source archive /nix/store/934ldh2vjdwm26gksqp2k2hval1943nb-source
source root is source
Running phase: patchPhase
Running phase: updateAutotoolsGnuConfigScriptsPhase
Running phase: configurePhase
Running phase: composerVendorConfigureHook
Setting COMPOSER_ROOT_VERSION to 5.1.1
Found 'composer.lock' in source root.
Finished phase: composerVendorConfigureHook
Running phase: buildPhase
Running phase: composerVendorBuildHook
Setting some required environment variables for Composer...
Installing Composer dependencies to 'vendor'...
Installing dependencies from lock file
Verifying lock file contents can be installed on current platform.
Package operations: 28 installs, 0 updates, 0 removals
  - Downloading symfony/finder (v7.3.5)
  - Downloading psr/event-dispatcher (1.0.0)
  - Downloading symfony/event-dispatcher-contracts (v3.6.0)
  - Downloading symfony/event-dispatcher (v7.3.3)
  - Downloading symfony/polyfill-mbstring (v1.33.0)
  - Downloading symfony/polyfill-intl-normalizer (v1.33.0)
  - Downloading symfony/polyfill-intl-grapheme (v1.33.0)
  - Downloading symfony/polyfill-ctype (v1.33.0)
  - Downloading symfony/string (v7.3.4)
  - Downloading symfony/deprecation-contracts (v3.6.0)
  - Downloading psr/container (2.0.2)
  - Downloading symfony/service-contracts (v3.6.1)
  - Downloading symfony/console (v7.3.6)
  - Downloading psr/log (3.0.2)
  - Downloading dflydev/dot-access-data (v3.0.3)
  - Downloading consolidation/output-formatters (4.7.0)
  - Downloading consolidation/annotated-command (4.10.4)
  - Downloading grasmash/expander (3.0.1)
  - Downloading consolidation/config (3.2.0)
  - Downloading consolidation/log (3.1.1)
  - Downloading league/container (4.2.5)
  - Downloading symfony/polyfill-php81 (v1.33.0)
  - Downloading phootwork/lang (v3.2.3)
  - Downloading phootwork/collection (v3.2.3)
  - Downloading phpowermove/docblock (v4.0)
  - Downloading symfony/filesystem (v7.3.6)
  - Downloading symfony/process (v7.3.4)
  - Downloading symfony/yaml (v7.3.5)
  - Installing symfony/finder (v7.3.5): Extracting archive
  - Installing psr/event-dispatcher (1.0.0): Extracting archive
  - Installing symfony/event-dispatcher-contracts (v3.6.0): Extracting archive
  - Installing symfony/event-dispatcher (v7.3.3): Extracting archive
  - Installing symfony/polyfill-mbstring (v1.33.0): Extracting archive
  - Installing symfony/polyfill-intl-normalizer (v1.33.0): Extracting archive
  - Installing symfony/polyfill-intl-grapheme (v1.33.0): Extracting archive
  - Installing symfony/polyfill-ctype (v1.33.0): Extracting archive
  - Installing symfony/string (v7.3.4): Extracting archive
  - Installing symfony/deprecation-contracts (v3.6.0): Extracting archive
  - Installing psr/container (2.0.2): Extracting archive
  - Installing symfony/service-contracts (v3.6.1): Extracting archive
  - Installing symfony/console (v7.3.6): Extracting archive
  - Installing psr/log (3.0.2): Extracting archive
  - Installing dflydev/dot-access-data (v3.0.3): Extracting archive
  - Installing consolidation/output-formatters (4.7.0): Extracting archive
  - Installing consolidation/annotated-command (4.10.4): Extracting archive
  - Installing grasmash/expander (3.0.1): Extracting archive
  - Installing consolidation/config (3.2.0): Extracting archive
  - Installing consolidation/log (3.1.1): Extracting archive
  - Installing league/container (4.2.5): Extracting archive
  - Installing symfony/polyfill-php81 (v1.33.0): Extracting archive
  - Installing phootwork/lang (v3.2.3): Extracting archive
  - Installing phootwork/collection (v3.2.3): Extracting archive
  - Installing phpowermove/docblock (v4.0): Extracting archive
  - Installing symfony/filesystem (v7.3.6): Extracting archive
  - Installing symfony/process (v7.3.4): Extracting archive
  - Installing symfony/yaml (v7.3.5): Extracting archive
Package patchwork/jsqueeze is abandoned, you should avoid using it. No replacement was suggested.
Cleaning up Composer 'bin' directory (will be regenerated during install).
Finished phase: composerVendorBuildHook
Running phase: checkPhase
Running phase: composerVendorCheckHook
Finished phase: composerVendorCheckHook
Running phase: installPhase
Running phase: composerVendorInstallHook
Preserving Composer vendor directory from 'vendor'...
Finished phase: composerVendorInstallHook
Running phase: fixupPhase
shrinking RPATHs of ELF executables and libraries in /nix/store/dmlv67r7b53dyqp9za5vlf258vkph8yj-robo-composer-vendor-5.1.1
checking for references to /build/ in /nix/store/dmlv67r7b53dyqp9za5vlf258vkph8yj-robo-composer-vendor-5.1.1...
/nix/store/dmlv67r7b53dyqp9za5vlf258vkph8yj-robo-composer-vendor-5.1.1
```
</details>


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
