### PR TITLE
nginxModules.vod: fix build on gcc 15; cleanup

### DIFF
--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -1010,6 +1010,9 @@ let
             --replace-fail "MAX_CLIPS (128)" "MAX_CLIPS (1024)"
           substituteInPlace vod/subtitle/dfxp_format.c \
             --replace-fail '(!ctxt->wellFormed && !ctxt->recovery))' '!ctxt->wellFormed)'
+          # https://github.com/kaltura/nginx-vod-module/pull/1593
+          substituteInPlace ngx_http_vod_module.c \
+            --replace-fail 'ngx_http_vod_exit_process()' 'ngx_http_vod_exit_process(ngx_cycle_t *cycle)'
         '';
       };
 

--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -2,6 +2,7 @@
   lib,
   config,
   nixosTests,
+  applyPatches,
   fetchFromGitHub,
   fetchFromGitLab,
   fetchhg,
@@ -996,16 +997,18 @@ let
 
     vod = {
       name = "vod";
-      src = fetchFromGitHub {
+      src = applyPatches {
         name = "vod";
-        owner = "kaltura";
-        repo = "nginx-vod-module";
-        rev = "1.33";
-        hash = "sha256-pForXU1VBxa4F3F7xK+DJtMKC4wgcykJImlQjxz5GnE=";
-        postFetch = ''
-          substituteInPlace $out/vod/media_set.h \
-            --replace "MAX_CLIPS (128)" "MAX_CLIPS (1024)"
-          substituteInPlace $out/vod/subtitle/dfxp_format.c \
+        src = fetchFromGitHub {
+          owner = "kaltura";
+          repo = "nginx-vod-module";
+          tag = "1.33";
+          hash = "sha256-hf4iprkdNP7lVlrm/7kMkrp/8440PuTZiL1hv/Icfm4=";
+        };
+        postPatch = ''
+          substituteInPlace vod/media_set.h \
+            --replace-fail "MAX_CLIPS (128)" "MAX_CLIPS (1024)"
+          substituteInPlace vod/subtitle/dfxp_format.c \
             --replace-fail '(!ctxt->wellFormed && !ctxt->recovery))' '!ctxt->wellFormed)'
         '';
       };


### PR DESCRIPTION
Related to #475479.

## Things done

`nix-build -A nixosTests.frigate` (when combined with #476048)

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
