### PR TITLE
linear-cli: init at 1.5.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13251,6 +13251,12 @@
     githubId = 2469618;
     name = "Junji Hashimoto";
   };
+  jupblb = {
+    email = "nixpkgs@kielbowi.cz";
+    github = "jupblb";
+    githubId = 3370617;
+    name = "Michal Kielbowicz";
+  };
   jurraca = {
     email = "julienu@pm.me";
     github = "jurraca";

--- a/pkgs/by-name/li/linear-cli/package.nix
+++ b/pkgs/by-name/li/linear-cli/package.nix
@@ -1,0 +1,91 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  installShellFiles,
+  versionCheckHook,
+}:
+
+let
+  inherit (stdenv.hostPlatform) system;
+  version = "1.5.0";
+
+  sources = {
+    aarch64-darwin = fetchurl {
+      url = "https://github.com/schpet/linear-cli/releases/download/v${version}/linear-aarch64-apple-darwin.tar.xz";
+      hash = "sha256-OnN+mH+tkmvquzHNFucdHvHtZPUu9MpF1lFJEyl44MU=";
+    };
+    x86_64-darwin = fetchurl {
+      url = "https://github.com/schpet/linear-cli/releases/download/v${version}/linear-x86_64-apple-darwin.tar.xz";
+      hash = "sha256-vvmKcv/vdIuyFHeDLtB6qSNKzfR+azncO11tLOaW9hc=";
+    };
+    aarch64-linux = fetchurl {
+      url = "https://github.com/schpet/linear-cli/releases/download/v${version}/linear-aarch64-unknown-linux-gnu.tar.xz";
+      hash = "sha256-sSek63aVfTcFRnmRdLJAA5moEDW++vvpMHbV7M17DXY=";
+    };
+    x86_64-linux = fetchurl {
+      url = "https://github.com/schpet/linear-cli/releases/download/v${version}/linear-x86_64-unknown-linux-gnu.tar.xz";
+      hash = "sha256-xd5D7r+HbrD5+C/5SfDhDq2hk533Cznoe1KUKsMI9wQ=";
+    };
+  };
+
+  platforms = builtins.attrNames sources;
+in
+
+stdenv.mkDerivation {
+  pname = "linear-cli";
+  inherit version;
+
+  src =
+    if (builtins.elem system platforms) then
+      sources.${system}
+    else
+      throw "Source for linear-cli is not available for ${system}";
+
+  sourceRoot =
+    let
+      platformSuffix = {
+        aarch64-darwin = "aarch64-apple-darwin";
+        x86_64-darwin = "x86_64-apple-darwin";
+        aarch64-linux = "aarch64-unknown-linux-gnu";
+        x86_64-linux = "x86_64-unknown-linux-gnu";
+      };
+    in
+    "linear-${platformSuffix.${system}}";
+
+  nativeBuildInputs = [
+    installShellFiles
+  ]
+  ++ lib.optional stdenv.hostPlatform.isLinux autoPatchelfHook;
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 linear $out/bin/linear
+    runHook postInstall
+  '';
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd linear \
+      --bash <($out/bin/linear completions bash) \
+      --fish <($out/bin/linear completions fish) \
+      --zsh <($out/bin/linear completions zsh)
+  '';
+
+  dontStrip = stdenv.hostPlatform.isDarwin;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+  versionCheckProgram = "${placeholder "out"}/bin/linear";
+
+  meta = {
+    description = "CLI for Linear issue tracker - list, start, and create PRs for issues";
+    homepage = "https://github.com/schpet/linear-cli";
+    changelog = "https://github.com/schpet/linear-cli/blob/main/CHANGELOG.md";
+    license = lib.licenses.isc;
+    maintainers = with lib.maintainers; [ jupblb ];
+    mainProgram = "linear";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    inherit platforms;
+  };
+}


### PR DESCRIPTION
Added [linear-cli](https://github.com/schpet/linear-cli), a CLI for the [Linear](https://linear.app/) issue tracker. This package uses prebuilt binaries because nixpkgs doesn't yet have an established pattern for building Deno applications from source.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`. (versionCheckHook)
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
