### PR TITLE
pasystray: 0.8.2 -> 0.8.2-unstable-2025-10-04

### DIFF
--- a/pkgs/by-name/pa/pasystray/package.nix
+++ b/pkgs/by-name/pa/pasystray/package.nix
@@ -15,30 +15,21 @@
   gsettings-desktop-schemas,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "pasystray";
-  version = "0.8.2";
+  version = "0.8.2-unstable-2025-10-04";
 
   src = fetchFromGitHub {
     owner = "christophgysin";
     repo = "pasystray";
-    rev = version;
-    sha256 = "sha256-QaTQ8yUviJaFEQaQm2vYAUngqHliKe8TDYqfWt1Nx/0=";
+    rev = "5a199dc6958bcaac07a8031eb48b9fad8730bf71";
+    sha256 = "sha256-1vP1ZNvq7raz9te5WK+RPTP09BzF/jAFoeRjsvYXmZo=";
   };
 
   patches = [
-    # Use ayatana-appindicator instead of appindicator
-    # https://github.com/christophgysin/pasystray/issues/98
-    (fetchpatch {
-      url = "https://sources.debian.org/data/main/p/pasystray/0.8.1-1/debian/patches/0001-Build-against-ayatana-appindicator.patch";
-      sha256 = "sha256-/HKPqVARfHr/3Vyls6a1n8ejxqW9Ztu4+8KK4jK8MkI=";
-    })
     # Require X11 backend
     # https://github.com/christophgysin/pasystray/issues/90#issuecomment-361881076
-    (fetchpatch {
-      url = "https://sources.debian.org/data/main/p/pasystray/0.8.1-1/debian/patches/0002-Require-X11-backend.patch";
-      sha256 = "sha256-6njC3vqBPWFS1xAsa1katQ4C0KJdVkHAP1MCPiZ6ELM=";
-    })
+    ./require-x11-backend.patch
   ];
 
   nativeBuildInputs = [
@@ -46,6 +37,7 @@ stdenv.mkDerivation rec {
     autoreconfHook
     wrapGAppsHook3
   ];
+
   buildInputs = [
     adwaita-icon-theme
     avahi

--- a/pkgs/by-name/pa/pasystray/require-x11-backend.patch
+++ b/pkgs/by-name/pa/pasystray/require-x11-backend.patch
@@ -1,0 +1,19 @@
+From: Scott Leggett <scott@sl.id.au>
+Date: Mon, 29 Oct 2018 22:40:16 +1100
+Subject: Require X11 backend
+Forwarded: not-needed
+
+---
+ src/pasystray.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/src/pasystray.c
++++ b/src/pasystray.c
+@@ -38,6 +38,7 @@ static menu_infos_t* mis;
+ 
+ int main(int argc, char *argv[])
+ {
++    gdk_set_allowed_backends ("x11");
+     GOptionEntry* options = get_options();
+     GError *error = NULL;
+     gtk_init_with_args(&argc, &argv, NULL, options, NULL, &error);


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Closes https://github.com/NixOS/nixpkgs/issues/476184

Tracks https://github.com/NixOS/nixpkgs/issues/475479

~~This PR fixes compile errors on function declarations without explicit parameters.~~

~~I also found that this issue has actually been fixed in the latest commit of the upstream repository. Should I upgrade this package?~~

This PR upgrades `pasystray` from `0.8.2` to `0.8.2-unstable-2025-10-04`. As the latest official release was on February 2023, I think it makes sense to update the package, without patching probably outdated source codes. Fix for compile errors was included in the recent commit from upstream.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
