### PR TITLE
zeroc-ice: fix build failure with GCC 15

### DIFF
--- a/pkgs/by-name/ze/zeroc-ice/func-params-and-keywords.patch
+++ b/pkgs/by-name/ze/zeroc-ice/func-params-and-keywords.patch
@@ -1,0 +1,53 @@
+diff --git a/main.c b/main.c
+index 54a62b2..44265ad 100644
+--- a/main.c
++++ b/main.c
+@@ -302,7 +302,7 @@ int     mcpp_lib_main
+     inc_dirp = &null;   /* Initialize to current (null) directory   */
+     cur_fname = cur_fullname = "(predefined)";  /* For predefined macros    */
+     init_defines();                         /* Predefine macros     */
+-    mb_init(TRUE);      /* Should be initialized prior to get options   */
++    mb_init();      /* Should be initialized prior to get options   */
+     do_options( argc, argv, &in_file, &out_file);   /* Command line options */
+ 
+     /* Open input file, "-" means stdin.    */
+diff --git a/system.c b/system.c
+index a3501f9..18d35a9 100644
+--- a/system.c
++++ b/system.c
+@@ -1734,7 +1734,7 @@ static int  open_file(
+     if (! fullname)                 /* Non-existent or directory    */
+         return  FALSE;
+     if (included( fullname))        /* Once included    */
+-        goto  true;
++        goto  TRUE_LABEL;
+ 
+     if ((max_open != 0 && max_open <= include_nest)
+                             /* Exceed the known limit of open files */
+@@ -1761,12 +1761,12 @@ static int  open_file(
+         if ((fp = mcpp_fopen( fullname, "r")) == NULL) {
+             file->fp = mcpp_fopen( cur_fullname, "r");
+             fseek( file->fp, file->pos, SEEK_SET);
+-            goto  false;
++            goto  FALSE_LABEL;
+         }
+         if (max_open == 0)      /* Remember the limit of the system */
+             max_open = include_nest;
+     } else if (fp == NULL)                  /* No read permission   */
+-        goto  false;
++        goto  FALSE_LABEL;
+     /* Truncate buffer of the includer to save memory   */
+     len = (int) (file->bptr - file->buffer);
+     if (len) {
+@@ -1798,9 +1798,9 @@ static int  open_file(
+     if (mkdep && ((mkdep & MD_SYSHEADER) || ! infile->sys_header))
+         put_depend( fullname);          /* Output dependency line   */
+ 
+-true:
++TRUE_LABEL:
+     return  TRUE;
+-false:
++FALSE_LABEL:
+     free( fullname);
+     return  FALSE;
+ }

--- a/pkgs/by-name/ze/zeroc-ice/package.nix
+++ b/pkgs/by-name/ze/zeroc-ice/package.nix
@@ -24,6 +24,8 @@ let
       sha256 = "1psryc2ql1cp91xd3f8jz84mdaqvwzkdq2pr96nwn03ds4cd88wh";
     };
 
+    patches = [ ./func-params-and-keywords.patch ];
+
     configureFlags = [ "--enable-mcpplib" ];
     installFlags = [ "PREFIX=$(out)" ];
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Resolves https://github.com/NixOS/nixpkgs/issues/475949

Track https://github.com/NixOS/nixpkgs/issues/475479

The build failure of the inner derivation `zeroc-mcpp` was caused by:

- Call to a function with an excessive argument;
- Use reserved keywords `true` & `false` in C23 as label.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
