### PR TITLE
tlp-pd: init at 1.9.0

### DIFF
--- a/pkgs/by-name/tl/tlp-pd/package.nix
+++ b/pkgs/by-name/tl/tlp-pd/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  python3Packages,
+  tlp,
+  coreutils,
+}:
+
+python3Packages.buildPythonApplication {
+  pname = "tlp-pd";
+  inherit (tlp)
+    version
+    src
+    patches
+    postPatch
+    ;
+
+  pyproject = false; # Built with make
+
+  dependencies = with python3Packages; [
+    pygobject3
+    dbus-python
+  ];
+
+  makeFlags = [ "DESTDIR=${placeholder "out"}" ];
+
+  installTargets = [
+    "install-pd"
+    "install-man-pd"
+  ];
+
+  makeWrapperArgs = [ "--prefix PATH : ${lib.makeBinPath [ tlp ]}" ];
+
+  postInstall = ''
+    substituteInPlace $out/share/dbus-1/system-services/*.service \
+      --replace-fail "/bin/false" "${coreutils}/false"
+  '';
+
+  checkPhase = ''
+    runHook preCheck
+
+    # The program will error out but at least we are not missing python deps
+    ($out/bin/tlpctl --help 2>&1 || true) |\
+      grep -q 'g-io-error-quark: Could not connect: No such file or directory'
+    $out/bin/tlp-pd --help
+
+    runHook postCheck
+  '';
+
+  meta = {
+    inherit (tlp.meta)
+      homepage
+      changelog
+      platforms
+      maintainers
+      license
+      ;
+    description = "Power-rofiles-daemon like DBus interface for TLP";
+    mainProgram = "tlp-pd";
+  };
+}

--- a/pkgs/tools/misc/tlp/default.nix
+++ b/pkgs/tools/misc/tlp/default.nix
@@ -20,6 +20,7 @@
   systemd,
   udevCheckHook,
   util-linux,
+  glib,
   x86_energy_perf_policy,
   # RDW only works with NetworkManager, and thus is optional with default off
   enableRDW ? false,
@@ -105,6 +106,7 @@ stdenv.mkDerivation rec {
           smartmontools
           systemd
           util-linux
+          glib # gdbus
         ]
         ++ lib.optional enableRDW networkmanager
         ++ lib.optional (lib.meta.availableOn stdenv.hostPlatform x86_energy_perf_policy) x86_energy_perf_policy

--- a/pkgs/tools/misc/tlp/default.nix
+++ b/pkgs/tools/misc/tlp/default.nix
@@ -24,6 +24,7 @@
   # RDW only works with NetworkManager, and thus is optional with default off
   enableRDW ? false,
   networkmanager,
+  tlp-pd,
 }:
 stdenv.mkDerivation rec {
   pname = "tlp";
@@ -135,6 +136,10 @@ stdenv.mkDerivation rec {
       rm -rf $out/var
       rm -rf $out/share/metainfo
     '';
+
+  passthru.tests = {
+    inherit tlp-pd;
+  };
 
   meta = {
     description = "Advanced Power Management for Linux";


### PR DESCRIPTION
This adds power-profiles support for tlp. As it's mainly a python package, it would be more flexible to package separately.

Related: https://github.com/NixOS/nixpkgs/pull/473626 https://github.com/NixOS/nixpkgs/pull/466801

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
