### PR TITLE
kubefwd: 1.22.5 -> 1.25.9

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4944,6 +4944,12 @@
     githubId = 136485;
     name = "Chad Jablonski";
   };
+  cjimti = {
+    email = "cj@imti.co";
+    github = "cjimti";
+    githubId = 356698;
+    name = "Craig Johnston";
+  };
   cjshearer = {
     email = "cjshearer@live.com";
     github = "cjshearer";

--- a/pkgs/by-name/ku/kubefwd/package.nix
+++ b/pkgs/by-name/ku/kubefwd/package.nix
@@ -6,16 +6,18 @@
 
 buildGoModule (finalAttrs: {
   pname = "kubefwd";
-  version = "1.22.5";
+  version = "1.25.9";
 
   src = fetchFromGitHub {
     owner = "txn2";
     repo = "kubefwd";
-    rev = finalAttrs.version;
-    hash = "sha256-xTd/1h9fW2GbZ2u3RsExbQouRZot9CUDuqNLItRySxM=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-eJcmQRVrBYcT/o++d4hKUd8UWJDS/Z395M/sz8kpLfw=";
   };
 
-  vendorHash = "sha256-qAlzgPw1reDZYK+InlnAsBgVemVumWwLgEuYm+ALcCs=";
+  vendorHash = "sha256-l0iHkuSX1ECtOYY2HIFTPFVSYiZL9fi5BDOjhxWpDyA=";
+
+  subPackages = [ "cmd/kubefwd" ];
 
   ldflags = [
     "-s"
@@ -25,9 +27,9 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Bulk port forwarding Kubernetes services for local development";
-    homepage = "https://github.com/txn2/kubefwd";
+    homepage = "https://kubefwd.com";
     license = lib.licenses.asl20;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ cjimti ];
     mainProgram = "kubefwd";
   };
 })


### PR DESCRIPTION
Update kubefwd from 1.22.5 to 1.25.9.

**Changes in this update:**
- Fixed `rev` pattern: tags changed from `1.x.x` to `v1.x.x` format
- Updated homepage to https://kubefwd.com

**Release notes:** https://github.com/txn2/kubefwd/releases/tag/v1.25.8

**Highlights since 1.22.5:**
- Interactive TUI mode with real-time service monitoring
- Auto-reconnect with exponential backoff
- Windows hosts path auto-detection
- MCP (Model Context Protocol) server support
- HTTP traffic inspection

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
