### PR TITLE
kodiPackages.pvr-hts: fix GCC15 compat

### DIFF
--- a/pkgs/applications/video/kodi/addons/pvr-hts/default.nix
+++ b/pkgs/applications/video/kodi/addons/pvr-hts/default.nix
@@ -3,6 +3,7 @@
   rel,
   buildKodiBinaryAddon,
   fetchFromGitHub,
+  fetchpatch2,
 }:
 buildKodiBinaryAddon rec {
   pname = "pvr-hts";
@@ -15,6 +16,14 @@ buildKodiBinaryAddon rec {
     rev = "${version}-${rel}";
     sha256 = "sha256-opxNgin+Sz/Nb9IGZ+OFrCzbDc4FXl2LaNKUu5LAgFM=";
   };
+
+  patches = [
+    # fix gcc-15 compat. See https://github.com/kodi-pvr/pvr.hts/pull/693
+    (fetchpatch2 {
+      url = "https://github.com/kodi-pvr/pvr.hts/commit/b8fb7f6cbe9e3e9ea2737dc465a70fb4bb0951eb.patch?full_index=1";
+      hash = "sha256-GgdEQUwwebQVjsEJAX9V7NRe954HCNMggNUcik8j+lU=";
+    })
+  ];
 
   meta = {
     homepage = "https://github.com/kodi-pvr/pvr.hts";


### PR DESCRIPTION
Fixes compatibility with GCC15. 

Related: #475479

Ping: @NixOS/kodi 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
