### PR TITLE
python3Packages.langchain-{community,experimental,mongodb}: fixes

### DIFF
--- a/pkgs/development/python-modules/langchain-community/default.nix
+++ b/pkgs/development/python-modules/langchain-community/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
 
@@ -107,6 +108,9 @@ buildPythonPackage rec {
     # flaky
     "test_llm_caching"
     "test_llm_caching_async"
+    # Triggered by https://github.com/Mause/duckdb_engine/issues/1379
+    "test_table_info"
+    "test_sql_database_run"
   ];
 
   disabledTestPaths = [

--- a/pkgs/development/python-modules/langchain-community/default.nix
+++ b/pkgs/development/python-modules/langchain-community/default.nix
@@ -3,6 +3,7 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
+  pythonAtLeast,
 
   # build-system
   pdm-backend,
@@ -111,6 +112,11 @@ buildPythonPackage rec {
     # Triggered by https://github.com/Mause/duckdb_engine/issues/1379
     "test_table_info"
     "test_sql_database_run"
+  ]
+  ++ lib.optionals (pythonAtLeast "3.14") [
+    # AttributeError: module 'ast' has no attribute 'Str'
+    # https://github.com/langchain-ai/langchain-community/issues/492
+    "test_no_dynamic__all__"
   ];
 
   disabledTestPaths = [

--- a/pkgs/development/python-modules/langchain-experimental/default.nix
+++ b/pkgs/development/python-modules/langchain-experimental/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  pythonAtLeast,
 
   # build-system
   pdm-backend,
@@ -61,6 +62,13 @@ buildPythonPackage rec {
   pytestFlagsArray = [ "tests/unit_tests" ];
 
   pythonImportsCheck = [ "langchain_experimental" ];
+
+  disabledTests = lib.optionals (pythonAtLeast "3.14") [
+    # AttributeError: module 'ast' has no attribute 'Str'
+    # https://github.com/langchain-ai/langchain-community/issues/492
+    "test_color_question_1"
+    "test_color_question_2"
+  ];
 
   passthru.updateScript = gitUpdater {
     rev-prefix = "libs/experimental/v";

--- a/pkgs/development/python-modules/langchain-mongodb/default.nix
+++ b/pkgs/development/python-modules/langchain-mongodb/default.nix
@@ -88,6 +88,11 @@ buildPythonPackage rec {
     "tests/unit_tests/test_index.py"
   ];
 
+  pytestFlags = [
+    # DeprecationWarning: 'asyncio.get_event_loop_policy' is deprecated
+    "-Wignore::DeprecationWarning"
+  ];
+
   pythonImportsCheck = [ "langchain_mongodb" ];
 
   passthru = {


### PR DESCRIPTION
1. Disabled two failing tests on Darwin. Introduced with #474603 and due to https://github.com/Mause/duckdb_engine/issues/1379
2. Disabled failing `test_no_dynamic__all__` conditional on on python3.14 and filed https://github.com/langchain-ai/langchain-community/issues/492
3. Disabled failing `test_color_question_1` and `test_color_question_2` in `langchain-experimental` and updated langchain-community bug as these are maintained by the same people.
4. Ignored `DeprecationWarning: 'asyncio.get_event_loop_policy' is deprecated` in `langchain-mongodb` under Python 3.14. 

Tracking: #475732

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
