### PR TITLE
python3Packages.pymupdf-layout: init at 1.26.6

### DIFF
--- a/pkgs/development/python-modules/pymupdf-layout/default.nix
+++ b/pkgs/development/python-modules/pymupdf-layout/default.nix
@@ -1,0 +1,95 @@
+{
+  lib,
+  stdenv,
+  buildPythonPackage,
+  fetchPypi,
+  pythonOlder,
+  python,
+  runCommand,
+
+  # dependencies
+  pymupdf,
+  pyyaml,
+  numpy,
+  onnxruntime,
+  networkx,
+}:
+
+buildPythonPackage rec {
+  pname = "pymupdf-layout";
+  version = "1.26.6";
+  format = "wheel";
+
+  disabled = pythonOlder "3.9";
+
+  src =
+    let
+      platforms = {
+        aarch64-darwin = {
+          platform = "macosx_11_0_arm64";
+          hash = "sha256-8dRfcuwI739kSShIfnoGffbfYxctaC0LsFFYiW0NnHE=";
+        };
+        x86_64-darwin = {
+          platform = "macosx_10_9_x86_64";
+          hash = "sha256-1jL4MgjbiyRgDrisVNMTX6tqsfJRo4+mBh50cOgblIE=";
+        };
+        aarch64-linux = {
+          platform = "manylinux_2_28_aarch64";
+          hash = "sha256-BWG5SFpqwaQLseLsehZIqmTkvlbasvORgrEaaePkMCQ=";
+        };
+        x86_64-linux = {
+          platform = "manylinux_2_28_x86_64";
+          hash = "sha256-7o4r/tEtS2QhsnofiYN6wJ2Lw/eD95Zw2zl+wkYUvz0=";
+        };
+      };
+      info =
+        platforms.${stdenv.hostPlatform.system}
+          or (throw "pymupdf-layout: Unsupported system: ${stdenv.hostPlatform.system}");
+    in
+    fetchPypi {
+      pname = "pymupdf_layout";
+      inherit version format;
+      inherit (info) platform hash;
+      python = "cp310";
+      abi = "abi3";
+      dist = "cp310";
+    };
+
+  # curl https://pypi.org/pypi/pymupdf-layout/json | jq .info.requires_dist
+  dependencies = [
+    pymupdf
+    pyyaml
+    numpy
+    onnxruntime
+    networkx
+  ];
+
+  doCheck = false;
+
+  # pythonImportsCheck doesn't work because pymupdf is not an Implicit Namespace Package (PEP 420).
+  # pythonImportsCheck = [ "pymupdf.layout" ];
+  # Use passthru.tests to verify imports in a merged environment.
+  passthru.tests.import =
+    runCommand "pymupdf-layout-import-test"
+      {
+        nativeBuildInputs = [ (python.withPackages (ps: [ ps.pymupdf-layout ])) ];
+      }
+      ''
+        python -c "import pymupdf.layout; print('pymupdf.layout imported successfully')"
+        touch $out
+      '';
+
+  meta = {
+    description = "Lightweight layout analysis extension for PyMuPDF";
+    homepage = "https://pypi.org/project/pymupdf-layout/";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ ryota2357 ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    platforms = [
+      "aarch64-darwin"
+      "x86_64-darwin"
+      "aarch64-linux"
+      "x86_64-linux"
+    ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13953,6 +13953,8 @@ self: super: with self; {
 
   pymupdf-fonts = callPackage ../development/python-modules/pymupdf-fonts { };
 
+  pymupdf-layout = callPackage ../development/python-modules/pymupdf-layout { };
+
   pymupdf4llm = callPackage ../development/python-modules/pymupdf4llm { };
 
   pymvglive = callPackage ../development/python-modules/pymvglive { };


### PR DESCRIPTION
PyMuPDF Layout is a lightweight layout analysis extension for PyMuPDF (https://pymupdf.readthedocs.io/en/latest/pymupdf-layout/index.html)

`pymupdf-layout` is optional dependency of latest `pymupdf4llm`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
