### PR TITLE
kaldi: fix build

### DIFF
--- a/pkgs/by-name/ka/kaldi/fix-gcc15-copy-constructor.patch
+++ b/pkgs/by-name/ka/kaldi/fix-gcc15-copy-constructor.patch
@@ -1,0 +1,42 @@
+From fece8a6f239c7323c61238dfdd1e0dd47885fc88 Mon Sep 17 00:00:00 2001
+From: matthiasdotsh <git@matthias.sh>
+Date: Fri, 2 Jan 2026 11:08:17 +0100
+Subject: [PATCH] Fix copy constructor member access in VectorHashBiTable
+
+The copy constructor of VectorHashBiTable was incorrectly accessing
+`table.s_` instead of `table.selector_`, causing a compilation error
+with stricter C++ compilers.
+
+This issue manifests with GCC 15, which enforces more rigorous checks
+on template member access. The compiler error was:
+
+  error: 'const class fst::VectorHashBiTable<...>' has no member
+  named 's_'; did you mean 'h_'?
+
+The member variable is actually named `selector_`, not `s_`. This fix
+aligns the copy constructor with the correct member variable name used
+throughout the class definition.
+
+Fixes build failures on systems with GCC 15.
+
+Related: https://github.com/gpustack/gpustack/issues/1798#issuecomment-2980869111
+---
+ src/include/fst/bi-table.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/include/fst/bi-table.h b/src/include/fst/bi-table.h
+index 9651cfe..fb747fe 100644
+--- a/src/include/fst/bi-table.h
++++ b/src/include/fst/bi-table.h
+@@ -317,7 +317,7 @@ class VectorHashBiTable {
+   }
+ 
+   VectorHashBiTable(const VectorHashBiTable<I, T, S, FP, H, HS> &table)
+-      : selector_(new S(table.s_)), fp_(new FP(*table.fp_)),
++      : selector_(new S(table.selector_)), fp_(new FP(*table.fp_)),
+         h_(new H(*table.h_)), id2entry_(table.id2entry_),
+         fp2id_(table.fp2id_), hash_func_(*this), hash_equal_(*this),
+         keys_(table.keys_.size(), hash_func_, hash_equal_) {
+-- 
+2.52.0
+

--- a/pkgs/by-name/ka/kaldi/package.nix
+++ b/pkgs/by-name/ka/kaldi/package.nix
@@ -73,9 +73,14 @@ stdenv.mkDerivation (finalAttrs: {
         owner = "kkm000";
         repo = "openfst";
         rev = "338225416178ac36b8002d70387f5556e44c8d05";
-        hash = "sha256-y1E6bQgBfYt1Co02UutOyEM2FnETuUl144tHwypiX+M=";
-        # https://github.com/kkm000/openfst/issues/59
-        postFetch = ''(cd "$out"; patch -p1 < '${./gcc14.patch}')'';
+        hash = "sha256-9xsL78mkR40zkoRYWsH+iaPa5MYc4BzwslzxGKv4j4I=";
+        postFetch = ''
+          cd "$out"
+          # https://github.com/kkm000/openfst/issues/59
+          patch -p1 < ${./gcc14.patch}
+          # Patch for compiling openfst with gcc >= 15
+          patch -p1 < ${./fix-gcc15-copy-constructor.patch}
+        '';
       };
     };
 


### PR DESCRIPTION
Fix kaldi no longer building with gcc15.

Build failed when compiling dependency openfst.
```bash
nix-build -A kaldi
[...]
       >                  from /nix/store/78h4f39zcv9js54af27wys7yba4vzj57-source/src/lib/fst.cc:12:
       > /nix/store/78h4f39zcv9js54af27wys7yba4vzj57-source/src/include/fst/bi-table.h: In copy constructor 'fst::VectorHashBiTable<I, T, S, FP, H, HS>::VectorHashBiTable(const fst::VectorHashBiTable<I, T, S, FP, H, HS>&)':
       > /nix/store/78h4f39zcv9js54af27wys7yba4vzj57-source/src/include/fst/bi-table.h:320:31: error: 'const class fst::VectorHashBiTable<I, T, S, FP, H, HS>' has no member named 's_'; did you mean 'h_'? [-Wtemplate-body]
       >   320 |       : selector_(new S(table.s_)), fp_(new FP(*table.fp_)),
       >       |                               ^~
       >       |                               h_
       > /nix/store/78h4f39zcv9js54af27wys7yba4vzj57-source/src/include/fst/replace.h: In member function 'bool fst::internal::ReplaceFstImpl<Arc, StateTable, CacheStore>::ComputeArc(const StateTuple&, const Arc&, Arc*, uint32)':
       > /nix/store/78h4f39zcv9js54af27wys7yba4vzj57-source/src/include/fst/replace.h:804:32: warning: expected 'template' keyword before dependent template name [-Wmissing-template-keyword]
       >   804 |     if (arc.olabel == 0 || arc.olabel < *nonterminal_set_.begin() ||
       >       |                                ^~~~~~
       >       |                                template
       > make[2]: *** [_deps/openfst-build/src/lib/CMakeFiles/fst.dir/build.make:121: _deps/openfst-build/src/lib/CMakeFiles/fst.dir/fst.cc.o] Error 1
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
