### PR TITLE
nbytes: init at 0.1.2

### DIFF
--- a/pkgs/by-name/nb/nbytes/package.nix
+++ b/pkgs/by-name/nb/nbytes/package.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  cmake,
+  fetchFromGitHub,
+  fetchpatch2,
+  gtest,
+  nix-update-script,
+  stdenv,
+  testers,
+  validatePkgConfig,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "nbytes";
+  version = "0.1.2";
+
+  src = fetchFromGitHub {
+    owner = "nodejs";
+    repo = "nbytes";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-lsd1Qrv1HEz/5ry10s7Pq7unoh3y9ZmwCaT+6nTlxkc=";
+  };
+
+  patches = [
+    # Use `gtest` from Nixpkgs to allow an offline build
+    ./use-nix-googletest.patch
+    # Add support for pkgconfig for use as a shared lib
+    # TODO: remove when included in the next release
+    (fetchpatch2 {
+      url = "https://github.com/nodejs/nbytes/commit/00f48a0620cef800054d4aab061f09d89990a1b9.patch?full_index=1";
+      hash = "sha256-uOPEI70Dq446K56BSFHVyxDHNaYY5OASu3QeWGCLQmI=";
+    })
+  ];
+
+  outputs = [
+    "out"
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    validatePkgConfig
+  ];
+  buildInputs = [
+    gtest
+  ];
+
+  passthru = {
+    updateScript = nix-update-script { };
+
+    tests.pkg-config = testers.hasPkgConfigModules {
+      package = finalAttrs.finalPackage;
+    };
+  };
+
+  meta = {
+    description = "Library of byte handling functions extracted from Node.js core";
+    homepage = "https://github.com/nodejs/nbytes";
+    changelog = "https://github.com/nodejs/nbytes/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ aduh95 ];
+    platforms = lib.platforms.all;
+    pkgConfigModules = [ "nbytes" ];
+  };
+})

--- a/pkgs/by-name/nb/nbytes/use-nix-googletest.patch
+++ b/pkgs/by-name/nb/nbytes/use-nix-googletest.patch
@@ -1,0 +1,22 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f2efa3c..3f363dd 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -11,15 +11,9 @@ endif()
+ option(NBYTES_DEVELOPMENT_CHECKS "Enable development checks" OFF)
+ 
+ include(GNUInstallDirs)
+-include(FetchContent)
+ 
+-FetchContent_Declare(
+-  googletest
+-  URL https://github.com/google/googletest/archive/03597a01ee50ed33e9dfd640b249b4be3799d395.zip
+-)
+-# For Windows: Prevent overriding the parent project's compiler/linker settings
+-set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+-FetchContent_MakeAvailable(googletest)
++# Use find_package to use the gtest package provided by Nix
++find_package(GTest REQUIRED)
+ 
+ add_subdirectory(src)
+ enable_testing()


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

https://github.com/nodejs/nbytes

Nice to have for https://github.com/NixOS/nixpkgs/pull/401454. I took inspiration from `pkgs/by-name/pr/protonmail-bridge-gui/use-nix-googletest.patch` for googletest handling – given that that version has not moved since the repo creation (https://github.com/nodejs/nbytes/commits/main/CMakeLists.txt), I don't expect the patch to be high maintenance.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
