### PR TITLE
gnumake: fix "No impure bin sh" patch

### DIFF
--- a/pkgs/development/tools/build-managers/gnumake/patches/0001-No-impure-bin-sh.patch
+++ b/pkgs/development/tools/build-managers/gnumake/patches/0001-No-impure-bin-sh.patch
@@ -1,4 +1,4 @@
-From b69e3740e68afaec97b9957d40b9c135db87eaab Mon Sep 17 00:00:00 2001
+From 532276a537fbfc08c946c9f808f1b0bb54e16523 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?J=C3=B6rg=20Thalheim?= <joerg@thalheim.io>
 Date: Sat, 24 Apr 2021 10:11:40 +0200
 Subject: [PATCH 1/3] No impure bin sh
@@ -13,12 +13,14 @@ hard-coded has some advantages:
   shells there (bash vs. dash)
 - In the past I had issues with LD_PRELOAD with BEAR, where /bin/sh
   used a different glibc than BEAR which came from my development shell.
+
+Co-authored-by: Michael Daniels <mdaniels5757@gmail.com>
 ---
- src/job.c | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
+ src/job.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/src/job.c b/src/job.c
-index ea885614..8a9bd8e0 100644
+index ea885614..1f26e0e8 100644
 --- a/src/job.c
 +++ b/src/job.c
 @@ -76,7 +76,7 @@ char * vms_strsignal (int status);
@@ -30,6 +32,17 @@ index ea885614..8a9bd8e0 100644
  int batch_mode_shell = 0;
  
  #endif
+@@ -2470,8 +2470,8 @@ child_execute_job (struct childbase *child, int good_stdin, char **argv)
+       nargv[1] = cmd;
+       memcpy (&nargv[2], &argv[1], sizeof (char *) * l);
+ 
+-      while ((r = posix_spawn (&pid, nargv[0], &fa, &attr, nargv,
+-                               child->environment)) == EINTR)
++      while ((r = posix_spawnp (&pid, nargv[0], &fa, &attr, nargv,
++                                child->environment)) == EINTR)
+         ;
+ 
+       free (nargv);
 -- 
-2.44.1
+2.51.2
 


### PR DESCRIPTION
* Bug introduced in: #120501
* Fixes: #475670

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
