### PR TITLE
libeb: fix build with gcc15

### DIFF
--- a/pkgs/by-name/li/libeb/package.nix
+++ b/pkgs/by-name/li/libeb/package.nix
@@ -18,8 +18,13 @@ stdenv.mkDerivation rec {
   patches = [
     (fetchpatch {
       name = "gcc-14.patch";
-      url = "https://salsa.debian.org/debian/eb/-/raw/50c84ee2d190083fc88a14e62ef9fef779d088de/debian/patches/0002-gcc14-fix.patch";
+      url = "https://salsa.debian.org/debian/eb/-/raw/7f4f013678f307efaa463b187e0ecd643df1d0ba/debian/patches/0002-gcc14-fix.patch";
       hash = "sha256-0hht7ojj4MLNfFbemDR2hD1PbSmBxrC2JtDl2WJINlM=";
+    })
+    (fetchpatch {
+      name = "gcc-15.patch";
+      url = "https://salsa.debian.org/debian/eb/-/raw/7f4f013678f307efaa463b187e0ecd643df1d0ba/debian/patches/0003-gcc15-fix.patch";
+      hash = "sha256-2Q54Xy6I9NrHtXQeNmcR+r71KnRsXDma1GIk9qSOP1g=";
     })
   ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
