### PR TITLE
python3Packages.grpclib: ignore DeprecationWarning for asyncio

### DIFF
--- a/pkgs/development/python-modules/grpclib/default.nix
+++ b/pkgs/development/python-modules/grpclib/default.nix
@@ -52,6 +52,11 @@ buildPythonPackage rec {
     certifi
   ];
 
+  pytestFlags = [
+    #  DeprecationWarning: 'asyncio.get_event_loop_policy' is deprecated
+    "-Wignore::DeprecationWarning"
+  ];
+
   pythonImportsCheck = [ "grpclib" ];
 
   meta = {


### PR DESCRIPTION
While building for Python 3.14:
```sh
...
┃        > ERROR tests/test_utils.py::test_wrapper - DeprecationWarning: 'asyncio.get_event_loop_policy' is deprecated and slate...
┃        > ERROR tests/test_utils.py::test_wrapper_concurrent - DeprecationWarning: 'asyncio.get_event_loop_policy' is deprecated and slate...
┃        > ERROR tests/test_utils.py::test_deadline_wrapper - DeprecationWarning: 'asyncio.get_event_loop_policy' is deprecated and slate...
┃        > ERROR tests/test_utils.py::test_graceful_exit_normal_server[2] - DeprecationWarning: 'asyncio.get_event_loop_policy' is deprecated and slate...
┃        > ERROR tests/test_utils.py::test_graceful_exit_normal_server[15] - DeprecationWarning: 'asyncio.get_event_loop_policy' is deprecated and slate...
┃        > ERROR tests/test_utils.py::test_graceful_exit_sluggish_server[2-2] - DeprecationWarning: 'asyncio.get_event_loop_policy' is deprecated and slate...
┃        > ERROR tests/test_utils.py::test_graceful_exit_sluggish_server[15-15] - DeprecationWarning: 'asyncio.get_event_loop_policy' is deprecated and slate...
┃        > ERROR tests/test_utils.py::test_graceful_exit_sluggish_server[2-15] - DeprecationWarning: 'asyncio.get_event_loop_policy' is deprecated and slate...
┃        > ERROR tests/test_utils.py::test_graceful_exit_sluggish_server[15-2] - DeprecationWarning: 'asyncio.get_event_loop_policy' is deprecated and slate...
┃        > ERROR tests/test_utils.py::test_cached - DeprecationWarning: 'asyncio.get_event_loop_policy' is deprecated and slate...
┃        > 215 errors in 1.20s
```sh

Disabled `DeprecationWarning`.

Tracking: #475732

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
