### PR TITLE
pkgs/{shoko,shoko-webui}: fix to only use stable versions; nixos/shoko: fix linkFarm

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18309,10 +18309,13 @@
   };
   nanoyaki = {
     name = "Hana Kretzer";
-    email = "hanakretzer@gmail.com";
+    email = "hanakretzer@nanoyaki.space";
     github = "nanoyaki";
     githubId = 144328493;
-    keys = [ { fingerprint = "D89F 440C 6CD7 4753 090F  EC7A 4682 C5CB 4D9D EA3C"; } ];
+    keys = [
+      { fingerprint = "D89F 440C 6CD7 4753 090F  EC7A 4682 C5CB 4D9D EA3C"; }
+      { fingerprint = "5A1D C7CE 51DC 0A85 6DEA  41F7 31A8 CE0D 2E7D 30C3"; }
+    ];
   };
   naora = {
     name = "Joris Gundermann";

--- a/nixos/modules/services/misc/shoko.nix
+++ b/nixos/modules/services/misc/shoko.nix
@@ -16,6 +16,13 @@ let
     ;
 
   cfg = config.services.shoko;
+
+  shokoPlugins = pkgs.linkFarm "shoko-plugins" (
+    map (pkg: {
+      inherit (pkg) name;
+      path = "${pkg}/lib/${pkg.pname}";
+    }) cfg.plugins
+  );
 in
 {
   options = {
@@ -67,7 +74,7 @@ in
         ''
         + optionalString (cfg.plugins != [ ]) ''
           rm -rf "$STATE_DIRECTORY/plugins"
-          ln -s '${pkgs.linkFarmFromDrvs cfg.plugins}' "$STATE_DIRECTORY/plugins"
+          ln -s '${shokoPlugins}' "$STATE_DIRECTORY/plugins"
         '';
 
       serviceConfig = {

--- a/pkgs/by-name/sh/shoko-webui/package.nix
+++ b/pkgs/by-name/sh/shoko-webui/package.nix
@@ -49,7 +49,12 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  passthru.updateSript = nix-update-script { };
+  passthru.updateSript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      ''v([0-9]+\.[0-9]+\.[0-9]+).*''
+    ];
+  };
 
   meta = {
     homepage = "https://github.com/ShokoAnime/Shoko-WebUI";

--- a/pkgs/by-name/sh/shoko/package.nix
+++ b/pkgs/by-name/sh/shoko/package.nix
@@ -9,6 +9,7 @@
   rhash,
   nix-update-script,
 }:
+
 buildDotnetModule (finalAttrs: {
   pname = "shoko";
   version = "5.1.0";
@@ -38,7 +39,13 @@ buildDotnetModule (finalAttrs: {
   runtimeDeps = [ rhash ];
 
   passthru = {
-    updateScript = nix-update-script { };
+    updateScript = nix-update-script {
+      extraArgs = [
+        "--version-regex"
+        ''v([0-9]+\.[0-9]+\.[0-9]+).*''
+      ];
+    };
+
     tests.shoko = nixosTests.shoko;
   };
 


### PR DESCRIPTION
This PR only checks for stable versions in the nix-update-script for the packages `shoko` and `shoko-webui`. It also fixes the uncompleted `linkFarm` function in the `shoko` nixos module to use the path of a built dotnet module.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
