### PR TITLE
brotato: init at 1.1.13.2

### DIFF
--- a/pkgs/by-name/br/brotato/package.nix
+++ b/pkgs/by-name/br/brotato/package.nix
@@ -1,0 +1,76 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  makeWrapper,
+  godot3,
+  libicns,
+  copyDesktopItems,
+  makeDesktopItem,
+  requireFile,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "brotato";
+  version = "1.1.13.2";
+
+  src = requireFile {
+    name = "Brotato.pck";
+    url = "https://store.epicgames.com/en-US/p/brotato-ed4097";
+    hash = "sha256-/k/rnypHS3Gtj5nHb1cnx1JvCiJAKe+1JxlXolWksS0=";
+  };
+
+  srcIcon = fetchurl {
+    name = "brotato.icns";
+    url = "https://shared.fastly.steamstatic.com/community_assets/images/apps/1942280/c096e6b30bcb9749183fe5d1b78f77de7ae89383.icns";
+    hash = "sha256-6ZZ1kqdOjqwIByrX1Bqrhy2yMaShlsbsEhuDBTK77gw=";
+  };
+
+  dontUnpack = true;
+
+  nativeBuildInputs = [
+    makeWrapper
+    godot3
+    libicns
+    copyDesktopItems
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+
+    makeWrapper ${lib.getExe godot3} $out/bin/brotato \
+      --add-flags "--main-pack $src"
+
+    cp $srcIcon brotato.icns
+    icns2png -x brotato.icns
+    mkdir -p $out/share/icons/hicolor/512x512/apps
+    install -Dm644 brotato_512x512x32.png $out/share/icons/hicolor/512x512/apps/brotato.png
+
+    runHook postInstall
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "brotato";
+      desktopName = "Brotato";
+      exec = "brotato";
+      icon = "brotato";
+      comment = finalAttrs.meta.description;
+      categories = [
+        "Game"
+        "ActionGame"
+        "Shooter"
+      ];
+      terminal = false;
+    })
+  ];
+
+  meta = {
+    description = "Only potato capable of handling 6 weapons at the same time";
+    homepage = "https://www.blobfishgames.com/";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ appsforartists ];
+    platforms = lib.platforms.linux;
+    mainProgram = "brotato";
+  };
+})

--- a/pkgs/development/tools/godot/3/default.nix
+++ b/pkgs/development/tools/godot/3/default.nix
@@ -182,6 +182,7 @@ stdenv.mkDerivation (self: {
       "x86_64-linux"
       "aarch64-linux"
     ];
+    mainProgram = "godot3";
     maintainers = with lib.maintainers; [
       rotaerk
       twey


### PR DESCRIPTION
Brotato is a popular indie game written for the cross-platform Godot engine.  It has an official Linux release on Steam, but not on Epic.  Many people have the Epic version, because it is sometimes offered there for free.

This allows the Epic version to be run in Nix, following the same spirit as the [`balatro` derivation](https://github.com/NixOS/nixpkgs/blob/nixos-25.11/pkgs/by-name/ba/balatro/package.nix)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage]. 
   (I tried and I got an OOM error.  I don't think this should be needed for a simple package addition.)
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
