### PR TITLE
ffmpeg: enable MinGW cross-compilation

### DIFF
--- a/pkgs/by-name/fr/fribidi/package.nix
+++ b/pkgs/by-name/fr/fribidi/package.nix
@@ -42,7 +42,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
 
-  doCheck = true;
+  # Cross builds cannot execute target binaries.
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
   nativeCheckInputs = [ python3 ];
 
   passthru.tests = {
@@ -56,7 +57,8 @@ stdenv.mkDerivation (finalAttrs: {
     description = "GNU implementation of the Unicode Bidirectional Algorithm (bidi)";
     mainProgram = "fribidi";
     license = lib.licenses.lgpl21;
-    platforms = lib.platforms.unix;
+    # MSYS2 ships fribidi for MinGW; allow Windows so pkgsCross.mingwW64 can evaluate it.
+    platforms = lib.platforms.unix ++ lib.platforms.windows;
     pkgConfigModules = [ "fribidi" ];
   };
 })

--- a/pkgs/by-name/ja/jack2/mingw/0001-wscript-remove-hardcoded-includedir.patch
+++ b/pkgs/by-name/ja/jack2/mingw/0001-wscript-remove-hardcoded-includedir.patch
@@ -1,0 +1,12 @@
+--- a/wscript
++++ b/wscript
+@@ -224,7 +224,7 @@ def configure(conf):
+         conf.env.append_unique('CCDEFINES', '_POSIX')
+         conf.env.append_unique('CXXDEFINES', '_POSIX')
+         if Options.options.platform in ('msys', 'win32'):
+-            conf.env.append_value('INCLUDES', ['/mingw64/include'])
++            #conf.env.append_value('INCLUDES', ['/mingw64/include'])
+             conf.check(
+                 header_name='pa_asio.h',
+                 msg='Checking for PortAudio ASIO support',
+

--- a/pkgs/by-name/ja/jack2/mingw/0002-fix-format-security.patch
+++ b/pkgs/by-name/ja/jack2/mingw/0002-fix-format-security.patch
@@ -1,0 +1,9 @@
+--- a/windows/JackWinNamedPipeServerChannel.cpp
++++ b/windows/JackWinNamedPipeServerChannel.cpp
+@@ -1,7 +1,7 @@
+ int JackWinNamedPipeServerChannel::Open(const char* server_name, JackServer* server)
+ {
+     jack_log("JackWinNamedPipeServerChannel::Open");
+-    snprintf(fServerName, sizeof(fServerName), server_name);
++    snprintf(fServerName, sizeof(fServerName), "%s", server_name);
+ 

--- a/pkgs/by-name/ja/jack2/mingw/0003-relocate-plugins-libdir.patch
+++ b/pkgs/by-name/ja/jack2/mingw/0003-relocate-plugins-libdir.patch
@@ -1,0 +1,27 @@
+--- a/common/JackDriverLoader.cpp
++++ b/common/JackDriverLoader.cpp
+@@ -49,13 +49,17 @@ static wchar_t* locate_dll_driver_dir()
+     // For WIN32 ADDON_DIR is defined in JackConstants.h as relative path
+     wchar_t driver_dir_storage[512];
+     if (3 < GetModuleFileNameW(libjack_handle, driver_dir_storage, 512)) {
+-        wchar_t *p = wcsrchr(driver_dir_storage, L'\\');
+-        if (p && (p != driver_dir_storage)) {
+-            *p = 0;
+-        }   
+-        jack_info("Drivers/internals found in : %S", driver_dir_storage);
+-        wcscat(driver_dir_storage, L"\\");
++        wchar_t *bindir = wcsrchr(driver_dir_storage, L'\\');
++        if (bindir && (bindir != driver_dir_storage)) {
++            *bindir = L'\0';
++        }
++        wchar_t *prefix = wcsrchr(driver_dir_storage, L'\\');
++        if (prefix && (prefix != driver_dir_storage)) {
++            *prefix = L'\0';
++        }
++        wcscat(driver_dir_storage, L"\\lib\\");
+         wcscat(driver_dir_storage, ADDON_DIRW);
++        jack_info("Drivers/internals found in : %S", driver_dir_storage);
+         return wcsdup(driver_dir_storage);
+     } else {
+         jack_error("Cannot get JACK dll directory : %d", GetLastError());
+

--- a/pkgs/by-name/ja/jack2/mingw/0004-relocate-jackd-path.patch
+++ b/pkgs/by-name/ja/jack2/mingw/0004-relocate-jackd-path.patch
@@ -1,0 +1,23 @@
+--- a/windows/JackWinServerLaunch.cpp
++++ b/windows/JackWinServerLaunch.cpp
+@@ -154,7 +154,18 @@ static int start_server_aux(const char* server_name)
+ 	}
+ 
+     if (!good) {
+-		strcpy(buffer, JACK_LOCATION "/jackd.exe");
++        HMODULE libjack_handle = NULL;
++        GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
++                           reinterpret_cast<LPCSTR>(start_server_aux), &libjack_handle);
++        if (3 < GetModuleFileNameA(libjack_handle, buffer, MAX_PATH)) {
++            char *bindir = strrchr(buffer, '\\');
++            if (bindir && (bindir != buffer)) {
++                *bindir = '\0';
++            }
++            strcat(buffer, "\\jackd.exe");
++        }
++        else
++            strcpy(buffer, "jackd.exe");
+ 		command = (char*)malloc((strlen(buffer))+1);
+ 		strcpy(command, buffer);
+         strncpy(arguments, "jackd.exe -S -d " JACK_DEFAULT_DRIVER, 255);
+

--- a/pkgs/by-name/ja/jack2/mingw/0005-fix-new-python.patch
+++ b/pkgs/by-name/ja/jack2/mingw/0005-fix-new-python.patch
@@ -1,0 +1,21 @@
+--- jack2-1.9.22/waflib/Context.py.orig	2023-02-02 12:04:10.000000000 +0100
++++ jack2-1.9.22/waflib/Context.py	2025-07-18 11:14:00.319286900 +0200
+@@ -6,7 +6,7 @@
+ Classes and functions enabling the command system
+ """
+ 
+-import os, re, imp, sys
++import os, re, types, sys
+ from waflib import Utils, Errors, Logs
+ import waflib.Node
+ 
+@@ -660,7 +660,7 @@
+ 	except KeyError:
+ 		pass
+ 
+-	module = imp.new_module(WSCRIPT_FILE)
++	module = types.ModuleType(name=WSCRIPT_FILE)
+ 	try:
+ 		code = Utils.readf(path, m='r', encoding=encoding)
+ 	except EnvironmentError:
+

--- a/pkgs/by-name/ja/jack2/mingw/0006-missing-dllexport.patch
+++ b/pkgs/by-name/ja/jack2/mingw/0006-missing-dllexport.patch
@@ -1,0 +1,30 @@
+--- a/common/jack/uuid.h
++++ b/common/jack/uuid.h
+@@ -30,17 +30,17 @@
+ #define JACK_UUID_STRING_SIZE (JACK_UUID_SIZE+1) /* includes trailing null */
+ #define JACK_UUID_EMPTY_INITIALIZER 0
+ 
+-extern jack_uuid_t jack_client_uuid_generate ();
+-extern jack_uuid_t jack_port_uuid_generate (uint32_t port_id);
++JACK_LIB_EXPORT extern jack_uuid_t jack_client_uuid_generate ();
++JACK_LIB_EXPORT extern jack_uuid_t jack_port_uuid_generate (uint32_t port_id);
+ 
+-extern uint32_t jack_uuid_to_index (jack_uuid_t);
++JACK_LIB_EXPORT extern uint32_t jack_uuid_to_index (jack_uuid_t);
+ 
+-extern int  jack_uuid_compare (jack_uuid_t, jack_uuid_t);
+-extern void jack_uuid_copy (jack_uuid_t* dst, jack_uuid_t src);
+-extern void jack_uuid_clear (jack_uuid_t*);
+-extern int  jack_uuid_parse (const char *buf, jack_uuid_t*);
+-extern void jack_uuid_unparse (jack_uuid_t, char buf[JACK_UUID_STRING_SIZE]);
+-extern int  jack_uuid_empty (jack_uuid_t);
++JACK_LIB_EXPORT extern int  jack_uuid_compare (jack_uuid_t, jack_uuid_t);
++JACK_LIB_EXPORT extern void jack_uuid_copy (jack_uuid_t* dst, jack_uuid_t src);
++JACK_LIB_EXPORT extern void jack_uuid_clear (jack_uuid_t*);
++JACK_LIB_EXPORT extern int  jack_uuid_parse (const char *buf, jack_uuid_t*);
++JACK_LIB_EXPORT extern void jack_uuid_unparse (jack_uuid_t, char buf[JACK_UUID_STRING_SIZE]);
++JACK_LIB_EXPORT extern int  jack_uuid_empty (jack_uuid_t);
+ 
+ #ifdef __cplusplus
+ } /* namespace */
+

--- a/pkgs/by-name/ja/jack2/mingw/0007-unknown-autoimport-option-clang.patch
+++ b/pkgs/by-name/ja/jack2/mingw/0007-unknown-autoimport-option-clang.patch
@@ -1,0 +1,30 @@
+--- a/common/wscript
++++ b/common/wscript
+@@ -178,7 +178,7 @@
+         clientlib.env['implib_PATTERN'] = 'lib%s.dll.a'
+         if staticbuild:
+             clientlib.env['SHLIB_MARKER'] = ''
+-        clientlib.env.append_value('LINKFLAGS', ['-static-libstdc++', '--disable-auto-import'])
++        #clientlib.env.append_value('LINKFLAGS', ['-static-libstdc++', '--disable-auto-import'])
+         clientlib.env.append_value('LINKFLAGS', ['-Wl,--output-def,lib%s.def' % clientlib.target])
+         bld.install_files(clientlib.install_path, [os.path.join(buildbindir, 'lib%s.def' % clientlib.target)])
+ 
+@@ -262,7 +262,7 @@
+         serverlib.env['implib_PATTERN'] = 'lib%s.dll.a'
+         if staticbuild:
+             serverlib.env['SHLIB_MARKER'] = ''
+-        serverlib.env.append_value('LINKFLAGS', ['-static-libstdc++', '--disable-auto-import'])
++        #serverlib.env.append_value('LINKFLAGS', ['-static-libstdc++', '--disable-auto-import'])
+         serverlib.env.append_value('LINKFLAGS', ['-Wl,--output-def,lib%s.def' % serverlib.target])
+         bld.install_files(serverlib.install_path, [os.path.join(buildbindir, 'lib%s.def' % serverlib.target)])
+     serverlib.source = [] + common_libsources
+@@ -378,7 +378,7 @@
+             netlib.env['implib_PATTERN'] = 'lib%s.dll.a'
+             if staticbuild:
+                 netlib.env['SHLIB_MARKER'] = ''
+-            netlib.env.append_value('LINKFLAGS', ['-static-libstdc++', '--disable-auto-import'])
++            #netlib.env.append_value('LINKFLAGS', ['-static-libstdc++', '--disable-auto-import'])
+             netlib.env.append_value('LINKFLAGS', ['-Wl,--output-def,lib%s.def' % netlib.target])
+             bld.install_files(netlib.install_path, [os.path.join(buildbindir, 'lib%s.def' % netlib.target)])
+         elif not bld.env['IS_MACOSX']:
+

--- a/pkgs/by-name/li/libbluray/package.nix
+++ b/pkgs/by-name/li/libbluray/package.nix
@@ -68,7 +68,8 @@ stdenv.mkDerivation rec {
     description = "Library to access Blu-Ray disks for video playback";
     license = lib.licenses.lgpl21;
     maintainers = [ ];
-    platforms = lib.platforms.unix;
+    # MSYS2 ships libbluray for MinGW; allow Windows so pkgsCross.mingwW64 can evaluate it.
+    platforms = lib.platforms.unix ++ lib.platforms.windows;
   };
 
   passthru = {

--- a/pkgs/by-name/li/libevent/mingw/001-event2-02-win32.patch
+++ b/pkgs/by-name/li/libevent/mingw/001-event2-02-win32.patch
@@ -1,0 +1,11 @@
+--- libevent-2.1.8-stable/evutil.c.orig	2017-09-25 23:12:58.960674400 +0200
++++ libevent-2.1.8-stable/evutil.c	2017-09-25 23:13:49.827963900 +0200
+@@ -1838,7 +1838,7 @@
+ 	int r;
+ 	if (!buflen)
+ 		return 0;
+-#if defined(_MSC_VER) || defined(_WIN32)
++#if (defined(_MSC_VER) && _MSC_VER < 1900) || (defined(_WIN32) && (!defined(__USE_MINGW_ANSI_STDIO) || (__USE_MINGW_ANSI_STDIO + 0) == 0))
+ 	r = _vsnprintf(buf, buflen, format, ap);
+ 	if (r < 0)
+ 		r = _vscprintf(format, ap);

--- a/pkgs/by-name/li/libevent/mingw/002-http-server-win32.patch
+++ b/pkgs/by-name/li/libevent/mingw/002-http-server-win32.patch
@@ -1,0 +1,20 @@
+diff -bur libevent-2.1.12-stable-orig/sample/http-server.c libevent-2.1.12-stable/sample/http-server.c
+--- libevent-2.1.12-stable-orig/sample/http-server.c	2024-03-16 14:46:32.888774200 -0600
++++ libevent-2.1.12-stable/sample/http-server.c	2024-03-16 14:47:16.838938500 -0600
+@@ -384,11 +384,15 @@
+ }
+ 
+ static void
+-do_term(int sig, short events, void *arg)
++do_term(evutil_socket_t sig, short events, void *arg)
+ {
+ 	struct event_base *base = arg;
+ 	event_base_loopbreak(base);
++#ifdef _WIN64
++	fprintf(stderr, "Got %lld, Terminating\n", sig);
++#else
+ 	fprintf(stderr, "Got %i, Terminating\n", sig);
++#endif
+ }
+ 
+ static int

--- a/pkgs/by-name/li/libevent/mingw/003-cmake-update.patch
+++ b/pkgs/by-name/li/libevent/mingw/003-cmake-update.patch
@@ -1,0 +1,1016 @@
+diff -Naur a/cmake/AddEventLibrary.cmake b/cmake/AddEventLibrary.cmake
+--- a/cmake/AddEventLibrary.cmake	2025-05-20 15:12:42.864354000 +0300
++++ b/cmake/AddEventLibrary.cmake	2025-05-20 15:17:50.253181100 +0300
+@@ -1,4 +1,5 @@
+ include(CMakeParseArguments)
++include(GNUInstallDirs)
+ 
+ set(LIBEVENT_SHARED_LIBRARIES "")
+ set(LIBEVENT_STATIC_LIBRARIES "")
+@@ -11,38 +12,33 @@
+ endmacro()
+ 
+ macro(generate_pkgconfig LIB_NAME)
+-    set(prefix      ${CMAKE_INSTALL_PREFIX})
+-    set(exec_prefix ${CMAKE_INSTALL_PREFIX})
+-    set(libdir      ${CMAKE_INSTALL_PREFIX}/lib)
+-    set(includedir  ${CMAKE_INSTALL_PREFIX}/include)
++    set(prefix      "${CMAKE_INSTALL_PREFIX}")
++    set(exec_prefix "\${prefix}")
++    set(libdir      "\${prefix}/${CMAKE_INSTALL_LIBDIR}")
++    set(includedir  "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
+ 
+     set(VERSION ${EVENT_ABI_LIBVERSION})
+ 
+     set(LIBS         "")
+     foreach (LIB ${LIB_PLATFORM})
+-        set(LIBS "${LIBS} -L${LIB}")
+-    endforeach()
+-
+-    set(OPENSSL_LIBS "")
+-    foreach(LIB ${OPENSSL_LIBRARIES})
+-        set(OPENSSL_LIBS "${OPENSSL_LIBS} -L${LIB}")
++        set(LIBS "${LIBS} -l${LIB}")
+     endforeach()
+ 
+     configure_file("lib${LIB_NAME}.pc.in" "lib${LIB_NAME}.pc" @ONLY)
+     install(
+         FILES "${CMAKE_CURRENT_BINARY_DIR}/lib${LIB_NAME}.pc"
+-        DESTINATION "${CMAKE_INSTALL_PREFIX}/lib/pkgconfig"
++        DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
+     )
+ endmacro()
+ 
+ # LIB_NAME maybe event_core, event_extra, event_openssl, event_pthreads or event.
+ # Targets whose LIB_NAME is not 'event' should be exported and installed.
+-macro(export_install_target TYPE LIB_NAME OUTER_INCLUDES)
++macro(export_install_target TYPE LIB_NAME)
+     if("${LIB_NAME}" STREQUAL "event")
+         install(TARGETS "${LIB_NAME}_${TYPE}"
+-            LIBRARY DESTINATION "lib" COMPONENT lib
+-            ARCHIVE DESTINATION "lib" COMPONENT lib
+-            RUNTIME DESTINATION "lib" COMPONENT lib
++            LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT lib
++            ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT lib
++            RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT bin
+             COMPONENT dev
+         )
+     else()
+@@ -57,7 +53,6 @@
+             PUBLIC  "$<INSTALL_INTERFACE:include>"
+                     "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>"
+                     "$<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>"
+-                    ${OUTER_INCS}
+         )
+         set_target_properties("${LIB_NAME}_${TYPE}" PROPERTIES EXPORT_NAME ${PURE_NAME})
+         export(TARGETS "${LIB_NAME}_${TYPE}"
+@@ -67,9 +62,9 @@
+         )
+         install(TARGETS "${LIB_NAME}_${TYPE}"
+             EXPORT LibeventTargets-${TYPE}
+-            LIBRARY DESTINATION "lib" COMPONENT lib
+-            ARCHIVE DESTINATION "lib" COMPONENT lib
+-            RUNTIME DESTINATION "lib" COMPONENT lib
++            LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT lib
++            ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT lib
++            RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT bin
+             COMPONENT dev
+         )
+     endif()
+@@ -81,8 +76,7 @@
+ # - EVENT_ABI_LIBVERSION_REVISION
+ # - EVENT_ABI_LIBVERSION_AGE
+ # - EVENT_PACKAGE_RELEASE
+-# - CMAKE_THREAD_LIBS_INIT LIB_PLATFORM
+-# - OPENSSL_LIBRARIES
++# - LIB_PLATFORM
+ # - EVENT_SHARED_FLAGS
+ # - EVENT_LIBRARY_STATIC
+ # - EVENT_LIBRARY_SHARED
+@@ -94,14 +88,12 @@
+     cmake_parse_arguments(LIB
+         "" # Options
+         "VERSION" # One val
+-        "SOURCES;LIBRARIES;INNER_LIBRARIES;OUTER_INCLUDES" # Multi val
++        "SOURCES;LIBRARIES;INNER_LIBRARIES" # Multi val
+         ${ARGN}
+     )
+ 
+-    if ("${LIB_OUTER_INCLUDES}" STREQUAL "")
+-        set(LIB_OUTER_INCLUDES NONE)
+-    endif()
+     set(ADD_EVENT_LIBRARY_INTERFACE)
++    set(INNER_LIBRARIES)
+ 
+     if (${EVENT_LIBRARY_STATIC})
+         add_library("${LIB_NAME}_static" STATIC ${LIB_SOURCES})
+@@ -113,12 +105,11 @@
+             set(INNER_LIBRARIES "${LIB_INNER_LIBRARIES}_static")
+         endif()
+         target_link_libraries("${LIB_NAME}_static"
+-            ${CMAKE_THREAD_LIBS_INIT}
+             ${LIB_PLATFORM}
+             ${INNER_LIBRARIES}
+             ${LIB_LIBRARIES})
+ 
+-        export_install_target(static "${LIB_NAME}" "${LIB_OUTER_INCLUDES}")
++        export_install_target(static "${LIB_NAME}")
+ 
+         set(ADD_EVENT_LIBRARY_INTERFACE "${LIB_NAME}_static")
+     endif()
+@@ -130,7 +121,6 @@
+             set(INNER_LIBRARIES "${LIB_INNER_LIBRARIES}_shared")
+         endif()
+         target_link_libraries("${LIB_NAME}_shared"
+-            ${CMAKE_THREAD_LIBS_INIT}
+             ${LIB_PLATFORM}
+             ${INNER_LIBRARIES}
+             ${LIB_LIBRARIES})
+@@ -150,7 +140,6 @@
+             set_target_properties(
+                 "${LIB_NAME}_shared" PROPERTIES
+                 OUTPUT_NAME "${LIB_NAME}-${EVENT_PACKAGE_RELEASE}.${CURRENT_MINUS_AGE}"
+-                INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/lib"
+                 LINK_FLAGS "-compatibility_version ${COMPATIBILITY_VERSION} -current_version ${COMPATIBILITY_VERSION}.${EVENT_ABI_LIBVERSION_REVISION}")
+         else()
+             math(EXPR CURRENT_MINUS_AGE "${EVENT_ABI_LIBVERSION_CURRENT}-${EVENT_ABI_LIBVERSION_AGE}")
+@@ -158,8 +147,7 @@
+                 "${LIB_NAME}_shared" PROPERTIES
+                 OUTPUT_NAME "${LIB_NAME}-${EVENT_PACKAGE_RELEASE}"
+                 VERSION "${CURRENT_MINUS_AGE}.${EVENT_ABI_LIBVERSION_AGE}.${EVENT_ABI_LIBVERSION_REVISION}"
+-                SOVERSION "${CURRENT_MINUS_AGE}"
+-                INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
++                SOVERSION "${CURRENT_MINUS_AGE}")
+         endif()
+ 
+         if (NOT WIN32)
+@@ -174,14 +162,14 @@
+                 WORKING_DIRECTORY "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
+         endif()
+ 
+-        export_install_target(shared "${LIB_NAME}" "${LIB_OUTER_INCLUDES}")
++        export_install_target(shared "${LIB_NAME}")
+ 
+         set(ADD_EVENT_LIBRARY_INTERFACE "${LIB_NAME}_shared")
+ 
+         if (NOT WIN32)
+             install(FILES
+                 "$<TARGET_FILE_DIR:${LIB_NAME}_shared>/${LIB_LINK_NAME}"
+-                DESTINATION "lib"
++                DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+                 COMPONENT lib)
+         endif()
+     endif()
+diff -Naur a/cmake/AddLinkerFlags.cmake b/cmake/AddLinkerFlags.cmake
+--- a/cmake/AddLinkerFlags.cmake	1970-01-01 03:00:00.000000000 +0300
++++ b/cmake/AddLinkerFlags.cmake	2025-05-20 15:17:50.266242800 +0300
+@@ -0,0 +1,14 @@
++include(CheckLinkerFlag)
++
++macro(add_linker_flags)
++	foreach(flag ${ARGN})
++		string(REGEX REPLACE "[-.+/:= ]" "_" _flag_esc "${flag}")
++
++		check_linker_flag(C "${flag}" check_c_linker_flag_${_flag_esc})
++
++		if (check_c_linker_flag_${_flag_esc})
++			set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${flag}")
++			set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${flag}")
++		endif()
++	endforeach()
++endmacro()
+diff -Naur a/cmake/LibeventConfig.cmake.in b/cmake/LibeventConfig.cmake.in
+--- a/cmake/LibeventConfig.cmake.in	2020-07-05 15:01:34.000000000 +0300
++++ b/cmake/LibeventConfig.cmake.in	2025-05-20 15:17:50.381942000 +0300
+@@ -32,10 +33,17 @@
+ # find_package() can handle dependencies automatically. For example, given the 'openssl' component,
+ # all dependencies (libevent_core, libssl, libcrypto and openssl include directories) will be found.
+ 
+-set(CONFIG_FOR_INSTALL_TREE @CONFIG_FOR_INSTALL_TREE@)
+-
+ set(LIBEVENT_VERSION @EVENT_PACKAGE_VERSION@)
+ 
++# Load the dependencies of all components. As find_dependency propagates the original
++# find_package attributes (i.e. required or not), there's no need to repeat this or filter
++# by component.
++include(CMakeFindDependencyMacro)
++find_dependency(Threads)
++if(@EVENT__HAVE_OPENSSL@)
++    find_dependency(OpenSSL)
++endif()
++
+ # IMPORTED targets from LibeventTargets.cmake
+ set(LIBEVENT_STATIC_LIBRARIES "@LIBEVENT_STATIC_LIBRARIES@")
+ set(LIBEVENT_SHARED_LIBRARIES "@LIBEVENT_SHARED_LIBRARIES@")
+@@ -45,21 +56,20 @@
+     set(LIBEVENT_STATIC_LINK NOT @EVENT_LIBRARY_SHARED@)
+ endif()
+ 
+-set(CMAKE_FIND_LIBRARY_SUFFIXES_SAVE "${CMAKE_FIND_LIBRARY_SUFFIXES}")
+ if(${LIBEVENT_STATIC_LINK})
+     set(_LIB_TYPE static)
+-    set(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_STATIC_LIBRARY_SUFFIX})
+     set(_AVAILABLE_LIBS "${LIBEVENT_STATIC_LIBRARIES}")
++
++    # CMake before 3.15 doesn't link OpenSSL to pthread/dl, do it ourselves instead
++    if (${CMAKE_VERSION} VERSION_LESS "3.15.0" AND "${LIBEVENT_STATIC_LINK}" AND "${OPENSSL_FOUND}" AND "${Threads_FOUND}")
++        set_property(TARGET OpenSSL::Crypto APPEND PROPERTY INTERFACE_LINK_LIBRARIES Threads::Threads)
++        set_property(TARGET OpenSSL::Crypto APPEND PROPERTY INTERFACE_LINK_LIBRARIES ${CMAKE_DL_LIBS})
++    endif ()
+ else()
+     set(_LIB_TYPE shared)
+-    set(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_SHARED_LIBRARY_SUFFIX})
+     set(_AVAILABLE_LIBS "${LIBEVENT_SHARED_LIBRARIES}")
+ endif()
+ 
+-# Get the path of the current file.
+-get_filename_component(LIBEVENT_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+-get_filename_component(_INSTALL_PREFIX "${LIBEVENT_CMAKE_DIR}/../../.." ABSOLUTE)
+-
+ macro(message_if_needed _flag _msg)
+     if (NOT ${CMAKE_FIND_PACKAGE_NAME}_FIND_QUIETLY)
+         message(${_flag} "${_msg}")
+@@ -110,63 +120,22 @@
+     endforeach()
+ endmacro()
+ 
+-if(CONFIG_FOR_INSTALL_TREE)
+-    ## Config for install tree ----------------------------------------
+-    # Find includes
+-    unset(_event_h CACHE)
+-    find_path(_event_h
+-              NAMES event2/event.h
+-              PATHS "${_INSTALL_PREFIX}/include"
+-              NO_DEFAULT_PATH)
+-    if(_event_h)
+-        set(LIBEVENT_INCLUDE_DIRS "${_event_h}")
+-        message_if_needed(STATUS "Found libevent include directory: ${_event_h}")
+-    else()
+-        message_if_needed(WARNING "Your libevent library does not contain header files!")
+-    endif()
++foreach(_comp ${_EVENT_COMPONENTS})
++    list(APPEND LIBEVENT_LIBRARIES "libevent::${_comp}")
++    set_case_insensitive_found(${_comp})
++endforeach()
+ 
+-    # Find libraries
+-    macro(find_event_lib _comp)
+-        unset(_event_lib CACHE)
+-        find_library(_event_lib
+-                    NAMES "event_${_comp}"
+-                    PATHS "${_INSTALL_PREFIX}/lib"
+-                    NO_DEFAULT_PATH)
+-        if(_event_lib)
+-            list(APPEND LIBEVENT_LIBRARIES "libevent::${_comp}")
+-            set_case_insensitive_found(${_comp})
+-            message_if_needed(STATUS "Found libevent component: ${_event_lib}")
+-        else()
+-            no_component_msg(${_comp})
+-        endif()
+-    endmacro()
+-
+-    foreach(comp ${_EVENT_COMPONENTS})
+-        find_event_lib(${comp})
+-    endforeach()
+-else()
+-    ## Config for build tree ----------------------------------------
+-    set(LIBEVENT_INCLUDE_DIRS "@EVENT__INCLUDE_DIRS@")
+-    foreach(_comp ${_EVENT_COMPONENTS})
+-        list(APPEND LIBEVENT_LIBRARIES "libevent::${_comp}")
+-        set_case_insensitive_found(${_comp})
+-    endforeach()
+-endif()
+-
+-set(LIBEVENT_INCLUDE_DIR ${LIBEVENT_INCLUDE_DIRS})
+ if(LIBEVENT_LIBRARIES)
+     set(LIBEVENT_LIBRARY ${LIBEVENT_LIBRARIES})
+-    if(CONFIG_FOR_INSTALL_TREE)
+-        message_if_needed(STATUS "Found libevent ${LIBEVENT_VERSION} in ${_INSTALL_PREFIX}")
+-    else()
+-        message_if_needed(STATUS "Found libevent ${LIBEVENT_VERSION} in ${LIBEVENT_CMAKE_DIR}")
+-    endif()
+ 
+-    # Avoid including targets more than one times
+-    if(NOT TARGET event_core_${_LIB_TYPE})
++    # Avoid including targets more than once.
++    if(NOT TARGET libevent::core)
+         # Include the project Targets file, this contains definitions for IMPORTED targets.
+-        include(${LIBEVENT_CMAKE_DIR}/LibeventTargets-${_LIB_TYPE}.cmake)
++        include(${CMAKE_CURRENT_LIST_DIR}/LibeventTargets-${_LIB_TYPE}.cmake)
+     endif()
++    get_target_property(LIBEVENT_INCLUDE_DIRS libevent::core INTERFACE_INCLUDE_DIRECTORIES)
++    get_filename_component(LIBEVENT_INSTALL_PREFIX "${LIBEVENT_INCLUDE_DIRS}" PATH)
++    message_if_needed(STATUS "Found libevent ${LIBEVENT_VERSION} in ${LIBEVENT_INSTALL_PREFIX}")
+ else()
+     if(${CMAKE_FIND_PACKAGE_NAME}_FIND_REQUIRED)
+         message(FATAL_ERROR "Can not find any libraries for libevent.")
+@@ -174,10 +143,9 @@
+         message_if_needed(WARNING "Can not find any libraries for libevent.")
+     endif()
+ endif()
++set(LIBEVENT_INCLUDE_DIR ${LIBEVENT_INCLUDE_DIRS})
+ 
+-set(CMAKE_FIND_LIBRARY_SUFFIXES "${CMAKE_FIND_LIBRARY_SUFFIXES_SAVE}")
+ unset(_LIB_TYPE)
+ unset(_AVAILABLE_LIBS)
+ unset(_EVENT_COMPONENTS)
+ unset(_POSSIBLE_PKG_NAMES)
+-unset(_INSTALL_PREFIX)
+diff -Naur a/cmake/RenameDoxygen.cmake b/cmake/RenameDoxygen.cmake
+--- a/cmake/RenameDoxygen.cmake	1970-01-01 03:00:00.000000000 +0300
++++ b/cmake/RenameDoxygen.cmake	2025-05-20 15:17:50.411471200 +0300
+@@ -0,0 +1,17 @@
++# Add prefix "libevent_" for manual pages
++
++message(STATUS "Rename man pages in ${CMAKE_BINARY_DIR}")
++
++# Remove old pages to avoid stalled copies
++file(GLOB LIBEVENT_MAN_PAGES RELATIVE ${CMAKE_BINARY_DIR} libevent_*)
++list(LENGTH LIBEVENT_MAN_PAGES LEN)
++if (${LEN} GREATER 0)
++    file(REMOVE ${LIBEVENT_MAN_PAGES})
++endif()
++
++# Create new
++file(GLOB LIBEVENT_MAN_PAGES RELATIVE ${CMAKE_BINARY_DIR} *)
++list(FILTER LIBEVENT_MAN_PAGES EXCLUDE REGEX ^libevent_.*$)
++foreach(MAN_PAGE ${LIBEVENT_MAN_PAGES})
++  file(RENAME ${CMAKE_BINARY_DIR}/${MAN_PAGE} ${CMAKE_BINARY_DIR}/libevent_${MAN_PAGE})
++endforeach()
+diff -Naur a/cmake/UseDoxygen.cmake b/cmake/UseDoxygen.cmake
+--- a/cmake/UseDoxygen.cmake	2020-07-05 15:01:34.000000000 +0300
++++ b/cmake/UseDoxygen.cmake	2025-05-20 15:17:50.425128700 +0300
+@@ -2,7 +2,6 @@
+ 
+ option(DOXYGEN_GENERATE_HTML  "Generate HTML"      ON)
+ option(DOXYGEN_GENERATE_MAN   "Generate man pages" OFF)
+-option(DOXYGEN_MAN_LINKS      "Generate man links" ON)
+ option(DOXYGEN_GENERATE_LATEX "Generate LaTeX"     OFF)
+ 
+ # If the case-insensitive value of the cmake option is one of
+@@ -90,16 +90,23 @@
+       if ("${DOXYGEN_GENERATE_HTML}" STREQUAL "YES")
+         install(DIRECTORY
+           ${PROJECT_BINARY_DIR}/${DOXYGEN_OUTPUT_DIRECTORY}/html
+-          DESTINATION ${CMAKE_INSTALL_PREFIX}/share/doc/${PROJECT_NAME}
++          DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/doc/${PROJECT_NAME}
+           COMPONENT doc
+         )
+       endif()
+ 
+-      # Install manual into <prefix>/share/man/man3
+       if ("${DOXYGEN_GENERATE_MAN}" STREQUAL "YES")
++        set(MAN_PAGES_DIR ${PROJECT_BINARY_DIR}/${DOXYGEN_OUTPUT_DIRECTORY}/man/man3)
++        # Add prefix "libevent_" for manual pages
++        add_custom_target(doxygen-rename-man-pages ALL
++          COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/RenameDoxygen.cmake
++          DEPENDS doxygen
++          WORKING_DIRECTORY ${MAN_PAGES_DIR})
++
++        # Install manual into <prefix>/share/man/man3
+         install(DIRECTORY
+-          ${PROJECT_BINARY_DIR}/${DOXYGEN_OUTPUT_DIRECTORY}/man/man3
+-          DESTINATION ${CMAKE_INSTALL_PREFIX}/share/man
++          ${MAN_PAGES_DIR}
++          DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/man
+           COMPONENT doc
+         )
+       endif()
+diff -Naur a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt	2025-05-21 09:38:25.519376100 +0300
++++ b/CMakeLists.txt	2025-05-21 10:00:55.384905300 +0300
+@@ -19,11 +19,8 @@
+ #       start libevent.sln
+ #
+ 
+-cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
++cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
+ 
+-if (POLICY CMP0054)
+-    cmake_policy(SET CMP0054 NEW)
+-endif()
+ if (POLICY CMP0074)
+     cmake_policy(SET CMP0074 NEW)
+ endif()
+@@ -30,13 +30,18 @@
+ 
+ if(NOT CMAKE_BUILD_TYPE)
+     set(CMAKE_BUILD_TYPE Release
+-        CACHE STRING "Set build type to Debug o Release (default Release)" FORCE)
++        CACHE STRING "Set build type to Debug or Release (default Release)" FORCE)
++    message(STATUS "Set CMAKE_BUILD_TYPE to Release (default)")
+ endif()
+ string(TOLOWER "${CMAKE_BUILD_TYPE}" CMAKE_BUILD_TYPE_LOWER)
+ 
+-# get rid of the extra default configurations
+-# what? why would you get id of other useful build types? - Ellzey
+-set(CMAKE_CONFIGURATION_TYPES "Debug;Release" CACHE STRING "Limited configurations" FORCE)
++# Usually it is OK to define it unconditionally, but the problem is that we use
++# CMAKE_DEBUG_POSTFIX in *.pc.in
++if (CMAKE_BUILD_TYPE_LOWER STREQUAL "debug")
++    if(NOT DEFINED CMAKE_DEBUG_POSTFIX)
++        set(CMAKE_DEBUG_POSTFIX d)
++    endif()
++endif()
+ 
+ set(EVENT__LIBRARY_TYPE DEFAULT CACHE STRING
+     "Set library type to SHARED/STATIC/BOTH (default SHARED for MSVC, otherwise BOTH)")
+@@ -58,6 +63,7 @@
+ include(CheckFunctionKeywords)
+ include(CheckConstExists)
+ include(AddCompilerFlags)
++include(AddLinkerFlags)
+ include(VersionViaGit)
+ 
+ event_fuzzy_version_from_git()
+@@ -165,10 +171,35 @@
+     set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
+ endif()
+ 
++include(GNUInstallDirs)
++
++# The RPATH to be used when installing, but only if it's not a system directory
++#
++# Refs: https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/RPATH-handling
++macro(Configure_RPATH)
++    # NOTE: that CMAKE_INSTALL_FULL_LIBDIR not always normalized correctly, i.e.:
++    # - "///" -> "/"
++    # - "/////usr///" -> "//usr"
++    # So it should be normalized again.
++    get_filename_component(CMAKE_INSTALL_LIBDIR_NORMALIZED "${CMAKE_INSTALL_FULL_LIBDIR}" REALPATH)
++    list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_LIBDIR_NORMALIZED}" isSystemDir)
++
++    if(DEFINED CMAKE_INSTALL_RPATH)
++        message(STATUS "CMAKE_INSTALL_RPATH already set")
++    elseif("${isSystemDir}" STREQUAL "-1")
++        set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_LIBDIR_NORMALIZED}")
++    else()
++        message(STATUS "Detected install to system directory")
++    endif()
++endmacro()
++Configure_RPATH()
++
+ if (EVENT__ENABLE_VERBOSE_DEBUG)
+     add_definitions(-DUSE_DEBUG=1)
+ endif()
+ 
++add_linker_flags(-Wl,-z,max-page-size=16384)
++
+ # make it colorful under ninja-build
+ if ("${CMAKE_GENERATOR}" STREQUAL "Ninja")
+     add_compiler_flags(-fdiagnostics-color=always)
+@@ -182,9 +213,9 @@
+ 
+     message(STATUS "Setting coverage compiler flags")
+ 
+-    set(CMAKE_REQUIRED_LIBRARIES "--coverage")
++    list(APPEND CMAKE_REQUIRED_LIBRARIES "--coverage")
+     add_compiler_flags(-g -O0 --coverage)
+-    set(CMAKE_REQUIRED_LIBRARIES "")
++    list(REMOVE_ITEM CMAKE_REQUIRED_LIBRARIES "--coverage")
+ endif()
+ 
+ set(GNUC 0)
+@@ -265,10 +296,9 @@
+     option(EVENT__ENABLE_GCC_FUNCTION_SECTIONS "Enable gcc function sections" OFF)
+     option(EVENT__ENABLE_GCC_WARNINGS "Make all GCC warnings into errors" OFF)
+ 
+-    set(GCC_V ${CMAKE_C_COMPILER_VERSION})
+-
+     list(APPEND __FLAGS
+          -Wall -Wextra -Wno-unused-parameter -Wstrict-aliasing -Wstrict-prototypes
++         -Wundef
+ 
+          -fno-strict-aliasing # gcc 2.9.5+
+          -Wmissing-prototypes
+@@ -287,10 +317,19 @@
+          -Wlogical-op
+ 
+          -Wwrite-strings
++
++         # Disable unused-function warnings. These trigger for minheap-internal.h.
++         -Wno-unused-function
++
++         -Wno-pragmas
++
++         -Wvla
+     )
+ 
+     if (${CLANG})
+-        list(APPEND __FLAGS -Wno-unused-function)
++        list(APPEND __FLAGS
++             # we use this hack in tests
++             -Wno-void-pointer-to-enum-cast)
+     endif()
+ 
+     if (EVENT__DISABLE_GCC_WARNINGS)
+@@ -334,11 +373,19 @@
+ 
+ # Winsock.
+ if(WIN32)
+-    set(CMAKE_REQUIRED_LIBRARIES  ws2_32 shell32 advapi32)
++    list(APPEND CMAKE_REQUIRED_LIBRARIES
++        ws2_32
++        shell32
++        advapi32
++        bcrypt
++    )
+     set(CMAKE_REQUIRED_DEFINITIONS -FIwinsock2.h -FIws2tcpip.h -D_WIN32_WINNT=0x0600)
+ endif()
+ if (SOLARIS)
+-    set(CMAKE_REQUIRED_LIBRARIES socket nsl)
++    list(APPEND CMAKE_REQUIRED_LIBRARIES
++        socket
++        nsl
++    )
+ endif()
+ 
+ # Check if _GNU_SOURCE is available.
+@@ -427,6 +474,13 @@
+     )
+ endif()
+ 
++if (NOT EVENT__DISABLE_THREAD_SUPPORT AND NOT WIN32)
++    list(APPEND FILES_TO_CHECK pthread.h)
++    # (Only `CHECK_TYPE_SIZE()' will use `CMAKE_EXTRA_INCLUDE_FILES')
++    list(APPEND CMAKE_EXTRA_INCLUDE_FILES pthread.h)
++endif()
++
++# Fills EVENT_INCLUDES
+ foreach(FILE ${FILES_TO_CHECK})
+     CHECK_INCLUDE_FILE_CONCAT(${FILE} "EVENT")
+ endforeach()
+@@ -463,53 +517,87 @@
+ 
+ if (WIN32)
+     list(APPEND SYMBOLS_TO_CHECK
+-        _gmtime64_s
+         _gmtime64
++        _gmtime64_s
+     )
+ else()
+     list(APPEND SYMBOLS_TO_CHECK
+-        getifaddrs
+-        select
++        accept4
++        arc4random
++        arc4random_buf
++        arc4random_stir
+         epoll_create
+         epoll_create1
+         epoll_ctl
++        epoll_pwait2
+         eventfd
+-        poll
+-        port_create
+-        kqueue
+         fcntl
++        getegid
++        geteuid
++        gethostbyname_r
++        getifaddrs
++        getrandom
++        issetugid
++        kqueue
+         mmap
++        mmap64
+         pipe
+         pipe2
++        poll
++        port_create
++        pread
++        select
+         sendfile
++        setenv
++        setrlimit
+         sigaction
+         strsignal
+         sysctl
+-        accept4
+-        arc4random
+-        arc4random_buf
+-        arc4random_addrandom
+-        getrandom
+-        getegid
+-        geteuid
+-        issetugid
+-        usleep
+         timerfd_create
+-        setenv
+         unsetenv
+-        setrlimit
+-        gethostbyname_r
++        usleep
+     )
+     if (APPLE)
+         list(APPEND SYMBOLS_TO_CHECK mach_absolute_time)
+     endif()
+ endif()
+ 
+-# Add stdio.h for vasprintf
+-set(EVENT_INCLUDES ${EVENT_INCLUDES} stdio.h)
+-CHECK_SYMBOLS_EXIST("${SYMBOLS_TO_CHECK}" "${EVENT_INCLUDES}" "EVENT")
++set(PTHREADS_AVAILABLE OFF)
++if (NOT EVENT__DISABLE_THREAD_SUPPORT)
++    if (WIN32)
++        list(APPEND SRC_CORE evthread_win32.c)
++    elseif(ANDROID)
++        # pthreads is built in to bionic
++        set(EVENT__HAVE_PTHREADS 1)
++        CHECK_TYPE_SIZE(pthread_t EVENT__SIZEOF_PTHREAD_T)
++        list(APPEND SYMBOLS_TO_CHECK pthread_mutexattr_setprotocol)
++        set(PTHREADS_AVAILABLE ON)
++    else()
++        find_package(Threads REQUIRED)
++        if (NOT CMAKE_USE_PTHREADS_INIT)
++            message(FATAL_ERROR
++                    "Failed to find Pthreads, set EVENT__DISABLE_THREAD_SUPPORT to disable")
++        endif()
++        set(PTHREADS_AVAILABLE ON)
++
++        set(EVENT__HAVE_PTHREADS 1)
++        # for CHECK_SYMBOLS_EXIST()
++        list(APPEND CMAKE_REQUIRED_LIBRARIES ${CMAKE_THREAD_LIBS_INIT})
++        list(APPEND LIB_APPS Threads::Threads)
++
++        CHECK_TYPE_SIZE(pthread_t EVENT__SIZEOF_PTHREAD_T)
++        list(APPEND SYMBOLS_TO_CHECK pthread_mutexattr_setprotocol)
++    endif()
++endif()
++
++list(APPEND CMAKE_EXTRA_INCLUDE_FILES ${EVENT_INCLUDES} stdio.h)
++CHECK_SYMBOLS_EXIST("${SYMBOLS_TO_CHECK}" "${CMAKE_EXTRA_INCLUDE_FILES}" "EVENT")
+ unset(SYMBOLS_TO_CHECK)
+ set(EVENT__HAVE_EPOLL ${EVENT__HAVE_EPOLL_CREATE})
++set(EVENT__HAVE_SIGNALFD ${EVENT__HAVE_SYS_SIGNALFD_H})
++if(WIN32 AND NOT CYGWIN)
++    set(EVENT__HAVE_WEPOLL 1)
++endif()
+ 
+ # Get the gethostbyname_r prototype.
+ if(EVENT__HAVE_GETHOSTBYNAME_R)
+@@ -536,9 +624,6 @@
+     set(EVENT__HAVE_EVENT_PORTS 1)
+ endif()
+ 
+-# Only `CHECK_TYPE_SIZE()' will use `CMAKE_EXTRA_INCLUDE_FILES'
+-set(CMAKE_EXTRA_INCLUDE_FILES ${EVENT_INCLUDES})
+-
+ CHECK_TYPE_SIZE("struct sockaddr_un" EVENT__HAVE_STRUCT_SOCKADDR_UN)
+ CHECK_TYPE_SIZE("uint8_t" EVENT__HAVE_UINT8_T)
+ CHECK_TYPE_SIZE("uint16_t" EVENT__HAVE_UINT16_T)
+@@ -575,7 +660,6 @@
+ CHECK_SYMBOL_EXISTS("__func__"     "" EVENT__HAVE___func__)
+ CHECK_SYMBOL_EXISTS("__FUNCTION__" "" EVENT__HAVE___FUNCTION__)
+ 
+-CHECK_SYMBOL_EXISTS(TAILQ_FOREACH sys/queue.h EVENT__HAVE_TAILQFOREACH)
+ CHECK_CONST_EXISTS(CTL_KERN sys/sysctl.h EVENT__HAVE_DECL_CTL_KERN)
+ CHECK_CONST_EXISTS(KERN_ARND sys/sysctl.h EVENT__HAVE_DECL_KERN_ARND)
+ CHECK_SYMBOL_EXISTS(F_SETFD fcntl.h EVENT__HAVE_SETFD)
+@@ -584,10 +668,7 @@
+ 
+ CHECK_TYPE_SIZE(size_t EVENT__SIZEOF_SIZE_T)
+ if(NOT EVENT__SIZEOF_SIZE_T)
+-  set(EVENT__size_t "unsigned")
+   set(EVENT__SIZEOF_SIZE_T ${EVENT__SIZEOF_UNSIGNED})
+-else()
+-    set(EVENT__size_t size_t)
+ endif()
+ 
+ CHECK_TYPE_SIZE("off_t" EVENT__SIZEOF_OFF_T LANGUAGE C)
+@@ -604,13 +685,10 @@
+ 
+ if (EVENT__SIZEOF_SSIZE_T_LOWER)
+     set(EVENT__ssize_t "ssize_t")
+-    set(EVENT__SIZEOF_SSIZE_T ${EVENT__SIZEOF_SSIZE_T_LOWER})
+ elseif (EVENT__SIZEOF_SSIZE_T_UPPER)
+     set(EVENT__ssize_t "SSIZE_T")
+-    set(EVENT__SIZEOF_SSIZE_T ${EVENT__SIZEOF_SSIZE_T_UPPER})
+ else()
+     set(EVENT__ssize_t "int")
+-    set(EVENT__SIZEOF_SSIZE_T ${EVENT__SIZEOF_INT})
+ endif()
+ 
+ CHECK_TYPE_SIZE(socklen_t EVENT__SIZEOF_SOCKLEN_T)
+@@ -628,17 +706,6 @@
+ 	set(EVENT__SIZEOF_PID_T EVENT__SIZEOF_PID_T)
+ endif()
+ 
+-if (NOT EVENT__DISABLE_THREAD_SUPPORT)
+-    if (NOT WIN32)
+-        list(APPEND CMAKE_EXTRA_INCLUDE_FILES pthread.h)
+-    endif()
+-    CHECK_TYPE_SIZE(pthread_t EVENT__SIZEOF_PTHREAD_T)
+-endif()
+-
+-if(EVENT__HAVE_CLOCK_GETTIME)
+-  set(EVENT__DNS_USE_CPU_CLOCK_FOR_ID 1)
+-endif()
+-
+ # we're just getting lazy now.
+ CHECK_TYPE_SIZE("uintptr_t" EVENT__HAVE_UINTPTR_T)
+ CHECK_TYPE_SIZE("void *" EVENT__SIZEOF_VOID_P)
+@@ -701,15 +768,6 @@
+ endif()
+ 
+ CHECK_TYPE_SIZE("struct in6_addr" EVENT__HAVE_STRUCT_IN6_ADDR)
+-if(EVENT__HAVE_STRUCT_IN6_ADDR)
+-    CHECK_STRUCT_HAS_MEMBER("struct in6_addr"
+-            s6_addr16 "${SOCKADDR_HEADERS}"
+-            EVENT__HAVE_STRUCT_IN6_ADDR_S6_ADDR16)
+-
+-    CHECK_STRUCT_HAS_MEMBER("struct in6_addr"
+-            s6_addr32 "${SOCKADDR_HEADERS}"
+-            EVENT__HAVE_STRUCT_IN6_ADDR_S6_ADDR32)
+-endif()
+ 
+ CHECK_TYPE_SIZE("sa_family_t" EVENT__HAVE_SA_FAMILY_T)
+ CHECK_TYPE_SIZE("struct sockaddr_in6" EVENT__HAVE_STRUCT_SOCKADDR_IN6)
+@@ -795,7 +853,7 @@
+     include/event2/visibility.h
+     ${PROJECT_BINARY_DIR}/include/event2/event-config.h)
+ 
+-set(SRC_CORE
++list(APPEND SRC_CORE
+     buffer.c
+     bufferevent.c
+     bufferevent_filter.c
+@@ -837,45 +895,33 @@
+     list(APPEND SRC_CORE evport.c)
+ endif()
+ 
+-if (NOT EVENT__DISABLE_OPENSSL)
+-    find_package(OpenSSL REQUIRED)
+-
+-    set(EVENT__HAVE_OPENSSL 1)
+-
+-    message(STATUS "OpenSSL include: ${OPENSSL_INCLUDE_DIR}")
+-    message(STATUS "OpenSSL lib: ${OPENSSL_LIBRARIES}")
+-
+-    include_directories(${OPENSSL_INCLUDE_DIR})
++if (EVENT__DISABLE_OPENSSL STREQUAL "OFF" OR EVENT__DISABLE_OPENSSL STREQUAL "AUTO")
++    find_package(OpenSSL)
+ 
+-    list(APPEND SRC_OPENSSL bufferevent_openssl.c)
+-    list(APPEND HDR_PUBLIC include/event2/bufferevent_ssl.h)
+-    list(APPEND LIB_APPS ${OPENSSL_LIBRARIES})
+-endif()
+-
+-if (NOT EVENT__DISABLE_THREAD_SUPPORT)
+-    if (WIN32)
+-        list(APPEND SRC_CORE evthread_win32.c)
+-    else()
+-        find_package(Threads REQUIRED)
+-        if (NOT CMAKE_USE_PTHREADS_INIT)
+-            message(FATAL_ERROR
+-                    "Failed to find Pthreads, set EVENT__DISABLE_THREAD_SUPPORT to disable")
+-        endif()
+-
+-        set(EVENT__HAVE_PTHREADS 1)
+-        list(APPEND LIB_APPS ${CMAKE_THREAD_LIBS_INIT})
++    if (OPENSSL_FOUND)
++        set(EVENT__HAVE_OPENSSL 1)
++        set(OPENSSL_TARGETS OpenSSL::SSL)
++
++        message(STATUS "OpenSSL include: ${OPENSSL_INCLUDE_DIR}")
++        message(STATUS "OpenSSL lib: ${OPENSSL_LIBRARIES}")
++
++        list(APPEND SRC_OPENSSL bufferevent_openssl.c)
++        list(APPEND HDR_PUBLIC include/event2/bufferevent_ssl.h)
++        list(APPEND LIB_APPS ${OPENSSL_TARGETS})
++    elseif (EVENT__DISABLE_OPENSSL STREQUAL "OFF")
++        message(FATAL_ERROR "OpenSSL required, but not found.")
+     endif()
++elseif (EVENT__DISABLE_OPENSSL STREQUAL "ON")
++    message(STATUS "Disable OpenSSL support")
+ endif()
+ 
+ if (NOT EVENT__DISABLE_TESTS)
+     # Zlib is only used for testing.
+     find_package(ZLIB)
+ 
+     if (ZLIB_LIBRARY AND ZLIB_INCLUDE_DIR)
+-        include_directories(${ZLIB_INCLUDE_DIRS})
+-
+         set(EVENT__HAVE_LIBZ 1)
+-        list(APPEND LIB_APPS ${ZLIB_LIBRARIES})
++        list(APPEND LIB_APPS ZLIB::ZLIB)
+     endif()
+ endif()
+ 
+@@ -885,6 +931,15 @@
+     evdns.c
+     evrpc.c)
+ 
++if(${CMAKE_VERSION} VERSION_LESS "3.20")
++  include(TestBigEndian)
++  TEST_BIG_ENDIAN(IS_BIG_ENDIAN)
++  if(IS_BIG_ENDIAN)
++    set(CMAKE_C_BYTE_ORDER BIG_ENDIAN)
++  else()
++    set(CMAKE_C_BYTE_ORDER LITTLE_ENDIAN)
++  endif()
++endif()
+ add_definitions(-DHAVE_CONFIG_H)
+ 
+ # We use BEFORE here so we don't accidentally look in system directories
+@@ -902,8 +957,7 @@
+ 
+     list(APPEND HDR_PRIVATE WIN32-Code/getopt.h)
+ 
+-    set(EVENT__DNS_USE_FTIME_FOR_ID 1)
+-    set(LIB_PLATFORM ws2_32 shell32 advapi32)
++    set(LIB_PLATFORM ws2_32 shell32 advapi32 bcrypt iphlpapi)
+     add_definitions(
+             -D_CRT_SECURE_NO_WARNINGS
+             -D_CRT_NONSTDC_NO_DEPRECATE)
+@@ -949,19 +1003,25 @@
+     INNER_LIBRARIES event_core
+     SOURCES ${SRC_EXTRA})
+ 
+-if (NOT EVENT__DISABLE_OPENSSL)
++if (EVENT__HAVE_OPENSSL)
+     add_event_library(event_openssl
+         INNER_LIBRARIES event_core
+-        OUTER_INCLUDES ${OPENSSL_INCLUDE_DIR}
+-        LIBRARIES ${OPENSSL_LIBRARIES}
++        LIBRARIES ${OPENSSL_TARGETS}
+         SOURCES ${SRC_OPENSSL})
+ endif()
+ 
+ if (EVENT__HAVE_PTHREADS)
+     set(SRC_PTHREADS evthread_pthread.c)
+-    add_event_library(event_pthreads
+-        INNER_LIBRARIES event_core
+-        SOURCES ${SRC_PTHREADS})
++    if(ANDROID)
++        add_event_library(event_pthreads
++            INNER_LIBRARIES event_core
++            SOURCES ${SRC_PTHREADS})
++    else()
++        add_event_library(event_pthreads
++            INNER_LIBRARIES event_core
++            LIBRARIES Threads::Threads
++            SOURCES ${SRC_PTHREADS})
++    endif()
+ endif()
+ 
+ # library exists for historical reasons; it contains the contents of
+@@ -1000,8 +1060,8 @@
+                           ${LIB_APPS}
+                           ${LIB_PLATFORM})
+ 
+-    if (${ssl})
+-        target_link_libraries(${name} event_openssl)
++    if (TARGET ${ssl})
++        target_link_libraries(${name} ${ssl})
+         if(WIN32)
+             target_link_libraries(${name} crypt32)
+         endif()
+@@ -1019,7 +1079,7 @@
+         add_sample_prog(OFF ${SAMPLE} sample/${SAMPLE}.c)
+     endforeach()
+ 
+-    if (NOT EVENT__DISABLE_OPENSSL)
++    if (EVENT__HAVE_OPENSSL)
+         add_sample_prog(ON https-client
+                         sample/https-client.c
+                         sample/openssl_hostname_validation.c
+@@ -1069,20 +1129,23 @@
+                           event_extra
+                           ${ARGN})
+ endmacro()
++
+ if (NOT EVENT__DISABLE_TESTS)
+     #
+     # Generate Regress tests.
+     #
+     if (NOT EVENT__DISABLE_REGRESS)
+         # (We require python to generate the regress tests)
+-        find_package(PythonInterp 3)
++        find_package(Python3 COMPONENTS Interpreter)
+ 
+-        if (PYTHONINTERP_FOUND)
++        if (Python3_FOUND)
+             set(__FOUND_USABLE_PYTHON 1)
++            set(PYTHON_EXECUTABLE ${Python3_EXECUTABLE})
+         else()
+-            find_package(PythonInterp 2)
+-            if (PYTHONINTERP_FOUND)
++            find_package(Python2 COMPONENTS Interpreter)
++            if (Python2_FOUND)
+                 set(__FOUND_USABLE_PYTHON 1)
++                set(PYTHON_EXECUTABLE ${Python2_EXECUTABLE})
+             else()
+                 message(ERROR "No suitable Python version found, bailing...")
+             endif()
+@@ -1135,7 +1198,7 @@
+                 list(APPEND SRC_REGRESS test/regress_zlib.c)
+             endif()
+ 
+-            if (NOT EVENT__DISABLE_OPENSSL)
++            if (EVENT__HAVE_OPENSSL)
+                 list(APPEND SRC_REGRESS test/regress_ssl.c)
+             endif()
+ 
+@@ -1146,10 +1209,10 @@
+                                   ${LIB_PLATFORM}
+                                   event_core
+                                   event_extra)
+-            if (NOT EVENT__DISABLE_OPENSSL)
++            if (EVENT__HAVE_OPENSSL)
+                 target_link_libraries(regress event_openssl)
+             endif()
+-            if (CMAKE_USE_PTHREADS_INIT)
++            if (PTHREADS_AVAILABLE)
+                 target_link_libraries(regress event_pthreads)
+             endif()
+         else()
+@@ -1450,22 +1513,13 @@
+ #
+ 
+ set(EVENT_INSTALL_CMAKE_DIR
+-    "${CMAKE_INSTALL_PREFIX}/lib/cmake/libevent")
++    "${CMAKE_INSTALL_LIBDIR}/cmake/libevent")
+ 
+ export(PACKAGE libevent)
+ 
+-function(gen_package_config forinstall)
+-    if(${forinstall})
+-        set(CONFIG_FOR_INSTALL_TREE 1)
+-        set(dir "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}")
+-    else()
+-        set(CONFIG_FOR_INSTALL_TREE 0)
+-        set(dir "${PROJECT_BINARY_DIR}")
+-    endif()
+-    configure_file(${PROJECT_SOURCE_DIR}/cmake/LibeventConfig.cmake.in
+-                "${dir}/LibeventConfig.cmake"
+-                @ONLY)
+-endfunction()
++configure_file(${PROJECT_SOURCE_DIR}/cmake/LibeventConfig.cmake.in
++    "${PROJECT_BINARY_DIR}/LibeventConfig.cmake"
++    @ONLY)
+ 
+ # Generate the config file for the build-tree.
+ set(EVENT__INCLUDE_DIRS
+@@ -1476,11 +1530,6 @@
+     ${EVENT__INCLUDE_DIRS}
+     CACHE PATH "Libevent include directories")
+ 
+-gen_package_config(0)
+-
+-# Generate the config file for the installation tree.
+-gen_package_config(1)
+-
+ # Generate version info for both build-tree and install-tree.
+ configure_file(${PROJECT_SOURCE_DIR}/cmake/LibeventConfigVersion.cmake.in
+                ${PROJECT_BINARY_DIR}/LibeventConfigVersion.cmake
+@@ -1488,17 +1537,17 @@
+ 
+ # Install compat headers
+ install(FILES ${HDR_COMPAT}
+-        DESTINATION "include"
++        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+         COMPONENT dev)
+ 
+ # Install public headers
+ install(FILES ${HDR_PUBLIC}
+-        DESTINATION "include/event2"
++        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/event2"
+         COMPONENT dev)
+ 
+ # Install the configs.
+ install(FILES
+-        ${PROJECT_BINARY_DIR}/${CMAKE_FILES_DIRECTORY}/LibeventConfig.cmake
++        ${PROJECT_BINARY_DIR}/LibeventConfig.cmake
+         ${PROJECT_BINARY_DIR}/LibeventConfigVersion.cmake
+         DESTINATION "${EVENT_INSTALL_CMAKE_DIR}"
+         COMPONENT dev)
+@@ -1521,7 +1570,7 @@
+ # Install the scripts.
+ install(PROGRAMS
+        ${CMAKE_CURRENT_SOURCE_DIR}/event_rpcgen.py
+-       DESTINATION "bin"
++       DESTINATION "${CMAKE_INSTALL_BINDIR}"
+        COMPONENT runtime)
+ 
+ # Create documents with doxygen.
+@@ -1562,11 +1611,17 @@
+ message(STATUS "CMAKE_SYSTEM_VERSION:     ${CMAKE_SYSTEM_VERSION}")
+ message(STATUS "CMAKE_SYSTEM_PROCESSOR:   ${CMAKE_SYSTEM_PROCESSOR}")
+ message(STATUS "CMAKE_SKIP_RPATH:         ${CMAKE_SKIP_RPATH}")
++message(STATUS "CMAKE_SKIP_INSTALL_RPATH: ${CMAKE_SKIP_INSTALL_RPATH}")
++message(STATUS "CMAKE_INSTALL_RPATH:      ${CMAKE_INSTALL_RPATH}")
+ message(STATUS "CMAKE_VERBOSE_MAKEFILE:   ${CMAKE_VERBOSE_MAKEFILE}")
+ message(STATUS "CMAKE_C_FLAGS:            ${CMAKE_C_FLAGS}")
+ message(STATUS "CMAKE_BUILD_TYPE:         ${CMAKE_BUILD_TYPE}")
+-message(STATUS "CMAKE_C_COMPILER:         ${CMAKE_C_COMPILER} (id ${CMAKE_C_COMPILER_ID}, clang ${CLANG}, GNUC ${GNUC})")
++message(STATUS "CMAKE_C_COMPILER:         ${CMAKE_C_COMPILER} (id ${CMAKE_C_COMPILER_ID}, clang ${CLANG}, GNUC ${GNUC}, version ${CMAKE_C_COMPILER_VERSION})")
++message(STATUS "CMAKE_SHARED_LINKER_FLAGS:${CMAKE_SHARED_LINKER_FLAGS}")
++message(STATUS "CMAKE_EXE_LINKER_FLAGS:   ${CMAKE_EXE_LINKER_FLAGS}")
+ message(STATUS "CMAKE_AR:                 ${CMAKE_AR}")
+ message(STATUS "CMAKE_RANLIB:             ${CMAKE_RANLIB}")
++message(STATUS "CMAKE_INSTALL_PREFIX:     ${CMAKE_INSTALL_PREFIX}")
++message(STATUS "CMAKE_DEBUG_POSTFIX:      ${CMAKE_DEBUG_POSTFIX}")
+ message(STATUS "")
+ 

--- a/pkgs/by-name/li/libevent/mingw/004-time_t-compute.patch
+++ b/pkgs/by-name/li/libevent/mingw/004-time_t-compute.patch
@@ -1,0 +1,12 @@
+--- libevent-2.1.12-stable/event-config.h.cmake.orig	2025-05-20 15:53:25.663066900 +0300
++++ libevent-2.1.12-stable/event-config.h.cmake	2025-05-20 15:53:35.806436300 +0300
+@@ -482,6 +482,9 @@
+ /* The size of 'void *', as computer by sizeof */
+ #define EVENT__SIZEOF_VOID_P @EVENT__SIZEOF_VOID_P@
+ 
++/* The size of 'time_t', as computer by sizeof */
++#define EVENT__SIZEOF_TIME_T @EVENT__SIZEOF_TIME_T@
++
+ /* Define to `__inline__' or `__inline' if that's what the C compiler
+    calls it, or to nothing if 'inline' is not supported under any name.  */
+ #ifndef __cplusplus

--- a/pkgs/by-name/li/libevent/mingw/005-limit-MSVC-to-clang-cl.patch
+++ b/pkgs/by-name/li/libevent/mingw/005-limit-MSVC-to-clang-cl.patch
@@ -1,0 +1,22 @@
+From 236762a30d3e49bde8256876758539be4b4788a8 Mon Sep 17 00:00:00 2001
+From: Jan Beich <jbeich@FreeBSD.org>
+Date: Tue, 28 May 2019 12:45:59 +0000
+Subject: [PATCH] cmake: limit MSVC to Clang-CL
+
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 8eafe860bb..038503c5c3 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -187,7 +187,7 @@ endif()
+ if (("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU") OR (${CLANG}))
+     set(GNUC 1)
+ endif()
+-if (("${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC") OR (${CLANG}))
++if (("${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC") OR ("${CMAKE_C_SIMULATE_ID}" STREQUAL "MSVC"))
+     set(MSVC 1)
+ endif()
+ 

--- a/pkgs/by-name/li/libevent/mingw/006-fix-build-on-aarch64.patch
+++ b/pkgs/by-name/li/libevent/mingw/006-fix-build-on-aarch64.patch
@@ -1,0 +1,12 @@
+--- a/evutil.c
++++ b/evutil.c
+@@ -37,9 +37,6 @@
+ #include <io.h>
+ #include <tchar.h>
+ #include <process.h>
+-#undef _WIN32_WINNT
+-/* For structs needed by GetAdaptersAddresses */
+-#define _WIN32_WINNT 0x0501
+ #include <iphlpapi.h>
+ #include <netioapi.h>
+ #endif

--- a/pkgs/by-name/li/libevent/mingw/007-fix-dll-version.patch
+++ b/pkgs/by-name/li/libevent/mingw/007-fix-dll-version.patch
@@ -1,0 +1,11 @@
+--- libevent-2.1.12-stable/cmake/AddEventLibrary.cmake.orig	2025-05-26 14:16:21.442791800 +0300
++++ libevent-2.1.12-stable/cmake/AddEventLibrary.cmake	2025-05-26 14:16:27.044588200 +0300
+@@ -133,7 +133,7 @@
+             set_target_properties(
+                 "${LIB_NAME}_shared" PROPERTIES
+                 OUTPUT_NAME "${LIB_NAME}"
+-                SOVERSION ${EVENT_ABI_LIBVERSION})
++                SOVERSION ${EVENT_ABI_LIBVERSION_CURRENT})
+         elseif (APPLE)
+             math(EXPR COMPATIBILITY_VERSION "${EVENT_ABI_LIBVERSION_CURRENT}+1")
+             math(EXPR CURRENT_MINUS_AGE "${EVENT_ABI_LIBVERSION_CURRENT}-${EVENT_ABI_LIBVERSION_AGE}")

--- a/pkgs/by-name/li/libevent/mingw/008-automatic-choose-linkage-type.patch
+++ b/pkgs/by-name/li/libevent/mingw/008-automatic-choose-linkage-type.patch
@@ -1,0 +1,11 @@
+--- libevent-2.1.12-stable/cmake/LibeventConfig.cmake.in.orig	2025-12-03 09:16:15.382975500 +0300
++++ libevent-2.1.12-stable/cmake/LibeventConfig.cmake.in	2025-12-03 09:17:23.989690200 +0300
+@@ -49,7 +49,7 @@
+ 
+ # Default to the same type as libevent was built:
+ if(NOT DEFINED LIBEVENT_STATIC_LINK)
+-    set(LIBEVENT_STATIC_LINK NOT @EVENT_LIBRARY_SHARED@)
++    set(LIBEVENT_STATIC_LINK NOT BUILD_SHARED_LIBS)
+ endif()
+ 
+ if(${LIBEVENT_STATIC_LINK})

--- a/pkgs/by-name/li/libevent/package.nix
+++ b/pkgs/by-name/li/libevent/package.nix
@@ -1,13 +1,16 @@
 {
   lib,
   stdenv,
+  cmake,
   fetchurl,
   findutils,
   fixDarwinDylibNames,
+  ninja,
   updateAutotoolsGnuConfigScriptsHook,
   sslSupport ? true,
   openssl,
   fetchpatch,
+  windows,
 
   static ? stdenv.hostPlatform.isStatic,
 }:
@@ -16,26 +19,65 @@ stdenv.mkDerivation rec {
   pname = "libevent";
   version = "2.1.12";
 
+  # MSYS2 reference:
+  # - fix-nixpkgs/MINGW-packages/mingw-w64-libevent/PKGBUILD (+ patch stack)
+  isMinGW = stdenv.hostPlatform.isMinGW;
+
   src = fetchurl {
     url = "https://github.com/libevent/libevent/releases/download/release-${version}-stable/libevent-${version}-stable.tar.gz";
     sha256 = "1fq30imk8zd26x8066di3kpc5zyfc5z6frr3zll685zcx4dxxrlj";
   };
 
-  patches = [
-    # Don't define BIO_get_init() for LibreSSL 3.5+
-    (fetchpatch {
-      url = "https://github.com/libevent/libevent/commit/883630f76cbf512003b81de25cd96cb75c6cf0f9.patch";
-      sha256 = "sha256-VPJqJUAovw6V92jpqIXkIR1xYGbxIWxaHr8cePWI2SU=";
-    })
-  ];
+  patches =
+    [
+      # Don't define BIO_get_init() for LibreSSL 3.5+
+      (fetchpatch {
+        url = "https://github.com/libevent/libevent/commit/883630f76cbf512003b81de25cd96cb75c6cf0f9.patch";
+        sha256 = "sha256-VPJqJUAovw6V92jpqIXkIR1xYGbxIWxaHr8cePWI2SU=";
+      })
+    ]
+    ++ lib.optionals isMinGW [
+      ./mingw/001-event2-02-win32.patch
+      ./mingw/002-http-server-win32.patch
+      ./mingw/003-cmake-update.patch
+      ./mingw/004-time_t-compute.patch
+      ./mingw/005-limit-MSVC-to-clang-cl.patch
+      ./mingw/006-fix-build-on-aarch64.patch
+      ./mingw/007-fix-dll-version.patch
+      ./mingw/008-automatic-choose-linkage-type.patch
+    ];
 
   configureFlags = lib.flatten [
     (lib.optional (!sslSupport) "--disable-openssl")
+    # Avoid building sample programs on Windows in the autotools build.
+    (lib.optional (stdenv.hostPlatform.isWindows && !isMinGW) "--disable-samples")
     (lib.optionals static [
       "--disable-shared"
       "--with-pic"
     ])
   ];
+
+  cmakeGenerator = lib.optionalString isMinGW "Ninja";
+
+  cmakeFlags = lib.optionals isMinGW (
+    [
+      "-DCMAKE_DLL_NAME_WITH_SOVERSION=ON"
+
+      # NOTE: libevent's upstream CMake uses EVENT__LIBRARY_TYPE, but MSYS2 passes
+      # EVENT_LIBRARY_TYPE. Set both for maximum compatibility across versions.
+      "-DEVENT__LIBRARY_TYPE=${if static then "STATIC" else "BOTH"}"
+      "-DEVENT_LIBRARY_TYPE=${if static then "STATIC" else "BOTH"}"
+
+      "-DEVENT__DISABLE_BENCHMARK=ON"
+      "-DEVENT__DISABLE_TESTS=ON"
+      "-DEVENT__DISABLE_REGRESS=ON"
+      "-DEVENT__DISABLE_SAMPLES=ON"
+      "-DEVENT__DISABLE_MBEDTLS=ON"
+    ]
+    ++ lib.optional (!sslSupport) "-DEVENT__DISABLE_OPENSSL=ON"
+  );
+
+  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isWindows "-DWINVER=0x0600 -D_WIN32_WINNT=0x0600";
 
   preConfigure = lib.optionalString (lib.versionAtLeast stdenv.hostPlatform.darwinMinVersion "11") ''
     MACOSX_DEPLOYMENT_TARGET=10.16
@@ -51,21 +93,46 @@ stdenv.mkDerivation rec {
   outputBin = "dev";
   propagatedBuildOutputs = [ "out" ] ++ lib.optional sslSupport "openssl";
 
-  nativeBuildInputs = [
-    updateAutotoolsGnuConfigScriptsHook
-  ]
-  ++ lib.optional stdenv.hostPlatform.isDarwin fixDarwinDylibNames;
+  nativeBuildInputs =
+    lib.optionals (!isMinGW) [
+      updateAutotoolsGnuConfigScriptsHook
+    ]
+    ++ lib.optionals isMinGW [
+      cmake
+      ninja
+    ]
+    ++ lib.optional stdenv.hostPlatform.isDarwin fixDarwinDylibNames;
 
   buildInputs =
-    lib.optional sslSupport openssl ++ lib.optional stdenv.hostPlatform.isCygwin findutils;
+    lib.optional sslSupport openssl
+    ++ lib.optional stdenv.hostPlatform.isCygwin findutils
+    ++ lib.optionals isMinGW [ windows.pthreads ];
 
   doCheck = false; # needs the net
 
   postInstall = lib.optionalString sslSupport ''
     moveToOutput "lib/libevent_openssl*" "$openssl"
-    substituteInPlace "$dev/lib/pkgconfig/libevent_openssl.pc" \
-      --replace "$out" "$openssl"
-    sed "/^libdir=/s|$out|$openssl|" -i "$openssl"/lib/libevent_openssl.la
+
+    # Fix pkg-config paths for Nix multi-output builds.
+    #
+    # The upstream CMake .pc generation can end up joining absolute install dirs
+    # with the pkg-config "prefix" variable, resulting in strings like:
+    #   libdir=$prefix//nix/store/...
+    #
+    # Normalize .pc files to refer to the correct outputs explicitly.
+    for pc in "$out"/lib/pkgconfig/libevent*.pc; do
+      [ -f "$pc" ] || continue
+
+      pc_libdir="$out/lib"
+      case "$pc" in
+        */libevent_openssl.pc) pc_libdir="$openssl/lib" ;;
+      esac
+
+      sed -i \
+        -e "s|^libdir=.*$|libdir=$pc_libdir|" \
+        -e "s|^includedir=.*$|includedir=$dev/include|" \
+        "$pc"
+    done
   '';
 
   enableParallelBuilding = true;

--- a/pkgs/by-name/li/libopenmpt/package.nix
+++ b/pkgs/by-name/li/libopenmpt/package.nix
@@ -72,6 +72,7 @@ stdenv.mkDerivation rec {
     homepage = "https://lib.openmpt.org/libopenmpt/";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ OPNA2608 ];
-    platforms = lib.platforms.unix;
+    # MSYS2 ships libopenmpt for MinGW; allow Windows so pkgsCross.mingwW64 can evaluate it.
+    platforms = lib.platforms.unix ++ lib.platforms.windows;
   };
 }

--- a/pkgs/by-name/li/librist/package.nix
+++ b/pkgs/by-name/li/librist/package.nix
@@ -8,6 +8,7 @@
   cjson,
   cmocka,
   mbedtls,
+  windows,
 }:
 
 stdenv.mkDerivation rec {
@@ -34,11 +35,31 @@ stdenv.mkDerivation rec {
     pkg-config
   ];
 
+  mesonFlags = lib.optionals stdenv.hostPlatform.isMinGW [
+    # Enable the MinGW+winpthreads path. Without this, librist forces
+    # HAVE_PTHREADS=0 on Windows and builds its internal pthread/time shims,
+    # which then conflict with winpthreads (and with deps like mbedtls that
+    # include <pthread.h>).
+    "-Dhave_mingw_pthreads=true"
+  ];
+
   buildInputs = [
     cjson
     cmocka
     mbedtls
+  ] ++ lib.optionals stdenv.hostPlatform.isMinGW [
+    # librist uses pthreads on MinGW when available (MSYS2 depends on libwinpthread).
+    # Also avoids conflicts with librist's internal pthread shim when a dependency
+    # (e.g. mbedtls) includes <pthread.h>.
+    windows.pthreads
   ];
+
+  env.NIX_LDFLAGS = lib.optionalString stdenv.hostPlatform.isMinGW "-lpthread";
+
+  # Upstream's Meson test suite includes multicast networking tests, which fail
+  # in Nix's sandboxed build environment (e.g. exit 99). Keep checks disabled to
+  # avoid breaking dependents during evaluation/builds.
+  doCheck = false;
 
   meta = {
     description = "Library that can be used to easily add the RIST protocol to your application";

--- a/pkgs/by-name/li/libsamplerate/package.nix
+++ b/pkgs/by-name/li/libsamplerate/package.nix
@@ -18,7 +18,15 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ libsndfile ];
 
-  configureFlags = [ "--disable-fftw" ];
+  # MSYS2 ships mingw-w64-libsamplerate. The existing shared-library build in
+  # nixpkgs trips over MinGW-specific DLL export/.def handling; keep it simple
+  # for cross builds by producing a static library on MinGW.
+  configureFlags =
+    [ "--disable-fftw" ]
+    ++ lib.optionals stdenv.hostPlatform.isMinGW [
+      "--disable-shared"
+      "--enable-static"
+    ];
 
   outputs = [
     "dev"
@@ -31,7 +39,6 @@ stdenv.mkDerivation rec {
     license = lib.licenses.bsd2;
     maintainers = with lib.maintainers; [ lovek323 ];
     platforms = lib.platforms.all;
-    # Linker is unhappy with the `.def` file.
-    broken = stdenv.hostPlatform.isMinGW;
+    broken = false;
   };
 }

--- a/pkgs/by-name/li/libsystre/package.nix
+++ b/pkgs/by-name/li/libsystre/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  stdenv,
+  meson,
+  ninja,
+  pkg-config,
+  python3,
+  tre,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libsystre";
+  version = "1.0.2";
+
+  # MSYS2 carries libsystre as a small, standalone wrapper source bundle.
+  # Reference: fix-nixpkgs/MINGW-packages/mingw-w64-libsystre
+  src = ./src;
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    python3
+  ];
+
+  buildInputs = [
+    tre
+  ];
+
+  # libsystre's installed regex.h includes <tre/tre.h>, so consumers need tre headers.
+  propagatedBuildInputs = [
+    tre.dev
+  ];
+
+  postPatch = ''
+    patchShebangs meson_post_install.py
+  '';
+
+  meta = {
+    description = "Wrapper around TRE that provides a POSIX regex API (libgnurx/libregex replacement)";
+    homepage = "https://github.com/msys2/MINGW-packages/tree/master/mingw-w64-libsystre";
+    license = lib.licenses.bsd2;
+    platforms = lib.platforms.windows;
+  };
+})
+
+

--- a/pkgs/by-name/li/libsystre/src/COPYING
+++ b/pkgs/by-name/li/libsystre/src/COPYING
@@ -1,0 +1,30 @@
+This is the license, copyright notice, and disclaimer for libsystre, a wrapper
+around the TRE Regular Expression library.
+
+Copyright (c) 2015 LRN <lrn1986@gmail.com>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+  1. Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER AND CONTRIBUTORS
+``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+

--- a/pkgs/by-name/li/libsystre/src/README
+++ b/pkgs/by-name/li/libsystre/src/README
@@ -1,0 +1,6 @@
+This is a wrapper around TRE that provides POSIX API.
+
+Because it's a standalone library, it is a drop-in replacement for
+the outdated libgnurx or libregex, able to satisfy any configure check.
+
+

--- a/pkgs/by-name/li/libsystre/src/meson.build
+++ b/pkgs/by-name/li/libsystre/src/meson.build
@@ -1,0 +1,33 @@
+project(
+    'systre',
+    'c',
+    version: '1.0.2',
+    license: 'BSD-2-Clause',
+    meson_version: '>=0.50.0',
+    default_options: ['warning_level=1', 'default_library=both'],
+)
+
+tre_dep = dependency('tre')
+
+libsystre = library(
+    'systre',
+    'systre.c',
+    soversion: 0,
+    install: true,
+    dependencies: tre_dep,
+)
+
+install_headers('regex.h')
+
+pkg = import('pkgconfig')
+pkg.generate(
+    libsystre,
+    name: 'regex',
+    libraries: tre_dep,
+    description: 'Regular Expressions library',
+    filebase: 'regex',
+)
+
+meson.add_install_script('meson_post_install.py')
+
+

--- a/pkgs/by-name/li/libsystre/src/meson_post_install.py
+++ b/pkgs/by-name/li/libsystre/src/meson_post_install.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import shutil
+
+def main():
+    prefix = os.environ.get('MESON_INSTALL_DESTDIR_PREFIX')
+    assert prefix, 'MESON_INSTALL_DESTDIR_PREFIX not set'
+
+    libdir = os.path.join(prefix, 'lib')
+    pkgconfigdir = os.path.join(libdir, 'pkgconfig')
+
+    if os.path.exists(os.path.join(libdir, "libsystre.dll.a")):
+        shutil.copy2(
+            os.path.join(libdir, "libsystre.dll.a"),
+            os.path.join(libdir, "libgnurx.dll.a")
+        )
+        shutil.copy2(
+            os.path.join(libdir, "libsystre.dll.a"),
+            os.path.join(libdir, "libregex.dll.a")
+        )
+
+    if os.path.exists(os.path.join(libdir, "libsystre.a")):
+        shutil.copy2(
+            os.path.join(libdir, "libsystre.a"),
+            os.path.join(libdir, "libgnurx.a")
+        )
+        shutil.copy2(
+            os.path.join(libdir, "libsystre.a"),
+            os.path.join(libdir, "libregex.a")
+        )
+
+    if os.path.exists(os.path.join(pkgconfigdir, "regex.pc")):
+        shutil.copy2(
+            os.path.join(pkgconfigdir, "regex.pc"),
+            os.path.join(pkgconfigdir, "gnurx.pc")
+        )
+
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())
+
+

--- a/pkgs/by-name/li/libsystre/src/regex.h
+++ b/pkgs/by-name/li/libsystre/src/regex.h
@@ -1,0 +1,31 @@
+/*
+  regex.h - POSIX regular expression API definitions
+
+  This header is under public domain.
+
+*/
+
+#ifndef _REGEX_H
+#define _REGEX_H 1
+
+#include <tre/tre.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int regcomp(regex_t *preg, const char *pattern,
+       int cflags);
+size_t regerror(int errcode, const regex_t *preg,
+       char *errbuf, size_t errbuf_size);
+int regexec(const regex_t *preg, const char *string,
+       size_t nmatch, regmatch_t pmatch[], int eflags);
+void regfree(regex_t *preg);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* regex.h */
+
+

--- a/pkgs/by-name/li/libsystre/src/systre.c
+++ b/pkgs/by-name/li/libsystre/src/systre.c
@@ -1,0 +1,36 @@
+/*
+  systre.c - TRE wrapper
+
+  This software is released under a BSD-style license.
+  See the file COPYING  for details and copyright.
+
+*/
+
+#include "regex.h"
+
+int
+regcomp(regex_t *preg, const char *regex, int cflags)
+{
+  return tre_regcomp(preg, regex, cflags);
+}
+
+void
+regfree(regex_t *preg)
+{
+  tre_regfree(preg);
+}
+
+size_t
+regerror(int errcode, const regex_t *preg, char *errbuf, size_t errbuf_size)
+{
+  return tre_regerror(errcode, preg, errbuf, errbuf_size);
+}
+
+int
+regexec(const regex_t *preg, const char *str,
+	size_t nmatch, regmatch_t pmatch[], int eflags)
+{
+  return tre_regexec(preg, str, nmatch, pmatch, eflags);
+}
+
+

--- a/pkgs/by-name/po/portaudio/package.nix
+++ b/pkgs/by-name/po/portaudio/package.nix
@@ -22,9 +22,12 @@ stdenv.mkDerivation rec {
     pkg-config
     which
   ];
-  buildInputs = [
-    libjack2
-  ]
+  buildInputs =
+    # PortAudio's JACK backend is not built on MinGW in MSYS2 (their mingw-w64-portaudio
+    # does not depend on jack2). Avoid pulling jack2 into the MinGW build.
+    lib.optionals (stdenv.hostPlatform.isUnix && lib.meta.availableOn stdenv.hostPlatform libjack2) [
+      libjack2
+    ]
   # Enabling alsa causes linux-only sources to be built
   ++ lib.optionals stdenv.hostPlatform.isLinux [ alsa-lib ];
 
@@ -65,7 +68,8 @@ stdenv.mkDerivation rec {
     # Not exactly a bsd license, but alike
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ lovek323 ];
-    platforms = lib.platforms.unix;
+    # MSYS2 ships portaudio for MinGW; allow Windows so pkgsCross.mingwW64 can evaluate it.
+    platforms = lib.platforms.unix ++ lib.platforms.windows;
   };
 
   passthru = {

--- a/pkgs/by-name/te/termcap/fix-termcap-prototypes.patch
+++ b/pkgs/by-name/te/termcap/fix-termcap-prototypes.patch
@@ -1,0 +1,31 @@
+--- a/termcap.c
++++ b/termcap.c
+@@ -124,5 +124,5 @@
+ static char *term_entry;
+ 
+-static char *tgetst1 ();
++static char *tgetst1 (char *ptr, char **area);
+ 
+ /* Search entry BP for capability CAP.
+@@ -306,7 +306,7 @@
+ void
+ tputs (str, nlines, outfun)
+      register char *str;
+      int nlines;
+-     register int (*outfun) ();
++     register int (*outfun) (int);
+ {
+   register int padcount = 0;
+@@ -386,8 +386,8 @@
+ /* Forward declarations of static functions.  */
+ 
+-static int scan_file ();
+-static char *gobble_line ();
+-static int compare_contin ();
+-static int name_match ();
++static int scan_file (char *str, int fd, struct termcap_buffer *bufp);
++static char *gobble_line (int fd, struct termcap_buffer *bufp, char *append_end);
++static int compare_contin (char *str1, char *str2);
++static int name_match (char *line, char *name);
+ 
+ #ifdef VMS

--- a/pkgs/by-name/te/termcap/fix-tparam1-prototype.patch
+++ b/pkgs/by-name/te/termcap/fix-tparam1-prototype.patch
@@ -1,0 +1,12 @@
+--- a/tparam.c
++++ b/tparam.c
+@@ -89,7 +89,7 @@
+ 
+    The fourth and following args to tparam serve as the parameter values.  */
+ 
+-static char *tparam1 ();
++static char *tparam1 (char *string, char *outstring, int len, char *up, char *left, int *argp);
+ 
+ /* VARARGS 2 */
+ char *
+

--- a/pkgs/by-name/te/termcap/package.nix
+++ b/pkgs/by-name/te/termcap/package.nix
@@ -23,6 +23,10 @@ stdenv.mkDerivation rec {
       url = "https://github.com/msys2/MINGW-packages/raw/c6691ad1bd9d4c6823a18068ca0683c3e32ea005/mingw-w64-termcap/0001-tparam-replace-write-with-fprintf.patch";
       hash = "sha256-R9XaLfa8fzQBt+M+uA1AFTvKYCeOWLUD/7GViazXwto=";
     })
+    # Fix K&R-style forward declaration that breaks with newer compilers.
+    ./fix-tparam1-prototype.patch
+    # Fix remaining K&R-style forward declarations and callback prototypes.
+    ./fix-termcap-prototypes.patch
   ];
 
   outputs = [

--- a/pkgs/by-name/tr/tre/mingw/001-autotools.patch
+++ b/pkgs/by-name/tr/tre/mingw/001-autotools.patch
@@ -1,0 +1,20 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -435,16 +435,6 @@
+   fi
+ fi
+ 
+-case $host in
+-  *-mingw*)
+-    dnl wcsrtombs and wcstombs don't seem to work at all on MinGW.
+-    if test "$tre_libutf8" != "yes"; then
+-      tre_wchar_reason="Not supported on MinGW"
+-      tre_wchar="no ($tre_wchar_reason)"
+-    fi
+-    ;;
+-esac
+-
+ # Fail if wide character support was specifically requested but is
+ # not supported on this system.
+ if test "$tre_enable_wchar" = "yes"; then
+

--- a/pkgs/by-name/tr/tre/mingw/002-pointer-cast.patch
+++ b/pkgs/by-name/tr/tre/mingw/002-pointer-cast.patch
@@ -1,0 +1,14 @@
+--- a/lib/tre-internal.h
++++ b/lib/tre-internal.h
+@@ -127,8 +127,8 @@
+ /* Returns number of bytes to add to (char *)ptr to make it
+    properly aligned for the type. */
+ #define ALIGN(ptr, type) \
+-  ((((long)ptr) % sizeof(type)) \
+-   ? (sizeof(type) - (((long)ptr) % sizeof(type))) \
++  ((((intptr_t)ptr) % sizeof(type)) \
++   ? (sizeof(type) - (((intptr_t)ptr) % sizeof(type))) \
+    : 0)
+ 
+ #undef MAX
+

--- a/pkgs/by-name/tr/tre/package.nix
+++ b/pkgs/by-name/tr/tre/package.nix
@@ -36,6 +36,13 @@ stdenv.mkDerivation (finalAttrs: {
     libiconv
   ];
 
+  patches = lib.optionals stdenv.hostPlatform.isMinGW [
+    # MSYS2 mingw-w64-libtre patch stack:
+    # fix-nixpkgs/MINGW-packages/mingw-w64-libtre/{001-autotools.patch,002-pointer-cast.patch}
+    ./mingw/001-autotools.patch
+    ./mingw/002-pointer-cast.patch
+  ];
+
   preConfigure = ''
     ./utils/autogen.sh
   '';
@@ -46,6 +53,7 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/laurikari/tre/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.bsd2;
     mainProgram = "agrep";
-    platforms = lib.platforms.unix;
+    # MSYS2 provides libtre for MinGW (mingw-w64-libtre).
+    platforms = lib.platforms.unix ++ lib.platforms.windows;
   };
 })

--- a/pkgs/by-name/zv/zvbi/mingw-no-undefined.patch
+++ b/pkgs/by-name/zv/zvbi/mingw-no-undefined.patch
@@ -1,0 +1,14 @@
+diff --git a/src/Makefile.am b/src/Makefile.am
+index a48c026..e32aeeb 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -124,7 +124,7 @@ libzvbi_la_LIBADD = \
+ 	$(LIBS) \
+ 	$(UNICODE_LIBS)
+ 
+-libzvbi_la_LDFLAGS = -version-info $(LIBZVBI_SO_VERSION)
++libzvbi_la_LDFLAGS = -version-info $(LIBZVBI_SO_VERSION) -no-undefined
+ 
+ libzvbi_chains_la_SOURCES = \
+ 	chains.c \
+

--- a/pkgs/development/libraries/db/db-5.3.nix
+++ b/pkgs/development/libraries/db/db-5.3.nix
@@ -4,14 +4,16 @@
   fetchpatch,
   fetchurl,
   autoreconfHook,
+  windows,
   ...
 }@args:
 
 import ./generic.nix (
-  args
+  (lib.removeAttrs args [ "windows" ])
   // {
     version = "5.3.28";
     sha256 = "0a1n5hbl7027fbz5lm0vp0zzfp1hmxnz14wx3zl9563h83br5ag0";
+    pthreads = windows.pthreads;
     extraPatches = [
       ./clang-5.3.patch
       ./CVE-2017-10140-cwd-db_config.patch

--- a/pkgs/development/libraries/db/db-6.2.nix
+++ b/pkgs/development/libraries/db/db-6.2.nix
@@ -4,15 +4,17 @@
   fetchpatch,
   fetchurl,
   autoreconfHook,
+  windows,
   ...
 }@args:
 
 import ./generic.nix (
-  args
+  (lib.removeAttrs args [ "windows" ])
   // {
     version = "6.2.32";
     sha256 = "1yx8wzhch5wwh016nh0kfxvknjkafv6ybkqh6nh7lxx50jqf5id9";
     license = lib.licenses.agpl3Only;
+    pthreads = windows.pthreads;
     extraPatches = [
       ./clang-6.0.patch
       ./CVE-2017-10140-cwd-db_config.patch

--- a/pkgs/development/libraries/db/mingw-winioctl-case.patch
+++ b/pkgs/development/libraries/db/mingw-winioctl-case.patch
@@ -1,0 +1,13 @@
+--- a/src/dbinc/win_db.h
++++ b/src/dbinc/win_db.h
+@@ -46,7 +46,7 @@
+ #define	WIN32_LEAN_AND_MEAN
+ #include <windows.h>
+ #include <winsock2.h>
+ #ifndef DB_WINCE
+-#include <WinIoCtl.h>
++#include <winioctl.h>
+ #endif
+ 
+ #ifdef HAVE_GETADDRINFO
+

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -109,7 +109,10 @@
   withNvdec ? withHeadlessDeps && withNvcodec,
   withNvenc ? withHeadlessDeps && withNvcodec,
   withOpenal ? withFullDeps, # OpenAL 1.1 capture support
-  withOpenapv ? withHeadlessDeps && lib.versionAtLeast version "8.0", # APV encoding support
+  # APV encoding support (via openapv).
+  # NOTE: MSYS2's MinGW ffmpeg build does not enable this by default, but nixpkgs
+  # should still be able to build it for MinGW once openapv is MinGW-clean.
+  withOpenapv ? withHeadlessDeps && lib.versionAtLeast version "8.0",
   withOpencl ? withHeadlessDeps,
   withOpencoreAmrnb ? withFullDeps && withVersion3, # AMR-NB de/encoder
   withOpencoreAmrwb ? withFullDeps && withVersion3, # AMR-WB decoder
@@ -123,7 +126,11 @@
   withQrencode ? withFullDeps && lib.versionAtLeast version "7", # QR encode generation
   withQuirc ? withFullDeps && lib.versionAtLeast version "7", # QR decoding
   withRav1e ? withFullDeps, # AV1 encoder (focused on speed and safety)
-  withRist ? withHeadlessDeps, # Reliable Internet Stream Transport (RIST) protocol
+  # Reliable Internet Stream Transport (RIST) protocol
+  # NOTE: MSYS2's MinGW ffmpeg build does not enable librist by default, but
+  # nixpkgs should still be able to build it for MinGW once librist/mbedtls are
+  # MinGW-clean.
+  withRist ? withHeadlessDeps,
   withRtmp ? false, # RTMP[E] support via librtmp
   withRubberband ? withFullDeps && withGPL && !stdenv.hostPlatform.isFreeBSD, # Rubberband filter
   withSamba ? withFullDeps && !stdenv.hostPlatform.isDarwin && withGPLv3, # Samba protocol
@@ -967,7 +974,10 @@ stdenv.mkDerivation (
       ++ optionals withZimg [ zimg ]
       ++ optionals withZlib [ zlib ]
       ++ optionals withZmq [ zeromq ]
-      ++ optionals withZvbi [ zvbi ];
+      ++ optionals withZvbi [
+        zvbi
+        zvbi.dev
+      ];
 
     buildFlags = [ "all" ] ++ optional buildQtFaststart "tools/qt-faststart"; # Build qt-faststart executable
 
@@ -1067,8 +1077,11 @@ stdenv.mkDerivation (
         ++ optional buildSwresample "libswresample"
         ++ optional buildSwscale "libswscale";
       platforms = lib.platforms.all;
+      # Previously marked broken for MinGW64 (see link), but this derivation now
+      # builds under pkgsCross.mingwW64 (Linux -> MinGW) with the dependency/packaging
+      # fixes in this branch.
       # See https://github.com/NixOS/nixpkgs/pull/295344#issuecomment-1992263658
-      broken = stdenv.hostPlatform.isMinGW && stdenv.hostPlatform.is64bit;
+      broken = false;
       maintainers = with lib.maintainers; [
         atemu
         jopejoe1


### PR DESCRIPTION
Enable `ffmpeg` cross-compilation by fixing its dependency chain.

This PR enables FFmpeg to build under MinGW cross-compilation by addressing platform gating (`meta.platforms`), pthread linkage, and build system issues in FFmpeg's dependency tree. All changes use MSYS2 MINGW-packages as the reference implementation. 

This is submitted as a large PR because this was a required sidequest to get qt6 packages cross compiling, in this case `qt3d` consumes `qtmultimedia` which consumes `ffmpeg`).

## Dependencies
- #476272 
-  #476281 
- #476314 
- #476269 
- #476343 

## Changes

### FFmpeg
- Remove `meta.broken` gate for MinGW
- Add `zvbi.dev` to inputs for pkg-config discovery

### Dependency fixes (ordered by dependency depth)

**termcap**: Fix K&R-style function prototypes for modern compilers (GCC 14+)

**db** (Berkeley DB): Enable MinGW builds
- Add `--enable-mingw` and winpthreads support
- Fix Windows header case sensitivity (`WinIoCtl.h` → `winioctl.h`)
- Disable replication on MinGW (MSYS2-aligned)

**tre**: Enable MinGW builds with MSYS2 patch stack

**libsystre**: Add new package (POSIX `regex.h` wrapper for MinGW, required by jack2)

**jack2**: Enable MinGW builds
- Apply MSYS2 patch stack
- Add libsystre, winpthreads, and format-security fix

**libevent**: Enable MinGW builds
- Switch to CMake+Ninja for MinGW (MSYS2 approach)
- Apply MSYS2 patch stack (8 patches)
- Disable tests/samples/mbedtls on MinGW

**unbound**: Disable libevent on MinGW (MSYS2-aligned; avoids callback type mismatch)

**mbedtls**: Add winpthreads on MinGW; relax `-Werror=format`

**librist**: Enable MinGW builds
- Add winpthreads and `-Dhave_mingw_pthreads=true`
- Fix `clock_gettime` redefinition clash with winpthreads

**zvbi**: Enable MinGW builds
- Add winpthreads (propagated for downstream `<pthread.h>` includes)
- Apply `-no-undefined` patch for libtool shared libs
- Disable tests/examples on MinGW

**xvidcore**: Fix MinGW import library naming (`libxvidcore.dll.a`)

**openapv**: Enable MinGW builds; fix winpthreads and pkg-config paths

**cjson**: Enable MinGW builds; disable `-Werror` custom flags

**fribidi**: Allow Windows platforms; gate tests on executable host

**libbluray**: Allow Windows platforms

**portaudio**: Allow Windows platforms; gate Unix-only backends

**libopenmpt**: Allow Windows platforms

**libsamplerate**: Enable MinGW builds (CMake+Ninja approach)

## Motivation

As I said, Qt6's multimedia stack (`qt3d -> qtmultimedia -> ffmpeg`) requires FFmpeg to cross-compile for MinGW. MSYS2 ships all these packages for mingw-w64, so I used them as reference.

## Validation

### Cross build (MinGW)
`nix build .#pkgsCross.mingwW64.ffmpeg --no-link -L`
`nix build .#pkgsCross.mingwW64.{libevent,unbound,gnutls,zvbi,libbluray,jack2,librist,openapv,cjson} --no-link -L`

### Native build (regression check)
`nix build .#ffmpeg --no-link -L`
`nix build .#{libevent,unbound,gnutls,zvbi,libbluray,jack2,librist,openapv,cjson} --no-link -L`

- Built on platform:
  - [x] x86_64-linux (cross to mingwW64)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR.
- [x] Tested basic functionality of all binary files.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pk