### PR TITLE
nixos: add cygwin system builder

### DIFF
--- a/nixos/maintainers/scripts/cygwin/profile.nix
+++ b/nixos/maintainers/scripts/cygwin/profile.nix
@@ -1,0 +1,94 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+
+{
+  imports = [
+    ../../../modules/profiles/minimal.nix
+  ];
+
+  config = lib.mkIf pkgs.stdenv.hostPlatform.isCygwin {
+    boot = {
+      bcache.enable = false;
+      initrd = {
+        supportedFilesystems = [ ];
+      };
+      kernel.sysctl = lib.mkForce { };
+      loader.grub.enable = false;
+      modprobeConfig.enable = false;
+      supportedFilesystems = [ ];
+    };
+
+    console.enable = false;
+
+    fonts.fontconfig.enable = false;
+
+    # the default requires glibcLocales
+    i18n.supportedLocales = [ ];
+
+    networking = {
+      dhcpcd.enable = false;
+      firewall.enable = false;
+      resolvconf.enable = false;
+    };
+
+    programs = {
+      fuse.enable = false;
+      less.enable = lib.mkForce false;
+      nano.enable = false;
+      ssh.systemd-ssh-proxy.enable = false;
+    };
+
+    security = {
+      pam.enable = false;
+      shadow.enable = false;
+      sudo.enable = false;
+    };
+
+    services = {
+      lvm.enable = false;
+      udev.enable = false;
+    };
+
+    system = {
+      disableInstallerTools = true;
+      # this is needed because tasks/filesystems.nix unconditionally adds
+      # dosfstools, and tasks/filesystems/ext adds e2fsprogs
+      fsPackages = lib.mkForce [ ];
+      # these match the cygwin defaults when "file" is prepended
+      nssDatabases = {
+        passwd = [ "db" ];
+        group = [ "db" ];
+      };
+    };
+
+    systemd = {
+      enable = false;
+      coredump.enable = false;
+    };
+
+    users = {
+      users = lib.mkForce { };
+      groups = lib.mkForce { };
+    };
+
+    environment.corePackages =
+      with pkgs;
+      lib.mkForce [
+        bash
+        coreutils
+        openssh
+        curl
+        config.nix.package
+      ];
+    environment.defaultPackages = lib.mkForce [ ];
+
+    nix = {
+      settings.sandbox = false;
+      package = pkgs.nixVersions.git;
+    };
+  };
+}

--- a/nixos/maintainers/scripts/cygwin/system.nix
+++ b/nixos/maintainers/scripts/cygwin/system.nix
@@ -1,0 +1,76 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+
+let
+  inherit (pkgs)
+    bash
+    buildEnv
+    coreutils
+    runCommand
+    writeShellScript
+    cygwin
+    ;
+
+  nix = config.nix.package;
+
+  sw = buildEnv {
+    name = "cygwin-root";
+
+    paths = config.environment.systemPackages;
+
+    nativeBuildInputs = [
+      ../../../../pkgs/build-support/setup-hooks/make-symlinks-relative.sh
+    ];
+  };
+
+  activate = writeShellScript "activate" ''
+    (
+      export PATH=${
+        lib.makeBinPath [
+          coreutils
+          nix
+        ]
+      }:/bin
+      mkdir -p /nix/var/nix/gcroots
+      ln -sfn /run/current-system /nix/var/nix/gcroots/current-system
+      mkdir -p /run
+      ln -sfn '${lib.getExe bash}' /bin/sh
+      ln -sfn '@out@' /run/current-system
+      ln -sfn /run/current-system/etc /etc
+      if [[ -f /nix-path-registration ]]; then
+        nix-store --load-db < /nix-path-registration
+        rm -f /nix-path-registration
+      fi
+    )
+  '';
+
+  cygwin1 = cygwin.newlib-cygwin.out + "/bin/cygwin1.dll";
+
+in
+{
+  options = {
+    system.cygwin.toplevel = lib.mkOption {
+      type = lib.types.package;
+      readOnly = true;
+    };
+  };
+
+  imports = [
+    ./profile.nix
+  ];
+
+  config = {
+    system.cygwin.toplevel = runCommand "cygwin-system" { } ''
+      mkdir "$out"
+      ln -sr "${sw}" "$out"/sw
+      ln -sr "${cygwin1}" "$out"/
+      cp "${activate}" "$out"/activate
+      substituteInPlace $out/activate --subst-var-by out "$out"
+      ln -sr "${config.system.build.etc}"/etc $out/etc
+    '';
+  };
+}

--- a/nixos/maintainers/scripts/cygwin/tarball.nix
+++ b/nixos/maintainers/scripts/cygwin/tarball.nix
@@ -1,0 +1,146 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+
+let
+  inherit (pkgs)
+    bash
+    buildPackages
+    cygwin
+    gnutar
+    lib
+    runCommand
+    writeShellScript
+    writeText
+    ;
+
+  nix = config.nix.package;
+
+  bootScript = writeText "cygwin.ps1" (
+    lib.replaceString "\n" "\r\n" ''
+      $ErrorActionPreference = 'Stop'
+      cp $PSScriptRoot\nix\var\nix\profiles\system\cygwin1.dll $PSScriptRoot\bin\cygwin1.dll
+      $bash = "$PSScriptRoot${lib.replaceString "/" "\\" (lib.getBin bash).outPath}\bin\bash.exe"
+      & $bash /nix/var/nix/profiles/system/activate
+      if (!$?) { throw 'activation script failed' }
+      & $bash --login -i $args
+      if (!$?) { exit 1 }
+    ''
+  );
+
+  cygwin1 = cygwin.newlib-cygwin.out + "/bin/cygwin1.dll";
+
+in
+{
+  options.system.cygwin.tarball = lib.mkOption {
+    type = lib.types.package;
+    readOnly = true;
+  };
+
+  config = {
+    environment.etc."profile".text = ''
+      export CYGWIN=winsymlinks=native\ $CYGWIN
+    '';
+
+    system.cygwin = {
+
+      tarball =
+        let
+          install = writeText "install.ps1" (
+            lib.replaceString "\n" "\r\n" ''
+              param ([Parameter(Mandatory=$true)][string]$dir)
+
+              $ErrorActionPreference = 'Stop'
+
+              $_ = mkdir -force $dir
+
+              fsutil file setCaseSensitiveInfo $dir enable
+              if (!$?) { throw 'setCaseSensitiveInfo failed, this may require: Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Windows-Subsystem-Linux' }
+
+              $_ = ni $dir\.test-target
+              try {
+                cmd /c mklink $dir\.test-link $dir\.test-target
+                if (!$?) {
+                  throw 'failed to create symbolic link: developer mode may need to be enabled'
+                }
+              } catch {
+                throw
+              } finally {
+                rm $dir\.test-target
+              }
+              rm $dir\.test-link
+
+              $env:CYGWIN = "winsymlinks=native"
+              # create cygwin1.dll so that symlinks to it are created properly
+              if(!(Test-Path $dir\bin\cygwin1.dll))
+              {
+                mkdir -f $dir\bin
+                ni $dir\bin\cygwin1.dll
+              }
+              & $PSScriptRoot\tar -C $dir --force-local -xpf $PSScriptRoot\${config.system.cygwin.tarball.fileName}.tar${config.system.cygwin.tarball.extension}
+              if (!$?) { throw 'failed to extract tarball' }
+            ''
+          );
+
+          system = config.system.cygwin.toplevel;
+        in
+        (pkgs.callPackage ../../../lib/make-system-tarball.nix {
+          # HACK: disable compression
+          compressCommand = "cat";
+          compressionExtension = "";
+
+          contents = [
+            {
+              source = bootScript;
+              target = "cygwin.ps1";
+            }
+          ];
+
+          storeContents = [
+            {
+              object = system;
+              symlink = "none";
+            }
+          ];
+
+          extraCommands = buildPackages.writeShellScript "extra-commands.sh" ''
+            chmod -R +w nix
+            mkdir -p tmp nix/var/nix/profiles dev
+            mkdir -m 01777 dev/{shm,mqueue}
+            ln -s "$(realpath -s --relative-to=/nix/var/nix/profiles "${system}")" nix/var/nix/profiles/system
+            find . -type l -print0 | while read -r -d "" f; do
+                symlinkTarget=$(readlink "$f")
+                if [[ "$symlinkTarget"/ != /nix/store* ]]; then
+                    # skip this symlink as it doesn't point to /nix/store
+                    continue
+                fi
+
+                relativeTarget=''${symlinkTarget#/}
+
+                if [ ! -e "$relativeTarget" ]; then
+                    echo "the symlink $f is broken, it points to $relativeTarget (which is missing)"
+                fi
+
+                relativeTarget=$(realpath -s --relative-to=$(dirname "$f") "$relativeTarget")
+
+                echo "changing symlink $f -> $symlinkTarget to $relativeTarget"
+                ln -snf "$relativeTarget" "$f"
+            done
+
+            mkdir -p "$out"/tarball
+            cp "${install}" "$out"/tarball/install.ps1
+            cp "${gnutar}/bin/tar.exe" "$out"/tarball/
+            for dll in "${gnutar}/bin"/*.dll; do
+              if [[ $dll != */cygwin1.dll ]]; then
+                cp "$dll" "$out"/tarball/
+              fi
+            done
+            cp "${cygwin1}" "$out"/tarball/
+          '';
+        });
+    };
+  };
+}

--- a/nixos/modules/config/nix.nix
+++ b/nixos/modules/config/nix.nix
@@ -135,6 +135,24 @@ in
 
   options = {
     nix = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = ''
+          Whether to enable Nix.
+          Disabling Nix makes the system hard to modify and the Nix programs and configuration will not be made available by NixOS itself.
+        '';
+      };
+
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = pkgs.nix;
+        defaultText = lib.literalExpression "pkgs.nix";
+        description = ''
+          This option specifies the Nix package instance to use throughout the system.
+        '';
+      };
+
       checkConfig = mkOption {
         type = types.bool;
         default = true;

--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -1656,6 +1656,10 @@ in
 
   options = {
 
+    security.pam.enable = lib.mkEnableOption "enable pam" // {
+      default = true;
+    };
+
     security.pam.package = lib.mkPackageOption pkgs "pam" { };
 
     security.pam.loginLimits = lib.mkOption {
@@ -2277,7 +2281,7 @@ in
 
   ###### implementation
 
-  config = {
+  config = lib.mkIf config.security.pam.enable {
     assertions = [
       {
         assertion = config.users.motd == "" || config.users.motdFile == null;

--- a/nixos/modules/services/system/nix-daemon.nix
+++ b/nixos/modules/services/system/nix-daemon.nix
@@ -70,24 +70,6 @@ in
 
     nix = {
 
-      enable = lib.mkOption {
-        type = lib.types.bool;
-        default = true;
-        description = ''
-          Whether to enable Nix.
-          Disabling Nix makes the system hard to modify and the Nix programs and configuration will not be made available by NixOS itself.
-        '';
-      };
-
-      package = lib.mkOption {
-        type = lib.types.package;
-        default = pkgs.nix;
-        defaultText = lib.literalExpression "pkgs.nix";
-        description = ''
-          This option specifies the Nix package instance to use throughout the system.
-        '';
-      };
-
       daemonCPUSchedPolicy = lib.mkOption {
         type = lib.types.enum [
           "other"

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -240,6 +240,10 @@ in
 
   options.systemd = {
 
+    enable = mkEnableOption "enable systemd" // {
+      default = true;
+    };
+
     package = mkPackageOption pkgs "systemd" { };
 
     enableStrictShellChecks = mkEnableOption "" // {
@@ -484,7 +488,7 @@ in
 
   ###### implementation
 
-  config = {
+  config = mkIf cfg.enable {
 
     warnings =
       let

--- a/nixos/modules/system/boot/systemd/tmpfiles.nix
+++ b/nixos/modules/system/boot/systemd/tmpfiles.nix
@@ -192,7 +192,7 @@ in
     };
   };
 
-  config = {
+  config = lib.mkIf config.systemd.enable {
     warnings =
       let
         paths = lib.filter (path: path != null && lib.hasPrefix "/etc/tmpfiles.d/" path) (

--- a/nixos/modules/system/boot/systemd/user.nix
+++ b/nixos/modules/system/boot/systemd/user.nix
@@ -191,7 +191,7 @@ in
     };
   };
 
-  config = {
+  config = lib.mkIf config.systemd.enable {
     systemd.additionalUpstreamSystemUnits = [
       "user.slice"
     ];

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -456,6 +456,32 @@ rec {
         )
       );
 
+  cygwinTarball =
+    forMatchingSystems
+      [
+        "x86_64-linux"
+        "aarch64-linux"
+      ]
+      (
+        system:
+
+        hydraJob (
+          (import lib/eval-config.nix {
+            system = null;
+            modules = [
+              configuration
+              versionModule
+              ./maintainers/scripts/cygwin/system.nix
+              ./maintainers/scripts/cygwin/tarball.nix
+              {
+                nixpkgs.buildPlatform = lib.mkDefault system;
+                nixpkgs.hostPlatform = lib.mkDefault "x86_64-cygwin";
+              }
+            ];
+          }).config.system.cygwin.tarball
+        )
+      );
+
   # Ensure that all packages used by the minimal NixOS config end up in the channel.
   dummy = forAllSystems (
     system:


### PR DESCRIPTION
This is the nixos portion of #447520.  It won't build until all the package fixes are in, but it does evaluate.

I'd like feedback on the architecture of this.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
