### PR TITLE
nordvpn: init at 5.2.0, maintainers: add different-error 

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6769,6 +6769,11 @@
     githubId = 2096594;
     email = "Dietrich@Daroch.me";
   };
+  different-error = {
+    name = "Sanfer D'souza";
+    github = "different-error";
+    githubId = 9338001;
+  };
   different-name = {
     name = "different-name";
     email = "hello@different-name.dev";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6905,6 +6905,11 @@
     githubId = 2096594;
     email = "Dietrich@Daroch.me";
   };
+  different-error = {
+    name = "Sanfer D'souza";
+    github = "different-error";
+    githubId = 9338001;
+  };
   different-name = {
     name = "different-name";
     email = "hello@different-name.dev";

--- a/pkgs/by-name/no/nordvpn/cli.nix
+++ b/pkgs/by-name/no/nordvpn/cli.nix
@@ -1,0 +1,151 @@
+{
+  desktopItemArgs,
+  meta,
+  src,
+  version,
+
+  buildGoModule,
+  copyDesktopItems,
+  e2fsprogs,
+  fetchFromGitHub,
+  iproute2,
+  iptables,
+  lib,
+  libxslt,
+  makeDesktopItem,
+  makeWrapper,
+  openvpn,
+  procps,
+  systemdMinimal,
+  wireguard-tools,
+}:
+let
+  patchedOpenvpn = openvpn.overrideAttrs (old: {
+    # Apply XOR obfuscation patches to disguise OpenVPN traffic,
+    # enabling connectivity on networks that block VPN protocols via DPI.
+    patches =
+      let
+        tunnelblickSrc = fetchFromGitHub {
+          owner = "Tunnelblick";
+          repo = "Tunnelblick";
+          # https://github.com/NordSecurity/nordvpn-linux/blob/4.6.0/ci/openvpn/env.sh#L11
+          tag = "v6.0beta09";
+          hash = "sha256-uLYrBgwX3HkEV06snlIYLsgfhD5lNDVR21D56ygoStY=";
+        };
+
+        pathDir = "third_party/sources/openvpn/openvpn-2.6.12/patches";
+      in
+      (old.patches or [ ])
+      ++ (map (fname: "${tunnelblickSrc}/${pathDir}/${fname}") [
+        "02-tunnelblick-openvpn_xorpatch-a.diff"
+        "03-tunnelblick-openvpn_xorpatch-b.diff"
+        "04-tunnelblick-openvpn_xorpatch-c.diff"
+        "05-tunnelblick-openvpn_xorpatch-d.diff"
+        "06-tunnelblick-openvpn_xorpatch-e.diff"
+      ]);
+  });
+
+in
+buildGoModule (finalAttrs: {
+  inherit src version;
+
+  pname = "nordvpn-cli";
+
+  nativeBuildInputs = [
+    copyDesktopItems
+    makeWrapper
+  ];
+
+  vendorHash = "sha256-rUrzHb5ILnHGeLtbv4dI298dFbuFueWovT1aUXv+wZs=";
+
+  preBuild = ''
+    # redirect AppDataPathStatic (/usr/lib/nordvpn) to $out/bin so that
+    # NorduserdBinaryPath resolves to $out/bin/norduserd.
+    substituteInPlace internal/constants.go \
+        --replace-fail "/usr/lib/nordvpn" "$out/bin"
+
+    # hardcode the openvpn path to the patched one
+    old_ovpn_path='filepath.Join(internal.AppDataPathStatic, "openvpn")'
+    new_ovpn_path='"${patchedOpenvpn}/bin/openvpn"'
+    substituteInPlace daemon/vpn/openvpn/config.go \
+        --replace-fail "$old_ovpn_path" "$new_ovpn_path"
+  '';
+
+  ldflags = [
+    "-X main.Environment=prod"
+    "-X main.Version=${finalAttrs.version}"
+  ];
+
+  subPackages = [
+    "cmd/cli"
+    "cmd/daemon"
+    "cmd/norduser"
+  ];
+
+  checkPhase = ''
+    runHook preCheck
+
+    go test ./cli
+    # skip tests that require network access
+    go test ./daemon -skip \
+        'TestTransports|TestH1Transport_RoundTrip|Test.*FileList_RealURL'
+    go test ./norduser
+
+    runHook postCheck
+  '';
+
+  postInstall = ''
+    # rename to standard names
+    BIN_DIR=$out/bin
+    mv $BIN_DIR/cli $BIN_DIR/nordvpn
+    mv $BIN_DIR/daemon $BIN_DIR/nordvpnd
+    mv $BIN_DIR/norduser $BIN_DIR/norduserd
+
+    # nordvpn needs icons for the system tray and notifications
+    ICONS_PATH=$out/share/icons/hicolor/scalable/apps
+    install -d $ICONS_PATH
+    install --mode=0444 assets/icon.svg $ICONS_PATH/nordvpn.svg
+    for file in assets/tray-*.svg; do
+        install --mode=0444 "$file" "$ICONS_PATH/nordvpn-$(basename $file)"
+    done
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/nordvpnd --prefix PATH : ${
+      lib.makeBinPath [
+        e2fsprogs
+        iproute2
+        iptables
+        libxslt # xsltproc: used to populate OpenVPN configuration files from templates
+        patchedOpenvpn
+        procps
+        systemdMinimal
+        wireguard-tools
+      ]
+    }
+  '';
+
+  desktopItems = [
+    (makeDesktopItem (
+      desktopItemArgs
+      // {
+        comment = "Handles NordVPN OAuth browser login callbacks.";
+        desktopName = "NordVPN CLI";
+        exec = "nordvpn click %u";
+        mimeTypes = [ "x-scheme-handler/nordvpn" ];
+        name = "nordvpn";
+        noDisplay = true;
+        terminal = true;
+      }
+    ))
+  ];
+
+  meta = meta // {
+    description = "NordVPN command-line client and daemon";
+    longDescription = ''
+      Contains the nordvpn client and nordvpnd daemon.
+      Even if you intend to use the GUI only, you'd need this package.
+    '';
+    mainProgram = "nordvpn";
+  };
+})

--- a/pkgs/by-name/no/nordvpn/cli.nix
+++ b/pkgs/by-name/no/nordvpn/cli.nix
@@ -1,0 +1,151 @@
+{
+  desktopItemArgs,
+  meta,
+  src,
+  version,
+
+  buildGoModule,
+  copyDesktopItems,
+  e2fsprogs,
+  fetchFromGitHub,
+  iproute2,
+  lib,
+  libxslt,
+  makeDesktopItem,
+  makeWrapper,
+  nftables,
+  openvpn,
+  procps,
+  systemdMinimal,
+  wireguard-tools,
+}:
+let
+  patchedOpenvpn = openvpn.overrideAttrs (old: {
+    # Apply XOR obfuscation patches to disguise OpenVPN traffic,
+    # enabling connectivity on networks that block VPN protocols via DPI.
+    patches =
+      let
+        tunnelblickSrc = fetchFromGitHub {
+          owner = "Tunnelblick";
+          repo = "Tunnelblick";
+          # https://github.com/NordSecurity/nordvpn-linux/blob/4.6.0/ci/openvpn/env.sh#L11
+          tag = "v6.0beta09";
+          hash = "sha256-uLYrBgwX3HkEV06snlIYLsgfhD5lNDVR21D56ygoStY=";
+        };
+
+        pathDir = "third_party/sources/openvpn/openvpn-2.6.12/patches";
+      in
+      (old.patches or [ ])
+      ++ (map (fname: "${tunnelblickSrc}/${pathDir}/${fname}") [
+        "02-tunnelblick-openvpn_xorpatch-a.diff"
+        "03-tunnelblick-openvpn_xorpatch-b.diff"
+        "04-tunnelblick-openvpn_xorpatch-c.diff"
+        "05-tunnelblick-openvpn_xorpatch-d.diff"
+        "06-tunnelblick-openvpn_xorpatch-e.diff"
+      ]);
+  });
+
+in
+buildGoModule (finalAttrs: {
+  inherit src version;
+
+  pname = "nordvpn-cli";
+
+  nativeBuildInputs = [
+    copyDesktopItems
+    makeWrapper
+  ];
+
+  vendorHash = "sha256-I81sn+tHTny9bX5eNGQLPQtoabbaNZINMjYotCXt88A=";
+
+  preBuild = ''
+    # redirect AppDataPathStatic (/usr/lib/nordvpn) to $out/bin so that
+    # NorduserdBinaryPath resolves to $out/bin/norduserd.
+    substituteInPlace internal/constants.go \
+        --replace-fail "/usr/lib/nordvpn" "$out/bin"
+
+    # hardcode the openvpn path to the patched one
+    old_ovpn_path='filepath.Join(internal.AppDataPathStatic, "openvpn")'
+    new_ovpn_path='"${patchedOpenvpn}/bin/openvpn"'
+    substituteInPlace daemon/vpn/openvpn/config.go \
+        --replace-fail "$old_ovpn_path" "$new_ovpn_path"
+  '';
+
+  ldflags = [
+    "-X main.Environment=prod"
+    "-X main.Version=${finalAttrs.version}"
+  ];
+
+  subPackages = [
+    "cmd/cli"
+    "cmd/daemon"
+    "cmd/norduser"
+  ];
+
+  checkPhase = ''
+    runHook preCheck
+
+    go test ./cli
+    # skip tests that require network access
+    go test ./daemon -skip \
+        'TestTransports|TestH1Transport_RoundTrip|Test.*FileList_RealURL'
+    go test ./norduser
+
+    runHook postCheck
+  '';
+
+  postInstall = ''
+    # rename to standard names
+    BIN_DIR=$out/bin
+    mv $BIN_DIR/cli $BIN_DIR/nordvpn
+    mv $BIN_DIR/daemon $BIN_DIR/nordvpnd
+    mv $BIN_DIR/norduser $BIN_DIR/norduserd
+
+    # nordvpn needs icons for the system tray and notifications
+    ICONS_PATH=$out/share/icons/hicolor/scalable/apps
+    install -d $ICONS_PATH
+    install --mode=0444 assets/icon.svg $ICONS_PATH/nordvpn.svg
+    for file in assets/tray-*.svg; do
+        install --mode=0444 "$file" "$ICONS_PATH/nordvpn-$(basename $file)"
+    done
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/nordvpnd --prefix PATH : ${
+      lib.makeBinPath [
+        e2fsprogs
+        iproute2
+        libxslt # xsltproc: used to populate OpenVPN configuration files from templates
+        nftables
+        patchedOpenvpn
+        procps
+        systemdMinimal
+        wireguard-tools
+      ]
+    }
+  '';
+
+  desktopItems = [
+    (makeDesktopItem (
+      desktopItemArgs
+      // {
+        comment = "Handles NordVPN OAuth browser login callbacks.";
+        desktopName = "NordVPN CLI";
+        exec = "nordvpn click %u";
+        mimeTypes = [ "x-scheme-handler/nordvpn" ];
+        name = "nordvpn";
+        noDisplay = true;
+        terminal = true;
+      }
+    ))
+  ];
+
+  meta = meta // {
+    description = "NordVPN command-line client and daemon";
+    longDescription = ''
+      Contains the nordvpn client and nordvpnd daemon.
+      Even if you intend to use the GUI only, you'd need this package.
+    '';
+    mainProgram = "nordvpn";
+  };
+})

--- a/pkgs/by-name/no/nordvpn/gui.nix
+++ b/pkgs/by-name/no/nordvpn/gui.nix
@@ -1,0 +1,48 @@
+{
+  desktopItemArgs,
+  meta,
+  src,
+  version,
+
+  copyDesktopItems,
+  flutter,
+  lib,
+  makeDesktopItem,
+  libx11,
+}:
+flutter.buildFlutterApplication {
+  pname = "nordvpn-gui";
+  inherit src version;
+
+  sourceRoot = "${src.name}/gui";
+
+  buildInputs = [
+    libx11
+  ];
+
+  nativeBuildInputs = [
+    copyDesktopItems
+  ];
+
+  pubspecLock = lib.importJSON ./pubspec.lock.json;
+
+  # finds X11 using pkg-config
+  patches = [ ./linux-cmake.patch ];
+
+  desktopItems = [
+    (makeDesktopItem (
+      desktopItemArgs
+      // {
+        comment = "NordVPN's GUI to manage vpn connection, settings, etc.";
+        desktopName = "NordVPN GUI";
+        exec = "nordvpn-gui";
+        name = "nordvpn-gui";
+      }
+    ))
+  ];
+
+  meta = meta // {
+    description = "NordVPN graphical interface";
+    mainProgram = "nordvpn-gui";
+  };
+}

--- a/pkgs/by-name/no/nordvpn/linux-cmake.patch
+++ b/pkgs/by-name/no/nordvpn/linux-cmake.patch
@@ -1,0 +1,23 @@
+--- a/linux/CMakeLists.txt
++++ b/linux/CMakeLists.txt
+@@ -51,10 +51,10 @@
+ # System-level dependencies.
+ find_package(PkgConfig REQUIRED)
+ pkg_check_modules(GTK REQUIRED IMPORTED_TARGET gtk+-3.0)
++pkg_check_modules(X11 REQUIRED IMPORTED_TARGET x11)
+ 
+ add_definitions(-DAPPLICATION_ID="${APPLICATION_ID}")
+ # Fix for: https://github.com/NordSecurity/nordvpn-linux/issues/1136
+-find_package(X11 REQUIRED)
+ 
+ # Define the application target. To change its name, change BINARY_NAME above,
+ # not the value here, or `flutter run` will no longer work.
+@@ -73,7 +73,7 @@
+ # Add dependency libraries. Add any application-specific dependencies here.
+ target_link_libraries(${BINARY_NAME} PRIVATE flutter)
+ target_link_libraries(${BINARY_NAME} PRIVATE PkgConfig::GTK)
+-target_link_libraries(${BINARY_NAME} PRIVATE X11::X11)
++target_link_libraries(${BINARY_NAME} PRIVATE PkgConfig::X11)
+ 
+ # Run the Flutter tool portions of the build. This must not be removed.
+ add_dependencies(${BINARY_NAME} flutter_assemble)

--- a/pkgs/by-name/no/nordvpn/package.nix
+++ b/pkgs/by-name/no/nordvpn/package.nix
@@ -1,0 +1,63 @@
+{
+  callPackage,
+  fetchFromGitHub,
+  lib,
+  nix-update-script,
+  symlinkJoin,
+}:
+let
+  version = "4.6.0";
+
+  common = {
+    inherit version;
+
+    src = fetchFromGitHub {
+      owner = "NordSecurity";
+      repo = "nordvpn-linux";
+      tag = version;
+      hash = "sha256-Pz0tMy7SZtiF/PXNNa84x8yuNr//IHzFULrwyQcBhwo=";
+    };
+
+    # rec so that changelog can reference homepage
+    meta = rec {
+      homepage = "https://github.com/NordSecurity/nordvpn-linux";
+      changelog = "${homepage}/releases/tag/${version}";
+      license = lib.licenses.gpl3Only;
+      maintainers = with lib.maintainers; [ different-error ];
+      platforms = lib.platforms.linux;
+    };
+
+    desktopItemArgs = {
+      categories = [ "Network" ];
+      genericName = "VPN Client";
+      icon = "nordvpn";
+      type = "Application";
+    };
+  };
+in
+symlinkJoin {
+  pname = "nordvpn";
+  inherit version;
+
+  paths = [
+    (callPackage ./cli.nix common)
+    (callPackage ./gui.nix common)
+  ];
+
+  passthru = {
+    cli = callPackage ./cli.nix common;
+    gui = callPackage ./gui.nix common;
+    updateScript = nix-update-script { };
+  };
+
+  meta = common.meta // {
+    description = "NordVPN client and GUI for Linux";
+    longDescription = ''
+      NordVPN CLI and GUI applications for Linux.
+      This package currently does not support meshnet.
+      Additionally, if `networking.firewall.enable = true;`,
+      then also set `networking.firewall.checkReversePath = "loose";`.
+      The closed-source nordwhisper protocol is also not supported.
+    '';
+  };
+}

--- a/pkgs/by-name/no/nordvpn/package.nix
+++ b/pkgs/by-name/no/nordvpn/package.nix
@@ -1,0 +1,66 @@
+{
+  callPackage,
+  fetchFromGitHub,
+  lib,
+  nix-update-script,
+  symlinkJoin,
+}:
+let
+  version = "5.2.0";
+
+  common = {
+    inherit version;
+
+    src = fetchFromGitHub {
+      owner = "NordSecurity";
+      repo = "nordvpn-linux";
+      tag = version;
+      hash = "sha256-F7iw856HVLbOz97j9sMkVwyZl0ZDwID1Tf0YwtdvZsU=";
+    };
+
+    # rec so that changelog can reference homepage
+    meta = rec {
+      homepage = "https://github.com/NordSecurity/nordvpn-linux";
+      changelog = "${homepage}/releases/tag/${version}";
+      license = lib.licenses.gpl3Only;
+      maintainers = with lib.maintainers; [ different-error ];
+      platforms = lib.platforms.linux;
+    };
+
+    desktopItemArgs = {
+      categories = [ "Network" ];
+      genericName = "VPN Client";
+      icon = "nordvpn";
+      type = "Application";
+    };
+  };
+in
+symlinkJoin {
+  pname = "nordvpn";
+  inherit version;
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  paths = [
+    (callPackage ./cli.nix common)
+    (callPackage ./gui.nix common)
+  ];
+
+  passthru = {
+    cli = callPackage ./cli.nix common;
+    gui = callPackage ./gui.nix common;
+    updateScript = nix-update-script { };
+  };
+
+  meta = common.meta // {
+    description = "NordVPN client and GUI for Linux";
+    longDescription = ''
+      NordVPN CLI and GUI applications for Linux.
+      This package currently does not support meshnet.
+      Additionally, if `networking.firewall.enable = true;`,
+      then also set `networking.firewall.checkReversePath = "loose";`.
+      The closed-source nordwhisper protocol is also not supported.
+    '';
+  };
+}

--- a/pkgs/by-name/no/nordvpn/pubspec.lock.json
+++ b/pkgs/by-name/no/nordvpn/pubspec.lock.json
@@ -1,0 +1,1516 @@
+{
+  "packages": {
+    "_fe_analyzer_shared": {
+      "dependency": "transitive",
+      "description": {
+        "name": "_fe_analyzer_shared",
+        "sha256": "da0d9209ca76bde579f2da330aeb9df62b6319c834fa7baae052021b0462401f",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "85.0.0"
+    },
+    "analyzer": {
+      "dependency": "transitive",
+      "description": {
+        "name": "analyzer",
+        "sha256": "f4ad0fea5f102201015c9aae9d93bc02f75dd9491529a8c21f88d17a8523d44c",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "7.6.0"
+    },
+    "analyzer_plugin": {
+      "dependency": "transitive",
+      "description": {
+        "name": "analyzer_plugin",
+        "sha256": "a5ab7590c27b779f3d4de67f31c4109dbe13dd7339f86461a6f2a8ab2594d8ce",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.13.4"
+    },
+    "args": {
+      "dependency": "transitive",
+      "description": {
+        "name": "args",
+        "sha256": "d0481093c50b1da8910eb0bb301626d4d8eb7284aa739614d2b394ee09e3ea04",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.7.0"
+    },
+    "async": {
+      "dependency": "transitive",
+      "description": {
+        "name": "async",
+        "sha256": "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.13.0"
+    },
+    "boolean_selector": {
+      "dependency": "transitive",
+      "description": {
+        "name": "boolean_selector",
+        "sha256": "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.1.2"
+    },
+    "build": {
+      "dependency": "transitive",
+      "description": {
+        "name": "build",
+        "sha256": "51dc711996cbf609b90cbe5b335bbce83143875a9d58e4b5c6d3c4f684d3dda7",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.5.4"
+    },
+    "build_config": {
+      "dependency": "transitive",
+      "description": {
+        "name": "build_config",
+        "sha256": "4ae2de3e1e67ea270081eaee972e1bd8f027d459f249e0f1186730784c2e7e33",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.1.2"
+    },
+    "build_daemon": {
+      "dependency": "transitive",
+      "description": {
+        "name": "build_daemon",
+        "sha256": "bf05f6e12cfea92d3c09308d7bcdab1906cd8a179b023269eed00c071004b957",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "4.1.1"
+    },
+    "build_resolvers": {
+      "dependency": "transitive",
+      "description": {
+        "name": "build_resolvers",
+        "sha256": "ee4257b3f20c0c90e72ed2b57ad637f694ccba48839a821e87db762548c22a62",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.5.4"
+    },
+    "build_runner": {
+      "dependency": "direct dev",
+      "description": {
+        "name": "build_runner",
+        "sha256": "382a4d649addbfb7ba71a3631df0ec6a45d5ab9b098638144faf27f02778eb53",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.5.4"
+    },
+    "build_runner_core": {
+      "dependency": "transitive",
+      "description": {
+        "name": "build_runner_core",
+        "sha256": "85fbbb1036d576d966332a3f5ce83f2ce66a40bea1a94ad2d5fc29a19a0d3792",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "9.1.2"
+    },
+    "built_collection": {
+      "dependency": "transitive",
+      "description": {
+        "name": "built_collection",
+        "sha256": "376e3dd27b51ea877c28d525560790aee2e6fbb5f20e2f85d5081027d94e2100",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "5.1.1"
+    },
+    "built_value": {
+      "dependency": "transitive",
+      "description": {
+        "name": "built_value",
+        "sha256": "6ae8a6435a8c6520c7077b107e77f1fb4ba7009633259a4d49a8afd8e7efc5e9",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "8.12.4"
+    },
+    "characters": {
+      "dependency": "transitive",
+      "description": {
+        "name": "characters",
+        "sha256": "f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.4.0"
+    },
+    "checked_yaml": {
+      "dependency": "transitive",
+      "description": {
+        "name": "checked_yaml",
+        "sha256": "959525d3162f249993882720d52b7e0c833978df229be20702b33d48d91de70f",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.0.4"
+    },
+    "ci": {
+      "dependency": "transitive",
+      "description": {
+        "name": "ci",
+        "sha256": "145d095ce05cddac4d797a158bc4cf3b6016d1fe63d8c3d2fbd7212590adca13",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.1.0"
+    },
+    "cli_util": {
+      "dependency": "transitive",
+      "description": {
+        "name": "cli_util",
+        "sha256": "ff6785f7e9e3c38ac98b2fb035701789de90154024a75b6cb926445e83197d1c",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.4.2"
+    },
+    "clock": {
+      "dependency": "direct main",
+      "description": {
+        "name": "clock",
+        "sha256": "fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.1.2"
+    },
+    "code_builder": {
+      "dependency": "transitive",
+      "description": {
+        "name": "code_builder",
+        "sha256": "6a6cab2ba4680d6423f34a9b972a4c9a94ebe1b62ecec4e1a1f2cba91fd1319d",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "4.11.1"
+    },
+    "collection": {
+      "dependency": "direct main",
+      "description": {
+        "name": "collection",
+        "sha256": "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.19.1"
+    },
+    "convert": {
+      "dependency": "transitive",
+      "description": {
+        "name": "convert",
+        "sha256": "b30acd5944035672bc15c6b7a8b47d773e41e2f17de064350988c5d02adb1c68",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.1.2"
+    },
+    "crypto": {
+      "dependency": "transitive",
+      "description": {
+        "name": "crypto",
+        "sha256": "c8ea0233063ba03258fbcf2ca4d6dadfefe14f02fab57702265467a19f27fadf",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.0.7"
+    },
+    "csv": {
+      "dependency": "transitive",
+      "description": {
+        "name": "csv",
+        "sha256": "c6aa2679b2a18cb57652920f674488d89712efaf4d3fdf2e537215b35fc19d6c",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "6.0.0"
+    },
+    "cupertino_icons": {
+      "dependency": "direct main",
+      "description": {
+        "name": "cupertino_icons",
+        "sha256": "ba631d1c7f7bef6b729a622b7b752645a2d076dba9976925b8f25725a30e1ee6",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.0.8"
+    },
+    "custom_lint": {
+      "dependency": "direct dev",
+      "description": {
+        "name": "custom_lint",
+        "sha256": "9656925637516c5cf0f5da018b33df94025af2088fe09c8ae2ca54c53f2d9a84",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.7.6"
+    },
+    "custom_lint_builder": {
+      "dependency": "transitive",
+      "description": {
+        "name": "custom_lint_builder",
+        "sha256": "6cdc8e87e51baaaba9c43e283ed8d28e59a0c4732279df62f66f7b5984655414",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.7.6"
+    },
+    "custom_lint_core": {
+      "dependency": "transitive",
+      "description": {
+        "name": "custom_lint_core",
+        "sha256": "31110af3dde9d29fb10828ca33f1dce24d2798477b167675543ce3d208dee8be",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.7.5"
+    },
+    "custom_lint_visitor": {
+      "dependency": "transitive",
+      "description": {
+        "name": "custom_lint_visitor",
+        "sha256": "4a86a0d8415a91fbb8298d6ef03e9034dc8e323a599ddc4120a0e36c433983a2",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.0.0+7.7.0"
+    },
+    "dart_style": {
+      "dependency": "transitive",
+      "description": {
+        "name": "dart_style",
+        "sha256": "8a0e5fba27e8ee025d2ffb4ee820b4e6e2cf5e4246a6b1a477eb66866947e0bb",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.1.1"
+    },
+    "fake_async": {
+      "dependency": "direct dev",
+      "description": {
+        "name": "fake_async",
+        "sha256": "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.3.3"
+    },
+    "faker": {
+      "dependency": "direct main",
+      "description": {
+        "name": "faker",
+        "sha256": "544c34e9e1d322824156d5a8d451bc1bb778263b892aded24ec7ba77b0706624",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.2.0"
+    },
+    "ffi": {
+      "dependency": "transitive",
+      "description": {
+        "name": "ffi",
+        "sha256": "6d7fd89431262d8f3125e81b50d3847a091d846eafcd4fdb88dd06f36d705a45",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.2.0"
+    },
+    "file": {
+      "dependency": "transitive",
+      "description": {
+        "name": "file",
+        "sha256": "a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "7.0.1"
+    },
+    "fixnum": {
+      "dependency": "direct main",
+      "description": {
+        "name": "fixnum",
+        "sha256": "b6dc7065e46c974bc7c5f143080a6764ec7a4be6da1285ececdc37be96de53be",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.1.1"
+    },
+    "flutter": {
+      "dependency": "direct main",
+      "description": "flutter",
+      "source": "sdk",
+      "version": "0.0.0"
+    },
+    "flutter_driver": {
+      "dependency": "transitive",
+      "description": "flutter",
+      "source": "sdk",
+      "version": "0.0.0"
+    },
+    "flutter_lints": {
+      "dependency": "direct dev",
+      "description": {
+        "name": "flutter_lints",
+        "sha256": "3105dc8492f6183fb076ccf1f351ac3d60564bff92e20bfc4af9cc1651f4e7e1",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "6.0.0"
+    },
+    "flutter_localizations": {
+      "dependency": "transitive",
+      "description": "flutter",
+      "source": "sdk",
+      "version": "0.0.0"
+    },
+    "flutter_riverpod": {
+      "dependency": "direct main",
+      "description": {
+        "name": "flutter_riverpod",
+        "sha256": "9532ee6db4a943a1ed8383072a2e3eeda041db5657cdf6d2acecf3c21ecbe7e1",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.6.1"
+    },
+    "flutter_svg": {
+      "dependency": "direct main",
+      "description": {
+        "name": "flutter_svg",
+        "sha256": "87fbd7c534435b6c5d9d98b01e1fd527812b82e68ddd8bd35fc45ed0fa8f0a95",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.2.3"
+    },
+    "flutter_test": {
+      "dependency": "direct dev",
+      "description": "flutter",
+      "source": "sdk",
+      "version": "0.0.0"
+    },
+    "flutter_web_plugins": {
+      "dependency": "direct main",
+      "description": "flutter",
+      "source": "sdk",
+      "version": "0.0.0"
+    },
+    "freezed": {
+      "dependency": "direct dev",
+      "description": {
+        "name": "freezed",
+        "sha256": "2d399f823b8849663744d2a9ddcce01c49268fb4170d0442a655bf6a2f47be22",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.1.0"
+    },
+    "freezed_annotation": {
+      "dependency": "direct main",
+      "description": {
+        "name": "freezed_annotation",
+        "sha256": "7294967ff0a6d98638e7acb774aac3af2550777accd8149c90af5b014e6d44d8",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.1.0"
+    },
+    "frontend_server_client": {
+      "dependency": "transitive",
+      "description": {
+        "name": "frontend_server_client",
+        "sha256": "f64a0333a82f30b0cca061bc3d143813a486dc086b574bfb233b7c1372427694",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "4.0.0"
+    },
+    "fuchsia_remote_debug_protocol": {
+      "dependency": "transitive",
+      "description": "flutter",
+      "source": "sdk",
+      "version": "0.0.0"
+    },
+    "get_it": {
+      "dependency": "direct main",
+      "description": {
+        "name": "get_it",
+        "sha256": "568d62f0e68666fb5d95519743b3c24a34c7f19d834b0658c46e26d778461f66",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "9.2.1"
+    },
+    "glob": {
+      "dependency": "transitive",
+      "description": {
+        "name": "glob",
+        "sha256": "c3f1ee72c96f8f78935e18aa8cecced9ab132419e8625dc187e1c2408efc20de",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.1.3"
+    },
+    "go_router": {
+      "dependency": "direct main",
+      "description": {
+        "name": "go_router",
+        "sha256": "7974313e217a7771557add6ff2238acb63f635317c35fa590d348fb238f00896",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "17.1.0"
+    },
+    "google_identity_services_web": {
+      "dependency": "transitive",
+      "description": {
+        "name": "google_identity_services_web",
+        "sha256": "5d187c46dc59e02646e10fe82665fc3884a9b71bc1c90c2b8b749316d33ee454",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.3.3+1"
+    },
+    "googleapis_auth": {
+      "dependency": "transitive",
+      "description": {
+        "name": "googleapis_auth",
+        "sha256": "b81fe352cc4a330b3710d2b7ad258d9bcef6f909bb759b306bf42973a7d046db",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.0.0"
+    },
+    "graphs": {
+      "dependency": "transitive",
+      "description": {
+        "name": "graphs",
+        "sha256": "741bbf84165310a68ff28fe9e727332eef1407342fca52759cb21ad8177bb8d0",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.3.2"
+    },
+    "grpc": {
+      "dependency": "direct main",
+      "description": {
+        "name": "grpc",
+        "sha256": "807a4da90fc1ba94dccc3a44653d3ff7bcf26818f030259d6a8f9fab405cb880",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "4.3.1"
+    },
+    "hotreloader": {
+      "dependency": "transitive",
+      "description": {
+        "name": "hotreloader",
+        "sha256": "bc167a1163807b03bada490bfe2df25b0d744df359227880220a5cbd04e5734b",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "4.3.0"
+    },
+    "http": {
+      "dependency": "direct main",
+      "description": {
+        "name": "http",
+        "sha256": "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.6.0"
+    },
+    "http2": {
+      "dependency": "transitive",
+      "description": {
+        "name": "http2",
+        "sha256": "382d3aefc5bd6dc68c6b892d7664f29b5beb3251611ae946a98d35158a82bbfa",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.3.1"
+    },
+    "http_multi_server": {
+      "dependency": "transitive",
+      "description": {
+        "name": "http_multi_server",
+        "sha256": "aa6199f908078bb1c5efb8d8638d4ae191aac11b311132c3ef48ce352fb52ef8",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.2.2"
+    },
+    "http_parser": {
+      "dependency": "transitive",
+      "description": {
+        "name": "http_parser",
+        "sha256": "178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "4.1.2"
+    },
+    "integration_test": {
+      "dependency": "direct dev",
+      "description": "flutter",
+      "source": "sdk",
+      "version": "0.0.0"
+    },
+    "intl": {
+      "dependency": "direct main",
+      "description": {
+        "name": "intl",
+        "sha256": "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.20.2"
+    },
+    "io": {
+      "dependency": "transitive",
+      "description": {
+        "name": "io",
+        "sha256": "dfd5a80599cf0165756e3181807ed3e77daf6dd4137caaad72d0b7931597650b",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.0.5"
+    },
+    "js": {
+      "dependency": "transitive",
+      "description": {
+        "name": "js",
+        "sha256": "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.7.2"
+    },
+    "json_annotation": {
+      "dependency": "transitive",
+      "description": {
+        "name": "json_annotation",
+        "sha256": "cb09e7dac6210041fad964ed7fbee004f14258b4eca4040f72d1234062ace4c8",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "4.11.0"
+    },
+    "leak_tracker": {
+      "dependency": "transitive",
+      "description": {
+        "name": "leak_tracker",
+        "sha256": "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "11.0.2"
+    },
+    "leak_tracker_flutter_testing": {
+      "dependency": "direct dev",
+      "description": {
+        "name": "leak_tracker_flutter_testing",
+        "sha256": "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.0.10"
+    },
+    "leak_tracker_testing": {
+      "dependency": "transitive",
+      "description": {
+        "name": "leak_tracker_testing",
+        "sha256": "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.0.2"
+    },
+    "lints": {
+      "dependency": "transitive",
+      "description": {
+        "name": "lints",
+        "sha256": "12f842a479589fea194fe5c5a3095abc7be0c1f2ddfa9a0e76aed1dbd26a87df",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "6.1.0"
+    },
+    "logger": {
+      "dependency": "direct main",
+      "description": {
+        "name": "logger",
+        "sha256": "a7967e31b703831a893bbc3c3dd11db08126fe5f369b5c648a36f821979f5be3",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.6.2"
+    },
+    "logging": {
+      "dependency": "transitive",
+      "description": {
+        "name": "logging",
+        "sha256": "c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.3.0"
+    },
+    "matcher": {
+      "dependency": "transitive",
+      "description": {
+        "name": "matcher",
+        "sha256": "dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.12.17"
+    },
+    "material_color_utilities": {
+      "dependency": "transitive",
+      "description": {
+        "name": "material_color_utilities",
+        "sha256": "f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.11.1"
+    },
+    "meta": {
+      "dependency": "transitive",
+      "description": {
+        "name": "meta",
+        "sha256": "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.17.0"
+    },
+    "mime": {
+      "dependency": "transitive",
+      "description": {
+        "name": "mime",
+        "sha256": "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.0.0"
+    },
+    "package_config": {
+      "dependency": "transitive",
+      "description": {
+        "name": "package_config",
+        "sha256": "f096c55ebb7deb7e384101542bfba8c52696c1b56fca2eb62827989ef2353bbc",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.2.0"
+    },
+    "package_info_plus": {
+      "dependency": "direct main",
+      "description": {
+        "name": "package_info_plus",
+        "sha256": "f69da0d3189a4b4ceaeb1a3defb0f329b3b352517f52bed4290f83d4f06bc08d",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "9.0.0"
+    },
+    "package_info_plus_platform_interface": {
+      "dependency": "transitive",
+      "description": {
+        "name": "package_info_plus_platform_interface",
+        "sha256": "202a487f08836a592a6bd4f901ac69b3a8f146af552bbd14407b6b41e1c3f086",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.2.1"
+    },
+    "path": {
+      "dependency": "direct main",
+      "description": {
+        "name": "path",
+        "sha256": "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.9.1"
+    },
+    "path_parsing": {
+      "dependency": "transitive",
+      "description": {
+        "name": "path_parsing",
+        "sha256": "883402936929eac138ee0a45da5b0f2c80f89913e6dc3bf77eb65b84b409c6ca",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.1.0"
+    },
+    "path_provider_linux": {
+      "dependency": "transitive",
+      "description": {
+        "name": "path_provider_linux",
+        "sha256": "f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.2.1"
+    },
+    "path_provider_platform_interface": {
+      "dependency": "transitive",
+      "description": {
+        "name": "path_provider_platform_interface",
+        "sha256": "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.1.2"
+    },
+    "path_provider_windows": {
+      "dependency": "transitive",
+      "description": {
+        "name": "path_provider_windows",
+        "sha256": "bd6f00dbd873bfb70d0761682da2b3a2c2fccc2b9e84c495821639601d81afe7",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.3.0"
+    },
+    "petitparser": {
+      "dependency": "transitive",
+      "description": {
+        "name": "petitparser",
+        "sha256": "91bd59303e9f769f108f8df05e371341b15d59e995e6806aefab827b58336675",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "7.0.2"
+    },
+    "platform": {
+      "dependency": "transitive",
+      "description": {
+        "name": "platform",
+        "sha256": "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.1.6"
+    },
+    "plugin_platform_interface": {
+      "dependency": "direct dev",
+      "description": {
+        "name": "plugin_platform_interface",
+        "sha256": "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.1.8"
+    },
+    "pool": {
+      "dependency": "transitive",
+      "description": {
+        "name": "pool",
+        "sha256": "978783255c543aa3586a1b3c21f6e9d720eb315376a915872c61ef8b5c20177d",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.5.2"
+    },
+    "posix": {
+      "dependency": "direct main",
+      "description": {
+        "name": "posix",
+        "sha256": "185ef7606574f789b40f289c233efa52e96dead518aed988e040a10737febb07",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "6.5.0"
+    },
+    "process": {
+      "dependency": "transitive",
+      "description": {
+        "name": "process",
+        "sha256": "c6248e4526673988586e8c00bb22a49210c258dc91df5227d5da9748ecf79744",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "5.0.5"
+    },
+    "protobuf": {
+      "dependency": "direct main",
+      "description": {
+        "name": "protobuf",
+        "sha256": "2fcc8a202ca7ec17dab7c97d6b6d91cf03aa07fe6f65f8afbb6dfa52cc5bd902",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "5.1.0"
+    },
+    "pub_semver": {
+      "dependency": "transitive",
+      "description": {
+        "name": "pub_semver",
+        "sha256": "5bfcf68ca79ef689f8990d1160781b4bad40a3bd5e5218ad4076ddb7f4081585",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.2.0"
+    },
+    "pubspec_parse": {
+      "dependency": "transitive",
+      "description": {
+        "name": "pubspec_parse",
+        "sha256": "0560ba233314abbed0a48a2956f7f022cce7c3e1e73df540277da7544cad4082",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.5.0"
+    },
+    "riverpod": {
+      "dependency": "direct main",
+      "description": {
+        "name": "riverpod",
+        "sha256": "59062512288d3056b2321804332a13ffdd1bf16df70dcc8e506e411280a72959",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.6.1"
+    },
+    "riverpod_analyzer_utils": {
+      "dependency": "transitive",
+      "description": {
+        "name": "riverpod_analyzer_utils",
+        "sha256": "03a17170088c63aab6c54c44456f5ab78876a1ddb6032ffde1662ddab4959611",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.5.10"
+    },
+    "riverpod_annotation": {
+      "dependency": "direct main",
+      "description": {
+        "name": "riverpod_annotation",
+        "sha256": "e14b0bf45b71326654e2705d462f21b958f987087be850afd60578fcd502d1b8",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.6.1"
+    },
+    "riverpod_generator": {
+      "dependency": "direct dev",
+      "description": {
+        "name": "riverpod_generator",
+        "sha256": "44a0992d54473eb199ede00e2260bd3c262a86560e3c6f6374503d86d0580e36",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.6.5"
+    },
+    "riverpod_lint": {
+      "dependency": "direct dev",
+      "description": {
+        "name": "riverpod_lint",
+        "sha256": "89a52b7334210dbff8605c3edf26cfe69b15062beed5cbfeff2c3812c33c9e35",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.6.5"
+    },
+    "rxdart": {
+      "dependency": "transitive",
+      "description": {
+        "name": "rxdart",
+        "sha256": "5c3004a4a8dbb94bd4bf5412a4def4acdaa12e12f269737a5751369e12d1a962",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.28.0"
+    },
+    "screen_retriever": {
+      "dependency": "transitive",
+      "description": {
+        "name": "screen_retriever",
+        "sha256": "570dbc8e4f70bac451e0efc9c9bb19fa2d6799a11e6ef04f946d7886d2e23d0c",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.2.0"
+    },
+    "screen_retriever_linux": {
+      "dependency": "transitive",
+      "description": {
+        "name": "screen_retriever_linux",
+        "sha256": "f7f8120c92ef0784e58491ab664d01efda79a922b025ff286e29aa123ea3dd18",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.2.0"
+    },
+    "screen_retriever_macos": {
+      "dependency": "transitive",
+      "description": {
+        "name": "screen_retriever_macos",
+        "sha256": "71f956e65c97315dd661d71f828708bd97b6d358e776f1a30d5aa7d22d78a149",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.2.0"
+    },
+    "screen_retriever_platform_interface": {
+      "dependency": "transitive",
+      "description": {
+        "name": "screen_retriever_platform_interface",
+        "sha256": "ee197f4581ff0d5608587819af40490748e1e39e648d7680ecf95c05197240c0",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.2.0"
+    },
+    "screen_retriever_windows": {
+      "dependency": "transitive",
+      "description": {
+        "name": "screen_retriever_windows",
+        "sha256": "449ee257f03ca98a57288ee526a301a430a344a161f9202b4fcc38576716fe13",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.2.0"
+    },
+    "searchable_listview": {
+      "dependency": "direct main",
+      "description": {
+        "name": "searchable_listview",
+        "sha256": "902c0038a10e11aa4cc9305dc9e7ec339fad6e5a23c484283f784b67ae6cf7d1",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.19.4"
+    },
+    "shared_preferences": {
+      "dependency": "direct main",
+      "description": {
+        "name": "shared_preferences",
+        "sha256": "2939ae520c9024cb197fc20dee269cd8cdbf564c8b5746374ec6cacdc5169e64",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.5.4"
+    },
+    "shared_preferences_android": {
+      "dependency": "transitive",
+      "description": {
+        "name": "shared_preferences_android",
+        "sha256": "cbc40be9be1c5af4dab4d6e0de4d5d3729e6f3d65b89d21e1815d57705644a6f",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.4.20"
+    },
+    "shared_preferences_foundation": {
+      "dependency": "transitive",
+      "description": {
+        "name": "shared_preferences_foundation",
+        "sha256": "4e7eaffc2b17ba398759f1151415869a34771ba11ebbccd1b0145472a619a64f",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.5.6"
+    },
+    "shared_preferences_linux": {
+      "dependency": "transitive",
+      "description": {
+        "name": "shared_preferences_linux",
+        "sha256": "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.4.1"
+    },
+    "shared_preferences_platform_interface": {
+      "dependency": "direct dev",
+      "description": {
+        "name": "shared_preferences_platform_interface",
+        "sha256": "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.4.1"
+    },
+    "shared_preferences_web": {
+      "dependency": "transitive",
+      "description": {
+        "name": "shared_preferences_web",
+        "sha256": "c49bd060261c9a3f0ff445892695d6212ff603ef3115edbb448509d407600019",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.4.3"
+    },
+    "shared_preferences_windows": {
+      "dependency": "transitive",
+      "description": {
+        "name": "shared_preferences_windows",
+        "sha256": "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.4.1"
+    },
+    "shelf": {
+      "dependency": "transitive",
+      "description": {
+        "name": "shelf",
+        "sha256": "e7dd780a7ffb623c57850b33f43309312fc863fb6aa3d276a754bb299839ef12",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.4.2"
+    },
+    "shelf_web_socket": {
+      "dependency": "transitive",
+      "description": {
+        "name": "shelf_web_socket",
+        "sha256": "3632775c8e90d6c9712f883e633716432a27758216dfb61bd86a8321c0580925",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.0.0"
+    },
+    "sky_engine": {
+      "dependency": "transitive",
+      "description": "flutter",
+      "source": "sdk",
+      "version": "0.0.0"
+    },
+    "slang": {
+      "dependency": "direct main",
+      "description": {
+        "name": "slang",
+        "sha256": "81e277dc5e2305f53412b92afeb803620453259afe147d5cd6417700f998a7a6",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "4.12.1"
+    },
+    "slang_flutter": {
+      "dependency": "direct main",
+      "description": {
+        "name": "slang_flutter",
+        "sha256": "0f0276c400660c8b67150005aa4df57643b86ce6ae9c824abee8e25f345d9abc",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "4.12.1"
+    },
+    "source_gen": {
+      "dependency": "transitive",
+      "description": {
+        "name": "source_gen",
+        "sha256": "35c8150ece9e8c8d263337a265153c3329667640850b9304861faea59fc98f6b",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.0.0"
+    },
+    "source_helper": {
+      "dependency": "transitive",
+      "description": {
+        "name": "source_helper",
+        "sha256": "a447acb083d3a5ef17f983dd36201aeea33fedadb3228fa831f2f0c92f0f3aca",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.3.7"
+    },
+    "source_span": {
+      "dependency": "transitive",
+      "description": {
+        "name": "source_span",
+        "sha256": "56a02f1f4cd1a2d96303c0144c93bd6d909eea6bee6bf5a0e0b685edbd4c47ab",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.10.2"
+    },
+    "stack_trace": {
+      "dependency": "transitive",
+      "description": {
+        "name": "stack_trace",
+        "sha256": "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.12.1"
+    },
+    "state_notifier": {
+      "dependency": "transitive",
+      "description": {
+        "name": "state_notifier",
+        "sha256": "b8677376aa54f2d7c58280d5a007f9e8774f1968d1fb1c096adcb4792fba29bb",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.0.0"
+    },
+    "stream_channel": {
+      "dependency": "transitive",
+      "description": {
+        "name": "stream_channel",
+        "sha256": "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.1.4"
+    },
+    "stream_transform": {
+      "dependency": "transitive",
+      "description": {
+        "name": "stream_transform",
+        "sha256": "ad47125e588cfd37a9a7f86c7d6356dde8dfe89d071d293f80ca9e9273a33871",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.1.1"
+    },
+    "string_scanner": {
+      "dependency": "transitive",
+      "description": {
+        "name": "string_scanner",
+        "sha256": "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.4.1"
+    },
+    "sync_http": {
+      "dependency": "transitive",
+      "description": {
+        "name": "sync_http",
+        "sha256": "7f0cd72eca000d2e026bcd6f990b81d0ca06022ef4e32fb257b30d3d1014a961",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.3.1"
+    },
+    "term_glyph": {
+      "dependency": "transitive",
+      "description": {
+        "name": "term_glyph",
+        "sha256": "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.2.2"
+    },
+    "test_api": {
+      "dependency": "transitive",
+      "description": {
+        "name": "test_api",
+        "sha256": "ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.7.7"
+    },
+    "theme_tailor": {
+      "dependency": "direct dev",
+      "description": {
+        "name": "theme_tailor",
+        "sha256": "ba98be1d04856deef932757a3ca8fa7a5e2a6f96c30466a59c48924eeb608b97",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.0.3"
+    },
+    "theme_tailor_annotation": {
+      "dependency": "direct main",
+      "description": {
+        "name": "theme_tailor_annotation",
+        "sha256": "6219cff1c1c31f28d853e7b443e508b9b81e09581ea7d9403998b1d31356ff3b",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.1.2"
+    },
+    "timing": {
+      "dependency": "transitive",
+      "description": {
+        "name": "timing",
+        "sha256": "62ee18aca144e4a9f29d212f5a4c6a053be252b895ab14b5821996cff4ed90fe",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.0.2"
+    },
+    "typed_data": {
+      "dependency": "transitive",
+      "description": {
+        "name": "typed_data",
+        "sha256": "f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.4.0"
+    },
+    "url_launcher": {
+      "dependency": "direct main",
+      "description": {
+        "name": "url_launcher",
+        "sha256": "f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "6.3.2"
+    },
+    "url_launcher_android": {
+      "dependency": "transitive",
+      "description": {
+        "name": "url_launcher_android",
+        "sha256": "767344bf3063897b5cf0db830e94f904528e6dd50a6dfaf839f0abf509009611",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "6.3.28"
+    },
+    "url_launcher_ios": {
+      "dependency": "transitive",
+      "description": {
+        "name": "url_launcher_ios",
+        "sha256": "580fe5dfb51671ae38191d316e027f6b76272b026370708c2d898799750a02b0",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "6.4.1"
+    },
+    "url_launcher_linux": {
+      "dependency": "transitive",
+      "description": {
+        "name": "url_launcher_linux",
+        "sha256": "d5e14138b3bc193a0f63c10a53c94b91d399df0512b1f29b94a043db7482384a",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.2.2"
+    },
+    "url_launcher_macos": {
+      "dependency": "transitive",
+      "description": {
+        "name": "url_launcher_macos",
+        "sha256": "368adf46f71ad3c21b8f06614adb38346f193f3a59ba8fe9a2fd74133070ba18",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.2.5"
+    },
+    "url_launcher_platform_interface": {
+      "dependency": "direct dev",
+      "description": {
+        "name": "url_launcher_platform_interface",
+        "sha256": "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.3.2"
+    },
+    "url_launcher_web": {
+      "dependency": "transitive",
+      "description": {
+        "name": "url_launcher_web",
+        "sha256": "d0412fcf4c6b31ecfdb7762359b7206ffba3bbffd396c6d9f9c4616ece476c1f",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.4.2"
+    },
+    "url_launcher_windows": {
+      "dependency": "transitive",
+      "description": {
+        "name": "url_launcher_windows",
+        "sha256": "712c70ab1b99744ff066053cbe3e80c73332b38d46e5e945c98689b2e66fc15f",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.1.5"
+    },
+    "uuid": {
+      "dependency": "transitive",
+      "description": {
+        "name": "uuid",
+        "sha256": "1fef9e8e11e2991bb773070d4656b7bd5d850967a2456cfc83cf47925ba79489",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "4.5.3"
+    },
+    "vector_graphics": {
+      "dependency": "transitive",
+      "description": {
+        "name": "vector_graphics",
+        "sha256": "a4f059dc26fc8295b5921376600a194c4ec7d55e72f2fe4c7d2831e103d461e6",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.1.19"
+    },
+    "vector_graphics_codec": {
+      "dependency": "transitive",
+      "description": {
+        "name": "vector_graphics_codec",
+        "sha256": "99fd9fbd34d9f9a32efd7b6a6aae14125d8237b10403b422a6a6dfeac2806146",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.1.13"
+    },
+    "vector_graphics_compiler": {
+      "dependency": "transitive",
+      "description": {
+        "name": "vector_graphics_compiler",
+        "sha256": "5a88dd14c0954a5398af544651c7fb51b457a2a556949bfb25369b210ef73a74",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.2.0"
+    },
+    "vector_math": {
+      "dependency": "transitive",
+      "description": {
+        "name": "vector_math",
+        "sha256": "d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.2.0"
+    },
+    "vm_service": {
+      "dependency": "transitive",
+      "description": {
+        "name": "vm_service",
+        "sha256": "45caa6c5917fa127b5dbcfbd1fa60b14e583afdc08bfc96dda38886ca252eb60",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "15.0.2"
+    },
+    "watcher": {
+      "dependency": "transitive",
+      "description": {
+        "name": "watcher",
+        "sha256": "1398c9f081a753f9226febe8900fce8f7d0a67163334e1c94a2438339d79d635",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.2.1"
+    },
+    "web": {
+      "dependency": "transitive",
+      "description": {
+        "name": "web",
+        "sha256": "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.1.1"
+    },
+    "web_socket": {
+      "dependency": "transitive",
+      "description": {
+        "name": "web_socket",
+        "sha256": "34d64019aa8e36bf9842ac014bb5d2f5586ca73df5e4d9bf5c936975cae6982c",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.0.1"
+    },
+    "web_socket_channel": {
+      "dependency": "transitive",
+      "description": {
+        "name": "web_socket_channel",
+        "sha256": "d645757fb0f4773d602444000a8131ff5d48c9e47adfe9772652dd1a4f2d45c8",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.0.3"
+    },
+    "webdriver": {
+      "dependency": "transitive",
+      "description": {
+        "name": "webdriver",
+        "sha256": "2f3a14ca026957870cfd9c635b83507e0e51d8091568e90129fbf805aba7cade",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.1.0"
+    },
+    "win32": {
+      "dependency": "transitive",
+      "description": {
+        "name": "win32",
+        "sha256": "d7cb55e04cd34096cd3a79b3330245f54cb96a370a1c27adb3c84b917de8b08e",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "5.15.0"
+    },
+    "window_manager": {
+      "dependency": "direct main",
+      "description": {
+        "name": "window_manager",
+        "sha256": "7eb6d6c4164ec08e1bf978d6e733f3cebe792e2a23fb07cbca25c2872bfdbdcd",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.5.1"
+    },
+    "xdg_directories": {
+      "dependency": "transitive",
+      "description": {
+        "name": "xdg_directories",
+        "sha256": "7a3f37b05d989967cdddcbb571f1ea834867ae2faa29725fd085180e0883aa15",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.1.0"
+    },
+    "xml": {
+      "dependency": "transitive",
+      "description": {
+        "name": "xml",
+        "sha256": "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "6.6.1"
+    },
+    "yaml": {
+      "dependency": "transitive",
+      "description": {
+        "name": "yaml",
+        "sha256": "b9da305ac7c39faa3f030eccd175340f968459dae4af175130b3fc47e40d76ce",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.1.3"
+    }
+  },
+  "sdks": {
+    "dart": ">=3.10.0 <3.10.1",
+    "flutter": ">=3.38.0"
+  }
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

This PR contains just the package found in #406725.

I manually verified vpn connection over OpenVPN and NordLynx using both cli and gui.

**configuration.nix**
```nix
{
  pkgs,
  ...
}:

{
  imports = [
    ./hardware-configuration.nix
  ];

  boot.loader.systemd-boot.enable = true;
  boot.loader.efi.canTouchEfiVariables = true;
  networking.firewall.enable = true;
  networking.firewall.checkReversePath = "loose";

  services.xserver.enable = true;
  services.displayManager.gdm.enable = true;
  services.desktopManager.plasma6.enable = true;

  virtualisation.vmVariant = {
    virtualisation = {
      memorySize = 8192;
      cores = 3;
    };
  };
  users.groups.alice = { };
  users.groups.nordvpn = { };
  users.users.alice = {
    isSystemUser = true;
    password = "alice";
    group = "alice";
    extraGroups = [
      "wheel"
      "nordvpn"
    ];
    shell = pkgs.bash;
    home = "/home/alice";
    createHome = true;
    packages = with pkgs; [
      tree
      tmux
      dunst
      libnotify
      socat
      vim
      nordvpn
    ];
  };
  system.stateVersion = "24.11"; # Did you read the comment?
}
``` 

To build, `nixos-rebuild build-vm -I nixos-config=/path/to/configuration.nix -I nixpkgs=/path/to/nixpkgs --max-jobs 4`

Inside vm:

```bash
sudo nordvpnd
sudo chown alice:alice /run/nordvpn/nordvpnd.sock
# login to nordvpn using nordvpn login or nordvpn login --token, not shown here
nordvpn set technology nordlynx && nordvpn c
nordvpn set technology openvpn && nordvpn c
nordvpn-gui
```
---

Note: I use Claude btw.

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
