### PR TITLE
umami: update fetchPnpmDeps.fetcherVersion to 3

### DIFF
--- a/pkgs/by-name/um/umami/package.nix
+++ b/pkgs/by-name/um/umami/package.nix
@@ -95,18 +95,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       version
       src
       ;
-    # prevent downloading dependencies for windows
-    # which bloat derivation size and fail to build on hydra
-    # https://github.com/NixOS/nixpkgs/pull/467820#issuecomment-3624054271
-    pnpmInstallFlags = [
-      "--force=false"
-      "--os=linux"
-      "--os=darwin"
-      "--cpu=x64"
-      "--cpu=arm64"
-    ];
-    fetcherVersion = 2;
-    hash = "sha256-bqeJ0wzCtnuR6V67Qe1N9UcaHPLziuBhsn7eN8JVJbQ=";
+    fetcherVersion = 3;
+    hash = "sha256-GFN94oySPCZA5K13XR8f/tByuHS571ohlYTFqaVw/Ns=";
   };
 
   env.CYPRESS_INSTALL_BINARY = "0";


### PR DESCRIPTION
This results in a much smaller pnpmDeps derivation, since the store's contents are compressed into a tarball.
Therefore, the workaround for reducing the derivation size has been removed, since it is now much smaller than the 4GB Hydra limit.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
