### PR TITLE
clangd-tidy: init at 1.1.0.post2

### DIFF
--- a/pkgs/by-name/cl/clangd-tidy/package.nix
+++ b/pkgs/by-name/cl/clangd-tidy/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  python3,
+  fetchFromGitHub,
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "clangd-tidy";
+  version = "1.1.0.post2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "lljbash";
+    repo = "clangd-tidy";
+    rev = "v${version}";
+    hash = "sha256-ozFJVZhOl/h7BAyp7abHd+VDFRZ8R+cN3j/sEcoIfjk=";
+  };
+
+  build-system = [
+    python3.pkgs.setuptools
+    python3.pkgs.setuptools-scm
+  ];
+
+  dependencies = [
+    python3.pkgs.attrs
+    python3.pkgs.cattrs
+    python3.pkgs.tqdm
+    python3.pkgs.typing-extensions
+  ];
+
+  pythonImportsCheck = [
+    "clangd_tidy"
+  ];
+
+  meta = {
+    description = "A faster alternative to clang-tidy";
+    homepage = "https://github.com/lljbash/clangd-tidy";
+    license = lib.licenses.mit;
+    maintainers = [ ];
+    mainProgram = "clangd-tidy";
+  };
+}


### PR DESCRIPTION
https://github.com/lljbash/clangd-tidy

Still not sure if I want to maintain it.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
