### PR TITLE
maintainers: drop gaelreyrol

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9234,14 +9234,6 @@
     github = "gaelj";
     githubId = 8884632;
   };
-  gaelreyrol = {
-    email = "me@gaelreyrol.dev";
-    matrix = "@Zevran:matrix.org";
-    name = "Gaël Reyrol";
-    github = "gaelreyrol";
-    githubId = 498465;
-    keys = [ { fingerprint = "3492 D8FA ACFF 4C5F A56E  50B7 DFB9 B69A 2C42 7F61"; } ];
-  };
   GaetanLepage = {
     email = "gaetan@glepage.com";
     github = "GaetanLepage";

--- a/nixos/modules/services/misc/calibre-server.nix
+++ b/nixos/modules/services/misc/calibre-server.nix
@@ -176,5 +176,5 @@ in
 
   };
 
-  meta.maintainers = with lib.maintainers; [ gaelreyrol ];
+  meta.maintainers = [ ];
 }

--- a/nixos/tests/calibre-server.nix
+++ b/nixos/tests/calibre-server.nix
@@ -7,7 +7,6 @@
 let
   inherit (pkgs.lib)
     concatStringsSep
-    maintainers
     mapAttrs
     mkMerge
     removeSuffix
@@ -114,8 +113,8 @@ mapAttrs (
         ${nodeName}.shutdown()
       '';
 
-      meta = with maintainers; {
-        maintainers = [ gaelreyrol ];
+      meta = {
+        maintainers = [ ];
       };
     }
   ))

--- a/pkgs/by-name/bi/biscuit-cli/package.nix
+++ b/pkgs/by-name/bi/biscuit-cli/package.nix
@@ -32,10 +32,7 @@ rustPlatform.buildRustPackage rec {
   meta = {
     description = "CLI to generate and inspect biscuit tokens";
     homepage = "https://www.biscuitsec.org/";
-    maintainers = with lib.maintainers; [
-      shlevy
-      gaelreyrol
-    ];
+    maintainers = with lib.maintainers; [ shlevy ];
     license = lib.licenses.bsd3;
     mainProgram = "biscuit";
   };

--- a/pkgs/by-name/fr/frankenphp/package.nix
+++ b/pkgs/by-name/fr/frankenphp/package.nix
@@ -131,9 +131,7 @@ buildGoModule rec {
     homepage = "https://github.com/dunglas/frankenphp";
     license = lib.licenses.mit;
     mainProgram = "frankenphp";
-    maintainers = with lib.maintainers; [
-      gaelreyrol
-    ];
+    maintainers = [ ];
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
 }

--- a/pkgs/by-name/ip/ipatool/package.nix
+++ b/pkgs/by-name/ip/ipatool/package.nix
@@ -47,7 +47,7 @@ buildGoModule rec {
     homepage = "https://github.com/majd/ipatool";
     changelog = "https://github.com/majd/ipatool/blob/${src.rev}/CHANGELOG.md";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ gaelreyrol ];
+    maintainers = [ ];
     mainProgram = "ipatool";
   };
 }

--- a/pkgs/by-name/ki/kickstart/package.nix
+++ b/pkgs/by-name/ki/kickstart/package.nix
@@ -42,7 +42,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/Keats/kickstart";
     changelog = "https://github.com/Keats/kickstart/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ gaelreyrol ];
+    maintainers = [ ];
     mainProgram = "kickstart";
   };
 })

--- a/pkgs/by-name/ma/mago/package.nix
+++ b/pkgs/by-name/ma/mago/package.nix
@@ -37,7 +37,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     description = "Toolchain for PHP that aims to provide a set of tools to help developers write better code";
     homepage = "https://github.com/carthage-software/mago";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ gaelreyrol ];
+    maintainers = [ ];
     mainProgram = "mago";
   };
 })

--- a/pkgs/by-name/me/mercure/package.nix
+++ b/pkgs/by-name/me/mercure/package.nix
@@ -47,7 +47,7 @@ buildGoModule rec {
     homepage = "https://github.com/dunglas/mercure";
     changelog = "https://github.com/dunglas/mercure/releases/tag/v${version}";
     license = lib.licenses.agpl3Only;
-    maintainers = with lib.maintainers; [ gaelreyrol ];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
     mainProgram = "mercure";
   };

--- a/pkgs/by-name/mi/minify/package.nix
+++ b/pkgs/by-name/mi/minify/package.nix
@@ -50,7 +50,7 @@ buildGoModule rec {
     downloadPage = "https://github.com/tdewolff/minify";
     changelog = "https://github.com/tdewolff/minify/releases/tag/v${version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ gaelreyrol ];
+    maintainers = [ ];
     mainProgram = "minify";
   };
 }

--- a/pkgs/by-name/mo/moonfire-nvr/package.nix
+++ b/pkgs/by-name/mo/moonfire-nvr/package.nix
@@ -87,7 +87,7 @@ rustPlatform.buildRustPackage {
     homepage = "https://github.com/scottlamb/moonfire-nvr";
     changelog = "https://github.com/scottlamb/moonfire-nvr/releases/tag/v${version}";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ gaelreyrol ];
+    maintainers = [ ];
     mainProgram = "moonfire-nvr";
   };
 }

--- a/pkgs/by-name/mq/mqttx/package.nix
+++ b/pkgs/by-name/mq/mqttx/package.nix
@@ -54,7 +54,7 @@ appimageTools.wrapType2 {
     changelog = "https://github.com/emqx/MQTTX/releases/tag/v${version}";
     license = lib.licenses.asl20;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ gaelreyrol ];
+    maintainers = [ ];
     mainProgram = "mqttx";
   };
 }

--- a/pkgs/by-name/ot/otel-desktop-viewer/package.nix
+++ b/pkgs/by-name/ot/otel-desktop-viewer/package.nix
@@ -49,7 +49,6 @@ buildGoModule (finalAttrs: {
     homepage = "https://github.com/CtrlSpice/otel-desktop-viewer";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
-      gaelreyrol
       jkachmar
       lf-
     ];

--- a/pkgs/by-name/ow/owntracks-recorder/package.nix
+++ b/pkgs/by-name/ow/owntracks-recorder/package.nix
@@ -80,7 +80,7 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/owntracks/recorder/blob/master/Changelog";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ gaelreyrol ];
+    maintainers = [ ];
     mainProgram = "ot-recorder";
   };
 })

--- a/pkgs/by-name/pu/pulsarctl/package.nix
+++ b/pkgs/by-name/pu/pulsarctl/package.nix
@@ -72,7 +72,7 @@ buildGoModule rec {
     homepage = "https://github.com/streamnative/pulsarctl";
     license = with lib.licenses; [ asl20 ];
     platforms = lib.platforms.unix;
-    maintainers = with lib.maintainers; [ gaelreyrol ];
+    maintainers = [ ];
     mainProgram = "pulsarctl";
   };
 }

--- a/pkgs/by-name/ru/rustdesk-server/package.nix
+++ b/pkgs/by-name/ru/rustdesk-server/package.nix
@@ -48,8 +48,6 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/rustdesk/rustdesk-server/releases/tag/${version}";
     license = lib.licenses.agpl3Only;
     platforms = lib.platforms.unix;
-    maintainers = with lib.maintainers; [
-      gaelreyrol
-    ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/sc/scaphandre/package.nix
+++ b/pkgs/by-name/sc/scaphandre/package.nix
@@ -70,7 +70,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/hubblo-org/scaphandre";
     license = lib.licenses.asl20;
     platforms = [ "x86_64-linux" ];
-    maintainers = with lib.maintainers; [ gaelreyrol ];
+    maintainers = [ ];
     mainProgram = "scaphandre";
     # Upstream needs to decide what to do about a broken dependency
     # https://github.com/hubblo-org/scaphandre/issues/403

--- a/pkgs/by-name/so/sozu/package.nix
+++ b/pkgs/by-name/so/sozu/package.nix
@@ -40,9 +40,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://www.sozu.io";
     changelog = "https://github.com/sozu-proxy/sozu/releases/tag/${version}";
     license = lib.licenses.agpl3Only;
-    maintainers = with lib.maintainers; [
-      gaelreyrol
-    ];
+    maintainers = [ ];
     mainProgram = "sozu";
     # error[E0432]: unresolved import `std::arch::x86_64`
     broken = !stdenv.hostPlatform.isx86_64;

--- a/pkgs/by-name/wa/watcher/package.nix
+++ b/pkgs/by-name/wa/watcher/package.nix
@@ -25,10 +25,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/e-dant/watcher";
     changelog = "https://github.com/e-dant/watcher/releases/tag/${src.tag}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [
-      gaelreyrol
-      matthiasbeyer
-    ];
+    maintainers = with lib.maintainers; [ matthiasbeyer ];
     mainProgram = "tw";
     platforms = lib.platforms.all;
   };

--- a/pkgs/development/libraries/libpulsar/default.nix
+++ b/pkgs/development/libraries/libpulsar/default.nix
@@ -90,9 +90,6 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/apache/pulsar-client-cpp/releases/tag/v${finalAttrs.version}";
     platforms = lib.platforms.all;
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [
-      corbanr
-      gaelreyrol
-    ];
+    maintainers = with lib.maintainers; [ corbanr ];
   };
 })

--- a/pkgs/development/php-packages/castor/default.nix
+++ b/pkgs/development/php-packages/castor/default.nix
@@ -42,7 +42,7 @@ php.buildComposerProject2 (finalAttrs: {
     description = "DX oriented task runner and command launcher built with PHP";
     homepage = "https://github.com/jolicode/castor";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ gaelreyrol ];
+    maintainers = [ ];
     mainProgram = "castor";
   };
 })

--- a/pkgs/development/php-packages/memprof/default.nix
+++ b/pkgs/development/php-packages/memprof/default.nix
@@ -28,6 +28,6 @@ buildPecl {
     description = "Memory profiler for PHP. Helps finding memory leaks in PHP scripts";
     homepage = "https://github.com/arnaud-lb/php-memory-profiler";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ gaelreyrol ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/php-packages/opentelemetry/default.nix
+++ b/pkgs/development/php-packages/opentelemetry/default.nix
@@ -29,6 +29,6 @@ buildPecl rec {
     description = "OpenTelemetry PHP auto-instrumentation extension";
     homepage = "https://opentelemetry.io/";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ gaelreyrol ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/php-packages/phpspy/default.nix
+++ b/pkgs/development/php-packages/phpspy/default.nix
@@ -67,7 +67,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/adsr/phpspy";
     license = lib.licenses.mit;
     mainProgram = "phpspy";
-    maintainers = with lib.maintainers; [ gaelreyrol ];
+    maintainers = [ ];
     platforms = [ "x86_64-linux" ];
   };
 })

--- a/pkgs/development/php-packages/vld/default.nix
+++ b/pkgs/development/php-packages/vld/default.nix
@@ -29,7 +29,7 @@ buildPecl {
     description = "Vulcan Logic Dumper hooks into the Zend Engine and dumps all the opcodes (execution units) of a script";
     homepage = "https://github.com/derickr/vld";
     license = lib.licenses.bsd2;
-    maintainers = with lib.maintainers; [ gaelreyrol ];
+    maintainers = [ ];
     broken = lib.versionOlder php.version "8.2";
   };
 }

--- a/pkgs/development/python-modules/pulsar-client/default.nix
+++ b/pkgs/development/python-modules/pulsar-client/default.nix
@@ -89,6 +89,6 @@ buildPythonPackage rec {
     homepage = "https://pulsar.apache.org/docs/next/client-libraries-python/";
     changelog = "https://github.com/apache/pulsar-client-python/releases/tag/${src.tag}";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ gaelreyrol ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/servers/monitoring/prometheus/php-fpm-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/php-fpm-exporter.nix
@@ -57,7 +57,7 @@ buildGoModule rec {
     homepage = "https://github.com/hipages/php-fpm_exporter";
     description = "Prometheus exporter for PHP-FPM";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ gaelreyrol ];
+    maintainers = [ ];
     mainProgram = "php-fpm_exporter";
   };
 }

--- a/pkgs/servers/sql/postgresql/ext/pg_uuidv7.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_uuidv7.nix
@@ -20,7 +20,7 @@ postgresqlBuildExtension (finalAttrs: {
     description = "Tiny Postgres extension to create version 7 UUIDs";
     homepage = "https://github.com/fboulnois/pg_uuidv7";
     changelog = "https://github.com/fboulnois/pg_uuidv7/blob/main/CHANGELOG.md";
-    maintainers = with lib.maintainers; [ gaelreyrol ];
+    maintainers = [ ];
     platforms = postgresql.meta.platforms;
     license = lib.licenses.mpl20;
   };

--- a/pkgs/tools/networking/ebpf-verifier/default.nix
+++ b/pkgs/tools/networking/ebpf-verifier/default.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation {
     homepage = "https://github.com/vbpf/ebpf-verifier";
     license = lib.licenses.mit;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ gaelreyrol ];
+    maintainers = [ ];
     mainProgram = "ebpf-verifier";
   };
 }


### PR DESCRIPTION
## Reasons

- Last commented in [June of 2025](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Agaelreyrol)
- Hasn't created any PRs / Issues since [March 2025](https://github.com/NixOS/nixpkgs/issues?q=author%3Agaelreyrol)
- About 184 [unanswered](https://github.com/NixOS/nixpkgs/issues?q=involves%3Agaelreyrol%20-commenter%3Agaelreyrol%20-author%3Agaelreyrol%20-reviewed-by%3Agaelreyrol) PRs / Issues

See [losing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs. Please respond to this to not get removed. If you are still active, just close this PR :)

## Modules & Packages

Those modules and packages only have them as their maintainer and would need at least one new maintainer.

**Modules (1)**
- [ ] calibre-server

**Packages (22)**
- [ ] castor
- [ ] ebpf-verifier
- [ ] frankenphp
- [ ] ipatool
- [ ] kickstart
- [x] mago
- [ ] memprof
- [ ] mercure
- [ ] minify
- [ ] moonfire-nvr
- [ ] mqttx
- [ ] opentelemetry
- [ ] owntracks-recorder
- [ ] phpspy
- [ ] postgresql.ext.pg_uuidv7
- [ ] prometheus
- [ ] pulsar-client
- [ ] pulsarctl
- [ ] rustdesk-server
- [ ] scaphandre
- [ ] sozu
- [ ] vld


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
