### PR TITLE
xpilot-ng: fix build with gcc15

### DIFF
--- a/pkgs/by-name/xp/xpilot-ng/package.nix
+++ b/pkgs/by-name/xp/xpilot-ng/package.nix
@@ -38,6 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     ./xpilot-ng-gcc-14-fix.patch
     ./xpilot-ng-sdl-window-fix.patch
+    ./xpilot-ng-gcc-15-fix.patch
   ];
 
   meta = {

--- a/pkgs/by-name/xp/xpilot-ng/xpilot-ng-gcc-15-fix.patch
+++ b/pkgs/by-name/xp/xpilot-ng/xpilot-ng-gcc-15-fix.patch
@@ -1,0 +1,13 @@
+Only in xpilot-ng-4.7.3/src/server: .suibotdef.c.swp
+diff -r -U3 xpilot-ng-4.7.3.orig/src/server/suibotdef.c xpilot-ng-4.7.3/src/server/suibotdef.c
+--- xpilot-ng-4.7.3.orig/src/server/suibotdef.c	2026-01-03 16:26:37.070168944 +0100
++++ xpilot-ng-4.7.3/src/server/suibotdef.c	2026-01-03 16:27:31.970201518 +0100
+@@ -372,7 +372,7 @@
+ } object_proximity_t;
+ 
+ 
+-static bool Get_object_proximity();
++static bool Get_object_proximity(player_t *pl, object_t *shot, double sqmaxdist,int maxtime, object_proximity_t *object_proximity);
+ static bool Get_object_proximity(player_t *pl, object_t *shot, double sqmaxdist,int maxtime, object_proximity_t *object_proximity){
+    /* get square of closest distance between player and object
+     * compare with sqmaxdist and maxtime and return sqdistance and time


### PR DESCRIPTION
Trivial prototype fix

Will self-merge

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
