### PR TITLE
cargo-codspeed: 3.0.5 -> 4.2.0, modernize, adopt

### DIFF
--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -18,6 +18,8 @@
   adding `pkg-config`, `xfce4-dev-tools`, and `wrapGAppsHook3` to your `nativeBuildInputs` and
   `--enable-maintainer-mode` to your `configureFlags`.
 
+- `cargo-codspeed` has been updated from `3.0.5` to `4.2.0`. Version `4.0.0` includes breaking changes. For more information read the [changelog for 4.0.0](https://github.com/CodSpeedHQ/codspeed-rust/releases/tag/v4.0.0).
+
 - `corepack_latest` has been removed, as Corepack is no longer distributed with Node.js.
 
 - `spoof` has been removed, as there are many issues upstream with it working on modern OS versions, and it appears to be unmaintained.

--- a/pkgs/by-name/ca/cargo-codspeed/package.nix
+++ b/pkgs/by-name/ca/cargo-codspeed/package.nix
@@ -16,7 +16,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "CodSpeedHQ";
     repo = "codspeed-rust";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-ofVgb+9YUNiCPhRZHY3Fm1nXRZK+9Uq8pc5XAm3P6oU=";
   };
 
@@ -53,7 +53,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   };
 
   meta = {
-    changelog = "https://github.com/CodSpeedHQ/codspeed-rust/releases/tag/${finalAttrs.src.rev}";
+    changelog = "https://github.com/CodSpeedHQ/codspeed-rust/releases/tag/v${finalAttrs.version}";
     description = "Cargo extension to build & run your codspeed benchmarks";
     homepage = "https://github.com/CodSpeedHQ/codspeed-rust";
     license = with lib.licenses; [

--- a/pkgs/by-name/ca/cargo-codspeed/package.nix
+++ b/pkgs/by-name/ca/cargo-codspeed/package.nix
@@ -9,14 +9,14 @@
   zlib,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cargo-codspeed";
   version = "4.2.0";
 
   src = fetchFromGitHub {
     owner = "CodSpeedHQ";
     repo = "codspeed-rust";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-ofVgb+9YUNiCPhRZHY3Fm1nXRZK+9Uq8pc5XAm3P6oU=";
   };
 
@@ -35,7 +35,7 @@ rustPlatform.buildRustPackage rec {
   ];
 
   cargoBuildFlags = [ "-p=cargo-codspeed" ];
-  cargoTestFlags = cargoBuildFlags;
+  cargoTestFlags = finalAttrs.cargoBuildFlags;
   checkFlags = [
     # requires an extra dependency, blit
     "--skip=test_package_in_deps_build"
@@ -63,4 +63,4 @@ rustPlatform.buildRustPackage rec {
     maintainers = [ ];
     mainProgram = "cargo-codspeed";
   };
-}
+})

--- a/pkgs/by-name/ca/cargo-codspeed/package.nix
+++ b/pkgs/by-name/ca/cargo-codspeed/package.nix
@@ -11,16 +11,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-codspeed";
-  version = "3.0.5";
+  version = "4.2.0";
 
   src = fetchFromGitHub {
     owner = "CodSpeedHQ";
     repo = "codspeed-rust";
     rev = "v${version}";
-    hash = "sha256-vQGPROaTkEwvKw+4aPpS1whUwfeqBcYWJTIKm4KnIiw=";
+    hash = "sha256-ofVgb+9YUNiCPhRZHY3Fm1nXRZK+9Uq8pc5XAm3P6oU=";
   };
 
-  cargoHash = "sha256-1bFd35JScS3x0ttfSyNUgtB9xgtVUMRl4oUOn2r+t5M=";
+  cargoHash = "sha256-xcLs2Tdi7wp7F5Jwl1QvEC1wQeK7pBjBZKxGVrzqzu0=";
 
   nativeBuildInputs = [
     curl
@@ -39,6 +39,13 @@ rustPlatform.buildRustPackage rec {
   checkFlags = [
     # requires an extra dependency, blit
     "--skip=test_package_in_deps_build"
+
+    # requires criteron, which requires additional dependencies
+    "--skip=test_cargo_config_rustflags"
+
+    # requires additional dependencies
+    "--skip=test_criterion_build_and_run_filtered_by_name"
+    "--skip=test_criterion_build_and_run_filtered_by_name_single"
   ];
 
   env = {

--- a/pkgs/by-name/ca/cargo-codspeed/package.nix
+++ b/pkgs/by-name/ca/cargo-codspeed/package.nix
@@ -53,14 +53,14 @@ rustPlatform.buildRustPackage (finalAttrs: {
   };
 
   meta = {
+    changelog = "https://github.com/CodSpeedHQ/codspeed-rust/releases/tag/${finalAttrs.src.rev}";
     description = "Cargo extension to build & run your codspeed benchmarks";
     homepage = "https://github.com/CodSpeedHQ/codspeed-rust";
-    changelog = "https://github.com/CodSpeedHQ/codspeed-rust/releases/tag/${src.rev}";
     license = with lib.licenses; [
       mit
       asl20
     ];
-    maintainers = [ ];
     mainProgram = "cargo-codspeed";
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/ca/cargo-codspeed/package.nix
+++ b/pkgs/by-name/ca/cargo-codspeed/package.nix
@@ -1,11 +1,11 @@
 {
-  lib,
-  rustPlatform,
-  fetchFromGitHub,
   curl,
-  pkg-config,
+  fetchFromGitHub,
+  lib,
   libgit2,
   openssl,
+  pkg-config,
+  rustPlatform,
   zlib,
 }:
 

--- a/pkgs/by-name/ca/cargo-codspeed/package.nix
+++ b/pkgs/by-name/ca/cargo-codspeed/package.nix
@@ -61,6 +61,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
       asl20
     ];
     mainProgram = "cargo-codspeed";
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ hythera ];
   };
 })


### PR DESCRIPTION
Diff: https://github.com/CodSpeedHQ/codspeed-rust/compare/v3.0.5...v4.2.0
Part of #458096

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
