### PR TITLE
fusesoc: 2.2.1 -> 2.4.5; enable tests

### DIFF
--- a/pkgs/by-name/fu/fusesoc/package.nix
+++ b/pkgs/by-name/fu/fusesoc/package.nix
@@ -5,29 +5,54 @@
   iverilog,
   verilator,
   gnumake,
+  gitMinimal,
+  openssh,
+  writableTmpDirAsHomeHook,
 }:
-python3Packages.buildPythonPackage rec {
+python3Packages.buildPythonApplication rec {
   pname = "fusesoc";
-  version = "2.2.1";
-  format = "setuptools";
+  version = "2.4.5";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-M36bXBgY8hR33AVDlHoH8PZJG2Bi0KOEI07IMns7R4w=";
+    hash = "sha256-VBjJ7wiEz441iVquLMGabtdYbK07+dtHY05x8QzdSL8=";
   };
 
-  nativeBuildInputs = with python3Packages; [ setuptools-scm ];
+  build-system = with python3Packages; [
+    setuptools
+    setuptools-scm
+  ];
 
   dependencies = with python3Packages; [
     edalize
-    fastjsonschema
     pyparsing
     pyyaml
     simplesat
-    ipyxact
+    fastjsonschema
+    argcomplete
+  ];
+
+  nativeCheckInputs = [
+    gitMinimal
+    openssh
+    python3Packages.pytestCheckHook
+    writableTmpDirAsHomeHook
   ];
 
   pythonImportsCheck = [ "fusesoc" ];
+
+  disabledTestPaths = [
+    # These tests require network access
+    "tests/test_coremanager.py::test_export"
+    "tests/test_libraries.py::test_library_add"
+    "tests/test_libraries.py::test_library_update_with_initialize"
+    "tests/test_provider.py::test_git_provider"
+    "tests/test_provider.py::test_github_provider"
+    "tests/test_provider.py::test_url_provider"
+    "tests/test_usecases.py::test_git_library_with_default_branch_is_added_and_updated"
+    "tests/test_usecases.py::test_update_git_library_with_fixed_version"
+  ];
 
   makeWrapperArgs = [
     "--suffix PATH : ${


### PR DESCRIPTION
Closes: #335102
Closes: #419605
Closes: #449179

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
