### PR TITLE
kapowarr: init at 1.2.0-unstable-2026-01-04

### DIFF
--- a/nixos/modules/services/misc/servarr/kapowarr.nix
+++ b/nixos/modules/services/misc/servarr/kapowarr.nix
@@ -1,0 +1,151 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+with lib;
+
+let
+  cfg = config.services.kapowarr;
+in
+{
+  options = {
+    services.kapowarr = {
+      enable = mkEnableOption "Kapowarr is a software to build and manage a comic book library, fitting in the *arr suite of software.";
+
+      package = mkPackageOption pkgs "kapowarr" { };
+
+      host = mkOption {
+        description = ''
+          The host Kapowarr WebUI will listen on.
+        '';
+        default = "0.0.0.0";
+        type = types.str;
+      };
+
+      port = mkOption {
+        description = ''
+          The TCP port Kapowarr WebUI will listen on.
+        '';
+        default = "5656";
+        type = types.str;
+      };
+
+      databaseDir = mkOption {
+        description = ''
+          The folder in which the database will be stored or in which a database is for Kapowarr to use
+        '';
+        default = "/var/lib/kapowarr";
+        example = "/home/myuser/.local/share/kapowarr";
+        type = types.str;
+      };
+
+      tempdownloadDir = mkOption {
+        description = ''
+          The folder that direct downloads temporarily get downloaded to before being moved to the correct location
+        '';
+        default = "/var/lib/kapowarr/temp_downloads";
+        example = "/home/myuser/.local/share/kapowarr/temp_downloads";
+        type = types.str;
+      };
+
+      logDir = mkOption {
+        description = ''
+          The folder in which the logs from Kapowarr will be stored
+        '';
+        default = "/var/lib/kapowarr/logs";
+        example = "/home/myuser/.local/share/kapowarr/logs";
+        type = types.str;
+      };
+
+      logName = mkOption {
+        description = ''
+          The filename of the file in which the logs from Kapowarr will be stored
+        '';
+        default = "Kapowarr.log";
+        example = "my_kapowarr_logs.log";
+        type = types.str;
+      };
+
+      baseUrl = mkOption {
+        description = ''
+          For reverse proxy support, makes kapower listen on http://host:port/baseurl.
+        '';
+        default = "";
+        example = "kapowarr becomes http://0.0.0.0:5656/kapowarr";
+        type = types.str;
+      };
+
+      user = mkOption {
+        description = "User account under which Kapowarr runs.";
+        default = "kapowarr";
+        type = types.str;
+      };
+
+      group = mkOption {
+        description = "Group under which Kapowarr runs.";
+        default = "kapowarr";
+        type = types.str;
+      };
+
+      openFirewall = mkOption {
+        description = "Open port in the firewall for the Kapowarr web interface.";
+        default = false;
+        type = types.bool;
+      };
+
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+
+    systemd.services.kapowarr = {
+      description = "Kapowarr, a software to build and manage a comic book library";
+
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      preStart = mkIf (cfg.databaseDir == "/var/lib/kapowarr") ''
+        # make the default folders
+        mkdir -p ${cfg.databaseDir}
+        mkdir -p ${cfg.tempdownloadDir}
+        mkdir -p ${cfg.logDir}
+        # set the owner:group for them
+        chown -R ${cfg.user}:${cfg.group} ${cfg.databaseDir}
+        chown -R ${cfg.user}:${cfg.group} ${cfg.tempdownloadDir}
+        chown -R ${cfg.user}:${cfg.group} ${cfg.logDir}
+      '';
+
+      serviceConfig = {
+        Type = "simple";
+        User = cfg.user;
+        Group = cfg.group;
+        StateDirectory = mkIf (cfg.databaseDir == "/var/lib/kapowarr") "kapowarr";
+        WorkingDirectory = cfg.databaseDir;
+        ReadWritePaths = cfg.databaseDir;
+        ExecStart = "${cfg.package}/bin/kapowarr -o ${cfg.host} -p ${cfg.port} -d ${cfg.databaseDir} -l ${cfg.logDir} -f ${cfg.logName} -t ${cfg.tempdownloadDir}";
+        Restart = "on-failure";
+      };
+    };
+
+    users.users = mkIf (cfg.user == "kapowarr") {
+      kapowarr = {
+        isSystemUser = true;
+        group = cfg.group;
+        home = cfg.databaseDir;
+      };
+    };
+
+    users.groups = mkIf (cfg.group == "kapowarr") {
+      kapowarr = { };
+    };
+
+    networking.firewall = mkIf cfg.openFirewall {
+      allowedTCPPorts = [ cfg.port ];
+    };
+  };
+
+  meta.maintainers = with maintainers; [ JollyDevelopment ];
+}

--- a/pkgs/by-name/ka/kapowarr/package.nix
+++ b/pkgs/by-name/ka/kapowarr/package.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  python3,
+  python3Packages,
+  fetchFromGitHub,
+  makeWrapper,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "kapowarr";
+  version = "1.2.0-unstable-2026-01-04";
+  format = "other";
+
+  src = fetchFromGitHub {
+    owner = "Casvt";
+    repo = "Kapowarr";
+    rev = "ad0c8f915d451d662a1577a3a9ad3047d6ec6094";
+    hash = "sha256-eZZ8dkza+QqulybtuZithJgRAPoyEuU9cWcUOnaA7/0=";
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  propagatedBuildInputs = with python3Packages; [
+    typing-extensions
+    requests
+    beautifulsoup4
+    flask
+    waitress
+    cryptography
+    bencoding
+    aiohttp
+    flask-socketio
+    websocket-client
+  ];
+
+  # Since there's no setup.py, we need to manually install the package
+  installPhase = ''
+    runHook preInstall
+
+    # Install the package structure
+    mkdir -p $out/${python3.sitePackages}
+    cp -r backend $out/${python3.sitePackages}/
+    cp -r frontend $out/${python3.sitePackages}/
+
+    # the program checks its own pyproject.toml when running
+    # so make sure there is a copy it can find
+    cp pyproject.toml $out/${python3.sitePackages}
+
+    # Install the main script
+    mkdir -p $out/bin
+    cp ${src}/Kapowarr.py $out/bin/kapowarr
+    chmod +x $out/bin/kapowarr
+
+    # Make sure the script can find the modules
+    wrapProgram $out/bin/kapowarr \
+      --set PYTHONPATH "$out/${python3.sitePackages}:$PYTHONPATH"
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Kapowarr is a software to build and manage a comic book library, fitting in the *arr suite of software.";
+    homepage = "https://casvt.github.io/Kapowarr/";
+    license = licenses.gpl3Only;
+    maintainers = [
+      maintainers.JollyDevelopment
+    ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/python-modules/bencoding/default.nix
+++ b/pkgs/development/python-modules/bencoding/default.nix
@@ -1,0 +1,34 @@
+{
+  buildPythonPackage,
+  fetchPypi,
+  lib,
+  nix-update-script,
+}:
+
+buildPythonPackage rec {
+  pname = "bencoding";
+  version = "0.2.6";
+  format = "wheel";
+
+  src = fetchPypi rec {
+    inherit pname version format;
+    dist = python;
+    python = "py3";
+    sha256 = "sha256-7Kt39jmkuxln1fLDAs8EjqjoTZzk8zAGcYb5zBUYj/E=";
+  };
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Bencoding is a Bcode library for Python3.";
+    homepage = "https://github.com/dust8/bencoding";
+    license = with lib; [
+      licenses.mit
+    ];
+    maintainers = [
+      lib.maintainers.JollyDevelopment
+    ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1928,6 +1928,8 @@ self: super: with self; {
     bencodetools = pkgs.bencodetools;
   };
 
+  bencoding = callPackage ../development/python-modules/bencoding { };
+
   beniget = callPackage ../development/python-modules/beniget { };
 
   benqprojector = callPackage ../development/python-modules/benqprojector { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This adds [Kapowarr](https://casvt.github.io/Kapowarr/) "a software to build and manage a comic book library, fitting in the *arr suite of software."

To do that it:
* creates the by-name package
* adds a new python3 package "bencoding"
* adds the kapowarr service module under the misc/servarr location.

I dont know if its proper nix to add all these in one PR, so i'll leave this as WIP while I get opinions.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
