### PR TITLE
zeroc-ice: fix build failure of forked mcpp

### DIFF
--- a/pkgs/by-name/ze/zeroc-ice/fix-mb_init.patch
+++ b/pkgs/by-name/ze/zeroc-ice/fix-mb_init.patch
@@ -1,0 +1,34 @@
+From faa694a7171a06f83034fd869adc4cffa2ae0c18 Mon Sep 17 00:00:00 2001
+From: laurensmiers <laurensmiers@protonmail.com>
+Date: Wed, 22 Oct 2025 14:50:23 +0200
+Subject: [PATCH] fix: mb_init does not accept any parameter
+
+Defined in mbchar.c:114 :
+```c
+void    mb_init()
+/*
+ * Initialize multi-byte character settings.
+ * First called prior to setting the 'mcpp_mode'.
+ * Will be called again each time the multibyte character encoding is changed.
+ */
+{
+```
+
+It does not expect any parameters.
+---
+ mcpp_main.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/mcpp_main.c b/mcpp_main.c
+index 54a62b2..44265ad 100644
+--- a/mcpp_main.c
++++ b/mcpp_main.c
+@@ -302,7 +302,7 @@ int     mcpp_lib_main
+     inc_dirp = &null;   /* Initialize to current (null) directory   */
+     cur_fname = cur_fullname = "(predefined)";  /* For predefined macros    */
+     init_defines();                         /* Predefine macros     */
+-    mb_init(TRUE);      /* Should be initialized prior to get options   */
++    mb_init();      /* Should be initialized prior to get options   */
+     do_options( argc, argv, &in_file, &out_file);   /* Command line options */
+ 
+     /* Open input file, "-" means stdin.    */

--- a/pkgs/by-name/ze/zeroc-ice/fix-reserved-keywords.patch
+++ b/pkgs/by-name/ze/zeroc-ice/fix-reserved-keywords.patch
@@ -1,0 +1,55 @@
+From bd5ddbde9e4ed24101cdc86007f26e95f38dd5b1 Mon Sep 17 00:00:00 2001
+From: laurensmiers <laurensmiers@protonmail.com>
+Date: Wed, 22 Oct 2025 14:52:30 +0200
+Subject: [PATCH] fix: don't use reserved keyword for goto statement
+
+Rename:
+- 'true' to 'exit_success'
+- 'false' to 'exit_fail'
+
+Chose not to change the flow of the code by removing the goto's to
+avoid regressions.
+---
+ system.c | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/system.c b/system.c
+index 646caf6..0a15aec 100644
+--- a/system.c
++++ b/system.c
+@@ -1738,7 +1738,7 @@ static int  open_file(
+     if (! fullname)                 /* Non-existent or directory    */
+         return  FALSE;
+     if (included( fullname))        /* Once included    */
+-        goto  true;
++        goto  exit_success;
+ 
+     if ((max_open != 0 && max_open <= include_nest)
+                             /* Exceed the known limit of open files */
+@@ -1765,12 +1765,12 @@ static int  open_file(
+         if ((fp = mcpp_fopen( fullname, "r")) == NULL) {
+             file->fp = mcpp_fopen( cur_fullname, "r");
+             fseek( file->fp, file->pos, SEEK_SET);
+-            goto  false;
++            goto  exit_fail;
+         }
+         if (max_open == 0)      /* Remember the limit of the system */
+             max_open = include_nest;
+     } else if (fp == NULL)                  /* No read permission   */
+-        goto  false;
++        goto  exit_fail;
+     /* Truncate buffer of the includer to save memory   */
+     len = (int) (file->bptr - file->buffer);
+     if (len) {
+@@ -1802,9 +1802,9 @@ static int  open_file(
+     if (mkdep && ((mkdep & MD_SYSHEADER) || ! infile->sys_header))
+         put_depend( fullname);          /* Output dependency line   */
+ 
+-true:
++exit_success:
+     return  TRUE;
+-false:
++exit_fail:
+     free( fullname);
+     return  FALSE;
+ }

--- a/pkgs/by-name/ze/zeroc-ice/package.nix
+++ b/pkgs/by-name/ze/zeroc-ice/package.nix
@@ -6,6 +6,7 @@
   expat,
   libedit,
   lmdb,
+  mcpp,
   openssl,
   libxcrypt,
   python3, # for tests only
@@ -13,21 +14,26 @@
 }:
 
 let
-  zeroc_mcpp = stdenv.mkDerivation rec {
-    pname = "zeroc-mcpp";
-    version = "2.7.2.14";
+  mcpp' = mcpp.overrideAttrs (prevAttrs: rec {
+    pname = "mcpp-zeroc-ice";
+    version = "2.7.3";
 
     src = fetchFromGitHub {
       owner = "zeroc-ice";
       repo = "mcpp";
       rev = "v${version}";
-      sha256 = "1psryc2ql1cp91xd3f8jz84mdaqvwzkdq2pr96nwn03ds4cd88wh";
+      hash = "sha256-hZGU5mqMRTTHV2bR9uzM6ALj1sypjPxO5Ajg8aKzLxc=";
     };
 
-    configureFlags = [ "--enable-mcpplib" ];
-    installFlags = [ "PREFIX=$(out)" ];
-  };
+    # zeroc-ice's fork diverges quite a bit from upstream mcpp, so prevAttrs.patches is not used here
+    patches = [
+      # See https://github.com/zeroc-ice/mcpp/pull/12
+      ./fix-mb_init.patch
+      ./fix-reserved-keywords.patch
+    ];
 
+    installFlags = prevAttrs.installFlags or [ ] ++ [ "PREFIX=$(out)" ];
+  });
 in
 stdenv.mkDerivation rec {
   pname = "zeroc-ice";
@@ -41,7 +47,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [
-    zeroc_mcpp
+    mcpp'
     bzip2
     expat
     libedit


### PR DESCRIPTION
Bumps to the latest tag of https://github.com/zeroc-ice/mcpp and applies some pending patches, to fix build against GCC 15 from https://github.com/zeroc-ice/mcpp/pull/12.

Additionally, I used an override of mcpp instead of creating an inline derivation here, to make the code closer to what other packages are doing with forks like this.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
