### PR TITLE
kakoune: fix emoji display on darwin

### DIFF
--- a/pkgs/applications/editors/kakoune/darwin-wcwidth.patch
+++ b/pkgs/applications/editors/kakoune/darwin-wcwidth.patch
@@ -1,0 +1,59 @@
+diff --git a/src/highlighters.cc b/src/highlighters.cc
+--- a/src/highlighters.cc
++++ b/src/highlighters.cc
+@@ -1318,7 +1318,7 @@ void expand_unprintable(HighlightContext context, DisplayBuffer& display_buffer,
+             {
+                 auto next = it;
+                 Codepoint cp = utf8::read_codepoint(next, end);
+-                if (cp != '\n' and (cp < ' ' or cp > '~') and not iswprint((wchar_t)cp))
++                if (cp != '\n' and (cp < ' ' or cp > '~') and not kak_iswprint((wchar_t)cp))
+                 {
+                     if (ByteCount pos(it - line_data); pos != begin.column)
+                         atom_it = ++line.split(atom_it, {begin.line, pos});
+diff --git a/src/unicode.hh b/src/unicode.hh
+--- a/src/unicode.hh
++++ b/src/unicode.hh
+@@ -7,6 +7,34 @@
+ #include "array_view.hh"
+ #include "units.hh"
+
++#ifdef __APPLE__
++// macOS libc has outdated Unicode tables causing wcwidth() to return -1
++// for modern emoji. Use termux/wcwidth (Unicode 15) instead.
++// See: https://github.com/mawww/kakoune/issues/3059
++extern "C" int mk_wcwidth(wchar_t ucs);
++#define kak_wcwidth mk_wcwidth
++
++// musl-style iswprint - more permissive than macOS libc.
++// Considers all legal Unicode codepoints as printable except for:
++// - C0 and C1 control characters
++// - U+2028 and U+2029 (line/para break)
++// - U+FFF9 through U+FFFB (interlinear annotation controls)
++inline int kak_iswprint(wint_t wc) noexcept
++{
++    if (wc < 0xffU)
++        return (wc + 1 & 0x7f) >= 0x21;
++    if (wc < 0x2028U || wc - 0x202aU < 0xd800 - 0x202a || wc - 0xe000U < 0xfff9 - 0xe000)
++        return 1;
++    if (wc - 0xfffcU > 0x10ffff - 0xfffc || (wc & 0xfffe) == 0xfffe)
++        return 0;
++    return 1;
++}
++#else
++// On other platforms, use system functions
++#define kak_wcwidth wcwidth
++#define kak_iswprint iswprint
++#endif
++
+ namespace Kakoune
+ {
+
+@@ -103,7 +131,7 @@ inline bool is_identifier(Codepoint c) noexcept
+ {
+     if (c == '\n')
+         return 1;
+-    const auto width = wcwidth((wchar_t)c);
++    const auto width = kak_wcwidth((wchar_t)c);
+     return width >= 0 ? width : 1;
+ }
+

--- a/pkgs/applications/editors/kakoune/default.nix
+++ b/pkgs/applications/editors/kakoune/default.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchurl,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -14,6 +15,17 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-AJvh6NVFpbPsyzfeii/5muE+i4TwfxhwhDVgMLYOJCM=";
   };
 
+  # On Darwin, bundle termux/wcwidth for proper Unicode 15 emoji support.
+  # macOS libc has outdated Unicode tables causing wcwidth() to return -1
+  # for modern emoji, resulting in display corruption.
+  # See: https://github.com/mawww/kakoune/issues/3059
+  patches = lib.optionals stdenv.hostPlatform.isDarwin [ ./darwin-wcwidth.patch ];
+
+  wcwidth = fetchurl {
+    url = "https://raw.githubusercontent.com/termux/wcwidth/911263c514237997c9c590517672c6ea729388dc/wcwidth.c";
+    hash = "sha256-AMo/+xE6Kju6tK8OK5RaLT44/GFH/YfnGTcK6mqybCU=";
+  };
+
   makeFlags = [
     "debug=no"
     "PREFIX=${placeholder "out"}"
@@ -21,11 +33,20 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch = ''
     echo "v${finalAttrs.version}" >.version
+  ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    # Add termux wcwidth for Unicode 15 emoji support
+    cp ${finalAttrs.wcwidth} src/wcwidth.c
   '';
 
   enableParallelBuilding = true;
   preBuild = ''
     appendToVar makeFlags "CXX=$CXX"
+  ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    # Compile wcwidth.c with function renamed to mk_wcwidth
+    $CC -c -o src/wcwidth.o src/wcwidth.c -Dwcwidth=mk_wcwidth
+    appendToVar makeFlags "LDFLAGS=src/wcwidth.o"
   '';
 
   doInstallCheck = true;


### PR DESCRIPTION
## Summary

Fix emoji display corruption on macOS by bundling [termux/wcwidth](https://github.com/termux/wcwidth) (Unicode 15) on Darwin.

macOS libc has outdated Unicode tables (pre-2017) causing:
- `wcwidth()` to return -1 for modern emoji (should return 2)
- `iswprint()` to return false for newer emoji (should return true)

This results in emoji being replaced with `�` or causing display corruption.

## Implementation

- Patch `unicode.hh` and `highlighters.cc` to use `kak_wcwidth`/`kak_iswprint` macros
- On Darwin: these resolve to bundled termux/wcwidth (`mk_wcwidth`) and a musl-style `iswprint`
- On other platforms: these resolve to system `wcwidth`/`iswprint` (no change)
- The wcwidth.o object file is compiled separately with `-Dwcwidth=mk_wcwidth` to avoid symbol collision, then linked into the final binary

## Why not upstream?

The kakoune maintainer has [declined to bundle a Unicode database](https://github.com/mawww/kakoune/issues/3059#issuecomment-632669848), preferring to rely on system libc. This fix is Darwin-specific and doesn't affect other platforms.

## Things to know

- Adds ~40KB to binary size (Unicode tables)
- Unicode 15 tables are baked in at compile time - if Apple updates their libc, kakoune will still use bundled version on Darwin (consistent behavior across macOS versions)
- If termux/wcwidth updates to newer Unicode, the commit hash needs bumping

## Testing

Built and tested on aarch64-darwin (macOS Sequoia). Emoji display works correctly.

### before
<img width="1272" height="74" alt="Screenshot 2026-01-05 at 14 15 12" src="https://github.com/user-attachments/assets/dcda5133-cd07-45bd-9d61-8cfff46e453d" />

### after
<img width="1279" height="82" alt="Screenshot 2026-01-05 at 14 15 33" src="https://github.com/user-attachments/assets/d73ac37b-0d35-4707-92e6-ca6d3662941d" />

### emoji tested
```
define-command -override emoji -docstring "Insert emoji list for testing" %{
    execute-keys 'i🎃 🎄 😁 😊 😎 😚 😏 😇 🤠 🥳 🤓 💩 👏 🤜 🤟 🤘 👌 🖕 🧠 👀 🏆 🥁 🎷 🎺 🎸 🎻 🎲 🚲 🚀 🛸 💰 🎊 🎉 🧨 💣 🔪 🧻 🧼 💡 🧲 🧪 🔎 🧸 💗 💖 💝 🧡 💛 💚 💙 💜 🔆 ✅ 🔱 📛 ♻️ 🎵 🎶 💬 💭 🍏 🍎 🍐 🍊 🍋 🍌 🍉 🍇 🍓 🍈 🍒 🍑 🍍 🥭 🥥 🥝 🍅 🍆 🥑 🥦 🥒 🥬 🌶 🌽 🥕 🥔 🍠 🥐 🍞 🥖 🥨 🥯 🧀 🥚 🍳 🥞 🥓 🥩 🍗 🍖 🌭 🍔 🍟 🍕 🥪 🥙 🌮 🌯 🥗 🥘 🥫 🍝 🍜 🍲 🍛 🍣 🍱 🥟 🍤 🍙 🍚 🍘 🍥 🥮 🥠 🍢 🍡 🍧 🍨 🍦 🥧 🍰 🎂 🍮 🍭 🍬 🍫 🍿 🧂 🍩 🍪 🌰 🥜 ☕ 🍵 🥤 🍶 🍺 🥃 🥄 🍴 🥣 🥢 🐶 🐱 🐭 🐹 🐰 🦊 🦝 🐻 🐼 🦘 🦡 🐨 🐯 🦁 🐮 🐷 🐽 🐸 🐵 🙈 🙉 🙊 🐒 🐔 🐧 🐦 🐤 🐣 🐥 🦆 🦢 🦅 🦉 🦚 🦜 🦇 🐺 🐗 🐴 🦄 🐝 🐛 🦋 🐌 🐚 🐞 🐜 🦗 🕷 🕸 🦂 🦟 🐢 🐍 🦎 🦖 🦕 🐙 🦑 🦐 🦀 🐡 🐠 🐟 🐬 🐳 🐋 🦈 🐊 🐅 🐆 🦓 🦍 🐘 🦏 🦛 🐪 🐫 🦙 🦒 🐃 🐂 🐄 🐎 🐖 🐏 🐑 🐐 🦌 🐕 🐩 🐈 🐓 🦃 🕊 🐇 🐁 🐀 🐿 🦔 🐾 🐉 🐲 🌵 🎄 🌲 🌳 🌴 🌱 🌿 ☘ 🍀 🎍 🎋 🍃 🍂 🍁 🍄 🌾 💐 🌷 🌹 🥀 🌺 🌸 🌼 🌻 🌞 🌝 🌛 🌜 🌚 🌕 🌖 🌗 🌘 🌑 🌒 🌓 🌔 🌙 🌎 🌍 🌏 💫 ⭐ 🌟 ✨ ⚡ ☄ 💥 🔥 🌈 ☀ ⛅ ☁ ❄ ☃ ⛄ 💨 💧 💦 🌊<esc>'
}
```

Fixes: https://github.com/mawww/kakoune/issues/3059
Fixes: https://github.com/mawww/kakoune/issues/4257