### PR TITLE
plasticscm-client-gui-unwrapped: 11.0.16.9791 -> 11.0.16.9843, plasticscm-client-core-unwrapped: 11.0.16.9791 -> 11.0.16.9843, plasticscm-theme: 11.0.16.9791 -> 11.0.16.9843

### DIFF
--- a/pkgs/by-name/pl/plasticscm-client-core-unwrapped/package.nix
+++ b/pkgs/by-name/pl/plasticscm-client-core-unwrapped/package.nix
@@ -12,11 +12,11 @@
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "plasticscm-client-core-unwrapped";
-  version = "11.0.16.9791";
+  version = "11.0.16.9843";
 
   src = fetchurl {
     url = "https://www.plasticscm.com/plasticrepo/stable/debian/amd64/plasticscm-client-core_${finalAttrs.version}_amd64.deb";
-    hash = "sha256-NuMY75JnnWVRKBSh/1XYipqc0m+O0vt7lJMVkQyTaNA=";
+    hash = "sha256-f7DVNX9pjqSc7xtuGcWpJnuUXjzzZU+kOwgJUX1lm8E=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/pl/plasticscm-client-gui-unwrapped/package.nix
+++ b/pkgs/by-name/pl/plasticscm-client-gui-unwrapped/package.nix
@@ -11,11 +11,11 @@
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "plasticscm-client-gui-unwrapped";
-  version = "11.0.16.9791";
+  version = "11.0.16.9843";
 
   src = fetchurl {
     url = "https://www.plasticscm.com/plasticrepo/stable/debian/amd64/plasticscm-client-gui_${finalAttrs.version}_amd64.deb";
-    hash = "sha256-sSabW3j9h9uNQSwWKvAH+3D9lRWvMRYcuITDonD7Inw=";
+    hash = "sha256-bb63WgdJJm/mjTCUIopycrDP4JxdZX59NP1lZ42gE9Q=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/pl/plasticscm-theme/package.nix
+++ b/pkgs/by-name/pl/plasticscm-theme/package.nix
@@ -11,11 +11,11 @@
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "plasticscm-theme";
-  version = "11.0.16.9791";
+  version = "11.0.16.9843";
 
   src = fetchurl {
     url = "https://www.plasticscm.com/plasticrepo/stable/debian/amd64/plasticscm-theme_${finalAttrs.version}_amd64.deb";
-    hash = "sha256-sInKMW6KoUNZ/06+E8MTGyVtOd+8wFLPrFibNw/DYQ0=";
+    hash = "sha256-GpfgAOX9siNQfNKRxEyKdfOmQbT1+aeZ+oKQMN+l+k4=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Resolves #476860

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
