### PR TITLE
nixos/gnome: install xdg-user-dirs{,-gtk} systemd units

### DIFF
--- a/nixos/modules/services/desktop-managers/gnome.nix
+++ b/nixos/modules/services/desktop-managers/gnome.nix
@@ -390,6 +390,10 @@ in
       systemd.packages = [
         pkgs.gnome-session
         pkgs.gnome-shell
+      ]
+      ++ removeExcluded [
+        pkgs.xdg-user-dirs # Update user dirs as described in https://freedesktop.org/wiki/Software/xdg-user-dirs/
+        pkgs.xdg-user-dirs-gtk # Used to create the default bookmarks
       ];
 
       services.udev.packages = [


### PR DESCRIPTION
GNOME 49 has completely removed the built-in service manager, which allowed `.desktop` files to be used for launching services (https://gitlab.gnome.org/GNOME/gnome-session/-/blob/49.2/NEWS?ref_type=tags#L51-54). This mechanism was used by xdg-user-dirs and xdg-user-dirs-gtk to update the xdg user directories.

In recent versions of xdg-user-dirs and xdg-user-dirs-gtk, systemd units are included in the installation to work around that (https://gitlab.freedesktop.org/xdg/xdg-user-dirs/-/commit/2a63d3f0ffb76135790bb1168a3270a599904380).

This PR installs those systemd units so that xdg-user-dirs can continue to work as intended. The packages are kept in `environment.systemPackages` so that users can continue to execute `xdg-user-dirs-update` and similar commands in the terminal.

The updates that introduce the systemd units are:

- xdg-user-dirs: #476704
- xdg-user-dirs-gtk: #476719  

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
