### PR TITLE
docbook_xml*: fix source not found

### DIFF
--- a/pkgs/data/sgml+xml/schemas/xml-dtd/docbook/4.1.2.nix
+++ b/pkgs/data/sgml+xml/schemas/xml-dtd/docbook/4.1.2.nix
@@ -7,11 +7,11 @@
 }:
 
 let
-  # Urgh, DocBook 4.1.2 doesn't come with an XML catalog.  Use the one
+  # Urgh, DocBook 4.1.2 doesn't come with an XML catalog. Use the one
   # from 4.2.
   docbook42catalog = fetchurl {
-    url = "https://docbook.org/xml/4.2/catalog.xml";
-    sha256 = "18lhp6q2l0753s855r638shkbdwq9blm6akdjsc9nrik24k38j17";
+    url = "https://www.oasis-open.org/docbook/xml/4.2/catalog.xml";
+    hash = "sha256-J0g0JhEzZpuYlm0qU+lKmLc1oUbD5FKQHuUAKrC5kKI=";
   };
 in
 
@@ -19,14 +19,13 @@ import ./generic.nix {
   inherit
     lib
     stdenv
+    fetchurl
     unzip
     findXMLCatalogs
     ;
   version = "4.1.2";
-  src = fetchurl {
-    url = "https://docbook.org/xml/4.1.2/docbkx412.zip";
-    sha256 = "0wkp5rvnqj0ghxia0558mnn4c7s3n501j99q2isp3sp0ci069w1h";
-  };
+  url = "https://www.oasis-open.org/docbook/xml/4.1.2/docbkx412.zip";
+  hash = "sha256-MPBkQGTg6nF1FDglGUCxQx9GrK2oFKBihw9IbHcud3I=";
   postInstall = "
     sed 's|V4.2|V4.1.2|g' < ${docbook42catalog} > catalog.xml
   ";

--- a/pkgs/data/sgml+xml/schemas/xml-dtd/docbook/4.2.nix
+++ b/pkgs/data/sgml+xml/schemas/xml-dtd/docbook/4.2.nix
@@ -10,12 +10,10 @@ import ./generic.nix {
   inherit
     lib
     stdenv
+    fetchurl
     unzip
     findXMLCatalogs
     ;
   version = "4.2";
-  src = fetchurl {
-    url = "https://docbook.org/xml/4.2/docbook-xml-4.2.zip";
-    sha256 = "acc4601e4f97a196076b7e64b368d9248b07c7abf26b34a02cca40eeebe60fa2";
-  };
+  hash = "sha256-rMRgHk+XoZYHa35ks2jZJIsHx6vyazSgLMpA7uvmD6I=";
 }

--- a/pkgs/data/sgml+xml/schemas/xml-dtd/docbook/4.3.nix
+++ b/pkgs/data/sgml+xml/schemas/xml-dtd/docbook/4.3.nix
@@ -10,12 +10,10 @@ import ./generic.nix {
   inherit
     lib
     stdenv
+    fetchurl
     unzip
     findXMLCatalogs
     ;
   version = "4.3";
-  src = fetchurl {
-    url = "https://docbook.org/xml/4.3/docbook-xml-4.3.zip";
-    sha256 = "0r1l2if1z4wm2v664sqdizm4gak6db1kx9y50jq89m3gxaa8l1i3";
-  };
+  hash = "sha256-IwaKlOpv1ISwBMWnPsNqZqpH6o8Na2LMFpWTH1wUNGQ=";
 }

--- a/pkgs/data/sgml+xml/schemas/xml-dtd/docbook/4.4.nix
+++ b/pkgs/data/sgml+xml/schemas/xml-dtd/docbook/4.4.nix
@@ -10,12 +10,10 @@ import ./generic.nix {
   inherit
     lib
     stdenv
+    fetchurl
     unzip
     findXMLCatalogs
     ;
   version = "4.4";
-  src = fetchurl {
-    url = "https://docbook.org/xml/4.4/docbook-xml-4.4.zip";
-    sha256 = "141h4zsyc71sfi2zzd89v4bb4qqq9ca1ri9ix2als9f4i3mmkw82";
-  };
+  hash = "sha256-AvFZ64jEJU2V6DHFHBRLGGOyFtkJtf9FdDoc5vUnMJA=";
 }

--- a/pkgs/data/sgml+xml/schemas/xml-dtd/docbook/4.5.nix
+++ b/pkgs/data/sgml+xml/schemas/xml-dtd/docbook/4.5.nix
@@ -10,12 +10,10 @@ import ./generic.nix {
   inherit
     lib
     stdenv
+    fetchurl
     unzip
     findXMLCatalogs
     ;
   version = "4.5";
-  src = fetchurl {
-    url = "https://docbook.org/xml/4.5/docbook-xml-4.5.zip";
-    sha256 = "1d671lcjckjri28xfbf6dq7y3xnkppa910w1jin8rjc35dx06kjf";
-  };
+  hash = "sha256-Tk4DeiuDyYxslIGDkNS90/bhD27GLdeRiFlOJhkNx7Q=";
 }

--- a/pkgs/data/sgml+xml/schemas/xml-dtd/docbook/generic.nix
+++ b/pkgs/data/sgml+xml/schemas/xml-dtd/docbook/generic.nix
@@ -2,10 +2,15 @@
   lib,
   stdenv,
   unzip,
-  src,
-  version,
-  postInstall ? "true",
+  fetchurl,
   findXMLCatalogs,
+  src ? fetchurl {
+    inherit hash url;
+  },
+  version,
+  hash ? "",
+  url ? "https://www.oasis-open.org/docbook/xml/${version}/docbook-xml-${version}.zip",
+  postInstall ? "true",
 }:
 
 stdenv.mkDerivation {


### PR DESCRIPTION
`docbook.org` seems to no longer provide DocBook XML releases under /xml/, causing fetchurl 404 failures across all docbook-xml versions.

Switch to `www.oasis-open.org` as more stable source.

Fixes #477815


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
