### PR TITLE
shanggu-fonts: 1.024 -> 1.027

### DIFF
--- a/pkgs/by-name/sh/shanggu-fonts/package.nix
+++ b/pkgs/by-name/sh/shanggu-fonts/package.nix
@@ -5,7 +5,7 @@
   p7zip,
 }:
 let
-  version = "1.024";
+  version = "1.027";
 
   source =
     with lib.attrsets;
@@ -18,10 +18,10 @@ let
         })
       )
       {
-        Mono = "sha256-JSGr3/q5Ca0AphQlfWYKOnKYt2Nr0CtNmv/j27WxBz8=";
-        Round = "sha256-DDMGf+QK8MIRfGFb7QY4sycyGUGmoZAq1OhMQ2VgBbY=";
-        Sans = "sha256-V+fabg4yC1TBVePs4+mpv6LBqq5bH6dTSHtX+SWFR3E=";
-        Serif = "sha256-z55QTCtpVljW+JMdGJJLAm6TIq70maRiegehxoTvhWI=";
+        Mono = "sha256-Q1vFGfnVbZgpuk/dHNGIhQ8eZTMOChGjG2x7H/a/z9c=";
+        Round = "sha256-DtrXQsBPZM+LFZUBwlRni0oCTU30h+dF5pL1Bkb/y6A=";
+        Sans = "sha256-3vDFtygo3lNznhI/WDEvvYi1mz19zGi0yq6DzrTSgFs=";
+        Serif = "sha256-4xVMHgUXBjroehu01G3IP7gSlkjkx9SR7PwDwoVKWoo=";
       };
 
   extraOutputs = builtins.attrNames source;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
