### PR TITLE
minimacy: 1.2.0 -> 2.0.0

### DIFF
--- a/pkgs/by-name/mi/minimacy/package.nix
+++ b/pkgs/by-name/mi/minimacy/package.nix
@@ -12,13 +12,13 @@
 
 stdenv.mkDerivation rec {
   pname = "minimacy";
-  version = "1.2.0";
+  version = "2.0.0";
 
   src = fetchFromGitHub {
     owner = "ambermind";
     repo = "minimacy";
     rev = version;
-    hash = "sha256-uA+4dnhOnv7qRE7nqew8a14DGaQblsMY2uBZ+iyLtFU=";
+    hash = "sha256-VR7MCXRJHudFXBorjR6L/umn0p9NIu3zP2XMH3d9DHQ=";
   };
 
   nativeBuildInputs = [ makeBinaryWrapper ];
@@ -55,9 +55,10 @@ stdenv.mkDerivation rec {
   checkPhase = ''
     runHook preCheck
 
-    bin/${
-      if stdenv.hostPlatform.isDarwin then "minimacyMac" else "minimacy"
-    } system/demo/demo.fun.mandelbrot.mcy
+    prog=bin/${if stdenv.hostPlatform.isDarwin then "minimacyMac" else "minimacy"}
+
+    $prog programs/demo/demo.fun.mandelbrot.mcy
+    $prog programs/demo/demo.fun.maze.mcy
 
     runHook postCheck
   '';
@@ -66,7 +67,7 @@ stdenv.mkDerivation rec {
     runHook preInstall
 
     mkdir -p $out/lib/minimacy
-    cp -r {README.md,LICENSE,system,rom,topLevel.mcy} $out/lib/minimacy
+    cp -r {README.md,LICENSE,rom,topLevel.mcy} $out/lib/minimacy
     install bin/minimacy* -Dt $out/bin
 
     runHook postInstall


### PR DESCRIPTION
Update to [2.0.0 release](https://github.com/ambermind/minimacy/releases/tag/2.0.0) of Minimacy.

This addresses #472813.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
