### PR TITLE
libyuv: enable Windows builds and disable tests on MinGW

### DIFF
--- a/pkgs/by-name/li/libyuv/package.nix
+++ b/pkgs/by-name/li/libyuv/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchgit,
   cmake,
+  buildPackages,
   libjpeg,
   gtest,
 }:
@@ -23,15 +24,19 @@ stdenv.mkDerivation {
   ];
 
   nativeBuildInputs = [
-    cmake
+    # CMake must run on the build machine in cross builds.
+    buildPackages.cmake
   ];
 
   cmakeFlags = [
-    "-DUNIT_TEST=ON"
+    # The unit test binary is huge and can fail to assemble on MinGW
+    # ("too many sections"/"file too big"). It's also not runnable in cross builds.
+    (lib.cmakeBool "UNIT_TEST" (stdenv.hostPlatform == stdenv.buildPlatform && !stdenv.hostPlatform.isMinGW))
   ];
 
   buildInputs = [
     libjpeg
+  ] ++ lib.optionals (stdenv.hostPlatform == stdenv.buildPlatform && !stdenv.hostPlatform.isMinGW) [
     gtest
   ];
 
@@ -47,7 +52,7 @@ stdenv.mkDerivation {
   # [==========] 3454 tests from 8 test suites ran.
   # [  PASSED  ] 3376 tests.
   # [  FAILED  ] 78 tests
-  doCheck = !stdenv.hostPlatform.isLoongArch64;
+  doCheck = stdenv.hostPlatform == stdenv.buildPlatform && !stdenv.hostPlatform.isLoongArch64 && !stdenv.hostPlatform.isMinGW;
 
   checkPhase = ''
     runHook preCheck
@@ -61,7 +66,7 @@ stdenv.mkDerivation {
     homepage = "https://chromium.googlesource.com/libyuv/libyuv";
     description = "Open source project that includes YUV scaling and conversion functionality";
     mainProgram = "yuvconvert";
-    platforms = lib.platforms.unix;
+    platforms = lib.platforms.unix ++ lib.platforms.windows;
     maintainers = with lib.maintainers; [ leixb ];
     license = lib.licenses.bsd3;
   };


### PR DESCRIPTION
Enable MinGW cross-compilation for libyuv.

## Changes

- Use build-machine CMake in cross builds
- Gate tests/checks to native builds only (disable for cross/MinGW)
- Allow Windows in `meta.platforms`

## Motivation

libyuv's unit test binary is enormous and can fail to assemble on MinGW with errors like
"too many sections" or "file too big". Tests also cannot run in cross builds.

The library itself builds and works correctly on MinGW; this change ensures tests are
only built and run when they can actually execute (native builds).

## Reference

MSYS2 PKGBUILD: https://github.com/msys2/MINGW-packages/tree/master/mingw-w64-libyuv

## Validation

### Cross build (MinGW)
`nix build .#pkgsCross.mingwW64.libyuv --no-link -L`

### Native build (regression check)
`nix build .#libyuv --no-link -L`

## Things done

- Built on platform:
  - [x] x86_64-linux (cross to mingwW64)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR.
- [x] Tested basic functionality of all binary files.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests