### PR TITLE
mattermost-desktop: 5.13.1 -> 6.0.4

### DIFF
--- a/pkgs/by-name/ma/mattermost-desktop/package.nix
+++ b/pkgs/by-name/ma/mattermost-desktop/package.nix
@@ -2,7 +2,7 @@
   lib,
   fetchFromGitHub,
   buildNpmPackage,
-  electron_37,
+  electron_38,
   makeWrapper,
   testers,
   mattermost-desktop,
@@ -10,21 +10,21 @@
 }:
 
 let
-  electron = electron_37;
+  electron = electron_38;
 in
 
 buildNpmPackage rec {
   pname = "mattermost-desktop";
-  version = "5.13.1";
+  version = "6.0.4";
 
   src = fetchFromGitHub {
     owner = "mattermost";
     repo = "desktop";
     tag = "v${version}";
-    hash = "sha256-0SEA5zka7Uv82bFS0vqnzipu0Yhb5EJ/20sBkf150cc=";
+    hash = "sha256-9/HDkcQEyvcflHMk/M4181jT6xUzMUcD5GHRxqfgxSg=";
   };
 
-  npmDepsHash = "sha256-KYaagZBdOSAwb+zefXn1AAe5pIuCKF0enb/rds60Vmc=";
+  npmDepsHash = "sha256-ug7PSLj/AB5krMVJAhCpJHOOKkAootG6oPeMHoW6E0A=";
   npmBuildScript = "build-prod";
   makeCacheWritable = true;
 

--- a/pkgs/by-name/ma/mattermost-desktop/package.nix
+++ b/pkgs/by-name/ma/mattermost-desktop/package.nix
@@ -87,7 +87,7 @@ buildNpmPackage rec {
       command = "env HOME=/tmp ${meta.mainProgram} --version";
     };
     updateScript = nix-update-script {
-      extraArgs = [ "--version-regex=^(\\d+\\.\\d+\\.\\d+)$" ];
+      extraArgs = [ "--version-regex=^v(\\d+\\.\\d+\\.\\d+)$" ];
     };
   };
 


### PR DESCRIPTION
[New major release](https://docs.mattermost.com/product-overview/desktop-app-changelog.html).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
