### PR TITLE
apx: fix goModules hash

### DIFF
--- a/pkgs/by-name/cr/crun/package.nix
+++ b/pkgs/by-name/cr/crun/package.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "containers";
     repo = "crun";
     tag = finalAttrs.version;
-    hash = "sha256-WBAwyDODMrUDlgonRbxaNQ+aN8K6YicY2JVArXDJem8=";
+    hash = "sha256-v+Cq+r7uzHrfUtyEipIPGec3WBprUTq9Uyvm8BbZtbM=";
     fetchSubmodules = true;
     leaveDotGit = true;
     postFetch = ''


### PR DESCRIPTION
Fixes hash mismatch for `apx.goModules`.

This seems like a bit of an odd one because there was no source change. So the hash must have been wrong from the start?

Build logs:
- [before (2389884)](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/apx/goModules.before.log)
- [after (51441e0)](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/apx/goModules.after.log)
- The diff is empty. 

Source directories:
- [old source](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/apx/goModules.src.before/)
- [new source](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/apx/goModules.src.after/)

<details>
<summary>Source diff</summary>

```
warning: You've specified the same directory twice.

```
</details>

<details>
<summary>Build before (first 100 lines)</summary>

```
these 14 derivations will be built:
  /nix/store/gacdi6vb977jxlf2b0yb5vnbi1lc162r-yajl-2.1.0-unstable-2024-02-01.drv
  /nix/store/s3hxm3pibmkn3dqzhyi3gzy5w853znn7-protobuf-25.8.drv
  /nix/store/7dmzzh8s4ybnlc17p7v8lyr80ks139rk-protobuf-c-1.5.2.drv
  /nix/store/gsgxpicc5wcaj1a2ll04rwh81mfwyax9-criu-4.1.1.drv
  /nix/store/i5nxn13g5b8afh0nbp9qkiy0qarxys1w-source.drv
  /nix/store/811z5mx5lxvxvysp4cd2ygmlyr19p2ak-crun-1.25.1.drv
  /nix/store/gkiw3rqwfnwlvnw4x2kf8jgcjv67vp5w-source.drv
  /nix/store/90d29hk74m02bd6bfjy3vpdqxjipbkf9-gvproxy-0.8.7.drv
  /nix/store/r2rhz517sna2h98brwkak54wldpql20d-podman-helper-binary-wrapper.drv
  /nix/store/0qpbmam9y8p0pfj16wssyyw1jljhwjsk-hardcode-paths.patch.drv
  /nix/store/01x3pqgpix4gp27b8n9swzbv3kwllb95-podman-5.7.0.drv
  /nix/store/swij2j2dmlwks2m71s1az1asigwcp74d-wget-1.25.0.drv
  /nix/store/kvga3i4jd413kwp47vx9avlarfyflfvm-distrobox-1.8.2.2.drv
  /nix/store/bg2iw379fp9rp2xalicfs5gbrfp190j1-apx-2.4.5-go-modules.drv
building '/nix/store/swij2j2dmlwks2m71s1az1asigwcp74d-wget-1.25.0.drv'...
building '/nix/store/gkiw3rqwfnwlvnw4x2kf8jgcjv67vp5w-source.drv'...
building '/nix/store/i5nxn13g5b8afh0nbp9qkiy0qarxys1w-source.drv'...
building '/nix/store/gacdi6vb977jxlf2b0yb5vnbi1lc162r-yajl-2.1.0-unstable-2024-02-01.drv'...
structuredAttrs is enabled

trying https://github.com/containers/gvisor-tap-vsock/archive/v0.8.7.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0   0     0   0     0     0     0  --:--:-- --:--:-- --:--:--     0
structuredAttrs is enabled
exporting https://github.com/containers/crun.git (rev refs/tags/1.25.1) into /nix/store/b6plawqf2cnqffhl4r6mqg662710i2x9-source
Running phase: unpackPhase
unpacking source archive /nix/store/wgq8fsw5y0i2dhbgmj7dnmm03d47gfqj-wget-1.25.0.tar.lz
Initialized empty Git repository in /nix/store/b6plawqf2cnqffhl4r6mqg662710i2x9-source/.git/
Running phase: unpackPhase
unpacking source archive /nix/store/xshfc4n1lhr2fnsj6y493nh5nlq9jp5k-source
remote: Enumerating objects: 300, done.
remote: Counting objects: 100% (300/300), done.
remote: Compressing objects: 100% (280/280), done.
remote: Total 300 (delta 74), reused 114 (delta 11), pack-reused 0 (from 0)
Receiving objects: 100% (300/300), 489.39 KiB | 743.00 KiB/s, done.
Resolving deltas: 100% (74/74), done.
100 12923k   0 12923k   0     0  5064k     0  --:--:--  0:00:02 --:--:--  5705k
From https://github.com/containers/crun
 * tag               1.25.1     -> FETCH_HEAD
unpacking source archive /build/download.tar.gz
source root is source
Running phase: patchPhase
applying patch /nix/store/0m4c1xgdprhqks6jdi1hl7bp7qf6bqmm-yajl-cmake4-compat.patch
patching file CMakeLists.txt
patching file reformatter/CMakeLists.txt
patching file src/CMakeLists.txt
patching file verify/CMakeLists.txt
Running phase: updateAutotoolsGnuConfigScriptsPhase
Running phase: configurePhase
cmake flags: -DCMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY=OFF -DCMAKE_FIND_USE_PACKAGE_REGISTRY=OFF -DCMAKE_EXPORT_NO_PACKAGE_REGISTRY=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_LOCALEDIR=/nix/store/2kbkk0r79arq14hvl02gnl7n6y5iflig-yajl-2.1.0-unstable-2024-02-01/share/locale -DCMAKE_INSTALL_LIBEXECDIR=/nix/store/2kbkk0r79arq14hvl02gnl7n6y5iflig-yajl-2.1.0-unstable-2024-02-01/libexec -DCMAKE_INSTALL_LIBDIR=/nix/store/2kbkk0r79arq14hvl02gnl7n6y5iflig-yajl-2.1.0-unstable-2024-02-01/lib -DCMAKE_INSTALL_DOCDIR=/nix/store/2kbkk0r79arq14hvl02gnl7n6y5iflig-yajl-2.1.0-unstable-2024-02-01/share/doc/YetAnotherJSONParser -DCMAKE_INSTALL_INFODIR=/nix/store/2kbkk0r79arq14hvl02gnl7n6y5iflig-yajl-2.1.0-unstable-2024-02-01/share/info -DCMAKE_INSTALL_MANDIR=/nix/store/2kbkk0r79arq14hvl02gnl7n6y5iflig-yajl-2.1.0-unstable-2024-02-01/share/man -DCMAKE_INSTALL_INCLUDEDIR=/nix/store/2kbkk0r79arq14hvl02gnl7n6y5iflig-yajl-2.1.0-unstable-2024-02-01/include -DCMAKE_INSTALL_SBINDIR=/nix/store/2kbkk0r79arq14hvl02gnl7n6y5iflig-yajl-2.1.0-unstable-2024-02-01/sbin -DCMAKE_INSTALL_BINDIR=/nix/store/2kbkk0r79arq14hvl02gnl7n6y5iflig-yajl-2.1.0-unstable-2024-02-01/bin -DCMAKE_INSTALL_NAME_DIR=/nix/store/2kbkk0r79arq14hvl02gnl7n6y5iflig-yajl-2.1.0-unstable-2024-02-01/lib -DCMAKE_STRIP=/nix/store/r9wbjib6xxjkyb9yvjvrkl4sq61i2lyn-gcc-wrapper-15.2.0/bin/strip -DCMAKE_RANLIB=/nix/store/r9wbjib6xxjkyb9yvjvrkl4sq61i2lyn-gcc-wrapper-15.2.0/bin/ranlib -DCMAKE_AR=/nix/store/r9wbjib6xxjkyb9yvjvrkl4sq61i2lyn-gcc-wrapper-15.2.0/bin/ar -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_INSTALL_PREFIX=/nix/store/2kbkk0r79arq14hvl02gnl7n6y5iflig-yajl-2.1.0-unstable-2024-02-01
-- The C compiler identification is GNU 15.2.0
-- Detecting C compiler ABI info
Updating files: 100% (256/256), done.
Switched to a new branch 'fetchgit'
Submodule 'libocispec' (https://github.com/containers/libocispec.git) registered for path 'libocispec'
Cloning into '/nix/store/b6plawqf2cnqffhl4r6mqg662710i2x9-source/libocispec'...
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /nix/store/r9wbjib6xxjkyb9yvjvrkl4sq61i2lyn-gcc-wrapper-15.2.0/bin/gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
remote: Enumerating objects: 1992, done.        
remote: Counting objects: 100% (611/611), done.        
remote: Compressing objects: 100% (187/187), done.        
-- Performing Test HAVE_GCC_VISIBILITY
remote: Total 1992 (delta 486), reused 488 (delta 422), pack-reused 1381 (from 1)        
Receiving objects: 100% (1992/1992), 670.74 KiB | 546.00 KiB/s, done.
Resolving deltas: 100% (1215/1215), done.
-- Performing Test HAVE_GCC_VISIBILITY - Success
Submodule path 'libocispec': checked out '552ccbbad3aaff8e07e8fbad210ec3b4c9c95a66'
!! doxygen not found, not generating documentation
-- Configuring done (6.5s)
Submodule 'image-spec' (https://github.com/opencontainers/image-spec) registered for path 'libocispec/image-spec'
Submodule 'runtime-spec' (https://github.com/opencontainers/runtime-spec) registered for path 'libocispec/runtime-spec'
Submodule 'yajl' (https://github.com/containers/yajl.git) registered for path 'libocispec/yajl'
Cloning into '/nix/store/b6plawqf2cnqffhl4r6mqg662710i2x9-source/libocispec/image-spec'...
remote: Enumerating objects: 4769, done.        
remote: Counting objects: 100% (1042/1042), done.        
remote: Compressing objects: 100% (142/142), done.        
source root is wget-1.25.0
-- Generating done (4.1s)
CMake Warning:
  Manually-specified variables were not used by the project:

    CMAKE_CXX_COMPILER
    CMAKE_EXPORT_NO_PACKAGE_REGISTRY
    CMAKE_FIND_USE_PACKAGE_REGISTRY
    CMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY
    CMAKE_INSTALL_BINDIR
    CMAKE_INSTALL_DOCDIR
    CMAKE_INSTALL_INCLUDEDIR
    CMAKE_INSTALL_INFODIR
    CMAKE_INSTALL_LIBDIR
    CMAKE_INSTALL_LIBEXECDIR
    CMAKE_INSTALL_LOCALEDIR
    CMAKE_INSTALL_MANDIR
    CMAKE_INSTALL_SBINDIR


```
</details>

<details>
<summary>Build after (first 100 lines)</summary>

```
copying path '/nix/store/8hz0qnr9z5j1w7rjl9qmsb34v2cb4akr-wget-1.25.0' from 'https://cache.nixos.org'...
copying path '/nix/store/kbihfdxk5c2nhlrjvq1x7im44jpy60nj-gvproxy-0.8.7' from 'https://cache.nixos.org'...
copying path '/nix/store/2kbkk0r79arq14hvl02gnl7n6y5iflig-yajl-2.1.0-unstable-2024-02-01' from 'https://cache.nixos.org'...
copying path '/nix/store/dlnrpd58d7kqb9rnh67w3kkfnpdpf0my-criu-4.1.1' from 'https://cache.nixos.org'...
copying path '/nix/store/mcvqxx73xbq9qswz8v62jq703dbzjk6k-protobuf-25.8' from 'https://cache.nixos.org'...
copying path '/nix/store/5xmvdwa7cyaq2n5psqw98k8prv6hxdrr-distrobox-1.8.2.2' from 'https://cache.nixos.org'...
copying path '/nix/store/0c32dnhq5sqqnifch4rdh779qax9wdc1-protobuf-c-1.5.2' from 'https://cache.nixos.org'...
copying path '/nix/store/7yjxb0gz1rwpbdhr6r7xci9jvwcm1cpb-protobuf-c-1.5.2-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/z38db7pkjmg4mr1817yq19s4c771a4dg-criu-4.1.1-dev' from 'https://cache.nixos.org'...
building '/nix/store/0khpfa3flw8cqnfnj6ydd6nlw6ppa3c1-crun-1.25.1.drv'...
Using versionCheckHook
Running phase: unpackPhase
unpacking source archive /nix/store/zwc1r2sq888r3imr7mczg3dyyf9s1l5j-source
source root is source
Running phase: patchPhase
Running phase: autoreconfPhase
autoreconf: export WARNINGS=
autoreconf: Entering directory '.'
autoreconf: configure.ac: not using Gettext
autoreconf: running: aclocal --force -I m4
autoreconf: configure.ac: tracing
autoreconf: configure.ac: adding subdirectory libocispec to autoreconf
autoreconf: Entering directory 'libocispec'
autoreconf: configure.ac: not using Gettext
autoreconf: running: aclocal --force 
aclocal: warning: couldn't open directory 'm4': No such file or directory
autoreconf: configure.ac: tracing
autoreconf: configure.ac: adding subdirectory yajl to autoreconf
autoreconf: Entering directory 'yajl'
autoreconf: configure.ac: not using Gettext
autoreconf: running: aclocal --force 
autoreconf: configure.ac: tracing
autoreconf: running: libtoolize --copy --force
libtoolize: putting auxiliary files in '.'.
libtoolize: copying file './ltmain.sh'
libtoolize: Consider adding 'AC_CONFIG_MACRO_DIRS([m4])' to configure.ac,
libtoolize: and rerunning libtoolize and aclocal.
libtoolize: Consider adding '-I m4' to ACLOCAL_AMFLAGS in Makefile.am.
autoreconf: configure.ac: not using Intltool
autoreconf: configure.ac: not using Gtkdoc
autoreconf: running: aclocal --force 
autoreconf: running: /nix/store/i6vhgvkyljmgncgwff2jl1f0qyw2gjjb-autoconf-2.72/bin/autoconf --force
autoreconf: running: /nix/store/i6vhgvkyljmgncgwff2jl1f0qyw2gjjb-autoconf-2.72/bin/autoheader --force
autoreconf: running: automake --add-missing --copy --force-missing
configure.ac:7: installing './compile'
configure.ac:11: installing './config.guess'
configure.ac:11: installing './config.sub'
configure.ac:8: installing './install-sh'
configure.ac:8: installing './missing'
Makefile.am: installing './depcomp'
autoreconf: Leaving directory 'yajl'
autoreconf: running: libtoolize --copy --force
libtoolize: putting auxiliary files in AC_CONFIG_AUX_DIR, 'build-aux'.
libtoolize: copying file 'build-aux/ltmain.sh'
libtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'm4'.
libtoolize: copying file 'm4/libtool.m4'
libtoolize: copying file 'm4/ltoptions.m4'
libtoolize: copying file 'm4/ltsugar.m4'
libtoolize: copying file 'm4/ltversion.m4'
libtoolize: copying file 'm4/lt~obsolete.m4'
libtoolize: Consider adding '-I m4' to ACLOCAL_AMFLAGS in Makefile.am.
autoreconf: configure.ac: not using Intltool
autoreconf: configure.ac: not using Gtkdoc
autoreconf: running: aclocal --force 
autoreconf: running: /nix/store/i6vhgvkyljmgncgwff2jl1f0qyw2gjjb-autoconf-2.72/bin/autoconf --force
configure.ac:3: warning: The macro 'AC_CONFIG_HEADER' is obsolete.
configure.ac:3: You should run autoupdate.
./lib/autoconf/status.m4:719: AC_CONFIG_HEADER is expanded from...
configure.ac:3: the top level
autoreconf: running: /nix/store/i6vhgvkyljmgncgwff2jl1f0qyw2gjjb-autoconf-2.72/bin/autoheader --force
autoreconf: running: automake --add-missing --copy --force-missing
configure.ac:7: installing 'build-aux/compile'
configure.ac:9: installing 'build-aux/config.guess'
configure.ac:9: installing 'build-aux/config.sub'
configure.ac:11: installing 'build-aux/install-sh'
configure.ac:11: installing 'build-aux/missing'
Makefile.am: installing 'build-aux/depcomp'
parallel-tests: installing 'build-aux/test-driver'
autoreconf: Leaving directory 'libocispec'
autoreconf: running: libtoolize --copy --force
libtoolize: putting auxiliary files in AC_CONFIG_AUX_DIR, 'build-aux'.
libtoolize: copying file 'build-aux/ltmain.sh'
libtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'm4'.
libtoolize: copying file 'm4/libtool.m4'
libtoolize: copying file 'm4/ltoptions.m4'
libtoolize: copying file 'm4/ltsugar.m4'
libtoolize: copying file 'm4/ltversion.m4'
libtoolize: copying file 'm4/lt~obsolete.m4'
autoreconf: configure.ac: not using Intltool
autoreconf: configure.ac: not using Gtkdoc
autoreconf: running: aclocal --force -I m4
autoreconf: running: /nix/store/i6vhgvkyljmgncgwff2jl1f0qyw2gjjb-autoconf-2.72/bin/autoconf --force
autoreconf: running: /nix/store/i6vhgvkyljmgncgwff2jl1f0qyw2gjjb-autoconf-2.72/bin/autoheader --force
autoreconf: running: automake --add-missing --copy --force-missing
configure.ac:13: installing 'build-aux/compile'
configure.ac:13: installing 'build-aux/config.guess'
configure.ac:13: installing 'build-aux/config.sub'
configure.ac:15: installing 'build-aux/install-sh'
configure.ac:15: installing 'build-aux/missing'
configure.ac:8: installing 'build-aux/tap-driver.sh'
```
</details>


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
