### PR TITLE
EXODUS: init at unstable-2025-03-31

### DIFF
--- a/pkgs/by-name/ex/EXODUS/package.nix
+++ b/pkgs/by-name/ex/EXODUS/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  SDL2,
+  makeWrapper,
+}:
+stdenv.mkDerivation {
+  pname = "exodus";
+  version = "unstable-2025-03-31";
+  src = fetchFromGitHub {
+    owner = "nrootconauto";
+    repo = "EXODUS";
+    rev = "6d806dd5ae5507858c03c4d13be1f3d37a06fa4b";
+    hash = "sha256-EmIoJj5IjLy0dvuBQR46Oi/xgkbqv/IT+cJa59/aaWI=";
+  };
+  nativeBuildInputs = [
+    cmake
+    makeWrapper
+  ];
+  buildInputs = [ SDL2 ];
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    cp -a ../exodus $out/bin
+    runHook postInstall
+  '';
+  # tell the EXODUS program where the TempleOS root and bootstrap is
+  postFixup = ''
+    wrapProgram $out/bin/exodus \
+      --add-flags "--root=$src/T --hcrtfile=$src/HCRT_BOOTSTRAP.BIN"
+  '';
+  meta = with lib; {
+    description = "EXODUS - A TempleOS emulator";
+    homepage = "https://github.com/nrootconauto/EXODUS";
+    license = licenses.zlib;
+    maintainers = with maintainers; [ matthewcroughan ];
+    platforms = platforms.unix;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<img width="1286" height="1068" alt="image" src="https://github.com/user-attachments/assets/5eb0461a-6c87-49a3-a608-4c201a16f9e2" />

Initalizes the Executable Divine Operating System in Userspace so you can run TempleOS easily from a nix shell

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
