### PR TITLE
superseedr: init at 0.9.29

### DIFF
--- a/pkgs/by-name/su/superseedr/package.nix
+++ b/pkgs/by-name/su/superseedr/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  openssl,
+  pkg-config,
+  stdenv,
+  versionCheckHook,
+  nix-update-script,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "superseedr";
+  version = "0.9.29";
+
+  src = fetchFromGitHub {
+    owner = "Jagalite";
+    repo = "superseedr";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-EszIDtwteskQrD3GBmGsGBnmO+UGE7DSpER7CSSdR2U=";
+  };
+  cargoHash = "sha256-HfO+cbrM+WpZDTHB/W92U8EO0yswK4q02SuB3rTZJL4=";
+
+  buildInputs = [ openssl ];
+  nativeBuildInputs = [ pkg-config ];
+
+  # Skip tests accessing network stack
+  checkFlags = lib.optionals stdenv.hostPlatform.isDarwin [
+    "--skip=networking::protocol::tests"
+    "--skip=torrent_manager::manager::resource_tests::test_cpu_hashing_is_non_blocking"
+  ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "BitTorrent Client in your Terminal";
+    longDescription = ''
+      Superseedr is a modern Rust BitTorrent client featuring a
+      high-performance terminal UI, real-time swarm observability,
+      secure VPN-aware Docker setups, and zero manual network
+      configuration. It is fast, privacy-oriented, and built for both
+      desktop users and homelab/server workflows.
+    '';
+    homepage = "https://github.com/Jagalite/superseedr";
+    license = lib.licenses.gpl3Plus;
+    mainProgram = "superseedr";
+    maintainers = with lib.maintainers; [ louis-thevenet ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Superseedr is a modern Rust BitTorrent client featuring a high-performance terminal UI, real-time swarm observability, secure VPN-aware Docker setups, and zero manual network configuration. It is fast, privacy-oriented, and built for both desktop users and homelab/server workflows.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
