### PR TITLE
luajit: enable MinGW build

### DIFF
--- a/pkgs/development/interpreters/luajit/default.nix
+++ b/pkgs/development/interpreters/luajit/default.nix
@@ -93,10 +93,24 @@ stdenv.mkDerivation (finalAttrs: {
     "CROSS=${stdenv.cc.targetPrefix}"
     "HOST_CC=${buildStdenv.cc}/bin/cc"
   ]
+  # LuaJIT's build system needs an explicit target on MinGW, otherwise it can
+  # emit ELF-specific assembler directives (e.g. .hidden/.type/.size) that the
+  # PE/COFF toolchain doesn't accept.
+  ++ lib.optionals stdenv.hostPlatform.isMinGW [
+    "TARGET_SYS=Windows"
+  ]
   ++ lib.optional enableJITDebugModule "INSTALL_LJLIBD=$(INSTALL_LMOD)"
   ++ lib.optional stdenv.hostPlatform.isStatic "BUILDMODE=static";
   enableParallelBuilding = true;
   env.NIX_CFLAGS_COMPILE = toString XCFLAGS;
+
+  # The LuaJIT build produces `src/luajit.exe` on Windows targets, but the
+  # upstream install rule expects `src/luajit`. Provide a compatibility copy.
+  preInstall = lib.optionalString stdenv.hostPlatform.isMinGW ''
+    if [[ -e src/luajit.exe && ! -e src/luajit ]]; then
+      cp -p src/luajit.exe src/luajit
+    fi
+  '';
 
   postInstall = ''
     mkdir -p $out/nix-support
@@ -152,7 +166,9 @@ stdenv.mkDerivation (finalAttrs: {
       description = "High-performance JIT compiler for Lua 5.1";
       homepage = "https://luajit.org/";
       license = lib.licenses.mit;
-      platforms = lib.platforms.linux ++ lib.platforms.darwin;
+      # MSYS2 ships LuaJIT for mingw-w64, and nixpkgs consumers (like phosphor)
+      # need it in Windows cross builds.
+      platforms = lib.platforms.linux ++ lib.platforms.darwin ++ lib.platforms.windows;
       badPlatforms = [
         "loongarch64-linux" # See https://github.com/LuaJIT/LuaJIT/issues/1278
         "riscv64-linux" # See https://github.com/LuaJIT/LuaJIT/issues/628


### PR DESCRIPTION
Enable cross-compilation to MinGW/Windows for LuaJIT.

## Changes

- Set `TARGET_SYS=Windows` when cross-compiling to MinGW to avoid ELF-specific assembly directives
- Add `.exe` install compatibility workaround (copy `src/luajit.exe` to `src/luajit` in `preInstall`)
- Allow Windows in `meta.platforms`

## Motivation

LuaJIT's build system needs an explicit Windows target when cross-compiling to MinGW.
Without `TARGET_SYS=Windows`, the build emits ELF-specific assembler directives
(`.hidden`, `.type`, `.size`) in `buildvm_x86.dasc`, which fail with the PE/COFF toolchain.

Additionally, the upstream install rule expects `src/luajit` but MinGW produces `src/luajit.exe`,
causing install failures.

## Reference

MSYS2 PKGBUILD: https://github.com/msys2/MINGW-packages/tree/master/mingw-w64-luajit

## Validation

### Cross build (MinGW)
`nix build .#pkgsCross.mingwW64.luajit --no-link -L`

### Native build (regression check)
`nix build .#luajit --no-link -L`

## Things done

- Built on platform:
  - [x] x86_64-linux (cross to mingwW64)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR.
- [x] Tested basic functionality of all binary files.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests