### PR TITLE
python3Packages.supabase-functions: init at 2.28.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15806,6 +15806,11 @@
     githubId = 401263;
     keys = [ { fingerprint = "1147 43F1 E707 6F3E 6F4B  2C96 B9A8 B592 F126 F8E8"; } ];
   };
+  macbucheron = {
+    name = "Nathan Deprat";
+    github = "Macbucheron1";
+    githubId = 95475157;
+  };
   macronova = {
     name = "Sicheng Pan";
     email = "trivial@invariantspace.com";

--- a/pkgs/development/python-modules/supabase-functions/default.nix
+++ b/pkgs/development/python-modules/supabase-functions/default.nix
@@ -1,0 +1,60 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  httpx,
+  lib,
+  pyjwt,
+  pytest-asyncio,
+  pytestCheckHook,
+  strenum,
+  uv-build,
+  yarl,
+}:
+
+buildPythonPackage rec {
+  pname = "supabase-functions";
+  version = "2.28.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "supabase";
+    repo = "supabase-py";
+    tag = "v${version}";
+    hash = "sha256-nK+IZRrKjNy84EC8krBvAZll5E0+jV3bLJh8qIVRElI=";
+  };
+
+  sourceRoot = "${src.name}/src/functions";
+
+  build-system = [ uv-build ];
+
+  dependencies = [
+    strenum
+    yarl
+    httpx
+  ]
+  ++ httpx.optional-dependencies.http2;
+
+  # Upstream pins `uv_build>=0.8.3,<0.9.0`, but nixpkgs ships `uv-build` 0.9.x.
+  # Relax the upper bound to accept the 0.9 series, consistent with uv’s documentation examples:
+  # https://docs.astral.sh/uv/concepts/build-backend/#using-the-uv-build-backend
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-warn 'uv_build>=0.8.3,<0.9.0' 'uv_build>=0.8.3'
+  '';
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pyjwt
+    pytest-asyncio
+  ];
+
+  pythonImportsCheck = [ "supabase_functions" ];
+
+  meta = {
+    description = "Client library for Supabase Functions";
+    homepage = "https://github.com/supabase/supabase-py";
+    changelog = "https://github.com/supabase/supabase-py/blob/v${src.tag}/CHANGELOG.md";
+    maintainers = with lib.maintainers; [ macbucheron ];
+    license = lib.licenses.mit;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18330,7 +18330,7 @@ self: super: with self; {
 
   supabase = callPackage ../development/python-modules/supabase { };
 
-  supabase-functions = self.supafunc;
+  supabase-functions = callPackage ../development/python-modules/supabase-functions { };
 
   supafunc = callPackage ../development/python-modules/supafunc { };
 


### PR DESCRIPTION
Adds `python3Packages.supabase-functions` (import name: `supabase_functions`) packaged from PyPI `supabase_functions` 2.28.0.

nixpkgs already provides `python3Packages.supafunc`, but upstream has deprecated the `supafunc` distribution name in favor of `supabase_functions`. Downstream consumers are migrating their dependency name and imports accordingly (e.g. `from supabase_functions import ...`). This PR introduces the `supabase-functions` package/module name to match upstream naming and avoid import failures for consumers expecting `supabase_functions`, while keeping `supafunc` available for compatibility.

Note: upstream pins the build backend requirement as `uv_build>=0.8.3,<0.9.0` in `pyproject.toml`. nixpkgs currently provides `uv-build` 0.9.x, so this PR relaxes the upper bound to `<0.10.0` to allow non-isolated PEP-517 builds with the nixpkgs backend (consistent with uv’s build-backend documentation).

Homepage: https://github.com/supabase/supabase-py/tree/v2.28.0/src/functions
PyPI: https://pypi.org/project/supabase-functions/
Upstream deprecation/migration reference:
- https://pypi.org/project/supafunc/ (deprecation notice)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.

  Commands run:
  - `nix build -L .#python3Packages.supabase-functions`
  - `python -c "import supabase_functions"` via `python3.withPackages`

- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
