### PR TITLE
python314Packages.{sentence-transformers, llm, accelerate, llm-ollama, pydevd}: Python 3.14 fixes

### DIFF
--- a/pkgs/development/python-modules/accelerate/default.nix
+++ b/pkgs/development/python-modules/accelerate/default.nix
@@ -162,7 +162,15 @@ buildPythonPackage rec {
   ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) [
     # RuntimeError: torch_shm_manager: execl failed: Permission denied
     "CheckpointTest"
-  ];
+  ]
+  ++
+    lib.optionals
+      (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isx86_64 && (pythonAtLeast "3.14"))
+      [
+        # https://github.com/huggingface/accelerate/issues/3899
+        "test_accelerate_test"
+        "test_cpu"
+      ];
 
   disabledTestPaths = lib.optionals (!(stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isx86_64)) [
     # numerous instances of torch.multiprocessing.spawn.ProcessRaisedException:

--- a/pkgs/development/python-modules/llm-ollama/default.nix
+++ b/pkgs/development/python-modules/llm-ollama/default.nix
@@ -22,14 +22,14 @@
 
 buildPythonPackage rec {
   pname = "llm-ollama";
-  version = "0.14.0";
+  version = "0.15.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "taketwo";
     repo = "llm-ollama";
     tag = version;
-    hash = "sha256-8ELjUpHaIC8BOcmyQNeyQDPxQ5vO4Pj6FFnHFhvP+r0=";
+    hash = "sha256-iSLLFC+kYcKq6VOYspkgUyTobU6qUs7FxoAXBmm8H44=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/llm/default.nix
+++ b/pkgs/development/python-modules/llm/default.nix
@@ -6,6 +6,7 @@
   fetchFromGitHub,
   fetchpatch,
   pytestCheckHook,
+  pythonAtLeast,
   pythonOlder,
   replaceVars,
   setuptools,
@@ -249,6 +250,13 @@ let
       # TypeError: CliRunner.__init__() got an unexpected keyword argument 'mix_stderr
       # https://github.com/simonw/llm/issues/1293
       "test_embed_multi_files_encoding"
+    ]
+    ++ lib.optionals (pythonAtLeast "3.14") [
+      # Index out of range
+      # https://github.com/simonw/llm/issues/1335
+      "test_logs_fragments"
+      "test_expand_fragment_json"
+      "test_expand_fragment_markdown"
     ];
 
     pythonImportsCheck = [ "llm" ];

--- a/pkgs/development/python-modules/pydevd/default.nix
+++ b/pkgs/development/python-modules/pydevd/default.nix
@@ -10,24 +10,24 @@
   pytest-xdist,
   pytestCheckHook,
   pythonAtLeast,
-  pythonOlder,
   trio,
   untangle,
 }:
 
 buildPythonPackage rec {
   pname = "pydevd";
-  version = "3.3.0";
+  version = "3.4.1";
   pyproject = true;
-
-  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "fabioz";
     repo = "PyDev.Debugger";
-    rev = "pydev_debugger_${lib.replaceStrings [ "." ] [ "_" ] version}";
-    hash = "sha256-V5pM0xnMFnpR1oK0purHFCV3wu+4fOmd72kmy7pVeyk=";
+    tag = "pydev_debugger_${lib.replaceStrings [ "." ] [ "_" ] version}";
+    hash = "sha256-srcYeN4IsnX/B0AWLynr62UC5o+DcjnUrGjcTpvHTCM=";
   };
+
+  # https://github.com/fabioz/PyDev.Debugger/issues/316
+  disabled = pythonAtLeast "3.14";
 
   postPatch = ''
     sed -i '/addopts/d' pytest.ini
@@ -47,6 +47,10 @@ buildPythonPackage rec {
     pytestCheckHook
     trio
     untangle
+  ];
+
+  enabledTestPaths = [
+    "tests/"
   ];
 
   disabledTests = [

--- a/pkgs/development/python-modules/sentence-transformers/default.nix
+++ b/pkgs/development/python-modules/sentence-transformers/default.nix
@@ -3,6 +3,7 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
+  pythonAtLeast,
 
   # build-system
   setuptools,
@@ -128,6 +129,17 @@ buildPythonPackage rec {
     # NameError: name 'ParallelismConfig' is not defined
     "test_hf_argument_parser"
     "test_hf_argument_parser_incorrect_string_arguments"
+
+  ]
+  ++ lib.optionals (pythonAtLeast "3.14") [
+    # TypeError: Pickler._batch_setitems() takes 2 positional arguments but 3 were given
+    # https://github.com/huggingface/sentence-transformers/issues/3606
+    "test_group_by_label_batch_sampler_label_a"
+    "test_group_by_label_batch_sampler_label_b"
+    "test_group_by_label_batch_sampler_uneven_dataset"
+    "test_proportional_no_duplicates"
+    "test_round_robin_batch_sampler"
+    "test_round_robin_batch_sampler_vallue_error"
   ]
   ++ lib.optionals (!stdenv.hostPlatform.isAarch64 && stdenv.hostPlatform.isDarwin) [
     # These sparse tests also time out, on x86_64-darwin.


### PR DESCRIPTION
1. Disabled failing tests under Python 3.14
2. Filed https://github.com/huggingface/sentence-transformers/issues/3606
3. Filed https://github.com/simonw/llm/issues/1335
4. Filed https://github.com/huggingface/accelerate/issues/3899
5. `python3Packages.llm-ollama`: 0.14.0 -> 0.15.1 (fixes failing test). Supersedes #451807
6. `python3Packages.pydevd`: 3.3.0 -> 3.4.1, disabled for Python 3.14 per https://github.com/huggingface/accelerate/issues/3899 (This was hanging testing during nixpkgs-review)

Tracking #475732

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
