### PR TITLE
eli: fix build failure on GCC 15

### DIFF
--- a/pkgs/by-name/el/eli/function-declarations.patch
+++ b/pkgs/by-name/el/eli/function-declarations.patch
@@ -1,0 +1,231 @@
+diff --git a/Eli/pkg/Input/Include.fw b/Eli/pkg/Input/Include.fw
+index 7b841d9..17740c4 100644
+--- a/Eli/pkg/Input/Include.fw
++++ b/Eli/pkg/Input/Include.fw
+@@ -58,6 +58,7 @@ extern char *auxEOF();
+ #include "clp_dapto.h"
+ #endif
+ 
++extern void _dapto_source_changed(const char *, int, int, int, int, int);
+ 
+ /* Action to switch to a new input file: */
+ 
+diff --git a/Eli/pkg/burg/burg/be.c b/Eli/pkg/burg/burg/be.c
+index 8540f5b..55b1332 100644
+--- a/Eli/pkg/burg/burg/be.c
++++ b/Eli/pkg/burg/burg/be.c
+@@ -332,7 +332,7 @@ makeLHSmap()
+ 	fprintf(outfile, "};\n\n");
+ }
+ 
+-static int seminal(from, to)
++static int seminal(int from, int to)
+ {
+ 	return allpairs[from][to].rule ? allpairs[from][to].rule->erulenum : 0;
+ 
+diff --git a/Eli/pkg/cola/option/derivedSrcs/clpintf.c b/Eli/pkg/cola/option/derivedSrcs/clpintf.c
+index 77b28ce..ba988eb 100644
+--- a/Eli/pkg/cola/option/derivedSrcs/clpintf.c
++++ b/Eli/pkg/cola/option/derivedSrcs/clpintf.c
+@@ -53,6 +53,7 @@ Suite 330, Boston, MA 02111-1307, USA.  */
+ static CONST char *fileerrmsg;
+ static int fileerrmsgusage;
+ 
++extern void _dapto_source_changed(const char *, int, int, int, int, int);
+ /*
+  * SetFileErr
+  */
+diff --git a/Eli/pkg/cola/trafos/pgs2cmr/derivedSrcs/clpintf.c b/Eli/pkg/cola/trafos/pgs2cmr/derivedSrcs/clpintf.c
+index 77b28ce..ba988eb 100644
+--- a/Eli/pkg/cola/trafos/pgs2cmr/derivedSrcs/clpintf.c
++++ b/Eli/pkg/cola/trafos/pgs2cmr/derivedSrcs/clpintf.c
+@@ -53,6 +53,7 @@ Suite 330, Boston, MA 02111-1307, USA.  */
+ static CONST char *fileerrmsg;
+ static int fileerrmsgusage;
+ 
++extern void _dapto_source_changed(const char *, int, int, int, int, int);
+ /*
+  * SetFileErr
+  */
+diff --git a/Eli/pkg/eli/treebuild.c b/Eli/pkg/eli/treebuild.c
+index 9718bf0..c789a6b 100644
+--- a/Eli/pkg/eli/treebuild.c
++++ b/Eli/pkg/eli/treebuild.c
+@@ -40,6 +40,7 @@ Suite 330, Boston, MA 02111-1307, USA.  */
+ #endif
+ 
+ extern void Zerteiler ELI_ARG((void));
++extern void _dapto_source_changed(const char *, int, int, int, int, int);
+ 
+ void
+ #ifdef PROTO_OK
+diff --git a/Eli/pkg/gla/frontend/clpintf.c b/Eli/pkg/gla/frontend/clpintf.c
+index 77b28ce..ba988eb 100644
+--- a/Eli/pkg/gla/frontend/clpintf.c
++++ b/Eli/pkg/gla/frontend/clpintf.c
+@@ -53,6 +53,7 @@ Suite 330, Boston, MA 02111-1307, USA.  */
+ static CONST char *fileerrmsg;
+ static int fileerrmsgusage;
+ 
++extern void _dapto_source_changed(const char *, int, int, int, int, int);
+ /*
+  * SetFileErr
+  */
+diff --git a/Eli/pkg/info/texinfo/makeinfo.c b/Eli/pkg/info/texinfo/makeinfo.c
+index 9b2923f..d58e371 100644
+--- a/Eli/pkg/info/texinfo/makeinfo.c
++++ b/Eli/pkg/info/texinfo/makeinfo.c
+@@ -4788,7 +4788,7 @@ int px_ref_flag = 0;		/* Controls initial output string. */
+ 
+ /* Make a cross reference. */
+ int
+-cm_xref (arg)
++cm_xref (int arg)
+ {
+   if (arg == START)
+     {
+diff --git a/Eli/pkg/info/texinfo/texindex.c b/Eli/pkg/info/texinfo/texindex.c
+index 7bd6a00..d2003e3 100644
+--- a/Eli/pkg/info/texinfo/texindex.c
++++ b/Eli/pkg/info/texinfo/texindex.c
+@@ -897,6 +897,7 @@ readline (linebuffer, stream)
+ void
+ sort_offline (infile, nfiles, total, outfile)
+      char *infile;
++     int nfiles;
+      long total;
+      char *outfile;
+ {
+diff --git a/Eli/pkg/kwd/derivedSrcs/clpintf.c b/Eli/pkg/kwd/derivedSrcs/clpintf.c
+index 77b28ce..ba988eb 100644
+--- a/Eli/pkg/kwd/derivedSrcs/clpintf.c
++++ b/Eli/pkg/kwd/derivedSrcs/clpintf.c
+@@ -53,6 +53,7 @@ Suite 330, Boston, MA 02111-1307, USA.  */
+ static CONST char *fileerrmsg;
+ static int fileerrmsgusage;
+ 
++extern void _dapto_source_changed(const char *, int, int, int, int, int);
+ /*
+  * SetFileErr
+  */
+diff --git a/Eli/pkg/liga/frontend/derivedSrcs/treebuild.c b/Eli/pkg/liga/frontend/derivedSrcs/treebuild.c
+index 71ac16e..a463673 100644
+--- a/Eli/pkg/liga/frontend/derivedSrcs/treebuild.c
++++ b/Eli/pkg/liga/frontend/derivedSrcs/treebuild.c
+@@ -40,6 +40,7 @@ Suite 330, Boston, MA 02111-1307, USA.  */
+ #endif
+ 
+ extern void Zerteiler ELI_ARG((void));
++extern void _dapto_source_changed(const char *, int, int, int, int, int);
+ 
+ void
+ #ifdef PROTO_OK
+diff --git a/Eli/pkg/liga/idl/lookup_idl.c b/Eli/pkg/liga/idl/lookup_idl.c
+index 839bc7f..9350b8e 100644
+--- a/Eli/pkg/liga/idl/lookup_idl.c
++++ b/Eli/pkg/liga/idl/lookup_idl.c
+@@ -161,7 +161,7 @@ void free_did_table()
+ *****************************************/
+ 
+ Def 
+-lookup_def(did)
++lookup_def(int did)
+ {
+ 
+    /* returns a pointer to the definition with id did */
+@@ -175,7 +175,7 @@ lookup_def(did)
+ *****************************************/
+ 
+ Attrdef 
+-lookup_attrdef(did)
++lookup_attrdef(int did)
+ {
+ 
+    /* returns a pointer to the attributedefinition with id did */
+diff --git a/Eli/pkg/liga/ligaProd/derivedSrcs/treebuild.c b/Eli/pkg/liga/ligaProd/derivedSrcs/treebuild.c
+index 9718bf0..c789a6b 100644
+--- a/Eli/pkg/liga/ligaProd/derivedSrcs/treebuild.c
++++ b/Eli/pkg/liga/ligaProd/derivedSrcs/treebuild.c
+@@ -40,6 +40,7 @@ Suite 330, Boston, MA 02111-1307, USA.  */
+ #endif
+ 
+ extern void Zerteiler ELI_ARG((void));
++extern void _dapto_source_changed(const char *, int, int, int, int, int);
+ 
+ void
+ #ifdef PROTO_OK
+diff --git a/Eli/pkg/liga/middle/order/initdp.c b/Eli/pkg/liga/middle/order/initdp.c
+index 38358eb..0cfd822 100644
+--- a/Eli/pkg/liga/middle/order/initdp.c
++++ b/Eli/pkg/liga/middle/order/initdp.c
+@@ -313,7 +313,7 @@ char * pr_graphstate_text(graph_state)
+ ************************************************************************/
+ static
+ void enter_dp_matrix (seqexpr, pid, tosymptr, toaid)
+-	SEQExpr seqexpr; SLNODE *tosymptr; int toaid;
++	SEQExpr seqexpr; int pid; SLNODE *tosymptr; int toaid;
+ /*
+ on entry:	pid is the current rule,
+ 		row is the graph row of the target attribute,
+diff --git a/Eli/pkg/liga/option/derivedSrcs/treebuild.c b/Eli/pkg/liga/option/derivedSrcs/treebuild.c
+index 512803e..f64bddf 100644
+--- a/Eli/pkg/liga/option/derivedSrcs/treebuild.c
++++ b/Eli/pkg/liga/option/derivedSrcs/treebuild.c
+@@ -40,6 +40,7 @@ Suite 330, Boston, MA 02111-1307, USA.  */
+ #endif
+ 
+ extern void Zerteiler ELI_ARG((void));
++extern void _dapto_source_changed(const char *, int, int, int, int, int);
+ 
+ void
+ #ifdef PROTO_OK
+diff --git a/Eli/pkg/maptool/complete/clpintf.c b/Eli/pkg/maptool/complete/clpintf.c
+index 77b28ce..1e83aea 100644
+--- a/Eli/pkg/maptool/complete/clpintf.c
++++ b/Eli/pkg/maptool/complete/clpintf.c
+@@ -53,6 +53,8 @@ Suite 330, Boston, MA 02111-1307, USA.  */
+ static CONST char *fileerrmsg;
+ static int fileerrmsgusage;
+ 
++extern void _dapto_source_changed(const char *, int, int, int, int, int);
++
+ /*
+  * SetFileErr
+  */
+diff --git a/Eli/pkg/maptool/ebnf/clpintf.c b/Eli/pkg/maptool/ebnf/clpintf.c
+index 77b28ce..ba988eb 100644
+--- a/Eli/pkg/maptool/ebnf/clpintf.c
++++ b/Eli/pkg/maptool/ebnf/clpintf.c
+@@ -53,6 +53,7 @@ Suite 330, Boston, MA 02111-1307, USA.  */
+ static CONST char *fileerrmsg;
+ static int fileerrmsgusage;
+ 
++extern void _dapto_source_changed(const char *, int, int, int, int, int);
+ /*
+  * SetFileErr
+  */
+diff --git a/Eli/pkg/pdl/derivedSrcs/clpintf.c b/Eli/pkg/pdl/derivedSrcs/clpintf.c
+index ca18187..1920382 100644
+--- a/Eli/pkg/pdl/derivedSrcs/clpintf.c
++++ b/Eli/pkg/pdl/derivedSrcs/clpintf.c
+@@ -53,6 +53,8 @@ Suite 330, Boston, MA 02111-1307, USA.  */
+ static CONST char *fileerrmsg;
+ static int fileerrmsgusage;
+ 
++extern void _dapto_source_changed(const char *, int, int, int, int, int);
++
+ /*
+  * SetFileErr
+  */
+diff --git a/Eli/pkg/ptg/derivedSrcs/clpintf.c b/Eli/pkg/ptg/derivedSrcs/clpintf.c
+index 77b28ce..ba988eb 100644
+--- a/Eli/pkg/ptg/derivedSrcs/clpintf.c
++++ b/Eli/pkg/ptg/derivedSrcs/clpintf.c
+@@ -53,6 +53,7 @@ Suite 330, Boston, MA 02111-1307, USA.  */
+ static CONST char *fileerrmsg;
+ static int fileerrmsgusage;
+ 
++extern void _dapto_source_changed(const char *, int, int, int, int, int);
+ /*
+  * SetFileErr
+  */

--- a/pkgs/by-name/el/eli/package.nix
+++ b/pkgs/by-name/el/eli/package.nix
@@ -38,6 +38,12 @@ stdenv.mkDerivation rec {
     sha256 = "1vran8583hbwrr5dciji4zkhz3f88w4mn8n9sdpr6zw0plpf1whj";
   };
 
+  patches = [
+    # Newer GCC will reject function parameters with an implicit type of `int` and undefined
+    # references to undeclared functions.
+    ./function-declarations.patch
+  ];
+
   buildInputs = [
     ncurses
     fontconfig
@@ -59,7 +65,11 @@ stdenv.mkDerivation rec {
 
   # Workaround build failure on -fno-common toolchains:
   #   ld: cexp.o:(.bss+0x40): multiple definition of `obstck'; cccp.o:(.bss+0x0): first defined here
-  env.NIX_CFLAGS_COMPILE = "-fcommon";
+  # Workaround build failure on "function definitions with identifier lists":
+  #   C23 throws errors on "function definitions with identifier lists". As it is pervasively used
+  #   in the upstream codebase, it's impossible to fix that legacy syntax without a full treewide
+  #   refactor. So the currently fix is to pin the standard to C17.
+  env.NIX_CFLAGS_COMPILE = "-fcommon --std=gnu17";
 
   preConfigure = ''
     configureFlagsArray=(


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Resolves https://github.com/NixOS/nixpkgs/issues/475633

Track https://github.com/NixOS/nixpkgs/issues/475479

After the default GCC upgraded to 15, with its default C standard set to C23, lots of legacy syntax has been dropped. This PR fix the build failure by pinning the C standard to the previously used C17. While this prevents a majority of compile errors, patching some function declarations is still required for compiling with GCC 15. An additional patch is provided to fix those remaining issues.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
