### PR TITLE
labrador: init at 0-unstable-2026-01-05

### DIFF
--- a/pkgs/by-name/la/labrador/package.nix
+++ b/pkgs/by-name/la/labrador/package.nix
@@ -1,0 +1,141 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  pkg-config,
+  qt5,
+  libusb1,
+  fftw,
+  fftwFloat,
+  eigen,
+  llvmPackages,
+}:
+
+let
+  # Map Nix system to the architecture names used in bundled libdfuprog
+  dfuprogArch =
+    {
+      "x86_64-linux" = "x86_64";
+      "aarch64-linux" = "arm64";
+      "i686-linux" = "i386";
+      "armv7l-linux" = "arm";
+    }
+    .${stdenv.hostPlatform.system}
+      or (throw "labrador: unsupported system ${stdenv.hostPlatform.system}");
+
+  libExt = stdenv.hostPlatform.extensions.sharedLibrary;
+  # Build directory differs between platforms
+  buildDir = if stdenv.hostPlatform.isDarwin then "build_mac" else "build_linux";
+in
+stdenv.mkDerivation {
+  pname = "labrador";
+  version = "0-unstable-2026-02-16";
+
+  src = fetchFromGitHub {
+    owner = "espotek-org";
+    repo = "Labrador";
+    rev = "58f6d52452c3b9caf45b099c701f5b4f4e1b8fe2";
+    hash = "sha256-LjolfXJIO81iJ5G5SGVh5PYoNpFgV68v/iBlL2WSlho=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    qt5.wrapQtAppsHook
+    qt5.qmake
+  ];
+
+  buildInputs = [
+    qt5.qtbase
+    libusb1
+    fftw
+    fftwFloat
+    eigen
+    llvmPackages.openmp
+  ];
+
+  preConfigure = ''
+    cd Desktop_Interface
+
+    # Create library directory for bundled libdfuprog
+    mkdir -p $out/lib
+
+    # Copy the appropriate libdfuprog for this platform/architecture
+    ${
+      if stdenv.hostPlatform.isDarwin then
+        ''
+          cp ${buildDir}/libdfuprog/lib/libdfuprog-0.9${libExt} $out/lib/
+        ''
+      else
+        ''
+          cp ${buildDir}/libdfuprog/lib/${dfuprogArch}/libdfuprog-0.9${libExt} $out/lib/
+        ''
+    }
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    # Install binary (name differs on macOS)
+    mkdir -p $out/bin
+  ''
+  + (
+    if stdenv.hostPlatform.isDarwin then
+      ''
+        cp Labrador $out/bin/labrador
+      ''
+    else
+      ''
+        cp labrador $out/bin/
+      ''
+  )
+  + ''
+
+    mkdir -p $out/share/EspoTek/Labrador/firmware
+    cp resources/firmware/labrafirm* $out/share/EspoTek/Labrador/firmware/
+
+    mkdir -p $out/share/EspoTek/Labrador/waveforms
+    cp resources/waveforms/* $out/share/EspoTek/Labrador/waveforms/
+
+    ${lib.optionalString stdenv.hostPlatform.isLinux ''
+      mkdir -p $out/share/icons/hicolor/{48x48,256x256}/apps
+      cp build_linux/icon48/espotek-labrador.png $out/share/icons/hicolor/48x48/apps/
+      cp build_linux/icon256/espotek-labrador.png $out/share/icons/hicolor/256x256/apps/
+
+      mkdir -p $out/share/applications
+      cp build_linux/espotek-labrador.desktop $out/share/applications/
+
+      install -D build_linux/69-labrador.rules $out/lib/udev/rules.d/69-labrador.rules
+    ''}
+
+    runHook postInstall
+  '';
+
+  # Wrap the executable to find libdfuprog
+  preFixup =
+    if stdenv.hostPlatform.isDarwin then
+      ''
+        qtWrapperArgs+=(--prefix DYLD_LIBRARY_PATH : "$out/lib")
+      ''
+    else
+      ''
+        qtWrapperArgs+=(--prefix LD_LIBRARY_PATH : "$out/lib")
+      '';
+
+  meta = {
+    description = "EspoTek Labrador - oscilloscope, signal generator, logic analyzer, and more";
+    longDescription = ''
+      The EspoTek Labrador is an open-source board that turns your PC into a
+      full-featured electronics lab bench, complete with oscilloscope, signal
+      generator, logic analyzer, and more. This package provides the Qt5
+      desktop application for interfacing with the Labrador hardware.
+
+      On NixOS, add `services.udev.packages = [ pkgs.labrador ];` to enable
+      non-root USB access to the device.
+    '';
+    homepage = "https://github.com/espotek-org/Labrador";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ randomizedcoder ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    mainProgram = "labrador";
+  };
+}


### PR DESCRIPTION
## Summary

Add [EspoTek Labrador](https://github.com/espotek-org/Labrador) - an open-source USB device that turns your PC into a full-featured electronics lab bench with oscilloscope, signal generator, logic analyzer, and multimeter functionality.

This package builds the Qt5 desktop application for interfacing with the Labrador hardware.

### Features

- **Cross-platform**: Supports Linux (x86_64, aarch64, i686, armv7l) and macOS (Darwin)
- **Firmware updates**: Includes bundled libdfuprog library
- **Complete installation**: Firmware files, waveforms, icons, and desktop file

### udev rules (Linux)

For non-root USB access, users need to add udev rules. On NixOS:

```nix
services.udev.extraRules = ''
  ENV{ID_VENDOR_ID}=="03eb", ENV{ID_MODEL_ID}=="ba94", MODE="0666"
  ENV{ID_VENDOR_ID}=="03eb", ENV{ID_MODEL_ID}=="a000", MODE="0666"
  ENV{ID_VENDOR_ID}=="03eb", ENV{ID_MODEL_ID}=="2fe4", MODE="0666"
'';
```

### Build verification

```
$ nix-build -A labrador
/nix/store/...-labrador-0-unstable-2026-01-05

$ ls result/bin/
labrador

$ ldd result/bin/.labrador-wrapped | grep -E "(Qt|fftw|usb)"
libfftw3_omp.so.3 => /nix/store/...-fftw-double-3.3.10/lib/libfftw3_omp.so.3
libusb-1.0.so.0 => /nix/store/...-libusb-1.0.29/lib/libusb-1.0.so.0
libfftw3.so.3 => /nix/store/...-fftw-double-3.3.10/lib/libfftw3.so.3
libQt5PrintSupport.so.5 => /nix/store/...-qtbase-5.15.18/lib/libQt5PrintSupport.so.5
libQt5Widgets.so.5 => /nix/store/...-qtbase-5.15.18/lib/libQt5Widgets.so.5
libQt5Gui.so.5 => /nix/store/...-qtbase-5.15.18/lib/libQt5Gui.so.5
libQt5Core.so.5 => /nix/store/...-qtbase-5.15.18/lib/libQt5Core.so.5
```

Application launches successfully and scans for USB device (expected "DEVICE NOT FOUND" without hardware connected).

---

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
  - [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
  - [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
