### PR TITLE
ocamlPackages.cryptokit: 1.20.1 → 1.21.1

### DIFF
--- a/pkgs/development/ocaml-modules/cryptokit/default.nix
+++ b/pkgs/development/ocaml-modules/cryptokit/default.nix
@@ -1,23 +1,28 @@
 {
   lib,
   buildDunePackage,
+  ocaml,
   fetchFromGitHub,
   zlib,
   dune-configurator,
   zarith,
+  version ? if lib.versionAtLeast ocaml.version "4.13" then "1.21.1" else "1.20.1",
 }:
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "cryptokit";
-  version = "1.20.1";
-
-  minimalOCamlVersion = "4.08";
+  inherit version;
 
   src = fetchFromGitHub {
     owner = "xavierleroy";
     repo = "cryptokit";
-    rev = "release${lib.replaceStrings [ "." ] [ "" ] version}";
-    hash = "sha256-VFY10jGctQfIUVv7dK06KP8zLZHLXTxvLyTCObS+W+E=";
+    tag = "release${lib.replaceStrings [ "." ] [ "" ] finalAttrs.version}";
+    hash =
+      {
+        "1.21.1" = "sha256-9JU9grZpTTrYYO9gai2UPq119HfenI1JAY+EyoR6x7Q=";
+        "1.20.1" = "sha256-VFY10jGctQfIUVv7dK06KP8zLZHLXTxvLyTCObS+W+E=";
+      }
+      ."${finalAttrs.version}";
   };
 
   # dont do autotools configuration, but do trigger findlib's preConfigure hook
@@ -39,4 +44,4 @@ buildDunePackage rec {
     description = "Library of cryptographic primitives for OCaml";
     license = lib.licenses.lgpl2Only;
   };
-}
+})

--- a/pkgs/development/ocaml-modules/gapi-ocaml/default.nix
+++ b/pkgs/development/ocaml-modules/gapi-ocaml/default.nix
@@ -10,17 +10,20 @@
   ounit2,
 }:
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "gapi-ocaml";
-  version = "0.4.7";
-
-  minimalOCamlVersion = "4.08";
+  version = if lib.versionAtLeast cryptokit.version "1.21" then "0.4.8" else "0.4.7";
 
   src = fetchFromGitHub {
     owner = "astrada";
-    repo = pname;
-    rev = "v${version}";
-    hash = "sha256-uQJfrgF0oafURlamHslt9hX9MP4vFeVqDhuX7T/kjiY=";
+    repo = "gapi-ocaml";
+    tag = "v${finalAttrs.version}";
+    hash =
+      {
+        "0.4.7" = "sha256-uQJfrgF0oafURlamHslt9hX9MP4vFeVqDhuX7T/kjiY=";
+        "0.4.8" = "sha256-RvHcse3ech8BwnR0Kd1oE5ycAdSBpeQ0IGAp9egFbBY=";
+      }
+      ."${finalAttrs.version}";
   };
 
   nativeBuildInputs = [ cppo ];
@@ -41,4 +44,4 @@ buildDunePackage rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ bennofs ];
   };
-}
+})


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
