### PR TITLE
tftp-hpa: fix version name to comply with nixpkgs conventions

### DIFF
--- a/pkgs/by-name/tf/tftp-hpa/package.nix
+++ b/pkgs/by-name/tf/tftp-hpa/package.nix
@@ -8,7 +8,7 @@
 
 stdenv.mkDerivation {
   pname = "tftp-hpa";
-  version = "5.2-untagged-2024-06-10";
+  version = "5.2-unstable-2024-06-10";
   src = fetchgit {
     url = "git://git.kernel.org/pub/scm/network/tftp/tftp-hpa.git";
     hash = "sha256-lTMldYO/cZdLj0UjOPPBHfYf2GBG0O+5lhP9ikqn3tY=";


### PR DESCRIPTION
From https://github.com/NixOS/nixpkgs/tree/master/pkgs#versioning:
> *If a package is a commit from a repository without a version
assigned, then the version attribute should be the latest upstream version preceding that commit, followed by -unstable- and the date of the (fetched) commit*

Thanksfully, This is [the single instance `untagged` in nixpkgs](https://github.com/search?q=repo%3ANixOS%2Fnixpkgs%20%22-untagged-%22&type=code).

It seems to have been introduced within this pr:
- https://github.com/NixOS/nixpkgs/pull/369712


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
