### PR TITLE
modules/git: adopt

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18067,6 +18067,12 @@
     githubId = 96225281;
     name = "Mustafa Çalışkan";
   };
+  mushrowan = {
+    email = "roarch@proton.me";
+    name = "Rowan";
+    github = "mushrowan";
+    githubId = 69822445;
+  };
   musjj = {
     name = "musjj";
     github = "musjj";

--- a/nixos/modules/programs/git.nix
+++ b/nixos/modules/programs/git.nix
@@ -115,5 +115,5 @@ in
     })
   ];
 
-  meta.maintainers = [ ];
+  meta.maintainers = [ lib.maintainers.mushrowan ];
 }


### PR DESCRIPTION
For module `programs.git`:

* add myself to maintainers ([[Tracking] figsoda removed as maintainer -- adopt their packages! #458096](https://github.com/NixOS/nixpkgs/issues/458096));

## Things done

* Built on platform:

  * [ ]  x86_64-linux
  * [ ]  aarch64-linux
  * [ ]  x86_64-darwin
  * [ ]  aarch64-darwin

* Tested, as applicable:

  * [ ]  [NixOS tests](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) in [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests).
  * [ ]  [Package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests) at `passthru.tests`.
  * [ ]  Tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test) for functions and "core" functionality.

* [ ]  Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage).

* [ ]  Tested basic functionality of all binary files, usually in `./result/bin/`.

* Nixpkgs Release Notes

  * [ ]  Package update: when the change is major or breaking.

* NixOS Release Notes

  * [ ]  Module addition: when adding a new NixOS module.
  * [ ]  Module update: when the change is significant.

* [x]  Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other READMEs.

Add a 👍 [reaction](https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to [pull requests you find important](https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
