### PR TITLE
weblate: run pytest unit tests

### DIFF
--- a/nixos/modules/services/web-apps/weblate.nix
+++ b/nixos/modules/services/web-apps/weblate.nix
@@ -130,8 +130,12 @@ let
     inherit (finalPackage) GI_TYPELIB_PATH;
   };
 
+  # Packages needed at runtime
   weblatePath = with pkgs; [
     gitSVN
+    subversion
+    gettext
+    fontconfig
     borgbackup
 
     #optional
@@ -141,6 +145,7 @@ let
     mercurial
     openssh
   ];
+
 in
 {
 

--- a/pkgs/development/python-modules/aliyun-python-sdk-alimt/default.nix
+++ b/pkgs/development/python-modules/aliyun-python-sdk-alimt/default.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  aliyun-python-sdk-core,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "aliyun-python-sdk-alimt";
+  version = "3.2.0";
+  format = "pyproject";
+
+  # Upstream doesn't tag releases on Github
+  # https://github.com/aliyun/aliyun-openapi-python-sdk/issues/551
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-oz8PNY/j6xE7pY91F8O5ed2j02q8tFl1A/u9Q5fYbuA=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [ aliyun-python-sdk-core ];
+
+  # All components are stored in a mono repo
+  doCheck = false;
+
+  pythonImportsCheck = [ "aliyunsdkalimt" ];
+
+  meta = {
+    description = "ALIMT module of Aliyun Python SDK";
+    homepage = "https://github.com/aliyun/aliyun-openapi-python-sdk";
+    changelog = "https://github.com/aliyun/aliyun-openapi-python-sdk/blob/master/aliyun-python-sdk-sts/ChangeLog.txt";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ erictapen ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -640,6 +640,8 @@ self: super: with self; {
 
   alive-progress = callPackage ../development/python-modules/alive-progress { };
 
+  aliyun-python-sdk-alimt = callPackage ../development/python-modules/aliyun-python-sdk-alimt { };
+
   aliyun-python-sdk-cdn = callPackage ../development/python-modules/aliyun-python-sdk-cdn { };
 
   aliyun-python-sdk-config = callPackage ../development/python-modules/aliyun-python-sdk-config { };


### PR DESCRIPTION
Weblate has plenty of unit tests, but they require a running PostgreSQL instance.

~~The new `weblate-pytest` VM test allows to run these tests in reasonable time (35min on my Framework 13 laptop).~~

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
