### PR TITLE
piliplus: 1.1.5 -> 1.1.5.1

### DIFF
--- a/pkgs/by-name/pi/piliplus/package.nix
+++ b/pkgs/by-name/pi/piliplus/package.nix
@@ -13,10 +13,11 @@
 let
   srcInfo = lib.importJSON ./src-info.json;
   description = "Third-party Bilibili client developed in Flutter";
+  version = "1.1.5.1";
 in
 flutter338.buildFlutterApplication {
   pname = "piliplus";
-  inherit (srcInfo) version;
+  inherit version;
 
   src = fetchFromGitHub {
     owner = "bggRGjQaUbCoE";
@@ -43,7 +44,7 @@ flutter338.buildFlutterApplication {
     cat <<EOL > lib/build_config.dart
     class BuildConfig {
       static const int versionCode = ${toString srcInfo.revCount};
-      static const String versionName = '${srcInfo.version}';
+      static const String versionName = '${version}';
 
       static const int buildTime = ${toString srcInfo.commitDate};
       static const String commitHash = '${srcInfo.rev}';
@@ -85,7 +86,7 @@ flutter338.buildFlutterApplication {
   meta = {
     inherit description;
     homepage = "https://github.com/bggRGjQaUbCoE/PiliPlus";
-    changelog = "https://github.com/bggRGjQaUbCoE/PiliPlus/releases/tag/${srcInfo.version}";
+    changelog = "https://github.com/bggRGjQaUbCoE/PiliPlus/releases/tag/${version}";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ ulysseszhan ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/pi/piliplus/pubspec.lock.json
+++ b/pkgs/by-name/pi/piliplus/pubspec.lock.json
@@ -1186,11 +1186,11 @@
       "dependency": "transitive",
       "description": {
         "name": "image_picker_ios",
-        "sha256": "997d100ce1dda5b1ba4085194c5e36c9f8a1fb7987f6a36ab677a344cd2dc986",
+        "sha256": "956c16a42c0c708f914021666ffcd8265dde36e673c9fa68c81f7d085d9774ad",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.8.13+2"
+      "version": "0.8.13+3"
     },
     "image_picker_linux": {
       "dependency": "transitive",
@@ -1943,21 +1943,21 @@
       "dependency": "transitive",
       "description": {
         "name": "shared_preferences",
-        "sha256": "6e8bf70b7fef813df4e9a36f658ac46d107db4b4cfe1048b477d4e453a8159f5",
+        "sha256": "2939ae520c9024cb197fc20dee269cd8cdbf564c8b5746374ec6cacdc5169e64",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.5.3"
+      "version": "2.5.4"
     },
     "shared_preferences_android": {
       "dependency": "transitive",
       "description": {
         "name": "shared_preferences_android",
-        "sha256": "46a46fd64659eff15f4638bbe19de43f9483f0e0bf024a9fb6b3582064bacc7b",
+        "sha256": "83af5c682796c0f7719c2bbf74792d113e40ae97981b8f266fa84574573556bc",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.4.17"
+      "version": "2.4.18"
     },
     "shared_preferences_foundation": {
       "dependency": "transitive",
@@ -2541,6 +2541,6 @@
   },
   "sdks": {
     "dart": ">=3.10.0 <4.0.0",
-    "flutter": "3.38.3"
+    "flutter": "3.38.4"
   }
 }

--- a/pkgs/by-name/pi/piliplus/src-info.json
+++ b/pkgs/by-name/pi/piliplus/src-info.json
@@ -1,7 +1,6 @@
 {
-  "version": "1.1.5",
-  "rev": "a48f6b1ca52e20fb459c070a9f72d62019136350",
-  "revCount": 4403,
-  "commitDate": 1764474094,
-  "hash": "sha256-KviltS9IC0cYl2+FKDQ535ot+ieZ21KrxRTBPxuDoe0="
+  "rev": "3741fe54ff386f50c91e17b16046cb429648bb6a",
+  "revCount": 4442,
+  "commitDate": 1765360801,
+  "hash": "sha256-Y+/ukiy4DE6ofcE+PDvRdmSpAOKG4pfg7QOPyyzLvFU="
 }

--- a/pkgs/by-name/pi/piliplus/update.rb
+++ b/pkgs/by-name/pi/piliplus/update.rb
@@ -64,13 +64,14 @@ nix_filename = package_attr('meta.position')[/([^:]+):\d+/, 1] or abort "Failed 
 nix_dir = File.dirname nix_filename
 src_info_path = File.join nix_dir, 'src-info.json'
 json_write src_info_path, {
-  version: new_version,
   rev: new_rev,
   revCount: git_count,
   commitDate: date,
   hash: new_hash
 }
 log "Updated #{src_info_path}"
+File.write nix_filename, File.read(nix_filename).sub(old_version, new_version)
+log "Updated #{nix_filename}"
 
 pubspec_lock_path = File.join nix_dir, 'pubspec.lock.json'
 old_pubspec_lock = JSON.load_file pubspec_lock_path rescue abort "Failed to read #{pubspec_lock_path}"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Move version info to the nix file so that ryantm bot can work. Supersedes #475763.

CC @qzylinra 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
