### PR TITLE
opengothic: 1.0.3010 -> 1.0.3549

### DIFF
--- a/pkgs/by-name/op/opengothic/package.nix
+++ b/pkgs/by-name/op/opengothic/package.nix
@@ -17,20 +17,15 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "opengothic";
-  version = "1.0.3010";
+  version = "1.0.3549";
 
   src = fetchFromGitHub {
     owner = "Try";
     repo = "OpenGothic";
     tag = "opengothic-v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-ELDuyoAZmulMjFFctuCmdKDUMtrbVVndJxIf9Xo82N4=";
+    hash = "sha256-dXKZPfV434HHVPgulZZEKhypR6q+uACgmoNWvNQv92w=";
   };
-
-  outputs = [
-    "dev"
-    "out"
-  ];
 
   nativeBuildInputs = [
     cmake
@@ -54,13 +49,18 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail "-Werror" ""
   '';
 
-  cmakeFlags = [
-    (lib.cmakeFeature "CMAKE_POLICY_VERSION_MINIMUM" "3.10")
-  ];
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 -t $out/bin opengothic/Gothic2Notr
+    install -Dm755 -t $out/lib opengothic/libTempest.so
+
+    runHook postInstall
+  '';
 
   postFixup = ''
     wrapProgram $out/bin/Gothic2Notr \
-      --set LD_PRELOAD "${lib.getLib alsa-lib}/lib/libasound.so.2"
+      --prefix LD_PRELOAD : "${lib.getLib alsa-lib}/lib/libasound.so.2"
   '';
 
   passthru.updateScript = nix-update-script {


### PR DESCRIPTION
https://github.com/Try/OpenGothic/releases/tag/opengothic-v1.0.3549
https://github.com/Try/OpenGothic/compare/opengothic-v1.0.3010...opengothic-v1.0.3549
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
