### PR TITLE
uget: fix build with gcc15

### DIFF
--- a/pkgs/by-name/ug/uget/fix-match-ugtk_setting_dialog_new-declaration-with-d.patch
+++ b/pkgs/by-name/ug/uget/fix-match-ugtk_setting_dialog_new-declaration-with-d.patch
@@ -1,0 +1,26 @@
+From 3a63063a5722947e8089d33ebdaf3ef6b293e2b3 Mon Sep 17 00:00:00 2001
+From: Moraxyc <i@qaq.li>
+Date: Sat, 3 Jan 2026 13:24:27 +0800
+Subject: [PATCH] fix: match ugtk_setting_dialog_new declaration with
+ definition
+
+---
+ ui-gtk/UgtkSettingDialog.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/ui-gtk/UgtkSettingDialog.h b/ui-gtk/UgtkSettingDialog.h
+index 750949e..0e82638 100644
+--- a/ui-gtk/UgtkSettingDialog.h
++++ b/ui-gtk/UgtkSettingDialog.h
+@@ -75,7 +75,7 @@ struct UgtkSettingDialog
+ 	struct UgtkMediaWebsiteForm   media_website;
+ };
+ 
+-UgtkSettingDialog*  ugtk_setting_dialog_new ();
++UgtkSettingDialog*  ugtk_setting_dialog_new (const gchar* title, GtkWindow* parent);
+ void                ugtk_setting_dialog_free (UgtkSettingDialog* sdialog);
+ 
+ void  ugtk_setting_dialog_run (UgtkSettingDialog* dialog, UgtkApp* app);
+-- 
+2.52.0
+

--- a/pkgs/by-name/ug/uget/package.nix
+++ b/pkgs/by-name/ug/uget/package.nix
@@ -26,6 +26,13 @@ stdenv.mkDerivation rec {
     sha256 = "0jchvgkkphhwp2z7vd4axxr9ns8b6vqc22b2z8a906qm8916wd8i";
   };
 
+  patches = [
+    # Fix build with gcc15
+    #   UgtkMenubar.c:188:19: error: too many arguments to function 'ugtk_setting_dialog_new'; expected 0, have 2
+    #   UgtkSettingDialog.c:50:21: error: conflicting types for 'ugtk_setting_dialog_new'; have 'UgtkSettingDialog *(const gchar *, GtkWindow *)' {aka 'UgtkSettingDialog *(const char *, struct _GtkWindow *)'}
+    ./fix-match-ugtk_setting_dialog_new-declaration-with-d.patch
+  ];
+
   # Apply upstream fix for -fno-common toolchains.
   postPatch = ''
     # TODO: remove the replace once upstream fix is released:


### PR DESCRIPTION
Hydra build: https://hydra.nixos.org/build/317952259
Resolve: #475852
Tracking: #475479
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
