### PR TITLE
sgdboop: fix build

### DIFF
--- a/pkgs/by-name/sg/sgdboop/package.nix
+++ b/pkgs/by-name/sg/sgdboop/package.nix
@@ -21,6 +21,8 @@ stdenv.mkDerivation rec {
     # Hide the app from app launchers, as it is not meant to be run directly
     # Remove when https://github.com/SteamGridDB/SGDBoop/pull/112 is merged
     ./hide_desktop_entry.patch
+    # remove unused arg to fix build
+    ./remove-unused-arg.patch
   ];
 
   makeFlags = [

--- a/pkgs/by-name/sg/sgdboop/remove-unused-arg.patch
+++ b/pkgs/by-name/sg/sgdboop/remove-unused-arg.patch
@@ -1,0 +1,31 @@
+From 74bea8b264fa5d7ded02db66e2500ba9d72b58cf Mon Sep 17 00:00:00 2001
+From: Fazzi <faaris.ansari@proton.me>
+Date: Wed, 31 Dec 2025 20:57:45 +0000
+Subject: [PATCH] remove unused arg
+
+---
+ sgdboop.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/sgdboop.c b/sgdboop.c
+index f0d95c0..7e860f3 100644
+--- a/sgdboop.c
++++ b/sgdboop.c
+@@ -1,4 +1,4 @@
+-﻿#include <stdlib.h>
++#include <stdlib.h>
+ #include <stdio.h>
+ #include <string.h>
+ #include <curl/curl.h>
+@@ -1276,7 +1276,7 @@ int main(int argc, char** argv)
+ 					struct nonSteamApp* apps = getNonSteamApps();
+ 					struct nonSteamApp* appsMods = NULL;
+ 					if (includeMods) {
+-						appsMods = getMods(includeMods);
++						appsMods = getMods();
+ 					}
+ 
+ 					// Exit with an error if nothing found
+-- 
+2.51.2
+


### PR DESCRIPTION
as far as i can tell this argument goes completely unused and has recently broke build for sgdboop. Patch it out and get it building again.

Fixes #475987 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
