### PR TITLE
xonotic: fix build with c23

### DIFF
--- a/pkgs/games/xonotic/default.nix
+++ b/pkgs/games/xonotic/default.nix
@@ -91,6 +91,8 @@ let
       hash = "sha256-i5KseBz/SuicEhoj6s197AWiqr7azMI6GdGglYtAEqg=";
     };
 
+    patches = [ ./fix-build-with-c23.patch ];
+
     nativeBuildInputs = [ unzip ];
     buildInputs = [
       libjpeg

--- a/pkgs/games/xonotic/fix-build-with-c23.patch
+++ b/pkgs/games/xonotic/fix-build-with-c23.patch
@@ -1,0 +1,43 @@
+---
+ dpsoftrast.c | 4 ----
+ qtypes.h     | 7 +------
+ 2 files changed, 1 insertion(+), 10 deletions(-)
+
+diff --git a/dpsoftrast.c b/dpsoftrast.c
+index fff29b8..1eda341 100644
+--- a/dpsoftrast.c
++++ b/dpsoftrast.c
+@@ -10,10 +10,6 @@
+ #pragma warning(disable : 4324)
+ #endif
+
+-#ifndef __cplusplus
+-typedef qboolean bool;
+-#endif
+-
+ #define ALIGN_SIZE 16
+ #define ATOMIC_SIZE 4
+
+diff --git a/qtypes.h b/qtypes.h
+index 6c09614..e6e277b 100644
+--- a/qtypes.h
++++ b/qtypes.h
+@@ -2,14 +2,9 @@
+ #ifndef QTYPES_H
+ #define QTYPES_H
+
+-#undef true
+-#undef false
++#include <stdbool.h>
+
+-#ifndef __cplusplus
+-typedef enum qboolean_e {false, true} qboolean;
+-#else
+ typedef bool qboolean;
+-#endif
+
+ #ifndef NULL
+ #define NULL ((void *)0)
+--
+2.50.1
+


### PR DESCRIPTION
With the move to gcc15 as the default, c23 is now the default as well, which breaks the build of xonotic 0.8.6. This adds a patch from Arch Linux to fix the build on gcc15/c23.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
