### PR TITLE
iprover: 3.8.1 -> 3.9.2

### DIFF
--- a/pkgs/by-name/ip/iprover/package.nix
+++ b/pkgs/by-name/ip/iprover/package.nix
@@ -10,13 +10,13 @@
 
 stdenv.mkDerivation {
   pname = "iprover";
-  version = "3.8.1";
+  version = "3.9.2";
 
   src = fetchFromGitLab {
     owner = "korovin";
     repo = "iprover";
-    rev = "f61edb113b705606c7314dc4dce0687832c3169f";
-    hash = "sha256-XXqbEoYKjoktE3ZBEIEFjLhA1B75zhnfPszhe8SvbI8=";
+    rev = "v3.9.2";
+    hash = "sha256-CbqPtP2pKLFgo67EF0IhvIdv1dAog2vb3Es0asmmSyY=";
   };
 
   postPatch = ''
@@ -44,6 +44,10 @@ stdenv.mkDerivation {
   ]);
 
   preConfigure = "patchShebangs .";
+
+  env = {
+    NIX_CFLAGS_COMPILE = "-std=gnu17";
+  };
 
   installPhase = ''
     runHook preInstall


### PR DESCRIPTION
Will probably self-merge

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
