### PR TITLE
We10XOS-cursors: init at 0-unstable-2026-01-02

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -20398,6 +20398,12 @@
     github = "peret";
     githubId = 617977;
   };
+  persn = {
+    email = "jkerper@persn.dev";
+    github = "spjoes";
+    githubId = 34802651;
+    name = "Joey Kerper";
+  };
   perstark = {
     email = "perstark.se@gmail.com";
     github = "perstarkse";

--- a/pkgs/by-name/we/we10xos-cursors/package.nix
+++ b/pkgs/by-name/we/we10xos-cursors/package.nix
@@ -6,7 +6,7 @@
 
 stdenvNoCC.mkDerivation {
   pname = "we10xos-cursors";
-  version = "0-unstable-2026-01-02";
+  version = "0-unstable-2020-11-03";
 
   src = fetchFromGitHub {
     owner = "yeyushengfan258";

--- a/pkgs/by-name/we/we10xos-cursors/package.nix
+++ b/pkgs/by-name/we/we10xos-cursors/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "we10xos-cursors";
+  version = "0-unstable-2026-01-02";
+
+  src = fetchFromGitHub {
+    owner = "yeyushengfan258";
+    repo = "We10XOS-cursors";
+    rev = "b971891cc016ba780af791ac9872a15406695ad8";
+    hash = "sha256-dy6gA2jZa0pxwXDnc3ckxWd01k2UG0EWG8hoeU5T28Y=";
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/icons/We10XOS
+    cp -r $src/dist/* $out/share/icons/We10XOS/
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "We10XOS cursors for linux desktops";
+    homepage = "https://github.com/yeyushengfan258/We10XOS-cursors";
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.linux;
+    maintainers = [ ];
+  };
+}

--- a/pkgs/by-name/we/we10xos-cursors/package.nix
+++ b/pkgs/by-name/we/we10xos-cursors/package.nix
@@ -31,6 +31,6 @@ stdenvNoCC.mkDerivation {
     homepage = "https://github.com/yeyushengfan258/We10XOS-cursors";
     license = lib.licenses.gpl3Only;
     platforms = lib.platforms.linux;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ persn ];
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Add the [We10XOS cursors](https://github.com/yeyushengfan258/We10XOS-cursors) to Nixpkgs.

### Description
This PR adds the We10XOS-cursors package at version 0-unstable-2026-01-02.
We10XOS-cursors is an x-cursor theme inspired by Windows and based on [capitaine-cursors](https://github.com/keeferrourke/capitaine-cursors).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
