### PR TITLE
[Backport release-25.11] widelands: 1.2.1 -> 1.3

### DIFF
--- a/pkgs/by-name/wi/widelands/package.nix
+++ b/pkgs/by-name/wi/widelands/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   pkg-config, # needed to find minizip
   SDL2,
   SDL2_image,
@@ -37,6 +38,14 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "sha256-/MEeb0KnefK812w5y238Icd4gW85d/pvZ08xnlVXDdk=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "modern-asio.patch";
+      url = "https://codeberg.org/wl/widelands/pulls/5025.patch";
+      sha256 = "sha256-ip9ZG9u/z7G+yG7xrEvi+DH9vsjRzYWhEe0rEjxHzzY=";
+    })
+  ];
 
   postPatch = ''
     substituteInPlace xdg/org.widelands.Widelands.desktop \

--- a/pkgs/by-name/wi/widelands/package.nix
+++ b/pkgs/by-name/wi/widelands/package.nix
@@ -30,22 +30,14 @@
 
 stdenv.mkDerivation rec {
   pname = "widelands";
-  version = "1.2.1";
+  version = "1.3";
 
   src = fetchFromGitHub {
     owner = "widelands";
     repo = "widelands";
     rev = "v${version}";
-    sha256 = "sha256-/MEeb0KnefK812w5y238Icd4gW85d/pvZ08xnlVXDdk=";
+    sha256 = "sha256-943/pkxiIbhnZQMwMNpeu5KKkS+j58zU6r9i6mZGSMg=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "modern-asio.patch";
-      url = "https://codeberg.org/wl/widelands/pulls/5025.patch";
-      sha256 = "sha256-ip9ZG9u/z7G+yG7xrEvi+DH9vsjRzYWhEe0rEjxHzzY=";
-    })
-  ];
 
   postPatch = ''
     substituteInPlace xdg/org.widelands.Widelands.desktop \


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Backport Widelands 1.3 to stable.

https://widelands.org/news/2025/Dec/21/widelands-1-3-released

This merges https://github.com/NixOS/nixpkgs/pull/470832 and https://github.com/NixOS/nixpkgs/pull/473917

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
