### PR TITLE
slang-server: init at 0.1.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10796,6 +10796,12 @@
     githubId = 15371828;
     name = "Hugo Lageneste";
   };
+  hugom = {
+    email = "hugo.mcnally@gmail.com";
+    github = "HU90m";
+    githubId = 45573837;
+    name = "Hugo McNally";
+  };
   hugoreeves = {
     email = "hugo@hugoreeves.com";
     github = "HugoReeves";

--- a/pkgs/by-name/sl/slang-server/package.nix
+++ b/pkgs/by-name/sl/slang-server/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  boost,
+  catch2_3,
+  cmake,
+  ninja,
+  fmt_12,
+  mimalloc,
+  python3,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "slang-server";
+  version = "0.1.5";
+
+  src = fetchFromGitHub {
+    owner = "hudson-trading";
+    repo = "slang-server";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-L/L0jhaqWnwZVt1GWzJYa1/Ztx/c/oPKGw+P8CJQTuI=";
+    fetchSubmodules = true;
+  };
+
+  postPatch = ''
+    substituteInPlace external/slang/external/CMakeLists.txt --replace-fail \
+      'set(mimalloc_min_version "2.2")' \
+      'set(mimalloc_min_version "${lib.versions.majorMinor mimalloc.version}")'
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    python3
+    ninja
+  ];
+
+  buildInputs = [
+    boost
+    fmt_12
+    mimalloc
+    catch2_3
+  ];
+
+  strictDeps = true;
+
+  meta = {
+    description = "A SystemVerilog language server based on the Slang library.";
+    homepage = "https://hudson-trading.github.io/slang-server";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ hugom ];
+    mainProgram = "slang-server";
+    broken = stdenv.hostPlatform.isDarwin;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
