### PR TITLE
maintainers: drop genericnerdyusername

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9402,13 +9402,6 @@
     githubId = 34658064;
     name = "Grace Dinh";
   };
-  genericnerdyusername = {
-    name = "GenericNerdyUsername";
-    email = "genericnerdyusername@proton.me";
-    github = "GenericNerdyUsername";
-    githubId = 111183546;
-    keys = [ { fingerprint = "58CE D4BE 6B10 149E DA80  A990 2F48 6356 A4CB 30F3"; } ];
-  };
   genga898 = {
     email = "genga898@gmail.com";
     github = "genga898";

--- a/pkgs/applications/editors/jetbrains/ides/pycharm-community.nix
+++ b/pkgs/applications/editors/jetbrains/ides/pycharm-community.nix
@@ -53,7 +53,6 @@ in
     description = "Free Python IDE from JetBrains (built from source)";
     longDescription = "Python IDE with complete set of tools for productive development with Python programming language. In addition, the IDE provides high-class capabilities for professional Web development with Django framework and Google App Engine. It has powerful coding assistance, navigation, a lot of refactoring features, tight integration with various Version Control Systems, Unit testing, powerful all-singing all-dancing Debugger and entire customization. PyCharm is developer driven IDE. It was developed with the aim of providing you almost everything you need for your comfortable and productive development!";
     maintainers = with lib.maintainers; [
-      genericnerdyusername
       tymscar
     ];
     license = lib.licenses.asl20;

--- a/pkgs/applications/editors/jetbrains/ides/pycharm-oss.nix
+++ b/pkgs/applications/editors/jetbrains/ides/pycharm-oss.nix
@@ -60,7 +60,6 @@ in
       It has powerful coding assistance, navigation, a lot of refactoring features, tight integration with various Version Control Systems, Unit testing and powerful Debugger.
     '';
     maintainers = with lib.maintainers; [
-      genericnerdyusername
       tymscar
     ];
     license = lib.licenses.asl20;

--- a/pkgs/applications/editors/jetbrains/ides/pycharm.nix
+++ b/pkgs/applications/editors/jetbrains/ides/pycharm.nix
@@ -60,7 +60,6 @@ in
       It has powerful coding assistance, navigation, a lot of refactoring features, tight integration with various Version Control Systems, Unit testing and powerful Debugger.
     '';
     maintainers = with lib.maintainers; [
-      genericnerdyusername
       tymscar
     ];
     license = lib.licenses.unfree;

--- a/pkgs/applications/editors/jetbrains/ides/rust-rover.nix
+++ b/pkgs/applications/editors/jetbrains/ides/rust-rover.nix
@@ -68,7 +68,7 @@ in
     homepage = "https://www.jetbrains.com/rust/";
     description = "Rust IDE from JetBrains";
     longDescription = "Rust IDE from JetBrains";
-    maintainers = with lib.maintainers; [ genericnerdyusername ];
+    maintainers = [ ];
     license = lib.licenses.unfree;
     sourceProvenance =
       if stdenv.hostPlatform.isDarwin then

--- a/pkgs/applications/virtualization/sail-riscv/default.nix
+++ b/pkgs/applications/virtualization/sail-riscv/default.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = "https://github.com/riscv/sail-riscv";
     description = "Formal specification of the RISC-V architecture, written in Sail";
-    maintainers = with lib.maintainers; [ genericnerdyusername ];
+    maintainers = [ ];
     license = lib.licenses.bsd2;
   };
 }

--- a/pkgs/by-name/ab/abaddon/package.nix
+++ b/pkgs/by-name/ab/abaddon/package.nix
@@ -92,7 +92,7 @@ stdenv.mkDerivation rec {
     mainProgram = "abaddon";
     homepage = "https://github.com/uowuo/abaddon";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ genericnerdyusername ];
+    maintainers = [ ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/fu/fusesoc/package.nix
+++ b/pkgs/by-name/fu/fusesoc/package.nix
@@ -42,7 +42,7 @@ python3Packages.buildPythonPackage rec {
   meta = {
     homepage = "https://github.com/olofk/fusesoc";
     description = "Package manager and build tools for HDL code";
-    maintainers = with lib.maintainers; [ genericnerdyusername ];
+    maintainers = [ ];
     license = lib.licenses.bsd3;
     mainProgram = "fusesoc";
   };

--- a/pkgs/by-name/li/lief/package.nix
+++ b/pkgs/by-name/li/lief/package.nix
@@ -77,7 +77,6 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = with lib.platforms; linux ++ darwin;
     maintainers = with lib.maintainers; [
       lassulus
-      genericnerdyusername
     ];
   };
 })

--- a/pkgs/by-name/ls/lssecret/package.nix
+++ b/pkgs/by-name/ls/lssecret/package.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation {
     description = "Tool to list passwords and other secrets stored using the org.freedesktop.secrets dbus api";
     homepage = "https://gitlab.com/GrantMoyer/lssecret";
     license = lib.licenses.unlicense;
-    maintainers = with lib.maintainers; [ genericnerdyusername ];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
     mainProgram = "lssecret";
   };

--- a/pkgs/development/ocaml-modules/lem/default.nix
+++ b/pkgs/development/ocaml-modules/lem/default.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/rems-project/lem";
     description = "Tool for lightweight executable mathematics";
     mainProgram = "lem";
-    maintainers = with lib.maintainers; [ genericnerdyusername ];
+    maintainers = [ ];
     license = with lib.licenses; [
       bsd3
       gpl2

--- a/pkgs/development/ocaml-modules/linksem/default.nix
+++ b/pkgs/development/ocaml-modules/linksem/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = "https://github.com/rems-project/linksem";
     description = "Formalisation of substantial parts of ELF linking and DWARF debug information";
-    maintainers = with lib.maintainers; [ genericnerdyusername ];
+    maintainers = [ ];
     license = lib.licenses.bsd2;
     platforms = ocaml.meta.platforms;
     broken = !(lib.versionAtLeast ocaml.version "4.07");

--- a/pkgs/development/ocaml-modules/sail/default.nix
+++ b/pkgs/development/ocaml-modules/sail/default.nix
@@ -79,7 +79,7 @@ buildDunePackage {
   meta = {
     homepage = "https://github.com/rems-project/sail";
     description = "Language for describing the instruction-set architecture (ISA) semantics of processors";
-    maintainers = with lib.maintainers; [ genericnerdyusername ];
+    maintainers = [ ];
     license = lib.licenses.bsd2;
   };
 }

--- a/pkgs/development/python-modules/dataproperty/default.nix
+++ b/pkgs/development/python-modules/dataproperty/default.nix
@@ -48,6 +48,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/thombashi/DataProperty";
     changelog = "https://github.com/thombashi/DataProperty/releases/tag/${src.tag}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ genericnerdyusername ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/ipyxact/default.nix
+++ b/pkgs/development/python-modules/ipyxact/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
     homepage = "https://github.com/olofk/ipyxact";
     description = "IP-XACT parser";
     mainProgram = "ipxact2v";
-    maintainers = with lib.maintainers; [ genericnerdyusername ];
+    maintainers = [ ];
     license = lib.licenses.mit;
   };
 }

--- a/pkgs/development/python-modules/mbstrdecoder/default.nix
+++ b/pkgs/development/python-modules/mbstrdecoder/default.nix
@@ -35,7 +35,7 @@ buildPythonPackage rec {
   meta = {
     homepage = "https://github.com/thombashi/mbstrdecoder";
     description = "Library for decoding multi-byte character strings";
-    maintainers = with lib.maintainers; [ genericnerdyusername ];
+    maintainers = [ ];
     license = lib.licenses.mit;
   };
 }

--- a/pkgs/development/python-modules/okonomiyaki/default.nix
+++ b/pkgs/development/python-modules/okonomiyaki/default.nix
@@ -69,7 +69,7 @@ buildPythonPackage rec {
     description = "Experimental library aimed at consolidating a lot of low-level code used for Enthought's eggs";
     homepage = "https://github.com/enthought/okonomiyaki";
     changelog = "https://github.com/enthought/okonomiyaki/releases/tag/${src.tag}";
-    maintainers = with lib.maintainers; [ genericnerdyusername ];
+    maintainers = [ ];
     license = lib.licenses.bsd3;
   };
 }

--- a/pkgs/development/python-modules/pytablewriter/default.nix
+++ b/pkgs/development/python-modules/pytablewriter/default.nix
@@ -106,6 +106,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/thombashi/pytablewriter";
     changelog = "https://github.com/thombashi/pytablewriter/releases/tag/${src.tag}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ genericnerdyusername ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/riscof/default.nix
+++ b/pkgs/development/python-modules/riscof/default.nix
@@ -48,7 +48,7 @@ buildPythonPackage rec {
     mainProgram = "riscof";
     homepage = "https://github.com/riscv-software-src/riscof";
     changelog = "https://github.com/riscv-software-src/riscof/blob/${version}/CHANGELOG.md";
-    maintainers = with lib.maintainers; [ genericnerdyusername ];
+    maintainers = [ ];
     license = lib.licenses.bsd3;
   };
 }

--- a/pkgs/development/python-modules/riscv-config/default.nix
+++ b/pkgs/development/python-modules/riscv-config/default.nix
@@ -40,7 +40,7 @@ buildPythonPackage rec {
     homepage = "https://github.com/riscv/riscv-config";
     changelog = "https://github.com/riscv-software-src/riscv-config/blob/${version}/CHANGELOG.md";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ genericnerdyusername ];
+    maintainers = [ ];
     mainProgram = "riscv-config";
   };
 }

--- a/pkgs/development/python-modules/riscv-isac/default.nix
+++ b/pkgs/development/python-modules/riscv-isac/default.nix
@@ -52,6 +52,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/riscv/riscv-isac";
     changelog = "https://github.com/riscv-software-src/riscv-isac/blob/${version}/CHANGELOG.md";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ genericnerdyusername ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/simplesat/default.nix
+++ b/pkgs/development/python-modules/simplesat/default.nix
@@ -51,6 +51,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/enthought/sat-solver";
     changelog = "https://github.com/enthought/sat-solver/blob/${src.tag}/CHANGES.rst";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ genericnerdyusername ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/tabledata/default.nix
+++ b/pkgs/development/python-modules/tabledata/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
     homepage = "https://github.com/thombashi/tabledata";
     description = "Library to represent tabular data";
     changelog = "https://github.com/thombashi/tabledata/releases/tag/${src.tag}";
-    maintainers = with lib.maintainers; [ genericnerdyusername ];
+    maintainers = [ ];
     license = lib.licenses.mit;
   };
 }

--- a/pkgs/development/python-modules/tcolorpy/default.nix
+++ b/pkgs/development/python-modules/tcolorpy/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
   meta = {
     homepage = "https://github.com/thombashi/tcolorpy";
     description = "Library to apply true color for terminal text";
-    maintainers = with lib.maintainers; [ genericnerdyusername ];
+    maintainers = [ ];
     license = lib.licenses.mit;
   };
 }

--- a/pkgs/development/python-modules/typepy/default.nix
+++ b/pkgs/development/python-modules/typepy/default.nix
@@ -48,6 +48,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/thombashi/typepy";
     changelog = "https://github.com/thombashi/typepy/releases/tag/${src.tag}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ genericnerdyusername ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/zipfile2/default.nix
+++ b/pkgs/development/python-modules/zipfile2/default.nix
@@ -35,6 +35,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/cournape/zipfile2";
     changelog = "https://github.com/itziakos/zipfile2/releases/tag/v${version}";
     license = lib.licenses.psfl;
-    maintainers = with lib.maintainers; [ genericnerdyusername ];
+    maintainers = [ ];
   };
 }


### PR DESCRIPTION
Per their profile, no nixpkgs activity since December 2023.

Dropping per [maintainers/README.md](https://github.com/NixOS/nixpkgs/tree/a7808b41c3cfd040fbe03e12a68654db3c02d5bc/maintainers#losing-maintainer-status)

@genericnerdyusername: if you'd like to stay involved, please respond within a week. Even if you don't do so, you are welcome back at any time.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] 0 rebuilds.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
