### PR TITLE
pyxattr: render available on Darwin

### DIFF
--- a/pkgs/development/python-modules/pyxattr/default.nix
+++ b/pkgs/development/python-modules/pyxattr/default.nix
@@ -1,7 +1,8 @@
 {
   lib,
-  pkgs,
+  attr,
   fetchPypi,
+  stdenv,
   buildPythonPackage,
 }:
 
@@ -18,11 +19,12 @@ buildPythonPackage rec {
   # IOError: [Errno 95] Operation not supported (expected)
   doCheck = false;
 
-  buildInputs = with pkgs; [ attr ];
+  buildInputs = lib.optional (lib.meta.availableOn stdenv.buildPlatform attr) attr;
 
   meta = {
     description = "Python extension module which gives access to the extended attributes for filesystem objects available in some operating systems";
     license = lib.licenses.lgpl21Plus;
-    inherit (pkgs.attr.meta) platforms;
+    # Darwin doesn't need `attr` for this.
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
 }


### PR DESCRIPTION
pyxattr can function on Darwin as per
https://github.com/iustin/pyxattr/blob/main/setup.py#L47.

attr is not required to compile the C extension in this scenario.

The code is slightly cleaned up as well.

This was tested with `doCheck = true;` on Darwin as there's no sandbox there.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
