### PR TITLE
stdenv/cygwin: add cross bootstrap tools

### DIFF
--- a/pkgs/stdenv/cygwin/make-bootstrap-tools-cross.nix
+++ b/pkgs/stdenv/cygwin/make-bootstrap-tools-cross.nix
@@ -1,0 +1,30 @@
+{
+  system ? builtins.currentSystem,
+}:
+
+let
+  inherit (releaseLib) lib;
+  releaseLib = import ../../top-level/release-lib.nix {
+    # We're not using any functions from release-lib.nix that look at
+    # supportedSystems.
+    supportedSystems = [ ];
+  };
+
+  make =
+    crossSystem:
+    import ./make-bootstrap-tools.nix {
+      pkgs = releaseLib.pkgsForCross crossSystem system;
+    };
+in
+lib.mapAttrs (n: make) (
+  with lib.systems.examples;
+  {
+    # NOTE: Only add platforms for which there are files in `./bootstrap-files`
+    # or for which you plan to request the tarball upload soon. See the
+    #   maintainers/scripts/bootstrap-files/README.md
+    # on how to request an upload.
+    # Sort following the sorting in `./default.nix` `bootstrapFiles` argument.
+
+    x86_64-pc-cygwin = x86_64-cygwin;
+  }
+)

--- a/pkgs/stdenv/cygwin/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/cygwin/make-bootstrap-tools.nix
@@ -1,0 +1,92 @@
+{
+  pkgs ? import ../../.. { },
+}:
+let
+  inherit (pkgs) runCommand;
+  # splicing doesn't seem to work right here
+  inherit (pkgs.buildPackages) dumpnar rsync nukeReferences;
+
+  unpacked =
+    let
+      inherit (pkgs)
+        bashNonInteractive
+        binutils-unwrapped
+        bzip2
+        coreutils
+        curl
+        diffutils
+        file
+        findutils
+        gawk
+        gcc-unwrapped
+        gitMinimal # for fetchgit (newlib-cygwin)
+        gnugrep
+        gnumake
+        gnused
+        gnutar
+        gzip
+        patch
+        xz
+        ;
+
+      inherit (pkgs.cygwin)
+        newlib-cygwin
+        w32api
+        ;
+
+    in
+    runCommand "unpacked"
+      {
+        nativeBuildInputs = [ nukeReferences ];
+        # The result should not contain any references (store paths) so
+        # that we can safely copy them out of the store and to other
+        # locations in the store.
+        allowedReferences = [ ];
+        strictDeps = true;
+      }
+      ''
+        mkdir -p "$out"/{bin,include,lib,libexec}
+        cp -d "${bashNonInteractive}"/bin/* "$out"/bin/
+        cp -d "${binutils-unwrapped}"/bin/* "$out"/bin/
+        cp -d "${bzip2}"/bin/* "$out"/bin/
+        cp -d "${coreutils}"/bin/* "$out"/bin/
+        cp -d "${curl}"/bin/* "$out"/bin/
+        cp -d "${diffutils}"/bin/* "$out"/bin/
+        cp -d "${file}"/bin/* "$out"/bin/
+        cp -d "${findutils}"/bin/* "$out"/bin/
+        cp -d "${gawk}"/bin/* "$out"/bin/
+        cp -d "${gcc-unwrapped}"/bin/* "$out"/bin/
+        cp -rd ${gcc-unwrapped}/include/* $out/include/
+        cp -rd ${gcc-unwrapped}/lib/* $out/lib/
+        cp -rd ${gcc-unwrapped}/libexec/* $out/libexec/
+        cp -frd ${gcc-unwrapped.lib}/bin/* $out/bin/
+        cp -rd ${gcc-unwrapped.lib}/lib/* $out/lib/
+        cp -d "${gitMinimal}"/bin/* "$out"/bin/
+        cp -d "${gnugrep}"/bin/* "$out"/bin/
+        cp -d "${gnumake}"/bin/* "$out"/bin/
+        cp -d "${gnused}"/bin/* "$out"/bin/
+        cp -d "${gnutar}"/bin/* "$out"/bin/
+        (shopt -s dotglob; cp -d "${gzip}"/bin/* "$out"/bin/)
+        cp -rd ${newlib-cygwin.dev}/include/* $out/include/
+        cp -rd ${newlib-cygwin}/lib/* "$out"/lib/
+        cp -d "${patch}"/bin/* "$out"/bin/
+        cp -d "${w32api}"/lib/w32api/lib{advapi,shell,user,kernel}32.a "$out"/lib/
+        cp -d "${xz}"/bin/* "$out"/bin/
+
+        chmod -R +w "$out"
+
+        find "$out" -type l -print0 | while read -d $'\0' link; do
+          [[ -L "$link" && -e "$link" ]] || continue
+          [[ $(realpath "$link") != "$out"* ]] || continue
+          cp "$link" "$link"~
+          mv "$link"~ "$link"
+        done
+
+        find "$out" -print0 | xargs -0 nuke-refs -e "$out"
+      '';
+in
+{
+  unpack = runCommand "unpack.nar.xz" {
+    nativeBuildInputs = [ dumpnar ];
+  } "dumpnar ${unpacked} | xz -9 -e -T $NIX_BUILD_CORES >$out";
+}

--- a/pkgs/top-level/release-cross.nix
+++ b/pkgs/top-level/release-cross.nix
@@ -299,11 +299,15 @@ in
     let
       linuxTools = import ../stdenv/linux/make-bootstrap-tools-cross.nix { system = "x86_64-linux"; };
       freebsdTools = import ../stdenv/freebsd/make-bootstrap-tools-cross.nix { system = "x86_64-linux"; };
+      cygwinTools = import ../stdenv/cygwin/make-bootstrap-tools-cross.nix { system = "x86_64-linux"; };
       linuxMeta = {
         maintainers = [ maintainers.dezgeg ];
       };
       freebsdMeta = {
         maintainers = [ maintainers.rhelmot ];
+      };
+      cygwinMeta = {
+        maintainers = [ maintainers.corngood ];
       };
       mkBootstrapToolsJob =
         meta: drv:
@@ -330,8 +334,11 @@ in
       freebsd = mapAttrsRecursiveCond (as: !isDerivation as) (
         name: mkBootstrapToolsJob freebsdMeta
       ) freebsdTools;
+      cygwin = mapAttrsRecursiveCond (as: !isDerivation as) (
+        name: mkBootstrapToolsJob cygwinMeta
+      ) cygwinTools;
     in
-    linux // freebsd;
+    linux // freebsd // cygwin;
 
   # Cross-built nixStatic for platforms for enabled-but-unsupported platforms
   mips64el-nixCrossStatic = mapTestOnCross systems.examples.mips64el-linux-gnuabi64 nixCrossStatic;


### PR DESCRIPTION
I've built a working stdenv based on this, but I think this is a good starting point to get it merged.

Once this is in we should be able to get a tarball from hydra.

I'm marking this draft until I enumerate the package changes required for it to build.

Build with:

```
nix build -f pkgs/top-level/release-cross.nix bootstrapTools.x86_64-pc-cygwin.unpack
```

Dependencies:

- cc-wrapper: #468206
- {cc,bintools}-wrapper: #479741 
- libxcrypt: #476257
- file: #476283
- gnumake: #476284
- gzip: #476285
- zlib-ng: #476286
- gettext: #476288
- gnutar: #476289
- mpfr: #476290
- gmp: #476291
- isl: #476292
- coreutils: #476294
- git: #476295
- deterministic-uname: #476296
- binutils: #476298
- cygwin-dll-link: #476301
- gcc: #476299
- gettext: #493522
- zlib: #493530

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
