### PR TITLE
angband: 4.2.5 -> 4.2.6

### DIFF
--- a/pkgs/by-name/an/angband/package.nix
+++ b/pkgs/by-name/an/angband/package.nix
@@ -46,7 +46,10 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://angband.github.io/angband";
     description = "Single-player roguelike dungeon exploration game";
     mainProgram = "angband";
-    maintainers = [ lib.maintainers.kenran ];
+    maintainers = with lib.maintainers; [
+      kenran
+      x123
+    ];
     changelog = "https://github.com/angband/angband/releases/tag/${finalAttrs.version}";
     license = lib.licenses.gpl2Only;
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/an/angband/package.nix
+++ b/pkgs/by-name/an/angband/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitHub,
   autoreconfHook,
+  nix-update-script,
   ncurses5,
   enableSdl2 ? false,
   SDL2,
@@ -22,6 +23,8 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-XH2FUTJJaH5TqV2UD1CKKAXE4CRAb6zfg1UQ79a15k0=";
   };
 
+  passthru.updateScript = nix-update-script { };
+
   nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [
     ncurses5
@@ -33,6 +36,8 @@ stdenv.mkDerivation (finalAttrs: {
     SDL2_ttf
   ];
 
+  enableParallelBuilding = true;
+
   configureFlags = lib.optional enableSdl2 "--enable-sdl2";
 
   installFlags = [ "bindir=$(out)/bin" ];
@@ -42,6 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Single-player roguelike dungeon exploration game";
     mainProgram = "angband";
     maintainers = [ lib.maintainers.kenran ];
+    changelog = "https://github.com/angband/angband/releases/tag/${finalAttrs.version}";
     license = lib.licenses.gpl2Only;
     platforms = lib.platforms.unix;
   };

--- a/pkgs/by-name/an/angband/package.nix
+++ b/pkgs/by-name/an/angband/package.nix
@@ -14,13 +14,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "angband";
-  version = "4.2.5";
+  version = "4.2.6";
 
   src = fetchFromGitHub {
     owner = "angband";
     repo = "angband";
-    rev = finalAttrs.version;
-    hash = "sha256-XH2FUTJJaH5TqV2UD1CKKAXE4CRAb6zfg1UQ79a15k0=";
+    tag = "${finalAttrs.version}";
+    hash = "sha256-lx2EfE3ylcH1vLAHwNT1me1l4e4Jspkw4YJIAOlu/0E=";
   };
 
   passthru.updateScript = nix-update-script { };


### PR DESCRIPTION
- add automatic updates with nix-update-script
- enableParallelBuilding = true
- use tag instead of rev
- add x123 as a maintainer
- add changelog
- update angband 4.2.5 -> 4.2.6

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
