### PR TITLE
python3Packages.reflex: 0.8.14 -> 0.8.24

### DIFF
--- a/pkgs/development/python-modules/reflex/default.nix
+++ b/pkgs/development/python-modules/reflex/default.nix
@@ -2,77 +2,81 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  alembic,
-  attrs,
-  build,
-  ruff,
-  dill,
-  granian,
+  pythonAtLeast,
+
+  # build-system
   hatchling,
+  pre-commit,
+  toml,
+
+  # dependencies
+  alembic,
+  click,
+  granian,
   httpx,
-  numpy,
   packaging,
-  pandas,
-  pillow,
   platformdirs,
-  playwright,
-  plotly,
   psutil,
   pydantic,
-  pytest-asyncio,
-  pytest-mock,
-  python-dotenv,
-  pytestCheckHook,
   python-multipart,
   python-socketio,
   redis,
   reflex-hosting-cli,
   rich,
   sqlmodel,
-  starlette-admin,
-  stdenv,
-  typer,
+  starlette,
   typing-extensions,
+  wrapt,
+
+  # tests
+  attrs,
+  numpy,
+  pandas,
+  pillow,
+  playwright,
+  plotly,
+  pytest-asyncio,
+  pytest-mock,
+  pytestCheckHook,
+  python-dotenv,
+  ruff,
+  starlette-admin,
   unzip,
   uvicorn,
   versionCheckHook,
-  wrapt,
   writableTmpDirAsHomeHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "reflex";
-  version = "0.8.14";
+  version = "0.8.24";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "reflex-dev";
     repo = "reflex";
-    tag = "v${version}";
-    hash = "sha256-w3qikUqo61UBJHVjbzeNCf97AZyBHLI+PkkXrVQBNAk=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-l78pXsaPl6F7C850HD8/as/eJPaH1vOmnbNmuos7Yio=";
   };
 
-  # 'rich' is also somehow checked when building the wheel,
-  # pythonRelaxDepsHook modifies the wheel METADATA in postBuild
-  pypaBuildFlags = [ "--skip-dependency-check" ];
+  # For some reason, pre_commit is supposedly missing when python>=3.14
+  postPatch = lib.optionalString (pythonAtLeast "3.14") ''
+    substituteInPlace pyproject.toml \
+      --replace-fail '"pre_commit", ' ""
+  '';
 
-  pythonRelaxDeps = [
-    # needed
-    "click"
-    "starlette"
-    "rich"
+  build-system = [
+    hatchling
+    pre-commit
+    toml
   ];
-
-  build-system = [ hatchling ];
 
   dependencies = [
     alembic
-    build # used in custom_components/custom_components.py
-    dill # used in state.py
+    click
     granian
-    granian.optional-dependencies.reload
     httpx
-    packaging # used in utils/prerequisites.py
+    packaging
     platformdirs
     psutil
     pydantic
@@ -82,29 +86,31 @@ buildPythonPackage rec {
     reflex-hosting-cli
     rich
     sqlmodel
-    typer # optional dep
+    starlette
     typing-extensions
     wrapt
-  ];
+  ]
+  ++ granian.optional-dependencies.reload;
 
   nativeCheckInputs = [
-    pytestCheckHook
-    pytest-asyncio
-    pytest-mock
-    python-dotenv
-    ruff
-    playwright
     attrs
     numpy
-    plotly
     pandas
     pillow
+    playwright
+    plotly
+    pytest-asyncio
+    pytest-mock
+    pytestCheckHook
+    python-dotenv
+    ruff
+    starlette-admin
     unzip
     uvicorn
-    starlette-admin
-    writableTmpDirAsHomeHook
     versionCheckHook
+    writableTmpDirAsHomeHook
   ];
+  versionCheckProgramArg = "--version";
 
   disabledTests = [
     # Tests touch network
@@ -123,13 +129,9 @@ buildPythonPackage rec {
     "test_output_system_info"
     # Comparison with magic string
     "test_background_task_no_block"
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    # PermissionError: [Errno 1] Operation not permitted (fails in sandbox)
-    "test_is_process_on_port_free_port"
-    "test_is_process_on_port_occupied_port"
-    "test_is_process_on_port_both_protocols"
-    "test_is_process_on_port_concurrent_access"
+    # reflex.utils.exceptions.StateSerializationError: Failed to serialize state
+    # reflex___istate___dynamic____dill_state due to unpicklable object.
+    "test_fallback_pickle"
   ];
 
   disabledTestPaths = [
@@ -137,14 +139,16 @@ buildPythonPackage rec {
     "tests/integration/"
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   pythonImportsCheck = [ "reflex" ];
 
   meta = {
     description = "Web apps in pure Python";
     homepage = "https://github.com/reflex-dev/reflex";
-    changelog = "https://github.com/reflex-dev/reflex/releases/tag/${src.tag}";
+    changelog = "https://github.com/reflex-dev/reflex/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ pbsds ];
     mainProgram = "reflex";
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/reflex-dev/reflex/compare/v0.8.14...v0.8.24
Changelog: https://github.com/reflex-dev/reflex/releases/tag/v0.8.24

cc @pbsds

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
