### PR TITLE
libhwy, libjxl: enable MinGW cross builds

### DIFF
--- a/pkgs/by-name/li/libhwy/package.nix
+++ b/pkgs/by-name/li/libhwy/package.nix
@@ -89,7 +89,8 @@ stdenv.mkDerivation rec {
       asl20
       bsd3
     ];
-    platforms = lib.platforms.unix;
+    # MSYS2 ships highway for mingw-w64; allow evaluation for Windows/MinGW.
+    platforms = lib.platforms.unix ++ lib.platforms.windows;
     maintainers = with lib.maintainers; [ zhaofengli ];
   };
 }


### PR DESCRIPTION
Add MinGW/Windows cross-compilation support for `libjxl` and `libhwy`.

## Dependencies
- #476353 
- #476344 

## Changes

### libhwy
- Expand `meta.platforms` to include Windows
- MSYS2 ships it for mingw-w64

### libjxl
- Use `buildPackages.*` for build-time tooling (`cmake`, `pkg-config`, `asciidoc`, `doxygen`, `python3`, `graphviz`)
- Gate `makeWrapper` usage to native builds only (cross builds don't need wrapper scripts)
- For native builds: update gdk-pixbuf loader cache directly
- For cross builds with emulator (wine): attempt cache update via emulator; make non-fatal (`|| true`)
- For cross builds without emulator: skip cache update

## Motivation

libjxl (JPEG XL) is a modern image codec with growing adoption. MinGW support enables Windows cross builds for applications requiring JPEG XL support.

The primary blockers were:
1. **Evaluation failure**: `libhwy` (dependency) was marked Unix-only
2. **Cross build hygiene**: needed build-machine tooling, not target tooling
3. **Install issues**: attempted to run target binaries directly in cross builds

Reference: MSYS2 `mingw-w64-highway` and `mingw-w64-libjxl` packaging

This depends on `mingw-libavif` & `mingw-gdk-pixbuf`

## Validation

### Cross builds (MinGW)
`nix build .#pkgsCross.mingwW64.libhwy --no-link -L`
`nix build .#pkgsCross.mingwW64.libjxl --no-link -L`

### Native builds (regression check)
`nix build .#libhwy --no-link -L`
`nix build .#libjxl --no-link -L`

## Things done

- Built on platform:
  - [x] x86_64-linux (cross to mingwW64)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR.
- [x] Tested basic functionality of all binary files.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test