### PR TITLE
nixVersions.nix_2_28: unbreak builds

### DIFF
--- a/pkgs/tools/package-management/nix/common-meson.nix
+++ b/pkgs/tools/package-management/nix/common-meson.nix
@@ -174,6 +174,17 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch = ''
     patchShebangs --build tests
+  ''
+  # The ability to chmod the root filesystem only exist in filesystem namespacing capable Nix interpreters.
+  # At the time of writing, only Linux can do it.
+  + lib.optionalString stdenv.hostPlatform.isLinux ''
+    # The build system produces $HOME during the install check phase
+    # and will fail when ran without build user separation.
+    # This will surface as a FIFO synchronization deadlock.
+    # To avoid this, the $HOME directory is barred from being mkdir()
+    # by the build system here.
+    # https://github.com/NixOS/nix/issues/11295
+    chmod 555 /
   '';
 
   preConfigure =


### PR DESCRIPTION
Nix 2.28 seems to have been unbuildable for a long time due to https://github.com/NixOS/nix/issues/11295.

This particularly surfaces in advanced CI setups where the store locations are non standard and build user separation disappears as the build system seems to be hiding bugs using these features.

Reproducing the issue that this commit fixes can be achieved by running:

`$ nix-build '<nixpkgs>' -A nixVersions.nix_2_28 --store /tmp/alt --check`

This commit can be reverted once upstream fixes this issue.

Change-Id: I55d7adee2dee7c735490f33395ba061c27cf4319


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
