### PR TITLE
ecl: import upstream patches for gcc15 compat

### DIFF
--- a/pkgs/development/compilers/ecl/default.nix
+++ b/pkgs/development/compilers/ecl/default.nix
@@ -56,11 +56,24 @@ stdenv.mkDerivation rec {
       url = "https://raw.githubusercontent.com/sagemath/sage/9.2/build/pkgs/ecl/patches/write_error.patch";
       sha256 = "0hfxacpgn4919hg0mn4wf4m8r7y592r4gw7aqfnva7sckxi6w089";
     })
+    # Fix gcc15 compat for downstream packages e.g. sage
+    # error: ‘bool’ cannot be defined via ‘typedef’
+    (fetchpatch {
+      url = "https://gitlab.com/embeddable-common-lisp/ecl/-/commit/1aec8f741f69fd736f020b7fe4d3afc33e60ae6a.patch";
+      sha256 = "sha256-/cA6iOOob0ATViQm5EwBbdin5peqRMjLPKa7RjkrJ94=";
+    })
+    # error: too many arguments to function 'fn'; expected 0, have 1
+    (fetchpatch {
+      url = "https://gitlab.com/embeddable-common-lisp/ecl/-/commit/5b4e9c4bbd7cce4a678eecd493e56c495490e8b5.patch";
+      sha256 = "sha256-QHxswFiW2rfDAQ98Sl+VVmyP4M/eIjJWQEcR/B+m398=";
+    })
+    (fetchpatch {
+      url = "https://gitlab.com/embeddable-common-lisp/ecl/-/commit/5ec9e02f6db9694dcdef7574036f1e320d64a8af.patch";
+      sha256 = "sha256-ZRah0IqOt6OQZGqlCq0RKiToyxsRXQEXAiSUGgqZnKU=";
+    })
   ];
 
   configureFlags = [
-    # Fix build with gcc15
-    "CFLAGS=-std=gnu17"
     (if threadSupport then "--enable-threads" else "--disable-threads")
     "--with-gmp-incdir=${lib.getDev gmp}/include"
     "--with-gmp-libdir=${lib.getLib gmp}/lib"


### PR DESCRIPTION
- #475479

Instead of downgrading to C17, import upstream patches for gcc15 compatibility. So downstream packages e.g. sage can build correctly without setting CFLAGS.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
