### PR TITLE
gnome-calculator: Fix TLS support for currency conversion

### DIFF
--- a/pkgs/by-name/gn/gnome-calendar/package.nix
+++ b/pkgs/by-name/gn/gnome-calendar/package.nix
@@ -17,6 +17,7 @@
   libical,
   libsoup_3,
   glib,
+  glib-networking,
   gsettings-desktop-schemas,
   libadwaita,
 }:
@@ -46,6 +47,7 @@ stdenv.mkDerivation rec {
     libical
     libsoup_3
     glib
+    glib-networking
     libgweather
     geoclue2
     gsettings-desktop-schemas


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixes downloading currency rates in Currency Conversion mode:

```
** (gnome-calculator:3393074): WARNING **: 12:00:36.236: currency-provider.vala:207: Couldn't download UNT currency rate file: TLS support is not available

** (gnome-calculator:3393074): WARNING **: 12:00:36.241: currency-provider.vala:207: Couldn't download BC-TWD currency rate file: TLS support is not available

** (gnome-calculator:3393074): WARNING **: 12:00:36.241: currency-provider.vala:207: Couldn't download ECB currency rate file: TLS support is not available

** (gnome-calculator:3393074): WARNING **: 12:00:36.242: currency-provider.vala:207: Couldn't download IMF currency rate file: TLS support is not available
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
