### PR TITLE
gforth: fix build with GCC 15, 0.7.9_20251001-> 0.7.9_20251203

### DIFF
--- a/pkgs/by-name/gf/gforth/boot-forth.nix
+++ b/pkgs/by-name/gf/gforth/boot-forth.nix
@@ -16,6 +16,11 @@ stdenv.mkDerivation {
     sha256 = "1c1bahc9ypmca8rv2dijiqbangm1d9av286904yw48ph7ciz4qig";
   };
 
+  patches = [
+    # Newer GCC rejects casting between function pointers omitting parameters
+    ./function-pointers.patch
+  ];
+
   buildInputs = [ m4 ];
 
   configureFlags = lib.optionals stdenv.hostPlatform.isDarwin [ "--build=x86_64-apple-darwin" ];

--- a/pkgs/by-name/gf/gforth/function-pointers.patch
+++ b/pkgs/by-name/gf/gforth/function-pointers.patch
@@ -1,0 +1,26 @@
+diff --git a/engine/signals.c b/engine/signals.c
+index b522f19..7f89bcd 100644
+--- a/engine/signals.c
++++ b/engine/signals.c
+@@ -399,7 +399,7 @@ void install_signal_handlers(void)
+ #endif
+   };
+   int i;
+-  void (*throw_handler)() = die_on_signal ? graceful_exit : signal_throw;
++  void (*throw_handler)(int) = die_on_signal ? graceful_exit : signal_throw;
+ #ifdef SIGSTKSZ 
+   stack_t sigstack;
+   int sas_retval=-1;
+diff --git a/engine/support.c b/engine/support.c
+index 021fa22..069c32f 100644
+--- a/engine/support.c
++++ b/engine/support.c
+@@ -79,7 +79,7 @@ char *tilde_cstr(Char *from, UCell size, int clear)
+ {
+   char *s1,*s2;
+   int s1_len, s2_len;
+-  struct passwd *getpwnam (), *user_entry;
++  struct passwd *getpwnam (const char *), *user_entry;
+ 
+   if (size<1 || from[0]!='~')
+     return cstr(from, size, clear);

--- a/pkgs/by-name/gf/gforth/package.nix
+++ b/pkgs/by-name/gf/gforth/package.nix
@@ -17,13 +17,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "gforth";
-  version = "0.7.9_20251001";
+  version = "0.7.9_20251203";
 
   src = fetchFromGitHub {
     owner = "forthy42";
     repo = "gforth";
     rev = finalAttrs.version;
-    hash = "sha256-u9snXcFa/YYvITgMBY8FRYyyLFhHCP6hWA5ljwdKGLk=";
+    hash = "sha256-d1LU6FGnGOzL5Tdl0VLkYzHH+pUevGNCNwIqudS8emg=";
   };
 
   patches = [ ./use-nproc-instead-of-fhs.patch ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Closes https://github.com/NixOS/nixpkgs/issues/476251

Tracks https://github.com/NixOS/nixpkgs/issues/475479

Compilation of the inner derivation `gforth-boot` failed due to assigning values to function pointers without explicit parameters, where C23 was enforced by default on GCC 15.

This PR also bumps `gforth` to 0.7.9_20251203, cherry-picking changes from [the PR opened by r-ryantm](https://github.com/NixOS/nixpkgs/pull/464163).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
