### PR TITLE
python3: add MinGW support for 3.13+

### DIFF
--- a/pkgs/development/interpreters/python/cpython/3.13/mingw/0001-define-ms-windows-for-mingw.patch
+++ b/pkgs/development/interpreters/python/cpython/3.13/mingw/0001-define-ms-windows-for-mingw.patch
@@ -1,0 +1,49 @@
+diff --git a/Include/pyport.h b/Include/pyport.h
+index 72a157e..eecb181 100644
+--- a/Include/pyport.h
++++ b/Include/pyport.h
+@@ -49,6 +49,44 @@
+ #endif
+ 
+ 
++#ifdef __MINGW32__
++/* Translate GCC[mingw*] platform specific defines to those
++ * used in python code.
++ */
++#if !defined(MS_WIN64) && defined(_WIN64)
++#  define MS_WIN64
++#endif
++#if !defined(MS_WIN32) && defined(_WIN32)
++#  define MS_WIN32
++#endif
++#if !defined(MS_WINDOWS) && defined(MS_WIN32)
++#  define MS_WINDOWS
++#endif
++
++#if defined(Py_BUILD_CORE) || defined(Py_BUILD_CORE_BUILTIN) || defined(Py_BUILD_CORE_MODULE)
++#include <winapifamily.h>
++
++#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
++#define MS_WINDOWS_DESKTOP
++#endif
++#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP)
++#define MS_WINDOWS_APP
++#endif
++#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_SYSTEM)
++#define MS_WINDOWS_SYSTEM
++#endif
++#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_GAMES)
++#define MS_WINDOWS_GAMES
++#endif
++
++/* Define to 1 if you support windows console io */
++#if defined(MS_WINDOWS_DESKTOP) || defined(MS_WINDOWS_APP) || defined(MS_WINDOWS_SYSTEM)
++#define HAVE_WINDOWS_CONSOLE_IO 1
++#endif
++#endif /* Py_BUILD_CORE || Py_BUILD_CORE_BUILTIN || Py_BUILD_CORE_MODULE */
++
++#endif /* __MINGW32__*/
++
+ /**************************************************************************
+ Symbols and macros to supply platform-independent interfaces to basic
+ C language & library operations whose spellings vary across platforms.

--- a/pkgs/development/interpreters/python/cpython/3.13/mingw/0002-configure-add-mingw-platform.patch
+++ b/pkgs/development/interpreters/python/cpython/3.13/mingw/0002-configure-add-mingw-platform.patch
@@ -1,0 +1,43 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -327,6 +327,9 @@
+ 	*-*-cygwin*)
+ 		ac_sys_system=Cygwin
+ 		;;
++	*-*-mingw*)
++		ac_sys_system=MINGW
++		;;
+ 	*-apple-ios*)
+ 		ac_sys_system=iOS
+ 		;;
+@@ -366,6 +369,7 @@
+ 	linux*) MACHDEP="linux";;
+ 	cygwin*) MACHDEP="cygwin";;
+ 	darwin*) MACHDEP="darwin";;
++	mingw*) MACHDEP="win32";;
+ 	'')	MACHDEP="unknown";;
+     esac
+ 
+@@ -777,12 +781,22 @@
+ 	wasm32-*-* | wasm64-*-*)
+ 		_host_ident=$host_cpu
+ 		;;
++	*-*-mingw*)
++		_host_cpu=
++		;;
+ 	*)
+ 		# for now, limit cross builds to known configurations
+ 		MACHDEP="unknown"
+ 		AC_MSG_ERROR([cross build not supported for $host])
+ 	esac
+ 	_PYTHON_HOST_PLATFORM="$MACHDEP${_host_ident:+-$_host_ident}"
++
++	case "$host_os" in
++	mingw*)
++	# sys.platform() returns win32; use mingw for platform tagging
++	_PYTHON_HOST_PLATFORM=mingw
++	;;
++	esac
+ fi
+ 
+ # Some systems cannot stand _XOPEN_SOURCE being defined at all; they

--- a/pkgs/development/interpreters/python/cpython/3.13/mingw/0003-exports-add-mingw-support.patch
+++ b/pkgs/development/interpreters/python/cpython/3.13/mingw/0003-exports-add-mingw-support.patch
@@ -1,0 +1,50 @@
+diff --git a/Include/exports.h b/Include/exports.h
+index ce60121..2840241 100644
+--- a/Include/exports.h
++++ b/Include/exports.h
+@@ -15,12 +15,12 @@
+ */
+ 
+ /*
+-  All windows ports, except cygwin, are handled in PC/pyconfig.h.
++  Only MSVC windows ports is handled in PC/pyconfig.h.
+ 
+-  Cygwin is the only other autoconf platform requiring special
++  Cygwin and Mingw is the only other autoconf platform requiring special
+   linkage handling and it uses __declspec().
+ */
+-#if defined(__CYGWIN__)
++#if defined(__CYGWIN__) || defined(__MINGW32__)
+ #       define HAVE_DECLSPEC_DLL
+ #endif
+ 
+@@ -63,21 +63,23 @@
+ #                       define PyAPI_FUNC(RTYPE) Py_EXPORTED_SYMBOL RTYPE
+ #                       define PyAPI_DATA(RTYPE) extern Py_EXPORTED_SYMBOL RTYPE
+         /* module init functions inside the core need no external linkage */
+-        /* except for Cygwin to handle embedding */
+-#                       if defined(__CYGWIN__)
++        /* except for Cygwin/Mingw to handle embedding */
++#                       if defined(__CYGWIN__) || defined(__MINGW32__)
+ #                               define PyMODINIT_FUNC Py_EXPORTED_SYMBOL PyObject*
+-#                       else /* __CYGWIN__ */
++#                       else /* __CYGWIN__ || __MINGW32__*/
+ #                               define PyMODINIT_FUNC PyObject*
+-#                       endif /* __CYGWIN__ */
++#                       endif /* __CYGWIN__ || __MINGW32__*/
+ #               else /* Py_BUILD_CORE */
+         /* Building an extension module, or an embedded situation */
+         /* public Python functions and data are imported */
+         /* Under Cygwin, auto-import functions to prevent compilation */
+         /* failures similar to those described at the bottom of 4.1: */
+         /* http://docs.python.org/extending/windows.html#a-cookbook-approach */
+-#                       if !defined(__CYGWIN__)
++#                       if defined(__CYGWIN__) || defined(__MINGW32__)
++#                               define PyAPI_FUNC(RTYPE) RTYPE
++#                       else
+ #                               define PyAPI_FUNC(RTYPE) Py_IMPORTED_SYMBOL RTYPE
+-#                       endif /* !__CYGWIN__ */
++#                       endif /* __CYGWIN__ || __MINGW32__*/
+ #                       define PyAPI_DATA(RTYPE) extern Py_IMPORTED_SYMBOL RTYPE
+         /* module init functions outside the core must be exported */
+ #                       if defined(__cplusplus)

--- a/pkgs/development/interpreters/python/cpython/3.13/mingw/0004-configure-shared-build-mingw.patch
+++ b/pkgs/development/interpreters/python/cpython/3.13/mingw/0004-configure-shared-build-mingw.patch
@@ -1,0 +1,37 @@
+diff --git a/configure.ac b/configure.ac
+index 1083bce..ac248b6 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -1592,6 +1592,11 @@ if test $enable_shared = "yes"; then
+       BLDLIBRARY='-L. -lpython$(LDVERSION)'
+       DLLLIBRARY='libpython$(LDVERSION).dll'
+       ;;
++    MINGW*)
++      LDLIBRARY='libpython$(LDVERSION).dll.a'
++      DLLLIBRARY='libpython$(LDVERSION).dll'
++      BLDLIBRARY='-L. -lpython$(LDVERSION)'
++      ;;
+     SunOS*)
+       LDLIBRARY='libpython$(LDVERSION).so'
+       BLDLIBRARY='-Wl,-R,$(LIBDIR) -L. -lpython$(LDVERSION)'
+@@ -1651,6 +1656,9 @@ else # shared is disabled
+       BLDLIBRARY='$(LIBRARY)'
+       LDLIBRARY='libpython$(LDVERSION).dll.a'
+       ;;
++    MINGW*)
++      LDLIBRARY='libpython$(LDVERSION).a'
++      ;;
+   esac
+ fi
+ AC_MSG_RESULT([$LDLIBRARY])
+@@ -3656,6 +3664,10 @@ then
+ 	CYGWIN*)
+ 		LDSHARED="gcc -shared -Wl,--enable-auto-image-base"
+ 		LDCXXSHARED="g++ -shared -Wl,--enable-auto-image-base";;
++	MINGW*)
++		LDSHARED='$(CC) -shared -Wl,--enable-auto-image-base'
++		LDCXXSHARED='$(CXX) -shared -Wl,--enable-auto-image-base'
++		;;
+ 	*)	LDSHARED="ld";;
+ 	esac
+ fi

--- a/pkgs/development/interpreters/python/cpython/3.13/mingw/0005-dynamic-loading-mingw.patch
+++ b/pkgs/development/interpreters/python/cpython/3.13/mingw/0005-dynamic-loading-mingw.patch
@@ -1,0 +1,85 @@
+diff --git a/Makefile.pre.in b/Makefile.pre.in
+index a7dc970..ea2b64e 100644
+--- a/Makefile.pre.in
++++ b/Makefile.pre.in
+@@ -1737,6 +1737,12 @@ Python/dynload_hpux.o: $(srcdir)/Python/dynload_hpux.c Makefile
+ 		-DSHLIB_EXT='"$(EXT_SUFFIX)"' \
+ 		-o $@ $(srcdir)/Python/dynload_hpux.c
+ 
++Python/dynload_win.o: $(srcdir)/Python/dynload_win.c Makefile
++	$(CC) -c $(PY_CORE_CFLAGS) \
++		-DSHLIB_SUFFIX='"$(SHLIB_SUFFIX)"' \
++		-DEXT_SUFFIX='"$(EXT_SUFFIX)"' \
++		-o $@ $(srcdir)/Python/dynload_win.c
++
+ Python/sysmodule.o: $(srcdir)/Python/sysmodule.c Makefile $(srcdir)/Include/pydtrace.h
+ 	$(CC) -c $(PY_CORE_CFLAGS) \
+ 		-DABIFLAGS='"$(ABIFLAGS)"' \
+diff --git a/Python/dynload_win.c b/Python/dynload_win.c
+index a0ac31c..386a2c3 100644
+--- a/Python/dynload_win.c
++++ b/Python/dynload_win.c
+@@ -10,6 +10,12 @@
+ #include <windows.h>
+ 
+ const char *_PyImport_DynLoadFiletab[] = {
++#ifdef EXT_SUFFIX
++    EXT_SUFFIX, /* include SOABI flags where is encoded debug */
++#endif
++#ifdef SHLIB_SUFFIX
++    "-abi" PYTHON_ABI_STRING SHLIB_SUFFIX,
++#endif
+     PYD_TAGGED_SUFFIX,
+     PYD_UNTAGGED_SUFFIX,
+     NULL
+@@ -232,8 +238,7 @@ dl_funcptr _PyImport_FindSharedFuncptrWindows(const char *prefix,
+            ensure DLLs adjacent to the PYD are preferred. */
+         Py_BEGIN_ALLOW_THREADS
+         hDLL = LoadLibraryExW(wpathname, NULL,
+-                              LOAD_LIBRARY_SEARCH_DEFAULT_DIRS |
+-                              LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR);
++                              LOAD_WITH_ALTERED_SEARCH_PATH);
+         Py_END_ALLOW_THREADS
+         PyMem_Free(wpathname);
+ 
+diff --git a/configure.ac b/configure.ac
+index ac248b6..eaed12f 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -3530,6 +3530,9 @@ if test -z "$SHLIB_SUFFIX"; then
+ 	CYGWIN*)   SHLIB_SUFFIX=.dll;;
+ 	*)	   SHLIB_SUFFIX=.so;;
+ 	esac
++	case $host_os in
++	mingw*)    SHLIB_SUFFIX=.dll;;
++	esac
+ fi
+ AC_MSG_RESULT([$SHLIB_SUFFIX])
+ 
+@@ -5309,6 +5312,13 @@ then
+ 	fi
+ 	;;
+ 	esac
++	case $host in
++	*-*-mingw*)
++	DYNLOADFILE="dynload_win.o"
++	extra_machdep_objs="$extra_machdep_objs PC/dl_nt.o"
++	CFLAGS_NODIST="$CFLAGS_NODIST -DMS_DLL_ID='\"$VERSION\"' -DPY3_DLLNAME='L\"$DLLLIBRARY\"'"
++	;;
++	esac
+ fi
+ AC_MSG_RESULT([$DYNLOADFILE])
+ if test "$DYNLOADFILE" != "dynload_stub.o"
+@@ -7210,6 +7220,12 @@ case "$ac_cv_computed_gotos" in yes*)
+   AC_DEFINE([HAVE_COMPUTED_GOTOS], [1],
+   [Define if the C compiler supports computed gotos.])
+ esac
++case $host_os in
++    mingw*)
++	dnl Synchronized with _PyImport_DynLoadFiletab (dynload_win.c)
++	dnl Do not use more then one dot on this platform !
++	EXT_SUFFIX=-$SOABI$SHLIB_SUFFIX;;
++esac
+ 
+ case $ac_sys_system in
+ AIX*)

--- a/pkgs/development/interpreters/python/cpython/3.13/mingw/0006-link-extensions-with-libpython.patch
+++ b/pkgs/development/interpreters/python/cpython/3.13/mingw/0006-link-extensions-with-libpython.patch
@@ -1,0 +1,13 @@
+diff --git a/configure.ac b/configure.ac
+index eaed12f..c80c3a8 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -6588,7 +6588,7 @@ MODULE_DEPS_SHARED='$(MODULE_DEPS_STATIC) $(EXPORTSYMS)'
+ LIBPYTHON=''
+ 
+ # On Android and Cygwin the shared libraries must be linked with libpython.
+-if test "$PY_ENABLE_SHARED" = "1" && ( test -n "$ANDROID_API_LEVEL" || test "$MACHDEP" = "cygwin"); then
++if test "$PY_ENABLE_SHARED" = "1" && ( test -n "$ANDROID_API_LEVEL" || test "$MACHDEP" = "cygwin" || test "$MACHDEP" = "win32"); then
+   MODULE_DEPS_SHARED="$MODULE_DEPS_SHARED \$(LDLIBRARY)"
+   LIBPYTHON="\$(BLDLIBRARY)"
+ fi

--- a/pkgs/development/interpreters/python/cpython/3.13/mingw/0007-sysconfig-posix-layout-mingw.patch
+++ b/pkgs/development/interpreters/python/cpython/3.13/mingw/0007-sysconfig-posix-layout-mingw.patch
@@ -1,0 +1,67 @@
+diff --git a/Lib/sysconfig/__init__.py b/Lib/sysconfig/__init__.py
+index 93abee5..59690a0 100644
+--- a/Lib/sysconfig/__init__.py
++++ b/Lib/sysconfig/__init__.py
+@@ -100,8 +100,12 @@ _INSTALL_SCHEMES = {
+         },
+     }
+ 
++# GCC[mingw*] use posix build system
++_POSIX_BUILD = os.name == 'posix' or \
++    (os.name == "nt" and 'GCC' in sys.version)
++
+ # For the OS-native venv scheme, we essentially provide an alias:
+-if os.name == 'nt':
++if os.name == 'nt' and not _POSIX_BUILD:
+     _INSTALL_SCHEMES['venv'] = _INSTALL_SCHEMES['nt_venv']
+ else:
+     _INSTALL_SCHEMES['venv'] = _INSTALL_SCHEMES['posix_venv']
+@@ -123,7 +127,7 @@ def _getuserbase():
+     def joinuser(*args):
+         return os.path.expanduser(os.path.join(*args))
+ 
+-    if os.name == "nt":
++    if os.name == "nt" and not _POSIX_BUILD:
+         base = os.environ.get("APPDATA") or "~"
+         return joinuser(base,  _get_implementation())
+ 
+@@ -285,7 +289,7 @@ def _expand_vars(scheme, vars):
+ 
+ 
+ def _get_preferred_schemes():
+-    if os.name == 'nt':
++    if os.name == 'nt' and not _POSIX_BUILD:
+         return {
+             'prefix': 'nt',
+             'home': 'posix_home',
+@@ -426,7 +430,7 @@ def parse_config_h(fp, vars=None):
+ def get_config_h_filename():
+     """Return the path of pyconfig.h."""
+     if _PYTHON_BUILD:
+-        if os.name == "nt":
++        if os.name == "nt" and not _POSIX_BUILD:
+             inc_dir = os.path.dirname(sys._base_executable)
+         else:
+             inc_dir = _PROJECT_BASE
+@@ -496,10 +500,10 @@ def _init_config_vars():
+     except AttributeError:
+         _CONFIG_VARS['py_version_nodot_plat'] = ''
+ 
+-    if os.name == 'nt':
++    if os.name == 'nt' and not _POSIX_BUILD:
+         _init_non_posix(_CONFIG_VARS)
+         _CONFIG_VARS['VPATH'] = sys._vpath
+-    if os.name == 'posix':
++    if _POSIX_BUILD:
+         _init_posix(_CONFIG_VARS)
+     if _HAS_USER_BASE:
+         # Setting 'userbase' is done below the call to the
+@@ -512,7 +516,7 @@ def _init_config_vars():
+ 
+     # Always convert srcdir to an absolute path
+     srcdir = _CONFIG_VARS.get('srcdir', _PROJECT_BASE)
+-    if os.name == 'posix':
++    if _POSIX_BUILD:
+         if _PYTHON_BUILD:
+             # If srcdir is a relative path (typically '.' or '..')
+             # then it should be interpreted relative to the directory

--- a/pkgs/development/interpreters/python/cpython/3.13/mingw/0008-disable-dlfcn-mingw.patch
+++ b/pkgs/development/interpreters/python/cpython/3.13/mingw/0008-disable-dlfcn-mingw.patch
@@ -1,0 +1,52 @@
+diff --git a/configure.ac b/configure.ac
+index c80c3a8..55f94f6 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -3169,7 +3169,7 @@ AC_DEFINE([STDC_HEADERS], [1],
+ 
+ # checks for header files
+ AC_CHECK_HEADERS([ \
+-  alloca.h asm/types.h bluetooth.h conio.h direct.h dlfcn.h endian.h errno.h fcntl.h grp.h \
++  alloca.h asm/types.h bluetooth.h conio.h direct.h endian.h errno.h fcntl.h grp.h \
+   io.h langinfo.h libintl.h libutil.h linux/auxvec.h sys/auxv.h linux/fs.h linux/limits.h linux/memfd.h \
+   linux/random.h linux/soundcard.h \
+   linux/tipc.h linux/wait.h netdb.h net/ethernet.h netinet/in.h netpacket/packet.h poll.h process.h pty.h \
+@@ -3181,6 +3181,12 @@ AC_CHECK_HEADERS([ \
+   sys/types.h sys/uio.h sys/un.h sys/utsname.h sys/wait.h sys/xattr.h sysexits.h syslog.h \
+   termios.h util.h utime.h utmp.h \
+ ])
++
++case $host in
++  *-*-mingw*) ;;
++  *) AC_CHECK_HEADERS([dlfcn.h]);;
++esac
++
+ AC_HEADER_DIRENT
+ AC_HEADER_MAJOR
+ 
+@@ -3929,7 +3935,12 @@ AC_SUBST([PERF_TRAMPOLINE_OBJ])
+ 
+ # checks for libraries
+ AC_CHECK_LIB([sendfile], [sendfile])
+-AC_CHECK_LIB([dl], [dlopen])       # Dynamic linking for SunOS/Solaris and SYSV
++
++case $host in
++  *-*-mingw*) ;;
++  *) AC_CHECK_LIB([dl], [dlopen]) ;;	# Dynamic linking for SunOS/Solaris and SYSV
++esac
++
+ AC_CHECK_LIB([dld], [shl_load])    # Dynamic linking for HP-UX
+ 
+ 
+@@ -6453,7 +6464,10 @@ AS_VAR_IF([ac_cv_broken_sem_getvalue], [yes], [
+   )
+ ])
+ 
+-AC_CHECK_DECLS([RTLD_LAZY, RTLD_NOW, RTLD_GLOBAL, RTLD_LOCAL, RTLD_NODELETE, RTLD_NOLOAD, RTLD_DEEPBIND, RTLD_MEMBER], [], [], [[@%:@include <dlfcn.h>]])
++case $host in
++  *-*-mingw*) ;;
++  *) AC_CHECK_DECLS([RTLD_LAZY, RTLD_NOW, RTLD_GLOBAL, RTLD_LOCAL, RTLD_NODELETE, RTLD_NOLOAD, RTLD_DEEPBIND, RTLD_MEMBER], [], [], [[@%:@include <dlfcn.h>]]);;
++esac
+ 
+ # determine what size digit to use for Python's longs
+ AC_MSG_CHECKING([digit size for Python's longs])

--- a/pkgs/development/interpreters/python/cpython/3.13/mingw/0009-disable-posixsubprocess-mingw.patch
+++ b/pkgs/development/interpreters/python/cpython/3.13/mingw/0009-disable-posixsubprocess-mingw.patch
@@ -1,0 +1,20 @@
+diff --git a/configure.ac b/configure.ac
+index 55f94f6..b087801 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -8206,7 +8206,6 @@ PY_STDLIB_MOD_SIMPLE([_json])
+ PY_STDLIB_MOD_SIMPLE([_lsprof])
+ PY_STDLIB_MOD_SIMPLE([_opcode])
+ PY_STDLIB_MOD_SIMPLE([_pickle])
+-PY_STDLIB_MOD_SIMPLE([_posixsubprocess])
+ PY_STDLIB_MOD_SIMPLE([_queue])
+ PY_STDLIB_MOD_SIMPLE([_random])
+ PY_STDLIB_MOD_SIMPLE([select])
+@@ -8257,6 +8256,7 @@ PY_STDLIB_MOD([_scproxy],
+   [], [-framework SystemConfiguration -framework CoreFoundation])
+ PY_STDLIB_MOD([syslog], [], [test "$ac_cv_header_syslog_h" = yes])
+ PY_STDLIB_MOD([termios], [], [test "$ac_cv_header_termios_h" = yes])
++PY_STDLIB_MOD([_posixsubprocess], [], [test "$MACHDEP" != "win32"])
+ 
+ dnl _elementtree loads libexpat via CAPI hook in pyexpat
+ PY_STDLIB_MOD([pyexpat],

--- a/pkgs/development/interpreters/python/cpython/3.13/mingw/0010-configure-exeext-mingw.patch
+++ b/pkgs/development/interpreters/python/cpython/3.13/mingw/0010-configure-exeext-mingw.patch
@@ -1,0 +1,23 @@
+diff --git a/configure.ac b/configure.ac
+index b087801..c0401f4 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -1440,6 +1440,7 @@ AC_ARG_WITH([suffix],
+     [Emscripten/browser*], [EXEEXT=.js],
+     [Emscripten/node*], [EXEEXT=.js],
+     [WASI/*], [EXEEXT=.wasm],
++    [MINGW*], [EXEEXT=.exe],
+     [EXEEXT=]
+   )
+ ])
+@@ -1466,6 +1467,10 @@ else
+ fi
+ rmdir CaseSensitiveTestDir
+ 
++AS_CASE([$ac_sys_system],
++  [MINGW], [BUILDEXEEXT=".exe"]
++)
++
+ case $ac_sys_system in
+ hp*|HP*)
+     case $CC in

--- a/pkgs/development/interpreters/python/cpython/3.13/mingw/0011-bootstrap-python-link-flags.patch
+++ b/pkgs/development/interpreters/python/cpython/3.13/mingw/0011-bootstrap-python-link-flags.patch
@@ -1,0 +1,20 @@
+diff --git a/Makefile.pre.in b/Makefile.pre.in
+index ea2b64e..df51e7f 100644
+--- a/Makefile.pre.in
++++ b/Makefile.pre.in
+@@ -878,7 +878,7 @@ clinic-tests: check-clean-src $(srcdir)/Lib/test/clinic.test.c
+ 
+ # Build the interpreter
+ $(BUILDPYTHON):	Programs/python.o $(LINK_PYTHON_DEPS)
+-	$(LINKCC) $(PY_CORE_LDFLAGS) $(LINKFORSHARED) -o $@ Programs/python.o $(LINK_PYTHON_OBJS) $(LIBS) $(MODLIBS) $(SYSLIBS)
++	$(LINKCC) $(PY_CORE_LDFLAGS) $(LINKFORSHARED) -municode -mconsole -o $@ Programs/python.o $(LINK_PYTHON_OBJS) $(LIBS) $(MODLIBS) $(SYSLIBS)
+ 
+ platform: $(PYTHON_FOR_BUILD_DEPS) pybuilddir.txt
+ 	$(RUNSHARED) $(PYTHON_FOR_BUILD) -c 'import sys ; from sysconfig import get_platform ; print("%s-%d.%d" % (get_platform(), *sys.version_info[:2]))' >platform
+@@ -1486,7 +1486,7 @@ BOOTSTRAP_HEADERS = \
+ Programs/_bootstrap_python.o: Programs/_bootstrap_python.c $(BOOTSTRAP_HEADERS) $(PYTHON_HEADERS)
+ 
+ _bootstrap_python: $(LIBRARY_OBJS_OMIT_FROZEN) Programs/_bootstrap_python.o Modules/getpath.o Modules/Setup.local
+-	$(LINKCC) $(PY_LDFLAGS_NOLTO) -o $@ $(LIBRARY_OBJS_OMIT_FROZEN) \
++	$(LINKCC) $(PY_LDFLAGS_NOLTO) -municode -mconsole -o $@ $(LIBRARY_OBJS_OMIT_FROZEN) \
+ 		Programs/_bootstrap_python.o Modules/getpath.o $(LIBS) $(MODLIBS) $(SYSLIBS)

--- a/pkgs/development/interpreters/python/cpython/3.13/mingw/0012-fix-header-case-cross-build.patch
+++ b/pkgs/development/interpreters/python/cpython/3.13/mingw/0012-fix-header-case-cross-build.patch
@@ -1,0 +1,40 @@
+diff --git a/Modules/posixmodule.c b/Modules/posixmodule.c
+index 00eadab..d81f59d 100644
+--- a/Modules/posixmodule.c
++++ b/Modules/posixmodule.c
+@@ -9337,7 +9337,7 @@ os_setpgrp_impl(PyObject *module)
+ 
+ #ifdef MS_WINDOWS
+ #include <winternl.h>
+-#include <ProcessSnapshot.h>
++#include <processsnapshot.h>
+ 
+ // The structure definition in winternl.h may be incomplete.
+ // This structure is the full version from the MSDN documentation.
+diff --git a/PC/_wmimodule.cpp b/PC/_wmimodule.cpp
+index e05037d..6cf9856 100644
+--- a/PC/_wmimodule.cpp
++++ b/PC/_wmimodule.cpp
+@@ -14,9 +14,9 @@
+ #endif
+ 
+ #define _WIN32_DCOM
+-#include <Windows.h>
++#include <windows.h>
+ #include <comdef.h>
+-#include <Wbemidl.h>
++#include <wbemidl.h>
+ #include <propvarutil.h>
+ 
+ #include <Python.h>
+diff --git a/Modules/_ctypes/ctypes.h b/Modules/_ctypes/ctypes.h
+index 7dce188..80d651f 100644
+--- a/Modules/_ctypes/ctypes.h
++++ b/Modules/_ctypes/ctypes.h
+@@ -36,7 +36,7 @@
+ #endif
+ 
+ #ifdef MS_WIN32
+-#include <Unknwn.h> // for IUnknown interface
++#include <unknwn.h> // for IUnknown interface
+ #endif

--- a/pkgs/development/interpreters/python/cpython/3.13/mingw/0013-find-native-python-regen.patch
+++ b/pkgs/development/interpreters/python/cpython/3.13/mingw/0013-find-native-python-regen.patch
@@ -1,0 +1,22 @@
+diff --git a/configure.ac b/configure.ac
+index c0401f4..1bc047d 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -204,9 +204,16 @@ AC_SUBST([FREEZE_MODULE])
+ AC_SUBST([FREEZE_MODULE_DEPS])
+ AC_SUBST([PYTHON_FOR_BUILD_DEPS])
+ 
++dnl For MinGW cross builds, search in build system's PATH for native Python
++dnl rather than potentially finding a Windows Python in some prefix
++AS_CASE([$host],
++  [*-*-mingw*], [NATIVE_PYTHON_SEARCH_PATH="$PATH"],
++  [NATIVE_PYTHON_SEARCH_PATH="$PATH"]
++)
++
+ AC_CHECK_PROGS([PYTHON_FOR_REGEN],
+   [python$PACKAGE_VERSION python3.13 python3.12 python3.11 python3.10 python3 python],
+-  [python3])
++  [python3], [$NATIVE_PYTHON_SEARCH_PATH])
+ AC_SUBST([PYTHON_FOR_REGEN])
+ 
+ AC_MSG_CHECKING([Python for regen version])

--- a/pkgs/development/interpreters/python/cpython/3.13/mingw/0014-soabi-mingw-windows-style.patch
+++ b/pkgs/development/interpreters/python/cpython/3.13/mingw/0014-soabi-mingw-windows-style.patch
@@ -1,0 +1,28 @@
+diff --git a/configure.ac b/configure.ac
+index 1bc047d..295c442 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -6704,7 +6704,10 @@ AC_SUBST([SOABI])
+ AC_MSG_CHECKING([ABIFLAGS])
+ AC_MSG_RESULT([$ABIFLAGS])
+ AC_MSG_CHECKING([SOABI])
+-SOABI='cpython-'`echo $VERSION | tr -d .`${ABIFLAGS}${SOABI_PLATFORM:+-$SOABI_PLATFORM}
++case $host_os in
++    mingw*) SOABI='cp'`echo $VERSION | tr -d .`${ABIFLAGS}${SOABI_PLATFORM:+-$SOABI_PLATFORM};;
++    *) SOABI='cpython-'`echo $VERSION | tr -d .`${ABIFLAGS}${SOABI_PLATFORM:+-$SOABI_PLATFORM};;
++esac
+ AC_MSG_RESULT([$SOABI])
+ 
+ # Release build, debug build (Py_DEBUG), and trace refs build (Py_TRACE_REFS)
+@@ -6712,7 +6715,10 @@ AC_MSG_RESULT([$SOABI])
+ if test "$Py_DEBUG" = 'true'; then
+   # Similar to SOABI but remove "d" flag from ABIFLAGS
+   AC_SUBST([ALT_SOABI])
+-  ALT_SOABI='cpython-'`echo $VERSION | tr -d .``echo $ABIFLAGS | tr -d d`${SOABI_PLATFORM:+-$SOABI_PLATFORM}
++  case $host_os in
++      mingw*) ALT_SOABI='cp'`echo $VERSION | tr -d .``echo $ABIFLAGS | tr -d d`${SOABI_PLATFORM:+-$SOABI_PLATFORM};;
++      *) ALT_SOABI='cpython-'`echo $VERSION | tr -d .``echo $ABIFLAGS | tr -d d`${SOABI_PLATFORM:+-$SOABI_PLATFORM};;
++  esac
+   AC_DEFINE_UNQUOTED([ALT_SOABI], ["${ALT_SOABI}"],
+             [Alternative SOABI used in debug build to load C extensions built in release mode])
+ fi

--- a/pkgs/development/interpreters/python/cpython/3.13/mingw/0016-add-pc-include-path.patch
+++ b/pkgs/development/interpreters/python/cpython/3.13/mingw/0016-add-pc-include-path.patch
@@ -1,0 +1,16 @@
+--- a/Makefile.pre.in
++++ b/Makefile.pre.in
+@@ -106,7 +106,11 @@
+ # Both CPPFLAGS and LDFLAGS need to contain the shell's value for setup.py to
+ # be able to build extension modules using the directories specified in the
+ # environment variables
+-PY_CPPFLAGS=	$(BASECPPFLAGS) -I. -I$(srcdir)/Include $(CONFIGURE_CPPFLAGS) $(CPPFLAGS)
++ifneq (,$(findstring win32,@MACHDEP@))
++PY_CPPFLAGS=	$(BASECPPFLAGS) -I. -I$(srcdir)/Include -I$(srcdir)/PC $(CONFIGURE_CPPFLAGS) $(CPPFLAGS)
++else
++PY_CPPFLAGS=	$(BASECPPFLAGS) -I. -I$(srcdir)/Include $(CONFIGURE_CPPFLAGS) $(CPPFLAGS)
++endif
+ PY_LDFLAGS=	$(CONFIGURE_LDFLAGS) $(LDFLAGS)
+ PY_LDFLAGS_NODIST=$(CONFIGURE_LDFLAGS_NODIST) $(LDFLAGS_NODIST)
+ PY_LDFLAGS_NOLTO=$(PY_LDFLAGS) $(CONFIGURE_LDFLAGS_NOLTO) $(LDFLAGS_NODIST)
+

--- a/pkgs/development/interpreters/python/cpython/3.13/mingw/0017-with-nt-threads-default-mingw.patch
+++ b/pkgs/development/interpreters/python/cpython/3.13/mingw/0017-with-nt-threads-default-mingw.patch
@@ -1,0 +1,263 @@
+--- a/Include/internal/pycore_condvar.h
++++ b/Include/internal/pycore_condvar.h
+@@ -32,6 +32,10 @@
+ #ifndef WIN32_LEAN_AND_MEAN
+ #  define WIN32_LEAN_AND_MEAN
+ #endif
+ #include <windows.h>              // CRITICAL_SECTION
++/* winpthreads are involved via windows header, so need undef _POSIX_THREADS after header include */
++#if defined(_POSIX_THREADS)
++#undef _POSIX_THREADS
++#endif
+ 
+ /* options */
+ /* emulated condition variables are provided for those that want
+--- a/Include/internal/pycore_pythread.h
++++ b/Include/internal/pycore_pythread.h
+@@ -16,6 +16,12 @@ extern "C" {
+                             && !defined(_POSIX_SEMAPHORES))
+ #  include <unistd.h>             // _POSIX_THREADS, _POSIX_SEMAPHORES
+ #endif
++#ifdef __MINGW32__
++# if !defined(HAVE_PTHREAD_H) || defined(NT_THREADS)
++#  undef _POSIX_THREADS
++# endif
++#endif
++
+ #if (defined(HAVE_PTHREAD_H) && !defined(_POSIX_THREADS) \
+                              && !defined(_POSIX_SEMAPHORES))
+    // This means pthreads are not implemented in libc headers, hence the macro
+--- a/Include/pythread.h
++++ b/Include/pythread.h
+@@ -7,6 +7,12 @@ typedef void *PyThread_type_lock;
+ extern "C" {
+ #endif
+ 
++#ifdef __MINGW32__
++# if !defined(HAVE_PTHREAD_H) || defined(NT_THREADS)
++#  undef _POSIX_THREADS
++# endif
++#endif
++
+ /* Return status codes for Python lock acquisition.  Chosen for maximum
+  * backwards compatibility, ie failure -> 0, success -> 1.  */
+ typedef enum PyLockStatus {
+--- a/Modules/_multiprocessing/multiprocessing.h
++++ b/Modules/_multiprocessing/multiprocessing.h
+@@ -30,7 +30,10 @@
+ #  endif
+ #  define SEM_HANDLE HANDLE
+ #  define SEM_VALUE_MAX LONG_MAX
+-#  define HAVE_MP_SEMAPHORE
++#    define HAVE_MP_SEMAPHORE
++#  if defined(HAVE_SEM_OPEN) && defined(_POSIX_THREADS)
++#    include <semaphore.h>
++#  endif
+ #else
+ #  include <fcntl.h>                 /* O_CREAT and O_EXCL */
+ #  if defined(HAVE_SEM_OPEN) && !defined(POSIX_SEMAPHORES_NOT_ENABLED)
+--- a/configure.ac
++++ b/configure.ac
+@@ -2924,6 +2924,53 @@ then
+ 	BASECFLAGS="$BASECFLAGS $ac_arch_flags"
+ fi
+ 
++dnl NOTE:
++dnl - GCC 4.4+ for mingw* require and use posix threads(pthreads-w32)
++dnl - Host may contain installed pthreads-w32.
++dnl - On windows platform only NT-thread model is supported.
++dnl To avoid miss detection scipt first will check for NT-thread model
++dnl and if is not found will try to detect build options for pthread
++dnl model. Autodetection could be overiden if variable with_nt_threads
++dnl is set in "Site Configuration" (see autoconf manual).
++dnl If NT-thread model is enabled script skips some checks that
++dnl impact build process. When a new functionality is added, developers
++dnl are responsible to update configure script to avoid thread models
++dnl to be mixed.
++
++AC_MSG_CHECKING([for --with-nt-threads])
++AC_ARG_WITH(nt-threads,
++            AS_HELP_STRING([--with-nt-threads], [build with windows threads (default is system-dependent)]),
++[
++	case $withval in
++	no)	with_nt_threads=no;;
++	yes)	with_nt_threads=yes;;
++	*)	with_nt_threads=yes;;
++	esac
++], [
++	case $host in
++		*-*-mingw*) with_nt_threads=yes;;
++		*) with_nt_threads=no;;
++	esac
++])
++AC_MSG_RESULT([$with_nt_threads])
++
++if test $with_nt_threads = yes ; then
++AC_MSG_CHECKING([whether linking with nt-threads work])
++AC_LINK_IFELSE([
++    AC_LANG_PROGRAM([[#include <process.h>]], [[_beginthread(0, 0, 0);]])
++  ],
++  [AC_MSG_RESULT([yes])],
++  [AC_MSG_ERROR([failed to link with nt-threads])])
++fi
++
++if test $with_nt_threads = yes ; then
++  dnl temporary default flag to avoid additional pthread checks
++  dnl and initilize other ac..thread flags to no
++  ac_cv_pthread_is_default=no
++  ac_cv_kthread=no
++  ac_cv_pthread=no
++  dnl ac_cv_kpthread is set to no if default is yes (see below)
++else
+ # On some compilers, pthreads are available without further options
+ # (e.g. MacOS X). On some of these systems, the compiler will not
+ # complain if unaccepted options are passed (e.g. gcc on Mac OS X).
+@@ -3034,6 +3081,8 @@ int main(void){
+ CC="$ac_save_cc"])
+ fi
+ 
++fi
++
+ # If we have set a CC compiler flag for thread support then
+ # check if it works for CXX, too.
+ if test ! -z "$CXX"
+@@ -3053,6 +3102,10 @@ elif test "$ac_cv_pthread" = "yes"
+ then
+   CXX="$CXX -pthread"
+   ac_cv_cxx_thread=yes
++elif test "$with_nt_threads" = "yes"
++then
++  dnl set to always to skip extra pthread check below
++  ac_cv_cxx_thread=always
+ else
+   ac_cv_cxx_thread=no
+ fi
+@@ -3094,8 +3147,8 @@ AC_CHECK_HEADERS([ \
+   alloca.h asm/types.h bluetooth.h conio.h direct.h dlfcn.h endian.h errno.h fcntl.h grp.h \
+   io.h langinfo.h libintl.h libutil.h linux/auxvec.h sys/auxv.h linux/fs.h linux/limits.h linux/memfd.h \
+   linux/random.h linux/soundcard.h \
+-  linux/tipc.h linux/wait.h netdb.h net/ethernet.h netinet/in.h netpacket/packet.h poll.h process.h pthread.h pty.h \
+-  sched.h setjmp.h shadow.h signal.h spawn.h stropts.h sys/audioio.h sys/bsdtty.h sys/devpoll.h \
++  linux/tipc.h linux/wait.h netdb.h net/ethernet.h netinet/in.h netpacket/packet.h poll.h process.h pty.h \
++  setjmp.h shadow.h signal.h spawn.h stropts.h sys/audioio.h sys/bsdtty.h sys/devpoll.h \
+   sys/endian.h sys/epoll.h sys/event.h sys/eventfd.h sys/file.h sys/ioctl.h sys/kern_control.h \
+   sys/loadavg.h sys/lock.h sys/memfd.h sys/mkdev.h sys/mman.h sys/modem.h sys/param.h sys/pidfd.h sys/poll.h \
+   sys/random.h sys/resource.h sys/select.h sys/sendfile.h sys/socket.h sys/soundcard.h sys/stat.h \
+@@ -3106,6 +3159,14 @@ AC_CHECK_HEADERS([ \
+ AC_HEADER_DIRENT
+ AC_HEADER_MAJOR
+ 
++# If using nt threads, don't look for pthread.h or thread.h
++if test "x$with_nt_threads" = xno ; then
++AC_HEADER_STDC
++AC_CHECK_HEADERS(pthread.h sched.h thread.h)
++AC_HEADER_DIRENT
++AC_HEADER_MAJOR
++fi
++
+ # bluetooth/bluetooth.h has been known to not compile with -std=c99.
+ # http://permalink.gmane.org/gmane.linux.bluez.kernel/22294
+ SAVE_CFLAGS=$CFLAGS
+@@ -3316,6 +3377,10 @@ elif test "$ac_cv_pthread" = "yes"
+ then CC="$CC -pthread"
+ fi
+ 
++if test $with_nt_threads = yes ; then
++  dnl skip check for pthread_t if NT-thread model is enabled
++  ac_cv_have_pthread_t=skip
++else
+ AC_CACHE_CHECK([for pthread_t], [ac_cv_have_pthread_t], [
+ AC_COMPILE_IFELSE([
+   AC_LANG_PROGRAM([[@%:@include <pthread.h>]], [[pthread_t x; x = *(pthread_t*)0;]])
+@@ -3347,7 +3412,7 @@ AS_VAR_IF([ac_cv_pthread_key_t_is_arithmetic_type], [yes], [
+     AC_DEFINE([PTHREAD_KEY_T_IS_COMPATIBLE_WITH_INT], [1],
+               [Define if pthread_key_t is compatible with int.])
+ ])
+-
++fi
+ CC="$ac_save_cc"
+ 
+ AC_MSG_CHECKING([for --enable-framework])
+@@ -4014,10 +4079,15 @@ then
+   fi
+ fi
+ 
++if test $with_nt_threads = yes ; then
++  dnl do not search for sem_init if NT-thread model is enabled
++  :
++else
+ # 'Real Time' functions on Solaris
+ # posix4 on Solaris 2.6
+ # pthread (first!) on Linux
+ AC_SEARCH_LIBS([sem_init], [pthread rt posix4])
++fi
+ 
+ # check if we need libintl for locale functions
+ AC_CHECK_LIB([intl], [textdomain],
+@@ -4753,6 +4823,11 @@ then
+         CXX="$CXX -pthread"
+     fi
+     posix_threads=yes
++elif test $with_nt_threads = yes
++then
++    posix_threads=no
++    AC_DEFINE(NT_THREADS, 1,
++        [Define to 1 if you want to use native NT threads])
+ else
+     if test ! -z "$withval" -a -d "$withval"
+     then LDFLAGS="$LDFLAGS -L$withval"
+@@ -5352,6 +5427,15 @@ if test "$ac_sys_system" = "Linux-android"; then
+ fi
+ 
+ # checks for library functions
++if test $with_nt_threads = yes ; then
++  dnl GCC(mingw) 4.4+ require and use posix threads(pthreads-w32)
++  dnl and host may contain installed pthreads-w32.
++  dnl Skip checks for some functions declared in pthreads-w32 if
++  dnl NT-thread model is enabled.
++  ac_cv_func_pthread_kill=skip
++  ac_cv_func_sem_open=skip
++  ac_cv_func_sched_setscheduler=skip
++fi
+ AC_CHECK_FUNCS([ \
+   accept4 alarm bind_textdomain_codeset chmod chown clock closefrom close_range confstr \
+   copy_file_range ctermid dup dup3 execv explicit_bzero explicit_memset \
+@@ -6267,6 +6351,10 @@ dnl actually works.  For FreeBSD versions <= 7.2,
+ dnl the kernel module that provides POSIX semaphores
+ dnl isn't loaded by default, so an attempt to call
+ dnl sem_open results in a 'Signal 12' error.
++if test $with_nt_threads = yes ; then
++  dnl skip posix semaphores test if NT-thread model is enabled
++  ac_cv_posix_semaphores_enabled=no
++fi
+ AC_CACHE_CHECK([whether POSIX semaphores are enabled], [ac_cv_posix_semaphores_enabled],
+   AC_RUN_IFELSE([
+     AC_LANG_SOURCE([
+@@ -6300,6 +6388,14 @@ AS_VAR_IF([ac_cv_posix_semaphores_enabled], [no], [
+ ])
+ 
+ dnl Multiprocessing check for broken sem_getvalue
++if test $with_nt_threads = yes ; then
++  dnl Skip test if NT-thread model is enabled.
++  dnl NOTE the test case below fail for pthreads-w32 as:
++  dnl - SEM_FAILED is not defined;
++  dnl - sem_open is a stub;
++  dnl - sem_getvalue work(!).
++  ac_cv_broken_sem_getvalue=skip
++fi
+ AC_CACHE_CHECK([for broken sem_getvalue], [ac_cv_broken_sem_getvalue],
+   AC_RUN_IFELSE([
+     AC_LANG_SOURCE([
+--- a/pyconfig.h.in
++++ b/pyconfig.h.in
+@@ -1662,6 +1662,9 @@
+ /* Define if mvwdelch in curses.h is an expression. */
+ #undef MVWDELCH_IS_EXPRESSION
+ 
++/* Define to 1 if you want to use native NT threads */
++#undef NT_THREADS
++
+ /* Define to the address where bug reports for this package should be sent. */
+ #undef PACKAGE_BUGREPORT
+ 
+

--- a/pkgs/development/interpreters/python/cpython/3.13/mingw/0018-setenv-mingw.patch
+++ b/pkgs/development/interpreters/python/cpython/3.13/mingw/0018-setenv-mingw.patch
@@ -1,0 +1,29 @@
+--- a/Python/pylifecycle.c
++++ b/Python/pylifecycle.c
+@@ -76,6 +76,26 @@
+ #  undef BYTE
+ #endif
+ 
++#if defined(__MINGW32__) && defined(PY_COERCE_C_LOCALE)
++#  include <windows.h>
++
++static int
++setenv(const char *var, const char *val, int ovr)
++{
++    BOOL b;
++    char c[2];
++    if (!ovr) {
++        DWORD d;
++        d = GetEnvironmentVariableA(var, c, 2);
++        if (0 != d && GetLastError() != ERROR_ENVVAR_NOT_FOUND) {
++            return 1;
++        }
++    }
++    b = SetEnvironmentVariableA(var, val);
++    return b ? 0 : 1;
++}
++#endif
++
+ #define PUTS(fd, str) (void)_Py_write_noraise(fd, str, (int)strlen(str))
+ 
+ 

--- a/pkgs/development/interpreters/python/cpython/3.13/mingw/0019-def-vpath-sysmodule.patch
+++ b/pkgs/development/interpreters/python/cpython/3.13/mingw/0019-def-vpath-sysmodule.patch
@@ -1,0 +1,9 @@
+--- a/Makefile.pre.in
++++ b/Makefile.pre.in
+@@ -1742,6 +1742,7 @@ Python/sysmodule.o: $(srcdir)/Python/sysmodule.c Makefile $(srcdir)/Include/pydt
+ 	$(CC) -c $(PY_CORE_CFLAGS) \
+ 		-DABIFLAGS='"$(ABIFLAGS)"' \
++		-DVPATH='"$(VPATH)"' \
+ 		$(MULTIARCH_CPPFLAGS) \
+ 		-o $@ $(srcdir)/Python/sysmodule.c
+

--- a/pkgs/development/interpreters/python/cpython/3.13/mingw/0020-make-_Py_CheckPython3-extern.patch
+++ b/pkgs/development/interpreters/python/cpython/3.13/mingw/0020-make-_Py_CheckPython3-extern.patch
@@ -1,0 +1,24 @@
+--- a/Python/dynload_win.c
++++ b/Python/dynload_win.c
+@@ -152,8 +152,7 @@
+    Return whether the DLL was found.
+ */
+ extern HMODULE PyWin_DLLhModule;
+-static int
+-_Py_CheckPython3(void)
++int _Py_CheckPython3(void)
+ {
+     static int python3_checked = 0;
+     static HANDLE hPython3;
+@@ -207,9 +206,9 @@
+     dl_funcptr p;
+     char funcname[258], *import_python;
+ 
+-#ifdef Py_ENABLE_SHARED
++#ifdef _MSC_VER
+     _Py_CheckPython3();
+-#endif /* Py_ENABLE_SHARED */
++#endif /* _MSC_VER */
+ 
+     wchar_t *wpathname = PyUnicode_AsWideCharString(pathname, NULL);
+     if (wpathname == NULL)

--- a/pkgs/development/interpreters/python/cpython/3.13/mingw/0021-declare-timeval-mingw.patch
+++ b/pkgs/development/interpreters/python/cpython/3.13/mingw/0021-declare-timeval-mingw.patch
@@ -1,0 +1,12 @@
+--- a/Include/internal/pycore_time.h
++++ b/Include/internal/pycore_time.h
+@@ -58,7 +58,7 @@ extern "C" {
+ #endif
+ 
+ 
+-#ifdef __clang__
++#if defined(__clang__) || defined(__MINGW32__)
+ struct timeval;
+ #endif
+ 
+

--- a/pkgs/development/interpreters/python/cpython/3.13/mingw/0022-configure-mingw-socket-types-and-disable-alarm.patch
+++ b/pkgs/development/interpreters/python/cpython/3.13/mingw/0022-configure-mingw-socket-types-and-disable-alarm.patch
@@ -1,0 +1,44 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -4392,6 +4392,12 @@
+ AC_SUBST([LIBMPDEC_CFLAGS])
+ AC_SUBST([LIBMPDEC_INTERNAL])
+ 
++dnl On win32/mingw, sockets require additional system libraries
++AS_CASE([$MACHDEP],
++  [win32], [SOCKET_LIBS="-lws2_32 -liphlpapi -lrpcrt4"],
++  [SOCKET_LIBS=""]
++)
++
+ 
+ dnl detect sqlite3 from Emscripten emport
+ PY_CHECK_EMSCRIPTEN_PORT([LIBSQLITE3], [-sUSE_SQLITE3])
+@@ -5349,6 +5355,9 @@
+ fi
+ 
+ # checks for library functions
++if test "$MACHDEP" = "win32"; then
++  ac_cv_func_alarm=no
++fi
+ if test $with_nt_threads = yes ; then
+   dnl GCC(mingw) 4.4+ require and use posix threads(pthreads-w32)
+   dnl and host may contain installed pthreads-w32.
+@@ -7132,6 +7141,9 @@
+ AC_CHECK_TYPES([socklen_t], [],
+                [AC_DEFINE([socklen_t], [int],
+                           [Define to 'int' if <sys/socket.h> does not define.])], [
++#ifdef __MINGW32__
++#include <ws2tcpip.h>
++#endif
+ #ifdef HAVE_SYS_TYPES_H
+ #include <sys/types.h>
+ #endif
+@@ -7928,7 +7940,7 @@
+ PY_STDLIB_MOD_SIMPLE([_pickle])
+ PY_STDLIB_MOD_SIMPLE([_queue])
+ PY_STDLIB_MOD_SIMPLE([_random])
+-PY_STDLIB_MOD_SIMPLE([select])
++PY_STDLIB_MOD_SIMPLE([select], [], [$SOCKET_LIBS])
+ PY_STDLIB_MOD_SIMPLE([_struct])
+ PY_STDLIB_MOD_SIMPLE([_typing])
+ PY_STDLIB_MOD_SIMPLE([_interpreters])

--- a/pkgs/development/interpreters/python/cpython/3.13/mingw/0023-signal-bootstrap-link-ws2_32.patch
+++ b/pkgs/development/interpreters/python/cpython/3.13/mingw/0023-signal-bootstrap-link-ws2_32.patch
@@ -1,0 +1,12 @@
+--- a/Modules/Setup.bootstrap.in
++++ b/Modules/Setup.bootstrap.in
+@@ -9,7 +9,7 @@
+ atexit atexitmodule.c
+ faulthandler faulthandler.c
+ posix posixmodule.c
+-_signal signalmodule.c
++_signal signalmodule.c -lws2_32
+ _tracemalloc _tracemalloc.c
+ _suggestions _suggestions.c
+ 
+

--- a/pkgs/development/interpreters/python/cpython/3.13/mingw/0024-mingw-link-with-windows-libs.patch
+++ b/pkgs/development/interpreters/python/cpython/3.13/mingw/0024-mingw-link-with-windows-libs.patch
@@ -1,0 +1,16 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -7693,6 +7693,13 @@
+ AC_MSG_RESULT([$TEST_MODULES])
+ AC_SUBST([TEST_MODULES])
+ 
++# For mingw build need additional library for linking
++case $host in
++  *-*-mingw*)
++    LIBS="$LIBS -lversion -lshlwapi -lpathcch -lbcrypt"
++    ;;
++esac
++
+ # gh-109054: Check if -latomic is needed to get <pyatomic.h> atomic functions.
+ # On Linux aarch64, GCC may require programs and libraries to be linked
+ # explicitly to libatomic. Call _Py_atomic_or_uint64() which may require

--- a/pkgs/development/interpreters/python/cpython/3.13/mingw/0025-mingw-bootstrap-nt-and-winconsoleio.patch
+++ b/pkgs/development/interpreters/python/cpython/3.13/mingw/0025-mingw-bootstrap-nt-and-winconsoleio.patch
@@ -1,0 +1,37 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -922,6 +922,14 @@
+             [Define to include mbstate_t for mbrtowc])
+ fi
+ 
++AC_MSG_CHECKING([for init system calls])
++AC_SUBST([INITSYS])
++case $host in
++  *-*-mingw*)	INITSYS=nt;;
++  *)		INITSYS=posix;;
++esac
++AC_MSG_RESULT([$INITSYS])
++
+ # Record the configure-time value of MACOSX_DEPLOYMENT_TARGET,
+ # it may influence the way we can build extensions, so distutils
+ # needs to check it
+--- a/Modules/Setup.bootstrap.in
++++ b/Modules/Setup.bootstrap.in
+@@ -8,7 +8,7 @@
+ # module C APIs are used in core
+ atexit atexitmodule.c
+ faulthandler faulthandler.c
+-posix posixmodule.c
++@INITSYS@ posixmodule.c
+ _signal signalmodule.c -lws2_32
+ _tracemalloc _tracemalloc.c
+ _suggestions _suggestions.c
+@@ -17,7 +17,7 @@
+ _codecs _codecsmodule.c
+ _collections _collectionsmodule.c
+ errno errnomodule.c
+-_io _io/_iomodule.c _io/iobase.c _io/fileio.c _io/bytesio.c _io/bufferedio.c _io/textio.c _io/stringio.c
++_io _io/_iomodule.c _io/iobase.c _io/fileio.c _io/bytesio.c _io/bufferedio.c _io/textio.c _io/stringio.c _io/winconsoleio.c
+ itertools itertoolsmodule.c
+ _sre _sre/sre.c
+ _sysconfig _sysconfig.c

--- a/pkgs/development/interpreters/python/cpython/3.13/mingw/0026-mingw-disable-frozenmain.patch
+++ b/pkgs/development/interpreters/python/cpython/3.13/mingw/0026-mingw-disable-frozenmain.patch
@@ -1,0 +1,30 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -7237,6 +7237,16 @@
+   THREADHEADERS="$THREADHEADERS \$(srcdir)/$h"
+ done
+ 
++dnl Python interpreter main program for frozen scripts
++AC_SUBST(PYTHON_OBJS_FROZENMAIN)
++PYTHON_OBJS_FROZENMAIN="Python/frozenmain.o"
++case $host in
++  *-*-mingw*)
++    dnl 'PC/frozen_dllmain.c' - not yet
++    PYTHON_OBJS_FROZENMAIN=
++    ;;
++esac
++
+ AC_SUBST([SRCDIRS])
+ SRCDIRS="\
+   Modules \
+--- a/Makefile.pre.in
++++ b/Makefile.pre.in
+@@ -435,7 +435,7 @@
+ 		Python/errors.o \
+ 		Python/flowgraph.o \
+ 		Python/frame.o \
+-		Python/frozenmain.o \
++		@PYTHON_OBJS_FROZENMAIN@ \
+ 		Python/future.o \
+ 		Python/gc.o \
+ 		Python/gc_free_threading.o \

--- a/pkgs/development/interpreters/python/cpython/3.13/mingw/0027-ctypes-link-libs-mingw.patch
+++ b/pkgs/development/interpreters/python/cpython/3.13/mingw/0027-ctypes-link-libs-mingw.patch
@@ -1,0 +1,33 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -4398,6 +4398,12 @@
+   [SOCKET_LIBS=""]
+ )
+ 
++dnl On win32/mingw, ctypes requires COM/OLE libraries
++AS_CASE([$MACHDEP],
++  [win32], [CTYPES_LIBS="-lole32 -loleaut32 -luuid"],
++  [CTYPES_LIBS=""]
++)
++
+ 
+ dnl detect sqlite3 from Emscripten emport
+ PY_CHECK_EMSCRIPTEN_PORT([LIBSQLITE3], [-sUSE_SQLITE3])
+@@ -8020,7 +8026,7 @@
+ 
+ PY_STDLIB_MOD([_ctypes],
+   [], [test "$have_libffi" = yes],
+-  [$NO_STRICT_OVERFLOW_CFLAGS $LIBFFI_CFLAGS], [$LIBFFI_LIBS])
++  [$NO_STRICT_OVERFLOW_CFLAGS $LIBFFI_CFLAGS], [$LIBFFI_LIBS $CTYPES_LIBS])
+ PY_STDLIB_MOD([_curses],
+   [], [test "$have_curses" = "yes"],
+   [$CURSES_CFLAGS], [$CURSES_LIBS]
+@@ -8086,7 +8092,7 @@
+ PY_STDLIB_MOD([_xxtestfuzz], [test "$TEST_MODULES" = yes])
+ PY_STDLIB_MOD([_ctypes_test],
+   [test "$TEST_MODULES" = yes], [test "$have_libffi" = yes -a "$ac_cv_func_dlopen" = yes],
+-  [], [$LIBM])
++  [], [$LIBM $CTYPES_LIBS])
+ 
+ dnl Limited API template modules.
+ dnl Emscripten does not support shared libraries yet.

--- a/pkgs/development/interpreters/python/cpython/3.13/mingw/0028-ssl-link-ws2_32.patch
+++ b/pkgs/development/interpreters/python/cpython/3.13/mingw/0028-ssl-link-ws2_32.patch
@@ -1,0 +1,11 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -8095,7 +8095,7 @@
+ 
+ dnl OpenSSL bindings
+ PY_STDLIB_MOD([_ssl], [], [test "$ac_cv_working_openssl_ssl" = yes],
+-  [$OPENSSL_INCLUDES], [$OPENSSL_LDFLAGS $OPENSSL_LDFLAGS_RPATH $OPENSSL_LIBS])
++  [$OPENSSL_INCLUDES], [$OPENSSL_LDFLAGS $OPENSSL_LDFLAGS_RPATH $OPENSSL_LIBS -lws2_32])
+ PY_STDLIB_MOD([_hashlib], [], [test "$ac_cv_working_openssl_hashlib" = yes],
+   [$OPENSSL_INCLUDES], [$OPENSSL_LDFLAGS $OPENSSL_LDFLAGS_RPATH $LIBCRYPTO_LIBS])
+ 


### PR DESCRIPTION
Add MinGW cross-compilation support for Python 3.13 and later versions.

## Changes

- Add curated MinGW patch series for CPython 3.13+ under `pkgs/development/interpreters/python/cpython/3.13/mingw/` (28 patches)
- Maintain existing Fedora MinGW patchset for Python 3.11 (`pythonOlder "3.12"`)
- Update `meta.broken` condition to allow Python 3.13+ on MinGW while keeping Python 3.12 marked as broken (unsupported gap)
- Improve Windows `postInstall` shebang cleanup robustness under `nullglob`

## Motivation

Python 3.13 is the default `python3` in nixpkgs as of late 2024/2025, but upstream nixpkgs only supports Python 3.11 on MinGW via Fedora patches. Python 3.12+ is currently marked as `broken` on Windows/MinGW. This unblocks many projects that depend on `meson` (i.e `glibc` with some additional incoming patches) 

This creates a significant evaluation blocker for the MinGW ecosystem: any package that depends on target `python3` fails to evaluate because Python 3.13 is broken on Windows. This affects packages that install Python scripts for Windows, use `python3` in `buildInputs`, or touch the target Python derivation during evaluation.

The new patchset enables the full MinGW cross-compilation ecosystem that depends on Python.

## Patch Provenance

The 28 patches in `cpython/3.13/mingw/` are ported and adapted from the [MSYS2 MINGW-packages](https://github.com/msys2/MINGW-packages) repository, which maintains production-ready MinGW builds of CPython.

## Validation

`nix eval .#pkgsCross.mingwW64.python313.meta.broken`  # Expected: false
`nix eval .#pkgsCross.mingwW64.python312.meta.broken`  # Expected: true

### Cross build (MinGW)
nix build .#pkgsCross.mingwW64.python313 --no-link -L --keep-failed

### Native build (regression check)
nix build .#python313 --no-link -L --keep-failed

## Things done

- Built on platform:
  - [x] x86_64-linux (cross to mingwW64)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR.
- [x] Tested basic functionality of all binary files.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test