### PR TITLE
heptabase: update to 1.82.4

### DIFF
--- a/pkgs/by-name/he/heptabase/package.nix
+++ b/pkgs/by-name/he/heptabase/package.nix
@@ -5,10 +5,10 @@
 }:
 let
   pname = "heptabase";
-  version = "1.75.7";
+  version = "1.82.4";
   src = fetchurl {
     url = "https://github.com/heptameta/project-meta/releases/download/v${version}/Heptabase-${version}.AppImage";
-    hash = "sha256-XGbkfjmceb+IFl3sERpd8zqdTQQAkpiyTxZDoIyoFmY=";
+    hash = "sha256-u6PRs7kyYqqUCLQXAZElPpLDP43GGLk6XylTjWpMVJk=";
   };
 
   appimageContents = appimageTools.extractType2 { inherit pname version src; };


### PR DESCRIPTION
- Bump heptabase to 1.82.4.
- Update AppImage source URL and sha256.

https://github.com/heptameta/project-meta/issues/3


Changelog:
- https://wiki.heptabase.com/changelog (v1.82.4, 2025-12-30)
- https://github.com/heptameta/project-meta/releases/tag/v1.82.4

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] NixOS tests in nixos/tests.
  - [ ] Package tests at passthru.tests.
  - [ ] Tests in lib/tests or pkgs/test for functions and "core" functionality.
- [ ] Ran nixpkgs-review on this PR.
- [ ] Tested basic functionality of all binary files in ./result/bin/.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits CONTRIBUTING.md, pkgs/README.md, maintainers/README.md and other READMEs.
