### PR TITLE
gperftools: avoid pthread benchmarks on MinGW

### DIFF
--- a/pkgs/by-name/gp/gperftools/mingw-disable-benchmarks.patch
+++ b/pkgs/by-name/gp/gperftools/mingw-disable-benchmarks.patch
@@ -1,0 +1,21 @@
+diff --git a/Makefile.am b/Makefile.am
+index 52d5e2b..62b8ae6 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -523,6 +523,8 @@ debugallocation_test_LDADD = libtcmalloc_debug.la libgtest.la
+ 
+ endif WITH_DEBUGALLOC
+ 
++if !MINGW
++
+ noinst_LTLIBRARIES += librun_benchmark.la
+ librun_benchmark_la_SOURCES = \
+ 	benchmark/run_benchmark.cc
+@@ -552,8 +554,7 @@ binary_trees_shared_SOURCES = benchmark/binary_trees.cc
+ binary_trees_shared_LDFLAGS = $(TCMALLOC_FLAGS) $(AM_LDFLAGS)
+ binary_trees_shared_LDADD = libtcmalloc_minimal.la
+ 
+-if !MINGW
+ if WITH_HEAP_PROFILER_OR_CHECKER
+ 
+ noinst_PROGRAMS += malloc_bench_shared_full

--- a/pkgs/by-name/gp/gperftools/package.nix
+++ b/pkgs/by-name/gp/gperftools/package.nix
@@ -25,6 +25,9 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://src.fedoraproject.org/rpms/gperftools/raw/88ce8ee43a12b1a8146781a1b4d9abbd8df8af0e/f/gperftools-2.17-disable-generic-dynamic-tls.patch";
       hash = "sha256-IOLUf9mCEA+fVSJKU94akcnXTIm7+t+S9cjBHsEDwFA=";
     })
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isMinGW [
+    ./mingw-disable-benchmarks.patch
   ];
 
   nativeBuildInputs = [ autoreconfHook ];


### PR DESCRIPTION
Fix MinGW cross-compilation by disabling benchmark programs that require pthreads.

## Changes

The benchmark sources (`benchmark/binary_trees.cc` and others) unconditionally include `<pthread.h>`, which is not available on MinGW in a usable form for the benchmark harness.

This PR:
- Adds `./mingw-disable-benchmarks.patch` to skip building benchmark programs on MinGW
- The core gperftools library remains fully buildable and functional

The patch wraps the benchmark build rules in `Makefile.am` with `if !MINGW ... endif` conditionals.

## Reference

MSYS2 PKGBUILD: [mingw-w64-gperftools](https://github.com/msys2/MINGW-packages/tree/master/mingw-w64-gperftools)

## Validation

### Cross build (MinGW)
`nix build .#pkgsCross.mingwW64.gperftools --no-link -L`

### Native build (regression check)
`nix build .#gperftools --no-link -L`

## Things done

- Built on platform:
  - [x] x86_64-linux (cross to mingwW64)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test