### PR TITLE
gfxreconstruct: fix build with CMake and GCC 15

### DIFF
--- a/pkgs/by-name/gf/gfxreconstruct/package.nix
+++ b/pkgs/by-name/gf/gfxreconstruct/package.nix
@@ -28,6 +28,14 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
+  cmakeFlags = [
+    # The CMakeLists.txt is actually 3.10 compatible, but it specifies 3.5 as `CMAKE_VERSION_MINIMUM`
+    "-DCMAKE_POLICY_VERSION_MINIMUM=3.10"
+  ];
+
+  # Workaround for "error: ... class std::__cxx11::wstring_convert' is deprecated [-Werror=deprecated-declarations]"
+  env.NIX_CFLAGS_COMPILE = "-Wno-error=deprecated-declarations";
+
   buildInputs = [
     libX11
     libxcb


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Closes https://github.com/NixOS/nixpkgs/issues/476459

Tracks https://github.com/NixOS/nixpkgs/issues/475479

The build failure was caused by

- Too small but unnecessary `CMAKE_VERSION_MINIMUM` of 3.5. I have overriden it with 3.10 with no problem.
- strict `-Werror=deprecated-declarations` (implied by `-Werror`) which rejected deprecated `std::__cxx11::wstring_convert`. I couldn't replace the legacy usage with a trivial patch and this should be fixed by upstream.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
