### PR TITLE
moreutils: Create sub-packages per executable

### DIFF
--- a/pkgs/tools/misc/moreutils/default.nix
+++ b/pkgs/tools/misc/moreutils/default.nix
@@ -12,7 +12,25 @@
   cctools,
   gitUpdater,
 }:
-
+let
+  subPackages = [
+    "chronic"
+    "combine"
+    "errno"
+    "ifdata"
+    "ifne"
+    "isutf8"
+    "lckdo"
+    "mispipe"
+    "parallel"
+    "pee"
+    "sponge"
+    "ts"
+    "vidir"
+    "vipe"
+    "zrun"
+  ];
+in
 stdenv.mkDerivation rec {
   pname = "moreutils";
   version = "0.70";
@@ -22,6 +40,11 @@ stdenv.mkDerivation rec {
     tag = version;
     hash = "sha256-71ACHzzk258U4q2L7GJ59mrMZG99M7nQkcH4gHafGP0=";
   };
+
+  outputs = [
+    "out"
+  ]
+  ++ subPackages;
 
   strictDeps = true;
   nativeBuildInputs = [
@@ -49,6 +72,12 @@ stdenv.mkDerivation rec {
     "INSTALL_BIN=install"
     "PREFIX=${placeholder "out"}"
   ];
+
+  postInstall = lib.strings.join "\n" (
+    lib.lists.map (
+      p: "moveToOutput bin/${p} \$${p} && moveToOutput share/man/man1/${p}.1 \$${p}"
+    ) subPackages
+  );
 
   passthru.updateScript = gitUpdater {
     # No nicer place to find latest release.


### PR DESCRIPTION
Each sub-package contains a single executable and its manual page.

Closes #469882.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
