### PR TITLE
tracy: 0.11.1 -> {0.11.1, 0.12.2, 0.13.1}

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6099,6 +6099,12 @@
     githubId = 10701143;
     name = "David Crompton";
   };
+  davidkern = {
+    email = "nixpkgs-davidkern@proton.me";
+    github = "davidkern";
+    githubId = 1548554;
+    name = "David Kern";
+  };
   davidlghellin = {
     email = "hola@devel0pez.com";
     github = "davidlghellin";

--- a/pkgs/by-name/tr/tracy/README.md
+++ b/pkgs/by-name/tr/tracy/README.md
@@ -1,0 +1,137 @@
+# Tracy Profiler
+
+Upstream: [wolfpld/tracy](https://github.com/wolfpld/tracy)
+
+The Tracy profiler guarantees neither forward nor backward compatibility of its
+tracing protocol between releases of the Tracy UI, requiring the UI version to match
+the SDK version of the compiled target. Providing a single version of Tracy suffices
+for in-tree packages, however developers working on out-of-tree projects need a Tracy
+compatible with their build.
+
+To support both scenarios, this provides several versions of Tracy (`tracy_x_xx`)
+with the most recent available "by name" as `tracy`.
+
+## Version Retention Guidelines
+
+Older releases of Tracy are provided as a convenience, not a guarantee. Maintainers
+should balance relevance to nixpkgs, maintainance burden, and user need.
+
+- Dependants in nixpkgs use `tracy` rather than a pinned version;
+- No more than three pinned versions of Tracy are maintained, assuming annual release
+  cadence of upstream;
+- Older versions which block or inconvenience an upgrade to nixpkgs as a whole will be
+  dropped;
+- Exceptions or changes to guidelines are documented here.
+
+As with all packages, maintainers should use their best judgement on what to drop and
+what to retain.
+
+## Tracy Dependencies
+
+Tracy uses [CPM.cmake](https://github.com/cpm-cmake/CPM.cmake) to manage its dependencies.
+CPM normally downloads dependencies during cmake configure, but that is incompatible with a
+nixpkg build. This package uses several [Devendoring Strategies](#devendoring-strategies)
+to provide dependencies to upstream's cmake build environment.
+
+| Strategy                      | When to Use                                          |
+|-------------------------------|------------------------------------------------------|
+| nixpkgs                       | CPM NAME matches cmake package name                  |
+| nixpkgs FindPackage           | CPM NAME or target name differs from nixpkgs         |
+| nixpkgs src                   | Need different build options than nixpkgs default    |
+| vendored                      | Package not in nixpkgs or incompatible               |
+
+### Tracy 0.11.x
+
+| Dependency        | Tracy Ver | nixpkgs Ver | Strategy        | Notes                     |
+|-------------------|-----------|-------------|-----------------|---------------------------|
+| capstone          | 5.0.1     | 5.0.6       | nixpkgs         |                           |
+| glfw              | 3.3.8     | 3.4         | nixpkgs         |                           |
+| wayland-protocols | 1.32      | 1.46        | nixpkgs         | XML protocol files only   |
+
+### Tracy 0.12.x
+
+| Dependency           | Tracy Ver        | nixpkgs Ver | Strategy            | Notes                          |
+|----------------------|------------------|-------------|---------------------|--------------------------------|
+| capstone             | 6.0.0-Alpha1     | 5.0.6       | vendored            | Needs v6 alpha                 |
+| ImGui                | 1.91.9b-docking  | 1.91.4      | vendored            | Needs docking branch           |
+| nfd                  | 1.2.1            | 1.2.1       | nixpkgs src         | ABI mismatch (NFD_PORTAL)      |
+| PackageProject.cmake | 1.11.1           | -           | vendored            | Transitive dep of PPQSort      |
+| PPQSort              | 1.0.5            | -           | vendored            | Not in nixpkgs                 |
+| zstd                 | 1.5.6            | 1.5.7       | nixpkgs FindPackage | `Findzstd.cmake` alias         |
+| wayland-protocols    | 1.37             | 1.46        | nixpkgs             | XML protocol files only        |
+
+### Tracy 0.13.x
+
+| Dependency           | Tracy Ver        | nixpkgs Ver | Strategy              | Notes                          |
+|----------------------|------------------|-------------|-----------------------|--------------------------------|
+| base64               | 0.5.2            | -           | vendored              | Not in nixpkgs                 |
+| capstone             | 6.0.0-Alpha5     | 5.0.6       | vendored              | Needs v6 alpha                 |
+| curl                 | 8.17.0           | 8.17.0      | nixpkgs               |                                |
+| ImGui                | 1.92.5-docking   | 1.91.4      | vendored              | Needs docking branch           |
+| html-tidy            | 5.8.0            | 5.8.0       | nixpkgs FindPackage   | `Findtidy.cmake` shim          |
+| md4c                 | 0.5.2            | 0.5.2       | nixpkgs               |                                |
+| nfd                  | 1.2.1            | 1.2.1       | nixpkgs src           | ABI mismatch (NFD_PORTAL)      |
+| nlohmann_json        | 3.12.0           | 3.12.0      | nixpkgs FindPackage   | `Findjson.cmake` shim          |
+| PackageProject.cmake | 1.11.1           | -           | vendored              | Transitive dep of PPQSort      |
+| PPQSort              | 1.0.6            | -           | vendored              | Not in nixpkgs                 |
+| pugixml              | 1.15             | 1.15        | nixpkgs               |                                |
+| usearch              | 2.21.3           | -           | vendored              | Not in nixpkgs                 |
+| wayland-protocols    | 1.37             | 1.46        | nixpkgs               | XML protocol files only        |
+| zstd                 | 1.5.6            | 1.5.7       | nixpkgs FindPackage   | `Findzstd.cmake` alias         |
+
+## Devendoring Strategies
+
+## Strategy: nixpkgs
+
+The CPM `NAME` matches the cmake package name and the package provides cmake config or pkg-config.
+
+### Mechanism
+
+With `CPM_LOCAL_PACKAGES_ONLY=TRUE`, CPM calls `find_package()` before attempting download. If the
+nixpkgs package is found, CPM uses it.
+
+### Implementation
+
+Add the nixpkgs dependency to `extrabuildInputs`.
+
+## Strategy: nixpkgs FindPackage
+
+A compatible nixpkgs package exists but either:
+- CPM uses a different `NAME` than the cmake package name
+- cmake target names differ from what tracy expects
+
+### Mechanism
+
+Find modules in `CMAKE_MODULE_PATH` are tried before config files. When `find_package(foo)` is called, cmake finds our `Findfoo.cmake` which can delegate to the real package and create any necessary aliases.
+
+### Implementation
+
+- Add the nixpkgs dependency to `extrabuildInputs`.
+- Create a `Find<dep>.cmake` module in the `cmake` directory and adjust package and target names.
+
+## Strategy: nixpkgs src
+
+Package exists in nixpkgs with compatible source but upstream needs different build options.
+
+### Mechanism
+
+With a `CPM_<dep>_SOURCE` cmake option set, CPM finds the dependency sources in the provided directory.
+
+### Implementation
+
+Add the nixpkgs package `.src` attribute to the `cpmSrcs` list with a `name` attribute matching the
+CPM `NAME`.
+
+## Strategy: Vendored Source
+
+Package is not available in nixpkgs or is incompatible.
+
+### Mechansim
+
+Uses the same mechanism as a nixpkg src, except the source is downloaded with a fetcher such as
+`fetchFromGithub`.
+
+### Implementation
+
+Add an appropriate fetcher to the `cpmSrcs` list, ensuring that the name matches what CPM expects (case-sensitive).
+

--- a/pkgs/by-name/tr/tracy/cmake/Findjson.cmake
+++ b/pkgs/by-name/tr/tracy/cmake/Findjson.cmake
@@ -1,0 +1,5 @@
+# tracy CPM uses NAME `json` but nixpkgs provides `nlohmann_json`.
+find_package(nlohmann_json REQUIRED)
+
+set(json_FOUND TRUE)
+set(json_VERSION "${nlohmann_json_VERSION}")

--- a/pkgs/by-name/tr/tracy/cmake/Findtidy.cmake
+++ b/pkgs/by-name/tr/tracy/cmake/Findtidy.cmake
@@ -1,0 +1,13 @@
+# tracy CPM uses NAME `tidy` and links against `tidy-static`.
+# tracy also uses ${tidy_SOURCE_DIR}/include for headers.
+# nixpkgs `html-tidy` provides `tidy` via pkg-config.
+include(FindPkgConfig)
+pkg_check_modules(TIDY REQUIRED IMPORTED_TARGET tidy)
+
+add_library(tidy-static ALIAS PkgConfig::TIDY)
+
+# TIDY_INCLUDE_DIRS is e.g. /nix/store/.../include, we need the parent
+list(GET TIDY_INCLUDE_DIRS 0 _tidy_inc)
+get_filename_component(tidy_SOURCE_DIR "${_tidy_inc}" DIRECTORY)
+
+set(tidy_FOUND TRUE)

--- a/pkgs/by-name/tr/tracy/cmake/Findzstd.cmake
+++ b/pkgs/by-name/tr/tracy/cmake/Findzstd.cmake
@@ -1,0 +1,7 @@
+# nixpkgs `zstd` provides `zstd::libzstd` but tracy links against `libzstd`.
+#
+# Using CONFIG mode bypasses FindPackage modules, so this won't recurse.
+find_package(zstd CONFIG REQUIRED)
+
+add_library(libzstd INTERFACE IMPORTED GLOBAL)
+target_link_libraries(libzstd INTERFACE zstd::libzstd)

--- a/pkgs/by-name/tr/tracy/package-versions.nix
+++ b/pkgs/by-name/tr/tracy/package-versions.nix
@@ -1,0 +1,226 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchFromGitLab,
+  fetchurl,
+  callPackage,
+
+  coreutils,
+  cmake,
+  ninja,
+  pkg-config,
+  wayland-scanner,
+
+  capstone,
+  dbus,
+  freetype,
+  glfw,
+  onetbb,
+
+  withGtkFileSelector ? false,
+  gtk3,
+
+  withWayland ? stdenv.hostPlatform.isLinux,
+  libglvnd,
+  libxkbcommon,
+  wayland,
+  wayland-protocols,
+  libffi,
+
+  md4c,
+  pugixml,
+  curl,
+  zstd,
+  nlohmann_json,
+  nativefiledialog-extended,
+  html-tidy,
+}:
+
+assert withGtkFileSelector -> stdenv.hostPlatform.isLinux;
+
+let
+  mkTracyPackage =
+    {
+      version,
+      srcHash,
+      cpmSrcs ? [ ],
+      patches ? [ ],
+      extraBuildInputs ? [ ],
+    }:
+    stdenv.mkDerivation {
+      inherit patches;
+
+      pname = "tracy";
+      inherit version;
+
+      src = fetchFromGitHub {
+        name = "tracy";
+        owner = "wolfpld";
+        repo = "tracy";
+        rev = "v${version}";
+        hash = "${srcHash}";
+      };
+
+      postUnpack = (
+        lib.strings.concatLines (
+          lib.lists.forEach cpmSrcs (
+            s:
+            # Make CPM sources writable for patches and set CPM_<package>_SOURCE flags
+            ''
+              cp -R ${s.out} ${s.name}
+              chmod -R u+w ${s.name}
+              appendToVar cmakeFlags -DCPM_${s.name}_SOURCE=$(pwd)/${s.name}
+            ''
+
+            # PPQSort tries to download CPM.cmake
+            # Provide it the newer version from tracy instead
+            + lib.optionalString (s.name == "PPQSort") ''
+              cp ./tracy/cmake/CPM.cmake PPQSort/cmake/CPM.cmake
+            ''
+          )
+        )
+      );
+
+      nativeBuildInputs = [
+        cmake
+        ninja
+        pkg-config
+      ]
+      ++ lib.optionals stdenv.hostPlatform.isLinux [ wayland-scanner ]
+      ++ lib.optionals stdenv.cc.isClang [ stdenv.cc.cc.libllvm ];
+
+      buildInputs = [
+        freetype
+        onetbb
+      ]
+      ++ extraBuildInputs
+      ++ lib.optionals (stdenv.hostPlatform.isLinux && withGtkFileSelector) [ gtk3 ]
+      ++ lib.optionals (stdenv.hostPlatform.isLinux && !withGtkFileSelector) [ dbus ]
+      ++ lib.optionals (stdenv.hostPlatform.isLinux && withWayland) [
+        libglvnd
+        libxkbcommon
+        wayland
+        wayland-protocols
+        libffi
+      ]
+      ++ lib.optionals (stdenv.hostPlatform.isDarwin || (stdenv.hostPlatform.isLinux && !withWayland)) [
+        glfw
+      ];
+
+      cmakeFlags = [
+        (lib.cmakeBool "DOWNLOAD_CAPSTONE" false)
+        (lib.cmakeBool "TRACY_STATIC" false)
+        (lib.cmakeBool "CPM_LOCAL_PACKAGES_ONLY" true)
+        (lib.cmakeBool "CPM_FIND_DEBUG_MODE" true)
+        (lib.cmakeFeature "CMAKE_MODULE_PATH" "${./cmake}")
+      ]
+      ++ lib.optional (stdenv.hostPlatform.isLinux && withGtkFileSelector) (
+        lib.cmakeBool "GTK_FILESELECTOR" true
+      )
+      ++ lib.optional (stdenv.hostPlatform.isLinux && !withWayland) (lib.cmakeBool "LEGACY" true)
+      ++ lib.optional (stdenv.hostPlatform.isLinux && withWayland) (
+        lib.cmakeFeature "CPM_wayland-protocols_SOURCE" "${wayland-protocols}/share/wayland-protocols"
+      );
+
+      env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isLinux "-ltbb";
+
+      dontUseCmakeBuildDir = true;
+
+      postConfigure =
+        # CPM_<package>_SOURCE flags prevent downloads but cause each of the sub-projects
+        # to apply the same patches to the same source. The patch tool will return a
+        # non-zero status, failing the build, even if configured to ignore patch re-application.
+        #
+        # The workaround is to first configure the profiler since it includes all of the
+        # dependencies and then short-circuit the patch command for the remaining projects.
+        ''
+          cmake -B profiler/build -S profiler $cmakeFlags
+
+          appendToVar cmakeFlags -DPATCH_EXECUTABLE=${coreutils}/bin/true
+
+          cmake -B capture/build -S capture $cmakeFlags
+          cmake -B csvexport/build -S csvexport $cmakeFlags
+          cmake -B import/build -S import $cmakeFlags
+          cmake -B update/build -S update $cmakeFlags
+        '';
+
+      postBuild = ''
+        ninja -C capture/build
+        ninja -C csvexport/build
+        ninja -C import/build
+        ninja -C profiler/build
+        ninja -C update/build
+      '';
+
+      postInstall = ''
+        install -D -m 0555 capture/build/tracy-capture -t $out/bin
+        install -D -m 0555 csvexport/build/tracy-csvexport $out/bin
+        install -D -m 0555 import/build/{tracy-import-chrome,tracy-import-fuchsia} -t $out/bin
+        install -D -m 0555 profiler/build/tracy-profiler $out/bin/tracy
+        install -D -m 0555 update/build/tracy-update -t $out/bin
+      ''
+      + lib.optionalString stdenv.hostPlatform.isLinux ''
+        substituteInPlace extra/desktop/tracy.desktop \
+          --replace-fail Exec=/usr/bin/tracy Exec=tracy
+
+        install -D -m 0444 extra/desktop/application-tracy.xml $out/share/mime/packages/application-tracy.xml
+        install -D -m 0444 extra/desktop/tracy.desktop $out/share/applications/tracy.desktop
+        install -D -m 0444 icon/application-tracy.svg $out/share/icons/hicolor/scalable/apps/application-tracy.svg
+        install -D -m 0444 icon/icon.png $out/share/icons/hicolor/256x256/apps/tracy.png
+        install -D -m 0444 icon/icon.svg $out/share/icons/hicolor/scalable/apps/tracy.svg
+      '';
+
+      meta = {
+        description = "Real time, nanosecond resolution, remote telemetry frame profiler for games and other applications";
+        homepage = "https://github.com/wolfpld/tracy";
+        license = lib.licenses.bsd3;
+        mainProgram = "tracy";
+        maintainers = with lib.maintainers; [
+          mpickering
+          nagisa
+        ];
+        platforms = lib.platforms.linux ++ lib.optionals (!withWayland) lib.platforms.darwin;
+      };
+    };
+in
+rec {
+  tracy_0_11 = mkTracyPackage (
+    import ./tracy-0.11.nix {
+      inherit
+        lib
+        stdenv
+        capstone
+        ;
+    }
+  );
+
+  tracy_0_12 = mkTracyPackage (
+    import ./tracy-0.12.nix {
+      inherit
+        fetchFromGitHub
+        fetchFromGitLab
+        zstd
+        nativefiledialog-extended
+        ;
+    }
+  );
+
+  tracy_0_13 = mkTracyPackage (
+    import ./tracy-0.13.nix {
+      inherit
+        fetchFromGitHub
+
+        md4c
+        pugixml
+        curl
+        zstd
+        nlohmann_json
+        nativefiledialog-extended
+        html-tidy
+        ;
+    }
+  );
+
+  tracy_latest = tracy_0_13;
+}

--- a/pkgs/by-name/tr/tracy/package.nix
+++ b/pkgs/by-name/tr/tracy/package.nix
@@ -2,7 +2,11 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchFromGitLab,
+  fetchurl,
+  callPackage,
 
+  coreutils,
   cmake,
   ninja,
   pkg-config,
@@ -22,109 +26,54 @@
   libxkbcommon,
   wayland,
   wayland-protocols,
+  libffi,
+
+  md4c,
+  pugixml,
+  curl,
+  zstd,
+  nlohmann_json,
+  nativefiledialog-extended,
+  html-tidy,
 }:
 
-assert withGtkFileSelector -> stdenv.hostPlatform.isLinux;
+(import ./package-versions.nix {
+  inherit
+    lib
+    stdenv
+    fetchFromGitHub
+    fetchFromGitLab
+    fetchurl
+    callPackage
 
-stdenv.mkDerivation (finalAttrs: {
-  pname = if withWayland then "tracy-wayland" else "tracy-glfw";
-  version = "0.11.1";
-
-  src = fetchFromGitHub {
-    owner = "wolfpld";
-    repo = "tracy";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-HofqYJT1srDJ6Y1f18h7xtAbI/Gvvz0t9f0wBNnOZK8=";
-  };
-
-  patches = lib.optional (
-    stdenv.hostPlatform.isDarwin && lib.versionOlder stdenv.hostPlatform.darwinMinVersion "11"
-  ) ./dont-use-the-uniformtypeidentifiers-framework.patch;
-
-  nativeBuildInputs = [
+    coreutils
     cmake
     ninja
     pkg-config
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isLinux [ wayland-scanner ]
-  ++ lib.optionals stdenv.cc.isClang [ stdenv.cc.cc.libllvm ];
+    wayland-scanner
 
-  buildInputs = [
     capstone
+    dbus
     freetype
+    glfw
     onetbb
-  ]
-  ++ lib.optionals (stdenv.hostPlatform.isLinux && withGtkFileSelector) [ gtk3 ]
-  ++ lib.optionals (stdenv.hostPlatform.isLinux && !withGtkFileSelector) [ dbus ]
-  ++ lib.optionals (stdenv.hostPlatform.isLinux && withWayland) [
+
+    withGtkFileSelector
+    gtk3
+
+    withWayland
     libglvnd
     libxkbcommon
     wayland
     wayland-protocols
-  ]
-  ++ lib.optionals (stdenv.hostPlatform.isDarwin || (stdenv.hostPlatform.isLinux && !withWayland)) [
-    glfw
-  ];
+    libffi
 
-  cmakeFlags = [
-    "-DDOWNLOAD_CAPSTONE=off"
-    "-DTRACY_STATIC=off"
-  ]
-  ++ lib.optional (stdenv.hostPlatform.isLinux && withGtkFileSelector) "-DGTK_FILESELECTOR=ON"
-  ++ lib.optional (stdenv.hostPlatform.isLinux && !withWayland) "-DLEGACY=on";
-
-  env.NIX_CFLAGS_COMPILE = toString (
-    [ ]
-    ++ lib.optional stdenv.hostPlatform.isLinux "-ltbb"
-    # Workaround for https://github.com/NixOS/nixpkgs/issues/19098
-    ++ lib.optional (stdenv.cc.isClang && stdenv.hostPlatform.isDarwin) "-fno-lto"
-  );
-
-  dontUseCmakeBuildDir = true;
-
-  postConfigure = ''
-    cmake -B capture/build -S capture $cmakeFlags
-    cmake -B csvexport/build -S csvexport $cmakeFlags
-    cmake -B import/build -S import $cmakeFlags
-    cmake -B profiler/build -S profiler $cmakeFlags
-    cmake -B update/build -S update $cmakeFlags
-  '';
-
-  postBuild = ''
-    ninja -C capture/build
-    ninja -C csvexport/build
-    ninja -C import/build
-    ninja -C profiler/build
-    ninja -C update/build
-  '';
-
-  postInstall = ''
-    install -D -m 0555 capture/build/tracy-capture -t $out/bin
-    install -D -m 0555 csvexport/build/tracy-csvexport $out/bin
-    install -D -m 0555 import/build/{tracy-import-chrome,tracy-import-fuchsia} -t $out/bin
-    install -D -m 0555 profiler/build/tracy-profiler $out/bin/tracy
-    install -D -m 0555 update/build/tracy-update -t $out/bin
-  ''
-  + lib.optionalString stdenv.hostPlatform.isLinux ''
-    substituteInPlace extra/desktop/tracy.desktop \
-      --replace-fail Exec=/usr/bin/tracy Exec=tracy
-
-    install -D -m 0444 extra/desktop/application-tracy.xml $out/share/mime/packages/application-tracy.xml
-    install -D -m 0444 extra/desktop/tracy.desktop $out/share/applications/tracy.desktop
-    install -D -m 0444 icon/application-tracy.svg $out/share/icons/hicolor/scalable/apps/application-tracy.svg
-    install -D -m 0444 icon/icon.png $out/share/icons/hicolor/256x256/apps/tracy.png
-    install -D -m 0444 icon/icon.svg $out/share/icons/hicolor/scalable/apps/tracy.svg
-  '';
-
-  meta = {
-    description = "Real time, nanosecond resolution, remote telemetry frame profiler for games and other applications";
-    homepage = "https://github.com/wolfpld/tracy";
-    license = lib.licenses.bsd3;
-    mainProgram = "tracy";
-    maintainers = with lib.maintainers; [
-      mpickering
-      nagisa
-    ];
-    platforms = lib.platforms.linux ++ lib.optionals (!withWayland) lib.platforms.darwin;
-  };
-})
+    md4c
+    pugixml
+    curl
+    zstd
+    nlohmann_json
+    nativefiledialog-extended
+    html-tidy
+    ;
+}).tracy_latest

--- a/pkgs/by-name/tr/tracy/tracy-0.11.nix
+++ b/pkgs/by-name/tr/tracy/tracy-0.11.nix
@@ -1,0 +1,17 @@
+{
+  lib,
+  stdenv,
+
+  capstone,
+}:
+
+{
+  version = "0.11.1";
+  srcHash = "sha256-HofqYJT1srDJ6Y1f18h7xtAbI/Gvvz0t9f0wBNnOZK8=";
+  patches = lib.optional (
+    stdenv.hostPlatform.isDarwin && lib.versionOlder stdenv.hostPlatform.darwinMinVersion "11"
+  ) ./dont-use-the-uniformtypeidentifiers-framework.patch;
+  extraBuildInputs = [
+    capstone
+  ];
+}

--- a/pkgs/by-name/tr/tracy/tracy-0.12.nix
+++ b/pkgs/by-name/tr/tracy/tracy-0.12.nix
@@ -1,0 +1,45 @@
+{
+  fetchFromGitHub,
+  fetchFromGitLab,
+
+  zstd,
+  nativefiledialog-extended,
+}:
+{
+  version = "0.12.2";
+  srcHash = "sha256-voHql8ETnrUMef14LYduKI+0LpdnCFsvpt8B6M/ZNmc=";
+  extraBuildInputs = [ zstd ];
+  cpmSrcs = [
+    (fetchFromGitHub {
+      name = "ImGui";
+      owner = "ocornut";
+      repo = "imgui";
+      rev = "v1.91.9b-docking";
+      hash = "sha256-mQOJ6jCN+7VopgZ61yzaCnt4R1QLrW7+47xxMhFRHLQ=";
+    })
+    # Use nixpkgs source but let CPM build with tracy's options (NFD_PORTAL)
+    (nativefiledialog-extended.src // { name = "nfd"; })
+    (fetchFromGitHub {
+      name = "PPQSort";
+      owner = "GabTux";
+      repo = "PPQSort";
+      rev = "v1.0.5";
+      hash = "sha256-EMZVI/uyzwX5637/rdZuMZoql5FTrsx0ESJMdLVDmfk=";
+    })
+    # Transitive from PPQSort
+    (fetchFromGitHub {
+      name = "PackageProject.cmake";
+      owner = "TheLartians";
+      repo = "PackageProject.cmake";
+      rev = "v1.11.1";
+      hash = "sha256-E7WZSYDlss5bidbiWL1uX41Oh6JxBRtfhYsFU19kzIw=";
+    })
+    (fetchFromGitHub {
+      name = "capstone";
+      owner = "capstone-engine";
+      repo = "capstone";
+      rev = "6.0.0-Alpha1";
+      hash = "sha256-oKRu3P1inWueEMIpL0uI2ayCMHZ9FIVotil4sqwLqH4=";
+    })
+  ];
+}

--- a/pkgs/by-name/tr/tracy/tracy-0.13.nix
+++ b/pkgs/by-name/tr/tracy/tracy-0.13.nix
@@ -1,0 +1,71 @@
+{
+  fetchFromGitHub,
+
+  md4c,
+  pugixml,
+  curl,
+  zstd,
+  nlohmann_json,
+  nativefiledialog-extended,
+  html-tidy,
+}:
+{
+  version = "0.13.1";
+  srcHash = "sha256-D4aQ5kSfWH9qEUaithR0W/E5pN5on0n9YoBHeMggMSE=";
+  extraBuildInputs = [
+    md4c
+    pugixml
+    curl
+    zstd
+    nlohmann_json
+    html-tidy
+  ];
+  cpmSrcs = [
+    (fetchFromGitHub {
+      name = "ImGui";
+      owner = "ocornut";
+      repo = "imgui";
+      rev = "v1.92.5-docking";
+      hash = "sha256-/jVT7+874LCeSF/pdNVTFoSOfRisSqxCJnt5/SGCXPQ=";
+    })
+    # Use nixpkgs source but let CPM build with tracy's options (NFD_PORTAL)
+    (nativefiledialog-extended.src // { name = "nfd"; })
+    (fetchFromGitHub {
+      name = "PPQSort";
+      owner = "GabTux";
+      repo = "PPQSort";
+      rev = "v1.0.6";
+      hash = "sha256-HgM+p2QGd9C8A8l/VaEB+cLFDrY2HU6mmXyTNh7xd0A=";
+    })
+    # Transitive from PPQSort
+    (fetchFromGitHub {
+      name = "PackageProject.cmake";
+      owner = "TheLartians";
+      repo = "PackageProject.cmake";
+      rev = "v1.11.1";
+      hash = "sha256-E7WZSYDlss5bidbiWL1uX41Oh6JxBRtfhYsFU19kzIw=";
+    })
+    (fetchFromGitHub {
+      name = "capstone";
+      owner = "capstone-engine";
+      repo = "capstone";
+      rev = "6.0.0-Alpha5";
+      hash = "sha256-18PTj4hvBw8RTgzaFGeaDbBfkxmotxSoGtprIjcEuVg=";
+    })
+    (fetchFromGitHub {
+      name = "base64";
+      owner = "aklomp";
+      repo = "base64";
+      rev = "v0.5.2";
+      hash = "sha256-dIaNfQ/znpAdg0/vhVNTfoaG7c8eFrdDTI0QDHcghXU=";
+    })
+    (fetchFromGitHub {
+      name = "usearch";
+      owner = "unum-cloud";
+      repo = "usearch";
+      rev = "v2.21.3";
+      fetchSubmodules = true;
+      hash = "sha256-7IylunAkVNceKSXzCkcpp/kAsI3XoqniHe10u3teUVA=";
+    })
+  ];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2232,8 +2232,11 @@ with pkgs;
 
   tsm-client-withGui = callPackage ../by-name/ts/tsm-client/package.nix { enableGui = true; };
 
-  tracy-glfw = callPackage ../by-name/tr/tracy/package.nix { withWayland = false; };
-  tracy-wayland = callPackage ../by-name/tr/tracy/package.nix { withWayland = true; };
+  inherit (callPackages ../by-name/tr/tracy/package-versions.nix { })
+    tracy_0_11
+    tracy_0_12
+    tracy_0_13
+    ;
 
   uusi = haskell.lib.compose.justStaticExecutables haskellPackages.uusi;
 


### PR DESCRIPTION
Resolves #417177
Supersedes #428369

This splits the `tracy` package into three packages (`tracy_0_11`, `tracy_0_12`, `tracy_0_13`) which track the most recent upstream point releases of each. `tracy` is an alias to the most recent package, `tracy_0_13` (0.13.1).

The Tracy profiler guarantees neither forward nor backward compatibility between versions and selection of profiler version must match that of the project being profiled. This causes issues for developers supporting concurrent projects which require different versions of the tool.

This devendors dependencies which are compatible with those in nixpkgs. See the README for details on each dependency by tracy version.

This builds off of work by @MonaMayrhofer in #428369 and manages to avoid patches to `CPM.cmake` by arranging things in a very precise way determined via reading `CPM.cmake` and much trial-and-error.

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - [X] Profiler GUI working on Linux and Apple Silicon.
  - [ ] Other binaries and actually profiling a target not yet tested.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Devendors dependencies where possible, see package README.md for details
- [X] Submitted fix for Darwin UI scaling issue upstream: https://github.com/wolfpld/tracy/pull/1259

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
