### PR TITLE
disktest: init at 2.1.0

### DIFF
--- a/pkgs/by-name/di/disktest/package.nix
+++ b/pkgs/by-name/di/disktest/package.nix
@@ -1,0 +1,40 @@
+{
+  fetchFromGitHub,
+  rustPlatform,
+  lib,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "disktest";
+  version = "2.1.0";
+
+  src = fetchFromGitHub {
+    owner = "mbuesch";
+    repo = "disktest";
+    tag = "disktest-${finalAttrs.version}";
+    hash = "sha256-PjY0m56OjXGHEVMIvEJhlhPebCcehQNcyrYhjgRqmQ8=";
+  };
+
+  cargoHash = "sha256-TSzvmvAE3iurb4LGvoiibYim+qOOvOo8UJZjRHtFsnU=";
+
+  buildAndTestSubdir = "disktest";
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    mainProgram = "disktest";
+    description = "Solid State Disk (SSD), USB Stick, SD-Card, Hard Disk (HDD) tester";
+    homepage = "https://github.com/mbuesch/disktest";
+    license = [
+      lib.licenses.mit # or
+      lib.licenses.asl20
+    ];
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ cilki ];
+  };
+})


### PR DESCRIPTION
Add [disktest](https://github.com/mbuesch/disktest) which is a tool for testing storage hardware.

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
