### PR TITLE
libjpeg-turbo: fix mingw-boolean.patch preprocessor balance

### DIFF
--- a/pkgs/by-name/li/libjpeg_turbo/mingw-boolean.patch
+++ b/pkgs/by-name/li/libjpeg_turbo/mingw-boolean.patch
@@ -2,7 +2,7 @@ Ported to updated libjpeg-turbo from
 https://github.com/msys2/MINGW-packages/blob/master/mingw-w64-libjpeg-turbo/jpeg-typedefs.patch
 --- a/src/jmorecfg.h
 +++ b/src/jmorecfg.h
-@@ -200,6 +200,13 @@
+@@ -200,6 +200,14 @@
   */
  
  #ifndef HAVE_BOOLEAN
@@ -15,4 +15,5 @@ https://github.com/msys2/MINGW-packages/blob/master/mingw-w64-libjpeg-turbo/jpeg
 +#if !defined(HAVE_BOOLEAN) && !defined(__RPCNDR_H__)
  typedef int boolean;
  #endif
++#endif
  #ifndef FALSE                   /* in case these macros already exist */


### PR DESCRIPTION
Fix an unbalanced preprocessor block in `mingw-boolean.patch` that breaks MinGW cross-compilation builds.

## Changes

The patch `pkgs/by-name/li/libjpeg_turbo/mingw-boolean.patch` was missing a closing `#endif`, causing preprocessor block imbalance errors during MinGW builds. This led to cascading type errors that obscured the real issue.

This PR:
- Adds the missing `#endif` to close the `HAVE_BOOLEAN` conditional block
- Corrects the diff hunk header to match the actual patch content

## Validation

### Cross build (MinGW)
`nix build .#pkgsCross.mingwW64.libjpeg_turbo --no-link -L`

### Native build (regression check)
`nix build .#libjpeg_turbo --no-link -L`

## Things done

- Built on platform:
  - [x] x86_64-linux (cross to mingwW64)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob