### PR TITLE
uutils-diffutils: 0.4.2 -> 0.5.0, add installCheckPhase, fix `meta.changelog`

### DIFF
--- a/pkgs/by-name/uu/uutils-diffutils/package.nix
+++ b/pkgs/by-name/uu/uutils-diffutils/package.nix
@@ -30,6 +30,15 @@ rustPlatform.buildRustPackage (finalAttrs: {
     ln -s $out/bin/diffutils $out/bin/diff
   '';
 
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    $out/bin/diffutils 2>/dev/null | head -1 | grep -F 'diffutils ${finalAttrs.version}'
+
+    runHook postInstallCheck
+  '';
+
   passthru.updateScript = nix-update-script { };
 
   meta = {

--- a/pkgs/by-name/uu/uutils-diffutils/package.nix
+++ b/pkgs/by-name/uu/uutils-diffutils/package.nix
@@ -7,16 +7,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "uutils-diffutils";
-  version = "0.4.2";
+  version = "0.5.0";
 
   src = fetchFromGitHub {
     owner = "uutils";
     repo = "diffutils";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-IAgrCkhUC2Tkh+OM1lorpmD0GpsHUauLgU0KcmsvKb4=";
+    hash = "sha256-YZAa4A5fvW8BcaZn4xSVbSnzyoAaKKqBzpFOjnSRnc4=";
   };
 
-  cargoHash = "sha256-SiZIp0rJXl0ZqKaxLPtV1nypxSqKXW+NoFLxCVpW4OY=";
+  cargoHash = "sha256-jX3uuUopNaVi+XNskBUPzITlJrsVkXWR8LP7PTuwMm8=";
 
   checkFlags = [
     # called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }
@@ -24,6 +24,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "--skip=ed_diff::tests::test_permutations_reverse"
     "--skip=ed_diff::tests::test_permutations_empty_lines"
   ];
+
+  postInstall = ''
+    ln -s $out/bin/diffutils $out/bin/cmp
+    ln -s $out/bin/diffutils $out/bin/diff
+  '';
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/uu/uutils-diffutils/package.nix
+++ b/pkgs/by-name/uu/uutils-diffutils/package.nix
@@ -25,12 +25,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "--skip=ed_diff::tests::test_permutations_empty_lines"
   ];
 
-  passthru = {
-    updateScript = nix-update-script { };
-  };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
-    changelog = "https://github.com/uutils/diffutils/releases/tag/${finalAttrs.version}";
+    changelog = "https://github.com/uutils/diffutils/releases/tag/v${finalAttrs.version}";
     description = "Drop-in replacement of diffutils in Rust";
     homepage = "https://github.com/uutils/diffutils";
     license = lib.licenses.mit;


### PR DESCRIPTION
Changelog: https://github.com/uutils/diffutils/releases/tag/v0.5.0
Diff: https://github.com/uutils/diffutils/compare/v0.4.2...v0.5.0

Supersedes and closes #476475 
Supersedes and closes #460673 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
