### PR TITLE
apparmor-utils: fix cross compilation

### DIFF
--- a/pkgs/by-name/ap/apparmor-utils/package.nix
+++ b/pkgs/by-name/ap/apparmor-utils/package.nix
@@ -3,12 +3,11 @@
   makeWrapper,
   gawk,
   perl,
-  bash,
+  runtimeShellPackage,
   stdenv,
   which,
   linuxHeaders ? stdenv.cc.libc.linuxHeaders,
   python3Packages,
-  bashNonInteractive,
   buildPackages,
 
   # apparmor deps
@@ -23,7 +22,7 @@ python3Packages.buildPythonApplication {
   inherit (libapparmor) version src;
 
   postPatch = ''
-    patchShebangs .
+    patchShebangs common
     cd utils
 
     substituteInPlace aa-remove-unknown \
@@ -45,13 +44,12 @@ python3Packages.buildPythonApplication {
   nativeBuildInputs = [
     makeWrapper
     which
-    bashNonInteractive
     python3Packages.setuptools
   ];
 
   buildInputs = [
-    bash
     perl
+    runtimeShellPackage
   ];
 
   pythonPath = [


### PR DESCRIPTION
the `patchShebangs` in `postPatch` is for tools that are invoked at build-time. we don't want to patch the shebangs this early in the derivation for anything that would later be installed, so scope it more narrowly.

N.B.: `apparmor-utils` dependencies don't cross-compile until after https://github.com/NixOS/nixpkgs/pull/476808 , but i hope this change is acceptable regardless of when/if 476808 is merged.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
