### PR TITLE
[Backport release-25.11]: python3Packages.torchao, python3Packages.torchtune: disable tests that fail on darwin, adopt

### DIFF
--- a/pkgs/development/python-modules/torchao/default.nix
+++ b/pkgs/development/python-modules/torchao/default.nix
@@ -223,6 +223,9 @@ buildPythonPackage rec {
     homepage = "https://github.com/pytorch/ao";
     changelog = "https://github.com/pytorch/ao/releases/tag/v${version}";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ GaetanLepage ];
+    maintainers = with lib.maintainers; [
+      GaetanLepage
+      sarahec
+    ];
   };
 }

--- a/pkgs/development/python-modules/torchao/default.nix
+++ b/pkgs/development/python-modules/torchao/default.nix
@@ -185,6 +185,19 @@ buildPythonPackage rec {
     # RuntimeError: quantized engine NoQEngine is not supported
     "test_smooth_linear_cpu"
     "test_smooth_linear_edge_cases"
+
+    # TypeError: Trying to convert Float8_e4m3fn to the MPS backend but it does not have support for that dtype.
+    "test_subclass_slice_subclass2_shape0_device_mps"
+    "test_subclass_slice_subclass2_shape1_device_mps"
+    # torch._inductor.exc.InductorError: KeyError: torch.float8_e4m3fn
+    "test_optim_default_dtype_bf16_optim_name_AdamFp8_device_mps"
+    "test_optim_smoke_optim_name_AdamWFp8_bfloat16_device_mps"
+    "test_optim_smoke_optim_name_AdamWFp8_float32_device_mps"
+    "test_param_groups_optim_name_AdamFp8_device_mps"
+    "test_subclass_slice_subclass0_shape0_device_mps"
+    "test_optim_smoke_optim_name_AdamFp8_bfloat16_device_mps"
+    "test_optim_smoke_optim_name_AdamFp8_float32_device_mps"
+    "test_subclass_slice_subclass0_shape1_device_mps"
   ]
   ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) [
     # Flaky: [gw0] node down: keyboard-interrupt

--- a/pkgs/development/python-modules/torchao/default.nix
+++ b/pkgs/development/python-modules/torchao/default.nix
@@ -168,7 +168,7 @@ buildPythonPackage rec {
     "test_save_load_int8woqtensors_0_cpu"
     "test_save_load_int8woqtensors_1_cpu"
   ]
-  ++ lib.optionals (stdenv.hostPlatform.isDarwin) [
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # AssertionError: Scalars are not equal!
     "test_comm"
     "test_fsdp2"
@@ -176,8 +176,7 @@ buildPythonPackage rec {
     "test_precompute_bitnet_scale"
     "test_qlora_fsdp2"
     "test_uneven_shard"
-  ]
-  ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) [
+
     # RuntimeError: No packed_weights_format was selected
     "TestIntxOpaqueTensor"
     "test_accuracy_kleidiai"
@@ -206,7 +205,7 @@ buildPythonPackage rec {
     "test_int8_weight_only_quant_with_freeze_2_cpu"
   ];
 
-  disabledTestPaths = lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) [
+  disabledTestPaths = lib.optionals stdenv.hostPlatform.isDarwin [
     # Require unpackaged 'coremltools'
     "test/prototype/test_groupwise_lowbit_weight_lut_quantizer.py"
 

--- a/pkgs/development/python-modules/torchao/default.nix
+++ b/pkgs/development/python-modules/torchao/default.nix
@@ -203,6 +203,9 @@ buildPythonPackage rec {
     "test_int8_weight_only_quant_with_freeze_0_cpu"
     "test_int8_weight_only_quant_with_freeze_1_cpu"
     "test_int8_weight_only_quant_with_freeze_2_cpu"
+
+    # Illegal instruction in subclass_4bit.py::dequantize
+    "test_subclass_slice"
   ];
 
   disabledTestPaths = lib.optionals stdenv.hostPlatform.isDarwin [

--- a/pkgs/development/python-modules/torchtune/default.nix
+++ b/pkgs/development/python-modules/torchtune/default.nix
@@ -114,6 +114,21 @@ buildPythonPackage rec {
   ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [
     # Fatal Python error: Segmentation fault
     "test_forward_gqa"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # tests/torchtune/training/test_distributed.py
+    "test_init_from_env_no_dup"
+    "test_init_from_env_dup"
+  ];
+
+  disabledTestPaths = lib.optionals stdenv.hostPlatform.isDarwin [
+    # fail due to floating-point precision differences
+    "tests/torchtune/models/flux/test_flux_autoencoder.py::TestFluxAutoencoder::test_encode"
+    "tests/torchtune/modules/peft/test_dora.py::TestDoRALinear::test_qdora_parity[True-dtype1]"
+    "tests/torchtune/modules/peft/test_lora.py::TestLoRALinear::test_qlora_parity[True-dtype1]"
+
+    # hangs
+    "tests/torchtune/utils"
   ];
 
   meta = {

--- a/pkgs/development/python-modules/torchtune/default.nix
+++ b/pkgs/development/python-modules/torchtune/default.nix
@@ -85,6 +85,9 @@ buildPythonPackage rec {
     writableTmpDirAsHomeHook
   ];
 
+  # Exclude `regression` which depends on a specific llama model and `recipies` which are sample code
+  enabledTestPaths = [ "tests/torchtune" ];
+
   disabledTests = [
     # AssertionError (tensors are not equal)
     "test_stop_tokens"

--- a/pkgs/development/python-modules/torchtune/default.nix
+++ b/pkgs/development/python-modules/torchtune/default.nix
@@ -121,6 +121,9 @@ buildPythonPackage rec {
     homepage = "https://github.com/meta-pytorch/torchtune";
     changelog = "https://github.com/meta-pytorch/torchtune/releases/tag/${src.tag}";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ GaetanLepage ];
+    maintainers = with lib.maintainers; [
+      GaetanLepage
+      sarahec
+    ];
   };
 }


### PR DESCRIPTION
Manual backport of #471546 (without the executorch change, as executorch does not exist on 25.11).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
