### PR TITLE
units: fix GCC15 build and cleanup

### DIFF
--- a/pkgs/by-name/un/units/package.nix
+++ b/pkgs/by-name/un/units/package.nix
@@ -30,12 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ bison ];
 
-  buildInputs = [
-    readline
-  ]
-  ++ lib.optionals enableCurrenciesUpdater [
-    pythonEnv
-  ];
+  buildInputs = [ readline ];
 
   # Matches AUR PKGBuild change for unbreaking builds GCC15
   env.NIX_CFLAGS_COMPILE = "-std=gnu17";

--- a/pkgs/by-name/un/units/package.nix
+++ b/pkgs/by-name/un/units/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   fetchurl,
+  bison,
   python3,
   readline,
   stdenv,
@@ -27,12 +28,17 @@ stdenv.mkDerivation (finalAttrs: {
     "man"
   ];
 
+  nativeBuildInputs = [ bison ];
+
   buildInputs = [
     readline
   ]
   ++ lib.optionals enableCurrenciesUpdater [
     pythonEnv
   ];
+
+  # Matches AUR PKGBuild change for unbreaking builds GCC15
+  env.NIX_CFLAGS_COMPILE = "-std=gnu17";
 
   prePatch = lib.optionalString enableCurrenciesUpdater ''
     substituteInPlace units_cur \

--- a/pkgs/by-name/un/units/package.nix
+++ b/pkgs/by-name/un/units/package.nix
@@ -35,9 +35,9 @@ stdenv.mkDerivation (finalAttrs: {
   # Matches AUR PKGBuild change for unbreaking builds GCC15
   env.NIX_CFLAGS_COMPILE = "-std=gnu17";
 
-  prePatch = lib.optionalString enableCurrenciesUpdater ''
+  postPatch = lib.optionalString enableCurrenciesUpdater ''
     substituteInPlace units_cur \
-      --replace "#!/usr/bin/env python" ${pythonEnv}/bin/python
+      --replace-fail "#!/usr/bin/python" "#!${pythonEnv}/bin/python"
   '';
 
   postInstall = lib.optionalString enableCurrenciesUpdater ''


### PR DESCRIPTION
Part of https://github.com/NixOS/nixpkgs/issues/475479


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
