### PR TITLE
picoscope: use wrapGAppsHook3 instead of manual wrapping

### DIFF
--- a/pkgs/by-name/pi/picoscope/package.nix
+++ b/pkgs/by-name/pi/picoscope/package.nix
@@ -11,12 +11,12 @@
   libcap,
   librsvg,
   libusb1,
-  makeWrapper,
   openssl,
   patchelf,
   stdenv,
   systemdMinimal,
   onetbb,
+  wrapGAppsHook3,
   writeTextDir,
 }:
 
@@ -27,6 +27,7 @@ let
   libraryPath = lib.makeLibraryPath libraries;
   libraries = [
     gdk-pixbuf
+    glib
     glibc
     gtk3
     icu
@@ -38,8 +39,6 @@ let
     systemdMinimal
     onetbb
   ];
-
-  gdkLoadersCache = "${gdk-pixbuf.out}/${gdk-pixbuf.moduleDir}.cache";
 
 in
 stdenv.mkDerivation {
@@ -56,8 +55,10 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [
     dpkg
-    makeWrapper
+    wrapGAppsHook3
   ];
+
+  dontWrapGApps = true;
 
   buildInputs = libraries;
 
@@ -78,17 +79,13 @@ stdenv.mkDerivation {
 
     # LD_LIBRARY_PATH: not strictly needed for the main exe (rpath already covers it), but required
     # for dlopened plugins that ignore rpath or use absolute sonames.
-    # GDK_PIXBUF_MODULE_FILE: points gdk-pixbuf to Nix’s loader cache so image loaders (gif/svg/png)
-    # come from our matched version, not the host. This fixes the “g_module_*” symbol errors.
-    # GIO_MODULE_DIR: restricts GIO to GLib’s core modules only (no dconf/gvfs host bleed-through).
     # SSL_CERT_DIR/SSL_CERT_FILE: Gives OpenSSL a known CA bundle so any HTTPS inside the app works
     # without querying host paths.
     makeWrapper $out/lib/PicoScope.GTK $out/bin/picoscope \
       --set LD_LIBRARY_PATH "$out/lib:${libraryPath}" \
-      --set GDK_PIXBUF_MODULE_FILE "${gdkLoadersCache}" \
-      --set GIO_MODULE_DIR "${glib.out}/lib/gio/modules" \
       --set SSL_CERT_DIR "${cacert}/etc/ssl/certs" \
-      --set SSL_CERT_FILE "${cacert}/etc/ssl/certs/ca-bundle.crt"
+      --set SSL_CERT_FILE "${cacert}/etc/ssl/certs/ca-bundle.crt" \
+      ''${gappsWrapperArgs[@]}
     runHook postInstall
   '';
 


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
