### PR TITLE
python3Packages.pyslang: init at 9.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10796,6 +10796,12 @@
     githubId = 15371828;
     name = "Hugo Lageneste";
   };
+  hugom = {
+    email = "hugo.mcnally@gmail.com";
+    github = "HU90m";
+    githubId = 45573837;
+    name = "Hugo McNally";
+  };
   hugoreeves = {
     email = "hugo@hugoreeves.com";
     github = "HugoReeves";

--- a/pkgs/by-name/sv/sv-lang/package.nix
+++ b/pkgs/by-name/sv/sv-lang/package.nix
@@ -33,12 +33,13 @@ stdenv.mkDerivation (finalAttrs: {
     "-DCMAKE_INSTALL_INCLUDEDIR=include"
     "-DCMAKE_INSTALL_LIBDIR=lib"
 
+    "-DSLANG_INCLUDE_PYLIB=ON"
     "-DSLANG_INCLUDE_TESTS=${if finalAttrs.finalPackage.doCheck then "ON" else "OFF"}"
   ];
 
   nativeBuildInputs = [
     cmake
-    python3
+    (python3.withPackages (pyPkgs: with pyPkgs; [ pybind11 ]))
     ninja
   ];
 
@@ -55,6 +56,10 @@ stdenv.mkDerivation (finalAttrs: {
   # TODO: a mysterious linker error occurs when building the unittests on darwin.
   # The error occurs when using catch2_3 in nixpkgs, not when fetching catch2_3 using CMake
   doCheck = !stdenv.hostPlatform.isDarwin;
+
+  # Pass through the python version for which the pylib (python extension
+  # module) was built for.
+  passthru.pythonVersion = python3.pythonVersion;
 
   meta = {
     description = "SystemVerilog compiler and language services";

--- a/pkgs/development/python-modules/pyslang/default.nix
+++ b/pkgs/development/python-modules/pyslang/default.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  buildPythonPackage,
+  sv-lang,
+  python,
+}:
+buildPythonPackage {
+  pname = "pyslang";
+  version = sv-lang.version;
+  format = "other";
+
+  disabled = python.pythonVersion != sv-lang.pythonVersion;
+
+  src = sv-lang;
+  dontUnpack = true;
+
+  installPhase = ''
+    mkdir -p $out/${python.sitePackages}
+    cp $src/pyslang.*.so $out/${python.sitePackages}/
+  '';
+
+  pythonImportsCheck = [ "pyslang" ];
+
+  meta = sv-lang.meta // {
+    description = "Python bindings for the slang SystemVerilog parser.";
+    maintainers = with lib.maintainers; [ hugom ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14651,6 +14651,8 @@ self: super: with self; {
 
   pyskyqremote = callPackage ../development/python-modules/pyskyqremote { };
 
+  pyslang = callPackage ../development/python-modules/pyslang { };
+
   pyslim = callPackage ../development/python-modules/pyslim { };
 
   pyslurm = callPackage ../development/python-modules/pyslurm { inherit (pkgs) slurm; };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
