### PR TITLE
paratype-pt-{serif,sans,mono}: move src to google fonts, update license

### DIFF
--- a/pkgs/by-name/pa/paratype-pt-mono/package.nix
+++ b/pkgs/by-name/pa/paratype-pt-mono/package.nix
@@ -1,41 +1,37 @@
 {
   lib,
   stdenvNoCC,
-  fetchzip,
+  fetchFromGitHub,
 }:
 
 stdenvNoCC.mkDerivation {
   pname = "paratype-pt-mono";
-  version = "2.005";
+  version = "1.001";
 
-  src = fetchzip {
-    urls = [
-      "https://company.paratype.com/system/attachments/631/original/ptmono.zip"
-      "http://rus.paratype.ru/system/attachments/631/original/ptmono.zip"
-    ];
-    stripRoot = false;
-    hash = "sha256-mfDAu/KGelC6wZpUCrUrLVZKo+XiKNBqcpMI8tH2tMw=";
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = "fonts";
+    rev = "a4f3deeca2d7547351ff746f7bf3b51f5528dbcf";
+    hash = "sha256-wzm6KzO/arar7VMvm0l0L6gi3CnglmZKSGe7c0i530Q=";
+    rootDir = "ofl/ptmono";
   };
 
   installPhase = ''
     runHook preInstall
 
     install -Dm644 *.ttf -t $out/share/fonts/truetype
-    install -Dm644 *.txt -t $out/share/doc/paratype
 
     runHook postInstall
   '';
 
   meta = {
-    homepage = "http://www.paratype.ru/public/";
+    homepage = "https://www.paratype.ru/catalog/font/pt/pt-mono";
     description = "Open Paratype font";
-
-    license = lib.licenses.paratype;
-    # no commercial distribution of the font on its own
-    # must rename on modification
-    # http://www.paratype.ru/public/pt_openlicense.asp
-
+    license = lib.licenses.ofl;
     platforms = lib.platforms.all;
-    maintainers = with lib.maintainers; [ raskin ];
+    maintainers = with lib.maintainers; [
+      raskin
+      pancaek
+    ];
   };
 }

--- a/pkgs/by-name/pa/paratype-pt-sans/package.nix
+++ b/pkgs/by-name/pa/paratype-pt-sans/package.nix
@@ -1,41 +1,37 @@
 {
   lib,
   stdenvNoCC,
-  fetchzip,
+  fetchFromGitHub,
 }:
 
 stdenvNoCC.mkDerivation {
   pname = "paratype-pt-sans";
-  version = "2.005";
+  version = "2.003";
 
-  src = fetchzip {
-    urls = [
-      "https://company.paratype.com/system/attachments/629/original/ptsans.zip"
-      "http://rus.paratype.ru/system/attachments/629/original/ptsans.zip"
-    ];
-    stripRoot = false;
-    hash = "sha256-34TqYXtWzkAstaGQBhJy+/hVk5tg6ZvHZ/kvUroWVLs=";
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = "fonts";
+    rev = "a4f3deeca2d7547351ff746f7bf3b51f5528dbcf";
+    hash = "sha256-44G9Pdi4GxeC9hzvCKuE7AmHyjVrjzalr3XZOgl3l6o=";
+    rootDir = "ofl/ptsans";
   };
 
   installPhase = ''
     runHook preInstall
 
     install -Dm644 *.ttf -t $out/share/fonts/truetype
-    install -Dm644 *.txt -t $out/share/doc/paratype
 
     runHook postInstall
   '';
 
   meta = {
-    homepage = "http://www.paratype.ru/public/";
+    homepage = "https://www.paratype.ru/catalog/font/pt/pt-sans";
     description = "Open Paratype font";
-
-    license = lib.licenses.paratype;
-    # no commercial distribution of the font on its own
-    # must rename on modification
-    # http://www.paratype.ru/public/pt_openlicense.asp
-
+    license = lib.licenses.ofl;
     platforms = lib.platforms.all;
-    maintainers = with lib.maintainers; [ raskin ];
+    maintainers = with lib.maintainers; [
+      raskin
+      pancaek
+    ];
   };
 }

--- a/pkgs/by-name/pa/paratype-pt-serif/package.nix
+++ b/pkgs/by-name/pa/paratype-pt-serif/package.nix
@@ -1,41 +1,37 @@
 {
   lib,
   stdenvNoCC,
-  fetchzip,
+  fetchFromGitHub,
 }:
 
 stdenvNoCC.mkDerivation {
   pname = "paratype-pt-serif";
-  version = "2.005";
+  version = "1.000";
 
-  src = fetchzip {
-    urls = [
-      "https://company.paratype.com/system/attachments/634/original/ptserif.zip"
-      "http://rus.paratype.ru/system/attachments/634/original/ptserif.zip"
-    ];
-    stripRoot = false;
-    hash = "sha256-4L3t5NEHmj975fn8eBAkRUO1OL0xseNp9g7k7tt/O2c=";
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = "fonts";
+    rev = "a4f3deeca2d7547351ff746f7bf3b51f5528dbcf";
+    hash = "sha256-HpA4r5VqAVtPFY9ltRUeZERNfyFRkAvwununoDF+5mk=";
+    rootDir = "ofl/ptserif";
   };
 
   installPhase = ''
     runHook preInstall
 
     install -Dm644 *.ttf -t $out/share/fonts/truetype
-    install -Dm644 *.txt -t $out/share/doc/paratype
 
     runHook postInstall
   '';
 
   meta = {
-    homepage = "http://www.paratype.ru/public/";
+    homepage = "https://www.paratype.ru/catalog/font/pt/pt-serif";
     description = "Open Paratype font";
-
-    license = lib.licenses.paratype;
-    # no commercial distribution of the font on its own
-    # must rename on modification
-    # http://www.paratype.ru/public/pt_openlicense.asp
-
+    license = lib.licenses.ofl;
     platforms = lib.platforms.all;
-    maintainers = with lib.maintainers; [ raskin ];
+    maintainers = with lib.maintainers; [
+      raskin
+      pancaek
+    ];
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Closes #473042

There's also narrow and caption variants, looking at the cached version these were part of the sans and serif packages originally, but google fonts treats them as distinct fonts. Should I create new packages, or should I bundle them together like the old src did? Also, looks like google fonts uses different version numbering than the paratype site, so that's why the version changed.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
