### PR TITLE
faugus-launcher: 1.11.7 -> 1.11.8

### DIFF
--- a/pkgs/by-name/fa/faugus-launcher/package.nix
+++ b/pkgs/by-name/fa/faugus-launcher/package.nix
@@ -1,6 +1,5 @@
 {
   fetchFromGitHub,
-  gamemode,
   gobject-introspection,
   icoextract,
   imagemagick,
@@ -18,28 +17,25 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "faugus-launcher";
-  version = "1.11.7";
+  version = "1.11.8";
   pyproject = false;
 
   src = fetchFromGitHub {
     owner = "Faugus";
     repo = "faugus-launcher";
     tag = version;
-    hash = "sha256-ExvdbBZS70GfjzFkfStWrrS67lHgrzdOxsr0cabdm5M=";
+    hash = "sha256-VgafXX8EuX0WOpG0cxBNlUdLL4HrrcpdblpCMxka2ms=";
   };
 
   nativeBuildInputs = [
     gobject-introspection
+    meson
+    ninja
     wrapGAppsHook3
   ];
 
   buildInputs = [
     libayatana-appindicator
-  ];
-
-  build-system = [
-    meson
-    ninja
   ];
 
   dependencies = with python3Packages; [
@@ -60,9 +56,7 @@ python3Packages.buildPythonApplication rec {
 
     substituteInPlace faugus_run.py \
       --replace-fail "PathManager.find_binary('faugus-components')" "'$out/bin/.faugus-components-wrapped'" \
-      --replace-fail "PathManager.user_data('faugus-launcher/umu-run')" "'${lib.getExe umu-launcher}'" \
-      --replace-fail "PathManager.find_library('libgamemode.so.0')" "'${lib.getLib gamemode}/lib/libgamemode.so.0'" \
-      --replace-fail "PathManager.find_library('libgamemodeauto.so.0')" "'${lib.getLib gamemode}/lib/libgamemodeauto.so.0'"
+      --replace-fail "PathManager.user_data('faugus-launcher/umu-run')" "'${lib.getExe umu-launcher}'"
   '';
 
   dontWrapGApps = true;


### PR DESCRIPTION
[Changelog](https://github.com/Faugus/faugus-launcher/releases/tag/1.11.8)

Fixes build error from this change: https://github.com/Faugus/faugus-launcher/commit/ed64e35d494c87bcd076a325cad7523b37d996bf

Also moved meson build tools to `nativeBuildInputs` to adhere to the [manual](https://nixos.org/manual/nixpkgs/unstable/#buildpythonpackage-parameters):

> build-system ? []: Build-time only Python dependencies. Items listed in build-system.requires/setup_requires.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
