### PR TITLE
oculante: Fix build failure due to transitive dependency `libaom-sys` build failure

### DIFF
--- a/pkgs/by-name/oc/oculante/libaom-sys-0.17.2+libaom.3.11.0-cmake-nasm-fix.patch
+++ b/pkgs/by-name/oc/oculante/libaom-sys-0.17.2+libaom.3.11.0-cmake-nasm-fix.patch
@@ -1,0 +1,21 @@
+--- a/libaom-sys-0.17.2+libaom.3.11.0/vendor/build/cmake/aom_optimization.cmake
++++ b/libaom-sys-0.17.2+libaom.3.11.0/vendor/build/cmake/aom_optimization.cmake
+@@ -212,7 +212,7 @@ endfunction()
+ # Currently checks only for presence of required object formats and support for
+ # the -Ox argument (multipass optimization).
+ function(test_nasm)
+-  execute_process(COMMAND ${CMAKE_ASM_NASM_COMPILER} -hf
++  execute_process(COMMAND ${CMAKE_ASM_NASM_COMPILER} -hO
+                   OUTPUT_VARIABLE nasm_helptext)
+ 
+   if(NOT "${nasm_helptext}" MATCHES "-Ox")
+@@ -220,6 +220,9 @@ function(test_nasm)
+       FATAL_ERROR "Unsupported nasm: multipass optimization not supported.")
+   endif()
+ 
++  execute_process(COMMAND ${CMAKE_ASM_NASM_COMPILER} -hf
++                  OUTPUT_VARIABLE nasm_helptext)
++
+   if("${AOM_TARGET_CPU}" STREQUAL "x86")
+     if("${AOM_TARGET_SYSTEM}" STREQUAL "Darwin")
+       if(NOT "${nasm_helptext}" MATCHES "macho32")

--- a/pkgs/by-name/oc/oculante/package.nix
+++ b/pkgs/by-name/oc/oculante/package.nix
@@ -67,6 +67,18 @@ rustPlatform.buildRustPackage rec {
     "--skip=thumbnails::test_thumbs" # broken as of v0.9.2
   ];
 
+  patches = [
+    # The below patch is needed to fix this build, until the upstream dependency (libavif-rs) fixes the problem.
+    # The explicit `patchFlags` can also be removed when this patch becomes obsolete.
+    # <https://github.com/njaard/libavif-rs/issues/122>
+    ./libaom-sys-0.17.2+libaom.3.11.0-cmake-nasm-fix.patch
+  ];
+
+  patchFlags = [
+    "-p1"
+    "--directory=../${pname}-${version}-vendor"
+  ];
+
   postInstall = ''
     install -Dm444 $src/res/icons/icon.png $out/share/icons/hicolor/128x128/apps/oculante.png
     install -Dm444 $src/res/oculante.desktop -t $out/share/applications


### PR DESCRIPTION
Oculante build was failing due to a transitive dependency failing to build. The problem is basically the same as described in [this issue](https://github.com/woelper/oculante/issues/743). In short, `nasm` updating to 3.0 broke the build for libaom-sys, a transitive dependency of Oculante.

This PR implements a minimal fix to get oculante to build, as described in a comment in the [above issue](https://github.com/woelper/oculante/issues/743#issuecomment-3531188402) (thanks to @0323pin and @0-wiz-0).

This implementation of the fix is somewhat hacky because Oculate is a Rust project using (mostly) Cargo for building, and libaom-sys is a CMake project; libaom-sys gets vendored by `buildRustPackage` and after some experimentation the cleanest way I found to get `buildRustPackage` to patch a vendored, non-Rust dependency is by overriding `patchFlags`.

This PR becomes obsolete at the resolution of <https://github.com/njaard/libavif-rs/issues/122>.

Resolves #475989.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
