### PR TITLE
hostapd: windows 10/11 compatibility

### DIFF
--- a/nixos/modules/services/networking/hostapd.nix
+++ b/nixos/modules/services/networking/hostapd.nix
@@ -1047,7 +1047,7 @@ in
 
                           # IEEE 802.11i (authentication) related configuration
                           # Encrypt management frames to protect against deauthentication and similar attacks
-                          ieee80211w = mkDefault 1;
+                          ieee80211w = mkDefault 2;
                           sae_require_mfp = mkDefault 1;
 
                           # Only allow WPA by default and disable insecure WEP


### PR DESCRIPTION
I have several MDM managed windows 11 boxes that refuse to connect to hostapd. 

It took me a few hours to figure out why. 

Windows gives the helpful error message "Can't connect to network"
unless `MFP-required` is set in the AP beacons. Setting `ieee80211w = 2`
fixes that.

MFP is Management Frame Protection, which helps mitigate KRACK-like
attacks.

9f7335d44912c5af97e7dc01caba7c6340442f82 causes this regression. 

Android hotspot has MFP-required. 

Tested with mt7915, mt7916, bcrm4366 (which doesn't support it anyways) APs and windows 11 AX201, android 16, osx and linux AX201 stations. 

@oddlama @tomfitzhenry

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
