### PR TITLE
alpine: set std=gnu17 to fix build with gcc15

### DIFF
--- a/pkgs/by-name/al/alpine/package.nix
+++ b/pkgs/by-name/al/alpine/package.nix
@@ -43,9 +43,13 @@ stdenv.mkDerivation rec {
     "--with-c-client-target=slx"
   ];
 
-  # Fixes https://github.com/NixOS/nixpkgs/issues/372699
-  # See also https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1074804
-  env.NIX_CFLAGS_COMPILE = toString [ "-Wno-incompatible-pointer-types" ];
+  env.NIX_CFLAGS_COMPILE = toString [
+    # Fixes https://github.com/NixOS/nixpkgs/issues/372699
+    # See also https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1074804
+    "-Wno-incompatible-pointer-types"
+    # Opt out of C23 (and its stricter prototype rules) in GCC15
+    "-std=gnu17"
+  ];
 
   passthru.updateScript = gitUpdater { rev-prefix = "v"; };
 


### PR DESCRIPTION
Relevant to #475479 

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
