### PR TITLE
linux/common-config: enable fs-verity and IPE LSM

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -684,6 +684,8 @@ let
       TMPFS = yes;
       TMPFS_POSIX_ACL = yes;
       FS_ENCRYPTION = yes;
+      FS_VERITY = yes;
+      FS_VERITY_BUILTIN_SIGNATURES = yes;
 
       EXT2_FS_XATTR = yes;
       EXT2_FS_POSIX_ACL = yes;
@@ -795,6 +797,12 @@ let
       # The goal of Landlock is to enable to restrict ambient rights (e.g. global filesystem access) for a set of processes.
       # This does not have any effect if a program does not support it
       SECURITY_LANDLOCK = whenAtLeast "5.13" yes;
+
+      # IPE (Integrity Policy Enforcement) - LSM that can enforce file integrity based on
+      # fs-verity measurements or dm-verity. Useful for verified boot and immutable /nix/store.
+      SECURITY_IPE = whenAtLeast "6.12" yes;
+      IPE_PROP_FS_VERITY = whenAtLeast "6.12" yes;
+      IPE_PROP_FS_VERITY_BUILTIN_SIG = whenAtLeast "6.12" yes;
 
       DEVKMEM = lib.mkIf (!stdenv.hostPlatform.isAarch64) (whenOlder "5.13" no); # Disable /dev/kmem
 


### PR DESCRIPTION
Enable filesystem integrity verification features. These features have no runtime impact unless explicitly used. My use case of these is for creating /nix/store with f2fs fs-verity on to enable it checking that the store has not been tampered with.

- FS_VERITY: Per-file Merkle tree integrity verification, similar to dm-verity but read-write and supported by ext4, f2fs and some others. No impact if not being used.
- SECURITY_IPE: Integrity Policy Enforcement LSM (merged in 6.12). Allows enforcing policies based on file integrity properties like fs-verity measurements or dm-verity. Useful for verified boot and ensuring only integrity-verified files can be read/executed.
- FS_VERITY_BUILTIN_SIGNATURES: Allow verifying fs-verity signatures against keys in the kernel keyring
- IPE_PROP_FS_VERITY: Allow IPE to use fs-verity as a trust source.
- IPE_PROP_FS_VERITY_BUILTIN_SIG: Allow IPE to require signed fs-verity.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
