### PR TITLE
sdl3-image: 3.2.4 -> 3.2.6

### DIFF
--- a/pkgs/by-name/sd/sdl3-image/package.nix
+++ b/pkgs/by-name/sd/sdl3-image/package.nix
@@ -19,7 +19,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "sdl3-image";
-  version = "3.2.4";
+  version = "3.2.6";
 
   outputs = [
     "lib"
@@ -31,7 +31,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "libsdl-org";
     repo = "SDL_image";
     tag = "release-${finalAttrs.version}";
-    hash = "sha256-/orQ+YfH0CV8DOqXFMF9fOT4YaVpC1t55xM3j520Png=";
+    hash = "sha256-CnUCqFq9ZaM/WQcmaCpQdjtjR9l5ymzgeqEJx7ZW/s4=";
   };
 
   strictDeps = true;

--- a/pkgs/by-name/sd/sdl3-image/package.nix
+++ b/pkgs/by-name/sd/sdl3-image/package.nix
@@ -10,6 +10,7 @@
   validatePkgConfig,
   libpng,
   libjpeg,
+  libjxl,
   nix-update-script,
   # Boolean flags
   enableTests ? true,
@@ -47,6 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
     libtiff
     libwebp
     libavif
+    libjxl
   ]
   ++ (lib.optionals (!enableSTB) [
     libpng
@@ -64,6 +66,8 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "SDLIMAGE_BACKEND_IMAGEIO" enableImageIO)
     # enable tests
     (lib.cmakeBool "SDLIMAGE_TESTS" enableTests)
+    # enable jxl
+    (lib.cmakeBool "SDLIMAGE_JXL" true)
   ];
 
   passthru.updateScript = nix-update-script {

--- a/pkgs/by-name/sd/sdl3-image/package.nix
+++ b/pkgs/by-name/sd/sdl3-image/package.nix
@@ -47,9 +47,9 @@ stdenv.mkDerivation (finalAttrs: {
     sdl3
     libtiff
     libwebp
-    libavif
     libjxl
   ]
+  ++ (lib.optional (!stdenv.hostPlatform.isDarwin) libavif)
   ++ (lib.optionals (!enableSTB) [
     libpng
     libjpeg
@@ -68,6 +68,8 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "SDLIMAGE_TESTS" enableTests)
     # enable jxl
     (lib.cmakeBool "SDLIMAGE_JXL" true)
+    # disable avif on darwin (see https://github.com/NixOS/nixpkgs/issues/400910)
+    (lib.cmakeBool "SDLIMAGE_AVIF" (!stdenv.hostPlatform.isDarwin))
   ];
 
   passthru.updateScript = nix-update-script {


### PR DESCRIPTION
Update sdl3-image to 3.2.6

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
