### PR TITLE
qoi: 0-unstable-2023-08-10 -> 0-unstable-2025-11-13, modernize

### DIFF
--- a/pkgs/by-name/qo/qoi/add-install-target-and-pc-module.patch
+++ b/pkgs/by-name/qo/qoi/add-install-target-and-pc-module.patch
@@ -1,0 +1,65 @@
+diff --git a/.gitignore b/.gitignore
+index 9234e61..f137e88 100644
+--- a/.gitignore
++++ b/.gitignore
+@@ -3,3 +3,4 @@ stb_image.h
+ stb_image_write.h
+ qoibench
+ qoiconv
++qoi.pc
+diff --git a/Makefile b/Makefile
+index fb4b4d8..4660180 100644
+--- a/Makefile
++++ b/Makefile
+@@ -7,6 +7,11 @@ LFLAGS_CONV ?= $(LDFLAGS)
+ TARGET_BENCH ?= qoibench
+ TARGET_CONV ?= qoiconv
+ 
++PREFIX ?= /usr/local
++BINDIR ?= $(PREFIX)/bin
++INCLUDEDIR ?= $(PREFIX)/include
++LIBDIR ?= $(PREFIX)/lib
++
+ all: $(TARGET_BENCH) $(TARGET_CONV)
+ 
+ bench: $(TARGET_BENCH)
+@@ -17,6 +22,24 @@ conv: $(TARGET_CONV)
+ $(TARGET_CONV):$(TARGET_CONV).c qoi.h
+ 	$(CC) $(CFLAGS_CONV) $(CFLAGS) $(TARGET_CONV).c -o $(TARGET_CONV) $(LFLAGS_CONV)
+ 
++qoi.pc: qoi.pc.in
++	sed < qoi.pc.in > qoi.pc \
++		-e 's|@PREFIX@|$(PREFIX)|g' \
++		-e 's|@INCLUDEDIR@|$(INCLUDEDIR:$(PREFIX)%=$${prefix}%)|g'
++
++.PHONY: install
++install: install-tools install-header
++
++.PHONY: install-tools
++install-tools: all
++	install -Dm 755 $(TARGET_CONV) $(DESTDIR)$(BINDIR)/$(TARGET_CONV)
++	install -Dm 755 $(TARGET_BENCH) $(DESTDIR)$(BINDIR)/$(TARGET_BENCH)
++
++.PHONY: install-header
++install-header: qoi.h qoi.pc
++	install -Dm 644 qoi.h $(DESTDIR)$(INCLUDEDIR)/qoi.h
++	install -Dm 644 qoi.pc $(DESTDIR)$(LIBDIR)/pkgconfig/qoi.pc
++
+ .PHONY: clean
+ clean:
+ 	$(RM) $(TARGET_BENCH) $(TARGET_CONV)
+diff --git a/qoi.pc.in b/qoi.pc.in
+new file mode 100755
+index 0000000..dd83a36
+--- /dev/null
++++ b/qoi.pc.in
+@@ -0,0 +1,9 @@
++prefix=@PREFIX@
++includedir=@INCLUDEDIR@
++
++Name: qoi
++Description: The "Quite OK Image Format" for fast, lossless image compression
++Version: 0
++URL: https://qoiformat.org/
++License: MIT
++Cflags: -I${includedir}

--- a/pkgs/by-name/qo/qoi/package.nix
+++ b/pkgs/by-name/qo/qoi/package.nix
@@ -1,6 +1,7 @@
 {
   fetchFromGitHub,
   lib,
+  libpng,
   stb,
   stdenv,
 }:
@@ -21,15 +22,10 @@ stdenv.mkDerivation (finalAttrs: {
     "dev"
   ];
 
-  nativeBuildInputs = [ stb ];
+  strictDeps = true;
+  enableParalleBuilding = true;
 
-  buildPhase = ''
-    runHook preBuild
-
-    make CFLAGS_CONV="-I${stb}/include/stb -O3" qoiconv
-
-    runHook postBuild
-  '';
+  buildInputs = [ libpng ];
 
   installPhase = ''
     runHook preInstall
@@ -44,6 +40,10 @@ stdenv.mkDerivation (finalAttrs: {
 
     runHook postInstall
   '';
+
+  makeFlags = [
+    "CFLAGS=-I${lib.getDev stb}/include/stb"
+  ];
 
   meta = {
     description = "'Quite OK Image Format' for fast, lossless image compression";

--- a/pkgs/by-name/qo/qoi/package.nix
+++ b/pkgs/by-name/qo/qoi/package.nix
@@ -10,13 +10,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "qoi";
-  version = "0-unstable-2023-08-10"; # no upstream version yet.
+  version = "0-unstable-2025-11-13"; # no upstream version yet.
 
   src = fetchFromGitHub {
     owner = "phoboslab";
     repo = "qoi";
-    rev = "19b3b4087b66963a3699ee45f05ec9ef205d7c0e";
-    hash = "sha256-E1hMtjMuDS2zma2s5hlHby/sroRGhtyZm9gLQ+VztsM=";
+    rev = "44b233a95eda82fbd2e39a269199b73af0f4c4c3";
+    hash = "sha256-W5JG9Nz4NI2KZmUEtxEiGH7oxfAzEIaUyXTbSB25hZw=";
   };
 
   patches = [

--- a/pkgs/by-name/qo/qoi/package.nix
+++ b/pkgs/by-name/qo/qoi/package.nix
@@ -4,6 +4,7 @@
   libpng,
   stb,
   stdenv,
+  testers,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -41,6 +42,10 @@ stdenv.mkDerivation (finalAttrs: {
     "BINDIR=${placeholder "out"}/bin"
   ];
 
+  passthru = {
+    tests.pkg-config = testers.hasPkgConfigModules { package = finalAttrs.finalPackage; };
+  };
+
   meta = {
     description = "'Quite OK Image Format' for fast, lossless image compression";
     mainProgram = "qoiconv";
@@ -48,5 +53,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ hzeller ];
     platforms = lib.platforms.all;
+    pkgConfigModules = [ "qoi" ];
   };
 })

--- a/pkgs/by-name/qo/qoi/package.nix
+++ b/pkgs/by-name/qo/qoi/package.nix
@@ -2,6 +2,7 @@
   fetchFromGitHub,
   lib,
   libpng,
+  nix-update-script,
   stb,
   stdenv,
   testers,
@@ -44,6 +45,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     tests.pkg-config = testers.hasPkgConfigModules { package = finalAttrs.finalPackage; };
+    updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
   };
 
   meta = {

--- a/pkgs/by-name/qo/qoi/package.nix
+++ b/pkgs/by-name/qo/qoi/package.nix
@@ -17,6 +17,11 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-E1hMtjMuDS2zma2s5hlHby/sroRGhtyZm9gLQ+VztsM=";
   };
 
+  patches = [
+    # https://github.com/phoboslab/qoi/pull/322
+    ./add-install-target-and-pc-module.patch
+  ];
+
   outputs = [
     "out"
     "dev"
@@ -27,22 +32,13 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [ libpng ];
 
-  installPhase = ''
-    runHook preInstall
-
-    # Conversion utility for images->qoi. Not usually needed for development.
-    mkdir -p ${placeholder "out"}/bin
-    install qoiconv ${placeholder "out"}/bin
-
-    # The actual single-header implementation. Nothing to compile, just install.
-    mkdir -p ${placeholder "dev"}/include/
-    install qoi.h ${placeholder "dev"}/include
-
-    runHook postInstall
-  '';
+  # Don't bloat the header-only output with binaries
+  propagatedBuildOutputs = [ ];
 
   makeFlags = [
     "CFLAGS=-I${lib.getDev stb}/include/stb"
+    "PREFIX=${placeholder "dev"}"
+    "BINDIR=${placeholder "out"}/bin"
   ];
 
   meta = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
