### PR TITLE
ensemble-chorus: fix build with GCC 15

### DIFF
--- a/pkgs/by-name/en/ensemble-chorus/add-missing-cstdint-includes.patch
+++ b/pkgs/by-name/en/ensemble-chorus/add-missing-cstdint-includes.patch
@@ -1,0 +1,25 @@
+diff --git a/sources/core/dsp.h b/sources/core/dsp.h
+index 5e3b1c6..b1a4f2d 100644
+--- a/sources/core/dsp.h
++++ b/sources/core/dsp.h
+@@ -5,6 +5,7 @@
+ #pragma once
+
+ #include <jsl/dynarray>
++#include <cstdint>
+
+ namespace dsp {
+
+ uint32_t fastrandom(uint32_t *pseed);
+
+diff --git a/sources/fl/main_controller.h b/sources/fl/main_controller.h
+index 9a7c6b0..e3d4f1a 100644
+--- a/sources/fl/main_controller.h
++++ b/sources/fl/main_controller.h
+@@ -6,6 +6,7 @@
+ 
+ #pragma once
+ #include <memory>
++#include <cstdint>
+ class Message_Queue;
+ struct Basic_Message;

--- a/pkgs/by-name/en/ensemble-chorus/package.nix
+++ b/pkgs/by-name/en/ensemble-chorus/package.nix
@@ -29,6 +29,7 @@ stdenv.mkDerivation {
   patches = [
     # fix compile error regarding packed attribute in 3rd party juice library
     ./juice-cxx-packing-fix.diff
+    ./add-missing-cstdint-includes.patch
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
See: https://github.com/NixOS/nixpkgs/issues/475479

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
