### PR TITLE
wol: Fix build for GCC 15

### DIFF
--- a/pkgs/by-name/wo/wol/gcc-15.patch
+++ b/pkgs/by-name/wo/wol/gcc-15.patch
@@ -1,0 +1,19 @@
+diff --git a/lib/realloc.c b/lib/realloc.c
+index d0d3e4a..6e9e539 100644
+--- a/lib/realloc.c
++++ b/lib/realloc.c
+@@ -24,8 +24,12 @@
+ 
+ #include <sys/types.h>
+ 
+-char *malloc ();
+-char *realloc ();
++#if STDC_HEADERS
++# include <stdlib.h>
++#else
++void *malloc ();
++void *realloc ();
++#endif
+ 
+ /* Change the size of an allocated block of memory P to N bytes,
+    with error checking.  If N is zero, change it to 1.  If P is NULL,

--- a/pkgs/by-name/wo/wol/package.nix
+++ b/pkgs/by-name/wo/wol/package.nix
@@ -17,6 +17,7 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./gcc-14.patch
+    ./gcc-15.patch
     ./macos-10_7-getline.patch
   ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Fixed compilation for GCC 15. See https://github.com/NixOS/nixpkgs/issues/475479 and https://gcc.gnu.org/gcc-15/porting_to.html#c23-fn-decls-without-parameters

Patch [lifted from Archlinux](https://gitlab.archlinux.org/archlinux/packaging/packages/wol/-/blob/ab18967d176247d1d671f349261c660510404ee8/build-fix.patch). See also [Gentoo's patch](https://gitweb.gentoo.org/repo/gentoo.git/tree/net-misc/wol/files/wol-0.7.1-musl.patch).

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
