### PR TITLE
google-clasp: fix postInstall rm on missing symlinks

### DIFF
--- a/pkgs/by-name/go/google-clasp/package.nix
+++ b/pkgs/by-name/go/google-clasp/package.nix
@@ -19,9 +19,9 @@ buildNpmPackage rec {
 
   # `npm run build` tries installing clasp globally
   npmBuildScript = [ "compile" ];
-  # Remove dangling symlink of a dependency
+  # Remove dangling symlinks if they exist (npm prune may have already removed them)
   postInstall = ''
-    rm $out/lib/node_modules/@google/clasp/node_modules/.bin/sshpk-{verify,sign,conv}
+    rm -f $out/lib/node_modules/@google/clasp/node_modules/.bin/sshpk-{verify,sign,conv}
   '';
 
   meta = {


### PR DESCRIPTION
Use `rm -f` instead of `rm` to handle cases where npm prune has already removed the sshpk symlinks before postInstall runs.

The current `postInstall` fails with:
```
rm: cannot remove '.../node_modules/.bin/sshpk-verify': No such file or directory
rm: cannot remove '.../node_modules/.bin/sshpk-sign': No such file or directory
rm: cannot remove '.../node_modules/.bin/sshpk-conv': No such file or directory
```

This happens because newer npm versions properly clean up `.bin/` symlinks during `npm prune --omit=dev`, so by the time `postInstall` runs, the symlinks are already gone.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test