### PR TITLE
.github/ISSUE_TEMPLATE: include closed issues when checking duplicates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.yml
@@ -117,7 +117,7 @@ body:
       options:
         - label: "I assert that this is a bug and not a support request."
           required: true
-        - label: "I assert that this is not a [duplicate of an existing issue](https://github.com/NixOS/nixpkgs/issues?q=is%3Aopen+is%3Aissue+label%3A%220.kind%3A+bug%22+-label%3A%226.topic%3A+darwin%22+-label%3A%226.topic%3A+nixos%22). "
+        - label: "I assert that this is not a [duplicate of an existing issue](https://github.com/NixOS/nixpkgs/issues?q=is%3Aissue+label%3A%220.kind%3A+bug%22+-label%3A%226.topic%3A+darwin%22+-label%3A%226.topic%3A+nixos%22). "
           required: true
         - label: "I assert that I have read the [NixOS Code of Conduct](https://github.com/NixOS/.github/blob/master/CODE_OF_CONDUCT.md) and agree to abide by it."
           required: true

--- a/.github/ISSUE_TEMPLATE/02_bug_report_darwin.yml
+++ b/.github/ISSUE_TEMPLATE/02_bug_report_darwin.yml
@@ -131,7 +131,7 @@ body:
       options:
         - label: "I assert that this is a bug and not a support request."
           required: true
-        - label: "I assert that this is not a [duplicate of an existing issue](https://github.com/NixOS/nixpkgs/issues?q=is%3Aopen+is%3Aissue+label%3A%220.kind%3A+bug%22+label%3A%226.topic%3A+darwin%22). "
+        - label: "I assert that this is not a [duplicate of an existing issue](https://github.com/NixOS/nixpkgs/issues?q=is%3Aissue+label%3A%220.kind%3A+bug%22+label%3A%226.topic%3A+darwin%22). "
           required: true
         - label: "I assert that I have read the [NixOS Code of Conduct](https://github.com/NixOS/.github/blob/master/CODE_OF_CONDUCT.md) and agree to abide by it."
           required: true

--- a/.github/ISSUE_TEMPLATE/03_bug_report_nixos.yml
+++ b/.github/ISSUE_TEMPLATE/03_bug_report_nixos.yml
@@ -121,7 +121,7 @@ body:
       options:
         - label: "I assert that this is a bug and not a support request."
           required: true
-        - label: "I assert that this is not a [duplicate of an existing issue](https://github.com/NixOS/nixpkgs/issues?q=is%3Aopen+is%3Aissue+label%3A%220.kind%3A+bug%22+label%3A%226.topic%3A+nixos%22). "
+        - label: "I assert that this is not a [duplicate of an existing issue](https://github.com/NixOS/nixpkgs/issues?q=is%3Aissue+label%3A%220.kind%3A+bug%22+label%3A%226.topic%3A+nixos%22). "
           required: true
         - label: "I assert that I have read the [NixOS Code of Conduct](https://github.com/NixOS/.github/blob/master/CODE_OF_CONDUCT.md) and agree to abide by it."
           required: true

--- a/.github/ISSUE_TEMPLATE/04_build_failure.yml
+++ b/.github/ISSUE_TEMPLATE/04_build_failure.yml
@@ -127,7 +127,7 @@ body:
       options:
         - label: "I assert that this is a bug and not a support request."
           required: true
-        - label: "I assert that this is not a [duplicate of an existing issue](https://github.com/NixOS/nixpkgs/issues?q=is%3Aopen+is%3Aissue+label%3A%220.kind%3A+build+failure%22). "
+        - label: "I assert that this is not a [duplicate of an existing issue](https://github.com/NixOS/nixpkgs/issues?q=is%3Aissue+label%3A%220.kind%3A+build+failure%22)."
           required: true
         - label: "I assert that I have read the [NixOS Code of Conduct](https://github.com/NixOS/.github/blob/master/CODE_OF_CONDUCT.md) and agree to abide by it."
           required: true

--- a/.github/ISSUE_TEMPLATE/05_update_request.yml
+++ b/.github/ISSUE_TEMPLATE/05_update_request.yml
@@ -100,7 +100,7 @@ body:
       options:
         - label: "I assert that this package update does not yet exist in an [open pull request](https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+is%3Apr+label%3A%228.has%3A+package+%28update%29%22) or in [Nixpkgs Unstable](https://search.nixos.org/packages?channel=unstable)."
           required: true
-        - label: "I assert that this is not a [duplicate of any known issue](https://github.com/NixOS/nixpkgs/issues?q=is%3Aopen+is%3Aissue+label%3A%229.needs%3A+package+%28update%29%22)."
+        - label: "I assert that this is not a [duplicate of any known issue](https://github.com/NixOS/nixpkgs/issues?q=is%3Aissue+label%3A%229.needs%3A+package+%28update%29%22)."
           required: true
         - label: "I assert that I have read the [NixOS Code of Conduct](https://github.com/NixOS/.github/blob/master/CODE_OF_CONDUCT.md) and agree to abide by it."
           required: true

--- a/.github/ISSUE_TEMPLATE/06_module_request.yml
+++ b/.github/ISSUE_TEMPLATE/06_module_request.yml
@@ -75,7 +75,7 @@ body:
       options:
         - label: "I assert that this module does not yet exist in an [open pull request](https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+is%3Apr+label%3A%228.has%3A+module+%28new%29%22) or in [NixOS Unstable](https://search.nixos.org/options?channel=unstable)."
           required: true
-        - label: "I assert that this is not a [duplicate of an existing issue](https://github.com/NixOS/nixpkgs/issues?q=is%3Aopen+is%3Aissue+label%3A%229.needs%3A+module+%28new%29%22). "
+        - label: "I assert that this is not a [duplicate of an existing issue](https://github.com/NixOS/nixpkgs/issues?q=is%3Aissue+label%3A%229.needs%3A+module+%28new%29%22). "
           required: true
         - label: "I assert that I have read the [NixOS Code of Conduct](https://github.com/NixOS/.github/blob/master/CODE_OF_CONDUCT.md) and agree to abide by it."
           required: true

--- a/.github/ISSUE_TEMPLATE/07_backport_request.yml
+++ b/.github/ISSUE_TEMPLATE/07_backport_request.yml
@@ -81,7 +81,7 @@ body:
       options:
         - label: "I assert that this backport does not yet exist in an [open pull request](https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+in%3Atitle+backport)."
           required: true
-        - label: "I assert that this is not a [duplicate of any known issue](https://github.com/NixOS/nixpkgs/issues?q=is%3Aissue+is%3Aopen+label%3A%229.needs%3A+port+to+stable%22+)."
+        - label: "I assert that this is not a [duplicate of any known issue](https://github.com/NixOS/nixpkgs/issues?q=is%3Aissue+label%3A%229.needs%3A+port+to+stable%22+)."
           required: true
         - label: "I assert that I have read the [NixOS Code of Conduct](https://github.com/NixOS/.github/blob/master/CODE_OF_CONDUCT.md) and agree to abide by it."
           required: true

--- a/.github/ISSUE_TEMPLATE/08_documentation_request.yml
+++ b/.github/ISSUE_TEMPLATE/08_documentation_request.yml
@@ -63,7 +63,7 @@ body:
       options:
         - label: "I assert that this request is not already implemented in the latest [NixOS](https://nixos.org/manual/nixos/unstable/) or [Nixpkgs](https://nixos.org/manual/nixpkgs/unstable/) manuals."
           required: true
-        - label: "I assert that this is not a [duplicate of an existing documentation issue](https://github.com/NixOS/nixpkgs/issues?q=is%3Aissue+is%3Aopen+label%3A%229.needs%3A+documentation%22)."
+        - label: "I assert that this is not a [duplicate of an existing documentation issue](https://github.com/NixOS/nixpkgs/issues?q=is%3Aissue+label%3A%229.needs%3A+documentation%22)."
           required: true
         - label: "I assert that I have read the [NixOS Code of Conduct](https://github.com/NixOS/.github/blob/master/CODE_OF_CONDUCT.md) and agree to abide by it."
           required: true

--- a/.github/ISSUE_TEMPLATE/09_unreproducible_package.yml
+++ b/.github/ISSUE_TEMPLATE/09_unreproducible_package.yml
@@ -133,7 +133,7 @@ body:
     attributes:
       label: "I assert that this issue is relevant for Nixpkgs"
       options:
-        - label: "I assert that this is not a [duplicate of any known issue](https://github.com/NixOS/nixpkgs/issues?q=is%3Aopen+is%3Aissue+label%3A%226.topic%3A+reproducible+builds%22)."
+        - label: "I assert that this is not a [duplicate of any known issue](https://github.com/NixOS/nixpkgs/issues?q=is%3Aissue+label%3A%226.topic%3A+reproducible+builds%22)."
           required: true
         - label: "I assert that I have read the [NixOS Code of Conduct](https://github.com/NixOS/.github/blob/master/CODE_OF_CONDUCT.md) and agree to abide by it."
           required: true


### PR DESCRIPTION
Issues usually get closed after the related PR is merged. When users try to find an existing issue when the PR was recently merged and haven't landed in an unstable channel (or wasn't backported), they probably click on this duplicate issues link in this tempalte. The issue doesn't show up and they open a new one.

Most recent example is https://github.com/NixOS/nixpkgs/issues/476571, it's not too uncommon, especially after staging-next merges.

Personally when I search for anything in nixpkgs, I almost always go to the issues tab and query for `in:title PACKAGENAME`, deleting the `is:open` and `is:issue` to show both issues and PRs. Maybe we could also include PRs in the template?

Alternatively we should only close build failure issues that have landed in the reporter's channel, but if we ever plan to do that it should be automated.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
