### PR TITLE
probe-rs-tools: add udev rules

### DIFF
--- a/pkgs/by-name/pr/probe-rs-tools/package.nix
+++ b/pkgs/by-name/pr/probe-rs-tools/package.nix
@@ -2,12 +2,20 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
+  fetchurl,
   cmake,
   pkg-config,
   libusb1,
   openssl,
 }:
 
+let
+  # udev rules are in another unversioned repo
+  udevRules = fetchurl {
+    url = "https://raw.githubusercontent.com/probe-rs/webpage/054a0b16831593091a8a5624d0e2305573e860ee/public/files/69-probe-rs.rules";
+    hash = "sha256-yjxld5ebm2jpfyzkw+vngBfHu5Nfh2ioLUKQQDY4KYo=";
+  };
+in
 rustPlatform.buildRustPackage rec {
   pname = "probe-rs-tools";
   version = "0.30.0";
@@ -34,6 +42,10 @@ rustPlatform.buildRustPackage rec {
     libusb1
     openssl
   ];
+
+  postInstall = ''
+    install -D -m 444 ${udevRules} $out/etc/udev/rules.d/69-probe-rs.rules
+  '';
 
   checkFlags = [
     # require a physical probe


### PR DESCRIPTION
Hi,

Without udev rules, trying to flash an esp32-c3 fail:
```
$ probe-rs list
The following debug probes were found:
[0]: ESP JTAG -- 303a:1001:60:55:F9:BC:45:2C (EspJtag)

$ cargo embed
    Finished `dev` profile [optimized + debuginfo] target(s) in 0.15s
      Profile default
       Target something/target/riscv32imc-unknown-none-elf/debug/something
 WARN probe_rs::probe::list::linux: The 'plugdev' group does not exist.
 WARN probe_rs::probe::list::linux: On how to create it, read more under https://probe.rs/docs/getting-started/probe-setup/
 WARN probe_rs::probe::list::linux: There seems no probe-rs rule to be installed.
 WARN probe_rs::probe::list::linux: Read more under https://probe.rs/docs/getting-started/probe-setup/
 WARN probe_rs::probe::list::linux: If you manage your rules differently, put an empty rule file with 'probe-rs' in the name in /etc/udev/rules.d.
       Error Failed to open the debug probe.
             
             Caused by:
                 0: The debug probe could not be created.
                 1: A USB error occurred.
                 2: Permission denied (os error 13)
```

With this PR:

```
$ cargo embed
    Finished `dev` profile [optimized + debuginfo] target(s) in 1.30s
      Profile default
       Target something/target/riscv32imc-unknown-none-elf/debug/something
      Erasing ✔ 100% [####################] 896.00 KiB @ 223.50 KiB/s (took 4s)
  Programming ✔ 100% [####################] 420.02 KiB @  64.94 KiB/s (took 6s)                                             Finished in 10.50s
        Done processing config profile default
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
