### PR TITLE
nethack{,-x11}: fix build with GCC 15

### DIFF
--- a/pkgs/by-name/ne/nethack/function-parameters.patch
+++ b/pkgs/by-name/ne/nethack/function-parameters.patch
@@ -1,0 +1,86 @@
+diff --git a/include/system.h b/include/system.h
+index a2cb51f..9f40fdd 100644
+--- a/include/system.h
++++ b/include/system.h
+@@ -60,17 +60,17 @@ typedef long off_t;
+ #endif
+ #ifndef SIG_RET_TYPE
+ #if defined(NHSTDC) || defined(POSIX_TYPES) || defined(OS2) || defined(__DECC)
+-#define SIG_RET_TYPE void (*)()
++#define SIG_RET_TYPE void (*)(int)
+ #endif
+ #endif
+ #ifndef SIG_RET_TYPE
+ #if defined(ULTRIX) || defined(SUNOS4) || defined(SVR3) || defined(SVR4)
+ /* SVR3 is defined automatically by some systems */
+-#define SIG_RET_TYPE void (*)()
++#define SIG_RET_TYPE void (*)(int)
+ #endif
+ #endif
+ #ifndef SIG_RET_TYPE /* BSD, SIII, SVR2 and earlier, Sun3.5 and earlier */
+-#define SIG_RET_TYPE int (*)()
++#define SIG_RET_TYPE int (*)(int)
+ #endif
+ 
+ #if !defined(__cplusplus) && !defined(__GO32__)
+@@ -96,7 +96,7 @@ E long NDECL(lrand48);
+ E void FDECL(srand48, (long));
+ #else
+ E long lrand48();
+-E void srand48();
++E void srand48(long);
+ #endif /* MACOSX */
+ #endif /* BSD || ULTRIX || RANDOM */
+ 
+@@ -352,10 +352,10 @@ E char *FDECL(memset, (char *, int, int));
+ #endif /* MICRO */
+ 
+ #if defined(BSD) && defined(ultrix) /* i.e., old versions of Ultrix */
+-E void sleep();
++E void sleep(unsigned);
+ #endif
+ #if defined(ULTRIX) || defined(SYSV)
+-E unsigned sleep();
++E unsigned sleep(unsigned);
+ #endif
+ #if defined(HPUX)
+ E unsigned int FDECL(sleep, (unsigned int));
+@@ -519,7 +519,7 @@ E char *FDECL(tgoto, (const char *, int, int));
+ #else
+ #if !(defined(HPUX) && defined(_POSIX_SOURCE))
+ E int FDECL(tgetent, (char *, const char *));
+-E void FDECL(tputs, (const char *, int, int (*)()));
++E void FDECL(tputs, (const char *, int, int (*)(int)));
+ #endif
+ E int FDECL(tgetnum, (const char *));
+ E int FDECL(tgetflag, (const char *));
+diff --git a/include/winX.h b/include/winX.h
+index a1a5605..1d6b84b 100644
+--- a/include/winX.h
++++ b/include/winX.h
+@@ -279,7 +279,7 @@ typedef struct {
+ } AppResources;
+ 
+ E AppResources appResources;
+-E void (*input_func)();
++E void (*input_func)(Widget, XEvent *, String *, Cardinal *);
+ 
+ extern struct window_procs X11_procs;
+ 
+diff --git a/include/xwindow.h b/include/xwindow.h
+index 8b9cfa0..8307c25 100644
+--- a/include/xwindow.h
++++ b/include/xwindow.h
+@@ -76,8 +76,10 @@
+ #define XtNexposeCallback "exposeCallback"
+ #define XtNresizeCallback "resizeCallback"
+ 
+-extern XFontStruct *WindowFontStruct(/* Widget */);
+-extern Font WindowFont(/* Widget */);
++struct Widget;
++
++extern XFontStruct *WindowFontStruct(Widget);
++extern Font WindowFont(Widget);
+ 
+ #define XtCWindowResource "WindowResource"
+ #define XtCRows "Rows"

--- a/pkgs/by-name/ne/nethack/package.nix
+++ b/pkgs/by-name/ne/nethack/package.nix
@@ -67,6 +67,11 @@ stdenvUsed.mkDerivation (finalAttrs: {
     hash = "sha256-mM9n323r+WaKYXRaqEwJvKs2Ll0z9blE7FFV1E0qrLI=";
   };
 
+  patches = [
+    # Newer GCC rejects function declarations without explicit parameters.
+    ./function-parameters.patch
+  ];
+
   buildInputs = [
     ncurses
   ]


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Resolve https://github.com/NixOS/nixpkgs/issues/475923

Track https://github.com/NixOS/nixpkgs/issues/475479

This PR fixes incompatibility between GCC 15 and function declarations without explicit parameters. Note that `nethack-x11` also broke, though it wasn't discovered before.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
