### PR TITLE
sonic-visualiser: 4.5.1 -> 5.2.1

### DIFF
--- a/pkgs/by-name/so/sonic-visualiser/fix-atomic-qt.patch
+++ b/pkgs/by-name/so/sonic-visualiser/fix-atomic-qt.patch
@@ -1,0 +1,63 @@
+diff --git a/svcore/data/model/EditableDenseThreeDimensionalModel.cpp b/svcore/data/model/EditableDenseThreeDimensionalModel.cpp
+index da5ff90..7a62163 100644
+--- a/svcore/data/model/EditableDenseThreeDimensionalModel.cpp
++++ b/svcore/data/model/EditableDenseThreeDimensionalModel.cpp
+@@ -458,10 +458,10 @@ EditableDenseThreeDimensionalModel::toXml(QTextStream &out,
+     Model::toXml
+         (out, indent,
+          QString("type=\"dense\" dimensions=\"3\" windowSize=\"%1\" yBinCount=\"%2\" minimum=\"%3\" maximum=\"%4\" dataset=\"%5\" startFrame=\"%6\" %7")
+-         .arg(m_resolution)
+-         .arg(m_yBinCount)
+-         .arg(m_minimum)
+-         .arg(m_maximum)
++         .arg(m_resolution.load())
++         .arg(m_yBinCount.load())
++         .arg(m_minimum.load())
++         .arg(m_maximum.load())
+          .arg(getExportId())
+          .arg(m_startFrame)
+          .arg(extraAttributes));
+diff --git a/svcore/data/model/NoteModel.h b/svcore/data/model/NoteModel.h
+index 8c3a421..28e145c 100644
+--- a/svcore/data/model/NoteModel.h
++++ b/svcore/data/model/NoteModel.h
+@@ -403,8 +403,8 @@ public:
+              .arg(m_events.getExportId())
+              .arg(m_subtype == FLEXI_NOTE ? "flexinote" : "note")
+              .arg(m_valueQuantization)
+-             .arg(m_valueMinimum)
+-             .arg(m_valueMaximum)
++             .arg(m_valueMinimum.load())
++             .arg(m_valueMaximum.load())
+              .arg(encodeEntities(m_units))
+              .arg(extraAttributes));
+         
+diff --git a/svcore/data/model/RegionModel.h b/svcore/data/model/RegionModel.h
+index 916a047..db021ae 100644
+--- a/svcore/data/model/RegionModel.h
++++ b/svcore/data/model/RegionModel.h
+@@ -335,8 +335,8 @@ public:
+              .arg(m_events.getExportId())
+              .arg("region")
+              .arg(m_valueQuantization)
+-             .arg(m_valueMinimum)
+-             .arg(m_valueMaximum)
++             .arg(m_valueMinimum.load())
++             .arg(m_valueMaximum.load())
+              .arg(encodeEntities(m_units))
+              .arg(extraAttributes));
+         
+diff --git a/svcore/data/model/SparseTimeValueModel.h b/svcore/data/model/SparseTimeValueModel.h
+index fe6e70c..7033503 100644
+--- a/svcore/data/model/SparseTimeValueModel.h
++++ b/svcore/data/model/SparseTimeValueModel.h
+@@ -342,8 +342,8 @@ public:
+              .arg("true") // always true after model reaches 100% -
+                           // subsequent events are always notified
+              .arg(m_events.getExportId())
+-             .arg(m_valueMinimum)
+-             .arg(m_valueMaximum)
++             .arg(m_valueMinimum.load())
++             .arg(m_valueMaximum.load())
+              .arg(encodeEntities(m_units))
+              .arg(extraAttributes));

--- a/pkgs/by-name/so/sonic-visualiser/fix-modifier-names.patch
+++ b/pkgs/by-name/so/sonic-visualiser/fix-modifier-names.patch
@@ -1,0 +1,14 @@
+diff --git a/svgui/view/Pane.cpp b/svgui/view/Pane.cpp
+index fb802c4..9a8124c 100644
+--- a/svgui/view/Pane.cpp
++++ b/svgui/view/Pane.cpp
+@@ -1423,7 +1423,7 @@ modifierNames(Qt::KeyboardModifiers m)
+     if (m & Qt::GroupSwitchModifier) s << "GroupSwitch";
+     m &= (~ (Qt::ShiftModifier | Qt::ControlModifier | Qt::AltModifier |
+              Qt::MetaModifier | Qt::KeypadModifier | Qt::GroupSwitchModifier));
+-    if (m) s << QString(" (residue %1)").arg(m);
++    if (m) s << QString(" (residue %1)").arg(static_cast<int>(m));
+     if (s.empty()) return "(none)";
+     else return s.join(" | ");
+ }
+

--- a/pkgs/by-name/so/sonic-visualiser/package.nix
+++ b/pkgs/by-name/so/sonic-visualiser/package.nix
@@ -1,5 +1,3 @@
-# TODO add plugins having various licenses, see http://www.vamp-plugins.org/download.html
-
 {
   lib,
   stdenv,
@@ -29,53 +27,55 @@
   opusfile,
   meson,
   ninja,
-  cmake,
-  libsForQt5,
+  qt6,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "sonic-visualiser";
-  version = "4.5.1";
+  version = "5.2.1";
 
   src = fetchurl {
-    url = "https://code.soundsoftware.ac.uk/attachments/download/2841/sonic-visualiser-${finalAttrs.version}.tar.gz";
-    hash = "sha256-WauIaCWQs739IwJIorDCNymH//navxsbHUCVAUYl7+k=";
+    url = "https://github.com/sonic-visualiser/sonic-visualiser/releases/download/sv_v${finalAttrs.version}/sonic-visualiser-${finalAttrs.version}.tar.gz";
+    hash = "sha256-LzOK8CMekwU5xeXgTax8M4QleGbMKf2hEiFfjEEImMk=";
   };
 
   nativeBuildInputs = [
     meson
     ninja
-    cmake
     pkg-config
-    libsForQt5.wrapQtAppsHook
+    qt6.wrapQtAppsHook
   ];
+
   buildInputs = [
-    libsndfile
-    libsForQt5.qtbase
-    libsForQt5.qtsvg
+    alsa-lib
+    bzip2
+    capnproto
     fftw
     fftwFloat
-    bzip2
-    lrdf
-    rubberband
+    libfishsound
+    libid3tag
+    libjack2
+    liblo
+    libmad
+    liboggz
+    libpulseaudio
     libsamplerate
-    vamp-plugin-sdk
-    alsa-lib
+    libsndfile
+    libx11
+    lrdf
+    opusfile
+    qt6.qtbase
+    qt6.qtsvg
     redland
+    rubberband
     serd
     sord
-    # optional
-    libjack2
-    # portaudio
-    libpulseaudio
-    libmad
-    libfishsound
-    liblo
-    libx11
-    capnproto
-    liboggz
-    libid3tag
-    opusfile
+    vamp-plugin-sdk
+  ];
+
+  patches = [
+    ./fix-atomic-qt.patch
+    ./fix-modifier-names.patch
   ];
 
   enableParallelBuilding = true;
@@ -86,5 +86,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ marcweber ];
     platforms = lib.platforms.linux;
+    mainProgram = "sonic-visualiser";
   };
 })


### PR DESCRIPTION
At this moment the build for sonic-visualiser is failing in nixos-unstable. This PR updates sonic-visualiser to 5.2.1 and also fixes the build failure.

Updated qt5 to qt6. A few patches were needed due to changes in qt6. For some reason they are not (yet?) in the upstream source bundle, but the build fails without them.

Fixes: https://github.com/NixOS/nixpkgs/issues/480428

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
