### PR TITLE
dmlive: 5.6.0-unstable-2025-06-21 -> 5.7.0-unstable-2026-01-02

### DIFF
--- a/pkgs/by-name/dm/dmlive/package.nix
+++ b/pkgs/by-name/dm/dmlive/package.nix
@@ -7,8 +7,7 @@
   makeWrapper,
   openssl,
   mpv,
-  ffmpeg_6,
-  nodejs,
+  ffmpeg,
 }:
 
 let
@@ -20,16 +19,16 @@ in
 
 rustPlatform.buildRustPackage {
   pname = "dmlive";
-  version = "5.6.0-unstable-2025-06-21";
+  version = "5.7.0-unstable-2026-01-02";
 
   src = fetchFromGitHub {
     owner = "THMonster";
     repo = "dmlive";
-    rev = "485eae06737530360c0e6f6415c62791767d595b"; # no tag
-    hash = "sha256-0JjPZPtAtbxdh0HDycWHEonZggBcoqv5SJUnhKzXNIk=";
+    rev = "47b06e57fc0fa9cf888f7c054f776a73d65e77ce"; # no tag
+    hash = "sha256-Q1QOJZ6VW65MG0wzJAgW9p4mF6a48qYRdDaeQyDTbk8=";
   };
 
-  cargoHash = "sha256-B1v9m4Nn5wXMbNBlh7+A8zBejJ0tHdqvSXVpRz+wC5g=";
+  cargoHash = "sha256-hRJ81Opxh3tHHZAVTXzQKTmv+psbeGW1KHyoRBfnnWI=";
 
   nativeBuildInputs = [
     pkg-config
@@ -44,8 +43,7 @@ rustPlatform.buildRustPackage {
     wrapProgram "$out/bin/dmlive" --suffix PATH : "${
       lib.makeBinPath [
         mpv
-        ffmpeg_6
-        nodejs
+        ffmpeg
       ]
     }"
     install -Dm644 ${desktop} $out/share/applications/dmlive-mime.desktop
@@ -58,6 +56,9 @@ rustPlatform.buildRustPackage {
     homepage = "https://github.com/THMonster/dmlive";
     license = lib.licenses.mit;
     mainProgram = "dmlive";
-    maintainers = with lib.maintainers; [ nickcao ];
+    maintainers = with lib.maintainers; [
+      nickcao
+      rebmit
+    ];
   };
 }


### PR DESCRIPTION
Diff: https://github.com/THMonster/dmlive/compare/485eae06737530360c0e6f6415c62791767d595b...47b06e57fc0fa9cf888f7c054f776a73d65e77ce

See also the release notes at https://github.com/THMonster/Revda/releases/tag/5.7.0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
