### PR TITLE
buildPython*: extend overrideStdenvCompat to fixed-point arguments

### DIFF
--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -418,6 +418,7 @@ lib.extendMkDerivation {
           optional-dependencies
           ;
         updateScript = nix-update-script { };
+        ${if attrs ? stdenv then "__stdenvPythonCompat" else null} = attrs.stdenv;
       }
       // attrs.passthru or { };
 

--- a/pkgs/development/interpreters/python/python-packages-base.nix
+++ b/pkgs/development/interpreters/python/python-packages-base.nix
@@ -63,8 +63,8 @@ let
             '';
         in
         if !(lib.isFunction args) && (args ? stdenv) then
-          applyMsgStdenvArg (getName args) (
-            f'.override { inherit (args) stdenv; } (removeAttrs args [ "stdenv" ])
+          f'.override { stdenv = applyMsgStdenvArg (getName args) args.stdenv; } (
+            removeAttrs args [ "stdenv" ]
           )
         else
           f args


### PR DESCRIPTION
## Description

### Implementation
* Expose the `stdenv` argument as `passthru.__stdenvPythonCompat` when specified.
* Attach the warning message to `passthru.__stdenvPythonCompat` (instead of inside `overrideStdenvCompat`).
* Inside `overrideStdenvCompat` in `python-packages-base.nix`, construct a Python package with overridden `stdenv` if `<python pkg>.__stdenvPythonCompat` exists.
* Add argument `handleMsgStdenvArg` to `<python pkg>.override` to pass the message handling function (ignoreing, warning, throwing, etc.), with a comment about its being an implementation detail.
* Make `tests.overriding`'s `overridePythonAttrs-stdenv-deprecated` ignore the deprecation warning with `handleMsgStdenvArg`.

### Effect

* Extend backward compatibility to `python3Packages.buildPythonPackage`'s deprecated `stdenv` argument to the situation when `buildPythonPackage` takes fixed-point arguments, applying @MattSturgeon's suggestion in PR comment https://github.com/NixOS/nixpkgs/pull/271387#issuecomment-3450108690
* Make `overrideSdenvCompat` work with fixed-point arguments, giving us the freedom to decide whether to allow `overridePythonAttrs` to take extension-style update arguments (`finalAttrs: previousPythonAttrs: { ... }`) (issue #258246 )
* Guard the compatibility layer `overrideStdenvCompat` with tests even after warnings take effect, addressing @leona-ya and @MattSturgeon's PR comments https://github.com/NixOS/nixpkgs/pull/476401#issuecomment-3706466708 and https://github.com/NixOS/nixpkgs/pull/476401#discussion_r2659867912

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
