### PR TITLE
sparrow: some buttons not working because JavaFX version

### DIFF
--- a/pkgs/by-name/sp/sparrow/package.nix
+++ b/pkgs/by-name/sp/sparrow/package.nix
@@ -25,7 +25,7 @@
 
 let
   pname = "sparrow";
-  version = "2.2.3";
+  version = "2.4.0";
 
   openjdk = zulu25.override { enableJavaFX = true; };
 
@@ -41,8 +41,8 @@ let
     url = "https://github.com/sparrowwallet/${pname}/releases/download/${version}/sparrowwallet-${version}-${sparrowArch}.tar.gz";
     hash =
       {
-        x86_64-linux = "sha256-MsERgfJGpxRkQm4Ww30Tc95kThjlgI+nO4bq2zNGdeU=";
-        aarch64-linux = "sha256-31x4Ck/+Fa6CvBb6o9ncVH99Zeh0DUVv/hqVN31ysHk=";
+        x86_64-linux = "sha256-9rkyTEi+KvFDvMCSNkedxX9lYZPZvGwCClLz87DXrKc=";
+        aarch64-linux = "sha256-TvVJQVSkroZfl3VH5hxHpbMw5SZMN1rqROSDKhVV2x4=";
       }
       ."${stdenvNoCC.hostPlatform.system}";
 
@@ -73,12 +73,12 @@ let
 
   manifest = fetchurl {
     url = "https://github.com/sparrowwallet/${pname}/releases/download/${version}/${pname}-${version}-manifest.txt";
-    hash = "sha256-qPIllqFqe84BSIcYYYa+rKJvSpN/QnomHnsOoTxlyl4=";
+    hash = "sha256-hPgRK1pMnhpAOWFO+bySXgE7I1rJf1MVrA5FdIkSgu4=";
   };
 
   manifestSignature = fetchurl {
     url = "https://github.com/sparrowwallet/${pname}/releases/download/${version}/${pname}-${version}-manifest.txt.asc";
-    hash = "sha256-PpruG9l7MhI30b6dd96KAkkQvyMNuh36GtmEdYaRgac=";
+    hash = "sha256-suHr5oM0QVVGQnv8zqFBAuHCUs3Ss1O9U3wx9Exmy7U=";
   };
 
   publicKey = ./publickey.asc;
@@ -177,6 +177,8 @@ let
       # Delete unneeded native libs.
 
       rm -fR com.sparrowwallet.merged.module/com/sun/jna/freebsd-x86-64
+      rm -fR com.sparrowwallet.merged.module/com/sun/jna/dragonflybsd-x86-64
+      rm -fR com.sparrowwallet.merged.module/com/sun/jna/freebsd-aarch64
       rm -fR com.sparrowwallet.merged.module/com/sun/jna/freebsd-x86
       rm -fR com.sparrowwallet.merged.module/com/sun/jna/linux-arm
       rm -fR com.sparrowwallet.merged.module/com/sun/jna/linux-armel


### PR DESCRIPTION

This fixes the issue from https://github.com/sparrowwallet/sparrow/issues/1895 by updating the version and ignoring some new unneeded libraries for dragonflybsd-x86-64 and freebsd-aarch64. This isn’t just a version "bump", because this "bug" made some of the features of the app unavailable (e.g., you couldn't create a wallet because the pane of JavaFX couldn't be created) and this resolves that.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
