### PR TITLE
stripe-sync-engine: init at 0.48.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14877,6 +14877,11 @@
     github = "LogicalOverflow";
     githubId = 5919957;
   };
+  lgug2z = {
+    name = "Jeezy";
+    github = "LGUG2Z";
+    githubId = 13164844;
+  };
   lheintzmann1 = {
     email = "lheintzmann1@disroot.org";
     github = "lheintzmann1";

--- a/pkgs/by-name/st/stripe-sync-engine/package.nix
+++ b/pkgs/by-name/st/stripe-sync-engine/package.nix
@@ -1,0 +1,119 @@
+{
+  lib,
+  fetchFromGitHub,
+  fetchPnpmDeps,
+  gnused,
+  nodejs_22,
+  pnpm_10,
+  runCommand,
+  stdenv,
+  zstd,
+}:
+let
+  pnpm = pnpm_10;
+
+  version = "0.48.1";
+
+  src = fetchFromGitHub {
+    owner = "supabase";
+    repo = "stripe-sync-engine";
+    tag = "v${version}";
+    hash = "sha256-ihWr5IWklFkmxO91gO9ENCbb3GhHBtIRQIRCLzb2Ak8=";
+  };
+
+  # Patched source that allows the nixpkgs pnpm version and removes .npmrc
+  # which expects an $NPM_TOKEN
+  patchedSrc = runCommand "stripe-sync-engine-src-patched" { } ''
+    cp -r ${src} $out
+    chmod -R +w $out
+    # Update packageManager to match nixpkgs pnpm version
+    ${lib.getExe gnused} -i \
+      -e 's/"packageManager": "pnpm@[^"]*"/"packageManager": "pnpm@${pnpm.version}"/' \
+      $out/package.json
+    rm $out/.npmrc
+  '';
+
+  # Fetch pnpm dependencies as a separate fixed-output derivation
+  pnpmDeps = fetchPnpmDeps {
+    pname = "stripe-sync-engine-pnpm-deps";
+    inherit version;
+    src = patchedSrc;
+    fetcherVersion = 3;
+    hash = "sha256-5MVbNgIlQUnplKDlQ40puda7jMziTuDrYiQM6cjPJg0=";
+  };
+in
+stdenv.mkDerivation {
+  pname = "stripe-sync-engine";
+  inherit version;
+  src = patchedSrc;
+
+  nativeBuildInputs = [
+    nodejs_22
+    pnpm
+    zstd
+  ];
+
+  # Disable unnecessary fixup phases
+  dontStrip = true;
+  dontPatchShebangs = true;
+  dontPatchELF = true;
+
+  configurePhase = ''
+    runHook preConfigure
+
+    export HOME=$(mktemp -d)
+    export STORE_PATH=$(mktemp -d)
+
+    # Extract the pre-fetched pnpm store
+    echo "Extracting pnpm store..."
+    tar --zstd -xf "${pnpmDeps}/pnpm-store.tar.zst" -C "$STORE_PATH"
+    chmod -R +w "$STORE_PATH"
+
+    # Configure pnpm
+    pnpm config set store-dir "$STORE_PATH"
+    pnpm config set package-import-method clone-or-copy
+    pnpm config set manage-package-manager-versions false
+
+    # Install dependencies for all workspace packages
+    echo "Installing dependencies..."
+    pnpm install --offline --frozen-lockfile --ignore-scripts
+
+    runHook postConfigure
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    pnpm run build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/stripe-sync-engine
+
+    cp -r packages $out/lib/stripe-sync-engine/
+    cp -r node_modules $out/lib/stripe-sync-engine/
+    cp package.json $out/lib/stripe-sync-engine/
+
+    mkdir -p $out/bin
+    cat > $out/bin/stripe-sync-engine <<EOF
+    #!/usr/bin/env bash
+    cd $out/lib/stripe-sync-engine/packages/fastify-app
+    exec ${nodejs_22}/bin/node dist/src/server.js "\$@"
+    EOF
+    chmod +x $out/bin/stripe-sync-engine
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Sync your Stripe account to your Postgres database";
+    homepage = "https://github.com/supabase/stripe-sync-engine";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.lgug2z ];
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION
This PR adds a package for [stripe-sync-engine](https://github.com/supabase/stripe-sync-engine) by Supabase, and adds me to the maintainers list.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
