### PR TITLE
outfox: 0.5.0-pre042 -> 0.5.0-pre043

### DIFF
--- a/pkgs/by-name/ou/outfox/package.nix
+++ b/pkgs/by-name/ou/outfox/package.nix
@@ -10,29 +10,22 @@
   libpulseaudio,
   makeDesktopItem,
   makeWrapper,
+  openldap,
 }:
 
 stdenv.mkDerivation rec {
   pname = "outfox";
-  version = "0.5.0-pre042";
+  version = "0.5.0-pre043";
 
   src =
     {
-      i686-linux = fetchurl {
-        url = "https://github.com/TeamRizu/OutFox/releases/download/OF5.0.0-042/OutFox-alpha-0.5.0-pre042-Linux-14.04-32bit-i386-i386-legacy-date-20231227.tar.gz";
-        hash = "sha256-NFjNoqJ7Fq4A7Y0k6oQcWjykV+/b/MiRtJ1p6qlZdjs=";
-      };
       x86_64-linux = fetchurl {
-        url = "https://github.com/TeamRizu/OutFox/releases/download/OF5.0.0-042/OutFox-alpha-0.5.0-pre042-Linux-22.04-amd64-current-date-20231224.tar.gz";
-        hash = "sha256-dW+g/JYav3rUuI+nHDi6rXu/O5KYiEdk/HH82jgOUnI=";
+        url = "https://github.com/TeamRizu/OutFox/releases/download/OF5.0.0-043/OutFox-alpha-0.5.0-pre-043-Final-24.04-amd64-current-date-20250907.tar.gz";
+        hash = "sha256-1YN3YCcSluHBUpNRQdh0pJ9R9hTHKBuTSULTKL28OO0=";
       };
       aarch64-linux = fetchurl {
-        url = "https://github.com/TeamRizu/OutFox/releases/download/OF5.0.0-042/OutFox-alpha-0.5.0-pre042-Raspberry-Pi-Linux-18.04-arm64-arm64v8-modern-date-20231225.tar.gz";
-        hash = "sha256-7Qrq6t8KmUSIK4Rskkxw5l4UZ2vsb9/orzPegHySaJ4=";
-      };
-      armv7l-linux = fetchurl {
-        url = "https://github.com/TeamRizu/OutFox/releases/download/OF5.0.0-042/OutFox-alpha-0.5.0-pre042-Raspberry-Pi-Linux-14.04-arm32-arm32v7-legacy-date-20231227.tar.gz";
-        hash = "sha256-PRp7kuqFBRy7nextTCB+/poc+A9AX2EiQphx6aUfT8E=";
+        url = "https://github.com/TeamRizu/OutFox/releases/download/OF5.0.0-043/OutFox-alpha-0.5.0-pre-043-Final-RaspberryPi-debian12-arm64-aarch64-current-date-20250927.tar.gz";
+        hash = "sha256-/E4Keh1J3iytqaq0ziJy9F1mRR3mPbjlGto1Dbct3JM=";
       };
     }
     .${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
@@ -48,6 +41,7 @@ stdenv.mkDerivation rec {
     libjack2
     libglvnd
     libpulseaudio
+    openldap
   ];
 
   desktop = makeDesktopItem {
@@ -73,14 +67,12 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Rhythm game engine forked from StepMania";
     homepage = "https://projectoutfox.com";
-    changelog = "https://projectoutfox.com/releases/${version}";
+    changelog = "https://github.com/TeamRizu/OutFox/releases/tag/OF5.0.0-043";
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.unfree;
     platforms = [
       "x86_64-linux"
-      "i686-linux"
       "aarch64-linux"
-      "armv7l-linux"
     ];
     maintainers = with lib.maintainers; [ maxwell-lt ];
     mainProgram = "OutFox";


### PR DESCRIPTION
Changelog: https://github.com/TeamRizu/OutFox/releases/tag/OF5.0.0-043

I can't seem to find the 32 bit versions in [this release](https://github.com/TeamRizu/OutFox/releases/tag/OF5.0.0-043), so I dropped them. Please correct me if I'm wrong.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
