### PR TITLE
vrcx: 2025.12.06 -> 2026.01.04

### DIFF
--- a/pkgs/by-name/vr/vrcx/deps.json
+++ b/pkgs/by-name/vr/vrcx/deps.json
@@ -51,13 +51,13 @@
   },
   {
     "pname": "Microsoft.JavaScript.NodeApi",
-    "version": "0.9.17",
-    "hash": "sha256-mTJlmKIVLEJBsQcO0VFsitmLbpcGpI9SsJbIk3tI6jo="
+    "version": "0.9.18",
+    "hash": "sha256-FLpMBwfbLbyj+6LATS78WpvTfbpgWGhZZI6R53PKIYU="
   },
   {
     "pname": "Microsoft.JavaScript.NodeApi.Generator",
-    "version": "0.9.17",
-    "hash": "sha256-xF8J46OIr2+8FbppAdpMzm5GUV9SZ6RFN1AgIWr0pos="
+    "version": "0.9.18",
+    "hash": "sha256-I6sCIq5G6sfkxmaJnYpXY8w0Md6XuC39fDxy2yzTI9s="
   },
   {
     "pname": "Microsoft.NETCore.Platforms",
@@ -96,8 +96,8 @@
   },
   {
     "pname": "Microsoft.Win32.SystemEvents",
-    "version": "10.0.0",
-    "hash": "sha256-p0rfcBwM6pkVY+G49ujVcHwwFgrEq46FGPpGFOg0H5w="
+    "version": "10.0.1",
+    "hash": "sha256-fg806DoQzCBU9O6O9WId9he+Jk64YfaUIJfNAT9PXx8="
   },
   {
     "pname": "Newtonsoft.Json",
@@ -111,8 +111,8 @@
   },
   {
     "pname": "NLog",
-    "version": "6.0.6",
-    "hash": "sha256-vLtwZ32e1GWB93SGwmDAdUogQOf/5GuIcovO9Pn6qj8="
+    "version": "6.0.7",
+    "hash": "sha256-Le6ocjCN29rtgRiAroVfjUbMXCrjk0pSv2GEtZZy0qU="
   },
   {
     "pname": "runtime.any.System.Runtime",
@@ -181,8 +181,8 @@
   },
   {
     "pname": "System.CodeDom",
-    "version": "10.0.0",
-    "hash": "sha256-ffMXe35XVE49Gd6bbz2QRmTkCDeTuSnGYfKTZ6/MtS8="
+    "version": "10.0.1",
+    "hash": "sha256-ilpU2rkTepWP0e+DF4rEZJgz2UcNGrcTElGo4IGDTmM="
   },
   {
     "pname": "System.CodeDom",
@@ -231,8 +231,8 @@
   },
   {
     "pname": "System.Drawing.Common",
-    "version": "10.0.0",
-    "hash": "sha256-ZFneSifHbDj3O+IbwHSSs5YpDEunTeu9Hnz9APZKOA8="
+    "version": "10.0.1",
+    "hash": "sha256-tM5Cc45MJiR58yTSvcsC8oQ0xXSO4zIuKpCP/ozqFjw="
   },
   {
     "pname": "System.Drawing.Common",
@@ -241,13 +241,13 @@
   },
   {
     "pname": "System.IO.Pipelines",
-    "version": "10.0.0",
-    "hash": "sha256-0aeIxLFEBn9BoCa93UVNikdlqgPl3B1nmYCLQ9Yu9Ak="
+    "version": "10.0.1",
+    "hash": "sha256-3NHQjvO1mSPo8Hq9vMM5QeKJeS9/y3UpznideAf5pJA="
   },
   {
     "pname": "System.Management",
-    "version": "10.0.0",
-    "hash": "sha256-Nh3KOlsv6AxGkrWiHhuuTbRuIi2tp13NrbBwgQgKuSg="
+    "version": "10.0.1",
+    "hash": "sha256-CxFR8FycstzLJvNzbAcrO9CVftIAb3o6RekAEZgZqRE="
   },
   {
     "pname": "System.Memory",
@@ -326,13 +326,13 @@
   },
   {
     "pname": "System.Text.Encodings.Web",
-    "version": "10.0.0",
-    "hash": "sha256-OrsgqAPfEjjo+CzzrAzkKTXNv3VXw2dm3Wpn+uRHCM8="
+    "version": "10.0.1",
+    "hash": "sha256-dBN9Rpe+J1F8/cdzwNxLHYiqvzgSX1r9128YXyb2DKM="
   },
   {
     "pname": "System.Text.Json",
-    "version": "10.0.0",
-    "hash": "sha256-ZyAMIT3yQDJazYAObAlXmScGshGD9MVZgYmLqHyICq0="
+    "version": "10.0.1",
+    "hash": "sha256-WfSgOpRL4DKfIry/H+eHxJHHrj6ENZ3+P6Q2ol3R2XM="
   },
   {
     "pname": "System.Text.RegularExpressions",

--- a/pkgs/by-name/vr/vrcx/package.nix
+++ b/pkgs/by-name/vr/vrcx/package.nix
@@ -16,18 +16,18 @@ let
 in
 buildNpmPackage (finalAttrs: {
   pname = "vrcx";
-  version = "2025.12.06";
+  version = "2026.01.04";
 
   src = fetchFromGitHub {
     repo = "VRCX";
     owner = "vrcx-team";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-eyw8zFtKVR85ao1/gO8qJOF5VcBkZd7L5AB1JB8qAv0=";
+    hash = "sha256-ibsmlNfW64mzJOhIkJydpJ9ys2PbPfyj2XBGwY5xuww=";
   };
 
   makeCacheWritable = true;
   npmFlags = [ "--ignore-scripts" ];
-  npmDepsHash = "sha256-WHxrIzZLktU6Jd6wm5VeGnZAbNT3pkNfqcxE6tdBoq8=";
+  npmDepsHash = "sha256-TUdzrEa2dW4rKA/9HGgF6c9JTMiBmNWvc/9R0kIKSls=";
 
   nativeBuildInputs = [
     makeWrapper


### PR DESCRIPTION
https://github.com/vrcx-team/VRCX/releases/tag/v2026.01.04

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
