### PR TITLE
hidrd: fix build with gcc15

### DIFF
--- a/pkgs/by-name/hi/hidrd/allocate-hex-map-with-the-trailing-null.patch
+++ b/pkgs/by-name/hi/hidrd/allocate-hex-map-with-the-trailing-null.patch
@@ -1,0 +1,36 @@
+From 73a01e5e0091f5fbf452fd85ac3632f8c0171e65 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jaroslav=20=C5=A0karvada?= <jskarvad@redhat.com>
+Date: Thu, 7 Aug 2025 17:50:48 +0200
+Subject: [PATCH] Allocate hex map with the trailing NULL
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Compilers usually warns or errors on such allocations. This would require
+special compiler parameter or attribute to silence it. Unfortunately, it is
+compiler specific, e.g. with gcc one could use "__attribute__ ((nonstring))"
+or with C23 just "[[nonstring]]" or gcc parameter
+"-Wno-error=unterminated-string-initialization". With other compilers
+it's different. So do not over-complicate things and allocate it just one
+more byte longer with the dummy NULL which should silence most of the
+compilers. It's static allocation, just one byte, the overhead should be
+negligible.
+
+Signed-off-by: Jaroslav Škarvada <jskarvad@redhat.com>
+---
+ lib/util/hex.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/util/hex.c b/lib/util/hex.c
+index 653e733..2292bd7 100644
+--- a/lib/util/hex.c
++++ b/lib/util/hex.c
+@@ -84,7 +84,7 @@ hidrd_hex_buf_from_str(void        *buf,
+ char *
+ hidrd_hex_buf_to_str(const void *buf, size_t size)
+ {
+-    static const char   map[16] = "0123456789ABCDEF";
++    static const char   map[17] = "0123456789ABCDEF";
+     const uint8_t      *bbuf    = (const uint8_t *)buf;
+     char               *str;
+     char               *p;

--- a/pkgs/by-name/hi/hidrd/package.nix
+++ b/pkgs/by-name/hi/hidrd/package.nix
@@ -16,6 +16,13 @@ stdenv.mkDerivation {
     sha256 = "1rnhq6b0nrmphdig1qrpzpbpqlg3943gzpw0v7p5rwcdynb6bb94";
   };
 
+  patches = [
+    # Fix build with gcc15
+    #   hex.c:87:35: error: initializer-string for array of 'char' truncates NUL terminator but destination lacks 'nonstring' attribute (17 chars into 16 available) [-Werror=unterminated-string-initialization]
+    # https://github.com/DIGImend/hidrd/pull/33
+    ./allocate-hex-map-with-the-trailing-null.patch
+  ];
+
   nativeBuildInputs = [ autoreconfHook ];
 
   meta = {


### PR DESCRIPTION
https://hydra.nixos.org/build/318031369
Apply the patch from https://github.com/DIGImend/hidrd/pull/33

https://github.com/NixOS/nixpkgs/issues/475479
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
