### PR TITLE
sageWithDoc: import ipython 9.7 update patch

### DIFF
--- a/pkgs/by-name/sa/sage/sage-src.nix
+++ b/pkgs/by-name/sa/sage/sage-src.nix
@@ -60,10 +60,10 @@ stdenv.mkDerivation rec {
     # a more conservative version of https://github.com/sagemath/sage/pull/37951
     ./patches/gap-element-crash.patch
 
-    # https://github.com/sagemath/sage/pull/40895, positively reviewed
+    # https://github.com/sagemath/sage/pull/40895, landed in 10.8.beta6
     (fetchpatch2 {
       name = "doctest-absolute-path.patch";
-      url = "https://github.com/sagemath/sage/commit/3de32dccd2e32e5452ca3adf5bd63cbacb64ba9d.patch?full_index=1";
+      url = "https://github.com/sagemath/sage/commit/3a5904d43f552bf63ed1eed9154f87b1f0de53fb.patch?full_index=1";
       hash = "sha256-rp+9d8Y6kifWzufE07GWU68txPn//w7uMn4LcpITaBs=";
     })
   ];
@@ -81,6 +81,13 @@ stdenv.mkDerivation rec {
       url = "https://github.com/sagemath/sage/commit/54d4ddb132cc71ef26b4db1f48afd6736d41cc63.patch?full_index=1";
       hash = "sha256-PZyOXRsgcsPvgceGGZXet5URJgWiIlCfFx8tvwpLk5A=";
       excludes = [ "src/doc/zh/constructions/rep_theory.rst" ];
+    })
+
+    # https://github.com/sagemath/sage/pull/41141, landed in 10.8.beta9
+    (fetchpatch2 {
+      name = "ipython-9_7_0-unicode_to_str.patch";
+      url = "https://github.com/sagemath/sage/commit/fa00696112fde95e0c4241ad6063936200ce6f68.patch?full_index=1";
+      hash = "sha256-eFDpNu/2gcQATELmQ7/VzXI35xIzaVrD8bhhJ57e2gc=";
     })
   ];
 


### PR DESCRIPTION
Fixes new build failure caused by the latest IPython upgrade. Fixes #476812.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
