### PR TITLE
qdelay: init at 1.0.4

### DIFF
--- a/pkgs/by-name/qd/qdelay/package.nix
+++ b/pkgs/by-name/qd/qdelay/package.nix
@@ -1,0 +1,110 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  alsa-lib,
+  fontconfig,
+  freetype,
+  libX11,
+  libXcomposite,
+  libXcursor,
+  libXdmcp,
+  libXext,
+  libXinerama,
+  libXrandr,
+  libXtst,
+  writableTmpDirAsHomeHook,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "qdelay";
+  version = "1.0.4";
+
+  src = fetchFromGitHub {
+    owner = "tiagolr";
+    repo = "qdelay";
+    tag = "v${finalAttrs.version}";
+    fetchSubmodules = true;
+    hash = "sha256-6V9L8GTAHN3bzVZ00XlSwh71ZQrx4o37J8kOZtRzjC8=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    writableTmpDirAsHomeHook # fontconfig cache
+  ];
+
+  buildInputs = [
+    fontconfig
+    freetype
+  ]
+  ++ lib.optionals stdenv.isLinux [
+    alsa-lib
+    libX11
+    libXcomposite
+    libXcursor
+    libXdmcp
+    libXext
+    libXinerama
+    libXrandr
+    libXtst
+  ];
+
+  enableParallelBuilding = true;
+
+  cmakeFlags = [
+    "-DCOPY_PLUGIN_AFTER_BUILD=FALSE"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    "-DCMAKE_OSX_ARCHITECTURES=${stdenv.hostPlatform.darwinArch}"
+  ];
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail 'juce::juce_recommended_lto_flags' '# Not forcing LTO'
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/lib/vst3
+
+  ''
+  + (
+    if stdenv.hostPlatform.isDarwin then
+      ''
+        mkdir -p $out/Applications
+        cp -R QDelay_artefacts/Release/Standalone/QDelay.app \
+          $out/Applications/QDelay.app
+        ln -s \
+          $out/Applications/QDelay.app/Contents/MacOS/QDelay \
+          $out/bin/QDelay
+      ''
+    else
+      ''
+        install -Dm755 \
+          QDelay_artefacts/Release/Standalone/QDelay \
+          $out/bin/QDelay
+
+        mkdir -p $out/bin $out/lib/lv2
+        cp -r "QDelay_artefacts/Release/LV2/QDelay.lv2" $out/lib/lv2
+      ''
+  )
+  + ''
+    cp -r "QDelay_artefacts/Release/VST3/QDelay.vst3" $out/lib/vst3
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Dual delay with more features than it should";
+    homepage = "https://github.com/tiagolr/qdelay";
+    changelog = "https://github.com/tiagolr/qdelay/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ magnetophon ];
+    mainProgram = "QDelay";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
Dual delay with more features than it should.
For VST3, LV2 and standalone.

https://github.com/tiagolr/qdelay

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
