### PR TITLE
rgrc: init at 0.6.5

### DIFF
--- a/pkgs/by-name/rg/rgrc/package.nix
+++ b/pkgs/by-name/rg/rgrc/package.nix
@@ -1,0 +1,52 @@
+{
+  fetchFromGitHub,
+  installShellFiles,
+  lib,
+  nix-update-script,
+  rustPlatform,
+  stdenv,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "rgrc";
+  version = "0.6.5";
+
+  src = fetchFromGitHub {
+    owner = "lazywalker";
+    repo = "rgrc";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-OuNVX1whhJOMj2rX2yANyHie8dn9i5JAI29btOgNH38=";
+  };
+
+  cargoHash = "sha256-wQht/DJgTvnOIQ3u2Nz5jyUNhotDgA2/iXhb9ZElGI4=";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  checkFlags = [ "--skip=test_command_exists" ];
+
+  postInstall = ''
+    installManPage doc/rgrc.1
+    install -Dm644 share/conf.* -t $out/share/rgrc/
+  ''
+  + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd rgrc \
+      --bash <($out/bin/rgrc --completions bash) \
+      --fish <($out/bin/rgrc --completions fish) \
+      --zsh <($out/bin/rgrc --completions zsh)
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    changelog = "https://github.com/lazywalker/rgrc/releases/tag/v${finalAttrs.version}";
+    description = "Rusty Generic Colouriser - just like grc but fast";
+    homepage = "https://lazywalker.github.io/rgrc/";
+    license = lib.licenses.mit;
+    mainProgram = "rgrc";
+    maintainers = with lib.maintainers; [ sedlund ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

rgrc - Rusty Generic Colouriser - just like grc but fast

<img width="1241" height="288" alt="image" src="https://github.com/user-attachments/assets/2ae7c227-642b-4dc2-98b3-5a7c6b08cc9d" />

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
