### PR TITLE
librewolf{,-unwrapped}: Remove grimmauld from maintainers

### DIFF
--- a/ci/OWNERS
+++ b/ci/OWNERS
@@ -245,7 +245,7 @@ nixos/modules/installer/tools/nix-fallback-paths.nix  @NixOS/nix-team @raitobeza
 /pkgs/applications/networking/browsers/firefox/update.nix
 /pkgs/applications/networking/browsers/firefox/packages/firefox.nix @mweinelt
 /pkgs/applications/networking/browsers/firefox/packages/firefox-esr-*.nix @mweinelt
-/pkgs/applications/networking/browsers/librewolf @squalus @DominicWrege @fpletz @LordGrimmauld
+/pkgs/applications/networking/browsers/librewolf @squalus @DominicWrege @fpletz
 /pkgs/applications/networking/browsers/chromium @emilylange @networkException
 /nixos/tests/chromium.nix @emilylange @networkException
 

--- a/pkgs/applications/networking/browsers/librewolf/default.nix
+++ b/pkgs/applications/networking/browsers/librewolf/default.nix
@@ -33,7 +33,6 @@ in
       squalus
       dwrege
       fpletz
-      grimmauld
     ];
     platforms = lib.platforms.unix;
     broken = stdenv.buildPlatform.is32bit;


### PR DESCRIPTION
Librewolf is in a bad shape. Not just in nixpkgs, but upstream as well.

In nixpkgs, browsers have been a constant painful argument. I have written up #405187 to clarify some security requirements for packages. While Librewolf doesn't immediately violate the requirements outlined there, we should strive for better than just the absolute minimum. Personally, I no longer feel confident in my ability to adequately contribute, test, and backport Librewolf updates. The past few months have been stressful IRL, and maintaining a browser in nixpkgs is no longer sustainable for me. In the time I intended to take a break, #471511 was opened to update to 146.0.1. This was not merged in a timely manner, despite me not being the only committer among LW maintainers.

librewolf-bin isn't looking much better. #464467 is open since Nov 24th, entirely unacceptable for a browser. The single remaining maintainer, @DominicWrege, already proposed dropping the package entirely, LeSuisse marked it vulnerable in the meantime.

The situation upstream does not look much better. Checking the [commit history](https://codeberg.org/librewolf/source/commits/branch/main), they are barely keeping up with upstream firefox. The maintainers have repeatedly communicated (on matrix) they were close to burning out. The code changes being done are mostly bumps with patch rebases, removals of patches which no longer apply, and a lot of somewhat trivial changes. Very few substantial changes to librewolf itself are made.

I originally switched to Librewolf when firefox expanded their enshitification efforts, at a time where search engine policies were not possible to define with mainline firefox. Mainline started supporting search engine policies since. While enshitification did not slow down, librewolf does not keep up sufficiently to combat that effectively. I appreciate the project for what it does and tries to do. But i no longer believe the project is sustainable. Not in nixpkgs, and probably not upstream either.

Well, what now? I am not the last maintainer of librewolf source package. I am hoping someone else will step up, and maybe start actually committing open PRs too. Personally, i will be moving back to mainline firefox, and apply [Phoenix](https://github.com/celenityy/Phoenix). Phoenix has a nice flake, and does not require a browser recompile for the changes it does. Phoenix does many of the things librewolf does, while imposing less of a maintainance burden.

I wish the best of luck to all remaining librewolf maintainers.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
