### PR TITLE
python3.pkgs.numpy_{1,2}: define INI's configuration in passthru

### DIFF
--- a/pkgs/development/python-modules/numpy/1.nix
+++ b/pkgs/development/python-modules/numpy/1.nix
@@ -33,29 +33,6 @@
 
 assert (!blas.isILP64) && (!lapack.isILP64);
 
-let
-  cfg = writeTextFile {
-    name = "site.cfg";
-    text = lib.generators.toINI { } {
-      ${blas.implementation} = {
-        include_dirs = "${lib.getDev blas}/include:${lib.getDev lapack}/include";
-        library_dirs = "${blas}/lib:${lapack}/lib";
-        runtime_library_dirs = "${blas}/lib:${lapack}/lib";
-        libraries = "lapack,lapacke,blas,cblas";
-      };
-      lapack = {
-        include_dirs = "${lib.getDev lapack}/include";
-        library_dirs = "${lapack}/lib";
-        runtime_library_dirs = "${lapack}/lib";
-      };
-      blas = {
-        include_dirs = "${lib.getDev blas}/include";
-        library_dirs = "${blas}/lib";
-        runtime_library_dirs = "${blas}/lib";
-      };
-    };
-  };
-in
 buildPythonPackage (finalAttrs: {
   pname = "numpy";
   version = "1.26.4";
@@ -123,7 +100,7 @@ buildPythonPackage (finalAttrs: {
   '';
 
   preBuild = ''
-    ln -s ${cfg} site.cfg
+    ln -s ${finalAttrs.passthru.cfg} site.cfg
   '';
 
   enableParallelBuilding = true;
@@ -180,7 +157,28 @@ buildPythonPackage (finalAttrs: {
     # just for backwards compatibility
     blas = blas.provider;
     blasImplementation = blas.implementation;
-    inherit cfg;
+    buildConfig = {
+      ${blas.implementation} = {
+        include_dirs = "${lib.getDev blas}/include:${lib.getDev lapack}/include";
+        library_dirs = "${blas}/lib:${lapack}/lib";
+        runtime_library_dirs = "${blas}/lib:${lapack}/lib";
+        libraries = "lapack,lapacke,blas,cblas";
+      };
+      lapack = {
+        include_dirs = "${lib.getDev lapack}/include";
+        library_dirs = "${lapack}/lib";
+        runtime_library_dirs = "${lapack}/lib";
+      };
+      blas = {
+        include_dirs = "${lib.getDev blas}/include";
+        library_dirs = "${blas}/lib";
+        runtime_library_dirs = "${blas}/lib";
+      };
+    };
+    cfg = writeTextFile {
+      name = "site.cfg";
+      text = lib.generators.toINI { } finalAttrs.finalPackage.buildConfig;
+    };
     coreIncludeDir = "${finalAttrs.finalPackage}/${python.sitePackages}/numpy/core/include";
     tests = {
       inherit sage;

--- a/pkgs/development/python-modules/numpy/1.nix
+++ b/pkgs/development/python-modules/numpy/1.nix
@@ -3,7 +3,6 @@
   stdenv,
   fetchPypi,
   python,
-  numpy_1,
   pythonAtLeast,
   pythonOlder,
   buildPythonPackage,
@@ -57,14 +56,14 @@ let
     };
   };
 in
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "numpy";
   version = "1.26.4";
   pyproject = true;
   disabled = pythonOlder "3.9" || pythonAtLeast "3.13";
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     extension = "tar.gz";
     hash = "sha256-KgKrqe0S5KxOs+qUIcQgMBoMZGDZgw10qd+H76SRIBA=";
   };
@@ -182,7 +181,7 @@ buildPythonPackage rec {
     blas = blas.provider;
     blasImplementation = blas.implementation;
     inherit cfg;
-    coreIncludeDir = "${numpy_1}/${python.sitePackages}/numpy/core/include";
+    coreIncludeDir = "${finalAttrs.finalPackage}/${python.sitePackages}/numpy/core/include";
     tests = {
       inherit sage;
     };
@@ -193,10 +192,10 @@ buildPythonPackage rec {
   env.NOSE_EXCLUDE = "test_large_file_support";
 
   meta = {
-    changelog = "https://github.com/numpy/numpy/releases/tag/v${version}";
+    changelog = "https://github.com/numpy/numpy/releases/tag/v${finalAttrs.version}";
     description = "Scientific tools for Python";
     mainProgram = "f2py";
     homepage = "https://numpy.org/";
     license = lib.licenses.bsd3;
   };
-}
+})

--- a/pkgs/development/python-modules/numpy/2.nix
+++ b/pkgs/development/python-modules/numpy/2.nix
@@ -4,7 +4,6 @@
   fetchFromGitHub,
   fetchpatch2,
   python,
-  numpy_2,
   pythonAtLeast,
   pythonOlder,
   buildPythonPackage,
@@ -59,7 +58,7 @@ let
     };
   };
 in
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "numpy";
   version = "2.3.5";
   pyproject = true;
@@ -69,7 +68,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "numpy";
     repo = "numpy";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
     hash = "sha256-CMgJmsjPLgMCWN2iJk0OzcKIlnRRcayrTAns51S4B6k=";
   };
@@ -194,17 +193,17 @@ buildPythonPackage rec {
     blas = blas.provider;
     blasImplementation = blas.implementation;
     inherit cfg;
-    coreIncludeDir = "${numpy_2}/${python.sitePackages}/numpy/_core/include";
+    coreIncludeDir = "${finalAttrs.finalPackage}/${python.sitePackages}/numpy/_core/include";
     tests = {
       inherit sage;
     };
   };
 
   meta = {
-    changelog = "https://github.com/numpy/numpy/releases/tag/${src.tag}";
+    changelog = "https://github.com/numpy/numpy/releases/tag/${finalAttrs.src.tag}";
     description = "Scientific tools for Python";
     homepage = "https://numpy.org/";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ doronbehar ];
   };
-}
+})


### PR DESCRIPTION
## Things done

Tested with:

```diff
diff --git i/pkgs/top-level/all-packages.nix w/pkgs/top-level/all-packages.nix
index 45fda231747f..5564d65b496c 100644
--- i/pkgs/top-level/all-packages.nix
+++ w/pkgs/top-level/all-packages.nix
@@ -6667,6 +6667,26 @@ with pkgs;

   boost = boost187;

+  python-overriden = let
+    python =
+      let
+        packageOverrides = self: super: {
+          numpy = super.numpy_2.overrideAttrs (finalAttrs: oldAttrs: {
+            passthru = lib.recursiveUpdate oldAttrs.passthru {
+              buildConfig.properties = {
+                longdouble_format = "IEEE_DOUBLE_${if stdenv.hostPlatform.isLittleEndian then "LE" else "BE"}";
+              };
+            };
+          });
+        };
+      in
+      pkgs.python3.override {
+        inherit packageOverrides;
+        self = python;
+      };
+    in
+    python;
+
   botanEsdm = botan3.override { withEsdm = true; };

   c-ares = callPackage ../development/libraries/c-ares { };
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc