### PR TITLE
func: 1.16.2 -> 1.20.1

### DIFF
--- a/pkgs/by-name/fu/func/package.nix
+++ b/pkgs/by-name/fu/func/package.nix
@@ -10,24 +10,24 @@
 
 buildGoModule (finalAttrs: {
   pname = "func";
-  version = "1.16.2";
+  version = "1.20.1";
 
   src = fetchFromGitHub {
     owner = "knative";
     repo = "func";
     tag = "knative-v${finalAttrs.version}";
-    hash = "sha256-nbS7X5WPu+WBtPUKShE5aWve5m2gw2naQQzNeG7pbGM=";
+    hash = "sha256-SYqkWE7dVFy6stibcWayU2J+oIFIfwNDoK6TzchgBzo=";
   };
 
-  vendorHash = "sha256-Gn+nyck/VOwf8iKPeyLvsPWOpfdN/maUcQOLFAU0oic=";
+  vendorHash = "sha256-F/TQ1QwfQfum1DOY2xrzpTlm7jvuJQUjtBLY6pZfTh8=";
 
   subPackages = [ "cmd/func" ];
 
   ldflags = [
-    "-X knative.dev/func/pkg/app.vers=v${finalAttrs.version}"
+    "-X knative.dev/func/pkg/version.Vers=v${finalAttrs.version}"
     "-X main.date=19700101T000000Z"
-    "-X knative.dev/func/pkg/app.hash=${finalAttrs.version}"
-    "-X knative.dev/func/pkg/app.kver=${finalAttrs.src.tag}"
+    "-X knative.dev/func/pkg/version.Hash=${finalAttrs.version}"
+    "-X knative.dev/func/pkg/version.Kver=${finalAttrs.src.tag}"
   ];
 
   nativeBuildInputs = [ installShellFiles ];


### PR DESCRIPTION
Diff: https://github.com/knative/func/compare/knative-v1.16.2...knative-v1.20.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
