### PR TITLE
pcsclite: 2.3.0 -> 2.4.1

### DIFF
--- a/nixos/modules/services/hardware/pcscd.nix
+++ b/nixos/modules/services/hardware/pcscd.nix
@@ -134,5 +134,12 @@ in
         "${lib.getExe package} -f -x -c ${cfgFile} ${lib.escapeShellArgs cfg.extraArgs}"
       ];
     };
+
+    users.users.pcscd = {
+      isSystemUser = true;
+      group = "pcscd";
+    };
+
+    users.groups.pcscd = { };
   };
 }

--- a/nixos/modules/services/hardware/pcscd.nix
+++ b/nixos/modules/services/hardware/pcscd.nix
@@ -106,6 +106,8 @@ in
 
     services.pcscd.plugins = [ pkgs.ccid ];
 
+    services.udev.packages = [ pkgs.ccid ];
+
     systemd.sockets.pcscd.wantedBy = [ "sockets.target" ];
 
     systemd.services.pcscd = {

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1227,6 +1227,7 @@ in
   pass-secret-service = runTest ./pass-secret-service.nix;
   password-option-override-ordering = runTest ./password-option-override-ordering.nix;
   patroni = handleTestOn [ "x86_64-linux" ] ./patroni.nix { };
+  pcsclite = runTest ./pcsclite.nix;
   pdns-recursor = runTest ./pdns-recursor.nix;
   peerflix = runTest ./peerflix.nix;
   peering-manager = runTest ./web-apps/peering-manager.nix;

--- a/nixos/tests/pcsclite.nix
+++ b/nixos/tests/pcsclite.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  ...
+}:
+
+{
+  name = "pcsclite";
+  meta.maintainers = [ lib.maintainers.bjornfor ];
+
+  nodes = {
+    machine =
+      { pkgs, ... }:
+      {
+        environment.systemPackages = [
+          pkgs.pcsc-tools
+        ];
+        services.pcscd = {
+          enable = true;
+        };
+      };
+  };
+
+  testScript = ''
+    machine.wait_for_unit("pcscd.socket")
+
+    with subtest("client can connect"):
+        machine.succeed("pcsc_scan -r")
+  '';
+}

--- a/pkgs/by-name/cc/ccid/package.nix
+++ b/pkgs/by-name/cc/ccid/package.nix
@@ -61,6 +61,10 @@ stdenv.mkDerivation (finalAttrs: {
     install -Dm 0444 -t $out/lib/udev/rules.d ../src/92_pcscd_ccid.rules
     substituteInPlace $out/lib/udev/rules.d/92_pcscd_ccid.rules \
       --replace-fail "/usr/sbin/pcscd" "${pcsclite}/bin/pcscd"
+    # Disable reference to binary that we don't build.
+    substituteInPlace $out/lib/udev/rules.d/92_pcscd_ccid.rules \
+      --replace-fail 'ATTRS{idVendor}=="0d46", ATTRS{idProduct}=="4081", RUN+="/usr/sbin/Kobil_mIDentity_switch"' \
+                     '# disabled: ATTRS{idVendor}=="0d46", ATTRS{idProduct}=="4081", RUN+="/usr/sbin/Kobil_mIDentity_switch"'
   '';
 
   # The resulting shared object ends up outside of the default paths which are

--- a/pkgs/by-name/cc/ccid/package.nix
+++ b/pkgs/by-name/cc/ccid/package.nix
@@ -15,13 +15,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "ccid";
-  version = "1.6.2";
+  version = "1.7.0";
 
   src = fetchFromGitHub {
     owner = "LudovicRousseau";
     repo = "CCID";
     tag = finalAttrs.version;
-    hash = "sha256-n7rOjnLZH4RLmddtBycr3FK2Bi/OLR+9IjWBRbWjnUw=";
+    hash = "sha256-6eaznSIQZl1bpIe1F9EtwotF9BjOruJ9g/c2QrTgfUg=";
   };
 
   postPatch = ''
@@ -33,6 +33,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   mesonFlags = [
     (lib.mesonBool "serial" true)
+    # Upstream tries to install udev outside of PREFIX. It's easier to disable
+    # this and install it ourself than to patch meson.build.
+    (lib.mesonBool "udev-rules" false)
   ];
 
   # error: call to undeclared function 'InterruptRead';

--- a/pkgs/by-name/pc/pcsclite/package.nix
+++ b/pkgs/by-name/pc/pcsclite/package.nix
@@ -68,8 +68,6 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.mesonBool "libudev" false)
   ];
 
-  # disable building pcsc-wirecheck{,-gen} when cross compiling
-  # see also: https://github.com/LudovicRousseau/PCSC/issues/25
   postPatch = ''
     substituteInPlace src/libredirect.c src/spy/libpcscspy.c \
       --replace-fail "libpcsclite_real.so.1" "$lib/lib/libpcsclite_real.so.1"

--- a/pkgs/by-name/pc/pcsclite/package.nix
+++ b/pkgs/by-name/pc/pcsclite/package.nix
@@ -21,6 +21,7 @@
   nix-update-script,
   pname ? "pcsclite",
   polkitSupport ? false,
+  nixosTests,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -110,6 +111,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     tests = {
+      nixos = nixosTests.pcsclite;
       pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       version = testers.testVersion {
         package = finalAttrs.finalPackage;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Add NixOS test, update pcsclite (+ ccid) to latest and update NixOS module as needed.

Changelog: https://github.com/LudovicRousseau/PCSC/blob/2.4.1/ChangeLog

Only build tested.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
