### PR TITLE
lib.types.defaultTypeMerge: Fix for functors with no `wrapped` attr

### DIFF
--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -728,6 +728,8 @@ checkConfigOutput 'ok' config.freeformItems.foo.bar ./adhoc-freeformType-survive
 # Test that specifying both functor.wrapped and functor.payload isn't allowed
 checkConfigError 'Type foo defines both `functor.payload` and `functor.wrapped` at the same time, which is not supported.' config.result ./default-type-merge-both.nix
 
+# Test that not including functor.wrapped is allowed
+checkConfigOutput 'ok' config.result ./default-type-merge-payload.nix
 
 # Anonymous submodules don't get nixed by import resolution/deduplication
 # because of an `extendModules` bug, issue 168767.

--- a/lib/tests/modules/default-type-merge-payload.nix
+++ b/lib/tests/modules/default-type-merge-payload.nix
@@ -1,0 +1,32 @@
+{ lib, options, ... }:
+let
+  fooOf =
+    elemType:
+    lib.mkOptionType {
+      name = "foo";
+      functor = {
+        name = "foo";
+        type = payload: fooOf payload.elemType;
+        binOp = a: _b: a;
+        payload.elemType = elemType;
+      };
+    };
+in
+{
+  imports = [
+    {
+      options.foo = lib.mkOption {
+        type = fooOf lib.types.int;
+      };
+    }
+    {
+      options.foo = lib.mkOption {
+        type = fooOf lib.types.int;
+      };
+    }
+  ];
+
+  options.result = lib.mkOption {
+    default = builtins.seq options.foo "ok";
+  };
+}

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -158,8 +158,11 @@ rec {
         assert (f'.payload != null) == (f.payload != null);
         f.payload != null;
       hasWrapped =
-        assert (f'.wrapped != null) == (f.wrapped != null);
-        f.wrapped != null;
+        let
+          hasWrappedNonNull = set: set ? "wrapped" && set.wrapped != null;
+        in
+        assert (hasWrappedNonNull f') == (hasWrappedNonNull f);
+        hasWrappedNonNull f;
 
       typeFromPayload = if mergedPayload == null then null else f.type mergedPayload;
       typeFromWrapped = if mergedWrapped == null then null else f.type mergedWrapped;


### PR DESCRIPTION
Downstream types that want to use `lib.types.defaultTypeMerge` must include `wrapped` even though it is deprecated or the internal `wrappedDeprecationMessage`. This is caused by accessing the`wrapped` attr in `lib.types.defaultTypeMerge`. The logic should first check if the attr exists and then if it does check if it is null.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
