### PR TITLE
lamb: init at unstable-2025-12-22

### DIFF
--- a/pkgs/by-name/la/lamb/package.nix
+++ b/pkgs/by-name/la/lamb/package.nix
@@ -1,0 +1,75 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  gnugrep,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "lamb";
+  version = "unstable-2025-12-22";
+
+  src = fetchFromGitHub {
+    owner = "tsoding";
+    repo = "lamb";
+    rev = "50938686d4b8ae929121b62a67243baf72867cde";
+    hash = "sha256-ALqjh4DmvysdcGQQrCW87r5rvmCrEWPcViN4zg026nY=";
+  };
+
+  strictDeps = true;
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=unstable" ]; };
+
+  buildPhase = ''
+    runHook preBuild
+    ${stdenv.cc.targetPrefix}cc -o lamb lamb.c
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 lamb -t "$out/bin"
+    install -Dm644 std.lamb -t "$out/share/lamb"
+
+    runHook postInstall
+  '';
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  nativeCheckInputs = [
+    gnugrep
+  ];
+
+  checkPhase = ''
+    runHook preCheck
+
+    output="$(
+      {
+        printf '%s\n' \
+          'pair 69 (pair 420 1337)' \
+          'xs = pair 69 (pair 420 1337)' \
+          'first xs' \
+          'second xs' \
+          'first (second xs)' \
+          ':q'
+      } | ./lamb ./std.lamb 2>&1
+    )"
+
+    grep -Fq "RESULT: 69" <<<"$output"
+    grep -Fq "RESULT: 420" <<<"$output"
+
+    runHook postCheck
+  '';
+
+  meta = {
+    description = "Tiny pure functional programming language in C";
+    homepage = "https://github.com/tsoding/lamb";
+    license = lib.licenses.mit;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    maintainers = with lib.maintainers; [ Zaczero ];
+    mainProgram = "lamb";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
https://github.com/tsoding/lamb

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
