### PR TITLE
python3Packages.supabase-auth: init at 2.28.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15806,6 +15806,11 @@
     githubId = 401263;
     keys = [ { fingerprint = "1147 43F1 E707 6F3E 6F4B  2C96 B9A8 B592 F126 F8E8"; } ];
   };
+  macbucheron = {
+    name = "Nathan Deprat";
+    github = "Macbucheron1";
+    githubId = 95475157;
+  };
   macronova = {
     name = "Sicheng Pan";
     email = "trivial@invariantspace.com";

--- a/pkgs/development/python-modules/supabase-auth/default.nix
+++ b/pkgs/development/python-modules/supabase-auth/default.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  uv-build,
+  httpx,
+  pydantic,
+  pyjwt,
+  pytestCheckHook,
+  faker,
+  respx,
+  pytest-mock,
+  pytest-asyncio,
+}:
+buildPythonPackage rec {
+  pname = "supabase-auth";
+  version = "2.28.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "supabase";
+    repo = "supabase-py";
+    tag = "v${version}";
+    hash = "sha256-nK+IZRrKjNy84EC8krBvAZll5E0+jV3bLJh8qIVRElI=";
+  };
+
+  sourceRoot = "${src.name}/src/auth";
+
+  build-system = [ uv-build ];
+
+  dependencies = [
+    httpx
+    pydantic
+    pyjwt
+  ]
+  ++ httpx.optional-dependencies.http2
+  ++ pyjwt.optional-dependencies.crypto;
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-warn 'uv_build>=0.8.3,<0.9.0' 'uv_build>=0.8.3'
+  '';
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    faker
+    respx
+    pytest-mock
+    pytest-asyncio
+  ];
+
+  disabledTestPaths = [
+    "tests/_sync/"
+    "tests/_async/"
+  ];
+
+  pythonImportsCheck = [ "supabase_auth" ];
+
+  meta = {
+    description = "Client library for Supabase Auth";
+    homepage = "https://github.com/supabase/supabase-py/";
+    changelog = "https://github.com/supabase/supabase-py/blob/v${src.tag}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ macbucheron ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18324,6 +18324,8 @@ self: super: with self; {
 
   supabase = callPackage ../development/python-modules/supabase { };
 
+  supabase-auth = callPackage ../development/python-modules/supabase-auth { };
+
   supabase-functions = self.supafunc;
 
   supafunc = callPackage ../development/python-modules/supafunc { };


### PR DESCRIPTION
Adds `python3Packages.supabase-auth` (import name: `supabase_auth`) packaged from PyPI `supabase_auth` 2.28.0.

While nixpkgs already provides `python3Packages.gotrue`, upstream has deprecated the `gotrue` distribution name in favor of `supabase_auth`, and downstream consumers are migrating their imports accordingly (e.g. `from supabase_auth import ...`). This PR provides the new package name/module to match upstream naming and avoid import failures for consumers expecting `supabase_auth`.

Note: upstream pins the build backend requirement as `uv_build>=0.8.3,<0.9.0` in `pyproject.toml`. nixpkgs currently provides `uv-build` 0.9.x, so this PR relaxes the upper bound to `<0.10.0` to allow non-isolated PEP-517 builds with the nixpkgs backend.

Homepage: https://github.com/supabase/supabase-py/tree/v2.28.0/src/auth
PyPI: https://pypi.org/project/supabase-auth/2.28.0/
Upstream deprecation/migration references:
- https://pypi.org/project/gotrue/ (deprecation notice)
- https://github.com/supabase/supabase-py/issues/1166
- https://github.com/orgs/supabase/discussions/37798

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.

  Commands run:
  - `nix build -L .#python3Packages.supabase-auth`
  - `python -c "import supabase_auth"` via `python3.withPackages`

- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
