### PR TITLE
haskellPackages.reanimate: unbreak

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -843,6 +843,13 @@
     githubId = 209175;
     name = "Alesya Huzik";
   };
+  Ai-Ya-Ya = {
+    email = "spg2500@gmail.com";
+    github = "Ai-Ya-Ya";
+    githubId = 72513839;
+    matrix = "aiya:catgirl.cloud";
+    name = "aiya";
+  };
   aij = {
     email = "aij+git@mrph.org";
     github = "aij";

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2519,10 +2519,6 @@ with haskellLib;
     doJailbreak
   ];
 
-  # Test suite doesn't support hspec 2.8
-  # https://github.com/zellige/hs-geojson/issues/29
-  geojson = dontCheck super.geojson;
-
   # Test data missing from sdist
   # https://github.com/ngless-toolkit/ngless/issues/152
   NGLess = dontCheck super.NGLess;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2519,6 +2519,53 @@ with haskellLib;
     doJailbreak
   ];
 
+  # 2026-01-06: unbreak and modernize to GHC 9.10.3
+  reanimate-svg = overrideCabal (drv: {
+    # patching doesn't actually move files, need to do manually
+    prePatch = ''
+      # Move tests marked good due to previous librsvg failures
+      for f in \
+      animate-elem-32-t.svg \
+      fonts-desc-02-t.svg \
+      shapes-ellipse-02-t.svg \
+      shapes-intro-01-t.svg \
+      styling-css-06-b.svg \
+      text-intro-05-t.svg \
+      ; do
+      mv test/good/$f test/bad/$f
+      done
+
+      # Move tests previously marked bad but now fixed from new changes
+      for f in \
+      filters-displace-02-f.svg \
+      filters-gauss-01-b.svg \
+      masking-mask-01-b.svg \
+      painting-render-01-b.svg \
+      pservers-grad-04-b.svg \
+      pservers-grad-05-b.svg \
+      pservers-grad-07-b.svg \
+      pservers-grad-08-b.svg \
+      pservers-grad-09-b.svg \
+      pservers-grad-10-b.svg \
+      pservers-grad-11-b.svg \
+      pservers-grad-12-b.svg \
+      pservers-grad-14-b.svg \
+      pservers-grad-15-b.svg \
+      pservers-grad-16-b.svg \
+      pservers-grad-22-b.svg \
+      ; do
+      mv test/bad/$f test/good/$f
+      done
+    '';
+    patches = (drv.patches or [ ]) ++ [
+      (pkgs.fetchpatch2 {
+        name = "modernize-to-ghc-9.10.3-and-regress-tests-wrt-librsvg";
+        url = "https://github.com/reanimate/reanimate-svg/commit/3f2fab8eb08b7f35b03f5fa17819e43e3879ea80.patch";
+        sha256 = "sha256-Em10QyAAiIwHId3CZuByKJ4Fv9W6MII4go5rychg07Y=";
+      })
+    ];
+  }) super.reanimate-svg;
+
   # Test data missing from sdist
   # https://github.com/ngless-toolkit/ngless/issues/152
   NGLess = dontCheck super.NGLess;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2566,6 +2566,24 @@ with haskellLib;
     ];
   }) super.reanimate-svg;
 
+  # 2026-01-06: modernize to GHC 9.10.3
+  reanimate = overrideCabal (drv: {
+    # file in Hackage but not on github, need to remove here
+    # test relies on hegometry but that was removed as a dependency
+    # https://github.com/reanimate/reanimate/commit/f58a00e
+    prePatch = drv.prePatch or "" + ''
+      rm -f examples/decompose.hs
+    '';
+    patches = (drv.patches or [ ]) ++ [
+      # variant of PR https://github.com/reanimate/reanimate/pull/317
+      (pkgs.fetchpatch2 {
+        name = "modernize-to-ghc-9.10.3";
+        url = "https://github.com/reanimate/reanimate/commit/273f48c2b82dcfa027481133a6a606e73a22461b.patch";
+        sha256 = "sha256-aibbIoc54I4Ibg6t2o8vykL8MqzmxLvayUNa8MiibEw=";
+      })
+    ];
+  }) super.reanimate;
+
   # Test data missing from sdist
   # https://github.com/ngless-toolkit/ngless/issues/152
   NGLess = dontCheck super.NGLess;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2519,6 +2519,10 @@ with haskellLib;
     doJailbreak
   ];
 
+  # too strict bounds on extra < 1.8
+  # https://github.com/georgefst/svgone/pull/3
+  svgone = doJailbreak super.svgone;
+
   # 2026-01-06: unbreak and modernize to GHC 9.10.3
   reanimate-svg = overrideCabal (drv: {
     # patching doesn't actually move files, need to do manually

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -5274,7 +5274,6 @@ broken-packages:
   - readme-lhs # failure in job https://hydra.nixos.org/build/233248229 at 2023-09-02
   - readshp # failure in job https://hydra.nixos.org/build/233197835 at 2023-09-02
   - really-simple-xml-parser # failure in job https://hydra.nixos.org/build/233195945 at 2023-09-02
-  - reanimate-svg # failure in job https://hydra.nixos.org/build/233242271 at 2023-09-02
   - reason-export # failure in job https://hydra.nixos.org/build/233212942 at 2023-09-02
   - reasonable-lens # failure in job https://hydra.nixos.org/build/233233111 at 2023-09-02
   - rebound # failure in job https://hydra.nixos.org/build/311055152 at 2025-11-02

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -127,6 +127,9 @@ extra-packages:
 
 # keep-sorted start skip_lines=1 case=no
 package-maintainers:
+  Ai-Ya-Ya:
+    - reanimate
+    - reanimate-svg
   alexfmpe:
     - basic-sop
     - commutative-semigroups

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
@@ -2874,7 +2874,6 @@ dont-distribute-packages:
  - reactor
  - readline-in-other-words
  - readpyc
- - reanimate
  - record-aeson
  - record-gl
  - record-preprocessor
@@ -3383,7 +3382,6 @@ dont-distribute-packages:
  - sv-svfactor
  - SVG2Q
  - svg2q
- - svgone
  - swapper
  - switch
  - syb-with-class-instances-text

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -932,6 +932,15 @@ builtins.intersectAttrs super {
   # https://github.com/plow-technologies/servant-streaming/issues/12
   servant-streaming-server = dontCheck super.servant-streaming-server;
 
+  reanimate = overrideCabal (drv: {
+    buildTools = (drv.buildTools or [ ]) ++ [
+      # needed for testsuite
+      pkgs.ffmpeg
+      pkgs.librsvg
+      pkgs.texliveFull
+    ];
+  }) super.reanimate;
+
   reanimate-svg = overrideCabal (drv: {
     buildTools = (drv.buildTools or [ ]) ++ [
       # needed for testsuite

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -932,6 +932,15 @@ builtins.intersectAttrs super {
   # https://github.com/plow-technologies/servant-streaming/issues/12
   servant-streaming-server = dontCheck super.servant-streaming-server;
 
+  reanimate-svg = overrideCabal (drv: {
+    buildTools = (drv.buildTools or [ ]) ++ [
+      # needed for testsuite
+      pkgs.freefont_ttf
+      pkgs.librsvg
+      pkgs.pango
+    ];
+  }) super.reanimate-svg;
+
   # https://github.com/haskell-servant/servant/pull/1238
   servant-client-core =
     if (pkgs.lib.getVersion super.servant-client-core) == "0.16" then


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Reanimate stopped being actively maintained around GHC 9.2-4, so I needed to update some dependencies. I also needed to change the test suite to support Nix builds. 

### reanimate-svg

[Relevant PR](https://github.com/reanimate/reanimate-svg/pull/48). I also added a few tools needed for the testsuite to run on Nix as [discussed in an old PR](https://github.com/NixOS/nixpkgs/pull/178511) and [old issue](https://github.com/NixOS/nixpkgs/issues/153078): 

- `librsvg` is needed to render SVG -> PNG
- `pango` is needed for font support
- `freefonts_ttf` is needed to bold font, otherwise you get tests that work in an impure build but fail in Nix (see [upstream issue #33](https://github.com/reanimate/reanimate-svg/issues/33))

(There is a difference in the number of testfiles moved between `bad` and `good` between that PR and my patch. This is due to the fact that Nix pulls from Hackage, which is a few commits behind the Git repo.)

### geojson

Jailbroke; as discussed in my [previous PR](https://github.com/NixOS/nixpkgs/pull/472728) the relevant bounds have already been bumped upstream. Also, the testsuite works now (fixed upstream years ago), so I re-enabled tests. 

### svgone

Jailbroke: [relevant PR](https://github.com/georgefst/svgone/pull/3).

### reanimate

[Relevant PR](https://github.com/reanimate/reanimate/pull/317). I also added a few tools needed for the testsuite to run on Nix: `ffmpeg`, `texliveFull`, `librsvg` are needed for the rendering tests to compile. 

(There is a difference in the patch between that PR and my patch. This is due to the fact that Nix pulls from Hackage, which is a few commits behind the Git repo. For instane, `decompose.hs` is still in Hackage, eventhough it was removed later upstream.)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux (wsl2)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable: (not applicable)
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage]. 
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [X] Package update: when the change is major or breaking. (Maybe? A few deprecations)
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant. 
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

Output of `nixpkgs-review`: 

```
================================================================================
PR #475922: haskellPackages.reanimate: minimal patches to unbreak and work with latest GHC versions (directly affects: haskellPackages.reanimate-svg, haskellPackages.geojson; indirectly affects: a lot)
================================================================================
Author: Ai-Ya-Ya
Branch: Ai-Ya-Ya:haskell-updates -> NixOS:haskell-updates
State: open

Description:
----------------------------------------
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Reanimate stopped being actively maintained around GHC 9.2-4, so I needed to update some dependencies. I also needed to change the test suite to support Nix builds.

### reanimate-svg

[Relevant PR](https://github.com/reanimate/reanimate-svg/pull/48). I also added a few tools needed for the testsuite to run on Nix as [discussed in an old PR](https://github.com/NixOS/nixpkgs/pull/178511):

- `librsvg` is needed to render SVG -> PNG
- `pango` is needed for font support
- `freefonts_ttf` is needed to bold font, otherwise you get tests that work in an impure build but fail in Nix

(There is a difference in the number of testfiles moved between

... (truncated)
----------------------------------------

Files changed (4 files):
  - pkgs/development/haskell-modules/configuration-common.nix
  - pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
  - pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
  - pkgs/development/haskell-modules/hackage-packages.nix
================================================================================

-> Fetching eval results from GitHub actions
...Results are not (yet) available. Retrying in 10s
..
...........

-> Successfully fetched rebuilds: no local evaluation needed
$ git -c fetch.prune=false fetch --no-tags --force https://github.com/NixOS/nixpkgs 850a177157c20f5265a1b9ee4e0ffac8f2dc599f:refs/nixpkgs-review/0
$ git worktree add /home/<username>/.cache/nixpkgs-review/pr-475922-3/nixpkgs 850a177157c20f5265a1b9ee4e0ffac8f2dc599f
Preparing worktree (detached HEAD 850a177157c2)
Updating files: 100% (50480/50480), done.
HEAD is now at 850a177157c2 Merge 516d32c34d4efed82da25c2931a594febf414d14 into c4b96d2eea00ab4a1c3867545dea2967fa125c1f
warning: ignoring the client-specified setting 'system', because it is a restricted setting and you are not a trusted user

$ nix build --file /nix/store/ihslwbxj0y8jv0730zn2qna5vjn90pl3-nixpkgs-review-3.5.1/lib/python3.13/site-packages/nixpkgs_review/nix/review-shell.nix --nix-path 'nixpkgs=/home/<username>/.cache/nixpkgs-review/pr-475922-3/nixpkgs nixpkgs-overlays=/tmp/nix-shell-441771-3028748513/tmpz7mneyih' --extra-experimental-features 'nix-command no-url-literals' --no-link --keep-going --no-allow-import-from-derivation --option build-use-sandbox relaxed --argstr local-system x86_64-linux --argstr nixpkgs-path /home/<username>/.cache/nixpkgs-review/pr-475922-3/nixpkgs --argstr nixpkgs-config-path /tmp/nix-shell-441771-3028748513/tmp6o16e92_.nix --argstr attrs-path /home/<username>/.cache/nixpkgs-review/pr-475922-3/attrs.nix
warning: ignoring the client-specified setting 'sandbox', because it is a restricted setting and you are not a trusted user
warning: download buffer is full; consider increasing the 'download-buffer-size' setting
error: Cannot build '/nix/store/a47clbapci0iy1l224qdwan2naq9fnry-svgone-0.2.0.2.drv'.
       Reason: builder failed with exit code 1.
       Output paths:
         /nix/store/l3kwg1zk4bq7l3h94jh9nbqfjk0zwg20-svgone-0.2.0.2
         /nix/store/w1l4hj2jg0fm2fydms5cfzwpyhjif15v-svgone-0.2.0.2-doc
       Last 22 log lines:
       > Running phase: setupCompilerEnvironmentPhase
       > Build with /nix/store/7cbxkjrzh1kfj8mlqc561jz4n86rc6wk-ghc-9.10.3.
       > Running phase: unpackPhase
       > unpacking source archive /nix/store/niry0388g8gzjmpj52v83cf52wm0mcdl-svgone-0.2.0.2.tar.gz
       > source root is svgone-0.2.0.2
       > setting SOURCE_DATE_EPOCH to timestamp 1000000000 of file "svgone-0.2.0.2/svgone.cabal"
       > Running phase: patchPhase
       > Running phase: compileBuildDriverPhase
       > setupCompileFlags: -package-db=/build/tmp.zPfAtXr5Lh/setup-package.conf.d -threaded
       > [1 of 2] Compiling Main             ( /nix/store/4mdp8nhyfddh7bllbi7xszz7k9955n79-Setup.hs, /build/tmp.zPfAtXr5Lh/Main.o )
       > [2 of 2] Linking Setup
       > Running phase: updateAutotoolsGnuConfigScriptsPhase
       > Running phase: configurePhase
       > configureFlags: --verbose --prefix=/nix/store/l3kwg1zk4bq7l3h94jh9nbqfjk0zwg20-svgone-0.2.0.2 --libdir=$prefix/lib/$compiler/lib --libsubdir=$abi/$libname --docdir=/nix/store/w1l4hj2jg0fm2fydms5cfzwpyhjif15v-svgone-0.2.0.2-doc/share/doc/svgone-0.2.0.2 --with-gcc=gcc --package-db=/build/tmp.zPfAtXr5Lh/package.conf.d --ghc-option=-j8 --ghc-option=+RTS --ghc-option=-A64M --ghc-option=-RTS --enable-library-profiling --profiling-detail=exported-functions --disable-profiling --enable-shared --disable-coverage --enable-static --disable-executable-dynamic --enable-tests --disable-benchmarks --enable-library-vanilla --disable-library-for-ghci --enable-split-sections --enable-library-stripping --enable-executable-stripping --ghc-option=-haddock --extra-lib-dirs=/nix/store/ddranxbikfg4jkf3n1m0a0h9qqxj1vf0-ncurses-6.5/lib --extra-lib-dirs=/nix/store/1z031fwbsc8jhmm7i39r6z6m1xn7rbza-libffi-3.5.2/lib --extra-lib-dirs=/nix/store/vkq85nkpjwxfykbq9j9q3llm3ik1qy0c-elfutils-0.194/lib --extra-lib-dirs=/nix/store/2qzc0x9nm5nwq83svddaybwx806pnlws-gmp-with-cxx-6.3.0/lib --extra-lib-dirs=/nix/store/jm5r6v1x2vyvk2asbkbz5p5clr471h7l-numactl-2.0.18/lib --extra-include-dirs=/nix/store/q0jm93vapxiajdznrzglnqvzlpz77vmp-double-conversion-3.3.1-dev/include --extra-lib-dirs=/nix/store/q0jm93vapxiajdznrzglnqvzlpz77vmp-double-conversion-3.3.1-dev/lib --extra-lib-dirs=/nix/store/j5v73qrv4azjr1b9spp8pz9x6v4rvag1-double-conversion-3.3.1/lib
       > Using Parsec parser
       > Configuring svgone-0.2.0.2...
       > Error: [Cabal-8010]
       > Encountered missing or private dependencies:
       >     extra >=1.7.9 && <1.8
       > CallStack (from HasCallStack):
       >   dieWithException, called at libraries/Cabal/Cabal/src/Distribution/Simple/Configure.hs:1457:11 in Cabal-3.12.1.0-56b9:Distribution.Simple.Configure
       >
       For full logs, run:
         nix log /nix/store/a47clbapci0iy1l224qdwan2naq9fnry-svgone-0.2.0.2.drv
error: Cannot build '/nix/store/736mcwna12hbklqjn104m08i45vw77s5-review-shell.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/7jaiiw3mrl3n7z3p6a6k608qzdwpa7hg-review-shell

Link to currently reviewing PR:
https://github.com/NixOS/nixpkgs/pull/475922
--------- Report for 'x86_64-linux' ---------
2 packages failed to build:
haskellPackages.svgone haskellPackages.svgone.doc

8 packages built:
haskell.package-list haskellPackages.geojson haskellPackages.geojson.doc haskellPackages.reanimate haskellPackages.reanimate-svg haskellPackages.reanimate-svg.doc haskellPackages.reanimate.data haskellPackages.reanimate.doc

Logs can be found under:
/home/<username>/.cache/nixpkgs-review/pr-475922-3/logs


$ /nix/store/n5s95aq6my065mxv8nywdp24afqmk48q-nix-2.31.2/bin/nix-shell --argstr local-system x86_64-linux --argstr nixpkgs-path /home/<username>/.cache/nixpkgs-review/pr-475922-3/nixpkgs --argstr nixpkgs-config-path /tmp/nix-shell-441771-3028748513/tmp6o16e92_.nix --argstr attrs-path /home/<username>/.cache/nixpkgs-review/pr-475922-3/attrs.nix --nix-path 'nixpkgs=/home/<username>/.cache/nixpkgs-review/pr-475922-3/nixpkgs nixpkgs-overlays=/tmp/nix-shell-441771-3028748513/tmpz7mneyih' /nix/store/ihslwbxj0y8jv0730zn2qna5vjn90pl3-nixpkgs-review-3.5.1/lib/python3.13/site-packages/nixpkgs_review/nix/review-shell.nix
Welcome to fish, the friendly interactive shell
Type help for instructions on how to use fish
```

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
