### PR TITLE
retroarch-free: fix with gcc15

### DIFF
--- a/pkgs/applications/emulators/libretro/cores/same_cdi.nix
+++ b/pkgs/applications/emulators/libretro/cores/same_cdi.nix
@@ -30,6 +30,15 @@ mkLibretroCore {
     })
   ];
 
+  postPatch = ''
+    # Fix sol2 compatibility with GCC 15 (construct -> emplace)
+    # https://github.com/ThePhD/sol2/issues/1657
+    sed -i 's/this->construct(std::forward<Args>(args)\.\.\.);/this->emplace(std::forward<Args>(args)...);/g' 3rdparty/sol2/sol/sol.hpp
+
+    # Fix missing cstdint include for uint8_t
+    sed -i '1i #include <cstdint>' src/lib/util/corestr.cpp
+  '';
+
   extraNativeBuildInputs = [ python3 ];
   extraBuildInputs = [
     alsa-lib

--- a/pkgs/applications/emulators/libretro/cores/scummvm.nix
+++ b/pkgs/applications/emulators/libretro/cores/scummvm.nix
@@ -50,6 +50,9 @@ mkLibretroCore {
     cp -a ${libretro-deps-src}/* deps/libretro-deps
     chmod -R u+w deps/
 
+    # Fix conflicts with glibc index/rindex functions
+    sed -i 's/\bindex\b/faad_index/g; s/\brindex\b/faad_rindex/g' deps/libretro-deps/libfaad/libfaad/common.h
+
     patchShebangs ./scripts/*
   '';
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

I use retroarch-free in my system closure, so I made it build again on nixos-unstable. since I don't use any of these emulators directly I didn't really test them and I just wanted the build to succeed again. Happy for any feedback on those changes
