### PR TITLE
auto-multiple-choice: fix dependencies and $TEXINPUTS

### DIFF
--- a/pkgs/by-name/au/auto-multiple-choice/package.nix
+++ b/pkgs/by-name/au/auto-multiple-choice/package.nix
@@ -24,6 +24,29 @@
   pkg-config,
   poppler,
 }:
+let
+  perlWithPackages = perl.withPackages (
+    p: with p; [
+      ArchiveZip
+      Cairo
+      CairoGObject
+      DBDSQLite
+      DBI
+      Glib
+      GlibObjectIntrospection
+      Gtk3
+      HashMerge
+      LocaleGettext
+      NetCUPS
+      OpenOfficeOODoc
+      PerlMagick
+      TextCSV
+      XMLParser
+      XMLSimple
+      XMLWriter
+    ]
+  );
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "auto-multiple-choice";
   version = "1.7.0";
@@ -37,7 +60,7 @@ stdenv.mkDerivation (finalAttrs: {
   dontConfigure = true;
 
   makeFlags = [
-    "PERLPATH=${perl}/bin/perl"
+    "PERLPATH=${perlWithPackages}/bin/perl"
     # We *need* to set DESTDIR as empty and use absolute paths below,
     # because the Makefile ignores PREFIX and MODSDIR is required to
     # be an absolute path to not trigger "portable distribution" check
@@ -73,28 +96,7 @@ stdenv.mkDerivation (finalAttrs: {
   postFixup = ''
     wrapProgram $out/bin/auto-multiple-choice \
     ''${makeWrapperArgs[@]} \
-    --prefix PERL5LIB : "${
-      with perlPackages;
-      makeFullPerlPath [
-        ArchiveZip
-        DBDSQLite
-        Cairo
-        CairoGObject
-        DBI
-        Glib
-        GlibObjectIntrospection
-        Gtk3
-        HashMerge
-        LocaleGettext
-        NetCUPS
-        OpenOfficeOODoc
-        PerlMagick
-        TextCSV
-        XMLParser
-        XMLSimple
-        XMLWriter
-      ]
-    }:"$out/share/perl5 \
+    --prefix PERL5LIB : $out/share/perl5 \
     --prefix XDG_DATA_DIRS : "$out/share:$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH" \
     --prefix PATH : "$out/bin:${ghostscript}/bin:${netpbm}/bin" \
     --set TEXINPUTS ":.:$out/tex/latex"
@@ -123,24 +125,8 @@ stdenv.mkDerivation (finalAttrs: {
     opencv
     pango
     poppler
-  ]
-  ++ (with perlPackages; [
-    perl
-    ArchiveZip
-    Cairo
-    CairoGObject
-    DBDSQLite
-    DBI
-    Glib
-    GlibObjectIntrospection
-    Gtk3
-    LocaleGettext
-    PerlMagick
-    TextCSV
-    XMLParser
-    XMLSimple
-    XMLWriter
-  ]);
+    perlWithPackages
+  ];
 
   passthru = {
     tlType = "run";

--- a/pkgs/by-name/au/auto-multiple-choice/package.nix
+++ b/pkgs/by-name/au/auto-multiple-choice/package.nix
@@ -32,6 +32,10 @@ let
       CairoGObject
       DBDSQLite
       DBI
+      EmailAddress
+      EmailMIME
+      EmailSender
+      EmailSimple
       Glib
       GlibObjectIntrospection
       Gtk3

--- a/pkgs/by-name/au/auto-multiple-choice/package.nix
+++ b/pkgs/by-name/au/auto-multiple-choice/package.nix
@@ -98,7 +98,13 @@ stdenv.mkDerivation (finalAttrs: {
     ''${makeWrapperArgs[@]} \
     --prefix PERL5LIB : $out/share/perl5 \
     --prefix XDG_DATA_DIRS : "$out/share:$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH" \
-    --prefix PATH : "$out/bin:${ghostscript}/bin:${netpbm}/bin" \
+    --prefix PATH : ${
+      lib.makeBinPath [
+        (placeholder "out")
+        ghostscript
+        netpbm
+      ]
+    } \
     --set TEXINPUTS ":.:$out/tex/latex"
   '';
 

--- a/pkgs/by-name/au/auto-multiple-choice/package.nix
+++ b/pkgs/by-name/au/auto-multiple-choice/package.nix
@@ -7,6 +7,7 @@
   wrapGAppsHook3,
   cairo,
   dblatex,
+  ghostscript,
   gnumake,
   gobject-introspection,
   graphicsmagick,
@@ -85,6 +86,7 @@ stdenv.mkDerivation (finalAttrs: {
         Gtk3
         HashMerge
         LocaleGettext
+        NetCUPS
         OpenOfficeOODoc
         PerlMagick
         TextCSV
@@ -94,7 +96,7 @@ stdenv.mkDerivation (finalAttrs: {
       ]
     }:"$out/share/perl5 \
     --prefix XDG_DATA_DIRS : "$out/share:$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH" \
-    --prefix PATH : "$out/bin" \
+    --prefix PATH : "$out/bin:${ghostscript}/bin:${netpbm}/bin" \
     --set TEXINPUTS ":.:$out/tex/latex"
   '';
 

--- a/pkgs/by-name/au/auto-multiple-choice/package.nix
+++ b/pkgs/by-name/au/auto-multiple-choice/package.nix
@@ -109,7 +109,7 @@ stdenv.mkDerivation (finalAttrs: {
         netpbm
       ]
     } \
-    --set TEXINPUTS ":.:$out/tex/latex"
+    --set TEXINPUTS ".:$out/tex/latex:"
   '';
 
   nativeBuildInputs = [


### PR DESCRIPTION
This is a replacement for #380878: it includes the base commit, but rebased on master, and adds more commits on top.

The motivation is to add NetCUPS not only to the PERL5LIB path in the wrapper but also to `buildInputs`. This is needed for AMC to actually find NetCUPS (i.e without this additional patch, trying to print from AMC displays the same error message about missing NetCUPS perl package as without #380878). But instead of maintaining both lists synced by hand, use `perl.withPackages` to get a perl interpreter with all runtime dependencies available.

While I'm there, I also
- applied the suggestion made in #380878's comments.
- added email-related modules, as suggested in [#288249 (comment)](https://github.com/NixOS/nixpkgs/issues/288249#issuecomment-1938625751)
- fix a directory ordering issue in $TEXINPUTS noticed while playing with the package

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
