### PR TITLE
vault-tasks: 0.13.0 -> 1.0.0

### DIFF
--- a/pkgs/by-name/va/vault-tasks/package.nix
+++ b/pkgs/by-name/va/vault-tasks/package.nix
@@ -5,22 +5,20 @@
   stdenv,
   buildPackages,
   installShellFiles,
+  versionCheckHook,
   nix-update-script,
 }:
-let
-  version = "0.13.0";
-in
-rustPlatform.buildRustPackage {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "vault-tasks";
-  inherit version;
+  version = "1.0.0";
   src = fetchFromGitHub {
     owner = "louis-thevenet";
     repo = "vault-tasks";
-    rev = "v${version}";
-    hash = "sha256-XWeY2l82n51O4/LKPOJZOXf7PCRPOUshFg832iDvmuA=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-vNAqytsApQSxKbPFVeKdevtGiplOhFHO83eXJ5YheFk=";
   };
 
-  cargoHash = "sha256-znc2oKpovsXyrUhKvBVMorv7yWM39xNgaNDiq/5I6Dg=";
+  cargoHash = "sha256-srlEkNQ84gNI9qPZmPdZwcoJC9Knf0jEmldLrxQIEWA=";
 
   nativeBuildInputs = [
     installShellFiles
@@ -42,12 +40,15 @@ rustPlatform.buildRustPackage {
       export HOME="$(mktemp -d)"
 
       installShellCompletion --cmd vault-tasks \
-        --bash <(${vault-tasks}/bin/vault-tasks generate-completions bash) \
-        --fish <(${vault-tasks}/bin/vault-tasks generate-completions fish) \
-        --zsh <(${vault-tasks}/bin/vault-tasks generate-completions zsh)
+        --bash <(${vault-tasks}/bin/vault-tasks-tui generate-completions bash) \
+        --fish <(${vault-tasks}/bin/vault-tasks-tui generate-completions fish) \
+        --zsh <(${vault-tasks}/bin/vault-tasks-tui generate-completions zsh)
     ''
   );
 
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
   passthru.updateScript = nix-update-script { };
 
   meta = {
@@ -58,7 +59,7 @@ rustPlatform.buildRustPackage {
     '';
     homepage = "https://github.com/louis-thevenet/vault-tasks";
     license = lib.licenses.mit;
-    mainProgram = "vault-tasks";
+    mainProgram = "vault-tasks-tui";
     maintainers = with lib.maintainers; [ louis-thevenet ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Release: https://github.com/louis-thevenet/vault-tasks/releases/tag/v1.0.0

Binary name changed from `vault-tasks` to `vault-tasks-tui`. Package name remains the same as more programs might be added in the future (e.g. CLI and GUI)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
