### PR TITLE
nixos/autoUpgrade: re-introduce reboot triggers

### DIFF
--- a/nixos/modules/tasks/auto-upgrade.nix
+++ b/nixos/modules/tasks/auto-upgrade.nix
@@ -123,8 +123,8 @@ in
         '';
         defaultText = lib.literalExpression ''
           [
-            config.system.build.initialRamdisk
-            config.system.build.kernel
+            (config.system.build.initialRamdisk or null)
+            (config.system.build.kernel or null)
             config.hardware.firmware
             (pkgs.writeTextFile {
               name = "kernel-params";
@@ -223,8 +223,8 @@ in
     {
       system = {
         autoUpgrade.rebootTriggers = [
-          config.system.build.initialRamdisk
-          config.system.build.kernel
+          (config.system.build.initialRamdisk or null)
+          (config.system.build.kernel or null)
           config.hardware.firmware
           (pkgs.writeTextFile {
             name = "kernel-params";

--- a/nixos/modules/tasks/auto-upgrade.nix
+++ b/nixos/modules/tasks/auto-upgrade.nix
@@ -114,6 +114,27 @@ in
         '';
       };
 
+      rebootTriggers = lib.mkOption {
+        type = lib.types.listOf lib.types.pathInStore;
+        default = [ ];
+        description = ''
+          List of derivations that will cause an auto-reboot when changed when
+          {option}`system.autoUpgrade.allowReboot` is set to true.
+        '';
+        defaultText = lib.literalExpression ''
+          [
+            config.system.build.initialRamdisk
+            config.system.build.kernel
+            config.hardware.firmware
+            (pkgs.writeTextFile {
+              name = "kernel-params";
+              text = lib.concatStringsSep " " config.boot.kernelParams;
+            })
+          ]
+          ++ config.system.switch.inhibitors
+        '';
+      };
+
       randomizedDelaySec = lib.mkOption {
         default = "0";
         type = lib.types.str;
@@ -197,133 +218,205 @@ in
 
   };
 
-  config = lib.mkIf cfg.enable {
+  config = lib.mkMerge [
 
-    assertions = [
-      {
-        assertion = !((cfg.channel != null) && (cfg.flake != null));
-        message = ''
-          The options 'system.autoUpgrade.channel' and 'system.autoUpgrade.flake' cannot both be set.
-        '';
-      }
-      {
-        assertion = (cfg.runGarbageCollection -> config.nix.enable);
-        message = ''
-          The option 'system.autoUpgrade.runGarbageCollection = true' requires 'nix.enable = true'.
-        '';
-      }
-    ];
-
-    system.autoUpgrade.flags = (
-      if cfg.flake == null then
-        [ "--no-build-output" ]
-        ++ lib.optionals (cfg.channel != null) [
-          "-I"
-          "nixpkgs=${cfg.channel}/nixexprs.tar.xz"
+    {
+      system = {
+        autoUpgrade.rebootTriggers = [
+          config.system.build.initialRamdisk
+          config.system.build.kernel
+          config.hardware.firmware
+          (pkgs.writeTextFile {
+            name = "kernel-params";
+            text = lib.concatStringsSep " " config.boot.kernelParams;
+          })
         ]
-      else
-        [
-          "--refresh"
-          "--flake ${cfg.flake}"
-        ]
-    );
+        ++ config.system.switch.inhibitors;
 
-    systemd.services.nixos-upgrade = {
-      description = "NixOS Upgrade";
+        systemBuilderCommands = ''
+          ln -s ${config.system.build.rebootTriggers} $out/reboot-triggers
+        '';
 
-      restartIfChanged = false;
-      unitConfig.X-StopOnRemoval = false;
-      unitConfig.OnSuccess = lib.optional (
-        cfg.runGarbageCollection && config.nix.enable
-      ) "nix-gc.service";
+        build.rebootTriggers = pkgs.writeTextFile {
+          name = "reboot-triggers";
+          text = lib.concatMapStringsSep "\n" (drv: drv.outPath) config.system.autoUpgrade.rebootTriggers;
+        };
+      };
+    }
 
-      serviceConfig.Type = "oneshot";
-
-      environment =
-        config.nix.envVars
-        // {
-          inherit (config.environment.sessionVariables) NIX_PATH;
-          HOME = "/root";
+    (lib.mkIf cfg.enable {
+      assertions = [
+        {
+          assertion = !((cfg.channel != null) && (cfg.flake != null));
+          message = ''
+            The options 'system.autoUpgrade.channel' and 'system.autoUpgrade.flake' cannot both be set.
+          '';
         }
-        // config.networking.proxy.envVars;
-
-      path = with pkgs; [
-        coreutils
-        gnutar
-        xz.bin
-        gzip
-        gitMinimal
-        config.nix.package.out
-        config.programs.ssh.package
+        {
+          assertion = (cfg.runGarbageCollection -> config.nix.enable);
+          message = ''
+            The option 'system.autoUpgrade.runGarbageCollection = true' requires 'nix.enable = true'.
+          '';
+        }
       ];
 
-      script =
-        let
-          nixos-rebuild = "${config.system.build.nixos-rebuild}/bin/nixos-rebuild";
-          date = "${pkgs.coreutils}/bin/date";
-          readlink = "${pkgs.coreutils}/bin/readlink";
-          shutdown = "${config.systemd.package}/bin/shutdown";
-          upgradeFlag = lib.optional (cfg.channel == null && cfg.upgrade) "--upgrade";
-        in
-        if cfg.allowReboot then
-          ''
-            ${nixos-rebuild} boot ${toString (cfg.flags ++ upgradeFlag)}
-            booted="$(${readlink} /run/booted-system/{initrd,kernel,kernel-modules})"
-            built="$(${readlink} /nix/var/nix/profiles/system/{initrd,kernel,kernel-modules})"
-
-            ${lib.optionalString (cfg.rebootWindow != null) ''
-              current_time="$(${date} +%H:%M)"
-
-              lower="${cfg.rebootWindow.lower}"
-              upper="${cfg.rebootWindow.upper}"
-
-              if [[ "''${lower}" < "''${upper}" ]]; then
-                if [[ "''${current_time}" > "''${lower}" ]] && \
-                   [[ "''${current_time}" < "''${upper}" ]]; then
-                  do_reboot="true"
-                else
-                  do_reboot="false"
-                fi
-              else
-                # lower > upper, so we are crossing midnight (e.g. lower=23h, upper=6h)
-                # we want to reboot if cur > 23h or cur < 6h
-                if [[ "''${current_time}" < "''${upper}" ]] || \
-                   [[ "''${current_time}" > "''${lower}" ]]; then
-                  do_reboot="true"
-                else
-                  do_reboot="false"
-                fi
-              fi
-            ''}
-
-            if [ "''${booted}" = "''${built}" ]; then
-              ${nixos-rebuild} ${cfg.operation} ${toString cfg.flags}
-            ${lib.optionalString (cfg.rebootWindow != null) ''
-              elif [ "''${do_reboot}" != true ]; then
-                echo "Outside of configured reboot window, skipping."
-            ''}
-            else
-              ${shutdown} -r +1
-            fi
-          ''
+      system.autoUpgrade.flags = (
+        if cfg.flake == null then
+          [ "--no-build-output" ]
+          ++ lib.optionals (cfg.channel != null) [
+            "-I"
+            "nixpkgs=${cfg.channel}/nixexprs.tar.xz"
+          ]
         else
-          ''
-            ${nixos-rebuild} ${cfg.operation} ${toString (cfg.flags ++ upgradeFlag)}
-          '';
+          [
+            "--refresh"
+            "--flake ${cfg.flake}"
+          ]
+      );
 
-      startAt = cfg.dates;
+      systemd.services.nixos-upgrade = {
+        description = "NixOS Upgrade";
 
-      after = [ "network-online.target" ];
-      wants = [ "network-online.target" ];
-    };
+        restartIfChanged = false;
+        unitConfig.X-StopOnRemoval = false;
+        unitConfig.OnSuccess = lib.optional (
+          cfg.runGarbageCollection && config.nix.enable
+        ) "nix-gc.service";
 
-    systemd.timers.nixos-upgrade = {
-      timerConfig = {
-        RandomizedDelaySec = cfg.randomizedDelaySec;
-        FixedRandomDelay = cfg.fixedRandomDelay;
-        Persistent = cfg.persistent;
+        serviceConfig.Type = "oneshot";
+
+        environment =
+          config.nix.envVars
+          // {
+            inherit (config.environment.sessionVariables) NIX_PATH;
+            HOME = "/root";
+          }
+          // config.networking.proxy.envVars;
+
+        path = with pkgs; [
+          coreutils
+          gnutar
+          xz.bin
+          gzip
+          gitMinimal
+          config.nix.package.out
+          config.programs.ssh.package
+          config.system.build.nixos-rebuild
+          config.systemd.package
+        ];
+
+        script =
+          let
+            upgradeFlag = lib.optional (cfg.channel == null && cfg.flake == null) "--upgrade";
+          in
+          if cfg.allowReboot then
+            # bash
+            ''
+              echo "Running nixos-rebuild boot..."
+              new_configuration="$(
+                # For some reason we still get a newline here in the journal between the
+                # nixos-rebuild stderr output and us echoing the store path that was
+                # printed on stdout.
+                # This might have to do with the particular way in which systemd handles
+                # stdout/stderr, they are unix sockets and not normal streams.
+                store_path="$(nixos-rebuild boot ${toString (cfg.flags ++ upgradeFlag)})"
+                echo "$store_path" >&2
+                echo "$store_path"
+              )"
+              if [ -z "$new_configuration" ]; then
+                echo "Looks like nixos-rebuild failed... Aborting"
+                exit 1
+              fi
+              echo "New configuration is $new_configuration"
+              switch_to_new_configuration="$new_configuration"/bin/switch-to-configuration
+
+              ${lib.optionalString (cfg.rebootWindow != null) # bash
+                ''
+                  current_time="$(date +%H:%M)"
+
+                  lower="${cfg.rebootWindow.lower}"
+                  upper="${cfg.rebootWindow.upper}"
+
+                  if [[ "''${lower}" < "''${upper}" ]]; then
+                    if [[ "''${current_time}" > "''${lower}" ]] && [[ "''${current_time}" < "''${upper}" ]]; then
+                      do_reboot="true"
+                    else
+                      do_reboot="false"
+                    fi
+                  else
+                    # lower > upper, so we are crossing midnight (e.g. lower=23h, upper=6h)
+                    # we want to reboot if cur > 23h or cur < 6h
+                    if [[ "''${current_time}" < "''${upper}" ]] || [[ "''${current_time}" > "''${lower}" ]]; then
+                      do_reboot="true"
+                    else
+                      do_reboot="false"
+                    fi
+                  fi
+                ''
+              }
+
+              booted_triggers="$(realpath /run/booted-system)/reboot-triggers"
+              booted_triggers_sha="$(
+                if [ -f "$booted_triggers" ]; then
+                  sha256sum - < "$booted_triggers"
+                else
+                  echo 'none'
+                fi
+              )"
+
+              new_triggers="$(realpath "$new_configuration")/reboot-triggers"
+              new_triggers_sha="$(
+                if [ -f "$new_triggers" ]; then
+                  sha256sum - < "$new_triggers"
+                else
+                  echo 'none'
+                fi
+              )"
+
+              ${lib.optionalString (cfg.operation == "switch") # bash
+                ''
+                  echo "Running switch-to-configuration check..."
+                  if "$switch_to_new_configuration" check; then
+                    echo "Checking reboot triggers..."
+                    if [ "$new_triggers_sha" == "$booted_triggers_sha" ]; then
+                      echo "Switching into the new generation..."
+                      "$switch_to_new_configuration" ${cfg.operation}
+                      exit 0
+                    fi
+                  fi
+                ''
+              }
+              ${lib.optionalString (cfg.rebootWindow != null) # bash
+                ''
+                  if [ "''${do_reboot}" != true ]; then
+                    echo "Outside of configured reboot window, skipping."
+                    exit 0
+                  fi
+                ''
+              }
+              echo "Scheduling a reboot to activate the new generation"
+              systemctl reboot --when="+2min"
+            ''
+          else
+            # bash
+            ''
+              nixos-rebuild ${cfg.operation} ${toString (cfg.flags ++ upgradeFlag)}
+            '';
+
+        startAt = cfg.dates;
+
+        after = [ "network-online.target" ];
+        wants = [ "network-online.target" ];
       };
-    };
-  };
 
+      systemd.timers.nixos-upgrade = {
+        timerConfig = {
+          RandomizedDelaySec = cfg.randomizedDelaySec;
+          FixedRandomDelay = cfg.fixedRandomDelay;
+          Persistent = cfg.persistent;
+        };
+      };
+    })
+
+  ];
 }

--- a/nixos/modules/tasks/auto-upgrade.nix
+++ b/nixos/modules/tasks/auto-upgrade.nix
@@ -115,23 +115,19 @@ in
       };
 
       rebootTriggers = lib.mkOption {
-        type = lib.types.listOf lib.types.pathInStore;
-        default = [ ];
+        type = lib.types.attrsOf lib.types.str;
+        default = { };
         description = ''
-          List of derivations that will cause an auto-reboot when changed when
+          Attribute set of strings that will cause an auto-reboot when changed when
           {option}`system.autoUpgrade.allowReboot` is set to true.
         '';
         defaultText = lib.literalExpression ''
-          [
-            config.system.build.initialRamdisk
-            config.system.build.kernel
-            config.hardware.firmware
-            (pkgs.writeTextFile {
-              name = "kernel-params";
-              text = lib.concatStringsSep " " config.boot.kernelParams;
-            })
-          ]
-          ++ config.system.switch.inhibitors
+          {
+            kernel = "''${config.system.build.kernel}";
+            firmware = "''${config.hardware.firmware}";
+            kernel-params = lib.concatStringsSep "," config.boot.kernelParams;
+          }
+          // config.system.switch.inhibitors
         '';
       };
 
@@ -228,23 +224,16 @@ in
           ln -s ${config.system.build.rebootTriggers} $out/reboot-triggers
         '';
 
-        build.rebootTriggers = pkgs.writeTextFile {
-          name = "reboot-triggers";
-          text = lib.concatMapStringsSep "\n" (drv: drv.outPath) config.system.autoUpgrade.rebootTriggers;
-        };
+        build.rebootTriggers = pkgs.writers.writeJSON "reboot-triggers" config.system.autoUpgrade.rebootTriggers;
       };
     }
 
     (lib.mkIf (!config.boot.isContainer) {
-      system.autoUpgrade.rebootTriggers = [
-        config.system.build.initialRamdisk
-        config.system.build.kernel
-        config.hardware.firmware
-        (pkgs.writeTextFile {
-          name = "kernel-params";
-          text = lib.concatStringsSep " " config.boot.kernelParams;
-        })
-      ];
+      system.autoUpgrade.rebootTriggers = {
+        kernel = lib.mkIf config.boot.kernel.enable "${config.system.build.kernel}";
+        firmware = "${config.hardware.firmware}";
+        kernel-params = lib.concatStringsSep "," config.boot.kernelParams;
+      };
     })
 
     (lib.mkIf cfg.enable {
@@ -305,6 +294,7 @@ in
         path = with pkgs; [
           coreutils
           gnutar
+          jq
           xz.bin
           gzip
           gitMinimal
@@ -316,7 +306,8 @@ in
 
         script =
           let
-            upgradeFlag = lib.optional (cfg.channel == null && cfg.flake == null) "--upgrade";
+            upgradeFlag = lib.optional (cfg.channel == null && cfg.flake == null && cfg.upgrade) "--upgrade";
+            emptyTriggers = pkgs.writeText "empty-reboot-triggers" "{}";
           in
           if cfg.allowReboot then
             # bash
@@ -364,36 +355,63 @@ in
                 ''
               }
 
-              booted_triggers="$(realpath /run/booted-system)/reboot-triggers"
-              booted_triggers_sha="$(
-                if [ -f "$booted_triggers" ]; then
-                  sha256sum - < "$booted_triggers"
-                else
-                  echo 'none'
-                fi
+              # Fall back to an empty set when a generation does not have the
+              # reboot-triggers file.
+              booted_triggers="/run/booted-system/reboot-triggers"
+              if [ ! -f "$booted_triggers" ]; then
+                booted_triggers="${emptyTriggers}"
+              fi
+
+              new_triggers="$new_configuration/reboot-triggers"
+              if [ ! -f "$new_triggers" ]; then
+                new_triggers="${emptyTriggers}"
+              fi
+
+              diff="$(
+                jq \
+                  --raw-output \
+                  --null-input \
+                  --rawfile current "$booted_triggers" \
+                  --rawfile newgen "$new_triggers" \
+                '
+                  ($current | fromjson) as $old |
+                  ($newgen | fromjson) as $new |
+                  $old |
+                  to_entries |
+                  map(
+                    select(.key | in ($new)) |
+                    select(.value != $new.[.key]) |
+                    [ .key, ":", .value, "->", $new.[.key] ] | join(" ")
+                  ) |
+                  join("\n")
+                ' \
               )"
 
-              new_triggers="$(realpath "$new_configuration")/reboot-triggers"
-              new_triggers_sha="$(
-                if [ -f "$new_triggers" ]; then
-                  sha256sum - < "$new_triggers"
+              ${
+                if cfg.operation == "switch" then
+                  # bash
+                  ''
+                    echo "Running switch-to-configuration check..."
+                    if "$switch_to_new_configuration" check; then
+                      echo "Checking reboot triggers..."
+                      if [ -z "$diff" ]; then
+                        echo "Switching into the new generation..."
+                        "$switch_to_new_configuration" ${cfg.operation}
+                        exit 0
+                      fi
+                    fi
+                  ''
                 else
-                  echo 'none'
-                fi
-              )"
-
-              ${lib.optionalString (cfg.operation == "switch") # bash
-                ''
-                  echo "Running switch-to-configuration check..."
-                  if "$switch_to_new_configuration" check; then
-                    echo "Checking reboot triggers..."
-                    if [ "$new_triggers_sha" == "$booted_triggers_sha" ]; then
-                      echo "Switching into the new generation..."
-                      "$switch_to_new_configuration" ${cfg.operation}
+                  # operation == "boot": never switch live; reboot whenever the
+                  # toplevel changed at all, but skip pointless reboots when the
+                  # built generation is identical to the booted one.
+                  # bash
+                  ''
+                    if [ "$(realpath /run/booted-system)" = "$(realpath "$new_configuration")" ]; then
+                      echo "New generation is identical to the booted one, nothing to do."
                       exit 0
                     fi
-                  fi
-                ''
+                  ''
               }
               ${lib.optionalString (cfg.rebootWindow != null) # bash
                 ''
@@ -403,6 +421,10 @@ in
                   fi
                 ''
               }
+              if [ -n "$diff" ]; then
+                echo "Reboot triggers changed:"
+                echo "$diff"
+              fi
               echo "Scheduling a reboot to activate the new generation"
               systemctl reboot --when="+2min"
             ''

--- a/nixos/modules/tasks/auto-upgrade.nix
+++ b/nixos/modules/tasks/auto-upgrade.nix
@@ -114,6 +114,27 @@ in
         '';
       };
 
+      rebootTriggers = lib.mkOption {
+        type = lib.types.listOf lib.types.pathInStore;
+        default = [ ];
+        description = ''
+          List of derivations that will cause an auto-reboot when changed when
+          {option}`system.autoUpgrade.allowReboot` is set to true.
+        '';
+        defaultText = lib.literalExpression ''
+          [
+            config.system.build.initialRamdisk
+            config.system.build.kernel
+            config.hardware.firmware
+            (pkgs.writeTextFile {
+              name = "kernel-params";
+              text = lib.concatStringsSep " " config.boot.kernelParams;
+            })
+          ]
+          ++ config.system.switch.inhibitors
+        '';
+      };
+
       randomizedDelaySec = lib.mkOption {
         default = "0";
         type = lib.types.str;
@@ -197,133 +218,207 @@ in
 
   };
 
-  config = lib.mkIf cfg.enable {
+  config = lib.mkMerge [
 
-    assertions = [
-      {
-        assertion = !((cfg.channel != null) && (cfg.flake != null));
-        message = ''
-          The options 'system.autoUpgrade.channel' and 'system.autoUpgrade.flake' cannot both be set.
-        '';
-      }
-      {
-        assertion = (cfg.runGarbageCollection -> config.nix.enable);
-        message = ''
-          The option 'system.autoUpgrade.runGarbageCollection = true' requires 'nix.enable = true'.
-        '';
-      }
-    ];
-
-    system.autoUpgrade.flags = (
-      if cfg.flake == null then
-        [ "--no-build-output" ]
-        ++ lib.optionals (cfg.channel != null) [
-          "-I"
-          "nixpkgs=${cfg.channel}/nixexprs.tar.xz"
+    {
+      system = {
+        autoUpgrade.rebootTriggers = [
+          config.system.build.initialRamdisk
+          config.system.build.kernel
+          config.hardware.firmware
+          (pkgs.writeTextFile {
+            name = "kernel-params";
+            text = lib.concatStringsSep " " config.boot.kernelParams;
+          })
         ]
-      else
-        [
-          "--refresh"
-          "--flake ${cfg.flake}"
-        ]
-    );
+        ++ config.system.switch.inhibitors;
 
-    systemd.services.nixos-upgrade = {
-      description = "NixOS Upgrade";
+        systemBuilderCommands = ''
+          ln -s ${config.system.build.rebootTriggers} $out/reboot-triggers
+        '';
 
-      restartIfChanged = false;
-      unitConfig.X-StopOnRemoval = false;
-      unitConfig.OnSuccess = lib.optional (
-        cfg.runGarbageCollection && config.nix.enable
-      ) "nix-gc.service";
+        build.rebootTriggers = pkgs.writeTextFile {
+          name = "reboot-triggers";
+          text = lib.concatMapStringsSep "\n" (drv: drv.outPath) config.system.autoUpgrade.rebootTriggers;
+        };
+      };
+    }
 
-      serviceConfig.Type = "oneshot";
-
-      environment =
-        config.nix.envVars
-        // {
-          inherit (config.environment.sessionVariables) NIX_PATH;
-          HOME = "/root";
+    (lib.mkIf cfg.enable {
+      assertions = [
+        {
+          assertion = !((cfg.channel != null) && (cfg.flake != null));
+          message = ''
+            The options 'system.autoUpgrade.channel' and 'system.autoUpgrade.flake' cannot both be set.
+          '';
         }
-        // config.networking.proxy.envVars;
-
-      path = with pkgs; [
-        coreutils
-        gnutar
-        xz.bin
-        gzip
-        gitMinimal
-        config.nix.package.out
-        config.programs.ssh.package
+        {
+          assertion = (cfg.runGarbageCollection -> config.nix.enable);
+          message = ''
+            The option 'system.autoUpgrade.runGarbageCollection = true' requires 'nix.enable = true'.
+          '';
+        }
       ];
 
-      script =
-        let
-          nixos-rebuild = "${config.system.build.nixos-rebuild}/bin/nixos-rebuild";
-          date = "${pkgs.coreutils}/bin/date";
-          readlink = "${pkgs.coreutils}/bin/readlink";
-          shutdown = "${config.systemd.package}/bin/shutdown";
-          upgradeFlag = lib.optional (cfg.channel == null && cfg.upgrade) "--upgrade";
-        in
-        if cfg.allowReboot then
-          ''
-            ${nixos-rebuild} boot ${toString (cfg.flags ++ upgradeFlag)}
-            booted="$(${readlink} /run/booted-system/{initrd,kernel,kernel-modules})"
-            built="$(${readlink} /nix/var/nix/profiles/system/{initrd,kernel,kernel-modules})"
-
-            ${lib.optionalString (cfg.rebootWindow != null) ''
-              current_time="$(${date} +%H:%M)"
-
-              lower="${cfg.rebootWindow.lower}"
-              upper="${cfg.rebootWindow.upper}"
-
-              if [[ "''${lower}" < "''${upper}" ]]; then
-                if [[ "''${current_time}" > "''${lower}" ]] && \
-                   [[ "''${current_time}" < "''${upper}" ]]; then
-                  do_reboot="true"
-                else
-                  do_reboot="false"
-                fi
-              else
-                # lower > upper, so we are crossing midnight (e.g. lower=23h, upper=6h)
-                # we want to reboot if cur > 23h or cur < 6h
-                if [[ "''${current_time}" < "''${upper}" ]] || \
-                   [[ "''${current_time}" > "''${lower}" ]]; then
-                  do_reboot="true"
-                else
-                  do_reboot="false"
-                fi
-              fi
-            ''}
-
-            if [ "''${booted}" = "''${built}" ]; then
-              ${nixos-rebuild} ${cfg.operation} ${toString cfg.flags}
-            ${lib.optionalString (cfg.rebootWindow != null) ''
-              elif [ "''${do_reboot}" != true ]; then
-                echo "Outside of configured reboot window, skipping."
-            ''}
-            else
-              ${shutdown} -r +1
-            fi
-          ''
+      system.autoUpgrade.flags = (
+        if cfg.flake == null then
+          [ "--no-build-output" ]
+          ++ lib.optionals (cfg.channel != null) [
+            "-I"
+            "nixpkgs=${cfg.channel}/nixexprs.tar.xz"
+          ]
         else
-          ''
-            ${nixos-rebuild} ${cfg.operation} ${toString (cfg.flags ++ upgradeFlag)}
-          '';
+          [
+            "--refresh"
+            "--flake ${cfg.flake}"
+          ]
+      );
 
-      startAt = cfg.dates;
+      systemd.services.nixos-upgrade = {
+        description = "NixOS Upgrade";
 
-      after = [ "network-online.target" ];
-      wants = [ "network-online.target" ];
-    };
+        restartIfChanged = false;
+        unitConfig.X-StopOnRemoval = false;
+        unitConfig.OnSuccess = lib.optional (
+          cfg.runGarbageCollection && config.nix.enable
+        ) "nix-gc.service";
 
-    systemd.timers.nixos-upgrade = {
-      timerConfig = {
-        RandomizedDelaySec = cfg.randomizedDelaySec;
-        FixedRandomDelay = cfg.fixedRandomDelay;
-        Persistent = cfg.persistent;
+        serviceConfig.Type = "oneshot";
+
+        environment =
+          config.nix.envVars
+          // {
+            inherit (config.environment.sessionVariables) NIX_PATH;
+            HOME = "/root";
+          }
+          // config.networking.proxy.envVars;
+
+        path = with pkgs; [
+          coreutils
+          gnutar
+          xz.bin
+          gzip
+          gitMinimal
+          config.nix.package.out
+          config.programs.ssh.package
+          config.system.build.nixos-rebuild
+          config.systemd.package
+        ];
+
+        script =
+          let
+            upgradeFlag = lib.optional (cfg.channel == null && cfg.flake == null) "--upgrade";
+          in
+          if cfg.allowReboot then
+            # bash
+            ''
+              echo "Running nixos-rebuild boot..."
+              new_configuration="$(
+                # For some reason we still get a newline here in the journal between the
+                # nixos-rebuild stderr output and us echoing the store path that was
+                # printed on stdout.
+                # This might have to do with the particular way in which systemd handles
+                # stdout/stderr, they are unix sockets and not normal streams.
+                store_path="$(nixos-rebuild boot ${toString (cfg.flags ++ upgradeFlag)})"
+                echo "$store_path" >&2
+                echo "$store_path"
+              )"
+              if [ -z "$new_configuration" ]; then
+                echo "Looks like nixos-rebuild failed... Aborting"
+                exit 1
+              fi
+              echo "New configuration is $new_configuration"
+              switch_to_new_configuration="$new_configuration"/bin/switch-to-configuration
+
+              ${lib.optionalString (cfg.rebootWindow != null) # bash
+                ''
+                  current_time="$(date +%H:%M)"
+
+                  lower="${cfg.rebootWindow.lower}"
+                  upper="${cfg.rebootWindow.upper}"
+
+                  if [[ "''${lower}" < "''${upper}" ]]; then
+                    if [[ "''${current_time}" > "''${lower}" ]] && [[ "''${current_time}" < "''${upper}" ]]; then
+                      do_reboot="true"
+                    else
+                      do_reboot="false"
+                    fi
+                  else
+                    # lower > upper, so we are crossing midnight (e.g. lower=23h, upper=6h)
+                    # we want to reboot if cur > 23h or cur < 6h
+                    if [[ "''${current_time}" < "''${upper}" ]] || [[ "''${current_time}" > "''${lower}" ]]; then
+                      do_reboot="true"
+                    else
+                      do_reboot="false"
+                    fi
+                  fi
+                ''
+              }
+
+              booted_triggers="$(realpath /run/booted-system)/reboot-triggers"
+              booted_triggers_sha="$(
+                if [ -f "$booted_triggers" ]; then
+                  sha256sum - < "$booted_triggers"
+                else
+                  echo 'none'
+                fi
+              )"
+
+              new_triggers="$(realpath "$new_configuration")/reboot-triggers"
+              new_triggers_sha="$(
+                if [ -f "$new_triggers" ]; then
+                  sha256sum - < "$new_triggers"
+                else
+                  echo 'none'
+                fi
+              )"
+
+              ${lib.optionalString (cfg.operation == "switch") # bash
+                ''
+                  echo "Running switch-to-configuration check..."
+                  if "$switch_to_new_configuration" check; then
+                    echo "Checking reboot triggers..."
+                    if [ "$new_triggers_sha" == "$booted_triggers_sha" ]; then
+                      echo "Switching into the new generation..."
+                      # nixos-rebuild boot already set the profile and installed
+                      # the bootloader, so only activate here.
+                      "$switch_to_new_configuration" test
+                      exit 0
+                    fi
+                  fi
+                ''
+              }
+              ${lib.optionalString (cfg.rebootWindow != null) # bash
+                ''
+                  if [ "''${do_reboot}" != true ]; then
+                    echo "Outside of configured reboot window, skipping."
+                    exit 0
+                  fi
+                ''
+              }
+              echo "Scheduling a reboot to activate the new generation"
+              systemctl reboot --when="+2min"
+            ''
+          else
+            # bash
+            ''
+              nixos-rebuild ${cfg.operation} ${toString (cfg.flags ++ upgradeFlag)}
+            '';
+
+        startAt = cfg.dates;
+
+        after = [ "network-online.target" ];
+        wants = [ "network-online.target" ];
       };
-    };
-  };
 
+      systemd.timers.nixos-upgrade = {
+        timerConfig = {
+          RandomizedDelaySec = cfg.randomizedDelaySec;
+          FixedRandomDelay = cfg.fixedRandomDelay;
+          Persistent = cfg.persistent;
+        };
+      };
+    })
+
+  ];
 }

--- a/nixos/modules/tasks/auto-upgrade.nix
+++ b/nixos/modules/tasks/auto-upgrade.nix
@@ -115,23 +115,19 @@ in
       };
 
       rebootTriggers = lib.mkOption {
-        type = lib.types.listOf lib.types.pathInStore;
-        default = [ ];
+        type = lib.types.attrsOf lib.types.str;
+        default = { };
         description = ''
-          List of derivations that will cause an auto-reboot when changed when
+          Attribute set of strings that will cause an auto-reboot when changed when
           {option}`system.autoUpgrade.allowReboot` is set to true.
         '';
         defaultText = lib.literalExpression ''
-          [
-            config.system.build.initialRamdisk
-            config.system.build.kernel
-            config.hardware.firmware
-            (pkgs.writeTextFile {
-              name = "kernel-params";
-              text = lib.concatStringsSep " " config.boot.kernelParams;
-            })
-          ]
-          ++ config.system.switch.inhibitors
+          {
+            kernel = "''${config.system.build.kernel}";
+            firmware = "''${config.hardware.firmware}";
+            kernel-params = lib.concatStringsSep "," config.boot.kernelParams;
+          }
+          // config.system.switch.inhibitors
         '';
       };
 
@@ -228,23 +224,16 @@ in
           ln -s ${config.system.build.rebootTriggers} $out/reboot-triggers
         '';
 
-        build.rebootTriggers = pkgs.writeTextFile {
-          name = "reboot-triggers";
-          text = lib.concatMapStringsSep "\n" (drv: drv.outPath) config.system.autoUpgrade.rebootTriggers;
-        };
+        build.rebootTriggers = pkgs.writers.writeJSON "reboot-triggers" config.system.autoUpgrade.rebootTriggers;
       };
     }
 
-    (lib.mkIf (!config.boot.isContainer) {
-      system.autoUpgrade.rebootTriggers = [
-        config.system.build.initialRamdisk
-        config.system.build.kernel
-        config.hardware.firmware
-        (pkgs.writeTextFile {
-          name = "kernel-params";
-          text = lib.concatStringsSep " " config.boot.kernelParams;
-        })
-      ];
+    (lib.mkIf (!config.boot.isContainer && config.boot.kernel.enable) {
+      system.autoUpgrade.rebootTriggers = {
+        kernel = "${config.system.build.kernel}";
+        firmware = "${config.hardware.firmware}";
+        kernel-params = lib.concatStringsSep "," config.boot.kernelParams;
+      };
     })
 
     (lib.mkIf cfg.enable {
@@ -305,6 +294,7 @@ in
         path = with pkgs; [
           coreutils
           gnutar
+          jq
           xz.bin
           gzip
           gitMinimal
@@ -316,7 +306,8 @@ in
 
         script =
           let
-            upgradeFlag = lib.optional (cfg.channel == null && cfg.flake == null) "--upgrade";
+            upgradeFlag = lib.optional (cfg.channel == null && cfg.flake == null && cfg.upgrade) "--upgrade";
+            emptyTriggers = pkgs.writeText "empty-reboot-triggers" "{}";
           in
           if cfg.allowReboot then
             # bash
@@ -364,38 +355,65 @@ in
                 ''
               }
 
-              booted_triggers="$(realpath /run/booted-system)/reboot-triggers"
-              booted_triggers_sha="$(
-                if [ -f "$booted_triggers" ]; then
-                  sha256sum - < "$booted_triggers"
-                else
-                  echo 'none'
-                fi
+              # Fall back to an empty set when a generation does not have the
+              # reboot-triggers file.
+              booted_triggers="/run/booted-system/reboot-triggers"
+              if [ ! -f "$booted_triggers" ]; then
+                booted_triggers="${emptyTriggers}"
+              fi
+
+              new_triggers="$new_configuration/reboot-triggers"
+              if [ ! -f "$new_triggers" ]; then
+                new_triggers="${emptyTriggers}"
+              fi
+
+              diff="$(
+                jq \
+                  --raw-output \
+                  --null-input \
+                  --rawfile current "$booted_triggers" \
+                  --rawfile newgen "$new_triggers" \
+                '
+                  ($current | fromjson) as $old |
+                  ($newgen | fromjson) as $new |
+                  $old |
+                  to_entries |
+                  map(
+                    select(.key | in ($new)) |
+                    select(.value != $new.[.key]) |
+                    [ .key, ":", .value, "->", $new.[.key] ] | join(" ")
+                  ) |
+                  join("\n")
+                ' \
               )"
 
-              new_triggers="$(realpath "$new_configuration")/reboot-triggers"
-              new_triggers_sha="$(
-                if [ -f "$new_triggers" ]; then
-                  sha256sum - < "$new_triggers"
+              ${
+                if cfg.operation == "switch" then
+                  # bash
+                  ''
+                    echo "Running switch-to-configuration check..."
+                    if "$switch_to_new_configuration" check; then
+                      echo "Checking reboot triggers..."
+                      if [ -z "$diff" ]; then
+                        echo "Switching into the new generation..."
+                        # nixos-rebuild boot already set the profile and installed
+                        # the bootloader, so only activate here.
+                        "$switch_to_new_configuration" test
+                        exit 0
+                      fi
+                    fi
+                  ''
                 else
-                  echo 'none'
-                fi
-              )"
-
-              ${lib.optionalString (cfg.operation == "switch") # bash
-                ''
-                  echo "Running switch-to-configuration check..."
-                  if "$switch_to_new_configuration" check; then
-                    echo "Checking reboot triggers..."
-                    if [ "$new_triggers_sha" == "$booted_triggers_sha" ]; then
-                      echo "Switching into the new generation..."
-                      # nixos-rebuild boot already set the profile and installed
-                      # the bootloader, so only activate here.
-                      "$switch_to_new_configuration" test
+                  # operation == "boot": never switch live; reboot whenever the
+                  # toplevel changed at all, but skip pointless reboots when the
+                  # built generation is identical to the booted one.
+                  # bash
+                  ''
+                    if [ "$(realpath /run/booted-system)" = "$(realpath "$new_configuration")" ]; then
+                      echo "New generation is identical to the booted one, nothing to do."
                       exit 0
                     fi
-                  fi
-                ''
+                  ''
               }
               ${lib.optionalString (cfg.rebootWindow != null) # bash
                 ''
@@ -405,6 +423,10 @@ in
                   fi
                 ''
               }
+              if [ -n "$diff" ]; then
+                echo "Reboot triggers changed:"
+                echo "$diff"
+              fi
               echo "Scheduling a reboot to activate the new generation"
               systemctl reboot --when="+2min"
             ''


### PR DESCRIPTION
Reapply #473282 (reverted in #476303) together with the container fix from #476326, and rework the reboot-trigger mechanism to mirror the switch-inhibitors design from #477800.

`system.autoUpgrade.rebootTriggers` is now an attrset of named strings written to `$out/reboot-triggers` as JSON. The `nixos-upgrade` service compares the booted and newly-built trigger sets key-by-key with `jq` and decides between switching live or scheduling a reboot.

When `operation = "switch"` and `allowReboot = true`, the service runs `switch-to-configuration check` and switches live only when no trigger changed; otherwise it schedules a reboot. When `operation = "boot"` the service never switches live but skips the reboot when the built toplevel is identical to the booted one, avoiding daily no-op reboots.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
