### PR TITLE
wasm-language-tools: VS Code ext in update script

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/gplane.wasm-language-tools/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/gplane.wasm-language-tools/default.nix
@@ -4,6 +4,12 @@
   wasm-language-tools,
 }:
 
+# The update script for the wasm-language-tools package itself updates this
+# package too, so we disable nixpkgs-update for this package to avoid sometimes
+# accidentally updating just this package by itself.
+
+# nixpkgs-update: no auto update
+
 vscode-utils.buildVscodeMarketplaceExtension {
   mktplcRef = {
     publisher = "gplane";

--- a/pkgs/by-name/wa/wasm-language-tools/package.nix
+++ b/pkgs/by-name/wa/wasm-language-tools/package.nix
@@ -3,7 +3,9 @@
   rustPlatform,
   fetchFromGitHub,
   versionCheckHook,
+  _experimental-update-script-combinators,
   nix-update-script,
+  vscode-extension-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -23,7 +25,16 @@ rustPlatform.buildRustPackage (finalAttrs: {
   versionCheckProgram = "${placeholder "out"}/bin/wat_server";
   doInstallCheck = true;
 
-  passthru.updateScript = nix-update-script { };
+  passthru.updateScript = _experimental-update-script-combinators.sequence [
+    (nix-update-script { })
+    (vscode-extension-update-script {
+      attrPath = "vscode-extensions.gplane.wasm-language-tools";
+      extraArgs = [
+        "--override-filename"
+        "pkgs/applications/editors/vscode/extensions/gplane.wasm-language-tools/default.nix"
+      ];
+    })
+  ];
 
   meta = {
     description = "Language server and other tools for WebAssembly";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Since #463362 has now been merged, and since the author of this language server coordinates its releases with those of the VS Code extension, the `passthru.updateScript` should update them both together. So, this PR tacks on `vscode-extension-update-script` to the current usage of `nix-update-script` via `_experimental-update-script-combinators.sequence`.

Tested by downgrading `wasm-language-tools` and `vscode-extensions.gplane.wasm-language-tools` to v0.7.1 and v1.15.0 respectively, then running this command:

```sh
nix-shell maintainers/scripts/update.nix --argstr package wasm-language-tools
```

<details>
<summary>Expand to see the downgrade diff for testing.</summary>

```diff
diff --git a/pkgs/applications/editors/vscode/extensions/gplane.wasm-language-tools/default.nix b/pkgs/applications/editors/vscode/extensions/gplane.wasm-language-tools/default.nix
index 5fe3da3cabb0..ef3fcc18f428 100644
--- a/pkgs/applications/editors/vscode/extensions/gplane.wasm-language-tools/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/gplane.wasm-language-tools/default.nix
@@ -8,8 +8,8 @@ vscode-utils.buildVscodeMarketplaceExtension {
   mktplcRef = {
     publisher = "gplane";
     name = "wasm-language-tools";
-    version = "1.16.0";
-    hash = "sha256-H2exVPaF8tYdpXBcooFi5bysp85OLOwxbKrB3HJes0Y=";
+    version = "1.15.0";
+    hash = "sha256-PogHwExxQ9HjMEzh0ifqwk0KndLJLO8FkPVhiJSqvnQ=";
   };
 
   buildPhase = ''
diff --git a/pkgs/by-name/wa/wasm-language-tools/package.nix b/pkgs/by-name/wa/wasm-language-tools/package.nix
index e45e3dd0c0ad..9f8ff317b3ec 100644
--- a/pkgs/by-name/wa/wasm-language-tools/package.nix
+++ b/pkgs/by-name/wa/wasm-language-tools/package.nix
@@ -10,16 +10,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "wasm-language-tools";
-  version = "0.8.0";
+  version = "0.7.1";
 
   src = fetchFromGitHub {
     owner = "g-plane";
     repo = "wasm-language-tools";
     tag = "v${version}";
-    hash = "sha256-4PnagT1pufsEy1ROvhYYtkuSsU+irGpYV9iffwIQPmk=";
+    hash = "sha256-ySY1AIgr5HwSrfebfDkKZvl/1LQpU64nCF6TEi//JuM=";
   };
 
-  cargoHash = "sha256-h+HEOzS93XFuDm5luODAzzGtxxaxTTdxTWIKm41Sw6s=";
+  cargoHash = "sha256-veBxrnTRSI6kRy0bREBWCLEkbkPUWM7jGwlcFhG6FjU=";
 
   nativeInstallCheckInputs = [ versionCheckHook ];
   versionCheckProgram = "${placeholder "out"}/bin/wat_server";
```

</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
