### PR TITLE
oxdraw: init at 0.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -21421,6 +21421,12 @@
     githubId = 142632643;
     name = "purrpurrn";
   };
+  push_f = {
+    name = "Martin Fischer";
+    email = "martin@push-f.com";
+    github = "not-my-profile";
+    githubId = 73739153;
+  };
   putchar = {
     email = "slim.cadoux@gmail.com";
     matrix = "@putch4r:matrix.org";

--- a/pkgs/by-name/ox/oxdraw/package.nix
+++ b/pkgs/by-name/ox/oxdraw/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  fetchCrate,
+  rustPlatform,
+  pkg-config,
+  makeWrapper,
+  openssl,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "oxdraw";
+  version = "0.2.0";
+  src = fetchCrate {
+    inherit pname version;
+    hash = "sha256-Gcnh3VdcET2BV2LZb/KAn6gjdgdWoyFy0ORogHpWOBs=";
+  };
+  cargoHash = "sha256-YedNESkXKbfl7FWea7VpDR+59b9WLtZ7GNcyJ7D9yPg=";
+  cargoBuildFlags = [ "--bin oxdraw" ]; # Don't build library.
+
+  nativeBuildInputs = [
+    pkg-config
+    makeWrapper
+  ];
+
+  buildInputs = [
+    openssl
+  ];
+
+  # Setting OXDRAW_WEB_DIST here because buildRustPackage doesn't support build.rs.
+  postInstall = ''
+    wrapProgram $out/bin/oxdraw \
+      --set OXDRAW_WEB_DIST "${src}/frontend/out"
+  '';
+
+  meta = {
+    description = "Mermaid diagram tool with draggable editing";
+    homepage = "https://github.com/RohanAdwankar/oxdraw";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ push_f ];
+    mainProgram = "oxdraw";
+  };
+}


### PR DESCRIPTION
Adds a package for https://github.com/RohanAdwankar/oxdraw.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
