### PR TITLE
snell: init at 5.0.1

### DIFF
--- a/pkgs/by-name/sn/snell/package.nix
+++ b/pkgs/by-name/sn/snell/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  stdenv,
+  fetchzip,
+  autoPatchelfHook,
+  upx,
+}:
+let
+  platformMap = {
+    "x86_64-linux" = "linux-amd64";
+    "aarch64-linux" = "linux-aarch64";
+  };
+  system = stdenv.hostPlatform.system;
+  platform = platformMap.${system} or (throw "Unsupported platform: ${system}");
+  hashs = {
+    "x86_64-linux" = "sha256-J2kRVJRC0GhxLMarg7Ucdk8uvzTsKbFHePEflPjwsHU=";
+    "aarch64-linux" = "sha256-UT+Rd6TEMYL/+xfqGxGN/tiSBvN8ntDrkCBj4PuMRwg=";
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "snell-server";
+  version = "5.0.1";
+
+  src = fetchzip {
+    url = "https://dl.nssurge.com/snell/snell-server-v${finalAttrs.version}-${platform}.zip";
+    hash = hashs.${system};
+  };
+
+  nativeBuildInputs = [
+    upx
+    autoPatchelfHook
+  ];
+  buildInputs = [
+    (lib.getLib stdenv.cc.cc)
+  ];
+  installPhase = ''
+    runHook preInstall
+    upx -d snell-server
+    install -Dm755 snell-server $out/bin/snell-server
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Lean encrypted proxy protocol";
+    homepage = "https://kb.nssurge.com/surge-knowledge-base/release-notes/snell";
+    license = lib.licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    platforms = lib.attrNames platformMap;
+    maintainers = with lib.maintainers; [
+      mlyxshi
+    ];
+    mainProgram = "snell-server";
+  };
+})


### PR DESCRIPTION
Snell is a lean encrypted proxy protocol developed by [Surge](https://nssurge.com) team

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
