### PR TITLE
pasystray: fix gcc 15 build error

### DIFF
--- a/pkgs/by-name/pa/pasystray/package.nix
+++ b/pkgs/by-name/pa/pasystray/package.nix
@@ -39,6 +39,12 @@ stdenv.mkDerivation rec {
       url = "https://sources.debian.org/data/main/p/pasystray/0.8.1-1/debian/patches/0002-Require-X11-backend.patch";
       sha256 = "sha256-6njC3vqBPWFS1xAsa1katQ4C0KJdVkHAP1MCPiZ6ELM=";
     })
+    # Fix build with GCC 15
+    # https://github.com/christophgysin/pasystray/pull/183.patch
+    (fetchpatch {
+      url = "https://github.com/christophgysin/pasystray/commit/9883809c7956471cf085ae90af4a9831c1234417.patch";
+      hash = "sha256-BQ10LddqE3XwUeRklZE3S3+KOjJ9BtfddaFswgUqZ5g=";
+    })
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
GCC 15 breakage tracking issue: https://github.com/NixOS/nixpkgs/issues/475479

Closes: https://github.com/NixOS/nixpkgs/issues/476184


pasystray fails to build:

```
       > pasystray.c: In function 'main':
       > pasystray.c:54:5: error: too many arguments to function 'init'; expected 0, have 1
       >    54 |     init(&settings);
       >       |     ^~~~ ~~~~~~~~~
       > In file included from pasystray.c:25:
       > pasystray.h:25:6: note: declared here
       >    25 | void init();
       >       |      ^~~~
       > pasystray.c:56:5: error: too many arguments to function 'destroy'; expected 0, have 1
       >    56 |     destroy(&settings);
       >       |     ^~~~~~~ ~~~~~~~~~
       > pasystray.h:27:6: note: declared here
       >    27 | void destroy();
       >       |      ^~~~~~~
       > pasystray.c: At top level:
       > pasystray.c:61:6: error: conflicting types for 'init'; have 'void(settings_t *)' {aka 'void(struct settings_t_ *)'}
       >    61 | void init(settings_t* settings)
       >       |      ^~~~
       > pasystray.h:25:6: note: previous declaration of 'init' with type 'void(void)'
       >    25 | void init();
       >       |      ^~~~
       > pasystray.c:90:6: error: conflicting types for 'destroy'; have 'void(settings_t *)' {aka 'void(struct settings_t_ *)'}
       >    90 | void destroy(settings_t* settings)
       >       |      ^~~~~~~
       > pasystray.h:27:6: note: previous declaration of 'destroy' with type 'void(void)'
       >    27 | void destroy();
       >       |      ^~~~~~~
       > make[2]: *** [Makefile:590: pasystray-pasystray.o] Error 1
       > make[2]: Leaving directory '/build/source/src'
       > make[1]: *** [Makefile:394: all] Error 2
       > make[1]: Leaving directory '/build/source/src'
       > make: *** [Makefile:553: all-recursive] Error 1
       For full logs, run:
         nix log /nix/store/f9c52fdfy8adw2q45pjfj3kscqi0gr5x-pasystray-0.8.2.drv
```

This was fixed in https://github.com/christophgysin/pasystray/pull/183.
There is no release that includes this fix.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
