### PR TITLE
nixos/sub-store: init; nixosTests.sub-store: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1740,6 +1740,7 @@
   ./services/web-apps/stash.nix
   ./services/web-apps/stirling-pdf.nix
   ./services/web-apps/strfry.nix
+  ./services/web-apps/sub-store.nix
   ./services/web-apps/suwayomi-server.nix
   ./services/web-apps/szurubooru.nix
   ./services/web-apps/trilium.nix

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1807,6 +1807,7 @@
   ./services/web-apps/strfry.nix
   ./services/web-apps/strichliste.nix
   ./services/web-apps/stump.nix
+  ./services/web-apps/sub-store.nix
   ./services/web-apps/suwayomi-server.nix
   ./services/web-apps/szurubooru.nix
   ./services/web-apps/tabbyapi.nix

--- a/nixos/modules/services/web-apps/sub-store.nix
+++ b/nixos/modules/services/web-apps/sub-store.nix
@@ -1,0 +1,168 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.sub-store;
+  format = pkgs.formats.keyValue { };
+in
+{
+  meta.maintainers = with lib.maintainers; [ moraxyc ];
+
+  options.services.sub-store = {
+    enable = lib.mkEnableOption "sub-store service";
+
+    package = lib.mkPackageOption pkgs "sub-store" { };
+
+    frontendPackage = lib.mkPackageOption pkgs "sub-store-frontend" { nullable = true; };
+
+    host = lib.mkOption {
+      type = lib.types.str;
+      default = "127.0.0.1";
+      description = "The host address to bind to.";
+    };
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 3000;
+      description = "The backend API port.";
+    };
+
+    frontendPort = lib.mkOption {
+      type = lib.types.port;
+      default = 3001;
+      description = "The frontend port.";
+    };
+
+    mergeMode = lib.mkOption {
+      type = lib.types.bool;
+      description = ''
+        Whether to enable merge mode to serve the frontend and backend on a single port
+        defined by {option}`services.sub-store.port`.
+
+        When enabled:
+        - {option}`services.sub-store.settings.SUB_STORE_BACKEND_MERGE` is set to `true`.
+        - {env}`SUB_STORE_FRONTEND_BACKEND_PATH` must start with `/`.
+        - {option}`services.sub-store.frontendPort` is ignored as the backend handles frontend delivery.
+      '';
+      example = true;
+      default = false;
+    };
+
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      description = ''
+        Whether to open firewall ports for Sub-Store.
+
+        If {option}`services.sub-store.mergeMode` is enabled, only
+        {option}`services.sub-store.port` is opened. Otherwise, both
+        {option}`services.sub-store.port` and {option}`services.sub-store.frontendPort`
+        are opened.
+      '';
+      example = true;
+      default = false;
+    };
+
+    environmentFile = lib.mkOption {
+      type = lib.types.path;
+      description = ''
+        Path to an environment file loaded for the Sub-Store service.
+
+        This can be used to securely store tokens and secrets outside of the world-readable Nix store.
+
+        Example contents of the file:
+        SUB_STORE_FRONTEND_BACKEND_PATH=/random-path-for-security
+      '';
+      default = "/dev/null";
+      example = "/run/secrets/sub-store";
+    };
+
+    settings = lib.mkOption {
+      type = lib.types.submodule {
+        freeformType = format.type;
+      };
+      default = { };
+      description = ''
+        Environment variables passed to the Sub-Store service.
+
+        Since {env}`SUB_STORE_FRONTEND_BACKEND_PATH` or other variables may contain sensitive
+        information, it is highly recommended to provide them via
+        {option}`services.sub-store.environmentFile` to avoid leaking secrets into the
+        world-readable Nix store.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    networking.firewall.allowedTCPPorts = lib.optionals cfg.openFirewall (
+      [ cfg.port ] ++ lib.optional (!cfg.mergeMode) cfg.frontendPort
+    );
+    services.sub-store.settings =
+      lib.mapAttrs (_: v: lib.mkDefault v) {
+        SUB_STORE_FRONTEND_HOST = cfg.host;
+        SUB_STORE_FRONTEND_PORT = toString cfg.frontendPort;
+        SUB_STORE_BACKEND_API_HOST = cfg.host;
+        SUB_STORE_BACKEND_API_PORT = toString cfg.port;
+        SUB_STORE_BACKEND_MERGE = toString cfg.mergeMode;
+        SUB_STORE_DATA_BASE_PATH = "%S/sub-store";
+      }
+      // lib.optionalAttrs (cfg.frontendPackage != null) {
+        SUB_STORE_FRONTEND_PATH = "${cfg.frontendPackage}";
+      };
+    systemd.services.sub-store = {
+      description = "Sub-Store Service";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      restartTriggers = [
+        cfg.package
+        cfg.environmentFile
+      ];
+      environment = cfg.settings;
+      serviceConfig = {
+        ExecStart = lib.getExe cfg.package;
+        Type = "simple";
+        Restart = "on-failure";
+        EnvironmentFile = [ cfg.environmentFile ];
+
+        DynamicUser = true;
+        StateDirectory = "sub-store";
+        StateDirectoryMode = "0700";
+        WorkingDirectory = "%S/sub-store";
+
+        # Security hardening
+        CapabilityBoundingSet = "";
+        DevicePolicy = "closed";
+        LockPersonality = true;
+        MemoryDenyWriteExecute = false; # Required for Node.js JIT
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        PrivateTmp = true;
+        PrivateUsers = true;
+        ProcSubset = "pid";
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        ProtectSystem = "strict";
+        RemoveIPC = true;
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_UNIX"
+        ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [ "@system-service" ];
+        UMask = "0077";
+      };
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1451,6 +1451,7 @@ in
   strongswan-swanctl = runTest ./strongswan-swanctl.nix;
   stub-ld = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./stub-ld.nix { };
   stunnel = import ./stunnel.nix { inherit runTest; };
+  sub-store = runTest ./sub-store.nix;
   sudo = runTest ./sudo.nix;
   sudo-rs = runTest ./sudo-rs.nix;
   sunshine = runTest ./sunshine.nix;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1595,6 +1595,7 @@ in
   stub-ld = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./stub-ld.nix { };
   stump = runTest ./web-apps/stump.nix;
   stunnel = import ./stunnel.nix { inherit runTest; };
+  sub-store = runTest ./sub-store.nix;
   sudo = runTest ./sudo.nix;
   sudo-rs = runTest ./sudo-rs.nix;
   sunshine = runTest ./sunshine.nix;

--- a/nixos/tests/sub-store.nix
+++ b/nixos/tests/sub-store.nix
@@ -1,0 +1,76 @@
+{
+  lib,
+  pkgs,
+  ...
+}:
+let
+  testPort = 54321;
+  secretPath = "/random-path";
+
+  proxyData = {
+    type = "socks5";
+    host = "127.0.0.1";
+    port = "7890";
+  };
+  dataFile = pkgs.writers.writeJSON "sub-store.json" {
+    schemaVersion = "2.0";
+    subs = [
+      {
+        content = "${proxyData.type}://${proxyData.host}:${proxyData.port}";
+        name = "test";
+        source = "local";
+      }
+    ];
+  };
+in
+{
+  name = "sub-store";
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      systemd.tmpfiles.rules = [
+        "C /var/lib/sub-store/sub-store.json 0666 root root - ${dataFile}"
+      ];
+
+      services.sub-store = {
+        enable = true;
+        openFirewall = true;
+        port = testPort;
+        mergeMode = true;
+        environmentFile = pkgs.writeText "sub-store-env" (
+          lib.generators.toKeyValue { } {
+            SUB_STORE_FRONTEND_BACKEND_PATH = secretPath;
+          }
+        );
+      };
+    };
+
+  extraPythonPackages =
+    p: with p; [
+      pyyaml
+      types-pyyaml
+    ];
+
+  testScript = # py
+    ''
+      import yaml
+
+      start_all()
+
+      machine.wait_for_file("/var/lib/sub-store/sub-store.json")
+      machine.wait_for_unit("sub-store.service")
+      machine.wait_for_open_port(${toString testPort})
+
+      with subtest("Verify API response"):
+          response = machine.succeed("curl -sSf 'http://127.0.0.1:${toString testPort}${secretPath}/download/test?target=ShadowRocket'")
+
+          data = yaml.safe_load(response)
+
+          assert data["proxies"][0]["type"] == "${proxyData.type}"
+          assert data["proxies"][0]["server"] == "${proxyData.host}"
+          assert data["proxies"][0]["port"] == ${proxyData.port}
+    '';
+
+  meta.maintainers = with lib.maintainers; [ moraxyc ];
+}

--- a/pkgs/by-name/su/sub-store-frontend/package.nix
+++ b/pkgs/by-name/su/sub-store-frontend/package.nix
@@ -9,6 +9,7 @@
   pnpmConfigHook,
   nix-update-script,
   nodejs,
+  nixosTests,
 }:
 
 buildNpmPackage (finalAttrs: {
@@ -45,7 +46,12 @@ buildNpmPackage (finalAttrs: {
     runHook postInstall
   '';
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    updateScript = nix-update-script { };
+    tests = {
+      inherit (nixosTests) sub-store;
+    };
+  };
 
   meta = {
     description = "Sub-Store Progressive Web App";

--- a/pkgs/by-name/su/sub-store-frontend/package.nix
+++ b/pkgs/by-name/su/sub-store-frontend/package.nix
@@ -8,6 +8,7 @@
   pnpmConfigHook,
   nix-update-script,
   nodejs,
+  nixosTests,
 }:
 let
   pnpm = pnpm_10;
@@ -46,7 +47,12 @@ buildNpmPackage (finalAttrs: {
     runHook postInstall
   '';
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    updateScript = nix-update-script { };
+    tests = {
+      inherit (nixosTests) sub-store;
+    };
+  };
 
   meta = {
     description = "Sub-Store Progressive Web App";

--- a/pkgs/by-name/su/sub-store/package.nix
+++ b/pkgs/by-name/su/sub-store/package.nix
@@ -9,6 +9,7 @@
   pnpmConfigHook,
   makeBinaryWrapper,
   nix-update-script,
+  nixosTests,
 
   nodejs,
 }:
@@ -58,7 +59,12 @@ buildNpmPackage (finalAttrs: {
     runHook postInstall
   '';
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    updateScript = nix-update-script { };
+    tests = {
+      inherit (nixosTests) sub-store;
+    };
+  };
 
   meta = {
     description = "Advanced Subscription Manager for QX, Loon, Surge, Stash, Egern and Shadowrocket";

--- a/pkgs/by-name/su/sub-store/package.nix
+++ b/pkgs/by-name/su/sub-store/package.nix
@@ -8,6 +8,7 @@
   pnpmConfigHook,
   makeBinaryWrapper,
   nix-update-script,
+  nixosTests,
 
   nodejs,
 }:
@@ -59,7 +60,12 @@ buildNpmPackage (finalAttrs: {
     runHook postInstall
   '';
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    updateScript = nix-update-script { };
+    tests = {
+      inherit (nixosTests) sub-store;
+    };
+  };
 
   meta = {
     description = "Advanced Subscription Manager for QX, Loon, Surge, Stash, Egern and Shadowrocket";


### PR DESCRIPTION
- **nixos/sub-store: init**
- **nixosTests.sub-store: init**

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
