### PR TITLE
libmatchbox: 1.11 -> 1.14

### DIFF
--- a/pkgs/by-name/li/libmatchbox/package.nix
+++ b/pkgs/by-name/li/libmatchbox/package.nix
@@ -2,41 +2,47 @@
   lib,
   stdenv,
   fetchurl,
+  autoreconfHook,
+  libICE,
+  libjpeg,
+  libpng,
   libX11,
   libXext,
-  libpng,
   libXft,
-  libICE,
   pango,
-  libjpeg,
+  pkg-config,
 }:
 
 stdenv.mkDerivation rec {
   pname = "libmatchbox";
-  version = "1.11";
+  version = "1.14";
 
-  buildInputs = [
-    libXft
-    libICE
-    pango
-    libjpeg
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
   ];
   propagatedBuildInputs = [
+    libICE
+    libjpeg
+    libpng
     libX11
     libXext
-    libpng
+    libXft
+    pango
   ];
-  NIX_LDFLAGS = "-lX11";
 
   src = fetchurl {
-    url = "https://downloads.yoctoproject.org/releases/matchbox/libmatchbox/${version}/libmatchbox-${version}.tar.bz2";
-    sha256 = "0lvv44s3bf96zvkysa4ansxj2ffgj3b5kgpliln538q4wd9ank15";
+    url = "https://git.yoctoproject.org/libmatchbox/snapshot/libmatchbox-${version}.tar.gz";
+    sha256 = "1b66jl178pkwmswf1gqcyrpy15rll1znz38n07l9b3ybga13w31d";
   };
 
   meta = {
     description = "Library of the matchbox X window manager";
     homepage = "http://matchbox-project.org/";
-    license = lib.licenses.gpl2Plus;
+    license = with lib.licenses; [
+      lgpl2Plus
+      hpnd
+    ];
     platforms = lib.platforms.unix;
   };
 }


### PR DESCRIPTION
https://hydra.nixos.org/job/nixos/unstable/nixpkgs.libmatchbox.x86_64-linux
https://hydra.nixos.org/job/nixpkgs/unstable/matchbox.x86_64-linux

This [fixes](https://git.yoctoproject.org/libmatchbox/commit/?id=312c04b6ba60dca0d6c4a7d1393f0ec816a265e3) a GCC15 build error.
Also updates the license to reflect [upstream changes](https://git.yoctoproject.org/libmatchbox/commit/?id=bd46fea025212dac5e2a218a41f971d4cba92b76).

The newer releases are only available as snapshots so we need to use `autoreconfHook` and `pkg-config`.
Because of using `pkg-config` we need to propagate the build inputs, which allows us to drop the manual `NIX_LDFLAGS = "-lX11"`.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
