### PR TITLE
treewide: use overlays to pass a custom stdenv to buildPythonPackage / bulidPythonApplication

### DIFF
--- a/pkgs/applications/networking/browsers/webmacs/default.nix
+++ b/pkgs/applications/networking/browsers/webmacs/default.nix
@@ -7,9 +7,7 @@
   herbstluftwm,
 }:
 
-mkDerivationWith python3Packages.buildPythonApplication rec {
-  inherit stdenv;
-
+mkDerivationWith (python3Packages.buildPythonApplication.override { inherit stdenv; }) rec {
   pname = "webmacs";
   version = "0.8";
   format = "setuptools";

--- a/pkgs/by-name/xp/xpra/package.nix
+++ b/pkgs/by-name/xp/xpra/package.nix
@@ -48,7 +48,7 @@
   withHtml ? true,
   xpra-html5,
   udevCheckHook,
-}@args:
+}:
 
 let
   inherit (python3.pkgs) cython buildPythonApplication;
@@ -86,13 +86,14 @@ let
     mkdir -p $out/include $out/lib/pkgconfig
     substituteAll ${cudaPackages.libnvjpeg.dev}/share/pkgconfig/nvjpeg.pc $out/lib/pkgconfig/nvjpeg.pc
   '';
+  effectiveBuildPythonApplication = buildPythonApplication.override {
+    stdenv = if withNvenc then cudaPackages.backendStdenv else stdenv;
+  };
 in
-buildPythonApplication rec {
+effectiveBuildPythonApplication rec {
   pname = "xpra";
   version = "6.3.6";
   format = "setuptools";
-
-  stdenv = if withNvenc then cudaPackages.backendStdenv else args.stdenv;
 
   src = fetchFromGitHub {
     owner = "Xpra-org";

--- a/pkgs/development/python-modules/cupy/default.nix
+++ b/pkgs/development/python-modules/cupy/default.nix
@@ -49,12 +49,10 @@ let
       outpaths ++ lib.concatMap (outpath: lib.map (output: outpath.${output}) outpath.outputs) outpaths;
   };
 in
-buildPythonPackage rec {
+buildPythonPackage.override { stdenv = cudaPackages.backendStdenv; } rec {
   pname = "cupy";
   version = "13.6.0";
   pyproject = true;
-
-  stdenv = cudaPackages.backendStdenv;
 
   src = fetchFromGitHub {
     owner = "cupy";

--- a/pkgs/development/python-modules/dlib/default.nix
+++ b/pkgs/development/python-modules/dlib/default.nix
@@ -5,9 +5,8 @@
   more-itertools,
 }:
 
-buildPythonPackage {
+buildPythonPackage.override { inherit (dlib) stdenv; } {
   inherit (dlib)
-    stdenv
     pname
     version
     src

--- a/pkgs/development/python-modules/llama-cpp-python/default.nix
+++ b/pkgs/development/python-modules/llama-cpp-python/default.nix
@@ -39,7 +39,7 @@
 let
   stdenvTarget = if cudaSupport then gcc13Stdenv else stdenv;
 in
-buildPythonPackage rec {
+buildPythonPackage.override { stdenv = stdenvTarget; } rec {
   pname = "llama-cpp-python";
   version = "0.3.16";
   pyproject = true;
@@ -107,8 +107,6 @@ buildPythonPackage rec {
       libcublas # cublas_v2.h
     ]
   );
-
-  stdenv = stdenvTarget;
 
   dependencies = [
     diskcache

--- a/pkgs/development/python-modules/openusd/default.nix
+++ b/pkgs/development/python-modules/openusd/default.nix
@@ -33,6 +33,7 @@
   python,
   qt6,
   setuptools,
+  stdenv,
   onetbb,
   withDocs ? false,
   withOsl ? true,
@@ -60,8 +61,6 @@ buildPythonPackage rec {
     tag = "v${version}";
     hash = "sha256-gxikEC4MqTkhgYaRsCVYtS/VmXClSaCMdzpQ0LmiR7Q=";
   };
-
-  stdenv = python.stdenv;
 
   outputs = [ "out" ] ++ lib.optional withDocs "doc";
 

--- a/pkgs/development/python-modules/psutil/default.nix
+++ b/pkgs/development/python-modules/psutil/default.nix
@@ -14,8 +14,6 @@ buildPythonPackage rec {
   version = "7.1.3";
   pyproject = true;
 
-  inherit stdenv;
-
   src = fetchFromGitHub {
     owner = "giampaolo";
     repo = "psutil";

--- a/pkgs/development/python-modules/python-mapnik/default.nix
+++ b/pkgs/development/python-modules/python-mapnik/default.nix
@@ -5,6 +5,7 @@
   replaceVars,
   isPyPy,
   python,
+  stdenv,
   setuptools,
   pillow,
   pycairo,
@@ -27,7 +28,7 @@
   pybind11,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "python-mapnik";
   version = "4.1.3.unstable-2025-09-25";
   pyproject = true;
@@ -48,8 +49,6 @@ buildPythonPackage rec {
       libmapnik = "${mapnik}/lib";
     })
   ];
-
-  stdenv = python.stdenv;
 
   build-system = [ setuptools ];
 

--- a/pkgs/development/python-modules/torchaudio/default.nix
+++ b/pkgs/development/python-modules/torchaudio/default.nix
@@ -74,13 +74,12 @@ let
     else
       throw "No GPU targets specified"
   );
+  stdenv = torch.stdenv;
 in
-buildPythonPackage rec {
+buildPythonPackage.override { inherit stdenv; } rec {
   pname = "torchaudio";
   version = "2.9.1";
   pyproject = true;
-
-  stdenv = torch.stdenv;
 
   src = fetchFromGitHub {
     owner = "pytorch";

--- a/pkgs/development/python-modules/torchvision/default.nix
+++ b/pkgs/development/python-modules/torchvision/default.nix
@@ -30,11 +30,9 @@ let
   pname = "torchvision";
   version = "0.24.1";
 in
-buildPythonPackage {
+buildPythonPackage.override { stdenv = torch.stdenv; } {
   format = "setuptools";
   inherit pname version;
-
-  stdenv = torch.stdenv;
 
   src = fetchFromGitHub {
     owner = "pytorch";

--- a/pkgs/development/python-modules/verilogae/default.nix
+++ b/pkgs/development/python-modules/verilogae/default.nix
@@ -14,12 +14,10 @@
   zlib,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage.override { stdenv = llvmPackages.stdenv; } rec {
   pname = "verilogae";
   version = "24.0.0mob-unstable-2025-07-21";
   pyproject = true;
-
-  stdenv = llvmPackages.stdenv;
 
   src = fetchFromGitHub {
     owner = "OpenVAF";

--- a/pkgs/development/python-modules/vllm/default.nix
+++ b/pkgs/development/python-modules/vllm/default.nix
@@ -313,12 +313,10 @@ let
 
 in
 
-buildPythonPackage rec {
+buildPythonPackage.override { stdenv = torch.stdenv; } rec {
   pname = "vllm";
   version = "0.13.0";
   pyproject = true;
-
-  stdenv = torch.stdenv;
 
   src = fetchFromGitHub {
     owner = "vllm-project";

--- a/pkgs/development/python-modules/warp-lang/default.nix
+++ b/pkgs/development/python-modules/warp-lang/default.nix
@@ -43,7 +43,7 @@ let
 
   libmathdx = callPackage ./libmathdx.nix { };
 in
-buildPythonPackage {
+buildPythonPackage.override { stdenv = effectiveStdenv; } {
   pname = "warp-lang";
   inherit version;
   pyproject = true;
@@ -52,8 +52,6 @@ buildPythonPackage {
   # causing a bunch of missing math symbols (like expf) when linking against the static library
   # provided by NVCC.
   __structuredAttrs = true;
-
-  stdenv = effectiveStdenv;
 
   src = fetchFromGitHub {
     owner = "NVIDIA";

--- a/pkgs/development/python-modules/xformers/default.nix
+++ b/pkgs/development/python-modules/xformers/default.nix
@@ -35,8 +35,9 @@ let
   # version 0.0.32.post2 was confirmed to break CUDA.
   # Remove this note once the latest published revision "just works".
   version = "0.0.30";
+  effectiveStdenv = if cudaSupport then cudaPackages.backendStdenv else stdenv;
 in
-buildPythonPackage {
+buildPythonPackage.override { stdenv = effectiveStdenv; } {
   pname = "xformers";
   inherit version;
   pyproject = true;
@@ -65,8 +66,6 @@ buildPythonPackage {
   env = lib.attrsets.optionalAttrs cudaSupport {
     TORCH_CUDA_ARCH_LIST = "${lib.concatStringsSep ";" torch.cudaCapabilities}";
   };
-
-  stdenv = if cudaSupport then cudaPackages.backendStdenv else stdenv;
 
   buildInputs =
     lib.optional stdenv.hostPlatform.isDarwin openmp

--- a/pkgs/test/overriding.nix
+++ b/pkgs/test/overriding.nix
@@ -446,20 +446,6 @@ let
         expr = package-stub-libcxx.stdenv;
         expected = pkgs.libcxxStdenv;
       };
-      overridePythonAttrs-stdenv-deprecated = {
-        expr =
-          (package-stub.overridePythonAttrs (_: {
-            stdenv = pkgs.clangStdenv;
-          })).stdenv;
-        expected = pkgs.clangStdenv;
-      };
-      overridePythonAttrs-override-clangStdenv-deprecated-nested = {
-        expr =
-          (package-stub-gcc.overridePythonAttrs {
-            stdenv = pkgs.clangStdenv;
-          }).stdenv;
-        expected = pkgs.clangStdenv;
-      };
 
       overridePythonAttrs = {
         expr = (applyOverridePythonAttrs package-stub).overridePythonAttrsFlag;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Bumping `oldestSupportedRelease` to `2511` failed because of multiple

```
evaluation warning: Passing `stdenv` directly to `buildPythonPackage` or `buildPythonApplication` is deprecated. You should use their `.override` function instead, e.g:
    buildPythonPackage.override { stdenv = customStdenv; } { }
```

This PR either uses this approach or just removes superfluous `stdenv` declarations.

Required for #476384

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
