### PR TITLE
home-assistant: unpin google-genai; home-assistant-component-tests.google_generative_ai_conversation: disable non-robust test

### DIFF
--- a/pkgs/servers/home-assistant/tests.nix
+++ b/pkgs/servers/home-assistant/tests.nix
@@ -158,6 +158,10 @@ let
   };
 
   extraDisabledTestPaths = {
+    google_generative_ai_conversation = [
+      # Fails because googleapis/python-genai added 2 fields to a dict
+      "tests/components/google_generative_ai_conversation/test_conversation.py::test_function_call"
+    ];
     jellyfin = [
       # AssertionError: assert 'audio/x-flac' == 'audio/flac'
       "tests/components/jellyfin/test_media_source.py::test_resolve"


### PR DESCRIPTION
I had thought for some reason that the breakage was due to the breaking change in GHSA-c67j-w6g6-q2cm. That was wrong: it was because the tests weren't robust to new versions adding fields to a dict.

Closes: #476521

It had failed with:
```
FAILED tests/components/google_generative_ai_conversation/test_conversation.py::test_function_call - AssertionError: assert {'media_resolution': None, 'code_execution_result': None, 'executable_code': None, 'file_data': None, 'function_call': None, 'function_response': {'will_continue': None, 'scheduling': None, 'parts': None, 'id': None, 'name': 'test_tool', 'response': {'result': 'Test response'}}, 'inline_data': None, 'text': None, 'thought': None, 'thought_signature': None, 'video_metadata': None} == {'code_execution_result': None, 'executable_code': None, 'file_data': None, 'function_call': None, 'function_response': {'id': None, 'name': 'test_tool', 'response': {'result': 'Test response'}, 'scheduling': None, 'will_continue': None}, 'inline_data': None, 'text': None, 'thought': None, 'thought_signature': None, 'video_metadata': None}
homeassistant-test-google_generative_ai_conversation>
  Common items:
  {'code_execution_result': None,
   'executable_code': None,
   'file_data': None,
   'function_call': None,
   'inline_data': None,
   'text': None,
   'thought': None,
   'thought_signature': None,
   'video_metadata': None}
  Differing items:
  {'function_response': {'id': None, 'name': 'test_tool', 'parts': None, 'response': {'result': 'Test response'}, ...}} != {'function_response': {'id': None, 'name': 'test_tool', 'response': {'result': 'Test response'}, 'scheduling': None, ...}}
  Left contains 1 more item:
  {'media_resolution': None}
homeassistant-test-google_generative_ai_conversation>
  Full diff:
    {
        'code_execution_result': None,
        'executable_code': None,
        'file_data': None,
        'function_call': None,
        'function_response': {
            'id': None,
            'name': 'test_tool',
  +         'parts': None,
            'response': {
                'result': 'Test response',
            },
            'scheduling': None,
            'will_continue': None,
        },
        'inline_data': None,
  +     'media_resolution': None,
        'text': None,
        'thought': None,
        'thought_signature': None,
        'video_metadata': None,
    }
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
