### PR TITLE
solc: 0.8.28 -> 0.8.33

### DIFF
--- a/pkgs/by-name/so/solc/package.nix
+++ b/pkgs/by-name/so/solc/package.nix
@@ -25,9 +25,9 @@ assert cvc4Support -> cvc4 != null && cln != null && gmp != null;
 let
   pname = "solc";
 
-  version = "0.8.28";
-  linuxHash = "sha256-kosJ10stylGK5NUtsnMM7I+OfhR40TXPQDvnggOFLLc=";
-  darwinHash = "sha256-gVFbDlPeqiZtVJVFzKrApalubU6CAcd/ZzsscQl22eo=";
+  version = "0.8.33";
+  linuxHash = "sha256-sWCV0GOUW5GPNX1flk+UOrdwoHZHnx4MsZMGDDBxx6M=";
+  darwinHash = "sha256-gyQoBZHOOY1+JyKEa8EOzxd5sToyjvl7aHySzZxwgBo=";
 
   nativeInstallCheckInputs = [
     versionCheckHook
@@ -63,15 +63,6 @@ let
           url = "https://github.com/ethereum/solidity/releases/download/v${version}/solidity_${version}.tar.gz";
           hash = linuxHash;
         };
-
-        # Fix build with GCC 14
-        # Submitted upstream: https://github.com/ethereum/solidity/pull/15685
-        postPatch = ''
-          substituteInPlace test/yulPhaser/Chromosome.cpp \
-            --replace-fail \
-              "BOOST_TEST(abs" \
-              "BOOST_TEST(fabs"
-        '';
 
         cmakeFlags = [
           "-DBoost_USE_STATIC_LIBS=OFF"


### PR DESCRIPTION
Simply update the version fixes build with GCC 15 (fixes #475906)

I don't have darwin machine so can't test darwin build, can anyone help?

Side note: I haven't work on or use solc for many years, and is pretty out of the loop, so I'm not the best person to maintain the package. Other solc maintainers seems to be also inactive? If anyone like to take over the package please feel free to do so

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
