### PR TITLE
nvcat: init at 0.1.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19613,6 +19613,12 @@
     githubId = 14004859;
     name = "Ole Mussmann";
   };
+  olillin = {
+    email = "oli@olillin.com";
+    github = "olillin";
+    githubId = 55047947;
+    name = "Oli";
+  };
   oliver-koss = {
     email = "oliver.koss06@gmail.com";
     github = "oliver-koss";

--- a/pkgs/by-name/nv/nvcat/package.nix
+++ b/pkgs/by-name/nv/nvcat/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+buildGoModule (finalAttrs: {
+  pname = "nvcat";
+  version = "0.1.5";
+
+  src = fetchFromGitHub {
+    owner = "brianhuster";
+    repo = "nvcat";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-F23trNMmoifPyOVp5hK+xUM3m96PIBniO9mmyfTMnFE=";
+  };
+
+  vendorHash = "sha256-IZ1+RAKKYG9TblT30FmqMGswnUrzLdrK+haNmqGdGSk=";
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "v(.+)"
+    ];
+  };
+
+  meta = {
+    description = "`cat` but with syntax highlighting powered by Neovim";
+    homepage = "https://github.com/brianhuster/nvcat";
+    changelog = "https://github.com/brianhuster/nvcat/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    longDescription = ''
+      A command-line utility that displays files with Neovim's syntax highlighting in the terminal.
+    '';
+    mainProgram = "nvcat";
+    maintainers = with lib.maintainers; [ olillin ];
+  };
+})


### PR DESCRIPTION
Added `nvcat`, a command-line utility that displays files like `cat` but with Neovim's syntax highlighting.

Homepage/repository: [brianhuster/nvcat](https://github.com/brianhuster/nvcat)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
