### PR TITLE
libretro.parallel-n64: fix build with gcc15

### DIFF
--- a/pkgs/applications/emulators/libretro/cores/parallel-n64.nix
+++ b/pkgs/applications/emulators/libretro/cores/parallel-n64.nix
@@ -18,6 +18,14 @@ mkLibretroCore {
     hash = "sha256-Th8VqENewfTeRTH+lONN7ZTMLQ0G6901q6ZBNMgepL4=";
   };
 
+  patches = [
+    # Fix build with gcc15
+    # Upstream considers this core legacy (for "potato PC") and won't fix.
+    # See: https://github.com/libretro/parallel-n64/issues/797
+    #   /nix/store/...-glibc-2.40-66-dev/include/bits/mathcalls-narrow.h:36:20: error: conflicting types for 'fsqrt'; have 'float(double)'
+    ./patches/parallel-n64-gcc15.patch
+  ];
+
   extraBuildInputs = [
     libGLU
     libGL

--- a/pkgs/applications/emulators/libretro/cores/patches/parallel-n64-gcc15.patch
+++ b/pkgs/applications/emulators/libretro/cores/patches/parallel-n64-gcc15.patch
@@ -1,0 +1,62 @@
+From 3a891c0450c4968afbe76c594c22347354bd8834 Mon Sep 17 00:00:00 2001
+From: Moraxyc <i@qaq.li>
+Date: Sat, 3 Jan 2026 13:41:55 +0800
+Subject: [PATCH] Rename fsqrt to _fsqrt to avoid conflict
+
+---
+ mupen64plus-core/src/r4300/hacktarux_dynarec/assemble.h   | 2 +-
+ .../src/r4300/hacktarux_dynarec/hacktarux_dynarec.c       | 8 ++++----
+ 2 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/mupen64plus-core/src/r4300/hacktarux_dynarec/assemble.h b/mupen64plus-core/src/r4300/hacktarux_dynarec/assemble.h
+index 8161292..e256dd9 100644
+--- a/mupen64plus-core/src/r4300/hacktarux_dynarec/assemble.h
++++ b/mupen64plus-core/src/r4300/hacktarux_dynarec/assemble.h
+@@ -1650,7 +1650,7 @@ static INLINE void fchs(void)
+ }
+ 
+ 
+-static INLINE void fsqrt(void)
++static INLINE void _fsqrt(void)
+ {
+    put8(0xD9);
+    put8(0xFA);
+diff --git a/mupen64plus-core/src/r4300/hacktarux_dynarec/hacktarux_dynarec.c b/mupen64plus-core/src/r4300/hacktarux_dynarec/hacktarux_dynarec.c
+index 89fb982..2fc70d1 100644
+--- a/mupen64plus-core/src/r4300/hacktarux_dynarec/hacktarux_dynarec.c
++++ b/mupen64plus-core/src/r4300/hacktarux_dynarec/hacktarux_dynarec.c
+@@ -6317,13 +6317,13 @@ void gensqrt_d(void)
+ #ifdef __x86_64__
+    mov_xreg64_m64rel(RAX, (uint64_t *)(&reg_cop1_double[dst->f.cf.fs]));
+    fld_preg64_qword(RAX);
+-   fsqrt();
++   _fsqrt();
+    mov_xreg64_m64rel(RAX, (uint64_t *)(&reg_cop1_double[dst->f.cf.fd]));
+    fstp_preg64_qword(RAX);
+ #else
+    mov_eax_memoffs32((unsigned int *)(&reg_cop1_double[dst->f.cf.fs]));
+    fld_preg32_qword(EAX);
+-   fsqrt();
++   _fsqrt();
+    mov_eax_memoffs32((unsigned int *)(&reg_cop1_double[dst->f.cf.fd]));
+    fstp_preg32_qword(EAX);
+ #endif
+@@ -7301,13 +7301,13 @@ void gensqrt_s(void)
+ #ifdef __x86_64__
+    mov_xreg64_m64rel(RAX, (uint64_t *)(&reg_cop1_simple[dst->f.cf.fs]));
+    fld_preg64_dword(RAX);
+-   fsqrt();
++   _fsqrt();
+    mov_xreg64_m64rel(RAX, (uint64_t *)(&reg_cop1_simple[dst->f.cf.fd]));
+    fstp_preg64_dword(RAX);
+ #else
+    mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.fs]));
+    fld_preg32_dword(EAX);
+-   fsqrt();
++   _fsqrt();
+    mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.fd]));
+    fstp_preg32_dword(EAX);
+ #endif
+-- 
+2.52.0
+


### PR DESCRIPTION
Hydra build: https://hydra.nixos.org/build/317866929
Resolve: #475542
Tracking: #475479

It looks like upstream wants to keep this core as-is for legacy compatibility (discussed in https://github.com/libretro/parallel-n64/issues/797), so they likely won't accept a fix. I'm adding a vendor patch then.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
