### PR TITLE
immich: use vips_8_17

### DIFF
--- a/pkgs/by-name/im/immich/package.nix
+++ b/pkgs/by-name/im/immich/package.nix
@@ -33,7 +33,7 @@
   pango,
   perl,
   pixman,
-  vips,
+  vips_8_17, # thumbnail generation fails with vips 8.18
   buildPackages,
 }:
 let
@@ -109,7 +109,7 @@ let
 
   # Without this thumbnail generation for raw photos fails with
   #     Error: Input file has corrupt header: tiff2vips: samples_per_pixel not a whole number of bytes
-  vips' = vips.overrideAttrs (prev: {
+  vips' = vips_8_17.overrideAttrs (prev: {
     mesonFlags = prev.mesonFlags ++ [ "-Dtiff=disabled" ];
   });
 in

--- a/pkgs/by-name/vi/vips_8_17/package.nix
+++ b/pkgs/by-name/vi/vips_8_17/package.nix
@@ -1,0 +1,177 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+
+  # Native build inputs
+  docbook-xsl-nons,
+  gi-docgen,
+  gobject-introspection,
+  meson,
+  ninja,
+  pkg-config,
+  buildPackages,
+
+  # Build inputs
+  expat,
+  glib,
+  libxml2,
+  python3,
+
+  # Optional dependencies
+  cfitsio,
+  cgif,
+  fftw,
+  imagemagick,
+  lcms2,
+  libarchive,
+  libexif,
+  libheif,
+  libhwy,
+  libimagequant,
+  libjpeg,
+  libjxl,
+  librsvg,
+  libpng,
+  libtiff,
+  libwebp,
+  matio,
+  openexr,
+  openjpeg,
+  openslide,
+  pango,
+  poppler,
+  withIntrospection ?
+    lib.meta.availableOn stdenv.hostPlatform gobject-introspection
+    && stdenv.hostPlatform.emulatorAvailable buildPackages,
+
+  # passthru
+  testers,
+  nix-update-script,
+
+  # meta
+  immich,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "vips";
+  version = "8.17.3";
+
+  outputs = [
+    "bin"
+    "out"
+    "man"
+    "dev"
+  ]
+  ++ lib.optionals (!stdenv.hostPlatform.isDarwin && !stdenv.hostPlatform.isFreeBSD) [ "devdoc" ];
+
+  src = fetchFromGitHub {
+    owner = "libvips";
+    repo = "libvips";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-yxjfkb2R3JPHbz0vCG4hkW9Davoc9MUPHL9Cqc+Ik0Y=";
+    # Remove unicode file names which leads to different checksums on HFS+
+    # vs. other filesystems because of unicode normalisation.
+    postFetch = ''
+      rm -r $out/test/test-suite/images/
+    '';
+  };
+
+  postPatch = ''
+    patchShebangs .
+  '';
+
+  nativeBuildInputs = [
+    docbook-xsl-nons
+    gobject-introspection
+    meson
+    ninja
+    pkg-config
+  ]
+  ++ lib.optionals (!stdenv.hostPlatform.isDarwin && !stdenv.hostPlatform.isFreeBSD) [
+    gi-docgen
+  ];
+
+  buildInputs = [
+    glib
+    libxml2
+    expat
+    (python3.withPackages (p: [ p.pycairo ]))
+
+    # Optional dependencies
+    cfitsio
+    cgif
+    fftw
+    imagemagick
+    lcms2
+    libarchive
+    libexif
+    libheif
+    libhwy
+    libimagequant
+    libjpeg
+    libjxl
+    librsvg
+    libpng
+    libtiff
+    libwebp
+    matio
+    openexr
+    openjpeg
+    openslide
+    pango
+    poppler
+  ];
+
+  # Required by .pc file
+  propagatedBuildInputs = [
+    glib
+  ];
+
+  mesonFlags = [
+    (lib.mesonEnable "pdfium" false)
+    (lib.mesonEnable "nifti" false)
+    (lib.mesonEnable "spng" false) # we want to use libpng
+    (lib.mesonEnable "introspection" withIntrospection)
+  ]
+  ++ lib.optional (!stdenv.hostPlatform.isDarwin && !stdenv.hostPlatform.isFreeBSD) (
+    lib.mesonBool "docs" true
+  )
+  ++ lib.optional (imagemagick == null) (lib.mesonEnable "magick" false);
+
+  postFixup = ''
+    moveToOutput "share/doc" "$devdoc"
+  '';
+
+  passthru = {
+    tests = {
+      pkg-config = testers.hasPkgConfigModules {
+        package = finalAttrs.finalPackage;
+      };
+      version = testers.testVersion {
+        package = finalAttrs.finalPackage;
+        command = "vips --version";
+      };
+    };
+    updateScript = nix-update-script {
+      extraArgs = [
+        "--version-regex"
+        "^v([0-9.]+)$"
+      ];
+    };
+  };
+
+  meta = {
+    changelog = "https://github.com/libvips/libvips/blob/${finalAttrs.src.rev}/ChangeLog";
+    homepage = "https://www.libvips.org/";
+    description = "Image processing system for large images";
+    license = lib.licenses.lgpl2Plus;
+    inherit (immich.meta) maintainers;
+    pkgConfigModules = [
+      "vips"
+      "vips-cpp"
+    ];
+    platforms = lib.platforms.unix;
+    mainProgram = "vips";
+  };
+})


### PR DESCRIPTION
Otherwise thumbnail generation fails with

    Unable to run job handler (AssetGenerateThumbnails): Error: Unknown error

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
