### PR TITLE
{README.md,.github/*}: remove/replace references to 25.05 release

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.yml
@@ -37,7 +37,6 @@ body:
         - "Please select a version."
         - "- Unstable (26.05)"
         - "- Stable (25.11)"
-        - "- Old Stable (25.05)"
       default: 0
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/02_bug_report_darwin.yml
+++ b/.github/ISSUE_TEMPLATE/02_bug_report_darwin.yml
@@ -37,7 +37,6 @@ body:
         - "Please select a version."
         - "- Unstable (26.05)"
         - "- Stable (25.11)"
-        - "- Old Stable (25.05)"
       default: 0
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/03_bug_report_nixos.yml
+++ b/.github/ISSUE_TEMPLATE/03_bug_report_nixos.yml
@@ -37,7 +37,6 @@ body:
         - "Please select a version."
         - "- Unstable (26.05)"
         - "- Stable (25.11)"
-        - "- Old Stable (25.05)"
       default: 0
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/04_build_failure.yml
+++ b/.github/ISSUE_TEMPLATE/04_build_failure.yml
@@ -39,7 +39,6 @@ body:
         - "Please select a version."
         - "- Unstable (26.05)"
         - "- Stable (25.11)"
-        - "- Old Stable (25.05)"
       default: 0
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/05_update_request.yml
+++ b/.github/ISSUE_TEMPLATE/05_update_request.yml
@@ -39,7 +39,6 @@ body:
         - "Please select a version."
         - "- Unstable (26.05)"
         - "- Stable (25.11)"
-        - "- Old Stable (25.05)"
       default: 0
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/06_module_request.yml
+++ b/.github/ISSUE_TEMPLATE/06_module_request.yml
@@ -37,7 +37,6 @@ body:
         - "Please select a version."
         - "- Unstable (26.05)"
         - "- Stable (25.11)"
-        - "- Old Stable (25.05)"
       default: 0
     validations:
       required: true

--- a/.github/labeler-no-sync.yml
+++ b/.github/labeler-no-sync.yml
@@ -22,17 +22,6 @@
               - doc/**/*
               - nixos/doc/**/*
 
-"backport release-25.05":
-  - all:
-      - changed-files:
-          - any-glob-to-any-file:
-              - .github/actions/*
-              - .github/workflows/*
-              - .github/labeler*.yml
-              - ci/**/*.*
-              - maintainers/github-teams.json
-      - base-branch: ['master']
-
 "backport release-25.11":
   - all:
       - changed-files:

--- a/.github/workflows/periodic-merge-24h.yml
+++ b/.github/workflows/periodic-merge-24h.yml
@@ -31,10 +31,6 @@ jobs:
       max-parallel: 1
       matrix:
         pairs:
-          - from: release-25.05
-            into: staging-next-25.05
-          - from: staging-next-25.05
-            into: staging-25.05
           - from: release-25.11
             into: staging-next-25.11
           - from: staging-next-25.11

--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ Here are some of the main ones:
 Nixpkgs and NixOS are built and tested by our continuous integration system, [Hydra](https://hydra.nixos.org/).
 
 * [Continuous package builds for unstable/master](https://hydra.nixos.org/jobset/nixos/trunk-combined)
-* [Continuous package builds for the NixOS 25.05 release](https://hydra.nixos.org/jobset/nixos/release-25.05)
+* [Continuous package builds for the NixOS 25.11 release](https://hydra.nixos.org/jobset/nixos/release-25.11)
 * [Tests for unstable/master](https://hydra.nixos.org/job/nixos/trunk-combined/tested#tabs-constituents)
-* [Tests for the NixOS 25.05 release](https://hydra.nixos.org/job/nixos/release-25.05/tested#tabs-constituents)
+* [Tests for the NixOS 25.11 release](https://hydra.nixos.org/job/nixos/release-25.11/tested#tabs-constituents)
 
 Artifacts successfully built with Hydra are published to cache at https://cache.nixos.org/.
 When successful build and test criteria are met, the Nixpkgs expressions are distributed via [Nix channels](https://nix.dev/manual/nix/stable/command-ref/nix-channel.html).


### PR DESCRIPTION
I believe this should be most things in-tree needing removal/replacing (verified by a quick `rg 25.05`).

The only exception I'm aware of is `lib.trivial.oldestSupportedRelease`, which can't be backported, so it can be done seperately.

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
