### PR TITLE
python3Packages.tuf: cleanup

### DIFF
--- a/pkgs/development/python-modules/tuf/default.nix
+++ b/pkgs/development/python-modules/tuf/default.nix
@@ -1,17 +1,23 @@
 {
   lib,
   buildPythonPackage,
-  ed25519,
-  freezegun,
   fetchFromGitHub,
-  hatchling,
-  pytestCheckHook,
+
+  # build-system
   flit-core,
+  hatchling,
+
+  # dependencies
   requests,
   securesystemslib,
+
+  # tests
+  ed25519,
+  freezegun,
+  pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "tuf";
   version = "6.0.0";
   pyproject = true;
@@ -19,13 +25,13 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "theupdateframework";
     repo = "python-tuf";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-CPbZOpUYi7MWKLMj7kwTsmEkxLCf4wU7IOCcbzMkPlU=";
   };
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace-fail  "hatchling==1.27.0" "hatchling"
+      --replace-fail "hatchling==1.27.0" "hatchling"
   '';
 
   build-system = [
@@ -42,12 +48,9 @@ buildPythonPackage rec {
 
   __darwinAllowLocalNetworking = true;
 
-  checkInputs = [
-    freezegun
-  ];
-
   nativeCheckInputs = [
     ed25519
+    freezegun
     pytestCheckHook
   ];
 
@@ -60,11 +63,11 @@ buildPythonPackage rec {
   meta = {
     description = "Python reference implementation of The Update Framework (TUF)";
     homepage = "https://github.com/theupdateframework/python-tuf";
-    changelog = "https://github.com/theupdateframework/python-tuf/blob/v${version}/docs/CHANGELOG.md";
+    changelog = "https://github.com/theupdateframework/python-tuf/blob/${finalAttrs.src.tag}/docs/CHANGELOG.md";
     license = with lib.licenses; [
       asl20
       mit
     ];
     maintainers = with lib.maintainers; [ fab ];
   };
-}
+})


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
