### PR TITLE
opencode: 1.0.224 -> 1.1.3

### DIFF
--- a/pkgs/by-name/op/opencode/package.nix
+++ b/pkgs/by-name/op/opencode/package.nix
@@ -9,6 +9,7 @@
   nix-update-script,
   ripgrep,
   testers,
+  installShellFiles,
   writableTmpDirAsHomeHook,
 }:
 let
@@ -85,8 +86,10 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     bun
+    installShellFiles
     makeBinaryWrapper
     models-dev
+    writableTmpDirAsHomeHook
   ];
 
   patches = [
@@ -197,6 +200,11 @@ stdenvNoCC.mkDerivation (finalAttrs: {
           $out/lib/opencode/node_modules/@opentui/$pkgName
       fi
     done
+
+    ${lib.optionalString (stdenvNoCC.hostPlatform.system != "x86_64-darwin") ''
+      installShellCompletion --cmd opencode \
+        --bash <($out/bin/opencode completion)
+    ''}
   '';
 
   passthru = {

--- a/pkgs/by-name/op/opencode/package.nix
+++ b/pkgs/by-name/op/opencode/package.nix
@@ -14,12 +14,12 @@
 }:
 let
   pname = "opencode";
-  version = "1.0.224";
+  version = "1.1.3";
   src = fetchFromGitHub {
-    owner = "sst";
+    owner = "anomalyco";
     repo = "opencode";
     tag = "v${version}";
-    hash = "sha256-4ozluoXTovh1wpWVzxCN4jUO7cMxZER/0KMOBsJFO64=";
+    hash = "sha256-uNeje6WZ/FJVOtxdTdWXbWhPl7BwMws+7/Iz2Hz/stw=";
   };
 
   node_modules = stdenvNoCC.mkDerivation {
@@ -71,7 +71,7 @@ let
     # NOTE: Required else we get errors that our fixed-output derivation references store paths
     dontFixup = true;
 
-    outputHash = "sha256-+HEd3I11VqejTi7cikbTL5+DmNGyvUC4Cm4ysfujwes=";
+    outputHash = "sha256-LJ7xgKQP0ows76P8QVflS6SGGowVBYVvarkmCVkfe60=";
     outputHashAlgo = "sha256";
     outputHashMode = "recursive";
   };
@@ -201,10 +201,16 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       fi
     done
 
-    ${lib.optionalString (stdenvNoCC.hostPlatform.system != "x86_64-darwin") ''
-      installShellCompletion --cmd opencode \
-        --bash <($out/bin/opencode completion)
-    ''}
+    ${lib.optionalString
+      (
+        (stdenvNoCC.buildPlatform.canExecute stdenvNoCC.hostPlatform)
+        && (stdenvNoCC.hostPlatform.system != "x86_64-darwin")
+      )
+      ''
+        installShellCompletion --cmd opencode \
+          --bash <($out/bin/opencode completion)
+      ''
+    }
   '';
 
   passthru = {
@@ -229,7 +235,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       It combines a TypeScript/JavaScript core with a Go-based TUI
       to provide an interactive AI coding experience.
     '';
-    homepage = "https://github.com/sst/opencode";
+    homepage = "https://github.com/anomalyco/opencode";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ delafthi ];
     sourceProvenance = with lib.sourceTypes; [ fromSource ];


### PR DESCRIPTION
- install shell completions (bash only)
- repo moved from sst/opencode to anomalyco/opencode

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
