### PR TITLE
prisma_7, prisma-engines_7: 7.0.1 -> 7.2.0

### DIFF
--- a/pkgs/by-name/pr/prisma-engines_6/package.nix
+++ b/pkgs/by-name/pr/prisma-engines_6/package.nix
@@ -10,14 +10,14 @@
 # Updating this package will force an update for prisma. The
 # version of prisma-engines and prisma must be the same for them to
 # function correctly.
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "prisma-engines_6";
   version = "6.19.1";
 
   src = fetchFromGitHub {
     owner = "prisma";
     repo = "prisma-engines";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-z3GdnrLEMJIGPKXXbz2wrbiGpuNlgYxqg3iYINYTnPI=";
   };
 
@@ -70,7 +70,7 @@ rustPlatform.buildRustPackage rec {
       aqrln
     ];
   };
-}
+})
 
 ### Troubleshooting
 # Here's an example application using Prisma with Nix: https://github.com/pimeys/nix-prisma-example

--- a/pkgs/by-name/pr/prisma-engines_7/package.nix
+++ b/pkgs/by-name/pr/prisma-engines_7/package.nix
@@ -11,16 +11,16 @@
 # function correctly.
 rustPlatform.buildRustPackage rec {
   pname = "prisma-engines_7";
-  version = "7.0.1";
+  version = "7.2.0";
 
   src = fetchFromGitHub {
     owner = "prisma";
     repo = "prisma-engines";
     tag = version;
-    hash = "sha256-+8k+M2+WySR2CeywYlhU/jd3av/4UeUoEOlO/qHUk5o=";
+    hash = "sha256-1CwpUtNuqxGNjBmmmo/Aet8XrmnCQfDToI7vZaNupDI=";
   };
 
-  cargoHash = "sha256-n83hJfSlvuaoBb3w9Rk8+q2emjGCoPDHhFdoVzhf4sM=";
+  cargoHash = "sha256-U5d/HkuWnD/XSrAJr5AYh+WPVGDOcK/e4sC0udPZoyU=";
 
   # Use system openssl.
   OPENSSL_NO_VENDOR = 1;

--- a/pkgs/by-name/pr/prisma-engines_7/package.nix
+++ b/pkgs/by-name/pr/prisma-engines_7/package.nix
@@ -9,14 +9,14 @@
 # Updating this package will force an update for prisma. The
 # version of prisma-engines and prisma must be the same for them to
 # function correctly.
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "prisma-engines_7";
   version = "7.2.0";
 
   src = fetchFromGitHub {
     owner = "prisma";
     repo = "prisma-engines";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-1CwpUtNuqxGNjBmmmo/Aet8XrmnCQfDToI7vZaNupDI=";
   };
 
@@ -59,7 +59,7 @@ rustPlatform.buildRustPackage rec {
       aqrln
     ];
   };
-}
+})
 
 ### Troubleshooting
 # Here's an example application using Prisma with Nix: https://github.com/pimeys/nix-prisma-example

--- a/pkgs/by-name/pr/prisma_7/package.nix
+++ b/pkgs/by-name/pr/prisma_7/package.nix
@@ -15,13 +15,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "prisma_7";
-  version = "7.0.1";
+  version = "7.2.0";
 
   src = fetchFromGitHub {
     owner = "prisma";
     repo = "prisma";
     tag = finalAttrs.version;
-    hash = "sha256-bmmthEFMBMJAracWUCU/6Nyic05JglP5t1VAWPVKFnU=";
+    hash = "sha256-oDfb/RwSa63ErWHF86q5xPPUUsRUV2DwNHARTV5gxyk=";
   };
 
   nativeBuildInputs = [
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_10;
     fetcherVersion = 1;
-    hash = "sha256-sJmlMF8nay4/3LTHEWzBWaS8Xq91JRZlzKBfeMnJEMM=";
+    hash = "sha256-2I3QeSWCoZDNVrWY0VySHT05T4FQ0PQLoMirs2vuuNM=";
   };
 
   patchPhase = ''

--- a/pkgs/by-name/pr/prisma_7/package.nix
+++ b/pkgs/by-name/pr/prisma_7/package.nix
@@ -36,8 +36,8 @@ stdenv.mkDerivation (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_10;
-    fetcherVersion = 1;
-    hash = "sha256-2I3QeSWCoZDNVrWY0VySHT05T4FQ0PQLoMirs2vuuNM=";
+    fetcherVersion = 3;
+    hash = "sha256-HZsrHYUh4nxUgwVbmJ+fV4/OZvEWDKkD4CT8hIt1SRY=";
   };
 
   patchPhase = ''


### PR DESCRIPTION
https://github.com/prisma/prisma/releases/tag/7.1.0
https://github.com/prisma/prisma/releases/tag/7.2.0

Didn't update `fetcherVersion` of `prisma_6` to not cause unnecessary rebuilds, but I'm not opposed to it if someone thinks it's a good idea.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
