### PR TITLE
GNOME updates 2026-01-05

### DIFF
--- a/pkgs/by-name/gn/gnome-online-accounts/package.nix
+++ b/pkgs/by-name/gn/gnome-online-accounts/package.nix
@@ -32,7 +32,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-online-accounts";
-  version = "3.56.2";
+  version = "3.56.3";
 
   outputs = [
     "out"
@@ -45,7 +45,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-online-accounts/${lib.versions.majorMinor finalAttrs.version}/gnome-online-accounts-${finalAttrs.version}.tar.xz";
-    hash = "sha256-zojfZUV/DmOg2Nr/EzIuKey1hBl6GH9Io6Ib4vzRyCQ=";
+    hash = "sha256-OFlvF+Amn3fhYjpr95VpVzx733t82GP7R4p4rmZN6jA=";
   };
 
   mesonFlags = [

--- a/pkgs/by-name/gn/gnome-sudoku/package.nix
+++ b/pkgs/by-name/gn/gnome-sudoku/package.nix
@@ -23,11 +23,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-sudoku";
-  version = "49.2";
+  version = "49.3";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-sudoku/${lib.versions.major version}/gnome-sudoku-${version}.tar.xz";
-    hash = "sha256-ymcPrHPZ5cPngz/aNVZxC0Ig22Qz577FCnEFYNp9uEA=";
+    hash = "sha256-ybVGyN/pcWHfXVD1U4GCp0FTYmy8NoBbB4FSjvM7xZU=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-terminal/package.nix
+++ b/pkgs/by-name/gn/gnome-terminal/package.nix
@@ -30,11 +30,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-terminal";
-  version = "3.58.0";
+  version = "3.58.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-terminal/${lib.versions.majorMinor finalAttrs.version}/gnome-terminal-${finalAttrs.version}.tar.xz";
-    hash = "sha256-B+vHrxNRa+Wzd3f1INJkCzMSBiDpm7sF3upfgoD9ac4=";
+    hash = "sha256-HfuutVpxz8NqIaoe5KDUWcP96Ls9ZbCfvKaVx/3fvro=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gu/gucharmap/package.nix
+++ b/pkgs/by-name/gu/gucharmap/package.nix
@@ -47,7 +47,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "gucharmap";
-  version = "17.0.0";
+  version = "17.0.1";
 
   outputs = [
     "out"
@@ -61,7 +61,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "GNOME";
     repo = "gucharmap";
     rev = finalAttrs.version;
-    hash = "sha256-BYplW+gVTgWdXYW+h2g4xwxmFSl+WoygZfw8dug4qkw=";
+    hash = "sha256-86+D+WYIezo7ZXaKTWybinP9Q10Auy63+3VlescymC0=";
   };
 
   strictDeps = true;

--- a/pkgs/by-name/li/libshumate/package.nix
+++ b/pkgs/by-name/li/libshumate/package.nix
@@ -23,7 +23,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libshumate";
-  version = "1.5.1";
+  version = "1.5.2";
 
   outputs = [
     "out"
@@ -34,7 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/libshumate/${lib.versions.majorMinor finalAttrs.version}/libshumate-${finalAttrs.version}.tar.xz";
-    hash = "sha256-2q34twATQ4jH6TPgtiNYaqp/L76LOmJZOHUTMDuYduY=";
+    hash = "sha256-ppVlwetd2ezTkmi78UNeqlGlsCjtDGUqC2uTZ+BMk4Y=";
   };
 
   depsBuildBuild = [

--- a/pkgs/by-name/lo/loupe/package.nix
+++ b/pkgs/by-name/lo/loupe/package.nix
@@ -25,17 +25,17 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "loupe";
-  version = "49.1";
+  version = "49.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/loupe/${lib.versions.major finalAttrs.version}/loupe-${finalAttrs.version}.tar.xz";
-    hash = "sha256-MAmLyXmhyHouyye0patyWr+QC9cQu5wrzAyULVFcUcU=";
+    hash = "sha256-WFPnXM66f6K+oBvic80vCjBhlB573+OgCLIzFxBnFCw=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) src;
     name = "loupe-deps-${finalAttrs.version}";
-    hash = "sha256-GqPHvUBA5aRUnRSP+PpdOCC9sL8axnEdfqtHFp2KYJc=";
+    hash = "sha256-9jEz6hcdFUv5Daeh/0co1hHt49bE9kFAbFvnyiEaGJg=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/pa/papers/package.nix
+++ b/pkgs/by-name/pa/papers/package.nix
@@ -41,7 +41,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "papers";
-  version = "49.2";
+  version = "49.3";
 
   outputs = [
     "out"
@@ -51,7 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/papers/${lib.versions.major finalAttrs.version}/papers-${finalAttrs.version}.tar.xz";
-    hash = "sha256-SanKL2LFWY+ObKTmfIf09ZxewN5wTTspnVFkyR0fakE=";
+    hash = "sha256-dpddnR/S+Iw2j+yMMfDlb6ndk6G46F+s6qQDxZpVqpA=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {


### PR DESCRIPTION
Ofborg timeout on "wait for x" in aarch64 is unrelated to this PR...

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

