### PR TITLE
versatiles: 2.0.1 -> 3.1.0

### DIFF
--- a/pkgs/by-name/ve/versatiles/package.nix
+++ b/pkgs/by-name/ve/versatiles/package.nix
@@ -2,27 +2,27 @@
   lib,
   fetchFromGitHub,
   rustPlatform,
+  versionCheckHook,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "versatiles";
-  version = "2.0.1"; # When updating: Replace with current version
+  version = "3.1.0";
 
   src = fetchFromGitHub {
     owner = "versatiles-org";
     repo = "versatiles-rs";
-    tag = "v${version}"; # When updating: Replace with long commit hash of new version
-    hash = "sha256-qFVqikq1T6LQnOWgM66uKzFhWQbVjEuUK3N5vNvaDq4="; # When updating: Use `lib.fakeHash` for recomputing the hash once. Run: 'nix-build -A versatiles'. Swap with new hash and proceed.
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-U9Os5HiehujU+/O2ZeUEtBJCVOBOi4dfH89Y9d0+RlI=";
   };
 
-  cargoHash = "sha256-kkYdQEBydxPwxxSjTiwk4huCDK3xJ9FoyrcHL88ytfk="; # When updating: Same as above
+  cargoHash = "sha256-p2ezrYhAxGvxzI3Q8BA0nGWwzim3L3AdIdf+8oMquSA=";
 
   __darwinAllowLocalNetworking = true;
 
-  # Testing only necessary for the `bins` and `lib` features
+  # Testing only necessary for `bins`
   cargoTestFlags = [
     "--bins"
-    "--lib"
   ];
 
   # Skip tests that require network access
@@ -30,6 +30,7 @@ rustPlatform.buildRustPackage rec {
     "--skip=tools::convert::tests::test_remote1"
     "--skip=tools::convert::tests::test_remote2"
     "--skip=tools::probe::tests::test_remote"
+    "--skip=tools::serve::tests::test_config"
     "--skip=tools::serve::tests::test_remote"
     "--skip=utils::io::data_reader_http"
     "--skip=utils::io::data_reader_http::tests::read_range_git"
@@ -37,6 +38,12 @@ rustPlatform.buildRustPackage rec {
     "--skip=io::data_reader_http::tests::read_range_git"
     "--skip=io::data_reader_http::tests::read_range_googleapis"
   ];
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
 
   meta = {
     description = "Toolbox for converting, checking and serving map tiles in various formats";
@@ -46,10 +53,10 @@ rustPlatform.buildRustPackage rec {
     '';
     homepage = "https://versatiles.org/";
     downloadPage = "https://github.com/versatiles-org/versatiles-rs";
-    changelog = "https://github.com/versatiles-org/versatiles-rs/releases/tag/v${version}";
+    changelog = "https://github.com/versatiles-org/versatiles-rs/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ wilhelmines ];
     mainProgram = "versatiles";
     platforms = with lib.platforms; linux ++ darwin ++ windows;
   };
-}
+})


### PR DESCRIPTION
implemented some syntax changes, skipped test that requires internet access and removed old comments

There is a new test that requires internet access. In consulation with the lead dev of versatiles the test will be skipped like the others that require internet access.

In addition I removed old comments that were intended to guide me when updating the package. They aren't needed anymore.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
