### PR TITLE
iputils.apparmor: only include local/bin if exists

### DIFF
--- a/pkgs/os-specific/linux/iputils/default.nix
+++ b/pkgs/os-specific/linux/iputils/default.nix
@@ -67,7 +67,7 @@ stdenv.mkDerivation rec {
           [ libcap ] ++ lib.optional (!stdenv.hostPlatform.isMusl) libidn2
         )
       }"
-      include <local/bin.ping>
+      include if exists <local/bin.ping>
       capability net_raw,
       network inet raw,
       network inet6 raw,


### PR DESCRIPTION
otherwise `apparmor.service` will fail with:
> AppArmor parser error for
> /nix/store/zzfl79044n5px6arls0l8f7kgvp8s0p0-bin.ping in profile
> /nix/store/251z356c3h7q2cxrx43agk98mrgdg11l-iputils-20250605-apparmor/bin.ping
> at line 7: Could not open 'local/bin.ping'

this follows the pattern used by every other apparmor profile in nixpkgs; see:
- pkgs/applications/networking/p2p/transmission/4.nix
- pkgs/by-name/in/inetutils/package.nix
- nixos/modules/services/networking/murmur.nix
- nixos/modules/services/web-apps/miniflux.nix
- nixos/modules/virtualisation/incus.nix


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
