### PR TITLE
mdbook-nix-repl: init at 0.5.7

### DIFF
--- a/pkgs/by-name/md/mdbook-nix-repl/package.nix
+++ b/pkgs/by-name/md/mdbook-nix-repl/package.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  rustPlatform,
+  fetchCrate,
+  versionCheckHook,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "mdbook-nix-repl";
+  version = "0.5.7";
+
+  src = fetchCrate {
+    inherit pname version;
+    hash = "sha256-vLEWrR10AP0xl33RXtafdepAoEF2DZ4DlyXvThqSN1M=";
+  };
+
+  cargoHash = "sha256-+KjD2PuHOQIDoJrramlLkUO6sHHlNiTwOo/Ogs0OshY=";
+
+  nativeInstallCheckInuts = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
+
+  meta = {
+    description = "mdBook preprocessor to provide nix-repl functionality within mdbook";
+    mainProgram = "mdbook-nix-repl";
+    homePage = "https://github.com/saylesss88/mdbook-nix-repl";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.saylesss88 ];
+  };
+}


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] NixOS tests in nixos/tests.
  - [ ] Package tests at passthru.tests.
  - [ ] Tests in lib/tests or pkgs/test for functions and "core" functionality.
- [ ] Ran nixpkgs-review on this PR.
- [x] Tested basic functionality of all binary files, usually in ./result/bin/.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits CONTRIBUTING.md, pkgs/README.md, maintainers/README.md and other READMEs.
