### PR TITLE
libwebp: disable CLI tools on MinGW

### DIFF
--- a/pkgs/by-name/li/libwebp/package.nix
+++ b/pkgs/by-name/li/libwebp/package.nix
@@ -65,6 +65,18 @@ stdenv.mkDerivation rec {
     (lib.cmakeBool "WEBP_BUILD_EXTRAS" false) # Not installed
     (lib.cmakeBool "WEBP_ENABLE_SWAP_16BIT_CSP" swap16bitcspSupport)
     (lib.cmakeBool "WEBP_BUILD_LIBWEBPMUX" libwebpmuxSupport)
+  ]
+  # On MinGW, linking CLI tools like gif2webp/img2webp can fail due to mux/anim
+  # symbols not being resolved. gdk-pixbuf only needs the libraries, so disable
+  # these tools for cross compilation (MSYS2 does similarly for mingw-w64 builds).
+  ++ lib.optionals stdenv.hostPlatform.isMinGW [
+    (lib.cmakeBool "WEBP_BUILD_CWEBP" false)
+    (lib.cmakeBool "WEBP_BUILD_DWEBP" false)
+    (lib.cmakeBool "WEBP_BUILD_GIF2WEBP" false)
+    (lib.cmakeBool "WEBP_BUILD_IMG2WEBP" false)
+    (lib.cmakeBool "WEBP_BUILD_VWEBP" false)
+    (lib.cmakeBool "WEBP_BUILD_WEBPINFO" false)
+    (lib.cmakeBool "WEBP_BUILD_WEBPMUX" false)
   ];
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
Fix MinGW cross-compilation for libwebp by disabling fragile CLI tools.

## Dependencies
- #476269 

## Changes

- Disable CLI tool builds on MinGW (`-DWEBP_BUILD_ANIM_UTILS=OFF`, `-DWEBP_BUILD_CWEBP=OFF`, etc.)
- Consumers like `gdk-pixbuf` only need the libraries, not the CLI tools

## Motivation

When cross-compiling libwebp to MinGW, linking CLI tools (notably `img2webp.exe`) fails with
unresolved references to `WebPAnim*` and `WebPMux*` symbols. MSYS2 takes the same approach
of building library-only for MinGW.

The libraries themselves build and link correctly; this change only affects the optional
CLI utilities.

It depends on: `mingw-libjpeg-turbo`

## Reference

MSYS2 PKGBUILD: https://github.com/msys2/MINGW-packages/tree/master/mingw-w64-libwebp

## Validation

### Cross build (MinGW)
`nix build .#pkgsCross.mingwW64.libwebp --no-link -L`

### Native build (regression check)
`nix build .#libwebp --no-link -L`

## Things done

- Built on platform:
  - [x] x86_64-linux (cross to mingwW64)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR.
- [x] Tested basic functionality of all binary files.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests