### PR TITLE
daemonize: fix build

### DIFF
--- a/pkgs/by-name/da/daemonize/include-write-prototype.patch
+++ b/pkgs/by-name/da/daemonize/include-write-prototype.patch
@@ -1,0 +1,15 @@
+diff --git a/getopt.c b/getopt.c
+index 9b27812..3fac396 100644
+--- a/getopt.c
++++ b/getopt.c
+@@ -43,9 +43,9 @@
+ #include <stdio.h>
+ /* We're ANSI now; we're guaranteed to have strchr(). */
+ #include <string.h>
++#include <unistd.h>
+ 
+ #define ERR(s, c)	if(x_opterr){\
+-	extern int write();\
+ 	char errbuf[2];\
+ 	errbuf[0] = c; errbuf[1] = '\n';\
+ 	(void) write(2, argv[0], (unsigned)strlen(argv[0]));\

--- a/pkgs/by-name/da/daemonize/package.nix
+++ b/pkgs/by-name/da/daemonize/package.nix
@@ -15,6 +15,13 @@ stdenv.mkDerivation rec {
     sha256 = "1e6LZXf/lK7sB2CbXwOg7LOi0Q8IBQNAa4d7rX0Ej3A=";
   };
 
+  patches = [
+    # conbination of:
+    # https://github.com/bmc/daemonize/commit/eaf4746d47e171e7b8655690eb1e91fc216f2866
+    # https://github.com/bmc/daemonize/pull/39
+    ./include-write-prototype.patch
+  ];
+
   meta = {
     description = "Runs a command as a Unix daemon";
     homepage = "http://software.clapper.org/daemonize/";


### PR DESCRIPTION
Include PR https://github.com/bmc/daemonize/pull/39

It fixes `daemonize` after GCC update to 15.

In `master` and `nixpkgs-unstable` the package fails to build:
```
$ nix build .#daemonize                                                                                                                                                  
error: Cannot build '/nix/store/8m0xjz1hpc9fgqzas4dyd5dh5aly6zpi-daemonize-1.7.8.drv'.                                                                                                        
       Reason: builder failed with exit code 2.                                                                                                                                               
       Output paths:                                                                                                                                                                          
         /nix/store/ccnf5lgi8ai08b8a94kyqq3al7bng3fp-daemonize-1.7.8                                                                                                                          
       Last 25 log lines:                                                                      
       > getopt.c:52:16: error: too many arguments to function 'write'; expected 0, have 3     
       >    52 |         (void) write(2, s, (unsigned)strlen(s));\                             
       >       |                ^~~~~ ~                                                                                                                                                       
       > getopt.c:89:25: note: in expansion of macro 'ERR'                                     
       >    89 |                         ERR(": option requires an argument -- ", c);          
       >       |                         ^~~                                                   
       > getopt.c:48:20: note: declared here                                                   
       >    48 |         extern int write();\                                                  
       >       |                    ^~~~~                                                                                                                                                     
       > getopt.c:89:25: note: in expansion of macro 'ERR'                                     
       >    89 |                         ERR(": option requires an argument -- ", c);                                                                                                         
       >       |                         ^~~                                                   
       > getopt.c:53:16: error: too many arguments to function 'write'; expected 0, have 3                                                                                                    
       >    53 |         (void) write(2, errbuf, 2);}                                                                                                                                         
       >       |                ^~~~~ ~                                                                                                                                                       
       > getopt.c:89:25: note: in expansion of macro 'ERR'                                                                                                                                    
       >    89 |                         ERR(": option requires an argument -- ", c);          
       >       |                         ^~~                                                   
       > getopt.c:48:20: note: declared here                                                                                                                                                  
       >    48 |         extern int write();\                                                  
       >       |                    ^~~~~
       > getopt.c:89:25: note: in expansion of macro 'ERR'
       >    89 |                         ERR(": option requires an argument -- ", c);
       >       |                         ^~~
       > make: *** [Makefile:22: getopt.o] Error 1
       For full logs, run:
         nix log /nix/store/8m0xjz1hpc9fgqzas4dyd5dh5aly6zpi-daemonize-1.7.8.drv
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
