### PR TITLE
memento: 1.6.0 -> 1.7.0 + moved to by-name + OCR (optional) support

### DIFF
--- a/pkgs/applications/video/memento/default.nix
+++ b/pkgs/applications/video/memento/default.nix
@@ -9,23 +9,58 @@
   # before that => zeal
   sqlite,
   json_c,
-  mecab,
   libzip,
   mpv,
   yt-dlp,
-  # optional
   makeWrapper,
+  qcoro,
+  withOcr ? false,
+  python3,
 }:
+let
+  libmocr = stdenv.mkDerivation {
+    pname = "libmocr";
+    version = "unstable-2023-11-15"; # Placeholder version
+
+    src = fetchFromGitHub {
+      owner = "ripose-jp";
+      repo = "libmocr";
+      rev = "24ec081102208d0ff6954c3003df2fb691713bd5";
+      hash = "sha256-58W/LBJ+wIxQtutoXqq6TzpExbUBV3NfAfXTIl43ARg=";
+    };
+
+    nativeBuildInputs = [ cmake ];
+    buildInputs = [
+      qt6.qtbase
+      python3
+    ];
+    dontWrapQtApps = true;
+    meta = with lib; {
+      description = "A library for Manga OCR";
+      homepage = "https://github.com/ripose-jp/libmocr";
+      license = licenses.gpl2;
+      platforms = platforms.linux;
+    };
+  };
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "memento";
-  version = "1.6.0";
+  version = "1.7.0";
 
   src = fetchFromGitHub {
     owner = "ripose-jp";
     repo = "Memento";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-IvzvlToSyA20FWU0x+wgE3rT0dYbuY6xyaGgz1D1f6Q=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-6ipzorykt9GoGTHTTLCyDf7vXx9mT5AITKA9pyQ3GwI=";
   };
+
+  cmakeFlags = [
+    (lib.cmakeBool "SYSTEM_QCORO" true)
+    (lib.cmakeBool "SYSTEM_MOCR" true)
+  ]
+  ++ lib.optionals withOcr [
+    (lib.cmakeBool "OCR_SUPPORT" true)
+  ];
 
   nativeBuildInputs = [
     cmake
@@ -40,15 +75,26 @@ stdenv.mkDerivation (finalAttrs: {
     sqlite
     json_c
     libzip
-    mecab
-  ];
+    qcoro
+  ]
+
+  ++ lib.optionals withOcr [ libmocr ];
 
   propagatedBuildInputs = [ mpv ];
 
-  preFixup = ''
-    wrapProgram "$out/bin/memento" \
-      --prefix PATH : "${yt-dlp}/bin" \
-  '';
+  preFixup =
+    let
+      pyEnv = python3.withPackages (p: [
+        p.manga-ocr
+        p.jaconv
+      ]);
+    in
+    ''
+      wrapProgram "$out/bin/memento" \
+        --prefix PATH : "${yt-dlp}/bin" ${lib.optionalString withOcr "--suffix PYTHONPATH : \"${pyEnv}/${pyEnv.sitePackages}\""}
+    '';
+
+  passthru.libmocr = libmocr;
 
   meta = {
     description = "Mpv-based video player for studying Japanese";

--- a/pkgs/by-name/me/memento/package.nix
+++ b/pkgs/by-name/me/memento/package.nix
@@ -3,24 +3,21 @@
   stdenv,
   fetchFromGitHub,
   cmake,
-  qt6,
-  wrapQtAppsHook,
+  qt6Packages,
 
-  # before that => zeal
   sqlite,
   json_c,
   libzip,
   mpv,
   yt-dlp,
   makeWrapper,
-  qcoro,
   withOcr ? false,
   python3,
 }:
 let
   libmocr = stdenv.mkDerivation {
     pname = "libmocr";
-    version = "unstable-2023-11-15"; # Placeholder version
+    version = "0-unstable-2023-11-15";
 
     src = fetchFromGitHub {
       owner = "ripose-jp";
@@ -31,15 +28,15 @@ let
 
     nativeBuildInputs = [ cmake ];
     buildInputs = [
-      qt6.qtbase
+      qt6Packages.qtbase
       python3
     ];
     dontWrapQtApps = true;
-    meta = with lib; {
+    meta = {
       description = "A library for Manga OCR";
       homepage = "https://github.com/ripose-jp/libmocr";
-      license = licenses.gpl2;
-      platforms = platforms.linux;
+      license = lib.licenses.gpl2;
+      platforms = lib.platforms.linux;
     };
   };
 in
@@ -65,17 +62,17 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     cmake
     makeWrapper
-    wrapQtAppsHook
+    qt6Packages.wrapQtAppsHook
   ];
 
   buildInputs = [
-    qt6.qtbase
-    qt6.qtsvg
-    qt6.qtwayland
+    qt6Packages.qtbase
+    qt6Packages.qtsvg
+    qt6Packages.qtwayland
     sqlite
     json_c
     libzip
-    qcoro
+    qt6Packages.qcoro
   ]
 
   ++ lib.optionals withOcr [ libmocr ];
@@ -91,7 +88,7 @@ stdenv.mkDerivation (finalAttrs: {
     in
     ''
       wrapProgram "$out/bin/memento" \
-        --prefix PATH : "${yt-dlp}/bin" ${lib.optionalString withOcr "--suffix PYTHONPATH : \"${pyEnv}/${pyEnv.sitePackages}\""}
+        --prefix PATH : "${yt-dlp}/bin" ${lib.optionalString withOcr "--suffix PYTHONPATH : \"${pyEnv}/${python3.sitePackages}\""}
     '';
 
   passthru.libmocr = libmocr;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11337,9 +11337,6 @@ with pkgs;
     withConplay = false;
   };
 
-  # a somewhat more maintained fork of ympd
-  memento = qt6Packages.callPackage ../applications/video/memento { };
-
   mplayer = callPackage ../applications/video/mplayer (
     {
       libdvdnav = libdvdnav_4_2_1;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
