### PR TITLE
gfie: fix license

### DIFF
--- a/pkgs/by-name/gf/gfie/package.nix
+++ b/pkgs/by-name/gf/gfie/package.nix
@@ -40,9 +40,9 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    description = "Powerful open source image editor, especially suitable for creating icons, cursors, animations and icon libraries";
+    description = "Powerful image editor, especially suitable for creating icons, cursors, animations and icon libraries";
     homepage = "https://greenfishsoftware.org/gfie.php";
-    license = with lib.licenses; [ gpl3 ];
+    license = with lib.licenses; [ unfree ];
     maintainers = with lib.maintainers; [ pluiedev ];
     platforms = [ "x86_64-linux" ];
     mainProgram = "gfie";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Though the maintainer [knew that the source code is not available](https://github.com/NixOS/nixpkgs/issues/100666#issuecomment-2178107837) and there is a license.txt in the deb, for some unknown reasons, they ignored that and marked this as gpl3. This PR fix the wrong license.

<details>
<summary>license.txt</summary>

```
﻿Greenfish Icon Editor Pro
End-User License Agreement

Copyright (c) 2007-2025 Balázs Szalkai. All Rights Reserved.

Any person obtaining a copy of Greenfish Icon Editor Pro (hereinafter referred to as the "Software") is granted, free of charge, a perpetual, irrevocable, royalty-free, non-exclusive, worldwide license to use, copy, publish and distribute the Software, subject to the conditions contained herein. The Software is free for use in any environment, including but not limited to personal and commercial use.

Donations are appreciated, please see https://greenfishsoftware.org/donate.php.

You agree not to modify, adapt, rent, lease, loan, sell, or create derivative works based on the Software or any part thereof.

This End-User License Agreement shall be included in all copies or substantial portions of the Software.

THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
```

</details>

CC @pluiedev @Guanran928 @SuperSandro2000 @JonathanILevi

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
