### PR TITLE
gnucobol: fix build with GCC 15

### DIFF
--- a/pkgs/by-name/gn/gnucobol/package.nix
+++ b/pkgs/by-name/gn/gnucobol/package.nix
@@ -91,9 +91,23 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace configure --replace-fail '"GNU strip"' 'FAKE GNU strip'
   '';
 
-  # error: call to undeclared function 'xmlCleanupParser'
-  # ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
-  env.CFLAGS = lib.optionalString stdenv.hostPlatform.isDarwin "-Wno-error=implicit-function-declaration";
+  # GCC 15 changed some warnings to errors, particularly around function pointer types
+  # (C23 empty parentheses means no args, not unspecified). These flags are needed
+  # until gnucobol is updated to compile cleanly with GCC 15.
+  # See: https://gcc.gnu.org/gcc-15/porting_to.html
+  env.CFLAGS =
+    let
+      # Clang needs -Wno-error=implicit-function-declaration for xmlCleanupParser
+      clangFlags = "-Wno-error=implicit-function-declaration";
+      # GCC 15+ needs additional flags for incompatible pointer type errors
+      gcc15Flags = "-Wno-error=incompatible-pointer-types -std=gnu11";
+    in
+    if stdenv.cc.isGNU && lib.versionAtLeast stdenv.cc.version "15.0.0" then
+      gcc15Flags
+    else if stdenv.cc.isClang then
+      clangFlags
+    else
+      "";
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
## Summary
Fixes the gnucobol package build with GCC 15 by adding compiler flags to suppress incompatible pointer type errors.

## Problem
GCC 15 changed some warnings to errors, particularly around function pointer types (C23 empty parentheses means no args, not unspecified). The build was failing with errors like:
```
error: initialization of 'void * (*)(void)' from incompatible pointer type 'void * (*)(void *)' [-Wincompatible-pointer-types]
```

## Solution
Add `-Wno-error=incompatible-pointer-types -std=gnu11` to CFLAGS when building with GCC 15+.

## Testing
- Built on platform(s):
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests` (426 programs, 9748 tests passed)
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
```
--------- Report for 'x86_64-linux' ---------
4 packages built:
gnucobol gnucobol.bin gnucobol.dev gnucobol.lib
```
- [x] Tested basic functionality of all binary files (sanity check: "Hello, COBOL!" compiled and ran successfully).
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

## Notes
- The fix is conditional on GCC version to avoid affecting other compilers
- Pre-existing warnings in gnucobol (format-overflow, stringop-overflow) remain but don't block the build
    - **`-Wformat-overflow`**: Related to potential buffer overflow in format string handling (upstream code quality issue)
    - **`-Wstringop-overflow`**: Related to string operation bounds checking (upstream code quality issue)