### PR TITLE
super: init at 0.1.0

### DIFF
--- a/pkgs/by-name/su/super/package.nix
+++ b/pkgs/by-name/su/super/package.nix
@@ -1,0 +1,46 @@
+{
+  buildGoModule,
+  fetchFromGitHub,
+  lib,
+  runCommand,
+  super,
+}:
+buildGoModule (finalAttrs: {
+  pname = "super";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "brimdata";
+    repo = "super";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-wgduBXtLnvCTV/8JgCOeD8QutIqW5m9vCJZEbsxKxwY=";
+  };
+
+  vendorHash = "sha256-yGmQmxr2RzpOOwS7qpdBJysJpsgeWDNFBOws1FQQoM8=";
+
+  ldflags = [
+    "-s"
+    "-X"
+    "github.com/brimdata/super/cli.version=${finalAttrs.version}"
+  ];
+
+  subPackages = [
+    "cmd/super"
+  ];
+
+  passthru.tests = {
+    hello-world = runCommand "${finalAttrs.pname}-test" { } ''
+      echo \"'hello, world'\" | ${super}/bin/super -color=false -f=line - > $out
+      [ "$(cat $out)" = 'hello, world' ]
+    '';
+  };
+
+  meta = {
+    changelog = "https://github.com/brimdata/super/releases/tag/v${finalAttrs.version}";
+    description = "Analytics database that puts JSON and relational tables on equal footing";
+    homepage = "https://superdb.org";
+    license = lib.licenses.bsd3;
+    mainProgram = "super";
+    maintainers = with lib.maintainers; [ hythera ];
+  };
+})


### PR DESCRIPTION
Super is a replacement for `zed`, which has been discontinued. Super is still in development, so I don't think we can remove `zed` until it releases stable.

I'm not sure if the tests are good this way, but I found it in the docs so I thought I'd just add those as a simple test.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
