### PR TITLE
crun: fix src hash

### DIFF
--- a/pkgs/by-name/cr/crun/package.nix
+++ b/pkgs/by-name/cr/crun/package.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "containers";
     repo = "crun";
     tag = finalAttrs.version;
-    hash = "sha256-WBAwyDODMrUDlgonRbxaNQ+aN8K6YicY2JVArXDJem8=";
+    hash = "sha256-v+Cq+r7uzHrfUtyEipIPGec3WBprUTq9Uyvm8BbZtbM=";
     fetchSubmodules = true;
     leaveDotGit = true;
     postFetch = ''


### PR DESCRIPTION
Fixes hash mismatch for `crun.src`. Looks just like a dependency symlink change.

Build logs:
- [before (2389884)](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/crun/src.before.log)
- [after (df99c4b)](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/crun/src.after.log)
- [source diff](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/crun/src.diff.log)

Source directories:
- [old source](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/crun/src.src.before/)
- [new source](https://instance-20251227-2125.tail5ca7.ts.net/srcbot-srv/logs/crun/src.src.after/)

<details>
<summary>Source diff</summary>

```
COMMIT --- Text
1 156ae065d4a322d149c7307034f98d9637aa92a2
2 

libocispec/.git --- Text
1 gitdir: ../.git/modules/libocispec
2 

libocispec/runtime-spec/.git --- Text
1 gitdir: ../../.git/modules/libocispec/modules/runtime-spec
2 

libocispec/image-spec/.git --- Text
1 gitdir: ../../.git/modules/libocispec/modules/image-spec
2 

libocispec/yajl/.git --- Text
1 gitdir: ../../.git/modules/libocispec/modules/yajl
2 

```
</details>

<details>
<summary>Build before (first 100 lines)</summary>

```
this derivation will be built:
  /nix/store/i5nxn13g5b8afh0nbp9qkiy0qarxys1w-source.drv
building '/nix/store/i5nxn13g5b8afh0nbp9qkiy0qarxys1w-source.drv'...
structuredAttrs is enabled
exporting https://github.com/containers/crun.git (rev refs/tags/1.25.1) into /nix/store/b6plawqf2cnqffhl4r6mqg662710i2x9-source
Initialized empty Git repository in /nix/store/b6plawqf2cnqffhl4r6mqg662710i2x9-source/.git/
remote: Enumerating objects: 300, done.
remote: Counting objects: 100% (300/300), done.
remote: Compressing objects: 100% (280/280), done.
remote: Total 300 (delta 74), reused 113 (delta 11), pack-reused 0 (from 0)
Receiving objects: 100% (300/300), 489.39 KiB | 7.77 MiB/s, done.
Resolving deltas: 100% (74/74), done.
From https://github.com/containers/crun
 * tag               1.25.1     -> FETCH_HEAD
Switched to a new branch 'fetchgit'
Submodule 'libocispec' (https://github.com/containers/libocispec.git) registered for path 'libocispec'
Cloning into '/nix/store/b6plawqf2cnqffhl4r6mqg662710i2x9-source/libocispec'...
remote: Enumerating objects: 1992, done.        
remote: Counting objects: 100% (611/611), done.        
remote: Compressing objects: 100% (187/187), done.        
remote: Total 1992 (delta 486), reused 488 (delta 422), pack-reused 1381 (from 1)        
Receiving objects: 100% (1992/1992), 670.74 KiB | 7.29 MiB/s, done.
Resolving deltas: 100% (1215/1215), done.
Submodule path 'libocispec': checked out '552ccbbad3aaff8e07e8fbad210ec3b4c9c95a66'
Submodule 'image-spec' (https://github.com/opencontainers/image-spec) registered for path 'libocispec/image-spec'
Submodule 'runtime-spec' (https://github.com/opencontainers/runtime-spec) registered for path 'libocispec/runtime-spec'
Submodule 'yajl' (https://github.com/containers/yajl.git) registered for path 'libocispec/yajl'
Cloning into '/nix/store/b6plawqf2cnqffhl4r6mqg662710i2x9-source/libocispec/image-spec'...
remote: Enumerating objects: 4769, done.        
remote: Counting objects: 100% (1029/1029), done.        
remote: Compressing objects: 100% (135/135), done.        
remote: Total 4769 (delta 960), reused 894 (delta 894), pack-reused 3740 (from 2)        
Receiving objects: 100% (4769/4769), 5.33 MiB | 18.20 MiB/s, done.
Resolving deltas: 100% (2784/2784), done.
Cloning into '/nix/store/b6plawqf2cnqffhl4r6mqg662710i2x9-source/libocispec/runtime-spec'...
remote: Enumerating objects: 5493, done.        
remote: Counting objects: 100% (935/935), done.        
remote: Compressing objects: 100% (209/209), done.        
remote: Total 5493 (delta 818), reused 743 (delta 724), pack-reused 4558 (from 3)        
Receiving objects: 100% (5493/5493), 1.85 MiB | 7.56 MiB/s, done.
Resolving deltas: 100% (3296/3296), done.
Cloning into '/nix/store/b6plawqf2cnqffhl4r6mqg662710i2x9-source/libocispec/yajl'...
remote: Enumerating objects: 2388, done.        
remote: Counting objects: 100% (38/38), done.        
remote: Compressing objects: 100% (26/26), done.        
remote: Total 2388 (delta 18), reused 12 (delta 12), pack-reused 2350 (from 2)        
Receiving objects: 100% (2388/2388), 998.63 KiB | 920.00 KiB/s, done.
Resolving deltas: 100% (1352/1352), done.
Submodule path 'libocispec/image-spec': checked out '2daaaaf0e7c16a6a147be91fde277f38573be672'
Submodule path 'libocispec/runtime-spec': checked out 'e3c8d12d94cdd269a145a263ace7457f56c74eff'
Submodule path 'libocispec/yajl': checked out '6bc5219389fd2752631682b0a8368e6d8218a8c5'
Enumerating objects: 299, done.
Counting objects: 100% (299/299), done.
Compressing objects: 100% (290/290), done.
Writing objects: 100% (299/299), done.
Total 299 (delta 74), reused 223 (delta 0), pack-reused 0 (from 0)
Enumerating objects: 299, done.
Nothing new to pack.
Deleted remote-tracking branch origin/main (was abbae63).
Enumerating objects: 1992, done.
Counting objects: 100% (1992/1992), done.
Compressing objects: 100% (1956/1956), done.
Writing objects: 100% (1992/1992), done.
Total 1992 (delta 1222), reused 714 (delta 0), pack-reused 0 (from 0)
Enumerating objects: 1992, done.
Nothing new to pack.
Deleted remote-tracking branch origin/main (was 26647a4).
Deleted remote-tracking branch origin/v1.0 (was 0126d30).
Enumerating objects: 4769, done.
Counting objects: 100% (4769/4769), done.
Compressing objects: 100% (4706/4706), done.
Writing objects: 100% (4769/4769), done.
Total 4769 (delta 2815), reused 1811 (delta 0), pack-reused 0 (from 0)
Enumerating objects: 4769, done.
Nothing new to pack.
Deleted remote-tracking branch origin/main (was d64c1d9).
Deleted tag 'v1.3.0' (was 0eaca84)
Enumerating objects: 5492, done.
Counting objects: 100% (5492/5492), done.
Compressing objects: 100% (5455/5455), done.
Writing objects: 100% (5492/5492), done.
Total 5492 (delta 3325), reused 2009 (delta 0), pack-reused 0 (from 0)
Enumerating objects: 5492, done.
Nothing new to pack.
Deleted remote-tracking branch origin/1.x (was 6a8906d).
Deleted remote-tracking branch origin/2.1.0 (was 66cb08c).
Deleted remote-tracking branch origin/autotools (was 574140a).
Deleted remote-tracking branch origin/build-parse-config (was 083a832).
Deleted remote-tracking branch origin/gh-pages (was fc2a33e).
Deleted remote-tracking branch origin/lxrperf_multiple_tables (was 24d46a6).
Deleted remote-tracking branch origin/lxrperf_ptrs (was 53ff7dc).
Deleted remote-tracking branch origin/lxrperf_two_bytes (was 567874b).
Deleted remote-tracking branch origin/main (was 6bc5219).
Deleted remote-tracking branch origin/master (was 49923cc).
Deleted remote-tracking branch origin/yajl_reset (was 646b8b8).
Enumerating objects: 1766, done.
Counting objects: 100% (1766/1766), done.
Compressing objects: 100% (1696/1696), done.
Writing objects: 100% (1766/1766), done.
Total 1766 (delta 1153), reused 550 (delta 0), pack-reused 0 (from 0)
```
</details>

<details>
<summary>Build after (first 100 lines)</summary>

```
checking outputs of '/nix/store/ajzj7k5hz820phm7ljn4i27n4han5ziz-source.drv'...
structuredAttrs is enabled
exporting https://github.com/containers/crun.git (rev refs/tags/1.25.1) into /nix/store/zwc1r2sq888r3imr7mczg3dyyf9s1l5j-source
Initialized empty Git repository in /nix/store/zwc1r2sq888r3imr7mczg3dyyf9s1l5j-source/.git/
remote: Enumerating objects: 300, done.
remote: Counting objects: 100% (300/300), done.
remote: Compressing objects: 100% (280/280), done.
remote: Total 300 (delta 74), reused 113 (delta 11), pack-reused 0 (from 0)
Receiving objects: 100% (300/300), 489.39 KiB | 6.44 MiB/s, done.
Resolving deltas: 100% (74/74), done.
From https://github.com/containers/crun
 * tag               1.25.1     -> FETCH_HEAD
Switched to a new branch 'fetchgit'
Submodule 'libocispec' (https://github.com/containers/libocispec.git) registered for path 'libocispec'
Cloning into '/nix/store/zwc1r2sq888r3imr7mczg3dyyf9s1l5j-source/libocispec'...
remote: Enumerating objects: 1992, done.        
remote: Counting objects: 100% (611/611), done.        
remote: Compressing objects: 100% (187/187), done.        
remote: Total 1992 (delta 486), reused 488 (delta 422), pack-reused 1381 (from 1)        
Receiving objects: 100% (1992/1992), 670.74 KiB | 4.53 MiB/s, done.
Resolving deltas: 100% (1215/1215), done.
Submodule path 'libocispec': checked out '552ccbbad3aaff8e07e8fbad210ec3b4c9c95a66'
Submodule 'image-spec' (https://github.com/opencontainers/image-spec) registered for path 'libocispec/image-spec'
Submodule 'runtime-spec' (https://github.com/opencontainers/runtime-spec) registered for path 'libocispec/runtime-spec'
Submodule 'yajl' (https://github.com/containers/yajl.git) registered for path 'libocispec/yajl'
Cloning into '/nix/store/zwc1r2sq888r3imr7mczg3dyyf9s1l5j-source/libocispec/image-spec'...
remote: Enumerating objects: 4769, done.        
remote: Counting objects: 100% (1029/1029), done.        
remote: Compressing objects: 100% (135/135), done.        
remote: Total 4769 (delta 960), reused 894 (delta 894), pack-reused 3740 (from 2)        
Receiving objects: 100% (4769/4769), 5.33 MiB | 17.00 MiB/s, done.
Resolving deltas: 100% (2784/2784), done.
Cloning into '/nix/store/zwc1r2sq888r3imr7mczg3dyyf9s1l5j-source/libocispec/yajl'...
remote: Enumerating objects: 2388, done.        
remote: Counting objects: 100% (38/38), done.        
remote: Compressing objects: 100% (26/26), done.        
remote: Total 2388 (delta 18), reused 12 (delta 12), pack-reused 2350 (from 2)        
Receiving objects: 100% (2388/2388), 998.63 KiB | 4.82 MiB/s, done.
Resolving deltas: 100% (1352/1352), done.
Cloning into '/nix/store/zwc1r2sq888r3imr7mczg3dyyf9s1l5j-source/libocispec/runtime-spec'...
remote: Enumerating objects: 5493, done.        
remote: Counting objects: 100% (935/935), done.        
remote: Compressing objects: 100% (209/209), done.        
remote: Total 5493 (delta 818), reused 743 (delta 724), pack-reused 4558 (from 3)        
Receiving objects: 100% (5493/5493), 1.85 MiB | 10.27 MiB/s, done.
Resolving deltas: 100% (3296/3296), done.
Submodule path 'libocispec/image-spec': checked out '2daaaaf0e7c16a6a147be91fde277f38573be672'
Submodule path 'libocispec/runtime-spec': checked out 'e3c8d12d94cdd269a145a263ace7457f56c74eff'
Submodule path 'libocispec/yajl': checked out '6bc5219389fd2752631682b0a8368e6d8218a8c5'
Enumerating objects: 299, done.
Counting objects: 100% (299/299), done.
Compressing objects: 100% (290/290), done.
Writing objects: 100% (299/299), done.
Total 299 (delta 74), reused 223 (delta 0), pack-reused 0 (from 0)
Enumerating objects: 299, done.
Nothing new to pack.
Deleted remote-tracking branch origin/main (was abbae63).
Enumerating objects: 1992, done.
Counting objects: 100% (1992/1992), done.
Compressing objects: 100% (1956/1956), done.
Writing objects: 100% (1992/1992), done.
Total 1992 (delta 1222), reused 714 (delta 0), pack-reused 0 (from 0)
Enumerating objects: 1992, done.
Nothing new to pack.
Deleted remote-tracking branch origin/main (was 26647a4).
Deleted remote-tracking branch origin/v1.0 (was 0126d30).
Enumerating objects: 4769, done.
Counting objects: 100% (4769/4769), done.
Compressing objects: 100% (4706/4706), done.
Writing objects: 100% (4769/4769), done.
Total 4769 (delta 2815), reused 1811 (delta 0), pack-reused 0 (from 0)
Enumerating objects: 4769, done.
Nothing new to pack.
Deleted remote-tracking branch origin/main (was d64c1d9).
Deleted tag 'v1.3.0' (was 0eaca84)
Enumerating objects: 5492, done.
Counting objects: 100% (5492/5492), done.
Compressing objects: 100% (5455/5455), done.
Writing objects: 100% (5492/5492), done.
Total 5492 (delta 3325), reused 2009 (delta 0), pack-reused 0 (from 0)
Enumerating objects: 5492, done.
Nothing new to pack.
Deleted remote-tracking branch origin/1.x (was 6a8906d).
Deleted remote-tracking branch origin/2.1.0 (was 66cb08c).
Deleted remote-tracking branch origin/autotools (was 574140a).
Deleted remote-tracking branch origin/build-parse-config (was 083a832).
Deleted remote-tracking branch origin/gh-pages (was fc2a33e).
Deleted remote-tracking branch origin/lxrperf_multiple_tables (was 24d46a6).
Deleted remote-tracking branch origin/lxrperf_ptrs (was 53ff7dc).
Deleted remote-tracking branch origin/lxrperf_two_bytes (was 567874b).
Deleted remote-tracking branch origin/main (was 6bc5219).
Deleted remote-tracking branch origin/master (was 49923cc).
Deleted remote-tracking branch origin/yajl_reset (was 646b8b8).
Enumerating objects: 1766, done.
Counting objects: 100% (1766/1766), done.
Compressing objects: 100% (1696/1696), done.
Writing objects: 100% (1766/1766), done.
Total 1766 (delta 1153), reused 550 (delta 0), pack-reused 0 (from 0)
Enumerating objects: 1766, done.
Nothing new to pack.
```
</details>


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
