### PR TITLE
bazel_7: fix bazelDeps hash

### DIFF
--- a/pkgs/by-name/ba/bazel_7/package.nix
+++ b/pkgs/by-name/ba/bazel_7/package.nix
@@ -246,7 +246,7 @@ let
       outputHashMode = "recursive";
       outputHash =
         if stdenv.hostPlatform.system == "x86_64-linux" then
-          "sha256-yKy6IBIkjvN413kFMgkWCH3jAgF5AdpxrVnQyhgfWPA="
+          "sha256-NeIuu+m9yVdjI/uW/zDJCTG4BhMDPN34FJp5LUV+Ejs="
         else if stdenv.hostPlatform.system == "aarch64-linux" then
           "sha256-NW/JMVC7k2jBW+d8syMl9L5tDB7SQENJtlMFjAKascI="
         else if stdenv.hostPlatform.system == "aarch64-darwin" then


### PR DESCRIPTION
Fixes hash mismatch for `bazel_7.bazelDeps`.

These are some...fairly substantial changes. I looked through them, but I really don't know what I'm doing. Most of them look auto generated. I guess it's fine? It looks like they just bumped some dependencies. But there's a looot of new .jar files. I didn't go binary spelunking to confirm those changes are not malicious. Given the source is google, maybe we can black box trust it.

The package doesn't seem to have any maintainers AFAICT, but I think we should have someone who is familiar with bazel look through this diff before merging.

Also: I didn't update the other hashes. It's likely they're wrong. Maybe someone with a aarch64-linux can fix those? Or, I can make an issue about it.

Build logs:
- [before (8f48f39)](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/bazel_7/bazelDeps.before.log)
- [after (e939dca)](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/bazel_7/bazelDeps.after.log)
- [source diff](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/bazel_7/bazelDeps.diff.log)

<details>
<summary>Source diff (first 100 lines)</summary>

```
vendor_dir/@rules_jvm_external~~maven~com_google_auto_auto_common_1_2_1.marker --- Text
1 b5c5b266dff0271301a5db17d008f96113dc27d220e886ecc6482d694b192b78
2 ENV:BAZEL_HTTP_RULES_URLS_AS_DEFAULT_CANONICAL_ID \0
3 

vendor_dir/@rules_jvm_external~~maven~com_google_auto_auto_common_1_2_2.marker --- Text
1 4598b1b0ede1ad54b515bd1e5b10471e6218460b60a7f989ef072a543655a720
2 ENV:BAZEL_HTTP_RULES_URLS_AS_DEFAULT_CANONICAL_ID \0
3 

vendor_dir/@rules_jvm_external~~maven~com_google_code_java_allocation_instrumenter_java_allocation_instrumenter_3_3_0.marker --- Text
1 6551032f4459e132174b9b4274a25ff8d9ac0b39024d2efc8a990aac67270653
2 ENV:BAZEL_HTTP_RULES_URLS_AS_DEFAULT_CANONICAL_ID \0
3 

vendor_dir/@rules_jvm_external~~maven~com_google_code_java_allocation_instrumenter_java_allocation_instrumenter_3_3_4.marker --- Text
1 89b68273e5111690dabe61e9ad0050a34f966a38f151c4ec534c3a3489831ae2
2 ENV:BAZEL_HTTP_RULES_URLS_AS_DEFAULT_CANONICAL_ID \0
3 

vendor_dir/@rules_jvm_external~~maven~com_google_errorprone_error_prone_annotations_2_22_0.marker --- Text
1 5a1ea4f6fc4ac25d19228bb64869dbe5ffd8317d6c2ee88cd62f04231df915d4
2 ENV:BAZEL_HTTP_RULES_URLS_AS_DEFAULT_CANONICAL_ID \0
3 

vendor_dir/@rules_jvm_external~~maven~com_google_errorprone_error_prone_annotations_2_36_0.marker --- Text
1 b456d5b68d179ecd977e0b709a9c0b960e487d05a232072d303c96935d3d53c6
2 ENV:BAZEL_HTTP_RULES_URLS_AS_DEFAULT_CANONICAL_ID \0
3 

vendor_dir/@rules_jvm_external~~maven~com_google_errorprone_error_prone_type_annotations_2_22_0.marker --- Text
1 5265d3b612bcb028098a0c9c227beeacc5471a48371b531487fac03b5c1928e9
2 ENV:BAZEL_HTTP_RULES_URLS_AS_DEFAULT_CANONICAL_ID \0
3 

vendor_dir/@rules_jvm_external~~maven~com_google_errorprone_error_prone_type_annotations_2_36_0.marker --- Text
1 7c4dfba8e334c08a1cdb1186a8d89f82c1ac1cb77ac65e4e4f9379270b9c4b92
2 ENV:BAZEL_HTTP_RULES_URLS_AS_DEFAULT_CANONICAL_ID \0
3 

vendor_dir/@rules_jvm_external~~maven~com_google_guava_guava_32_1_1_jre.marker --- Text
1 3899ef833118821df91d9a1b796745e34555b25d99081fcfb468cd9af9b0c672
2 ENV:BAZEL_HTTP_RULES_URLS_AS_DEFAULT_CANONICAL_ID \0
3 

vendor_dir/@rules_jvm_external~~maven~com_google_guava_guava_32_1_3_jre.marker --- Text
1 6b33fc37ec4dec6aee055662c28499bd8effd920a0a6a18420cf911cf8b19e81
2 ENV:BAZEL_HTTP_RULES_URLS_AS_DEFAULT_CANONICAL_ID \0
3 

vendor_dir/rules_jvm_external~~maven~org_checkerframework_checker_qual_3_33_0/WORKSPACE --- Text
1 workspace(name = "rules_jvm_external~~maven~org_checkerframework_checker_qual_3_33_0")
2 

vendor_dir/rules_jvm_external~~maven~org_checkerframework_checker_qual_3_37_0/WORKSPACE --- Text
1 workspace(name = "rules_jvm_external~~maven~org_checkerframework_checker_qual_3_37_0")
2 

vendor_dir/rules_jvm_external~~maven~org_checkerframework_checker_qual_3_33_0/file/BUILD --- Text
1 package(default_visibility = ["//visibility:public"])
2 
3 filegroup(
4     name = "file",
5     srcs = ["v1/org/checkerframework/checker-qual/3.33.0/checker-qual-3.33.0.jar"],
6 )
7 

vendor_dir/rules_jvm_external~~maven~org_checkerframework_checker_qual_3_37_0/file/BUILD --- Text
1 package(default_visibility = ["//visibility:public"])
2 
3 filegroup(
4     name = "file",
5     srcs = ["v1/org/checkerframework/checker-qual/3.37.0/checker-qual-3.37.0.jar"],
6 )
7 

vendor_dir/rules_jvm_external~~maven~org_checkerframework_checker_qual_3_33_0/file/v1/org/checkerframework/checker-qual/3.33.0/checker-qual-3.33.0.jar --- Binary
Binary file removed (218.7 KiB).

vendor_dir/rules_jvm_external~~maven~org_checkerframework_checker_qual_3_37_0/file/v1/org/checkerframework/checker-qual/3.37.0/checker-qual-3.37.0.jar --- Binary
Binary file added (219.2 KiB).

vendor_dir/rules_jvm_external~~maven~org_ow2_asm_asm_9_2/WORKSPACE --- Text
1 workspace(name = "rules_jvm_external~~maven~org_ow2_asm_asm_9_2")
2 

vendor_dir/rules_jvm_external~~maven~org_ow2_asm_asm_9_2/file/BUILD --- Text
1 package(default_visibility = ["//visibility:public"])
2 
3 filegroup(
4     name = "file",
5     srcs = ["v1/org/ow2/asm/asm/9.2/asm-9.2.jar"],
6 )
7 

vendor_dir/rules_jvm_external~~maven~org_ow2_asm_asm_9_2/file/v1/org/ow2/asm/asm/9.2/asm-9.2.jar --- Binary
Binary file removed (119.1 KiB).

vendor_dir/rules_jvm_external~~maven~org_ow2_asm_asm_analysis_9_2/WORKSPACE --- Text
1 workspace(name = "rules_jvm_external~~maven~org_ow2_asm_asm_analysis_9_2")
```
</details>

<details>
<summary>Build before</summary>

```
checking outputs of '/nix/store/lvxknll5fld8icxm93pg3rq975saff87-bazelDeps.drv'...
Running phase: unpackPhase
unpacking source archive /nix/store/0fi0q1mqrzkvg9ljb1njrdy0yj3azzwk-bazel-7.6.0-dist.zip
source root is .
Running phase: patchPhase
applying patch /nix/store/jghsrq93v25j6d6zkizx8ilbzpc544ac-test_source_sort.patch
patching file src/test/shell/bazel/list_source_repository.bzl
Running phase: updateAutotoolsGnuConfigScriptsPhase
Running phase: configurePhase
Running phase: buildPhase
Extracting Bazel installation...
Starting local Bazel server and connecting to it...
 no actions running
 no actions running
 no actions running
DEBUG: /build/tmp.21qOLXBoVd/.cache/bazel/_bazel_nixbld/96c321f6d4067432c019ff2725c18acb/external/rules_jvm_external~/private/extensions/maven.bzl:146:14: The maven repository 'maven' is used in two different bazel modules, originally in 'bazel' and now in 'protobuf'
 no actions running
 no actions running
 no actions running
<root> (bazel@_)

Computing main repo mapping: 
Loading: 
Loading: 0 packages loaded
Analyzing: target //src:bazel_nojdk (1 packages loaded, 0 targets configured)
Analyzing: target //src:bazel_nojdk (143 packages loaded, 647 targets configured)
Analyzing: target //src:bazel_nojdk (144 packages loaded, 661 targets configured)
Analyzing: target //src:bazel_nojdk (144 packages loaded, 661 targets configured)
DEBUG: /build/tmp.21qOLXBoVd/.cache/bazel/_bazel_nixbld/96c321f6d4067432c019ff2725c18acb/external/rules_jvm_external~/coursier.bzl:721:18: Found duplicate artifact versions
    com.google.code.gson:gson has multiple versions 2.9.0, 2.8.9
    com.google.errorprone:error_prone_annotations has multiple versions 2.36.0, 2.3.2
    com.google.truth:truth has multiple versions 1.1.3, 1.1.2
    org.mockito:mockito-core has multiple versions 5.4.0, 4.3.1
Please remove duplicate artifacts from the artifact list so you do not get unexpected artifact versions
Analyzing: target //src:bazel_nojdk (377 packages loaded, 8596 targets configured)
Analyzing: target //src:bazel_nojdk (462 packages loaded, 9014 targets configured)
Analyzing: target //src:bazel_nojdk (503 packages loaded, 10456 targets configured)
Analyzing: target //src:bazel_nojdk (503 packages loaded, 10456 targets configured)
Analyzing: target //src:bazel_nojdk (503 packages loaded, 10456 targets configured)
Analyzing: target //src:bazel_nojdk (503 packages loaded, 10456 targets configured)
Analyzing: target //src:bazel_nojdk (503 packages loaded, 10456 targets configured)
INFO: Analyzed target //src:bazel_nojdk (504 packages loaded, 11642 targets configured).
INFO: Found 1 target...
INFO: Elapsed time: 13.076s, Critical Path: 0.00s
INFO: 0 processes.
INFO: Build completed successfully, 0 total actions
INFO: Vendoring dependencies for targets...
INFO: All external dependencies for the requested targets vendored successfully.
Running phase: installPhase
error: hash mismatch in fixed-output derivation '/nix/store/lvxknll5fld8icxm93pg3rq975saff87-bazelDeps.drv':
         specified: sha256-yKy6IBIkjvN413kFMgkWCH3jAgF5AdpxrVnQyhgfWPA=
            got:    sha256-NeIuu+m9yVdjI/uW/zDJCTG4BhMDPN34FJp5LUV+Ejs=
```
</details>

<details>
<summary>Build after</summary>

```
checking outputs of '/nix/store/w390b2rp83idp20g9rn7426dcvc9vxmp-bazelDeps.drv'...
Running phase: unpackPhase
unpacking source archive /nix/store/0fi0q1mqrzkvg9ljb1njrdy0yj3azzwk-bazel-7.6.0-dist.zip
source root is .
Running phase: patchPhase
applying patch /nix/store/jghsrq93v25j6d6zkizx8ilbzpc544ac-test_source_sort.patch
patching file src/test/shell/bazel/list_source_repository.bzl
Running phase: updateAutotoolsGnuConfigScriptsPhase
Running phase: configurePhase
Running phase: buildPhase
Extracting Bazel installation...
Starting local Bazel server and connecting to it...
 no actions running
 no actions running
 no actions running
DEBUG: /build/tmp.liW3dHFq2w/.cache/bazel/_bazel_nixbld/96c321f6d4067432c019ff2725c18acb/external/rules_jvm_external~/private/extensions/maven.bzl:146:14: The maven repository 'maven' is used in two different bazel modules, originally in 'bazel' and now in 'protobuf'
 no actions running
 no actions running
 no actions running
<root> (bazel@_)

Computing main repo mapping: 
Loading: 
Loading: 0 packages loaded
Analyzing: target //src:bazel_nojdk (1 packages loaded, 0 targets configured)
Analyzing: target //src:bazel_nojdk (143 packages loaded, 647 targets configured)
Analyzing: target //src:bazel_nojdk (144 packages loaded, 661 targets configured)
Analyzing: target //src:bazel_nojdk (144 packages loaded, 661 targets configured)
DEBUG: /build/tmp.liW3dHFq2w/.cache/bazel/_bazel_nixbld/96c321f6d4067432c019ff2725c18acb/external/rules_jvm_external~/coursier.bzl:721:18: Found duplicate artifact versions
    com.google.code.gson:gson has multiple versions 2.9.0, 2.8.9
    com.google.errorprone:error_prone_annotations has multiple versions 2.36.0, 2.3.2
    com.google.truth:truth has multiple versions 1.1.3, 1.1.2
    org.mockito:mockito-core has multiple versions 5.4.0, 4.3.1
Please remove duplicate artifacts from the artifact list so you do not get unexpected artifact versions
Analyzing: target //src:bazel_nojdk (359 packages loaded, 7117 targets configured)
Analyzing: target //src:bazel_nojdk (392 packages loaded, 8669 targets configured)
Analyzing: target //src:bazel_nojdk (422 packages loaded, 8821 targets configured)
Analyzing: target //src:bazel_nojdk (499 packages loaded, 9742 targets configured)
Analyzing: target //src:bazel_nojdk (503 packages loaded, 10456 targets configured)
Analyzing: target //src:bazel_nojdk (503 packages loaded, 10456 targets configured)
Analyzing: target //src:bazel_nojdk (503 packages loaded, 10456 targets configured)
Analyzing: target //src:bazel_nojdk (503 packages loaded, 10456 targets configured)
Analyzing: target //src:bazel_nojdk (504 packages loaded, 10684 targets configured)
INFO: Analyzed target //src:bazel_nojdk (504 packages loaded, 11642 targets configured).
INFO: Found 1 target...
INFO: Elapsed time: 13.886s, Critical Path: 0.00s
INFO: 0 processes.
INFO: Build completed successfully, 0 total actions
INFO: Vendoring dependencies for targets...
INFO: All external dependencies for the requested targets vendored successfully.
Running phase: installPhase
/nix/store/mmn0yvzjn32idfx0x8l4qx20gl6sp18y-bazelDeps
```
</details>


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
