### PR TITLE
python314Packages.beancount: fix failing tests

### DIFF
--- a/pkgs/development/python-modules/beancount/default.nix
+++ b/pkgs/development/python-modules/beancount/default.nix
@@ -5,6 +5,7 @@
   buildPythonPackage,
   click,
   fetchFromGitHub,
+  fetchpatch2,
   flex,
   gnupg,
   meson,
@@ -25,6 +26,19 @@ buildPythonPackage rec {
     tag = version;
     hash = "sha256-XWTgaBvB4/SONL44afvprZwJUVrkoda5XLGNxad0kec=";
   };
+
+  patches = [
+    (fetchpatch2 {
+      name = "accept-date-range-error-message-from-py3.14";
+      url = "https://salsa.debian.org/python-team/packages/beancount/-/raw/debian/sid/debian/patches/0003-Accept-date-range-error-message-from-py3.14.patch";
+      hash = "sha256-wqMTGSi4Gn5VADjV4MjZhFNWB3ThUhxvLYK7sentScQ=";
+    })
+    (fetchpatch2 {
+      name = "skip-ref-count-test-with-py3.14";
+      url = "https://salsa.debian.org/python-team/packages/beancount/-/raw/debian/sid/debian/patches/0004-Skip-refcount-test-with-py3.14.patch";
+      hash = "sha256-6P9xe15WBGaWpVYB2HfGfFHLMMmGkfnDwdjdktlSNxk=";
+    })
+  ];
 
   build-system = [
     meson


### PR DESCRIPTION
Tracks https://github.com/NixOS/nixpkgs/issues/475732

Fix failing tests using patches from Debian.
See discussion at https://github.com/beancount/beancount/issues/984

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
