### PR TITLE
mcabber: fix compilation with GCC15 by correcting function prototypes

### DIFF
--- a/pkgs/by-name/mc/mcabber/add-missing-arguments-to-function-prototypes.patch
+++ b/pkgs/by-name/mc/mcabber/add-missing-arguments-to-function-prototypes.patch
@@ -1,0 +1,44 @@
+GCC 15 uses C23 by default which is stricter about function prototypes.
+
+diff -r -U3 mcabber-1.1.2.orig/mcabber/screen.c mcabber-1.1.2/mcabber/screen.c
+--- mcabber-1.1.2.orig/mcabber/screen.c	2026-01-02 22:48:11.169262178 +0100
++++ mcabber-1.1.2/mcabber/screen.c	2026-01-02 22:51:01.428023634 +0100
+@@ -90,7 +90,7 @@
+                            const gchar *message, gpointer user_data);
+ 
+ #ifdef XEP0085
+-static gboolean scr_chatstates_timeout();
++static gboolean scr_chatstates_timeout(gpointer user_data);
+ #endif
+ 
+ #if defined(WITH_ENCHANT) || defined(WITH_ASPELL)
+@@ -2485,7 +2485,7 @@
+ }
+ 
+ #ifdef XEP0085
+-static gboolean scr_chatstates_timeout(void)
++static gboolean scr_chatstates_timeout(gpointer user_data)
+ {
+   time_t now;
+   time(&now);
+diff -r -U3 mcabber-1.1.2.orig/mcabber/xmpp.c mcabber-1.1.2/mcabber/xmpp.c
+--- mcabber-1.1.2.orig/mcabber/xmpp.c	2026-01-02 22:48:11.166975512 +0100
++++ mcabber-1.1.2/mcabber/xmpp.c	2026-01-02 22:52:30.355029495 +0100
+@@ -50,7 +50,7 @@
+ static guint AutoConnection;
+ 
+ inline void update_last_use(void);
+-inline gboolean xmpp_reconnect();
++inline gboolean xmpp_reconnect(gpointer user_data);
+ 
+ enum imstatus mystatus = offline;
+ static enum imstatus mywantedstatus = available;
+@@ -781,7 +781,7 @@
+     scr_LogPrint(LPRINT_LOGNORM, "Authentication failed");
+ }
+ 
+-gboolean xmpp_reconnect()
++gboolean xmpp_reconnect(gpointer user_data)
+ {
+   if (!lconnection)
+     xmpp_connect();

--- a/pkgs/by-name/mc/mcabber/package.nix
+++ b/pkgs/by-name/mc/mcabber/package.nix
@@ -29,6 +29,7 @@ stdenv.mkDerivation rec {
       sha256 = "01bc23z0mva9l9jv587sq2r9w3diachgkmb9ad99hlzgj02fmq4v";
       stripLen = 1;
     })
+    ./add-missing-arguments-to-function-prototypes.patch
   ];
 
   nativeBuildInputs = [ pkg-config ];


### PR DESCRIPTION
Fix build of mcabber by trivial prototype changes

Relevant to #475479 

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
