### PR TITLE
xdg-desktop-portal-luminous: 0.1.11 -> 0.1.13

### DIFF
--- a/pkgs/by-name/xd/xdg-desktop-portal-luminous/package.nix
+++ b/pkgs/by-name/xd/xdg-desktop-portal-luminous/package.nix
@@ -16,6 +16,7 @@
   libxkbcommon,
   glib,
   pipewire,
+  wayland,
   nix-update-script,
 }:
 
@@ -55,6 +56,13 @@ stdenv.mkDerivation (finalAttrs: {
     libGL
     libxkbcommon
   ];
+
+  postInstall = ''
+    patchelf \
+      --add-needed libwayland-client.so.0 \
+      --add-rpath ${lib.makeLibraryPath [ wayland ]} \
+      $out/libexec/xdg-desktop-portal-luminous
+  '';
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/xd/xdg-desktop-portal-luminous/package.nix
+++ b/pkgs/by-name/xd/xdg-desktop-portal-luminous/package.nix
@@ -9,9 +9,10 @@
   cargo,
   rustPlatform,
   xdg-desktop-portal,
-  slurp,
   cairo,
   pango,
+  libgbm,
+  libGL,
   libxkbcommon,
   glib,
   pipewire,
@@ -20,18 +21,18 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "xdg-desktop-portal-luminous";
-  version = "0.1.11";
+  version = "0.1.13";
 
   src = fetchFromGitHub {
     owner = "waycrate";
     repo = "xdg-desktop-portal-luminous";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-WxkCZwV4zuDvl0n4Qnanh/eSFTQu+8J1zMtBSTI2hM8=";
+    hash = "sha256-e5gW5oW9rSGzDlcBJ0Lg9rl4v6vULX2j2F7/+esC1lE=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-HUImAQ2lDqrLYh+YDHjXNTHZiTthocB5U5L4gBmIGQQ=";
+    hash = "sha256-+7rnlGkWG4MzxbXskNAd+awabAdC7XqcacX5AEmutlM=";
   };
 
   nativeBuildInputs = [
@@ -46,11 +47,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     xdg-desktop-portal
-    slurp
     cairo
     pango
     glib
     pipewire
+    libgbm
+    libGL
     libxkbcommon
   ];
 


### PR DESCRIPTION
Version bump. This version switches from using `slurp` as a picker to a built-in implementation made with iced.
Also wrapped the binary with libwayland to avoid crashing at runtime.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
