### PR TITLE
fbida: fix build with GCC 15

### DIFF
--- a/pkgs/by-name/fb/fbida/function-parameters.patch
+++ b/pkgs/by-name/fb/fbida/function-parameters.patch
@@ -1,0 +1,16 @@
+diff --git a/jpeg/62/jpeglib.h b/jpeg/62/jpeglib.h
+index d1be8dd..38436ef 100644
+--- a/jpeg/62/jpeglib.h
++++ b/jpeg/62/jpeglib.h
+@@ -814,11 +814,7 @@ typedef JMETHOD(boolean, jpeg_marker_parser_method, (j_decompress_ptr cinfo));
+  * Note JPP requires double parentheses.
+  */
+ 
+-#ifdef HAVE_PROTOTYPES
+ #define JPP(arglist)	arglist
+-#else
+-#define JPP(arglist)	()
+-#endif
+ 
+ 
+ /* Short forms of external names for systems with brain-damaged linkers.

--- a/pkgs/by-name/fb/fbida/package.nix
+++ b/pkgs/by-name/fb/fbida/package.nix
@@ -41,6 +41,8 @@ stdenv.mkDerivation rec {
       url = "https://git.kraxel.org/cgit/fbida/patch/?id=1bb8a8aa29845378903f3c690e17c0867c820da2";
       sha256 = "0n5vqbp8wd87q60zfwdf22jirggzngypc02ha34gsj1rd6pvwahi";
     })
+    # Prevents using function declaration without explicit parameters.
+    ./function-parameters.patch
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Closes https://github.com/NixOS/nixpkgs/issues/475918

Track https://github.com/NixOS/nixpkgs/issues/475479

The build failure was caused by conditionally excluding function parameters in function declarations, determined by a macro `HAVE_PROTOTYPES`. Removing that conditional logic and always exposing full function signatures fix this issue.

PS: I found that there are other versions of jpeglib vendored in the upstream codebase. I only patched the version that `fbida` actually depended on. (i.e. 62) 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
