### PR TITLE
python313Packages.eternalegypt: 0.0.16 -> 0.0.18

### DIFF
--- a/pkgs/development/python-modules/eternalegypt/default.nix
+++ b/pkgs/development/python-modules/eternalegypt/default.nix
@@ -4,30 +4,20 @@
   attrs,
   buildPythonPackage,
   fetchFromGitHub,
-  fetchpatch,
   setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "eternalegypt";
-  version = "0.0.16";
+  version = "0.0.18";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "amelchio";
     repo = "eternalegypt";
     tag = "v${version}";
-    hash = "sha256-ubKepd3yBaoYrIUe5WCt1zd4CjvU7SeftOR+2cBaEf0=";
+    hash = "sha256-dS4APZWOI8im1Ls1A5750FedTWBy3UpXvJmYpd1po94=";
   };
-
-  patches = [
-    # https://github.com/amelchio/eternalegypt/pull/38
-    (fetchpatch {
-      name = "move-from-async_timeout.timeout-to-asyncio.timeout.patch";
-      url = "https://github.com/amelchio/eternalegypt/commit/f496ae2d38b5d4a3f676310b5bb45c7c34b5262f.patch";
-      hash = "sha256-8AHFEP/2yMeyoSWCxNyG+ARS7T40hkEwJ/rp9S8ouSE=";
-    })
-  ];
 
   build-system = [ setuptools ];
 
@@ -44,8 +34,8 @@ buildPythonPackage rec {
   meta = {
     description = "Python API for Netgear LTE modems";
     homepage = "https://github.com/amelchio/eternalegypt";
-    changelog = "https://github.com/amelchio/eternalegypt/releases/tag/v${version}";
-    license = with lib.licenses; [ mit ];
+    changelog = "https://github.com/amelchio/eternalegypt/releases/tag/${src.tag}";
+    license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
   };
 }


### PR DESCRIPTION
Changelog: https://github.com/amelchio/eternalegypt/releases/tag/v0.0.18


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
