### PR TITLE
nixos/autoUpgrade: skip for containers

### DIFF
--- a/nixos/modules/tasks/auto-upgrade.nix
+++ b/nixos/modules/tasks/auto-upgrade.nix
@@ -220,7 +220,7 @@ in
 
   config = lib.mkMerge [
 
-    {
+    (lib.mkIf (!config.boot.isContainer) {
       system = {
         autoUpgrade.rebootTriggers = [
           config.system.build.initialRamdisk
@@ -242,10 +242,16 @@ in
           text = lib.concatMapStringsSep "\n" (drv: drv.outPath) config.system.autoUpgrade.rebootTriggers;
         };
       };
-    }
+    })
 
     (lib.mkIf cfg.enable {
       assertions = [
+        {
+          assertion = !config.boot.isContainer;
+          message = ''
+            The option 'system.autoUpgrade.enable' cannot be enabled for a container.
+          '';
+        }
         {
           assertion = !((cfg.channel != null) && (cfg.flake != null));
           message = ''


### PR DESCRIPTION
Recent changes to the auto-upgrade module [accidentally broke](https://github.com/NixOS/nixpkgs/pull/473282#discussion_r2658089305) NixOS containers - evaluating them (e.g. `nix-build -A nixosTests.containers-ip` on master) fails with:

```
       error: attribute 'initialRamdisk' missing
       at /home/pwy/x/nixpkgs/nixos/modules/tasks/auto-upgrade.nix:226:11:
          225|         autoUpgrade.rebootTriggers = [
          226|           config.system.build.initialRamdisk
             |           ^
          227|           config.system.build.kernel
```

Considering that the auto-upgrade module doesn't make sense for containers (as they can't update themselves, I think?), IMO the best way forward is to just guard the module on `!config.boot.isContainer`, with an extra assertion you can see in the diff.

Closes https://github.com/NixOS/nixpkgs/issues/476303.

cc @r-vdp