### PR TITLE
nghttp3, ngtcp2: add MinGW/Windows cross-compilation support

### DIFF
--- a/pkgs/development/libraries/ngtcp2/default.nix
+++ b/pkgs/development/libraries/ngtcp2/default.nix
@@ -30,9 +30,13 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [ cmake ];
   buildInputs = [
     brotli
-    libev
     nghttp3
     openssl
+  ]
+  # libev is only needed for example programs; when building library-only
+  # (e.g. on MinGW) avoid pulling it in.
+  ++ lib.optionals (!stdenv.hostPlatform.isMinGW) [
+    libev
   ]
   ++ lib.optional withJemalloc jemalloc;
 
@@ -41,13 +45,16 @@ stdenv.mkDerivation (finalAttrs: {
     # This works in the dynamic case where the targets have the same name, but not here where they're suffixed with `_static`.
     # Also, the examples depend on Linux-specific APIs, so we avoid them on FreeBSD/Cygwin too.
     (lib.cmakeBool "ENABLE_LIB_ONLY" (
-      stdenv.hostPlatform.isStatic || stdenv.hostPlatform.isFreeBSD || stdenv.hostPlatform.isCygwin
+      stdenv.hostPlatform.isStatic
+      || stdenv.hostPlatform.isFreeBSD
+      || stdenv.hostPlatform.isCygwin
+      || stdenv.hostPlatform.isMinGW
     ))
     (lib.cmakeBool "ENABLE_SHARED_LIB" (!stdenv.hostPlatform.isStatic))
     (lib.cmakeBool "ENABLE_STATIC_LIB" stdenv.hostPlatform.isStatic)
   ];
 
-  doCheck = true;
+  doCheck = !stdenv.hostPlatform.isMinGW;
 
   passthru.tests = {
     inherit curl;
@@ -58,7 +65,8 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/ngtcp2/ngtcp2/releases/tag/v${finalAttrs.version}";
     description = "Implementation of the QUIC protocol (RFC9000)";
     license = lib.licenses.mit;
-    platforms = lib.platforms.unix;
+    # MSYS2 ships ngtcp2 for mingw-w64, and nixpkgs' MinGW curl depends on it.
+    platforms = lib.platforms.unix ++ lib.platforms.windows;
     maintainers = with lib.maintainers; [ izorkin ];
   };
 })


### PR DESCRIPTION
Add MinGW cross-compilation support for nghttp3 and ngtcp2, enabling curl's HTTP/3 and QUIC support on Windows. This allows curl to cross compile under MinGW.

## Changes

### nghttp3
- Add `ENABLE_LIB_ONLY=ON` for MinGW builds
  - Skips example programs that use Unix-only headers (`<arpa/inet.h>`)
- Disable tests on MinGW (cross builds can't run target executables)
- Expand `meta.platforms` to include Windows

### ngtcp2
- Exclude `libev` on MinGW
  - Only needed for example programs, not the library itself
- Add MinGW to the `ENABLE_LIB_ONLY` condition
  - Avoids building examples that depend on Linux-specific APIs
- Disable tests on MinGW (cross builds can't run target executables)
- Expand `meta.platforms` to include Windows

## Motivation

These libraries are **required dependencies for curl's HTTP/3 support**. Without MinGW support in nghttp3/ngtcp2, `pkgsCross.mingwW64.curl` cannot be built with HTTP/3 capabilities.

The example programs in both libraries unconditionally include Unix/Linux-specific headers and APIs:
- nghttp3 examples use `<arpa/inet.h>` (BSD sockets API)
- ngtcp2 examples use Linux-specific APIs and depend on `libev`

However, the **libraries themselves are portable** and build successfully on MinGW when only the library components are built (`ENABLE_LIB_ONLY=ON`).

## Reference

- MSYS2 packaging:
  - [mingw-w64-nghttp3](https://github.com/msys2/MINGW-packages/blob/master/mingw-w64-nghttp3/PKGBUILD) uses `ENABLE_LIB_ONLY=ON`
  - [mingw-w64-ngtcp2](https://github.com/msys2/MINGW-packages/blob/master/mingw-w64-ngtcp2/PKGBUILD) uses `ENABLE_LIB_ONLY=ON`

## Validation

### Cross builds (MinGW)
`nix build .#pkgsCross.mingwW64.nghttp3 --no-link -L`
`nix build .#pkgsCross.mingwW64.ngtcp2 --no-link -L`
`nix build .#pkgsCross.mingwW64.curl --no-link -L`

### Native builds (regression check)
`nix build .#nghttp3 --no-link -L`
`nix build .#ngtcp2 --no-link -L`
`nix build .#curl --no-link -L`

All builds succeed.

## Things done

- Built on platform:
  - [x] x86_64-linux (cross to mingwW64)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests` (curl tests pass).
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test