### PR TITLE
cnijfilter2: 6.40 -> 6.90

### DIFF
--- a/pkgs/by-name/cn/cnijfilter2/package.nix
+++ b/pkgs/by-name/cn/cnijfilter2/package.nix
@@ -15,10 +15,10 @@
 stdenv.mkDerivation {
   pname = "cnijfilter2";
 
-  version = "6.40";
+  version = "6.90";
 
   src = fetchzip {
-    url = "https://gdlp01.c-wss.com/gds/1/0100011381/01/cnijfilter2-source-6.40-1.tar.gz";
+    url = "https://gdlp01.c-wss.com/gds/1/0100011381/01/cnijfilter2-source-6.90-1.tar.gz";
     sha256 = "3RoG83jLOsdTEmvUkkxb7wa8oBrJA4v1mGtxTGwSowU=";
   };
 
@@ -37,6 +37,7 @@ stdenv.mkDerivation {
   patches = [
     ./patches/get_protocol.patch
     ./patches/add_missing_import.patch
+    ./patches/gcc15-fix.patch
   ];
 
   # lgmon3's --enable-libdir flag is used solely for specifying in which

--- a/pkgs/by-name/cn/cnijfilter2/patches/gcc15-fix.patch
+++ b/pkgs/by-name/cn/cnijfilter2/patches/gcc15-fix.patch
@@ -1,0 +1,15 @@
+--- cnijfilter2-source-6.90-1/lgmon3/src/common/libcnnet2_type.h	2025-06-30 16:56:58.000000000 +1200
++++ cnijfilter2-source-6.90-1.new/lgmon3/src/common/libcnnet2_type.h	2025-11-02 01:38:14.944227622 +1300
+@@ -47,8 +47,10 @@
+   CNNET2_SETTING_FLAG_DISCOVER_PACKET_WAIT_MILLIS,         /*æ¤œç´¢ãƒ‘ã‚±ãƒƒãƒˆè¤‡æ•°é€ä¿¡æ™‚ã®å¾…ã¡æ™‚é–“*/
+ } CNNET2_SETTING_FLAGS;
+ 
+-#ifndef __cplusplus
+-typedef char bool;
++#if defined(__GNUC__) && __GNUC__ < 15
++  #ifndef __cplusplus
++  typedef char bool;
++  #endif
+ #endif
+ 
+ typedef struct {


### PR DESCRIPTION
Since cnijfilter is one of the packages breaking with #475479, I added a patch. I also upgraded it at the same time to the newest version.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
