### PR TITLE
lingeling: Fix build errors with GCC 15

### DIFF
--- a/pkgs/by-name/li/lingeling/gcc-15.patch
+++ b/pkgs/by-name/li/lingeling/gcc-15.patch
@@ -1,0 +1,58 @@
+From f1e35d1102a87eb576ce3f09da5cdf1d4b09722c Mon Sep 17 00:00:00 2001
+From: Anders Kaseorg <andersk@mit.edu>
+Date: Thu, 1 Jan 2026 21:50:52 -0800
+Subject: [PATCH] Fix incompatible pointer type errors from GCC 15
+
+Signed-off-by: Anders Kaseorg <andersk@mit.edu>
+---
+ treengeling.c | 16 +++++++++++++---
+ 1 file changed, 13 insertions(+), 3 deletions(-)
+
+diff --git a/treengeling.c b/treengeling.c
+index 1fcafc8..c26c5b5 100644
+--- a/treengeling.c
++++ b/treengeling.c
+@@ -292,6 +292,16 @@ UNLOCK (simplified)
+ UNLOCK (stats)
+ UNLOCK (workers)
+ 
++static void lockmsg_callback (void * voidptr) {
++  lockmsg();
++  (void) voidptr;
++}
++
++static void unlockmsg_callback (void * voidptr) {
++  unlockmsg();
++  (void) voidptr;
++}
++
+ /*------------------------------------------------------------------------*/
+ 
+ static void err (const char * fmt, ...) {
+@@ -818,7 +828,7 @@ static void initroot () {
+     lglsetopt (root, "bca", 0);
+     lglseterm (root, term, 0);
+     lglsetconsumeunits (root, consumeunits, &rootconsumed);
+-    lglsetmsglock (root, lockmsg, unlockmsg, 0);
++    lglsetmsglock (root, lockmsg_callback, unlockmsg_callback, 0);
+   }
+   lglsetime (root, getime);
+   lglsetprefix (root, "c (root) ");
+@@ -857,7 +867,7 @@ static Node * newnode (Node * parent, int decision) {
+   sprintf (prefix, "c (%d %lld) ", res->depth, (LL) res->id);
+   lglsetprefix (res->lgl, prefix);
+   lglseterm (res->lgl, term, 0);
+-  lglsetmsglock (res->lgl, lockmsg, unlockmsg, 0);
++  lglsetmsglock (res->lgl, lockmsg_callback, unlockmsg_callback, 0);
+   if (!noparallel) lglsetconsumeunits (res->lgl, consumeunits, &res->consumed);
+   cubemsg (res, "opened cube");
+   added++;
+@@ -1040,7 +1050,7 @@ static void startparallel (LGL * lgl) {
+   lglseterm (parallel.lgl, term, 0);
+   lglsetproduceunit (parallel.lgl, produceunit, 0);
+   lglsetconsumecls (parallel.lgl, consumecls, 0);
+-  lglsetmsglock (parallel.lgl, lockmsg, unlockmsg, 0);
++  lglsetmsglock (parallel.lgl, lockmsg_callback, unlockmsg_callback, 0);
+   parallel.decisions = lglgetdecs (parallel.lgl);
+   parallel.conflicts = lglgetconfs (parallel.lgl);
+   parallel.propagations = lglgetprops (parallel.lgl);

--- a/pkgs/by-name/li/lingeling/package.nix
+++ b/pkgs/by-name/li/lingeling/package.nix
@@ -17,6 +17,12 @@ stdenv.mkDerivation {
     sha256 = "1lb2g37nd8qq5hw5g6l691nx5095336yb2zlbaw43mg56hkj8357";
   };
 
+  patches = [
+    # Fix incompatible pointer type errors from GCC 15
+    # https://github.com/arminbiere/lingeling/pull/11
+    ./gcc-15.patch
+  ];
+
   configurePhase = ''
     runHook preConfigure
 


### PR DESCRIPTION
- https://hydra.nixos.org/job/nixos/unstable/nixpkgs.lingeling.x86_64-linux
- #475479
- arminbiere/lingeling#11

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
