### PR TITLE
[Backport release-25.11] pkgsite: 0-unstable-2025-11-28 -> 0-unstable-2026-01-01

### DIFF
--- a/pkgs/by-name/pk/pkgsite/package.nix
+++ b/pkgs/by-name/pk/pkgsite/package.nix
@@ -7,16 +7,16 @@
 
 buildGoModule {
   pname = "pkgsite";
-  version = "0-unstable-2025-11-28";
+  version = "0-unstable-2025-12-09";
 
   src = fetchFromGitHub {
     owner = "golang";
     repo = "pkgsite";
-    rev = "d74adeade195e94064b1dc38fd14b93037ad7694";
-    hash = "sha256-Rlm5XwOLjGYOtg12tlUtkd2+upY2EP7x5dI+Nx2JAF0=";
+    rev = "7dafa59905aea1f9f4a8d2f38c1505796d9b69b3";
+    hash = "sha256-aNpvU/4FFNDJAn11Js+1I41GjLic6gF8MyJXS3TLeRA=";
   };
 
-  vendorHash = "sha256-Zv9kyBGLicSJlWD0/wv6ggteA+DttOb18/P5s91tJxE=";
+  vendorHash = "sha256-6wgJNDzUzSCkwzjqGwzpa63+0HoN5PapKxMBFBuu16M=";
 
   subPackages = [ "cmd/pkgsite" ];
 

--- a/pkgs/by-name/pk/pkgsite/package.nix
+++ b/pkgs/by-name/pk/pkgsite/package.nix
@@ -7,13 +7,13 @@
 
 buildGoModule {
   pname = "pkgsite";
-  version = "0-unstable-2025-12-09";
+  version = "0-unstable-2025-12-15";
 
   src = fetchFromGitHub {
     owner = "golang";
     repo = "pkgsite";
-    rev = "7dafa59905aea1f9f4a8d2f38c1505796d9b69b3";
-    hash = "sha256-aNpvU/4FFNDJAn11Js+1I41GjLic6gF8MyJXS3TLeRA=";
+    rev = "4eb0af2c34bf5ae5d7e04cc47cd8f7b6269ef079";
+    hash = "sha256-BpNB8wrb3vR5NXAxwRfrQjwcSllWB1YlQJU25OlS8Hw=";
   };
 
   vendorHash = "sha256-6wgJNDzUzSCkwzjqGwzpa63+0HoN5PapKxMBFBuu16M=";

--- a/pkgs/by-name/pk/pkgsite/package.nix
+++ b/pkgs/by-name/pk/pkgsite/package.nix
@@ -7,13 +7,13 @@
 
 buildGoModule {
   pname = "pkgsite";
-  version = "0-unstable-2025-12-15";
+  version = "0-unstable-2025-12-23";
 
   src = fetchFromGitHub {
     owner = "golang";
     repo = "pkgsite";
-    rev = "4eb0af2c34bf5ae5d7e04cc47cd8f7b6269ef079";
-    hash = "sha256-BpNB8wrb3vR5NXAxwRfrQjwcSllWB1YlQJU25OlS8Hw=";
+    rev = "1a3bd3c788fea11057a8e696fd274c4c3f3e952c";
+    hash = "sha256-GnjzJhmH9mOBdpc+r3Hco0KFsTp4LMkbTn/oMBthemQ=";
   };
 
   vendorHash = "sha256-6wgJNDzUzSCkwzjqGwzpa63+0HoN5PapKxMBFBuu16M=";

--- a/pkgs/by-name/pk/pkgsite/package.nix
+++ b/pkgs/by-name/pk/pkgsite/package.nix
@@ -7,16 +7,16 @@
 
 buildGoModule {
   pname = "pkgsite";
-  version = "0-unstable-2025-12-23";
+  version = "0-unstable-2026-01-01";
 
   src = fetchFromGitHub {
     owner = "golang";
     repo = "pkgsite";
-    rev = "1a3bd3c788fea11057a8e696fd274c4c3f3e952c";
-    hash = "sha256-GnjzJhmH9mOBdpc+r3Hco0KFsTp4LMkbTn/oMBthemQ=";
+    rev = "3a74f05acd7522e74e16a35bdf80301dae44cfc9";
+    hash = "sha256-1YTCjaPf6t0Tn/u1ERBxoHeXAIMO4wsPIcODBPJjrlM=";
   };
 
-  vendorHash = "sha256-6wgJNDzUzSCkwzjqGwzpa63+0HoN5PapKxMBFBuu16M=";
+  vendorHash = "sha256-rruIjtXtFZ0MOJkWx4n+7apKGv4Pq6GrOWoQ3o+8KFs=";
 
   subPackages = [ "cmd/pkgsite" ];
 


### PR DESCRIPTION
Manual backport to release-25.11, for prs https://github.com/NixOS/nixpkgs/pull/469806 https://github.com/NixOS/nixpkgs/pull/471469 https://github.com/NixOS/nixpkgs/pull/473745 https://github.com/NixOS/nixpkgs/pull/477026

Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md?rgh-link-date=2026-01-03T07%3A29%3A16Z#changes-acceptable-for-releases).

Even as a non-committer, if you find that it is not acceptable, leave a comment.