### PR TITLE
bazel_9: init at 9.0.1

### DIFF
--- a/pkgs/by-name/ba/bazel_9/bazel-execlog.sh
+++ b/pkgs/by-name/ba/bazel_9/bazel-execlog.sh
@@ -1,0 +1,3 @@
+#!@runtimeShell@
+
+exec @binJava@ -jar @out@/share/parser_deploy.jar "$@"

--- a/pkgs/by-name/ba/bazel_9/build-support/bazelDerivation.nix
+++ b/pkgs/by-name/ba/bazel_9/build-support/bazelDerivation.nix
@@ -1,0 +1,77 @@
+{
+  stdenv,
+  lndir,
+  lib,
+}:
+
+args@{
+  bazel,
+  registry ? null,
+  bazelRepoCache ? null,
+  bazelVendorDeps ? null,
+  startupArgs ? [ ],
+  commandArgs ? [ ],
+  bazelPreBuild ? "",
+  bazelPostBuild ? "",
+  serverJavabase ? null,
+  targets,
+  command,
+  ...
+}:
+
+stdenv.mkDerivation (
+  {
+    preBuildPhases = [ "preBuildPhase" ];
+    preBuildPhase =
+      (lib.optionalString (bazelRepoCache != null) ''
+        # repo_cache needs to be writeable even in air-gapped builds
+        mkdir repo_cache
+        ${lndir}/bin/lndir -silent ${bazelRepoCache}/repo_cache repo_cache
+      '')
+
+      + (lib.optionalString (bazelVendorDeps != null) ''
+        mkdir vendor_dir
+        ${lndir}/bin/lndir -silent ${bazelVendorDeps}/vendor_dir vendor_dir
+
+        # pin all deps to avoid re-fetch attempts by Bazel
+        rm vendor_dir/VENDOR.bazel
+        find vendor_dir -mindepth 1 -maxdepth 1 -type d -printf "pin(\"@@%P\")\n" > vendor_dir/VENDOR.bazel
+      '')
+      # keep preBuildPhase always defined as it is listed in preBuildPhases
+      + ''
+        true
+      '';
+    buildPhase = ''
+      runHook preBuild
+
+      export HOME=$(mktemp -d)
+
+      ${bazelPreBuild}
+
+      ${bazel}/bin/bazel ${
+        lib.escapeShellArgs (
+          lib.optional (serverJavabase != null) "--server_javabase=${serverJavabase}"
+          ++ [ "--batch" ]
+          ++ startupArgs
+        )
+      } ${command} ${
+        lib.escapeShellArgs (
+          lib.optional (registry != null) "--registry=file://${registry}"
+          ++ lib.optionals (bazelRepoCache != null) [
+            "--repository_cache=repo_cache"
+            "--repo_contents_cache="
+          ]
+          ++ lib.optional (bazelVendorDeps != null) "--vendor_dir=vendor_dir"
+          ++ commandArgs
+          ++ targets
+        )
+      }
+
+      ${bazelPostBuild}
+
+      runHook postBuild
+    '';
+
+  }
+  // args
+)

--- a/pkgs/by-name/ba/bazel_9/build-support/bazelPackage.nix
+++ b/pkgs/by-name/ba/bazel_9/build-support/bazelPackage.nix
@@ -1,0 +1,172 @@
+{
+  callPackage,
+  gnugrep,
+  lib,
+  autoPatchelfHook,
+  stdenv,
+}:
+
+{
+  name,
+  src,
+  sourceRoot ? null,
+  version ? null,
+  targets,
+  bazel,
+  startupArgs ? [ ],
+  commandArgs ? [ ],
+  env ? { },
+  serverJavabase ? null,
+  registry ? null,
+  bazelRepoCacheFOD ? {
+    outputHash = null;
+    outputHashAlgo = "sha256";
+  },
+  bazelVendorDepsFOD ? {
+    outputHash = null;
+    outputHashAlgo = "sha256";
+  },
+  installPhase,
+  buildInputs ? [ ],
+  nativeBuildInputs ? [ ],
+  autoPatchelfIgnoreMissingDeps ? null,
+  patches ? [ ],
+}:
+let
+  # FOD produced by `bazel fetch`
+  # Repo cache contains content-addressed external Bazel dependencies without any patching
+  # Potentially this can be nixified via --experimental_repository_resolved_file
+  # (Note: file itself isn't reproducible because it has lots of extra info and order
+  #        isn't stable too. Parsing it into nix fetch* commands isn't trivial but might be possible)
+  bazelRepoCache =
+    if bazelRepoCacheFOD.outputHash == null then
+      null
+    else
+      (callPackage ./bazelDerivation.nix { } {
+        name = "bazelRepoCache";
+        inherit (bazelRepoCacheFOD) outputHash outputHashAlgo;
+        inherit
+          src
+          version
+          sourceRoot
+          env
+          buildInputs
+          nativeBuildInputs
+          patches
+          ;
+        inherit registry;
+        inherit
+          bazel
+          targets
+          startupArgs
+          serverJavabase
+          ;
+        command = "fetch";
+        outputHashMode = "recursive";
+        commandArgs = [
+          "--repository_cache=repo_cache"
+          "--repo_contents_cache="
+        ]
+        ++ commandArgs;
+        bazelPreBuild = ''
+          mkdir repo_cache
+        '';
+        installPhase = ''
+          mkdir -p $out/repo_cache
+          cp -r --reflink=auto repo_cache/* $out/repo_cache
+        '';
+      });
+  # Stage1: FOD produced by `bazel vendor`, Stage2: eventual patchelf or other tuning
+  # Vendor deps contains unpacked&patches external dependencies, this may need Nix-specific
+  # patching to address things like
+  # - broken symlinks
+  # - symlinks or other references to absolute nix store paths which isn't allowed for FOD
+  # - autoPatchelf for externally-fetched binaries
+  #
+  # Either repo cache or vendor deps should be enough to build a given package
+  bazelVendorDeps =
+    if bazelVendorDepsFOD.outputHash == null then
+      null
+    else
+      (
+        let
+          stage1 = callPackage ./bazelDerivation.nix { } {
+            name = "bazelVendorDepsStage1";
+            inherit (bazelVendorDepsFOD) outputHash outputHashAlgo;
+            inherit
+              src
+              version
+              sourceRoot
+              env
+              buildInputs
+              nativeBuildInputs
+              patches
+              ;
+            inherit registry;
+            inherit
+              bazel
+              targets
+              startupArgs
+              serverJavabase
+              ;
+            dontFixup = true;
+            command = "vendor";
+            outputHashMode = "recursive";
+            commandArgs = [ "--vendor_dir=vendor_dir" ] ++ commandArgs;
+            bazelPreBuild = ''
+              mkdir vendor_dir
+            '';
+            bazelPostBuild = ''
+              # remove symlinks that point to locations under bazel_src/
+              find vendor_dir -type l -lname "$HOME/*" -exec rm '{}' \;
+              # remove symlinks to temp build directory on darwin
+              find vendor_dir -type l -lname "/private/var/tmp/*" -exec rm '{}' \;
+              # remove broken symlinks
+              find vendor_dir -xtype l -exec rm '{}' \;
+
+              # remove .marker files referencing NIX_STORE as those references aren't allowed in FOD
+              (${gnugrep}/bin/grep -rI "$NIX_STORE/" vendor_dir --files-with-matches --include="*.marker" --null || true) \
+                | xargs -0 --no-run-if-empty rm
+            '';
+            installPhase = ''
+              mkdir -p $out/vendor_dir
+              cp -r --reflink=auto vendor_dir/* $out/vendor_dir
+            '';
+
+          };
+        in
+        stdenv.mkDerivation {
+          name = "bazelVendorDeps";
+          buildInputs = lib.optional (!stdenv.hostPlatform.isDarwin) autoPatchelfHook ++ buildInputs;
+          inherit autoPatchelfIgnoreMissingDeps;
+          src = stage1;
+          installPhase = ''
+            cp -r . $out
+          '';
+        }
+      );
+
+  package = callPackage ./bazelDerivation.nix { } {
+    inherit
+      name
+      src
+      version
+      sourceRoot
+      env
+      buildInputs
+      nativeBuildInputs
+      patches
+      ;
+    inherit registry bazelRepoCache bazelVendorDeps;
+    inherit
+      bazel
+      targets
+      startupArgs
+      serverJavabase
+      commandArgs
+      ;
+    inherit installPhase;
+    command = "build";
+  };
+in
+package // { passthru = { inherit bazelRepoCache bazelVendorDeps; }; }

--- a/pkgs/by-name/ba/bazel_9/build-support/patching.nix
+++ b/pkgs/by-name/ba/bazel_9/build-support/patching.nix
@@ -1,0 +1,24 @@
+{
+  stdenv,
+}:
+{
+  # If there's a need to patch external dependencies managed by Bazel
+  # one option is to configure patches on Bazel level. Bazel doesn't
+  # allow patches to be in absolute paths so this helper will produce
+  # sources patch that adds given file to given location
+  addFilePatch =
+    {
+      path,
+      file,
+    }:
+    stdenv.mkDerivation {
+      name = "add_file.patch";
+      dontUnpack = true;
+      buildPhase = ''
+        mkdir -p $(dirname "${path}")
+        cp ${file} "${path}"
+        diff -u /dev/null "${path}" >result.patch || true  # diff exit code is non-zero if there's a diff
+      '';
+      installPhase = "cp result.patch $out";
+    };
+}

--- a/pkgs/by-name/ba/bazel_9/defaultShell.nix
+++ b/pkgs/by-name/ba/bazel_9/defaultShell.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  makeBinaryWrapper,
+  writeShellApplication,
+  bash,
+  stdenv,
+}:
+{ defaultShellUtils }:
+let
+  defaultShellPath = lib.makeBinPath defaultShellUtils;
+
+  bashWithDefaultShellUtilsSh = writeShellApplication {
+    name = "bash";
+    runtimeInputs = defaultShellUtils;
+    # Empty PATH in Nixpkgs Bash is translated to /no-such-path
+    # On other distros empty PATH search fallback is looking in standard
+    # locations like /bin,/usr/bin
+    # For Bazel many rules rely on such search finding some common utils,
+    # so we provide them in case rules or arguments didn't specify a precise PATH
+    text = ''
+      if [[ "$PATH" == "/no-such-path" ]]; then
+        export PATH=${defaultShellPath}
+      fi
+      exec ${bash}/bin/bash "$@"
+    '';
+  };
+
+in
+{
+  inherit defaultShellUtils defaultShellPath;
+  # Script-based interpreters in shebangs aren't guaranteed to work,
+  # especially on MacOS. So let's produce a binary
+  bashWithDefaultShellUtils = stdenv.mkDerivation {
+    name = "bash";
+    src = bashWithDefaultShellUtilsSh;
+    nativeBuildInputs = [ makeBinaryWrapper ];
+    buildPhase = ''
+      makeWrapper ${bashWithDefaultShellUtilsSh}/bin/bash $out/bin/bash
+    '';
+  };
+}

--- a/pkgs/by-name/ba/bazel_9/examples.nix
+++ b/pkgs/by-name/ba/bazel_9/examples.nix
@@ -1,0 +1,151 @@
+{
+  fetchFromGitHub,
+  lib,
+  bazel_9,
+  libgcc,
+  cctools,
+  stdenv,
+  jdk_headless,
+  callPackage,
+  zlib,
+  libxcrypt-legacy,
+}:
+let
+  bazelPackage = callPackage ./build-support/bazelPackage.nix { };
+  registry = fetchFromGitHub {
+    owner = "bazelbuild";
+    repo = "bazel-central-registry";
+    rev = "0e9e0cfdb88577300cc369d0cbe81e678d0fb271";
+    sha256 = "sha256-YAR0tYVUdITfW/2H/LZky88nyoWTsgZf/CX4BtJ/Mwk=";
+  };
+  src = fetchFromGitHub {
+    owner = "bazelbuild";
+    repo = "examples";
+    rev = "2a8db5804341036b393ff7e1ba88edb30c8a82c7";
+    sha256 = "sha256-/+rU73WPIKguoEOJDCodE3pUGSGju0VhixIcr0zBVmY=";
+  };
+  inherit (callPackage ./build-support/patching.nix { }) addFilePatch;
+in
+{
+  java = bazelPackage {
+    inherit src registry;
+    sourceRoot = "source/java-tutorial";
+    name = "java-tutorial";
+    targets = [ "//:ProjectRunner" ];
+    bazel = bazel_9;
+    commandArgs = [
+      "--extra_toolchains=@@rules_java++toolchains+local_jdk//:all"
+      "--tool_java_runtime_version=local_jdk_21"
+    ]
+    ++ lib.optional stdenv.hostPlatform.isDarwin "--spawn_strategy=local";
+    env = {
+      JAVA_HOME = jdk_headless.home;
+      USE_BAZEL_VERSION = bazel_9.version;
+    };
+    installPhase = ''
+      mkdir $out
+      cp bazel-bin/ProjectRunner.jar $out/
+    '';
+    buildInputs = [
+      libgcc
+      libxcrypt-legacy
+      stdenv.cc.cc.lib
+    ];
+    nativeBuildInputs = lib.optional (stdenv.hostPlatform.isDarwin) cctools;
+    patches = [
+      ./patches/examples/java-tutorial.patch
+      (addFilePatch {
+        path = "b/rules_cc.patch";
+        file = ./patches/examples/rules_cc.patch;
+      })
+    ];
+    bazelVendorDepsFOD = {
+      outputHash =
+        {
+          aarch64-darwin = "sha256-MRm+Pm5mDXys8erQLKHRSClFzxWIYU7Y/otKxl5sJQg=";
+          aarch64-linux = "sha256-cJuNZapJ8LvfPRdv5V9iuy0xxCxLFI5uWTLtAa6bE/w=";
+          x86_64-darwin = "sha256-fOLRQIiRq7BATULy7W90bQ/DrW3Fn7vLut6fKFSoQDA=";
+          x86_64-linux = "sha256-nSe0ywhsTJz6ycqTZaUKfnOvpJOmwip8hYXck9HtW2Q=";
+        }
+        .${stdenv.hostPlatform.system};
+      outputHashAlgo = "sha256";
+    };
+  };
+  cpp = bazelPackage {
+    inherit src registry;
+    sourceRoot = "source/cpp-tutorial/stage3";
+    name = "cpp-tutorial";
+    targets = [ "//main:hello-world" ];
+    bazel = bazel_9;
+    installPhase = ''
+      mkdir $out
+      cp bazel-bin/main/hello-world $out/
+    '';
+    nativeBuildInputs = lib.optional (stdenv.hostPlatform.isDarwin) cctools;
+    commandArgs = lib.optionals (stdenv.hostPlatform.isDarwin) [
+      "--host_cxxopt=-xc++"
+      "--cxxopt=-xc++"
+      "--spawn_strategy=local"
+    ];
+    env = {
+      USE_BAZEL_VERSION = bazel_9.version;
+    };
+    patches = [
+      ./patches/examples/cpp-tutorial.patch
+      (addFilePatch {
+        path = "b/rules_cc.patch";
+        file = ./patches/examples/rules_cc.patch;
+      })
+    ];
+    bazelRepoCacheFOD = {
+      outputHash =
+        {
+          aarch64-darwin = "sha256-Yk+Y3XxlmE48RCYqmSfeBtElCGlVVdJvqRtuIMWbxrk=";
+          aarch64-linux = "sha256-Yk+Y3XxlmE48RCYqmSfeBtElCGlVVdJvqRtuIMWbxrk=";
+          x86_64-darwin = "sha256-Yk+Y3XxlmE48RCYqmSfeBtElCGlVVdJvqRtuIMWbxrk=";
+          x86_64-linux = "sha256-Yk+Y3XxlmE48RCYqmSfeBtElCGlVVdJvqRtuIMWbxrk=";
+        }
+        .${stdenv.hostPlatform.system};
+      outputHashAlgo = "sha256";
+    };
+  };
+  rust = bazelPackage {
+    inherit src registry;
+    sourceRoot = "source/rust-examples/01-hello-world";
+    name = "rust-examples-01-hello-world";
+    targets = [ "//:bin" ];
+    bazel = bazel_9;
+    env = {
+      USE_BAZEL_VERSION = bazel_9.version;
+    };
+    installPhase = ''
+      mkdir $out
+      cp bazel-bin/bin $out/hello-world
+    '';
+    buildInputs = [
+      zlib
+      libgcc
+    ];
+    nativeBuildInputs = lib.optional (stdenv.hostPlatform.isDarwin) cctools;
+    commandArgs = lib.optional stdenv.hostPlatform.isDarwin "--spawn_strategy=local";
+    autoPatchelfIgnoreMissingDeps = [ "librustc_driver-*.so" ];
+    patches = [
+      ./patches/examples/rust-examples.patch
+      (addFilePatch {
+        path = "b/rules_cc.patch";
+        file = ./patches/examples/rules_cc.patch;
+      })
+    ];
+    bazelVendorDepsFOD = {
+      outputHash =
+        {
+          aarch64-darwin = "sha256-6rUV8UMjFZXA053BXIruK8+OEturmtz+YeAlkivePdA=";
+          aarch64-linux = "sha256-/mv7HVsx97RLzYl12WwsI2gYf0qBr+78B5NiEpTRyrc=";
+          x86_64-darwin = "sha256-BpQFhalV5AfYSjWQp+9lxOnfbaD/NADtvrNMqznEojM=";
+          x86_64-linux = "sha256-uutDUAHYecqDYmS90jZfZ8IrhSzpWB6WgcsZPlRJVaM=";
+        }
+        .${stdenv.hostPlatform.system};
+      outputHashAlgo = "sha256";
+    };
+  };
+}

--- a/pkgs/by-name/ba/bazel_9/package.nix
+++ b/pkgs/by-name/ba/bazel_9/package.nix
@@ -1,0 +1,343 @@
+{
+  stdenv,
+  callPackage,
+  # nix tooling and utilities
+  darwin,
+  lib,
+  fetchzip,
+  makeWrapper,
+  replaceVars,
+  # native build inputs
+  runtimeShell,
+  zip,
+  unzip,
+  bash,
+  coreutils,
+  which,
+  gawk,
+  gnused,
+  gnutar,
+  gnugrep,
+  gzip,
+  findutils,
+  diffutils,
+  gnupatch,
+  file,
+  installShellFiles,
+  python3,
+  # Apple dependencies
+  cctools,
+  # Allow to independently override the jdks used to build and run respectively
+  jdk_headless,
+  version ? "9.0.1",
+}:
+
+let
+  inherit (callPackage ./build-support/patching.nix { }) addFilePatch;
+  inherit (stdenv.hostPlatform) isDarwin isAarch64;
+
+  defaultShellUtils =
+    # Keep this list conservative. For more exotic tools, prefer to use
+    # @rules_nixpkgs to pull in tools from the nix repository. Example:
+    #
+    # WORKSPACE:
+    #
+    #     nixpkgs_git_repository(
+    #         name = "nixpkgs",
+    #         revision = "def5124ec8367efdba95a99523dd06d918cb0ae8",
+    #     )
+    #
+    #     # This defines an external Bazel workspace.
+    #     nixpkgs_package(
+    #         name = "bison",
+    #         repositories = { "nixpkgs": "@nixpkgs//:default.nix" },
+    #     )
+    #
+    # some/BUILD.bazel:
+    #
+    #     genrule(
+    #        ...
+    #        cmd = "$(location @bison//:bin/bison) -other -args",
+    #        tools = [
+    #            ...
+    #            "@bison//:bin/bison",
+    #        ],
+    #     )
+    [
+      bash # see https://github.com/NixOS/nixpkgs/pull/489519
+      coreutils
+      diffutils
+      file
+      findutils
+      gawk
+      gnugrep
+      gnupatch
+      gnused
+      gnutar
+      gzip
+      python3 # see https://github.com/NixOS/nixpkgs/pull/489519
+      unzip
+      which
+      zip
+    ];
+  defaultShell = callPackage ./defaultShell.nix { } { inherit defaultShellUtils; };
+
+  bazelSystem = if isDarwin then "darwin" else "linux";
+
+  # on aarch64 Darwin, `uname -m` returns "arm64"
+  bazelArch = if isDarwin && isAarch64 then "arm64" else stdenv.hostPlatform.parsed.cpu.name;
+
+  src = fetchzip {
+    url = "https://github.com/bazelbuild/bazel/releases/download/${version}/bazel-${version}-dist.zip";
+    hash = "sha256-tdrSgtIXi8Xd03BgxLRWhw1bB1Zhuo0E2pWMCskBDG8=";
+    stripRoot = false;
+  };
+
+  commandArgs = [
+    "--nobuild_python_zip"
+    "--features=-module_maps"
+    "--host_features=-module_maps"
+    "--announce_rc"
+    "--verbose_failures"
+    "--curses=no"
+  ]
+  ++ lib.optionals isDarwin [
+    "--macos_sdk_version=${stdenv.hostPlatform.darwinMinVersion}"
+    "--action_env=NIX_CFLAGS_COMPILE_${stdenv.cc.suffixSalt}"
+  ];
+
+  extraCflags = lib.optionals isDarwin [
+    "-isystem ${lib.getDev darwin.libresolv}/include"
+    "-isystem ${lib.getDev stdenv.cc.libcxx}/include/c++/v1"
+  ];
+in
+stdenv.mkDerivation rec {
+  pname = "bazel";
+  inherit version src;
+
+  darwinPatches = [
+    # Bazel integrates with apple IOKit to inhibit and track system sleep.
+    # Inside the darwin sandbox, these API calls are blocked, and bazel
+    # crashes. It seems possible to allow these APIs inside the sandbox, but it
+    # feels simpler to patch bazel not to use it at all. So our bazel is
+    # incapable of preventing system sleep, which is a small price to pay to
+    # guarantee that it will always run in any nix context.
+    #
+    # See also ./bazel_darwin_sandbox.patch in bazel_5. That patch uses
+    # NIX_BUILD_TOP env var to conditionnally disable sleep features inside the
+    # sandbox.
+    #
+    # If you want to investigate the sandbox profile path,
+    # IORegisterForSystemPower can be allowed with
+    #
+    #     propagatedSandboxProfile = ''
+    #       (allow iokit-open (iokit-user-client-class "RootDomainUserClient"))
+    #     '';
+    #
+    # I do not know yet how to allow IOPMAssertion{CreateWithName,Release}
+    ./patches/darwin_sleep.patch
+
+    # Fix DARWIN_XCODE_LOCATOR_COMPILE_COMMAND by removing multi-arch support.
+    # Nixpkgs toolcahins do not support that (yet?) and get confused.
+    # Also add an explicit /usr/bin prefix that will be patched below.
+    (replaceVars ./patches/xcode.patch {
+      clangDarwin = "${stdenv.cc}/bin/clang";
+    })
+  ];
+
+  patches = lib.optionals isDarwin darwinPatches ++ [
+    # Revert preference for apple_support over rules_cc toolchain for now
+    # will need to figure out how to build with apple_support toolchain later
+    ./patches/apple_cc_toolchain.patch
+
+    ./patches/build_execlog_parser.patch
+
+    # --experimental_strict_action_env (which may one day become the default
+    # see bazelbuild/bazel#2574) hardcodes the default
+    # action environment to a non hermetic value (e.g. "/usr/local/bin").
+    # This is non hermetic on non-nixos systems. On NixOS, bazel cannot find the required binaries.
+    # So we are replacing this bazel paths by defaultShellPath,
+    # improving hermeticity and making it work in nixos.
+    (replaceVars ./patches/strict_action_env.patch {
+      strictActionEnvPatch = defaultShell.defaultShellPath;
+    })
+
+    (replaceVars ./patches/default_bash.patch {
+      defaultBash = "${defaultShell.bashWithDefaultShellUtils}/bin/bash";
+    })
+
+    # Provide default JRE for Bazel process by setting --server_javabase=
+    # in a new default system bazelrc file
+    (replaceVars ./patches/bazel_rc.patch {
+      bazelSystemBazelRCPath = replaceVars ./system.bazelrc {
+        serverJavabase = jdk_headless;
+      };
+    })
+
+    # patch that propagates rules_* patches below
+    # patches need to be within source root and can't be absolute paths in Nix store
+    # so rules_* patches are injected via addFilePatch
+    ./patches/deps_patches.patch
+    (addFilePatch {
+      path = "b/third_party/rules_python.patch";
+      file = replaceVars ./patches/rules_python.patch {
+        usrBinEnv = "${coreutils}/bin/env";
+      };
+    })
+    (addFilePatch {
+      path = "b/third_party/rules_java.patch";
+      file = replaceVars ./patches/rules_java.patch {
+        defaultBash = "${defaultShell.bashWithDefaultShellUtils}/bin/bash";
+      };
+    })
+    (addFilePatch {
+      path = "b/third_party/rules_cc.patch";
+      file = replaceVars ./patches/rules_cc.patch {
+        defaultBash = "${defaultShell.bashWithDefaultShellUtils}/bin/bash";
+      };
+    })
+    (addFilePatch {
+      path = "b/third_party/grpc.patch";
+      file = ./patches/grpc.patch;
+    })
+
+    (replaceVars ./patches/md5sum.patch {
+      md5sum = "${coreutils}/bin/md5sum";
+    })
+
+    # Nix build sandbox can configure custom PATH but doesn't have
+    # /usr/bin/env which is unfortunate https://github.com/NixOS/nixpkgs/issues/6227
+    # and we need to do a silly patch
+    (replaceVars ./patches/usr_bin_env.patch {
+      usrBinEnv = "${coreutils}/bin/env";
+    })
+  ];
+
+  meta = {
+    homepage = "https://github.com/bazelbuild/bazel/";
+    description = "Build tool that builds code quickly and reliably";
+    sourceProvenance = with lib.sourceTypes; [
+      fromSource
+      binaryBytecode # source bundles dependencies as jars
+    ];
+    license = lib.licenses.asl20;
+    teams = [ lib.teams.bazel ];
+    mainProgram = "bazel";
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+    jdk_headless
+    python3
+    unzip
+    which
+
+    # Shell completion
+    installShellFiles
+    python3.pkgs.absl-py # Needed to build fish completion
+  ]
+  # Needed for execlog
+  ++ lib.optional (!stdenv.hostPlatform.isDarwin) stdenv.cc
+  ++ lib.optional (stdenv.hostPlatform.isDarwin) cctools.libtool;
+
+  buildPhase = ''
+    runHook preBuild
+    export HOME=$(mktemp -d)
+
+    # If EMBED_LABEL isn't set, it'd be auto-detected from CHANGELOG.md
+    # and `git rev-parse --short HEAD` which would result in
+    # "3.7.0- (@non-git)" due to non-git build and incomplete changelog.
+    # Actual bazel releases use scripts/release/common.sh which is based
+    # on branch/tag information which we don't have with tarball releases.
+    # Note that .bazelversion is always correct and is based on bazel-*
+    # executable name, version checks should work fine
+    export EMBED_LABEL="${version}- (@non-git)"
+
+    echo "Stage 1 - Running bazel bootstrap script"
+    # Note: can't use lib.escapeShellArgs here because it will escape arguments
+    #       with = using single quotes. This is fine for command invocations,
+    #       but for string variable they become literal single quote chars,
+    #       compile.sh will not unquote them either and command will be invalid.
+    export EXTRA_BAZEL_ARGS="${lib.strings.concatStringsSep " " commandArgs}"
+    export NIX_CFLAGS_COMPILE_${stdenv.cc.suffixSalt}="${lib.strings.concatStringsSep " " extraCflags}"
+
+
+    ${bash}/bin/bash ./compile.sh
+
+    # XXX: get rid of this, or move it to another stage.
+    # It is plain annoying when builds fail.
+    echo "Stage 2 - Generate bazel completions"
+    ${bash}/bin/bash ./scripts/generate_bash_completion.sh \
+        --bazel=./output/bazel \
+        --output=./output/bazel-complete.bash \
+        --prepend=./scripts/bazel-complete-header.bash \
+        --prepend=./scripts/bazel-complete-template.bash
+    ${python3}/bin/python3 ./scripts/generate_fish_completion.py \
+        --bazel=./output/bazel \
+        --output=./output/bazel-complete.fish
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    # Bazel binary contains zip archive, which contains text files and a jar
+    # both of which can have store references that might be obscured to Nix
+    # builder in packaged form, so we unpack and extract those references
+
+    # Note: grep isn't necessarily 100% accurate, other approaches could be
+    #       to disassemble Jar (slow) or hardcode known references
+    mkdir -p $out/nix-support
+    INSTALL_BASE=$(./output/bazel --batch info install_base)
+    find "$INSTALL_BASE" -type f -exec \
+       ${gnugrep}/bin/grep --text --only-matching --no-filename "$NIX_STORE/[^/]*" '{}' \; \
+    | sort -u >> $out/nix-support/depends
+
+    mkdir -p $out/bin
+
+    # official wrapper scripts that searches for $WORKSPACE_ROOT/tools/bazel if
+    # it can’t find something in tools, it calls
+    # $out/bin/bazel-{version}-{os_arch} The binary _must_ exist with this
+    # naming if your project contains a .bazelversion file.
+    cp ./scripts/packages/bazel.sh $out/bin/bazel
+    versioned_bazel="$out/bin/bazel-${version}-${bazelSystem}-${bazelArch}"
+    mv ./output/bazel "$versioned_bazel"
+    wrapProgram "$versioned_bazel" --suffix PATH : ${defaultShell.defaultShellPath}
+
+    mkdir $out/share
+    cp ./output/parser_deploy.jar $out/share/parser_deploy.jar
+    substitute ${./bazel-execlog.sh} $out/bin/bazel-execlog \
+      --subst-var out \
+      --subst-var-by runtimeShell ${runtimeShell} \
+      --subst-var-by binJava ${jdk_headless}/bin/java
+    chmod +x $out/bin/bazel-execlog
+
+    # shell completion files
+    installShellCompletion --bash \
+      --name bazel.bash \
+      ./output/bazel-complete.bash
+    installShellCompletion --zsh \
+      --name _bazel \
+      ./scripts/zsh_completion/_bazel
+    installShellCompletion --fish \
+      --name bazel.fish \
+      ./output/bazel-complete.fish
+  '';
+
+  postFixup =
+    # verify that bazel binary still works post-fixup
+    ''
+      USE_BAZEL_VERSION=${version} $out/bin/bazel --batch info release
+    '';
+
+  # Bazel binary includes zip archive at the end that `strip` would end up discarding
+  stripExclude = [ "bin/.bazel-${version}-*-wrapped" ];
+
+  passthru = {
+    tests = {
+      inherit (callPackage ./examples.nix { }) cpp java rust;
+    };
+  };
+}

--- a/pkgs/by-name/ba/bazel_9/patches/apple_cc_toolchain.patch
+++ b/pkgs/by-name/ba/bazel_9/patches/apple_cc_toolchain.patch
@@ -1,0 +1,18 @@
+diff --git a/MODULE.bazel b/MODULE.bazel
+index 62c1c29d67..d845a0e98d 100644
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -39,10 +39,10 @@ bazel_dep(name = "with_cfg.bzl", version = "0.13.0")
+ bazel_dep(name = "zlib", version = "1.3.1.bcr.7")
+ bazel_dep(name = "zstd-jni", version = "1.5.6-9")
+ 
+-# Depend on apple_support first and then rules_cc so that the Xcode toolchain
+-# from apple_support wins over the generic Unix toolchain from rules_cc.
+-bazel_dep(name = "apple_support", version = "1.24.5")
++# Depend on apple_support second after rules_cc so that the Xcode toolchain
++# from apple_support does not win over the generic Unix toolchain from rules_cc.
+ bazel_dep(name = "rules_cc", version = "0.2.17")
++bazel_dep(name = "apple_support", version = "1.24.5")
+ 
+ # The starlark rules in @rules_cc are hidden behind macros but docgen needs to
+ # load the rule class directly, so we need to expose the cc_compatibility_proxy

--- a/pkgs/by-name/ba/bazel_9/patches/bazel_rc.patch
+++ b/pkgs/by-name/ba/bazel_9/patches/bazel_rc.patch
@@ -1,0 +1,13 @@
+diff --git a/src/main/cpp/option_processor.cc b/src/main/cpp/option_processor.cc
+index 8f8f15685f..a7ae52d1e4 100644
+--- a/src/main/cpp/option_processor.cc
++++ b/src/main/cpp/option_processor.cc
+@@ -56,7 +56,7 @@ OptionProcessor::OptionProcessor(
+     : workspace_layout_(workspace_layout),
+       startup_options_(std::move(default_startup_options)),
+       parse_options_called_(false),
+-      system_bazelrc_path_(BAZEL_SYSTEM_BAZELRC_PATH) {}
++      system_bazelrc_path_("@bazelSystemBazelRCPath@") {}
+ 
+ OptionProcessor::OptionProcessor(
+     const WorkspaceLayout* workspace_layout,

--- a/pkgs/by-name/ba/bazel_9/patches/build_execlog_parser.patch
+++ b/pkgs/by-name/ba/bazel_9/patches/build_execlog_parser.patch
@@ -1,0 +1,28 @@
+diff --git a/compile.sh b/compile.sh
+index 4712355d48..feec286704 100755
+--- a/compile.sh
++++ b/compile.sh
+@@ -76,6 +76,13 @@ bazel_build "src:bazel_nojdk${EXE_EXT}" \
+   --host_platform=@platforms//host \
+   --platforms=@platforms//host \
+   || fail "Could not build Bazel"
++
++bazel_build src/tools/execlog:parser_deploy.jar \
++  --action_env=PATH \
++  --host_platform=@platforms//host \
++  --platforms=@platforms//host \
++  || fail "Could not build parser_deploy.jar"
++
+ bazel_bin_path="$(get_bazel_bin_path)/src/bazel_nojdk${EXE_EXT}"
+ [ -e "$bazel_bin_path" ] \
+   || fail "Could not find freshly built Bazel binary at '$bazel_bin_path'"
+@@ -84,5 +91,8 @@ cp -f "$bazel_bin_path" "output/bazel${EXE_EXT}" \
+ chmod 0755 "output/bazel${EXE_EXT}"
+ BAZEL="$(pwd)/output/bazel${EXE_EXT}"
+ 
++cp "$(get_bazel_bin_path)/src/tools/execlog/parser_deploy.jar" output/ \
++  || fail "Could not copy 'parser_deploy.jar' to 'output/"
++
+ clear_log
+ display "Build successful! Binary is here: ${BAZEL}"
+

--- a/pkgs/by-name/ba/bazel_9/patches/darwin_sleep.patch
+++ b/pkgs/by-name/ba/bazel_9/patches/darwin_sleep.patch
@@ -1,0 +1,56 @@
+diff --git a/src/main/native/darwin/sleep_prevention_jni.cc b/src/main/native/darwin/sleep_prevention_jni.cc
+index 67c35b201e..e50a58320e 100644
+--- a/src/main/native/darwin/sleep_prevention_jni.cc
++++ b/src/main/native/darwin/sleep_prevention_jni.cc
+@@ -33,31 +33,13 @@ static int g_sleep_state_stack = 0;
+ static IOPMAssertionID g_sleep_state_assertion = kIOPMNullAssertionID;
+ 
+ int portable_push_disable_sleep() {
+-  std::lock_guard<std::mutex> lock(g_sleep_state_mutex);
+-  BAZEL_CHECK_GE(g_sleep_state_stack, 0);
+-  if (g_sleep_state_stack == 0) {
+-    BAZEL_CHECK_EQ(g_sleep_state_assertion, kIOPMNullAssertionID);
+-    CFStringRef reasonForActivity = CFSTR("build.bazel");
+-    IOReturn success = IOPMAssertionCreateWithName(
+-        kIOPMAssertionTypeNoIdleSleep, kIOPMAssertionLevelOn, reasonForActivity,
+-        &g_sleep_state_assertion);
+-    BAZEL_CHECK_EQ(success, kIOReturnSuccess);
+-  }
+-  g_sleep_state_stack += 1;
+-  return 0;
++  // Unreliable, disable for now
++  return -1;
+ }
+ 
+ int portable_pop_disable_sleep() {
+-  std::lock_guard<std::mutex> lock(g_sleep_state_mutex);
+-  BAZEL_CHECK_GT(g_sleep_state_stack, 0);
+-  g_sleep_state_stack -= 1;
+-  if (g_sleep_state_stack == 0) {
+-    BAZEL_CHECK_NE(g_sleep_state_assertion, kIOPMNullAssertionID);
+-    IOReturn success = IOPMAssertionRelease(g_sleep_state_assertion);
+-    BAZEL_CHECK_EQ(success, kIOReturnSuccess);
+-    g_sleep_state_assertion = kIOPMNullAssertionID;
+-  }
+-  return 0;
++  // Unreliable, disable for now
++  return -1;
+ }
+ 
+ }  // namespace blaze_jni
+diff --git a/src/main/native/darwin/system_suspension_monitor_jni.cc b/src/main/native/darwin/system_suspension_monitor_jni.cc
+index 3483aa7935..51782986ec 100644
+--- a/src/main/native/darwin/system_suspension_monitor_jni.cc
++++ b/src/main/native/darwin/system_suspension_monitor_jni.cc
+@@ -83,10 +83,7 @@ void portable_start_suspend_monitoring() {
+     // Register to receive system sleep notifications.
+     // Testing needs to be done manually. Use the logging to verify
+     // that sleeps are being caught here.
+-    suspend_state.connect_port = IORegisterForSystemPower(
+-        &suspend_state, &notifyPortRef, SleepCallBack, &notifierObject);
+-    BAZEL_CHECK_NE(suspend_state.connect_port, MACH_PORT_NULL);
+-    IONotificationPortSetDispatchQueue(notifyPortRef, queue);
++    // XXX: Unreliable, disable for now
+ 
+     // Register to deal with SIGCONT.
+     // We register for SIGCONT because we can't catch SIGSTOP.

--- a/pkgs/by-name/ba/bazel_9/patches/default_bash.patch
+++ b/pkgs/by-name/ba/bazel_9/patches/default_bash.patch
@@ -1,0 +1,22 @@
+diff --git a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java
+index a982b782e1..d49b047074 100644
+--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java
++++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java
+@@ -89,13 +89,13 @@ public class BazelRuleClassProvider {
+     public boolean useStrictActionEnv;
+   }
+ 
+-  private static final PathFragment FALLBACK_SHELL = PathFragment.create("/bin/bash");
++  private static final PathFragment FALLBACK_SHELL = PathFragment.create("@defaultBash@");
+ 
+   public static final ImmutableMap<OS, PathFragment> SHELL_EXECUTABLE =
+       ImmutableMap.<OS, PathFragment>builder()
+           .put(OS.WINDOWS, PathFragment.create("c:/msys64/usr/bin/bash.exe"))
+-          .put(OS.FREEBSD, PathFragment.create("/usr/local/bin/bash"))
+-          .put(OS.OPENBSD, PathFragment.create("/usr/local/bin/bash"))
++          .put(OS.FREEBSD, PathFragment.create("@defaultBash@"))
++          .put(OS.OPENBSD, PathFragment.create("@defaultBash@"))
+           .put(OS.UNKNOWN, FALLBACK_SHELL)
+           .buildOrThrow();
+ 
+

--- a/pkgs/by-name/ba/bazel_9/patches/deps_patches.patch
+++ b/pkgs/by-name/ba/bazel_9/patches/deps_patches.patch
@@ -1,0 +1,47 @@
+diff --git a/MODULE.bazel b/MODULE.bazel
+index d845a0e98d..be0aa7bd7c 100644
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -22,16 +22,30 @@ bazel_dep(name = "googleapis", version = "0.0.0-20250604-de157ca3")
+ bazel_dep(name = "googletest", version = "1.17.0.bcr.2", repo_name = "com_google_googletest")
+ bazel_dep(name = "grpc-java", version = "1.71.0")
+ bazel_dep(name = "grpc", version = "1.76.0.bcr.1", repo_name = "com_github_grpc_grpc")
++single_version_override(
++    module_name = "grpc",
++    patches = ["//third_party:grpc.patch"],
++    patch_strip = 1,
++)
+ bazel_dep(name = "platforms", version = "1.0.0")
+ bazel_dep(name = "protobuf", version = "33.4", repo_name = "com_google_protobuf")
+ bazel_dep(name = "re2", version = "2025-11-05.bcr.1")
+ bazel_dep(name = "rules_graalvm", version = "0.11.1")
+ bazel_dep(name = "rules_java", version = "9.0.3")
++single_version_override(
++    module_name = "rules_java",
++    patches = ["//third_party:rules_java.patch"],
++)
+ bazel_dep(name = "bazel_features", version = "1.42.1")
+ bazel_dep(name = "rules_jvm_external", version = "6.6")
+ bazel_dep(name = "rules_license", version = "1.0.0")
+ bazel_dep(name = "rules_pkg", version = "1.1.0")
+ bazel_dep(name = "rules_python", version = "1.7.0")
++single_version_override(
++    module_name = "rules_python",
++    patches = ["//third_party:rules_python.patch"],
++    patch_strip = 1,
++)
+ bazel_dep(name = "rules_shell", version = "0.6.1")
+ bazel_dep(name = "rules_testing", version = "0.9.0")
+ bazel_dep(name = "stardoc", version = "0.8.0", repo_name = "io_bazel_skydoc")
+@@ -42,6 +56,11 @@ bazel_dep(name = "zstd-jni", version = "1.5.6-9")
+ # Depend on apple_support second after rules_cc so that the Xcode toolchain
+ # from apple_support does not win over the generic Unix toolchain from rules_cc.
+ bazel_dep(name = "rules_cc", version = "0.2.17")
++single_version_override(
++    module_name = "rules_cc",
++    patches = ["//third_party:rules_cc.patch"],
++    patch_strip = 1,
++)
+ bazel_dep(name = "apple_support", version = "1.24.5")
+ 
+ # The starlark rules in @rules_cc are hidden behind macros but docgen needs to

--- a/pkgs/by-name/ba/bazel_9/patches/examples/cpp-tutorial.patch
+++ b/pkgs/by-name/ba/bazel_9/patches/examples/cpp-tutorial.patch
@@ -1,0 +1,15 @@
+diff --git a/BUILD b/BUILD
+new file mode 100644
+index 0000000..e69de29
+diff --git a/MODULE.bazel b/MODULE.bazel
+index 4874ffc..f4e0d56 100644
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1 +1,6 @@
+ bazel_dep(name = "rules_cc", version = "0.0.17")
++single_version_override(
++    module_name = "rules_cc",
++    patches = [":rules_cc.patch"],
++    patch_strip = 1,
++)
+

--- a/pkgs/by-name/ba/bazel_9/patches/examples/java-tutorial.patch
+++ b/pkgs/by-name/ba/bazel_9/patches/examples/java-tutorial.patch
@@ -1,0 +1,12 @@
+diff --git a/java-tutorial/MODULE.bazel b/java-tutorial/MODULE.bazel
+index 1496f64..d3df2d5 100644
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1 +1,7 @@
+ bazel_dep(name = "rules_java", version = "7.11.1")
++bazel_dep(name = "rules_cc", version = "0.2.13")
++single_version_override(
++    module_name = "rules_cc",
++    patches = [":rules_cc.patch"],
++    patch_strip = 1,
++)

--- a/pkgs/by-name/ba/bazel_9/patches/examples/rules_cc.patch
+++ b/pkgs/by-name/ba/bazel_9/patches/examples/rules_cc.patch
@@ -1,0 +1,10 @@
+diff --git a/cc/private/toolchain/generate_system_module_map.sh b/cc/private/toolchain/generate_system_module_map.sh
+index 6bcbd85..b5e4f2c 100755
+--- a/cc/private/toolchain/generate_system_module_map.sh
++++ b/cc/private/toolchain/generate_system_module_map.sh
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env bash
++#!/bin/bash
+ # Copyright 2020 The Bazel Authors. All rights reserved.
+ #
+ # Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkgs/by-name/ba/bazel_9/patches/examples/rust-examples.patch
+++ b/pkgs/by-name/ba/bazel_9/patches/examples/rust-examples.patch
@@ -1,0 +1,17 @@
+diff --git a/rust-examples/01-hello-world/MODULE.bazel b/rust-examples/01-hello-world/MODULE.bazel
+index 53f685c..9c1dccd 100644
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -5,6 +5,12 @@ module(
+
+ # https://github.com/bazelbuild/rules_rust/releases
+ bazel_dep(name = "rules_rust", version = "0.65.0")
++bazel_dep(name = "rules_cc", version = "0.2.4")
++single_version_override(
++    module_name = "rules_cc",
++    patches = [":rules_cc.patch"],
++    patch_strip = 1,
++)
+
+ # Rust toolchain
+ RUST_EDITION = "2021"  # NOTE: 2024 edition will be released with Rust 1.85.0

--- a/pkgs/by-name/ba/bazel_9/patches/grpc.patch
+++ b/pkgs/by-name/ba/bazel_9/patches/grpc.patch
@@ -1,0 +1,24 @@
+diff --git a/bazel/grpc_build_system.bzl b/bazel/grpc_build_system.bzl
+index 66d6368..8dd1b16 100644
+--- a/bazel/grpc_build_system.bzl
++++ b/bazel/grpc_build_system.bzl
+@@ -196,18 +196,11 @@ def grpc_proto_plugin(name, srcs = [], deps = []):
+         srcs = srcs,
+         deps = deps,
+     )
+-    universal_binary(
+-        name = name + "_universal",
+-        binary = name + "_native",
+-    )
+
+     # In order to avoid warnings from Bazel, names of the rule and its output file must differ.
+     native.genrule(
+         name = name,
+-        srcs = select({
+-            "@platforms//os:macos": [name + "_universal"],
+-            "//conditions:default": [name + "_native"],
+-        }),
++        srcs = [name + "_native"],
+         outs = [name + "_binary"],
+         cmd = "cp $< $@",
+         executable = True,

--- a/pkgs/by-name/ba/bazel_9/patches/md5sum.patch
+++ b/pkgs/by-name/ba/bazel_9/patches/md5sum.patch
@@ -1,0 +1,30 @@
+diff --git a/src/md5_darwin_freebsd.sh b/src/md5_darwin_freebsd.sh
+index cd9c7687bc..2c5e71959a 100755
+--- a/src/md5_darwin_freebsd.sh
++++ b/src/md5_darwin_freebsd.sh
+@@ -14,4 +14,4 @@
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+ #
+-/sbin/md5 "$@" | /sbin/md5 | head -c 32
++@md5sum@ "$@" | @md5sum@ | head -c 32
+diff --git a/src/md5_default.sh b/src/md5_default.sh
+index d5d4f0b8f4..2c5e71959a 100755
+--- a/src/md5_default.sh
++++ b/src/md5_default.sh
+@@ -14,4 +14,4 @@
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+ #
+-md5sum "$@" | md5sum | head -c 32
++@md5sum@ "$@" | @md5sum@ | head -c 32
+diff --git a/src/md5_openbsd.sh b/src/md5_openbsd.sh
+index 6c85df1899..67c3bd9fed 100755
+--- a/src/md5_openbsd.sh
++++ b/src/md5_openbsd.sh
+@@ -16,4 +16,4 @@
+ #
+ # We avoid using the `head` tool's `-c` option, since it does not exist
+ # on OpenBSD.
+-/bin/md5 "$@" | /bin/md5 | dd bs=32 count=1
++@md5sum@ "$@" | @md5sum@ | dd bs=32 count=1

--- a/pkgs/by-name/ba/bazel_9/patches/rules_cc.patch
+++ b/pkgs/by-name/ba/bazel_9/patches/rules_cc.patch
@@ -1,0 +1,11 @@
+diff --git a/cc/private/toolchain/generate_system_module_map.sh b/cc/private/toolchain/generate_system_module_map.sh
+index 6bcbd85..b5e4f2c 100755
+--- a/cc/private/toolchain/generate_system_module_map.sh
++++ b/cc/private/toolchain/generate_system_module_map.sh
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env bash
++#!@defaultBash@
+ # Copyright 2020 The Bazel Authors. All rights reserved.
+ #
+ # Licensed under the Apache License, Version 2.0 (the "License");
+

--- a/pkgs/by-name/ba/bazel_9/patches/rules_java.patch
+++ b/pkgs/by-name/ba/bazel_9/patches/rules_java.patch
@@ -1,0 +1,11 @@
+diff --git java/bazel/rules/java_stub_template.txt java/bazel/rules/java_stub_template.txt
+index 115b46e..56d2ff7 100644
+--- java/bazel/rules/java_stub_template.txt
++++ java/bazel/rules/java_stub_template.txt
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env bash
++#!@defaultBash@
+ # Copyright 2014 The Bazel Authors. All rights reserved.
+ #
+ # Licensed under the Apache License, Version 2.0 (the "License");
+

--- a/pkgs/by-name/ba/bazel_9/patches/rules_python.patch
+++ b/pkgs/by-name/ba/bazel_9/patches/rules_python.patch
@@ -1,0 +1,13 @@
+diff --git a/python/private/runtime_env_toolchain.bzl b/python/private/runtime_env_toolchain.bzl
+index de749007..72d14499 100644
+--- a/python/private/runtime_env_toolchain.bzl
++++ b/python/private/runtime_env_toolchain.bzl
+@@ -48,7 +48,7 @@ def define_runtime_env_toolchain(name):
+         name = "_runtime_env_py3_runtime",
+         interpreter = "//python/private:runtime_env_toolchain_interpreter.sh",
+         python_version = "PY3",
+-        stub_shebang = "#!/usr/bin/env python3",
++        stub_shebang = "#!@usrBinEnv@ python3",
+         visibility = ["//visibility:private"],
+         tags = ["manual"],
+         supports_build_time_venv = supports_build_time_venv,

--- a/pkgs/by-name/ba/bazel_9/patches/strict_action_env.patch
+++ b/pkgs/by-name/ba/bazel_9/patches/strict_action_env.patch
@@ -1,0 +1,13 @@
+diff --git a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java
+index a70b5559bc..10bdffe961 100644
+--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java
++++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java
+@@ -466,7 +466,7 @@ public class BazelRuleClassProvider {
+       // Note that --action_env does not propagate to the host config, so it is not a viable
+       // workaround when a genrule is itself built in the host config (e.g. nested genrules). See
+       // #8536.
+-      return "/bin:/usr/bin:/usr/local/bin";
++      return "@strictActionEnvPatch@";
+     }
+
+     String newPath = "";

--- a/pkgs/by-name/ba/bazel_9/patches/usr_bin_env.patch
+++ b/pkgs/by-name/ba/bazel_9/patches/usr_bin_env.patch
@@ -1,0 +1,76 @@
+diff --git a/src/zip_builtins.sh b/src/zip_builtins.sh
+index d78ca5526a..c7d8f251cc 100755
+--- a/src/zip_builtins.sh
++++ b/src/zip_builtins.sh
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env bash
++#!@usrBinEnv@ bash
+
+ # Copyright 2020 The Bazel Authors. All rights reserved.
+ #
+
+diff --git a/src/zip_files.sh b/src/zip_files.sh
+index 1422a6c659..4b1c221784 100755
+--- a/src/zip_files.sh
++++ b/src/zip_files.sh
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env bash
++#!@usrBinEnv@ bash
+
+ # Copyright 2019 The Bazel Authors. All rights reserved.
+ #
+
+diff --git a/src/package-bazel.sh b/src/package-bazel.sh
+index 56e94db400..65fef20988 100755
+--- a/src/package-bazel.sh
++++ b/src/package-bazel.sh
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env bash
++#!@usrBinEnv@ bash
+ #
+ # Copyright 2015 The Bazel Authors. All rights reserved.
+ #
+
+diff --git a/src/main/cpp/generate_jvm_module_options.sh b/src/main/cpp/generate_jvm_module_options.sh
+index dbed0e7576..421c432d3e 100755
+--- a/src/main/cpp/generate_jvm_module_options.sh
++++ b/src/main/cpp/generate_jvm_module_options.sh
+@@ -1,4 +1,4 @@
+-#!/bin/bash
++#!@usrBinEnv@ bash
+ #
+ # Copyright 2025 The Bazel Authors. All rights reserved.
+ #
+
+diff --git a/src/md5_darwin_freebsd.sh b/src/md5_darwin_freebsd.sh
+index 2c5e71959a..a77a0cebd3 100755
+--- a/src/md5_darwin_freebsd.sh
++++ b/src/md5_darwin_freebsd.sh
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env bash
++#!@usrBinEnv@ bash
+ #
+ # Copyright 2025 The Bazel Authors. All rights reserved.
+ #
+
+diff --git a/src/md5_default.sh b/src/md5_default.sh
+index 2c5e71959a..a77a0cebd3 100755
+--- a/src/md5_default.sh
++++ b/src/md5_default.sh
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env bash
++#!@usrBinEnv@ bash
+ #
+ # Copyright 2025 The Bazel Authors. All rights reserved.
+ #
+
+diff --git a/src/md5_openbsd.sh b/src/md5_openbsd.sh
+index 67c3bd9fed..17dca32477 100755
+--- a/src/md5_openbsd.sh
++++ b/src/md5_openbsd.sh
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env bash
++#!@usrBinEnv@ bash
+ #
+ # Copyright 2025 The Bazel Authors. All rights reserved.
+ #

--- a/pkgs/by-name/ba/bazel_9/patches/xcode.patch
+++ b/pkgs/by-name/ba/bazel_9/patches/xcode.patch
@@ -1,0 +1,27 @@
+diff --git a/scripts/bootstrap/compile.sh b/scripts/bootstrap/compile.sh
+index 1bad14cba7..d312fe08bb 100755
+--- a/scripts/bootstrap/compile.sh
++++ b/scripts/bootstrap/compile.sh
+@@ -402,7 +402,7 @@ cp $OUTPUT_DIR/libblaze.jar ${ARCHIVE_DIR}
+ # TODO(b/28965185): Remove when xcode-locator is no longer required in embedded_binaries.
+ log "Compiling xcode-locator..."
+ if [[ $PLATFORM == "darwin" ]]; then
+-  run /usr/bin/xcrun --sdk macosx clang -mmacosx-version-min=10.13 -fobjc-arc -framework CoreServices -framework Foundation -o ${ARCHIVE_DIR}/xcode-locator tools/osx/xcode_locator.m
++  run @clangDarwin@ -mmacosx-version-min=10.13 -fobjc-arc -framework CoreServices -framework Foundation -o ${ARCHIVE_DIR}/xcode-locator tools/osx/xcode_locator.m
+ else
+   cp tools/osx/xcode_locator_stub.sh ${ARCHIVE_DIR}/xcode-locator
+ fi
+diff --git a/tools/osx/BUILD b/tools/osx/BUILD
+index 5b99589ad4..3d3269772b 100644
+--- a/tools/osx/BUILD
++++ b/tools/osx/BUILD
+@@ -27,7 +27,7 @@ exports_files([
+ ])
+ 
+ DARWIN_XCODE_LOCATOR_COMPILE_COMMAND = """
+-  /usr/bin/xcrun --sdk macosx clang -mmacosx-version-min=10.13 -fobjc-arc -framework CoreServices \
++  @clangDarwin@ -mmacosx-version-min=10.13 -fobjc-arc -framework CoreServices \
+       -framework Foundation -arch arm64 -arch x86_64 -o $@ $<
+ """
+ 
+

--- a/pkgs/by-name/ba/bazel_9/system.bazelrc
+++ b/pkgs/by-name/ba/bazel_9/system.bazelrc
@@ -1,0 +1,4 @@
+startup --server_javabase=@serverJavabase@
+
+# load default location for the system wide configuration
+try-import /etc/bazel.bazelrc


### PR DESCRIPTION
Bazel 9 is now released, and has a number of exciting features (for instance C++20 modules).

This is substantially similar to the Bazel 8 package, with the following differences:
* Some patches are changed/reworked to match upstream (e.g., md5sum).
* Some patches have been upstreamed (e.g., env_bash).
* Bazel is now stricter about paths escaping the repository, so the way we inject libresolv for Darwin has to change. Now we leverage NIX_CFLAGS_COMPILE to wormhole it into the wrapper, rather than passing options to Bazel.

This effectively includes #464436, as `generate-xml.sh` fails when running tests without it.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] Tested, as applicable:
  - [NixOS tests] in [nixos/tests].
  - [Package tests] at `passthru.tests`.
  - Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
