### PR TITLE
python3Packages.pytensor: 2.36.1 -> 2.36.2

### DIFF
--- a/pkgs/development/python-modules/pytensor/default.nix
+++ b/pkgs/development/python-modules/pytensor/default.nix
@@ -3,7 +3,6 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
-  fetchpatch,
 
   # build-system
   setuptools,
@@ -34,7 +33,7 @@
 
 buildPythonPackage rec {
   pname = "pytensor";
-  version = "2.36.1";
+  version = "2.36.2";
   pyproject = true;
 
   src = fetchFromGitHub {
@@ -44,17 +43,8 @@ buildPythonPackage rec {
     postFetch = ''
       sed -i 's/git_refnames = "[^"]*"/git_refnames = " (tag: ${src.tag})"/' $out/pytensor/_version.py
     '';
-    hash = "sha256-rXLtrkuwmEe5+64Aao490VqD96LJ37/mxekWOzWRMlw=";
+    hash = "sha256-v6C3LL7ws+K7STqmd4j7/jNnMnnAmEUHzTHKv4446LU=";
   };
-
-  patches = [
-    # https://github.com/pymc-devs/pytensor/pull/1805
-    (fetchpatch {
-      name = "fix-test-tri-nonconcrete-jax-compatibility.patch";
-      url = "https://github.com/pymc-devs/pytensor/commit/86310f074267e24d1b3b99ecf3d9cc0b593b170d.patch";
-      hash = "sha256-KRywJLixmdDJ1GGYsd5Twjiwgce0ZFxUidhTgM6Obmg=";
-    })
-  ];
 
   build-system = [
     setuptools


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/pymc-devs/pytensor/compare/rel-2.36.1...rel-2.36.2
Changelog: https://github.com/pymc-devs/pytensor/releases/tag/rel-2.36.2

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
