### PR TITLE
python3Packages.starlette-admin: 0.15.1 -> 0.16.0

### DIFF
--- a/pkgs/development/python-modules/starlette-admin/default.nix
+++ b/pkgs/development/python-modules/starlette-admin/default.nix
@@ -3,15 +3,26 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
+  pythonAtLeast,
+
+  # build-system
   hatchling,
+
+  # dependencies
+  jinja2,
+  python-multipart,
+  starlette,
+
+  # optional-dependencies
+  babel,
+
+  # tests
   aiosqlite,
   arrow,
-  babel,
   cacert,
   colour,
   fasteners,
   httpx,
-  jinja2,
   mongoengine,
   motor,
   passlib,
@@ -21,25 +32,23 @@
   pydantic,
   pytest-asyncio,
   pytestCheckHook,
-  python-multipart,
   requests,
   sqlalchemy,
   sqlalchemy-file,
   sqlalchemy-utils,
   sqlmodel,
-  starlette,
 }:
 
 buildPythonPackage rec {
   pname = "starlette-admin";
-  version = "0.15.1";
+  version = "0.16.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "jowilf";
     repo = "starlette-admin";
     tag = version;
-    hash = "sha256-yPePxdKrg41kycXl1fDKf1jWx0YD+K26w8z2LmQV0g0=";
+    hash = "sha256-JVvrfbyKillkx6fOx4DEbHZoHIPxF1Gn3HzkxyJc66o=";
   };
 
   build-system = [ hatchling ];
@@ -85,12 +94,17 @@ buildPythonPackage rec {
     export LOCAL_PATH="$PWD/.storage"
   '';
 
-  disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [
-    # flaky, depends on test order
-    "test_ensuring_pk"
-    # flaky, of-by-one
-    "test_api"
-  ];
+  disabledTests =
+    lib.optionals (pythonAtLeast "3.14") [
+      # AssertionError: Regex pattern did not match
+      "test_not_supported_annotation"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      # flaky, depends on test order
+      "test_ensuring_pk"
+      # flaky, of-by-one
+      "test_api"
+    ];
 
   disabledTestPaths = [
     # odmantic is not packaged


### PR DESCRIPTION



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/jowilf/starlette-admin/compare/0.15.1...0.16.0
Changelog: https://jowilf.github.io/starlette-admin/changelog/

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
