### PR TITLE
python314Packages.argh: fix build failure

### DIFF
--- a/pkgs/development/python-modules/argh/default.nix
+++ b/pkgs/development/python-modules/argh/default.nix
@@ -18,6 +18,14 @@ buildPythonPackage rec {
     hash = "sha256-8wAj2L4Uyl7msbPuq4KRUde72kZK4H3E3VNHkZxYkvk=";
   };
 
+  patches = [
+    # python3.14 introduced a breaking change which caused a test to fail. A
+    # fix has been commited upstream in a pull request by the author, but has
+    # since been kept unmerged
+    # https://github.com/neithere/argh/pull/240
+    ./pr240-699568ad-06-01-2025-test_integration.patch
+  ];
+
   nativeBuildInputs = [ flit-core ];
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/argh/pr240-699568ad-06-01-2025-test_integration.patch
+++ b/pkgs/development/python-modules/argh/pr240-699568ad-06-01-2025-test_integration.patch
@@ -1,0 +1,57 @@
+diff --git a/tests/test_integration.py b/tests/test_integration.py
+index 8839265..6fc8a17 100644
+--- a/tests/test_integration.py
++++ b/tests/test_integration.py
+@@ -17,7 +17,7 @@
+ from argh.utils import unindent
+ 
+ from .base import CmdResult as R
+-from .base import DebugArghParser, get_usage_string, run
++from .base import DebugArghParser, run
+ 
+ if sys.version_info < (3, 10):
+     HELP_OPTIONS_LABEL = "optional arguments"
+@@ -796,11 +796,17 @@ def func():
+     parser = DebugArghParser()
+     parser.set_default_command(func)
+ 
+-    assert unindent(func.__doc__) in parser.format_help()
++    docstring = func.__doc__
++    assert docstring
++    assert unindent(docstring) in parser.format_help()
+ 
+ 
+ def test_prog(capsys: pytest.CaptureFixture[str]):
+-    "Program name propagates from sys.argv[0]"
++    """
++    Program name propagates to the usage string.
++    It's not just sys.argv[0], the logic is a bit more complicated in argparse,
++    so we just reuse whatever it has produced.
++    """
+ 
+     def cmd(*, foo=1):
+         return foo
+@@ -808,10 +814,12 @@ def cmd(*, foo=1):
+     parser = DebugArghParser()
+     parser.add_commands([cmd])
+ 
+-    usage = get_usage_string()
++    usage = f"usage: {parser.prog} [-h]"
+ 
+-    assert run(parser, "-h", exit=True) == 0
++    exit_code = run(parser, "-h", exit=True)
+     captured = capsys.readouterr()
++
++    assert exit_code == 0
+     assert captured.out.startswith(usage)
+ 
+ 
+@@ -822,8 +830,6 @@ def cmd(*, foo=1):
+     parser = DebugArghParser()
+     parser.set_default_command(cmd)
+ 
+-    get_usage_string("[-f FOO]")
+-
+     assert run(parser, "--foo 1") == R(out="1\n", err="")
+     assert run(parser, "--bar 1", exit=True) == "unrecognized arguments: --bar 1"
+     assert run(parser, "--bar 1", exit=False, kwargs={"skip_unknown_args": True}) == R(


### PR DESCRIPTION
python3.14 introduced a breaking change which caused a test to fail. A fix has been committed upstream in a pull request by the author, but has since been kept unmerged.

patch created with:
```
wget https://github.com/neithere/argh/pull/240/commits/699568ad674c5ea26d361202c386a8a8a82ec8ad.patch
filterdiff -i a/tests/test_integration.py -i b/tests/test_integration.py 699568ad674c5ea26d361202c386a8a8a82ec8ad.patch > pkgs/development/python-modules/argh/pr240-699568ad-06-01-2025-test_integration.patch
```

- https://github.com/NixOS/nixpkgs/issues/475732


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
