### PR TITLE
forth-lsp: init at 0.4.1-unstable-2025-12-18

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -817,6 +817,12 @@
     githubId = 207841739;
     name = "Savchenko Dmitriy";
   };
+  agx = {
+    email = "agxr@tuta.io";
+    github = "agx-r";
+    githubId = 55353943;
+    name = "David Shiferstein";
+  };
   aherrmann = {
     email = "andreash87@gmx.ch";
     github = "aherrmann";

--- a/pkgs/by-name/fo/forth-lsp/package.nix
+++ b/pkgs/by-name/fo/forth-lsp/package.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage {
+  pname = "forth-lsp";
+  version = "0.4.1-unstable-2025-12-18";
+
+  src = fetchFromGitHub {
+    owner = "AlexanderBrevig";
+    repo = "forth-lsp";
+    rev = "22988d65b80f5b57e4157c9bf3fb3e9c0dafb3aa";
+    hash = "sha256-hj0fsUdP67/XPzxce44kdl8dKi8XYU++qjo7z0MX4Xs=";
+  };
+
+  cargoHash = "sha256-lvQIzRNpO0MugybUBjaFr2gYtsk5o7H9+jBId86ZEgU=";
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
+
+  meta = {
+    description = "LSP for the Forth programming language";
+    mainProgram = "forth-lsp";
+    homepage = "https://github.com/AlexanderBrevig/forth-lsp";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ agx ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds forth-lsp, a Language Server Protocol implementation for the Forth programming language.

This package provides IDE features for Forth development including:
- Hover documentation for built-in words and user-defined functions
- Auto-completion
- Go to Definition
- Find References
- Rename symbols
- Document Symbols
- Workspace Symbols
- Signature Help
- Diagnostics
- Formatting

Homepage: https://github.com/AlexanderBrevig/forth-lsp

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
