### PR TITLE
lib.strings: Fix the surprising behaviour of toSentenceCase

### DIFF
--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -1564,6 +1564,9 @@ rec {
     ```nix
     toSentenceCase "home"
     => "Home"
+
+    toSentenceCase "homeAwayFromHome"
+    => "HomeAwayFromHome"
     ```
 
     :::
@@ -1577,7 +1580,7 @@ rec {
           firstChar = substring 0 1 str;
           rest = substring 1 (stringLength str) str;
         in
-        addContextFrom str (toUpper firstChar + toLower rest)
+        addContextFrom str (toUpper firstChar + rest)
       );
 
   /**

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -1083,8 +1083,8 @@ runTests {
   ];
 
   testToSentenceCase = {
-    expr = strings.toSentenceCase "hello world";
-    expected = "Hello world";
+    expr = strings.toSentenceCase "hello World";
+    expected = "Hello World";
   };
 
   testToSentenceCasePath = testingThrow (strings.toSentenceCase ./.);


### PR DESCRIPTION
The docs for the function says it converts the first character of a string to upper-case so it was surprising to see the rest of my string get modified.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
