### PR TITLE
slinktool: init at 4.5.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3486,6 +3486,11 @@
     githubId = 30630233;
     name = "Timo Triebensky";
   };
+  BIOS9 = {
+    name = "NightFish";
+    github = "BIOS9";
+    githubId = 15035908;
+  };
   birdee = {
     name = "birdee";
     github = "BirdeeHub";

--- a/pkgs/by-name/sl/slinktool/package.nix
+++ b/pkgs/by-name/sl/slinktool/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "slinktool";
+  version = "4.5.0";
+
+  src = fetchFromGitHub {
+    owner = "EarthScope";
+    repo = "slinktool";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-4UUvjlSqtBTiO200pb4FEFXEvUAmA4OlegrgF4wZII4=";
+  };
+
+  # slinktool uses K&R-style function pointers in some places; fails with modern GCC
+  env.NIX_CFLAGS_COMPILE = "-std=gnu89";
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D slinktool $out/bin/slinktool
+
+    runHook postInstall
+  '';
+
+  versionCheckProgramArg = "-V";
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "SeedLink client for data stream inspection, data collection and server testing";
+    homepage = "https://github.com/EarthScope/slinktool";
+    changelog = "https://github.com/EarthScope/slinktool/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.lgpl3Only;
+    maintainers = with lib.maintainers; [ BIOS9 ];
+    platforms = lib.platforms.all;
+    mainProgram = "slinktool";
+  };
+})

--- a/pkgs/by-name/sl/slinktool/package.nix
+++ b/pkgs/by-name/sl/slinktool/package.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "SeedLink client for data stream inspection, data collection and server testing";
     homepage = "https://github.com/EarthScope/slinktool";
-    changelog = "https://github.com/EarthScope/slinktool/releases/tag/v${finalAttrs.version}";
+    changelog = "https://github.com/EarthScope/slinktool/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.lgpl3Only;
     maintainers = with lib.maintainers; [ BIOS9 ];
     platforms = lib.platforms.all;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/EarthScope/slinktool
slinktool is a small command line utility to connect to and receive data from a [SeedLink ](https://docs.fdsn.org/projects/seedlink/en/latest/protocol.html) server.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [x] aarch64-linux
  - [X] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Manual Testing

You can test the tool by connecting to a public SeedLink server such as `rtserve.iris.washington.edu`

Example:

```shell
slinktool -Q rtserve.iris.washington.edu
```

You should see a list of data streams like the following:

```plain
YN SGBS3    VM1 D 2026-01-04 07:09:20  -  2026-01-04 08:09:09
YN SGBS3    VM4 D 2026-01-04 07:09:20  -  2026-01-04 08:09:09
YN SGBS3    VM5 D 2026-01-04 07:09:20  -  2026-01-04 08:09:09
YX UNM2     HHE D 2026-01-04 07:42:41  -  2026-01-04 08:27:54
YX UNM5     HHE D 2026-01-04 07:42:14  -  2026-01-04 08:28:35
...
```