### PR TITLE
netcat-openbsd: 1.219-1 -> 1.234-1; fix build with gcc15; modernize

### DIFF
--- a/pkgs/by-name/ne/netcat-openbsd/package.nix
+++ b/pkgs/by-name/ne/netcat-openbsd/package.nix
@@ -7,7 +7,7 @@
   installShellFiles,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "netcat-openbsd";
   version = "1.234-1";
 
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     domain = "salsa.debian.org";
     owner = "debian";
     repo = "netcat-openbsd";
-    tag = "debian/${version}";
+    tag = "debian/${finalAttrs.version}";
     hash = "sha256-6pCsBbS2IjXyXgNXURHK3uMRTJ0aXAsu29kc7f479Os=";
   };
 
@@ -35,8 +35,7 @@ stdenv.mkDerivation rec {
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/bin
-    mv nc $out/bin/nc
+    install -Dm755 -t $out/bin nc
     installManPage nc.1
 
     runHook postInstall
@@ -57,4 +56,4 @@ stdenv.mkDerivation rec {
     # never built on aarch64-darwin, x86_64-darwin since first introduction in nixpkgs
     broken = stdenv.hostPlatform.isDarwin;
   };
-}
+})

--- a/pkgs/by-name/ne/netcat-openbsd/package.nix
+++ b/pkgs/by-name/ne/netcat-openbsd/package.nix
@@ -9,14 +9,14 @@
 
 stdenv.mkDerivation rec {
   pname = "netcat-openbsd";
-  version = "1.219-1";
+  version = "1.234-1";
 
   src = fetchFromGitLab {
     domain = "salsa.debian.org";
     owner = "debian";
     repo = "netcat-openbsd";
-    rev = "refs/tags/debian/${version}";
-    sha256 = "sha256-rN8pl3Qf0T8bXGtVH22tBpGY/EcnbgGm1G8Z2patGbo=";
+    tag = "debian/${version}";
+    hash = "sha256-6pCsBbS2IjXyXgNXURHK3uMRTJ0aXAsu29kc7f479Os=";
   };
 
   strictDeps = true;


### PR DESCRIPTION
- **netcat-openbsd: 1.219-1 -> 1.234-1; fix build with gcc15**
- **netcat-openbsd: modernize**

Hydra build: https://hydra.nixos.org/build/317878771

Tracking: https://github.com/NixOS/nixpkgs/issues/475479

Resolve: #475983

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
