### PR TITLE
shntool: fix build with GCC 15, format and remove `rec`

### DIFF
--- a/pkgs/by-name/sh/shntool/bool-type.patch
+++ b/pkgs/by-name/sh/shntool/bool-type.patch
@@ -1,0 +1,48 @@
+diff --git a/include/format.h b/include/format.h
+index 567993e..ab293f8 100644
+--- a/include/format.h
++++ b/include/format.h
+@@ -35,7 +35,7 @@ void tagcpy(unsigned char *,unsigned char *);
+ int tagcmp(unsigned char *,unsigned char *);
+ 
+ /* function to check if a file name is about to be clobbered, and if so, asks whether this is OK */
+-int clobber_check(char *);
++bool clobber_check(char *);
+ 
+ /* find an output format module with the given name */
+ format_module *find_format(char *);
+diff --git a/include/mode.h b/include/mode.h
+index a9c8cd0..fc13d4f 100644
+--- a/include/mode.h
++++ b/include/mode.h
+@@ -78,7 +78,7 @@ void create_output_filename(char *,char *,char *);
+ FILE *open_output_stream(char *,proc_info *);
+ 
+ /* function to determine if two filenames point to the same file */
+-int files_are_identical(char *,char *);
++bool files_are_identical(char *,char *);
+ 
+ /* function to remove a file if it exists */
+ void remove_file(char *);
+diff --git a/include/module-types.h b/include/module-types.h
+index c49c661..2d7b0a3 100644
+--- a/include/module-types.h
++++ b/include/module-types.h
+@@ -23,6 +23,8 @@
+ #ifndef __MODULE_TYPES_H__
+ #define __MODULE_TYPES_H__
+ 
++#include <stdbool.h>
++
+ #ifdef HAVE_CONFIG_H
+ #include "config.h"
+ #endif
+@@ -44,8 +46,6 @@
+ #define PATHSEPCHAR '/'
+ #endif
+ 
+-/* boolean type */
+-typedef int bool;
+ 
+ /* wtypes */
+ typedef unsigned long wlong;

--- a/pkgs/by-name/sh/shntool/function-pointer-type.patch
+++ b/pkgs/by-name/sh/shntool/function-pointer-type.patch
@@ -1,0 +1,26 @@
+diff --git a/src/core_mode.c b/src/core_mode.c
+index d67e317..21d3b9e 100644
+--- a/src/core_mode.c
++++ b/src/core_mode.c
+@@ -564,17 +564,17 @@ static int compare_ascii(const wave_info **w1,const wave_info **w2)
+ 
+ static void ascii_sort_files(wave_info **filenames, int numfiles)
+ {
+-  int (*cmpfunc) ();
++  int (*cmpfunc) (const void *, const void *);
+ 
+-  cmpfunc = compare_ascii;
++  cmpfunc = (int (*)(const void *, const void *))compare_ascii;
+   qsort(filenames,numfiles,sizeof(wave_info *),cmpfunc);
+ }
+ 
+ static void version_sort_files(wave_info **filenames,int numfiles)
+ {
+-  int (*cmpfunc) ();
++  int (*cmpfunc) (const void *, const void *);
+ 
+-  cmpfunc = compare_version;
++  cmpfunc = (int (*)(const void *, const void *))compare_version;
+   qsort(filenames,numfiles,sizeof(wave_info *),cmpfunc);
+ }
+ 

--- a/pkgs/by-name/sh/shntool/package.nix
+++ b/pkgs/by-name/sh/shntool/package.nix
@@ -17,10 +17,18 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-Qn4LwVx34EhypiZDIxuveNhePigkuiICn1nBukoQf5Y=";
   };
 
+  patches = [
+    # Fix conflicts between reserved keywords `bool` (starting from C23) and custom `typedef`s.
+    ./bool-type.patch
+    # Fix implicit weak-typed pointer casting.
+    ./function-pointer-type.patch
+  ];
+
   buildInputs = [ flac ];
 
   prePatch = ''
-    patches=$(grep -v '#' ./debian/patches/series | while read patch; do echo "./debian/patches/$patch"; done | tr '\n' ' ')
+    additional_patches=$(grep -v '#' ./debian/patches/series | while read patch; do echo "./debian/patches/$patch"; done | tr '\n' ' ')
+    patches="$patches $additional_patches"
   '';
 
   meta = {

--- a/pkgs/by-name/sh/shntool/package.nix
+++ b/pkgs/by-name/sh/shntool/package.nix
@@ -5,7 +5,7 @@
   flac,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   version = "3.0.10+git20130108.4ca41f4-1";
   pname = "shntool";
 
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     domain = "salsa.debian.org";
     owner = "debian";
     repo = "shntool";
-    rev = "debian/${version}";
+    rev = "debian/${finalAttrs.version}";
     sha256 = "sha256-Qn4LwVx34EhypiZDIxuveNhePigkuiICn1nBukoQf5Y=";
   };
 
@@ -24,12 +24,14 @@ stdenv.mkDerivation rec {
     ./function-pointer-type.patch
   ];
 
-  buildInputs = [ flac ];
-
   prePatch = ''
     additional_patches=$(grep -v '#' ./debian/patches/series | while read patch; do echo "./debian/patches/$patch"; done | tr '\n' ' ')
     patches="$patches $additional_patches"
   '';
+
+  buildInputs = [
+    flac
+  ];
 
   meta = {
     description = "Multi-purpose WAVE data processing and reporting utility";
@@ -38,4 +40,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [ jcumming ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Resolves https://github.com/NixOS/nixpkgs/issues/476079

Tracks https://github.com/NixOS/nixpkgs/issues/475479

This PR fixes conflicts between reserved keyword `bool` and custom `typedef`s and implicit weak-typed pointer casting.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
