### PR TITLE
aws-gate: fix compatibility with marshmallow 4.x

### DIFF
--- a/pkgs/by-name/aw/aws-gate/fix-compatibility-with-marshmallow-4.x.patch
+++ b/pkgs/by-name/aw/aws-gate/fix-compatibility-with-marshmallow-4.x.patch
@@ -1,0 +1,28 @@
+From d6b05accc05abcd13aefd66c50e6f4414f098b71 Mon Sep 17 00:00:00 2001
+From: Moraxyc <i@qaq.li>
+Date: Thu, 1 Jan 2026 10:49:08 +0800
+Subject: [PATCH] fix(config.py): fix compatibility with marshmallow 4.x
+
+---
+ aws_gate/config.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/aws_gate/config.py b/aws_gate/config.py
+index bfb84bf..0a1153f 100644
+--- a/aws_gate/config.py
++++ b/aws_gate/config.py
+@@ -45,9 +45,9 @@ class HostSchema(Schema):
+ 
+ class GateConfigSchema(Schema):
+     defaults = fields.Nested(
+-        DefaultsSchema, required=False, missing={}, validate=validate_defaults
++        DefaultsSchema, required=False, load_default={}, validate=validate_defaults
+     )
+-    hosts = fields.List(fields.Nested(HostSchema), required=False, missing=[])
++    hosts = fields.List(fields.Nested(HostSchema), required=False, load_default=[])
+ 
+     # pylint: disable=unused-argument
+     @post_load
+-- 
+2.51.2
+

--- a/pkgs/by-name/aw/aws-gate/package.nix
+++ b/pkgs/by-name/aw/aws-gate/package.nix
@@ -20,6 +20,9 @@ python3Packages.buildPythonApplication rec {
 
   patches = [
     ./disable-bootstrap.patch
+    # default and missing parameters, which were replaced by dump_default and load_default
+    # https://github.com/xen0l/aws-gate/pull/1770
+    ./fix-compatibility-with-marshmallow-4.x.patch
   ];
 
   postPatch = ''


### PR DESCRIPTION
https://github.com/marshmallow-code/marshmallow/blob/dev/CHANGELOG.rst#401-2025-08-28

> Previously-deprecated APIs have been removed, including:
>> default and missing parameters, which were replaced by dump_default and load_default in 3.13.0

https://github.com/xen0l/aws-gate/pull/1770
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
