### PR TITLE
voicevox{,-engine}: 0.25.0 -> 0.25.1; voicevox-core: update modelVersion 0.16.1 -> 0.16.3

### DIFF
--- a/pkgs/by-name/vo/voicevox-core/package.nix
+++ b/pkgs/by-name/vo/voicevox-core/package.nix
@@ -21,8 +21,11 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "voicevox-core";
+
+  # Update only together with voicevox and voicevox-engine
+  # nixpkgs-update: no auto update
   version = "0.16.2";
-  modelVersion = "0.16.1";
+  passthru.modelVersion = "0.16.3";
 
   src = fetchFromGitHub {
     owner = "VOICEVOX";
@@ -61,13 +64,13 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   passthru.models = stdenv.mkDerivation {
     pname = "voicevox-models";
-    version = finalAttrs.modelVersion;
+    version = finalAttrs.passthru.modelVersion;
 
     src = fetchFromGitHub {
       owner = "VOICEVOX";
       repo = "voicevox_vvm";
-      tag = finalAttrs.modelVersion;
-      hash = "sha256-OY+xuvNjgmH/bxhL61XJZ3JVOxyec6kifkoGD4eN7HA=";
+      tag = finalAttrs.passthru.modelVersion;
+      hash = "sha256-VqSNEHJV/g9R+4XknRGi/s4C7/uXEGCK5/NC2XwiPcI=";
     };
 
     nativeBuildInputs = [ python3 ];
@@ -77,6 +80,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
       # convert multipart zip archive into single file
       python scripts/merge_vvm.py
+
+      # Exclude VOICEVOX Nemo models similar to upstream's CI, as voicevox-engine doesn't use them
+      rm vvms/n*
+
       mkdir -p "$out"
       cp vvms/* "$out"
 

--- a/pkgs/by-name/vo/voicevox-engine/package.nix
+++ b/pkgs/by-name/vo/voicevox-engine/package.nix
@@ -7,14 +7,14 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "voicevox-engine";
-  version = "0.25.0";
+  version = "0.25.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "VOICEVOX";
     repo = "voicevox_engine";
     tag = version;
-    hash = "sha256-ZthTXHXzexbffWoi8AKJrgX9/gd7fmKbYpCwuZZiQWQ=";
+    hash = "sha256-4pZs5f6Fe4kHIKcyww1eq9uRTf7rk5KAr/00H8aH9qA=";
   };
 
   patches = [
@@ -103,7 +103,7 @@ python3Packages.buildPythonApplication rec {
       owner = "VOICEVOX";
       repo = "voicevox_resource";
       tag = version;
-      hash = "sha256-yj3bwEB1qeoXAf3Dr02FF/HB6g7toAd2VUmR2937yzc=";
+      hash = "sha256-YaUVlZnpxu/IhLrp1XdcxDyus7DRhyzu4VKfabTsPUY=";
     };
 
     pyopenjtalk = python3Packages.callPackage ./pyopenjtalk.nix { };

--- a/pkgs/by-name/vo/voicevox/package.nix
+++ b/pkgs/by-name/vo/voicevox/package.nix
@@ -22,13 +22,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "voicevox";
-  version = "0.25.0";
+  version = "0.25.1";
 
   src = fetchFromGitHub {
     owner = "VOICEVOX";
     repo = "voicevox";
     tag = finalAttrs.version;
-    hash = "sha256-s8+uHwqxK9my/850C52VT5kshlGrHOOHtopUlsowNeI=";
+    hash = "sha256-l9aFuhOylcQrHa+0R0P4Jy5iL2gA6xJsUJt8KvWIMuM=";
   };
 
   patches = [


### PR DESCRIPTION
https://github.com/VOICEVOX/voicevox/releases/tag/0.25.1
https://github.com/VOICEVOX/voicevox_engine/releases/tag/0.25.1
https://github.com/VOICEVOX/voicevox_vvm/releases/tag/0.16.3

Supersedes https://github.com/NixOS/nixpkgs/pull/468859

I changed `modelVersion` to `passthru.modelVersion` so that the rust package doesn't need to be rebuilt when it changes next time.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
