### PR TITLE
libretro: fix build of some corese with GCC 15

### DIFF
--- a/pkgs/applications/emulators/libretro/cores/citra.nix
+++ b/pkgs/applications/emulators/libretro/cores/citra.nix
@@ -19,6 +19,11 @@ mkLibretroCore {
     fetchSubmodules = true;
   };
 
+  patches = [
+    # Fix build with GCC 15. See https://github.com/KhronosGroup/glslang/pull/3684.
+    ./patches/citra-gcc-15.patch
+  ];
+
   makefile = "Makefile";
 
   extraBuildInputs = [

--- a/pkgs/applications/emulators/libretro/cores/mupen64plus.nix
+++ b/pkgs/applications/emulators/libretro/cores/mupen64plus.nix
@@ -39,6 +39,8 @@ mkLibretroCore {
       url = "https://github.com/libretro/mupen64plus-libretro-nx/commit/3c3e7fbc70b8f533c09c964cf468ba5e8d61351c.patch?full_index=1";
       hash = "sha256-PCJLNYhhccnWLcnPaHL6tz+5qdjogJRYfzZIh3r+Vlk=";
     })
+    # Fix for GCC 15. See https://github.com/libretro/GLideN64/pull/1.
+    ./patches/mupen64plus-gcc-15.patch
   ];
 
   extraNativeBuildInputs = [

--- a/pkgs/applications/emulators/libretro/cores/patches/citra-gcc-15.patch
+++ b/pkgs/applications/emulators/libretro/cores/patches/citra-gcc-15.patch
@@ -1,0 +1,13 @@
+Submodule externals/glslang contains modified content
+diff --git a/externals/glslang/SPIRV/SpvBuilder.h b/externals/glslang/SPIRV/SpvBuilder.h
+index 02e9cf40..40efd59c 100644
+--- a/externals/glslang/SPIRV/SpvBuilder.h
++++ b/externals/glslang/SPIRV/SpvBuilder.h
+@@ -56,6 +56,7 @@ namespace spv {
+ }
+ 
+ #include <algorithm>
++#include <cstdint>
+ #include <map>
+ #include <memory>
+ #include <set>

--- a/pkgs/applications/emulators/libretro/cores/patches/mupen64plus-gcc-15.patch
+++ b/pkgs/applications/emulators/libretro/cores/patches/mupen64plus-gcc-15.patch
@@ -1,0 +1,13 @@
+diff --git a/GLideN64/src/GLideNHQ/TxHiResLoader.h b/GLideN64/src/GLideNHQ/TxHiResLoader.h
+index 4c13651..f887c78 100644
+--- a/GLideN64/src/GLideNHQ/TxHiResLoader.h
++++ b/GLideN64/src/GLideNHQ/TxHiResLoader.h
+@@ -13,6 +13,8 @@
+ #define CORRECTFILENAME(str)
+ #endif /* OS_WINDOWS */
+ 
++#include <cstdint>
++
+ #include "TxCache.h"
+ #include "TxQuantize.h"
+ #include "TxImage.h"


### PR DESCRIPTION
This merge request fixes some build errors in libretro cores caused by the recent update to GCC 15.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
