### PR TITLE
odoo: 18.0 -> 19.0

### DIFF
--- a/pkgs/by-name/od/odoo18/package.nix
+++ b/pkgs/by-name/od/odoo18/package.nix
@@ -8,8 +8,8 @@
 }:
 
 let
-  odoo_version = "19.0";
-  odoo_release = "20260104";
+  odoo_version = "18.0";
+  odoo_release = "20250506";
   python = python312.override {
     self = python;
   };
@@ -24,7 +24,7 @@ python.pkgs.buildPythonApplication rec {
     # find latest version on https://nightly.odoo.com/${odoo_version}/nightly/src
     url = "https://nightly.odoo.com/${odoo_version}/nightly/src/odoo_${version}.zip";
     name = "odoo-${version}";
-    hash = "sha256-JsbJ39zPZm4eyRTXkvdCMHwYaA08yUxZXcLglRn3kWs="; # odoo
+    hash = "sha256-rNG0He+51DnRT5g1SovGZ9uiE1HWXtcmAybcadBMjY4="; # odoo
   };
 
   makeWrapperArgs = [
@@ -38,13 +38,13 @@ python.pkgs.buildPythonApplication rec {
   ];
 
   propagatedBuildInputs = with python.pkgs; [
-    asn1crypto
     babel
-    cbor2
     chardet
     cryptography
-    distutils
+    decorator
     docutils
+    distutils
+    ebaysdk
     freezegun
     geoip2
     gevent
@@ -62,6 +62,7 @@ python.pkgs.buildPythonApplication rec {
     polib
     psutil
     psycopg2
+    pydot
     pyopenssl
     pypdf2
     pyserial
@@ -81,6 +82,9 @@ python.pkgs.buildPythonApplication rec {
     xlsxwriter
     xlwt
     zeep
+
+    setuptools
+    mock
   ];
 
   # takes 5+ minutes and there are not files to strip

--- a/pkgs/by-name/od/odoo18/update.sh
+++ b/pkgs/by-name/od/odoo18/update.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl gnused nix coreutils nix-prefetch
+# shellcheck shell=bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
+PKG=$(basename "$SCRIPT_DIR")
+
+LATEST="18" # increment manually
+VERSION="${PKG/#odoo}"
+VERSION="${VERSION:-$LATEST}.0"
+
+RELEASE="$(
+    curl "https://nightly.odoo.com/$VERSION/nightly/src/" |
+        sed -nE 's/.*odoo_'"$VERSION"'.(20[0-9]{6}).tar.gz.*/\1/p' |
+        tail -n 1
+)"
+
+latestVersion="$VERSION.$RELEASE"
+currentVersion=$(nix-instantiate --eval -E "with import ./. {}; $PKG.version or (lib.getVersion $PKG)" | tr -d '"')
+
+if [[ "$currentVersion" == "$latestVersion" ]]; then
+    echo "$PKG is up-to-date: $currentVersion"
+    exit 0
+fi
+
+cd "$SCRIPT_DIR"
+
+sed -ri "s| hash.+ # odoo| hash = \"$(nix-prefetch -q fetchzip --option extra-experimental-features flakes --url "https://nightly.odoo.com/${VERSION}/nightly/src/odoo_${latestVersion}.zip")\"; # odoo|g" package.nix
+sed -ri "s|odoo_version = .+|odoo_version = \"$VERSION\";|" package.nix
+sed -ri "s|odoo_release = .+|odoo_release = \"$RELEASE\";|" package.nix


### PR DESCRIPTION
 This PR updates odoo to a 19.0 nightly build. It includes additional runtime dependencies (cbor2, asn1crypto) that were required to fix a crash during the initial database connection. With these changes, the package now builds and the web UI successfully connects to a database.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
