### PR TITLE
fish: Revert "disable checks on darwin"

### DIFF
--- a/pkgs/by-name/fi/fish/package.nix
+++ b/pkgs/by-name/fi/fish/package.nix
@@ -341,8 +341,7 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optional (!stdenv.hostPlatform.isDarwin) man-db;
 
-  # disable darwin pending https://github.com/NixOS/nixpkgs/pull/462090 getting through staging
-  doCheck = !stdenv.hostPlatform.isDarwin;
+  doCheck = true;
 
   nativeCheckInputs = [
     coreutils


### PR DESCRIPTION
Per #462589, it can be reverted "once #462090 is through the staging cycles". #462090 is now in master, so this PR reverts #462589.