### PR TITLE
Revert "nixVersions.nix_2_28: unbreak builds"

### DIFF
--- a/pkgs/tools/package-management/nix/common-meson.nix
+++ b/pkgs/tools/package-management/nix/common-meson.nix
@@ -174,17 +174,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch = ''
     patchShebangs --build tests
-  ''
-  # The ability to chmod the root filesystem only exist in filesystem namespacing capable Nix interpreters.
-  # At the time of writing, only Linux can do it.
-  + lib.optionalString stdenv.hostPlatform.isLinux ''
-    # The build system produces $HOME during the install check phase
-    # and will fail when ran without build user separation.
-    # This will surface as a FIFO synchronization deadlock.
-    # To avoid this, the $HOME directory is barred from being mkdir()
-    # by the build system here.
-    # https://github.com/NixOS/nix/issues/11295
-    chmod 555 /
   '';
 
   preConfigure =


### PR DESCRIPTION
Reverts NixOS/nixpkgs#475643 as it caused a build breakage on Linux systems.
This approach cannot work as-is due to the existence of unsandboxed Linux systems. I would edit the commit message to add the reason for the revert, unfortunately, I'm unable to check out the branch properly and change the commit message.