### PR TITLE
picat: Fix build with GCC 15; 3.8#7 → 3.9#4

### DIFF
--- a/pkgs/by-name/pi/picat/package.nix
+++ b/pkgs/by-name/pi/picat/package.nix
@@ -8,11 +8,11 @@
 
 stdenv.mkDerivation {
   pname = "picat";
-  version = "3.8#7";
+  version = "3.9#4";
 
   src = fetchurl {
-    url = "https://picat-lang.org/download/picat387_src.tar.gz";
-    hash = "sha256-H+aFmagdb7jU4LZCYrNPa4ZWVB1ziiJHrUe4b1ImWks=";
+    url = "https://picat-lang.org/download/picat394_src.tar.gz";
+    hash = "sha256-dAYiV2zG2Z01qBshsqORL9oR2NvNnRavvGSDaOEJdDk=";
   };
 
   patches = [

--- a/pkgs/by-name/pi/picat/package.nix
+++ b/pkgs/by-name/pi/picat/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  fetchpatch,
   zlib,
 }:
 
@@ -13,6 +14,15 @@ stdenv.mkDerivation {
     url = "https://picat-lang.org/download/picat387_src.tar.gz";
     hash = "sha256-H+aFmagdb7jU4LZCYrNPa4ZWVB1ziiJHrUe4b1ImWks=";
   };
+
+  patches = [
+    # Fix build with GCC 15
+    # https://github.com/picat-lang/Picat/pull/1
+    (fetchpatch {
+      url = "https://github.com/picat-lang/Picat/commit/c50265dc565f1637e3d22c92b4bf9c4c79d57a03.patch";
+      hash = "sha256-21F35CVNgX4Zj0pK0zUyJaVpK0e399lQXD7vQf7GXgQ=";
+    })
+  ];
 
   buildInputs = [ zlib ];
 


### PR DESCRIPTION
Fix a `picat` [build error](https://hydra.nixos.org/job/nixos/unstable/nixpkgs.picat.x86_64-linux) with GCC 15, and update to the current version.

- #475479
- https://github.com/picat-lang/Picat/pull/1
- https://picat-lang.org/updates.txt

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
