### PR TITLE
lowfi: 1.7.2 -> 2.0.2

### DIFF
--- a/pkgs/by-name/lo/lowfi/package.nix
+++ b/pkgs/by-name/lo/lowfi/package.nix
@@ -10,16 +10,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "lowfi";
-  version = "1.7.2";
+  version = "2.0.0";
 
   src = fetchFromGitHub {
     owner = "talwat";
     repo = "lowfi";
     tag = version;
-    hash = "sha256-0Oim1nGll76APjjfNCuJgjOlEJxAU6vZteECEFhsWkI=";
+    hash = "sha256-TxERRLfXKtbtKiIOlwVJKXiAdQ4EvzgzdIrXoBYPPCg=";
   };
 
-  cargoHash = "sha256-vInuM96TJuewhFafDkhOiZiyxwc6SeBsSH8Fs8YIRRs=";
+  cargoHash = "sha256-9WYvzfCA7e+lN1P3/RhClxrHEA+/PIHggXUg4mjTY54=";
 
   buildFeatures = lib.optionals stdenv.hostPlatform.isLinux [ "mpris" ];
 
@@ -33,6 +33,11 @@ rustPlatform.buildRustPackage rec {
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     alsa-lib
+  ];
+
+  checkFlags = [
+    # Skip this test as it doesn't work in the nix sandbox
+    "--skip=tests::tracks::list::download"
   ];
 
   meta = {

--- a/pkgs/by-name/lo/lowfi/package.nix
+++ b/pkgs/by-name/lo/lowfi/package.nix
@@ -10,16 +10,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "lowfi";
-  version = "2.0.0";
+  version = "2.0.2";
 
   src = fetchFromGitHub {
     owner = "talwat";
     repo = "lowfi";
     tag = version;
-    hash = "sha256-TxERRLfXKtbtKiIOlwVJKXiAdQ4EvzgzdIrXoBYPPCg=";
+    hash = "sha256-RSdfZ0GrNhPcqDWutJW0VlplbpBNBCpSvw91fpl0d4E=";
   };
 
-  cargoHash = "sha256-9WYvzfCA7e+lN1P3/RhClxrHEA+/PIHggXUg4mjTY54=";
+  cargoHash = "sha256-OAg3ZpBmuINkc6KZJGKvYFnpv9hVbwlnOEP5ICtYh28=";
 
   buildFeatures = lib.optionals stdenv.hostPlatform.isLinux [ "mpris" ];
 


### PR DESCRIPTION
Changelog: https://github.com/talwat/lowfi/releases/tag/2.0.2
Diff: https://github.com/talwat/lowfi/compare/1.7.2...2.0.2

Skipping a track download test because that doesn't work in the nix sandbox.

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
