### PR TITLE
liboprf: 0.9.2 -> 0.9.3

### DIFF
--- a/pkgs/by-name/li/liboprf/no-static.patch
+++ b/pkgs/by-name/li/liboprf/no-static.patch
@@ -1,12 +1,13 @@
 diff --git a/makefile b/makefile
-index 444feae..0b2d482 100644
+index ce33665..d85152e 100644
 --- a/makefile
 +++ b/makefile
-@@ -134,8 +134,12 @@ clean:
+@@ -148,9 +148,12 @@ clean:
  
  install: install-oprf install-noiseXK
  
 -install-oprf: $(DESTDIR)$(PREFIX)/lib/liboprf.$(SOEXT) \
+-	$(DESTDIR)$(PREFIX)/$(DEBUGDIR)/liboprf.$(SOEXT).debug \
 -	$(DESTDIR)$(PREFIX)/lib/liboprf.$(STATICEXT) \
 +INSTALL_EXT=$(STATICEXT)
 +ifeq ($(findstring -shared,$(LDFLAGS)),)

--- a/pkgs/by-name/li/liboprf/package.nix
+++ b/pkgs/by-name/li/liboprf/package.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "liboprf";
-  version = "0.9.2";
+  version = "0.9.3";
 
   src = fetchFromGitHub {
     owner = "stef";
     repo = "liboprf";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Toja0rR0321i7L1dsB9YxrwNJwKUzuSfK5LLR3tex7U=";
+    hash = "sha256-BH7sLkj7vGtz2kSSuV2+BrwlQJ26s4UTlNL/owJhzCk=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/src";
@@ -23,6 +23,12 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     ./no-static.patch
   ];
+
+  # strip: error: option is not supported for MachO
+  postPatch = lib.optionalString stdenv.hostPlatform.isMacho ''
+    substituteInPlace makefile \
+      --replace-fail "--strip-unneeded" ""
+  '';
 
   strictDeps = true;
 


### PR DESCRIPTION
Changelog: https://github.com/stef/liboprf/releases/tag/v0.9.3


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
