### PR TITLE
switch-to-configuration-ng: fix systemd reexec/reload

### DIFF
--- a/pkgs/by-name/sw/switch-to-configuration-ng/src/src/main.rs
+++ b/pkgs/by-name/sw/switch-to-configuration-ng/src/src/main.rs
@@ -87,6 +87,12 @@ const DRY_RELOAD_BY_ACTIVATION_LIST_FILE: &str = "/run/nixos/dry-activation-relo
 // Reuse the same default timeout that systemd uses. See https://github.com/systemd/systemd/blob/8b4278d12ec55cc3f96764bc8197e1055fbb6d3f/src/libsystemd/sd-bus/bus-internal.h#L312
 const BUS_TIMEOUT: Duration = Duration::from_secs(25);
 
+// Reuse the same daemon reload/reexecute timeout that systemd uses. See https://github.com/systemd/systemd/blob/5366dbdbd44ba4dc0c914dd4daa1a5297e0b2bde/src/basic/constants.h#L18
+const DAEMON_RELOAD_TIMEOUT: Duration = Duration::from_secs(180);
+
+// Used during times of waiting for D-Bus to process messages.
+const DBUS_PROCESS_TIME: Duration = Duration::from_millis(500);
+
 #[derive(Debug, Clone, PartialEq)]
 enum Action {
     Switch,
@@ -932,7 +938,7 @@ fn block_on_jobs(
             "waiting for submitted jobs to finish, still have {} job(s)",
             submitted_jobs.borrow().len()
         );
-        _ = conn.process(Duration::from_millis(500));
+        _ = conn.process(DBUS_PROCESS_TIME);
     }
 }
 
@@ -987,7 +993,7 @@ fn do_user_switch(parent_exe: String) -> anyhow::Result<()> {
     log::debug!("waiting for nixos activation to finish");
     while !*nixos_activation_done.borrow() {
         _ = dbus_conn
-            .process(Duration::from_secs(500))
+            .process(DBUS_PROCESS_TIME)
             .context("Failed to process dbus messages")?;
     }
 
@@ -1695,10 +1701,18 @@ won't take effect until you reboot the system.
 
         log::debug!("waiting for systemd restart to finish");
 
+        let mut reexec_time_waited = Duration::from_secs(0);
         while *systemd_is_reloading.borrow() {
             _ = dbus_conn
-                .process(Duration::from_millis(500))
+                .process(DBUS_PROCESS_TIME)
                 .context("Failed to process dbus messages")?;
+            reexec_time_waited += DBUS_PROCESS_TIME;
+            if reexec_time_waited >= DAEMON_RELOAD_TIMEOUT {
+                anyhow::bail!(
+                    "systemd daemon reexecute failed, timeout after {:?}",
+                    DAEMON_RELOAD_TIMEOUT
+                );
+            }
         }
     }
 
@@ -1712,10 +1726,18 @@ won't take effect until you reboot the system.
     _ = systemd.reload(); // we don't get a dbus reply here
     log::debug!("waiting for systemd reload to finish");
 
+    let mut reload_time_waited = Duration::from_secs(0);
     while *systemd_is_reloading.borrow() {
         _ = dbus_conn
-            .process(Duration::from_millis(500))
+            .process(DBUS_PROCESS_TIME)
             .context("Failed to process dbus messages")?;
+        reload_time_waited += DBUS_PROCESS_TIME;
+        if reload_time_waited >= DAEMON_RELOAD_TIMEOUT {
+            anyhow::bail!(
+                "systemd daemon reload failed, timeout after {:?}",
+                DAEMON_RELOAD_TIMEOUT
+            );
+        }
     }
 
     dbus_conn


### PR DESCRIPTION
According to systemd's D-Bus API documentation, a `Reloading` signal will be sent with the value `false` will be sent when reloading has finished (indicating that reloading is not active). The entire reloading sequence has two signals, the with the first value indicating that reloading has started (active = true). Thus, we must wait for the active value to be false before we can continue.

Fixes https://github.com/NixOS/nixpkgs/issues/378535

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
