### PR TITLE
emacs-anywhere: init at v1.0.0

### DIFF
--- a/pkgs/by-name/em/emacs-anywhere/package.nix
+++ b/pkgs/by-name/em/emacs-anywhere/package.nix
@@ -1,0 +1,29 @@
+{
+  fetchFromGitHub,
+  lib,
+  stdenvNoCC,
+  ...
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "emacs-anywhere";
+  version = "0-unstable-2025-12-29";
+
+  src = fetchFromGitHub {
+    owner = "nohzafk";
+    repo = "emacs-anywhere";
+    rev = "58fcdd5565a41555092c0801029d46f5f48b7814";
+    sha256 = "sha256-ZHzJfABFnpquIsP6UknusPeYmx20p090JyvVMhJ/OOs=";
+  };
+
+  installPhase = ''
+    cp -R EmacsAnywhere.spoon/ $out/
+  '';
+
+  meta = {
+    description = "Edit text from any macOS application in Emacs";
+    homepage = finalAttrs.src.meta.homepage;
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ DamienCassou ];
+  };
+})


### PR DESCRIPTION
New package to edit text from any macOS application in Emacs.

Homepage: https://github.com/nohzafk/emacs-anywhere

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
