### PR TITLE
sg3_utils: fix hard coded paths in scripts

### DIFF
--- a/pkgs/by-name/sg/sg3_utils/package.nix
+++ b/pkgs/by-name/sg/sg3_utils/package.nix
@@ -4,17 +4,23 @@
   fetchurl,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "sg3_utils";
   version = "1.48";
 
   src = fetchurl {
-    url = "https://sg.danny.cz/sg/p/sg3_utils-${version}.tgz";
+    url = "https://sg.danny.cz/sg/p/sg3_utils-${finalAttrs.version}.tgz";
     sha256 = "sha256-1itsPPIDkPpzVwRDkAhBZtJfHZMqETXEULaf5cKD13M=";
   };
 
+  postPatch = ''
+    substituteInPlace scripts/rescan-scsi-bus.sh \
+      --replace-fail '/usr/bin/sg_' "$out/bin/sg_"
+  '';
+
   meta = {
     homepage = "https://sg.danny.cz/sg/";
+    changelog = "https://sg.danny.cz/sg/p/sg3_utils.ChangeLog";
     description = "Utilities that send SCSI commands to devices";
     platforms = lib.platforms.linux;
     license = with lib.licenses; [
@@ -22,4 +28,4 @@ stdenv.mkDerivation rec {
       gpl2Plus
     ];
   };
-}
+})


### PR DESCRIPTION
There were hard coded paths for utilities in some scripts, this replaces them.
Also update to finalattrs pattern and add changelog url.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
