### PR TITLE
kubectl-rabbitmq: init at 2.19.2

### DIFF
--- a/pkgs/by-name/ku/kubectl-rabbitmq/package.nix
+++ b/pkgs/by-name/ku/kubectl-rabbitmq/package.nix
@@ -1,0 +1,39 @@
+{
+  buildGoModule,
+  fetchFromGitHub,
+  lib,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "kubectl-rabbitmq";
+  version = "2.20.0";
+
+  src = fetchFromGitHub {
+    owner = "rabbitmq";
+    repo = "cluster-operator";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-anJZy0XUEJ0j912g7+ltq2bMVE/KPpyBWuh7AqGgx30=";
+  };
+
+  modRoot = "kubectl-rabbitmq";
+
+  vendorHash = "sha256-UnZ47TUarqZNYrvpfNJy5tm9Yq5/eFrkMSLRqjqM9PU=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.pluginVersion=${finalAttrs.version}"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "RabbitMQ Cluster Operator Plugin for kubectl";
+    homepage = "https://github.com/rabbitmq/cluster-operator";
+    license = lib.licenses.mpl20;
+    maintainers = with lib.maintainers; [ surfaceflinger ];
+    mainProgram = "kubectl-rabbitmq";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
