### PR TITLE
cloudsmith-api: 1.8.7 -> 1.11.1

### DIFF
--- a/pkgs/by-name/cl/cloudsmith-cli/package.nix
+++ b/pkgs/by-name/cl/cloudsmith-cli/package.nix
@@ -6,24 +6,15 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "cloudsmith-cli";
-  version = "1.8.7";
+  version = "1.11.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "cloudsmith-io";
     repo = "cloudsmith-cli";
     tag = "v${version}";
-    hash = "sha256-xUaa1B6f6W0Q/9q8sztFoCxEaxqXajImROC1sJb0Zdk=";
+    hash = "sha256-uYtDzC21hSXiEHhIPn5EW5bfYvRR2OWv/R0qg1WZPrA=";
   };
-
-  postPatch = ''
-    # Fix compatibility with urllib3 >= 2.0 - method_whitelist renamed to allowed_methods
-    # https://github.com/cloudsmith-io/cloudsmith-cli/pull/148
-    substituteInPlace cloudsmith_cli/core/rest.py \
-      --replace-fail 'method_whitelist=False' 'allowed_methods=False'
-    substituteInPlace setup.py \
-      --replace-fail 'urllib3<2.0' 'urllib3'
-  '';
 
   build-system = with python3Packages; [ setuptools ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
The cloudsmith-api package was pretty out of date.  This bumps the version to 1.11.1 which was released last month.  

https://github.com/cloudsmith-io/cloudsmith-cli/blob/master/CHANGELOG.md

Upstream patches are no longer needed and were removed

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
