### PR TITLE
libstrophe: fix build with GCC 15

### DIFF
--- a/pkgs/by-name/li/libstrophe/package.nix
+++ b/pkgs/by-name/li/libstrophe/package.nix
@@ -22,10 +22,17 @@ stdenv.mkDerivation rec {
     hash = "sha256-53O8hHyw9y0Bzs+BpGouAxuSGJxh6NSNNWZqi7RHAsY=";
   };
 
+  patches = [
+    # Newer GCC rejects implicitly weak-typed pointer casting.
+    # Upstream PR: https://github.com/strophe/libstrophe/pull/267
+    ./pointer-cast.patch
+  ];
+
   nativeBuildInputs = [
     autoreconfHook
     pkg-config
   ];
+
   buildInputs = [
     openssl
     expat

--- a/pkgs/by-name/li/libstrophe/pointer-cast.patch
+++ b/pkgs/by-name/li/libstrophe/pointer-cast.patch
@@ -1,0 +1,65 @@
+diff --git a/src/handler.c b/src/handler.c
+index 1c9bf9f..168df75 100644
+--- a/src/handler.c
++++ b/src/handler.c
+@@ -320,7 +320,7 @@ static void _timed_handler_delete(xmpp_ctx_t *ctx,
+  */
+ void xmpp_timed_handler_delete(xmpp_conn_t *conn, xmpp_timed_handler handler)
+ {
+-    _timed_handler_delete(conn->ctx, &conn->timed_handlers, handler);
++    _timed_handler_delete(conn->ctx, &conn->timed_handlers, (xmpp_void_handler)handler);
+ }
+ 
+ static void _id_handler_add(xmpp_conn_t *conn,
+@@ -349,7 +349,7 @@ static void _id_handler_add(xmpp_conn_t *conn,
+         return;
+ 
+     item->user_handler = user_handler;
+-    item->handler = handler;
++    item->handler = (xmpp_void_handler)handler;
+     item->userdata = userdata;
+     item->enabled = 0;
+     item->next = NULL;
+@@ -451,7 +451,7 @@ static void _handler_add(xmpp_conn_t *conn,
+ 
+     memset(item, 0, sizeof(*item));
+     item->user_handler = user_handler;
+-    item->handler = handler;
++    item->handler = (xmpp_void_handler)handler;
+     item->userdata = userdata;
+ 
+     if (_dup_string(conn->ctx, ns, &item->u.ns))
+@@ -530,7 +530,7 @@ void xmpp_timed_handler_add(xmpp_conn_t *conn,
+                             unsigned long period,
+                             void *userdata)
+ {
+-    _timed_handler_add(conn->ctx, &conn->timed_handlers, handler, period,
++    _timed_handler_add(conn->ctx, &conn->timed_handlers, (xmpp_void_handler)handler, period,
+                        userdata, 1);
+ }
+ 
+@@ -548,7 +548,7 @@ void handler_add_timed(xmpp_conn_t *conn,
+                        unsigned long period,
+                        void *userdata)
+ {
+-    _timed_handler_add(conn->ctx, &conn->timed_handlers, handler, period,
++    _timed_handler_add(conn->ctx, &conn->timed_handlers, (xmpp_void_handler)handler, period,
+                        userdata, 0);
+ }
+ 
+@@ -747,7 +747,7 @@ void xmpp_global_timed_handler_add(xmpp_ctx_t *ctx,
+                                    unsigned long period,
+                                    void *userdata)
+ {
+-    _timed_handler_add(ctx, &ctx->timed_handlers, handler, period, userdata, 1);
++    _timed_handler_add(ctx, &ctx->timed_handlers, (xmpp_void_handler)handler, period, userdata, 1);
+ }
+ 
+ /** Delete a global timed handler.
+@@ -760,5 +760,5 @@ void xmpp_global_timed_handler_add(xmpp_ctx_t *ctx,
+ void xmpp_global_timed_handler_delete(xmpp_ctx_t *ctx,
+                                       xmpp_global_timed_handler handler)
+ {
+-    _timed_handler_delete(ctx, &ctx->timed_handlers, handler);
++    _timed_handler_delete(ctx, &ctx->timed_handlers, (xmpp_void_handler)handler);
+ }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Resolves https://github.com/NixOS/nixpkgs/issues/475926

Tracks https://github.com/NixOS/nixpkgs/issues/475479

This PR fixes compile errors on implicitly weak-typed casting between pointers.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
