### PR TITLE
python314Packages.fava: 1.30.7 -> 1.30.9

### DIFF
--- a/pkgs/development/python-modules/fava-portfolio-returns/default.nix
+++ b/pkgs/development/python-modules/fava-portfolio-returns/default.nix
@@ -3,7 +3,6 @@
   buildPythonPackage,
   buildNpmPackage,
   fetchFromGitHub,
-  stdenv,
   fava,
   hatch-vcs,
   hatchling,
@@ -71,16 +70,10 @@ buildPythonPackage {
 
   pythonImportsCheck = [ "fava_portfolio_returns" ];
 
-  # Stay in the root of the repository, so that relative paths to example files
-  # loaded by tests stay correct.
-  # Remove `src` to avoid `PYTHONPATH` issues related to `pytestCheckHook` ([1])
+  # Use importlib import mode to avoid `PYTHONPATH` issues related to `pytestCheckHook` ([1])
   # [1]: https://github.com/NixOS/nixpkgs/issues/255262
-  preCheck = ''
-    rm -rf src
-  '';
-
   pytestFlags = [
-    "${placeholder "out"}"
+    "--import-mode=importlib"
   ];
 
   passthru = {

--- a/pkgs/development/python-modules/fava/default.nix
+++ b/pkgs/development/python-modules/fava/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   buildNpmPackage,
+  fetchpatch2,
   fetchFromGitHub,
   stdenv,
   babel,
@@ -24,17 +25,17 @@
 let
   src = buildNpmPackage (finalAttrs: {
     pname = "fava-frontend";
-    version = "1.30.7";
+    version = "1.30.9";
 
     src = fetchFromGitHub {
       owner = "beancount";
       repo = "fava";
       tag = "v${finalAttrs.version}";
-      hash = "sha256-gO6eJIFp/yWAXFWhUcqkkfk2pA8/vyTxgPRPBmv4a6Q=";
+      hash = "sha256-/Tnu1SgYhd22HVEzOtJ8YEHyxXuQ9xW0c/1oRyVePXw=";
     };
     sourceRoot = "${finalAttrs.src.name}/frontend";
 
-    npmDepsHash = "sha256-cXIhEzYFpLOxUEY7lhTWW7R3/ptkx7hB9K92Fd2m1Ng=";
+    npmDepsHash = "sha256-5ee044Ev2FoxcdChZwfHnLQiiP+Ag4bNSAlzEnenAa0=";
     makeCacheWritable = true;
 
     preBuild = ''
@@ -55,7 +56,15 @@ buildPythonPackage {
 
   inherit src;
 
-  patches = [ ./dont-compile-frontend.patch ];
+  patches = [
+    ./dont-compile-frontend.patch
+    # https://github.com/beancount/fava/pull/2176
+    (fetchpatch2 {
+      name = "fix-have-excel-replacement.patch";
+      url = "https://github.com/beancount/fava/commit/36eba34495d189cd391fae0276aa1b6c94940203.patch?full_index=1";
+      hash = "sha256-XSkzygnq8eHkIcp1TT7J3NdcLCIwUxDoyipO4M9M3nE=";
+    })
+  ];
 
   postPatch = ''
     substituteInPlace tests/test_cli.py \


### PR DESCRIPTION
Tracks https://github.com/NixOS/nixpkgs/issues/475732

Update fava to v1.30.9 to fix failing tests when running with Python 3.14

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
