### PR TITLE
python3Packages.pytorch-tokenizers: fix build by patching sentencepiece src

### DIFF
--- a/pkgs/development/python-modules/pytorch-tokenizers/add-missing-cstdint-sentencepiece.patch
+++ b/pkgs/development/python-modules/pytorch-tokenizers/add-missing-cstdint-sentencepiece.patch
@@ -1,0 +1,13 @@
+Submodule third-party/sentencepiece contains modified content
+diff --git a/third-party/sentencepiece/src/sentencepiece_processor.h b/third-party/sentencepiece/src/sentencepiece_processor.h
+index dd3f092..553fbff 100644
+--- a/third-party/sentencepiece/src/sentencepiece_processor.h
++++ b/third-party/sentencepiece/src/sentencepiece_processor.h
+@@ -16,6 +16,7 @@
+ #define SENTENCEPIECE_PROCESSOR_H_
+ 
+ #include <cstring>
++#include <cstdint>
+ #include <memory>
+ #include <string>
+ #include <string_view>

--- a/pkgs/development/python-modules/pytorch-tokenizers/default.nix
+++ b/pkgs/development/python-modules/pytorch-tokenizers/default.nix
@@ -45,6 +45,8 @@ buildPythonPackage rec {
     (replaceVars ./dont-fetch-pybind11.patch {
       pybind11 = pybind11-src;
     })
+    # error: ‘uint32_t’ does not name a type
+    ./add-missing-cstdint-sentencepiece.patch
   ];
 
   postPatch = ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Tracking #475479

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
