### PR TITLE
foomatic-filters: fix build with gcc15; modernize

### DIFF
--- a/pkgs/by-name/fo/foomatic-filters/fix-incompatible-pointer-types.patch
+++ b/pkgs/by-name/fo/foomatic-filters/fix-incompatible-pointer-types.patch
@@ -1,0 +1,25 @@
+From 822bf358b1e47704365feb84cac8a0af08611ea5 Mon Sep 17 00:00:00 2001
+From: Moraxyc <i@qaq.li>
+Date: Thu, 1 Jan 2026 20:28:52 +0800
+Subject: [PATCH] fix incompatible pointer types
+
+---
+ process.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/process.h b/process.h
+index b95dcb4..58aa8bf 100644
+--- a/process.h
++++ b/process.h
+@@ -28,7 +28,7 @@
+ #include <sys/types.h>
+ #include <sys/wait.h>
+ 
+-pid_t start_process(const char *name, int (*proc_func)(), void *user_arg, FILE **fdin, FILE **fdout);
++pid_t start_process(const char *name, int (*proc_func)(FILE *, FILE *, void *), void *user_arg, FILE **fdin, FILE **fdout);
+ pid_t start_system_process(const char *name, const char *command, FILE **fdin, FILE **fdout);
+ 
+ /* returns command's return status (see waitpid(2)) */
+-- 
+2.51.2
+

--- a/pkgs/by-name/fo/foomatic-filters/package.nix
+++ b/pkgs/by-name/fo/foomatic-filters/package.nix
@@ -33,6 +33,9 @@ stdenv.mkDerivation rec {
       url = "https://salsa.debian.org/debian/foomatic-filters/raw/a3abbef2d2f8c7e62d2fe64f64afe294563fdf8f/debian/patches/0500-r7406_also_consider_the_back_tick_as_an_illegal_shell_escape_character.patch";
       sha256 = "055nwi3sjf578nk40bqsch3wx8m2h65hdih0wmxflb6l0hwkq4p4";
     })
+    # Fix build with gcc15
+    #   process.h:31:45: note: expected 'int (*)(void)' but argument is of type 'int (*)(FILE *, FILE *, void *)'
+    ./fix-incompatible-pointer-types.patch
   ];
 
   preConfigure = ''

--- a/pkgs/by-name/fo/foomatic-filters/package.nix
+++ b/pkgs/by-name/fo/foomatic-filters/package.nix
@@ -8,15 +8,16 @@
   cups,
   dbus,
   enscript,
+  versionCheckHook,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "foomatic-filters";
   version = "4.0.17";
 
   src = fetchurl {
-    url = "https://www.openprinting.org/download/foomatic/foomatic-filters-${version}.tar.gz";
-    sha256 = "1qrkgbm5jay2r7sh9qbyf0aiyrsl1mdc844hxf7fhw95a0zfbqm2";
+    url = "https://www.openprinting.org/download/foomatic/foomatic-filters-${finalAttrs.version}.tar.gz";
+    hash = "sha256-ouLlPlAlceiO65AQxFoNVGcfFXB+4QT1ycIrWep6M+M=";
   };
 
   nativeBuildInputs = [ pkg-config ];
@@ -39,7 +40,8 @@ stdenv.mkDerivation rec {
   ];
 
   preConfigure = ''
-    substituteInPlace foomaticrip.c --replace /bin/bash ${stdenv.shell}
+    substituteInPlace foomaticrip.c \
+      --replace-fail /bin/bash ${stdenv.shell}
   '';
 
   # Workaround build failure on -fno-common toolchains like upstream
@@ -55,6 +57,9 @@ stdenv.mkDerivation rec {
     "CUPS_BACKENDS=$(out)/lib/cups/backend"
   ];
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
   meta = {
     description = "Foomatic printing filters";
     mainProgram = "foomatic-rip";
@@ -62,4 +67,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.linux;
     license = lib.licenses.gpl2Plus;
   };
-}
+})


### PR DESCRIPTION
- **foomatic-filters: fix build with gcc15**
- **foomatic-filters: modernize**

https://hydra.nixos.org/build/317836038

https://github.com/NixOS/nixpkgs/issues/475479

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
