### PR TITLE
mlterm: force c17 on gcc to fix build with gcc15

### DIFF
--- a/pkgs/by-name/ml/mlterm/package.nix
+++ b/pkgs/by-name/ml/mlterm/package.nix
@@ -251,5 +251,7 @@ stdenv.mkDerivation (finalAttrs: {
     ];
     platforms = lib.platforms.all;
     mainProgram = desktopBinary;
+    # https://github.com/arakiken/mlterm/issues/157
+    broken = stdenv.hostPlatform.isDarwin;
   };
 })

--- a/pkgs/by-name/ml/mlterm/package.nix
+++ b/pkgs/by-name/ml/mlterm/package.nix
@@ -181,8 +181,12 @@ stdenv.mkDerivation (finalAttrs: {
       --replace "-m 4755 -o root" " "
   '';
 
-  env = lib.optionalAttrs stdenv.cc.isClang {
-    NIX_CFLAGS_COMPILE = "-Wno-error=int-conversion -Wno-error=incompatible-function-pointer-types";
+  env = {
+    NIX_CFLAGS_COMPILE =
+      (lib.optionalString stdenv.cc.isClang "-Wno-error=int-conversion -Wno-error=incompatible-function-pointer-types ")
+      # GCC15 defaults to C23 which is stricter about prototypes
+      # There are upstream fixes, but they are not in 3.9.4 release
+      + (lib.optionalString stdenv.cc.isGNU " -std=c17 ");
   };
 
   configureFlags = [


### PR DESCRIPTION
Upstream has fixed the issues preventing build with GCC15, but the latest released version is incompatible with C23.

This PR requires a working uim, see #476118

This PR is an alternative to #476122 

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
