### PR TITLE
libnoise: fix cross MinGW build and install layout

### DIFF
--- a/pkgs/by-name/li/libnoise/package.nix
+++ b/pkgs/by-name/li/libnoise/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  buildPackages,
   fetchFromGitHub,
   cmake,
 }:
@@ -21,16 +22,34 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace CMakeLists.txt --replace-fail "cmake_minimum_required(VERSION 3.0)" "cmake_minimum_required(VERSION 3.10)"
   '';
 
-  nativeBuildInputs = [ cmake ];
+  # Ensure CMake runs on the build machine in cross builds.
+  nativeBuildInputs = [
+    (if stdenv.buildPlatform != stdenv.hostPlatform then buildPackages.cmake else cmake)
+  ];
 
   cmakeFlags = [
     (lib.cmakeBool "BUILD_SHARED_LIBS" true)
   ];
+
+  # Upstream installs libraries into the bindir; put them in libdir for sane consumers.
+  postInstall = ''
+    if [ -d "$out/bin" ]; then
+      mkdir -p "$out/lib"
+
+      # Unix: shared libraries
+      mv -v "$out/bin/"libnoise*.so* "$out/lib/" 2>/dev/null || true
+      mv -v "$out/bin/"libnoise*.dylib* "$out/lib/" 2>/dev/null || true
+
+      # MinGW: import libraries should live in libdir (keep DLLs in bindir)
+      mv -v "$out/bin/"*.dll.a "$out/lib/" 2>/dev/null || true
+    fi
+  '';
 
   meta = {
     description = "Portable, open-source, coherent noise-generating library for C++";
     homepage = "https://github.com/qknight/libnoise";
     license = lib.licenses.lgpl21;
     maintainers = with lib.maintainers; [ liberodark ];
+    platforms = lib.platforms.unix ++ lib.platforms.windows;
   };
 })


### PR DESCRIPTION
Fix cross-compilation and install layout for libnoise.

## Changes

- Use build-machine CMake in cross builds
- Move shared libraries and MinGW import libraries (`*.dll.a`) from `$out/bin` to `$out/lib`
  so consumers can link reliably
- Allow Windows in `meta.platforms`

## Motivation

Upstream libnoise's CMake install rules place libraries in the wrong directory (bindir
instead of libdir), which breaks consumers trying to link against it. This is particularly
problematic on MinGW where import libraries (`*.dll.a`) need to be found via standard
library search paths.

This change ensures CMake runs on the build machine in cross builds and fixes the install
layout so consumers can use standard `-L` flags.

## Reference

MSYS2 PKGBUILD: https://github.com/msys2/MINGW-packages/tree/master/mingw-w64-libnoise

## Validation

```bash
# Cross build (MinGW)
nix build .#pkgsCross.mingwW64.libnoise --no-link -L

# Native build (regression check)
nix build .#libnoise --no-link -L
```

## Things done

- Built on platform:
  - [x] x86_64-linux (cross to mingwW64)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR.
- [x] Tested basic functionality of all binary files.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests