### PR TITLE
libpqxx: enable tests, enable structuredAttrs

### DIFF
--- a/pkgs/by-name/li/libpqxx/package.nix
+++ b/pkgs/by-name/li/libpqxx/package.nix
@@ -46,7 +46,7 @@ gcc14Stdenv.mkDerivation (finalAttrs: {
   postPatch = ''
     patchShebangs ./tools/splitconfig.py
 
-    # Disable some tests that always fail -- unclear why.
+    # Disable some tests that always fail -- our postgresqlTestHook initializes the database with the default (ASCII) encoding.
     substituteInPlace test/unit/test_stream_from.cxx \
       --replace-fail "PQXX_REGISTER_TEST(test_stream_from_parses_awkward_strings);" ""
     substituteInPlace test/unit/test_stream_query.cxx \

--- a/pkgs/by-name/li/libpqxx/package.nix
+++ b/pkgs/by-name/li/libpqxx/package.nix
@@ -44,8 +44,6 @@ gcc14Stdenv.mkDerivation (finalAttrs: {
   ];
 
   postPatch = ''
-    patchShebangs ./tools/splitconfig.py
-
     # Disable some tests that always fail -- our postgresqlTestHook initializes the database with the default (ASCII) encoding.
     substituteInPlace test/unit/test_stream_from.cxx \
       --replace-fail "PQXX_REGISTER_TEST(test_stream_from_parses_awkward_strings);" ""
@@ -56,6 +54,7 @@ gcc14Stdenv.mkDerivation (finalAttrs: {
     substituteInPlace Makefile.am \
       --replace-fail "TESTS = tools/lint" ""
 
+    patchShebangs ./tools/splitconfig.py
     # Needed for autoreconfHook
     patchShebangs tools/*.py
   '';

--- a/pkgs/by-name/li/libpqxx/package.nix
+++ b/pkgs/by-name/li/libpqxx/package.nix
@@ -1,12 +1,15 @@
 {
   lib,
   stdenv,
+  gcc14Stdenv,
   fetchFromGitHub,
   libpq,
   python3,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+# Work around issue reported in https://github.com/NixOS/nixpkgs/issues/476278.
+# Should be solved when libpqxx 8.x is released.
+gcc14Stdenv.mkDerivation (finalAttrs: {
   pname = "libpqxx";
   version = "7.10.5";
 

--- a/pkgs/by-name/li/libpqxx/package.nix
+++ b/pkgs/by-name/li/libpqxx/package.nix
@@ -44,12 +44,6 @@ gcc14Stdenv.mkDerivation (finalAttrs: {
   ];
 
   postPatch = ''
-    # Disable some tests that always fail -- our postgresqlTestHook initializes the database with the default (ASCII) encoding.
-    substituteInPlace test/unit/test_stream_from.cxx \
-      --replace-fail "PQXX_REGISTER_TEST(test_stream_from_parses_awkward_strings);" ""
-    substituteInPlace test/unit/test_stream_query.cxx \
-      --replace-fail "PQXX_REGISTER_TEST(test_stream_parses_awkward_strings);" ""
-
     # Disable linting step for tests, it tries to install packages with pip.
     substituteInPlace Makefile.am \
       --replace-fail "TESTS = tools/lint" ""


### PR DESCRIPTION
Unfortunately results in a build failure because of a crash during/after testing. This seems to be related to the GCC15 update.
See https://github.com/NixOS/nixpkgs/issues/476278#issuecomment-3707019066 and https://github.com/jtv/libpqxx/issues/1015
for more background.

Some tests keep failing and it isn't obvious to me how to ensure postgresql uses a different (client) encoding. So they are disabled for now.

Draft since this breaks the build. But the package is broken regardless.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
