### PR TITLE
nixos/crowdsec-firewall-bouncer: Fix missing systemd dependencies to firewall services

### DIFF
--- a/nixos/modules/services/security/crowdsec-firewall-bouncer.nix
+++ b/nixos/modules/services/security/crowdsec-firewall-bouncer.nix
@@ -386,6 +386,9 @@ in
   };
 
   meta = {
-    maintainers = with lib.maintainers; [ nicomem ];
+    maintainers = with lib.maintainers; [
+      nicomem
+      tornax
+    ];
   };
 }

--- a/nixos/modules/services/security/crowdsec-firewall-bouncer.nix
+++ b/nixos/modules/services/security/crowdsec-firewall-bouncer.nix
@@ -306,17 +306,24 @@ in
               # Replace the api_key placeholder with the secret
               ${lib.getExe pkgs.replace-secret} '@API_KEY_FILE@' "$CREDENTIALS_DIRECTORY/API_KEY_FILE" ${final-config-file}
             '';
+
+            isIptables = (cfg.settings.mode == "iptables") || (cfg.settings.mode == "ipset");
+            isNftables = cfg.settings.mode == "nftables";
           in
           rec {
             description = "CrowdSec Firewall Bouncer";
             wantedBy = [ "multi-user.target" ];
-            after = [ "network.target" ] ++ (lib.optional config.services.crowdsec.enable "crowdsec.service");
+            partOf = lib.optional isNftables "nftables.service" ++ lib.optional isIptables "firewall.service";
+            after =
+              lib.optional isNftables "nftables.service"
+              ++ lib.optional isIptables "firewall.service"
+              ++ lib.optional config.services.crowdsec.enable "crowdsec.service";
             wants = after;
             requires = lib.optional cfg.registerBouncer.enable "crowdsec-firewall-bouncer-register.service";
 
             # When using iptables/ipset modes, the bouncer calls external binaries so they must be added to the path.
             # For nftables mode, it does not depend on external binaries.
-            path = lib.optionals ((cfg.settings.mode == "iptables") || (cfg.settings.mode == "ipset")) [
+            path = lib.optionals isIptables [
               pkgs.iptables
               pkgs.ipset
             ];


### PR DESCRIPTION
Fix #476253
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
