### PR TITLE
ezquake: 3.6.3 -> 3.6.8

### DIFF
--- a/pkgs/by-name/ez/ezquake/package.nix
+++ b/pkgs/by-name/ez/ezquake/package.nix
@@ -7,46 +7,45 @@
   jansson,
   libpng,
   libjpeg,
-  libGLU,
   libGL,
   libX11,
   libsndfile,
-  libXxf86vm,
-  pcre,
+  pcre2,
+  minizip,
+  cmake,
   pkg-config,
   SDL2,
-  vim,
-  speex,
 }:
 
 stdenv.mkDerivation rec {
   pname = "ezquake";
-  version = "3.6.3";
+  version = "3.6.8";
 
   src = fetchFromGitHub {
     owner = "QW-Group";
     repo = "ezquake" + "-source";
     tag = version;
     fetchSubmodules = true;
-    hash = "sha256-ThrsJfj+eP7Lv2ZSNLO6/b98VHrL6/rhwf2p0qMvTF8=";
+    hash = "sha256-BIkBl6ncwo0NljuqOHJ3yQeDTcClh5FGssdFsKUjN90=";
   };
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
   buildInputs = [
+    minizip
+    pcre2
     expat
     curl
     jansson
     libpng
     libjpeg
-    libGLU
     libGL
     libsndfile
     libX11
-    libXxf86vm
-    pcre
     SDL2
-    vim
-    speex
   ];
 
   installPhase =

--- a/pkgs/by-name/ez/ezquake/package.nix
+++ b/pkgs/by-name/ez/ezquake/package.nix
@@ -1,30 +1,31 @@
 {
-  lib,
-  stdenv,
-  fetchFromGitHub,
-  curl,
+  SDL2,
+  cmake,
+  curlMinimal,
   expat,
+  fetchFromGitHub,
   jansson,
-  libpng,
-  libjpeg,
+  lib,
   libGL,
   libX11,
+  libjpeg,
+  libpng,
   libsndfile,
-  pcre2,
   minizip,
-  cmake,
+  nix-update-script,
+  pcre2,
   pkg-config,
-  SDL2,
+  stdenv,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "ezquake";
   version = "3.6.8";
 
   src = fetchFromGitHub {
     owner = "QW-Group";
-    repo = "ezquake" + "-source";
-    tag = version;
+    repo = "ezquake-source";
+    tag = finalAttrs.version;
     fetchSubmodules = true;
     hash = "sha256-BIkBl6ncwo0NljuqOHJ3yQeDTcClh5FGssdFsKUjN90=";
   };
@@ -35,18 +36,20 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
+    SDL2
+    curlMinimal
+    expat
+    jansson
+    libGL
+    libX11
+    libjpeg
+    libpng
+    libsndfile
     minizip
     pcre2
-    expat
-    curl
-    jansson
-    libpng
-    libjpeg
-    libGL
-    libsndfile
-    libX11
-    SDL2
   ];
+
+  enableParallelBuilding = true;
 
   installPhase =
     let
@@ -54,12 +57,15 @@ stdenv.mkDerivation rec {
       arch = lib.head (lib.splitString "-" stdenv.hostPlatform.system);
     in
     ''
-      mkdir -p $out/bin
-      find .
-      mv ezquake-${sys}-${arch} $out/bin/ezquake
+      runHook preInstall
+
+      install -D \
+        ezquake-${sys}-${arch} $out/bin/${finalAttrs.meta.mainProgram}
+
+      runHook postInstall
     '';
 
-  enableParallelBuilding = true;
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     homepage = "https://ezquake.com/";
@@ -69,4 +75,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ edwtjo ];
   };
-}
+})


### PR DESCRIPTION
Resolves #476340

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
