### PR TITLE
lrs: fix compilation with gcc15

### DIFF
--- a/pkgs/by-name/lr/lrs/fix-signal-handler-type.patch
+++ b/pkgs/by-name/lr/lrs/fix-signal-handler-type.patch
@@ -1,0 +1,43 @@
+diff '--color=auto' -u -r a/lrslib.c b/lrslib.c
+--- a/lrslib.c
++++ b/lrslib.c
+@@ -84,10 +84,10 @@
+ /* signals handling            */
+ /*******************************/
+ #ifndef SIGNALS
+-static void checkpoint ();
+-static void die_gracefully ();
++static void checkpoint (int);
++static void die_gracefully (int);
+ static void setup_signals (void);
+-static void timecheck ();
++static void timecheck (int);
+ #endif
+ 
+ /*******************************/
+@@ -6368,7 +6368,7 @@
+ }
+ 
+ static void
+-timecheck ()
++timecheck (int)
+ {
+   lrs_dump_state ();
+   errcheck ("signal", signal (SIGALRM, timecheck));
+@@ -6376,14 +6376,14 @@
+ }
+ 
+ static void
+-checkpoint ()
++checkpoint (int)
+ {
+   lrs_dump_state ();
+   errcheck ("signal", signal (SIGUSR1, checkpoint));
+ }
+ 
+ static void
+-die_gracefully ()
++die_gracefully (int)
+ {
+   lrs_dump_state ();
+ 

--- a/pkgs/by-name/lr/lrs/package.nix
+++ b/pkgs/by-name/lr/lrs/package.nix
@@ -14,6 +14,11 @@ stdenv.mkDerivation {
     sha256 = "sha256-xJpOvYVhg0c9HVpieF/N/hBX1dZx1LlvOhJQ6xr+ToM=";
   };
 
+  patches = [
+    # fix passing argument 2 of 'signal' from incompatible pointer type error
+    ./fix-signal-handler-type.patch
+  ];
+
   buildInputs = [ gmp ];
 
   makeFlags = [


### PR DESCRIPTION
Fixes compilation error with gcc15:

```
lrs> lrslib.h:40:24: error: passing argument 2 of 'signal' from incompatible pointer type [-Wincompatible-pointer-types]
lrs>    40 | #define checkpoint suf(checkpoint)
lrs>       |                        ^~~~~~~~~~
lrs>       |                        |
lrs>       |                        void (*)(void)
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
