### PR TITLE
blobby: 1.1.1 -> 1.1.1-untagged-2025-07-26

### DIFF
--- a/pkgs/by-name/bl/blobby/package.nix
+++ b/pkgs/by-name/bl/blobby/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
   SDL2,
   SDL2_image,
   libGLU,
@@ -17,11 +17,13 @@
 
 stdenv.mkDerivation {
   pname = "blobby-volley";
-  version = "1.1.1";
+  version = "1.1.1-unstable-2025-07-26";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/blobby/Blobby%20Volley%202%20%28Linux%29/1.1.1/blobby2-linux-1.1.1.tar.gz";
-    sha256 = "sha256-NX7lE+adO1D2f8Bj1Ky3lZpf6Il3gX8KqxTMxw2yFLo=";
+  src = fetchFromGitHub {
+    owner = "danielknobe";
+    repo = "blobbyvolley2";
+    rev = "9bc797f0fade4766f2d98f8cf4db0a8a7b82a950";
+    sha256 = "sha256-0e1YOwHX2x/snkyH1qeQowJr1YGdExstUoCBOhG1kBU=";
   };
 
   nativeBuildInputs = [
@@ -38,10 +40,6 @@ stdenv.mkDerivation {
     boost
     zlib
   ];
-
-  preConfigure = ''
-    sed -e '1i#include <iostream>' -i src/NetworkMessage.cpp
-  '';
 
   inherit unzip;
 


### PR DESCRIPTION
Update to include upstream fixes, in particular for gcc15

Will self-merge

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
