### PR TITLE
warpgate 0.18.0 -> 0.19.1

### DIFF
--- a/nixos/modules/services/security/warpgate.nix
+++ b/nixos/modules/services/security/warpgate.nix
@@ -305,17 +305,6 @@ in
                 type = nullOr str;
               };
             };
-            config_provider = mkOption {
-              description = ''
-                Source of truth of users.
-                DO NOT change this, Warpgate only implemented database provider.
-              '';
-              default = "database";
-              type = enum [
-                "file"
-                "database"
-              ];
-            };
           };
         };
         default = { };

--- a/nixos/modules/services/security/warpgate.nix
+++ b/nixos/modules/services/security/warpgate.nix
@@ -283,6 +283,14 @@ in
               };
             };
             log = {
+              format = mkOption {
+                description = "The format Warpgate emits logs in.";
+                default = "text";
+                type = enum [
+                  "text"
+                  "json"
+                ];
+              };
               retention = mkOption {
                 description = "How long Warpgate keep its logs.";
                 default = "7days";

--- a/pkgs/by-name/wa/warpgate/package.nix
+++ b/pkgs/by-name/wa/warpgate/package.nix
@@ -20,7 +20,7 @@ rustPlatform.buildRustPackage (
 
       patches = [ ./web-ui-package-json.patch ];
 
-      npmDepsHash = "sha256-bsVlE0uOJu3JRAn5Hjt2PUhpgJXbQBUKO+6nl0EZkyc=";
+      npmDepsHash = "sha256-0AhbX+NhKGvWbOHwkIGE1pwJbD/ZLrOJCoWnCm8lYoY=";
 
       nativeBuildInputs = [ openapi-generator-cli ];
 
@@ -35,16 +35,16 @@ rustPlatform.buildRustPackage (
   in
   {
     pname = "warpgate";
-    version = "0.19.0";
+    version = "0.19.1";
 
     src = fetchFromGitHub {
       owner = "warp-tech";
       repo = "warpgate";
       tag = "v${finalAttrs.version}";
-      hash = "sha256-PBDAZDoCFwrO1/zfQwy1MOhDDx4xHHOSvKsIYk2ayM8=";
+      hash = "sha256-0eaN91Uu1kCOZLblXmY9qLP8L8+UBlZWuArICQkBBk4=";
     };
 
-    cargoHash = "sha256-8m2NznKIME1UywQxmaQm+TJhhro095oU0WM7JxIyMxU=";
+    cargoHash = "sha256-w6VMtqmo5TiMHY3x77UPXn0TJUT62/gBIVkjZ/WxgaE=";
 
     patches = [
       (replaceVars ./hardcode-version.patch { inherit (finalAttrs) version; })

--- a/pkgs/by-name/wa/warpgate/package.nix
+++ b/pkgs/by-name/wa/warpgate/package.nix
@@ -20,9 +20,7 @@ rustPlatform.buildRustPackage (
 
       patches = [ ./web-ui-package-json.patch ];
 
-      npmDepsHash = "sha256-jgsNF93DkEVgPGzdi192HKoSHPYhdrtog28jZvOLK6E=";
-      # Fix peer dependency conflicts with ESLint 9.
-      npmFlags = [ "--legacy-peer-deps" ];
+      npmDepsHash = "sha256-bsVlE0uOJu3JRAn5Hjt2PUhpgJXbQBUKO+6nl0EZkyc=";
 
       nativeBuildInputs = [ openapi-generator-cli ];
 
@@ -37,16 +35,16 @@ rustPlatform.buildRustPackage (
   in
   {
     pname = "warpgate";
-    version = "0.18.0";
+    version = "0.19.0";
 
     src = fetchFromGitHub {
       owner = "warp-tech";
       repo = "warpgate";
       tag = "v${finalAttrs.version}";
-      hash = "sha256-GLY/VGEKB6gFNTbBlbhpmqQZ62pk2wd6JwWwy4Tz0FE=";
+      hash = "sha256-PBDAZDoCFwrO1/zfQwy1MOhDDx4xHHOSvKsIYk2ayM8=";
     };
 
-    cargoHash = "sha256-hwAtj8tTDsYgzuDobMg97wepKKIpohSVClyRiaDd+8w=";
+    cargoHash = "sha256-8m2NznKIME1UywQxmaQm+TJhhro095oU0WM7JxIyMxU=";
 
     patches = [
       (replaceVars ./hardcode-version.patch { inherit (finalAttrs) version; })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Changelog: 
https://github.com/warp-tech/warpgate/releases/tag/v0.19.0
https://github.com/warp-tech/warpgate/releases/tag/v0.19.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
