### PR TITLE
python3Packages.returns: fix test and re-enable mypy tests

### DIFF
--- a/pkgs/development/python-modules/pytest-aio/default.nix
+++ b/pkgs/development/python-modules/pytest-aio/default.nix
@@ -16,16 +16,16 @@
 
 buildPythonPackage rec {
   pname = "pytest-aio";
-  version = "1.9.0";
+  version = "2.0.0";
   pyproject = true;
 
-  disabled = pythonOlder "3.9";
+  disabled = pythonOlder "3.10";
 
   src = fetchFromGitHub {
     owner = "klen";
     repo = "pytest-aio";
-    tag = version;
-    hash = "sha256-6RxYn8/HAvXv1AEgSIEOLiaBkGgTcqQhWK+xbtxgj/o=";
+    rev = "43681bcfc6d2ee07bf9397a1b42d1ccfbb891deb";
+    hash = "sha256-IBtiy4pyXblIkYQunFO6HpBkCnBcEpTqcFtVELrULkk=";
   };
 
   build-system = [ poetry-core ];
@@ -42,6 +42,9 @@ buildPythonPackage rec {
     anyio
     hypothesis
     pytestCheckHook
+  ]
+  # https://github.com/python-trio/trio-asyncio/issues/160
+  ++ lib.optionals (pythonOlder "3.14") [
     trio-asyncio
   ]
   ++ lib.concatAttrValues optional-dependencies;

--- a/pkgs/development/python-modules/returns/default.nix
+++ b/pkgs/development/python-modules/returns/default.nix
@@ -5,8 +5,11 @@
   fetchFromGitHub,
   httpx,
   hypothesis,
+  mypy,
   poetry-core,
   pytest-aio,
+  pytest-mypy,
+  pytest-mypy-plugins,
   pytest-subtests,
   pytestCheckHook,
   pythonOlder,
@@ -31,8 +34,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     sed -i setup.cfg \
-      -e '/--cov.*/d' \
-      -e '/--mypy.*/d'
+      -e '/--cov.*/d'
   '';
 
   nativeBuildInputs = [ poetry-core ];
@@ -42,17 +44,24 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     anyio
     httpx
-    hypothesis
+    # https://github.com/dry-python/returns/issues/2224
+    (hypothesis.overrideAttrs (old: {
+      src = fetchFromGitHub {
+        owner = "HypothesisWorks";
+        repo = "hypothesis";
+        tag = "hypothesis-python-6.136.9";
+        hash = "sha256-Q1wxIJwAYKZ0x6c85CJSGgcdKw9a3xFw8YpJROElSNU=";
+      };
+    }))
+    mypy
     pytestCheckHook
     pytest-aio
+    pytest-mypy
+    pytest-mypy-plugins
     pytest-subtests
     setuptools
     trio
   ];
-
-  preCheck = ''
-    rm -rf returns/contrib/mypy
-  '';
 
   pythonImportsCheck = [ "returns" ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Mypy was disabled in https://github.com/NixOS/nixpkgs/commit/dd9c0b8da5fa0b7e41b024eee2588db2523481a9. CC @supersandro2000. The cov tests are not re-enabled because covdefaults is required but it's not packaged.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
