### PR TITLE
treewide: fix missing "v" in meta.changelog URL

### DIFF
--- a/pkgs/by-name/co/coordgenlibs/package.nix
+++ b/pkgs/by-name/co/coordgenlibs/package.nix
@@ -60,7 +60,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Schrodinger-developed 2D Coordinate Generation";
     homepage = "https://github.com/schrodinger/coordgenlibs";
-    changelog = "https://github.com/schrodinger/coordgenlibs/releases/tag/${finalAttrs.version}";
+    changelog = "https://github.com/schrodinger/coordgenlibs/releases/tag/v${finalAttrs.version}";
     maintainers = [ lib.maintainers.rmcgibbo ];
     license = lib.licenses.bsd3;
   };

--- a/pkgs/by-name/co/cowsql/package.nix
+++ b/pkgs/by-name/co/cowsql/package.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   meta = {
-    changelog = "https://github.com/cowsql/cowsql/releases/tag/${finalAttrs.version}";
+    changelog = "https://github.com/cowsql/cowsql/releases/tag/v${finalAttrs.version}";
     description = "Embeddable, replicated and fault tolerant SQL engine";
     homepage = "https://github.com/cowsql/cowsql";
     license = lib.licenses.lgpl3Only;

--- a/pkgs/by-name/ef/efficient-compression-tool/package.nix
+++ b/pkgs/by-name/ef/efficient-compression-tool/package.nix
@@ -63,7 +63,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Fast and effective C++ file optimizer";
     homepage = "https://github.com/fhanau/Efficient-Compression-Tool";
-    changelog = "https://github.com/fhanau/Efficient-Compression-Tool/releases/tag/${finalAttrs.version}";
+    changelog = "https://github.com/fhanau/Efficient-Compression-Tool/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       jwillikers

--- a/pkgs/by-name/gd/gdb-dashboard/package.nix
+++ b/pkgs/by-name/gd/gdb-dashboard/package.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Modular visual interface for GDB in Python";
     homepage = "https://github.com/cyrus-and/gdb-dashboard";
     downloadPage = "https://github.com/cyrus-and/gdb-dashboard";
-    changelog = "https://github.com/cyrus-and/gdb-dashboard/releases/tag/${finalAttrs.version}";
+    changelog = "https://github.com/cyrus-and/gdb-dashboard/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ ethancedwards8 ];
   };

--- a/pkgs/by-name/is/ispc/package.nix
+++ b/pkgs/by-name/is/ispc/package.nix
@@ -98,7 +98,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Intel 'Single Program, Multiple Data' Compiler, a vectorised language";
     homepage = "https://ispc.github.io/";
-    changelog = "https://github.com/ispc/ispc/releases/tag/${finalAttrs.version}";
+    changelog = "https://github.com/ispc/ispc/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [
       thoughtpolice

--- a/pkgs/by-name/lu/luastatus/package.nix
+++ b/pkgs/by-name/lu/luastatus/package.nix
@@ -86,7 +86,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Universal status bar content generator";
     homepage = "https://github.com/shdown/luastatus";
-    changelog = "https://github.com/shdown/luastatus/releases/tag/${finalAttrs.version}";
+    changelog = "https://github.com/shdown/luastatus/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ kashw2 ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/sp/spedread/package.nix
+++ b/pkgs/by-name/sp/spedread/package.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Rapid word display tool for improved reading focus and reduced eye movement";
     homepage = "https://github.com/Darazaki/Spedread";
-    changelog = "https://github.com/Darazaki/Spedread/releases/tag/${finalAttrs.version}";
+    changelog = "https://github.com/Darazaki/Spedread/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.gpl3;
     maintainers = with lib.maintainers; [ thtrf ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/sy/systemd-netlogd/package.nix
+++ b/pkgs/by-name/sy/systemd-netlogd/package.nix
@@ -84,7 +84,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Forwards messages from the journal to other hosts over the network";
     homepage = "https://github.com/systemd/systemd-netlogd";
-    changelog = "https://github.com/systemd/systemd-netlogd/releases/tag/${finalAttrs.version}";
+    changelog = "https://github.com/systemd/systemd-netlogd/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ getchoo ];
     mainProgram = "systemd-netlogd";


### PR DESCRIPTION
This PR adds a missing "v" in the meta.changelog URL for packages that use finalAttrs.
Previously the URLs lead to a 404 page.

## Things done
- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
