### PR TITLE
nixVersions.nix_2_32: 2.32.4 -> 2.32.5

### DIFF
--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -198,25 +198,17 @@ lib.makeExtensible (
 
       nix_2_31 = addTests "nix_2_31" self.nixComponents_2_31.nix-everything;
 
-      nixComponents_2_32 =
-        (nixDependencies.callPackage ./modular/packages.nix rec {
-          version = "2.32.4";
-          inherit (self.nix_2_31.meta) maintainers teams;
-          otherSplices = generateSplicesForNixComponents "nixComponents_2_32";
-          src = fetchFromGitHub {
-            owner = "NixOS";
-            repo = "nix";
-            tag = version;
-            hash = "sha256-8QYnRyGOTm3h/Dp8I6HCmQzlO7C009Odqyp28pTWgcY=";
-          };
-        }).appendPatches
-          [
-            (fetchpatch2 {
-              name = "nix-2.32-14693-mdbook-0.5-support.patch";
-              url = "https://github.com/NixOS/nix/commit/ba5bede9f51f126b29aaa01a3170da281cef0231.patch";
-              hash = "sha256-jY5fWnJSBfHRmB0RnBKeu3aYQ8wmDKYVqTj85cWVZRA=";
-            })
-          ];
+      nixComponents_2_32 = nixDependencies.callPackage ./modular/packages.nix rec {
+        version = "2.32.5";
+        inherit (self.nix_2_31.meta) maintainers teams;
+        otherSplices = generateSplicesForNixComponents "nixComponents_2_32";
+        src = fetchFromGitHub {
+          owner = "NixOS";
+          repo = "nix";
+          tag = version;
+          hash = "sha256-vnlVgJ5VXn2LVvdzf1HUZeGq0pqa6vII11C8u5Q/YgM=";
+        };
+      };
 
       nix_2_32 = addTests "nix_2_32" self.nixComponents_2_32.nix-everything;
 


### PR DESCRIPTION
# Changelog: Nix 2.32.5

## Bug Fixes

### Critical Crashes Fixed

- **Fix heap-use-after-free crash under high build load** ([#14772](https://github.com/NixOS/nix/pull/14772))

  Fixed a daemon segfault that could occur under high build load. The issue was caused by the `initialOutputs` field referencing data from an activation frame that had gone out of scope during coroutine tail-call optimization in the build scheduler.

- **Fix segfault when querying non-existent derivation files** ([#14571](https://github.com/NixOS/nix/issues/14571), [#14572](https://github.com/NixOS/nix/pull/14572))

  Running `nix derivation show /nix/store/...-doesnotexist.drv` would crash with a segfault. Now properly returns an "invalid store path" error.

- **Fix RestrictedStore::addDependency crash** ([#14729](https://github.com/NixOS/nix/pull/14729))

  Fixed a crash caused by incorrect non-virtual interface pattern implementation that led to bad recursion/UB in `addDependencyPrep`.

### Regressions Fixed

- **Fix "dynamic attributes not allowed in let" regression** ([#14642](https://github.com/NixOS/nix/issues/14642), [#14646](https://github.com/NixOS/nix/pull/14646))

  Expressions like `let a = 1; "b" = 2; ${"c"} = 3; in [ a b c ]` that worked in 2.30 would incorrectly fail in 2.32.x. This was caused by the ExprString arena optimization, which has been reverted.

- **Fix fetchGit with `ref = "HEAD"` regression** ([#13948](https://github.com/NixOS/nix/issues/13948), [#14672](https://github.com/NixOS/nix/pull/14672))

  `fetchGit { url = "..."; ref = "HEAD"; }` was broken and returned "revspec 'HEAD' not found".

- **Fix unnecessary substituter queries** ([#14836](https://github.com/NixOS/nix/issues/14836), [#14837](https://github.com/NixOS/nix/pull/14837))

  Fixed a regression where Nix would query all substituters (including `cache.nixos.org`) even when a higher-priority local substituter already had the path. This caused unnecessary network traffic.

### Platform-Specific Fixes

- **Fix curl with c-ares failing DNS resolution in macOS sandbox** ([#14792](https://github.com/NixOS/nix/pull/14792))

  When curl is built with c-ares (as in recent nixpkgs), DNS resolution would fail inside the Nix build sandbox on macOS with "Could not contact DNS servers".

### Store & File System Fixes

- **Fix file system race conditions in store optimization** ([#14676](https://github.com/NixOS/nix/pull/14676), [#7273](https://github.com/NixOS/nix/issues/7273))

  Multiple fixes to `optimizePath_`:
  - Actually call `remove()` when `rename()` fails
  - Propagate error codes in `createSymlink()`
  - Make `AutoDelete` non-copyable and non-movable to prevent use-after-free

## Improvements

- **Include path in world-writable error messages** ([#14785](https://github.com/NixOS/nix/pull/14785))

  The error message for world-writable directory checks now includes the specific path that failed, making debugging easier.

- **Documentation: correct `build-dir` error information** ([#14745](https://github.com/NixOS/nix/pull/14745))

  Fixed out-of-date information in the manual about `build-dir` errors and added links to relevant settings.

## Maintenance

- CI improvements: added `upload-release.yml` workflow, improved Docker push workflow configurability, updated magic-nix-cache with post-build-hook fix
- Documented maintainer git tag signing process
- Fixed lowdown override compatibility with newer nixpkgs
- Removed mdbook-linkcheck and added support for mdbook 0.5.x
- Remove static data from headers to fix compilation issues
- **Fix heap-use-after-free crash under high build load** ([#14772](https://github.com/NixOS/nix/pull/14772))

---

Diff: https://github.com/NixOS/nix/compare/2.32.4...2.32.5

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
