### PR TITLE
zipperposition: init at 2.1-unstable-2024-02-08

### DIFF
--- a/pkgs/by-name/zi/zipperposition/package.nix
+++ b/pkgs/by-name/zi/zipperposition/package.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  fetchFromGitHub,
+  ocamlPackages,
+}:
+
+ocamlPackages.buildDunePackage {
+  pname = "zipperposition";
+  version = "2.1-unstable-2024-02-08";
+
+  src = fetchFromGitHub {
+    owner = "sneeuwballen";
+    repo = "zipperposition";
+    rev = "050072e01d8539f9126993482b595e09f921f66a";
+    hash = "sha256-GoZO2hRZgh1qydlR+Uq4TprcPG9s7ge1N0Z2ilQ5x/w=";
+  };
+
+  nativeBuildInputs = with ocamlPackages; [
+    menhir
+  ];
+
+  propagatedBuildInputs = with ocamlPackages; [
+    zarith
+    containers
+    containers-data
+    msat
+    iter
+    mtime
+    oseq
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+    dune build -p logtk,libzipperposition,zipperposition,zipperposition-tools ''${enableParallelBuilding:+-j $NIX_BUILD_CORES}
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    dune install --prefix $out --libdir $OCAMLFIND_DESTDIR logtk libzipperposition zipperposition zipperposition-tools
+    runHook postInstall
+  '';
+
+  doCheck = true;
+
+  checkInputs = with ocamlPackages; [
+    alcotest
+    qcheck-core
+    qcheck-alcotest
+  ];
+
+  checkPhase = ''
+    runHook preCheck
+    dune runtest -p logtk,libzipperposition,zipperposition,zipperposition-tools ''${enableParallelBuilding:+-j $NIX_BUILD_CORES}
+    runHook postCheck
+  '';
+
+  meta = {
+    description = "Superposition prover for full first order logic";
+    homepage = "https://github.com/sneeuwballen/zipperposition";
+    license = lib.licenses.bsd2;
+    maintainers = [ lib.maintainers.DieracDelta ];
+    mainProgram = "zipperposition";
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
This package was tricky because it had a bunch of packages involved. I kinda followed what sail did since it seems to have the same problem. I think there isn't another way (AFAICT) of telling the various phases to handle multiple packages.

I did ignore the python scripts, since they aren't core/I'm not using them.

I haven't yet tested this thoroughly (but I will be over the next few days as I use this as an overlay).

I think this package has a fair number of users even though there hasn't been a commit in 2 years. My specific usecase is because it enables some automation stuff (LeanHammer).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
