### PR TITLE
nixos/sandhole: init module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -60,6 +60,8 @@
 
 - [Komodo Periphery](https://github.com/moghtech/komodo), a multi-server Docker and Git deployment agent by Komodo. Available as [services.komodo-periphery](#opt-services.komodo-periphery.enable).
 
+- [Sandhole](https://github.com/EpicEric/sandhole), a reverse proxy that lets you expose HTTP/SSH/TCP services through SSH port forwarding. Available as [services.sandhole](#opt-services.sandhole.enable).
+
 - [Shoko](https://shokoanime.com), an anime management system. Available as [services.shoko](#opt-services.shoko.enable).
 
 ## Backward Incompatibilities {#sec-release-26.05-incompatibilities}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1358,6 +1358,7 @@
   ./services/networking/rpcbind.nix
   ./services/networking/rxe.nix
   ./services/networking/sabnzbd
+  ./services/networking/sandhole.nix
   ./services/networking/scion/scion-control.nix
   ./services/networking/scion/scion-daemon.nix
   ./services/networking/scion/scion-dispatcher.nix

--- a/nixos/modules/services/networking/sandhole.nix
+++ b/nixos/modules/services/networking/sandhole.nix
@@ -1,0 +1,268 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.sandhole;
+
+  inherit (lib) types;
+
+  name = "sandhole";
+
+  sshPort = cfg.settings.ssh-port or 2222;
+
+  httpPort = if cfg.settings.disable-http or false then null else cfg.settings.http-port or 80;
+
+  httpsPort = if cfg.settings.disable-https or false then null else cfg.settings.https-port or 443;
+
+  needsPrivilegedPorts =
+    sshPort < 1024 || (httpPort != null && httpPort < 1024) || (httpsPort != null && httpsPort < 1024);
+in
+
+{
+  options = {
+    services.sandhole = {
+      enable = lib.mkEnableOption "Sandhole, a reverse proxy that lets you expose HTTP/SSH/TCP services through SSH port forwarding";
+
+      package = lib.mkPackageOption pkgs "sandhole" { };
+
+      user = lib.mkOption {
+        type = types.str;
+        default = name;
+        description = ''
+          User to run Sandhole as.
+        '';
+      };
+
+      group = lib.mkOption {
+        type = types.str;
+        default = name;
+        description = ''
+          Group to run Sandhole as.
+        '';
+      };
+
+      openFirewall = lib.mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to automatically open the necessary ports in the firewall.
+
+          ::: {.warning}
+          If this option is true and `services.sandhole.settings.disable-tcp` is false or unset,
+          all unprivileged TCP ports (i.e. >= 1024) will be opened.
+          :::
+
+        '';
+        example = true;
+      };
+
+      settings = lib.mkOption {
+        type = types.submodule {
+          freeformType = types.attrsOf (
+            types.nullOr (
+              types.oneOf [
+                types.bool
+                types.ints.unsigned
+                types.path
+                types.str
+              ]
+            )
+          );
+
+          options = {
+            domain = lib.mkOption {
+              type = types.nullOr types.str;
+              default = null;
+              example = "nixos.org";
+              description = ''
+                The root domain of the application.
+              '';
+            };
+
+            no-domain = lib.mkOption {
+              type = types.bool;
+              default = false;
+              example = true;
+              description = ''
+                Whether to run Sandhole without a root domain.
+
+                This option disables subdomains.
+              '';
+            };
+
+            ssh-port = lib.mkOption {
+              type = types.port;
+              default = 2222;
+              example = 22;
+              description = ''
+                Port to listen for SSH connections.
+              '';
+            };
+
+            http-port = lib.mkOption {
+              type = types.port;
+              default = 80;
+              description = ''
+                Port to listen for HTTP connections.
+              '';
+            };
+
+            https-port = lib.mkOption {
+              type = types.port;
+              default = 443;
+              description = ''
+                Port to listen for HTTPS connections.
+              '';
+            };
+
+            disable-http = lib.mkOption {
+              type = types.bool;
+              default = false;
+              example = true;
+              description = ''
+                Disable all HTTP tunneling. By default, this is enabled globally.
+              '';
+            };
+
+            disable-https = lib.mkOption {
+              type = types.bool;
+              default = false;
+              example = true;
+              description = ''
+                Disable all HTTPS tunneling. By default, this is enabled globally.
+              '';
+            };
+
+            disable-tcp = lib.mkOption {
+              type = types.bool;
+              default = false;
+              example = true;
+              description = ''
+                Disable all TCP port tunneling except HTTP. By default, this is enabled globally.
+
+                ::: {.warning}
+                If this option is false or unset and `services.sandhole.openFirewall` is true,
+                all unprivileged TCP ports (i.e. >= 1024) will be opened.
+                :::
+              '';
+            };
+          };
+        };
+        default = { };
+        description = ''
+          Attribute set of command line options for Sandhole, without the leading hyphens.
+
+          If Sandhole is enabled, then either `services.sandhole.settings.domain` or `services.sandhole.settings.no-domain` must be set.
+
+          ::: {.note}
+          For all available settings, see [the Sandhole documentation](https://sandhole.com.br/cli.html).
+          :::
+        '';
+        example = lib.literalExpression ''
+          {
+            domain = "sandhole.com.br";
+            acme-contact-email = "admin@sandhole.com.br";
+            connect-ssh-on-https-port = true;
+            load-balancing = "replace";
+            allow-requested-subdomains = true;
+            allow-requested-ports = true;
+            random-subdomain-filter-profanities = true;
+            force-https = true;
+            directory-poll-interval = "10s";
+            pool-size = 1024;
+            pool-timeout = "10s";
+          }
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = (cfg.settings.domain or null != null) != (cfg.settings.no-domain or false);
+        message = "Sandhole requires exactly one of `services.sandhole.settings.domain` or `services.sandhole.settings.no-domain` to be set";
+      }
+    ];
+
+    environment = {
+      systemPackages = [ cfg.package ];
+    };
+
+    systemd.services.sandhole = {
+      description = "Sandhole - Expose HTTP/SSH/TCP services through SSH port forwarding";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+      serviceConfig = {
+        User = cfg.user;
+        Group = cfg.group;
+        ExecStart = "${lib.getExe cfg.package} ${lib.cli.toCommandLineShellGNU { } cfg.settings}";
+        Type = "simple";
+        Restart = "always";
+        StateDirectory = name;
+        StateDirectoryMode = "0750";
+        WorkingDirectory = "/var/lib/${name}";
+        AmbientCapabilities = lib.optional needsPrivilegedPorts "CAP_NET_BIND_SERVICE";
+        CapabilityBoundingSet = lib.optional needsPrivilegedPorts "CAP_NET_BIND_SERVICE";
+        # Hardening
+        NoNewPrivileges = true;
+        SystemCallFilter = [
+          "@system-service"
+          "~@privileged"
+          "~@resources"
+        ];
+        SystemCallArchitectures = "native";
+        MemoryDenyWriteExecute = true;
+        PrivateMounts = true;
+        PrivateUsers = !needsPrivilegedPorts; # Incompatible with CAP_NET_BIND_SERVICE
+        PrivateTmp = true;
+        PrivateDevices = true;
+        ProtectHome = true;
+        ProtectClock = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        ProtectSystem = "strict";
+        ProtectControlGroups = "strict";
+        LockPersonality = true;
+        RemoveIPC = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        RestrictNamespaces = true;
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+        ];
+      };
+    };
+
+    users.groups = lib.mkIf (cfg.group == name) { ${cfg.group} = { }; };
+
+    users.users = lib.mkIf (cfg.user == name) {
+      ${cfg.user} = {
+        description = "Sandhole daemon user";
+        group = cfg.group;
+        isSystemUser = true;
+      };
+    };
+
+    networking.firewall = lib.mkIf cfg.openFirewall {
+      allowedTCPPorts = lib.lists.filter (port: port != null) [
+        sshPort
+        httpPort
+        httpsPort
+      ];
+      allowedTCPPortRanges = lib.optional (!(cfg.settings.disable-tcp or false)) {
+        from = 1024;
+        to = 65535;
+      };
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1435,6 +1435,7 @@ in
   sabnzbd-module = runTest ./sabnzbd-module.nix;
   samba = runTest ./samba.nix;
   samba-wsdd = runTest ./samba-wsdd.nix;
+  sandhole = import ./sandhole { inherit runTest; };
   sane = runTest ./sane.nix;
   sanoid = runTest ./sanoid.nix;
   saunafs = runTest ./saunafs.nix;

--- a/nixos/tests/sandhole/complete.nix
+++ b/nixos/tests/sandhole/complete.nix
@@ -1,0 +1,196 @@
+# Set up a Sandhole server with HTTPS certificates,
+# a proxied service in a different machine, and a
+# client who's blacklisted by Sandhole.
+
+{ pkgs, ... }:
+
+let
+  inherit (import ../ssh-keys.nix pkgs)
+    snakeOilEd25519PrivateKey
+    snakeOilEd25519PublicKey
+    ;
+
+  pubKey = pkgs.writeTextDir "user_keys/snakeoil.pub" snakeOilEd25519PublicKey;
+
+  sandholeCerts = import ./generate-certs.nix {
+    inherit pkgs;
+    domain = "sandhole.nix";
+  };
+in
+
+{
+  name = "sandhole-complete";
+  meta.maintainers = with pkgs.lib.maintainers; [ EpicEric ];
+
+  nodes = {
+    # The reverse proxy running Sandhole.
+    sandhole =
+      { lib, ... }:
+      with lib;
+      {
+        virtualisation.vlans = [ 10 ];
+        networking = {
+          useDHCP = false;
+          interfaces.eth1 = {
+            useDHCP = false;
+            ipv4 = {
+              addresses = [
+                {
+                  address = "192.168.10.10";
+                  prefixLength = 24;
+                }
+              ];
+              routes = mkForce [
+                {
+                  address = "0.0.0.0";
+                  prefixLength = 0;
+                  via = "192.168.10.1";
+                }
+              ];
+            };
+          };
+          nameservers = [
+            "8.8.8.8"
+            "8.8.4.4"
+          ];
+        };
+        services.sandhole = {
+          enable = true;
+          openFirewall = true;
+          settings = {
+            domain = "sandhole.nix";
+            user-keys-directory = "${pubKey}/user_keys";
+            certificates-directory = sandholeCerts;
+            bind-hostnames = "all";
+            ip-blocklist = "192.168.10.30/32";
+            force-https = true;
+          };
+        };
+      };
+
+    # The server that will be proxied via SSH.
+    server =
+      { lib, ... }:
+      with lib;
+      {
+        virtualisation.vlans = [ 10 ];
+        networking = {
+          useDHCP = false;
+          interfaces.eth1 = {
+            useDHCP = false;
+            ipv4 = {
+              addresses = [
+                {
+                  address = "192.168.10.20";
+                  prefixLength = 24;
+                }
+              ];
+              routes = mkForce [
+                {
+                  address = "0.0.0.0";
+                  prefixLength = 0;
+                  via = "192.168.10.1";
+                }
+              ];
+            };
+          };
+          firewall.allowedTCPPorts = [ 80 ];
+        };
+
+        users.users.autossh = {
+          isNormalUser = true;
+        };
+        users.groups.autossh = { };
+
+        services.nginx = {
+          enable = true;
+          virtualHosts.localhost = {
+            locations."/" = {
+              return = "200 '<html><body>Hello, NixOS!</body></html>'";
+              extraConfig = ''
+                default_type text/html;
+              '';
+            };
+          };
+        };
+
+        services.autossh.sessions = [
+          {
+            name = "sandhole";
+            user = "autossh";
+            extraArguments = ''
+              -i ${snakeOilEd25519PrivateKey} \
+              -o StrictHostKeyChecking=accept-new \
+              -o ServerAliveInterval=30 \
+              -R hello.sandhole.nix:443:localhost:80 \
+              -p 2222 \
+              192.168.10.10
+            '';
+          }
+        ];
+      };
+
+    # The client that will be blocked from accessing Sandhole.
+    blocked =
+      { lib, ... }:
+      with lib;
+      {
+        virtualisation.vlans = [ 10 ];
+        networking = {
+          useDHCP = false;
+          interfaces.eth1 = {
+            useDHCP = false;
+            ipv4 = {
+              addresses = [
+                {
+                  address = "192.168.10.30";
+                  prefixLength = 24;
+                }
+              ];
+              routes = mkForce [
+                {
+                  address = "0.0.0.0";
+                  prefixLength = 0;
+                  via = "192.168.10.1";
+                }
+              ];
+            };
+          };
+        };
+      };
+  };
+
+  testScript = ''
+    sandhole.start()
+    sandhole.wait_for_unit("sandhole.service")
+    sandhole.wait_for_open_port(2222)
+
+    with subtest("connect to Sandhole"):
+      server.start()
+      server.wait_for_unit("autossh-sandhole.service")
+      server.wait_until_succeeds(
+        "${pkgs.curl}/bin/curl --fail"
+        "  --resolve hello.sandhole.nix:443:192.168.10.10"
+        "  --cacert ${sandholeCerts}/ca.cert.pem"
+        "  https://hello.sandhole.nix"
+        "  | grep 'Hello, NixOS!'",
+        timeout=30,
+      )
+
+    with subtest("get blocklisted by Sandhole"):
+      blocked.start()
+      blocked.wait_for_unit("network.target")
+      blocked.wait_until_succeeds(
+        "${pkgs.curl}/bin/curl --fail"
+        "  http://192.168.10.20"
+        "  | grep 'Hello, NixOS!'",
+        timeout=30,
+      )
+      blocked.fail(
+        "${pkgs.curl}/bin/curl --fail"
+        "  --resolve hello.sandhole.nix:443:192.168.10.10"
+        "  --cacert ${sandholeCerts}/ca.cert.pem"
+        "  https://hello.sandhole.nix"
+      )
+  '';
+}

--- a/nixos/tests/sandhole/default.nix
+++ b/nixos/tests/sandhole/default.nix
@@ -1,0 +1,7 @@
+{
+  runTest,
+}:
+{
+  complete = runTest ./complete.nix;
+  with-container = runTest ./with-container.nix;
+}

--- a/nixos/tests/sandhole/generate-certs.nix
+++ b/nixos/tests/sandhole/generate-certs.nix
@@ -1,0 +1,41 @@
+# Copy of ../common/acme/server/generate-certs.nix
+# to generate wildcard certificates with the directory
+# structure expected by Sandhole.
+{
+  pkgs,
+  domain,
+  minica ? pkgs.minica,
+  mkDerivation ? pkgs.stdenv.mkDerivation,
+}:
+
+let
+  caKey = ../common/acme/server/ca.key.pem;
+  caCert = ../common/acme/server/ca.cert.pem;
+in
+
+mkDerivation {
+  name = "sandhole-generate-certs";
+  buildInputs = [
+    (minica.overrideAttrs (old: {
+      prePatch = ''
+        sed -i 's_NotAfter: time.Now().AddDate(2, 0, 30),_NotAfter: time.Now().AddDate(20, 0, 0),_' main.go
+      '';
+    }))
+  ];
+  dontUnpack = true;
+
+  buildPhase = ''
+    minica \
+      --ca-key ${caKey} \
+      --ca-cert ${caCert} \
+      --domains '${domain},*.${domain}'
+  '';
+
+  installPhase = ''
+    mkdir -p $out/${domain}
+    cp ${caKey} $out/ca.key.pem
+    cp ${caCert} $out/ca.cert.pem
+    cp ${domain}/key.pem $out/${domain}/privkey.pem
+    cp ${domain}/cert.pem $out/${domain}/fullchain.pem
+  '';
+}

--- a/nixos/tests/sandhole/with-container.nix
+++ b/nixos/tests/sandhole/with-container.nix
@@ -1,0 +1,94 @@
+# Set up a Sandhole server without any privileged ports,
+# and a container on the same machine running httpd,
+# which will be proxied via Sandhole.
+
+{ pkgs, ... }:
+
+let
+  inherit (import ../ssh-keys.nix pkgs)
+    snakeOilEd25519PrivateKey
+    snakeOilEd25519PublicKey
+    ;
+
+  pubKey = pkgs.writeTextDir "user_keys/snakeoil.pub" snakeOilEd25519PublicKey;
+
+in
+
+{
+  name = "sandhole-with-container";
+  meta.maintainers = with pkgs.lib.maintainers; [ EpicEric ];
+
+  nodes.machine =
+    { ... }:
+    {
+      virtualisation.vlans = [ 10 ];
+      networking = {
+        nameservers = [
+          "8.8.8.8"
+          "8.8.4.4"
+        ];
+      };
+
+      services.sandhole = {
+        enable = true;
+        openFirewall = true;
+        settings = {
+          domain = "sandhole.nix";
+          user-keys-directory = "${pubKey}/user_keys";
+          bind-hostnames = "all";
+          disable-https = true;
+          http-port = 8080;
+        };
+      };
+
+      containers.httpd = {
+        autoStart = true;
+        privateNetwork = true;
+        hostAddress = "172.16.0.1";
+        localAddress = "172.16.0.2";
+        config = {
+          services.httpd = {
+            enable = true;
+            adminAddr = "foo@example.org";
+          };
+          networking.firewall.allowedTCPPorts = [ 80 ];
+          system.stateVersion = "25.11";
+        };
+      };
+
+      users.users.autossh = {
+        isNormalUser = true;
+      };
+      users.groups.autossh = { };
+      services.autossh.sessions = [
+        {
+          name = "httpd";
+          user = "autossh";
+          extraArguments = ''
+            -i ${snakeOilEd25519PrivateKey} \
+            -o StrictHostKeyChecking=accept-new \
+            -o ServerAliveInterval=30 \
+            -R httpd.sandhole.nix:80:172.16.0.2:80 \
+            -p 2222 \
+            127.0.0.1
+          '';
+        }
+      ];
+    };
+
+  testScript = ''
+    start_all()
+
+    machine.wait_for_unit("sandhole.service")
+    machine.wait_for_open_port(2222)
+    machine.wait_for_unit("autossh-httpd.service")
+    machine.wait_for_unit("multi-user.target")
+    machine.wait_until_succeeds(
+      "${pkgs.curl}/bin/curl --fail"
+      "  --resolve httpd.sandhole.nix:8080:127.0.0.1"
+      "  http://httpd.sandhole.nix:8080"
+      "  | grep 'It works!'",
+      timeout=30,
+    )
+  '';
+}

--- a/pkgs/by-name/sa/sandhole/package.nix
+++ b/pkgs/by-name/sa/sandhole/package.nix
@@ -2,6 +2,7 @@
   cmake,
   fetchFromGitHub,
   lib,
+  nixosTests,
   perl,
   rustPlatform,
   versionCheckHook,
@@ -39,6 +40,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.tests = { inherit (nixosTests) sandhole; };
 
   meta = {
     description = "Expose HTTP/SSH/TCP services through SSH port forwarding";


### PR DESCRIPTION
This adds [Sandhole](https://sandhole.com.br), a reverse proxy based on OpenSSH, as a NixOS module under `service.sandhole`, based on the configuration used to deploy three separate instances to NixOS servers (via [a module in the Sandhole repo](https://github.com/EpicEric/sandhole/blob/main/nix/modules/sandhole.nix)).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
