### PR TITLE
jules: init at 0.1.42

### DIFF
--- a/pkgs/by-name/ju/jules/package-lock.json
+++ b/pkgs/by-name/ju/jules/package-lock.json
@@ -1,0 +1,89 @@
+{
+  "name": "@google/jules",
+  "version": "0.1.42",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@google/jules",
+      "version": "0.1.42",
+      "hasInstallScript": true,
+      "dependencies": {
+        "tar": "^7.4.3"
+      },
+      "bin": {
+        "jules": "run.cjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/tar": {
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.2.tgz",
+      "integrity": "sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/pkgs/by-name/ju/jules/package.nix
+++ b/pkgs/by-name/ju/jules/package.nix
@@ -1,0 +1,96 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchzip,
+  fetchurl,
+  autoPatchelfHook,
+  stdenv,
+}:
+
+let
+  version = "0.1.42";
+
+  # Platform-specific binary sources
+  binarySources = {
+    x86_64-linux = {
+      platform = "linux";
+      arch = "amd64";
+      hash = "sha256-c869LI+Jubsk703MuM15Q8y2npmzfeJnwvV5Mjen0QM=";
+    };
+    aarch64-linux = {
+      platform = "linux";
+      arch = "arm64";
+      hash = "sha256-cB0Eo25xUC3G6p/Jc0U7IsoIVQatLLqmwLZzkX7N+/w=";
+    };
+    x86_64-darwin = {
+      platform = "darwin";
+      arch = "amd64";
+      hash = "sha256-CYqHk6+o1pMJmM9rQvr4+/RKjTZS7jBcAzWltybhFnQ=";
+    };
+    aarch64-darwin = {
+      platform = "darwin";
+      arch = "arm64";
+      hash = "sha256-iedh0tQC3dLObgY0Xf5HPfwCSxqYp2OZCQ9xPuKuklQ=";
+    };
+  };
+
+  binarySource =
+    binarySources.${stdenv.hostPlatform.system}
+      or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+
+  julesBinary = fetchurl {
+    url = "https://storage.googleapis.com/jules-cli/v${version}/jules_external_v${version}_${binarySource.platform}_${binarySource.arch}.tar.gz";
+    inherit (binarySource) hash;
+  };
+in
+buildNpmPackage (finalAttrs: {
+  pname = "jules";
+  inherit version;
+
+  src = fetchzip {
+    url = "https://registry.npmjs.org/@google/jules/-/jules-${version}.tgz";
+    hash = "sha256-EPOcnUChxdWtDvXqHPd2k9hkeNOA0SB9SH7yP+mMLoQ=";
+  };
+
+  postPatch = ''
+    cp ${./package-lock.json} package-lock.json
+  '';
+
+  npmDepsHash = "sha256-CIYydNcEavCbyupQAUGkT3AWv/2ih/IIrQccGmEHW+k=";
+
+  dontNpmBuild = true;
+
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [ stdenv.cc.cc.lib ];
+
+  postInstall = ''
+    # Extract and install the pre-built binary
+    tar -xzf ${julesBinary} -C $out/lib/node_modules/@google/jules
+    chmod +x $out/lib/node_modules/@google/jules/jules
+
+    # Link the binary directly instead of using the node wrapper
+    rm $out/bin/jules
+    ln -s $out/lib/node_modules/@google/jules/jules $out/bin/jules
+  '';
+
+  passthru.updateScript = ./update.sh;
+
+  meta = {
+    description = "Jules, the asynchronous coding agent from Google, in the terminal";
+    homepage = "https://jules.google";
+    downloadPage = "https://www.npmjs.com/package/@google/jules";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [
+      deftdawg
+    ];
+    mainProgram = "jules";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})

--- a/pkgs/by-name/ju/jules/update.sh
+++ b/pkgs/by-name/ju/jules/update.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env nix
+#!nix shell --ignore-environment .#cacert .#nodejs .#git .#nix-update .#nix .#gnused .#findutils .#bash .#curl .#jq --command bash
+
+set -euo pipefail
+
+version=$(npm view @google/jules version)
+
+# Update version and hashes for the npm package
+NIXPKGS_ALLOW_UNFREE=1 nix-update jules --version="$version" --generate-lockfile
+
+# Update the binary hashes for all platforms
+declare -A platforms=(
+  ["x86_64-linux"]="linux_amd64"
+  ["aarch64-linux"]="linux_arm64"
+  ["x86_64-darwin"]="darwin_amd64"
+  ["aarch64-darwin"]="darwin_arm64"
+)
+
+for nix_platform in "${!platforms[@]}"; do
+  binary_suffix="${platforms[$nix_platform]}"
+  binary_url="https://storage.googleapis.com/jules-cli/v${version}/jules_external_v${version}_${binary_suffix}.tar.gz"
+  binary_hash=$(nix-prefetch-url "$binary_url" 2>/dev/null | xargs nix hash convert --hash-algo sha256 --to sri)
+  # Update the hash for this platform
+  sed -i "/${nix_platform}/,/hash = /s|hash = \"sha256-[^\"]*\"|hash = \"${binary_hash}\"|" pkgs/by-name/ju/jules/package.nix
+done
+
+# Update the version in the binary URL pattern
+sed -i "s|jules_external_v[0-9.]*_|jules_external_v${version}_|g" pkgs/by-name/ju/jules/package.nix
+
+# nix-update can't update package-lock.json along with npmDepsHash
+# TODO: Remove this workaround if nix-update can update package-lock.json along with npmDepsHash.
+(nix-build --expr '((import ./.) { system = builtins.currentSystem; }).jules.npmDeps.overrideAttrs { outputHash = ""; outputHashAlgo = "sha256"; }' 2>&1 || true) \
+| sed -nE '$s/ *got: *(sha256-[A-Za-z0-9+/=-]+).*/\1/p' \
+| xargs -I{} sed -i 's|npmDepsHash = "sha256-[^"]*";|npmDepsHash = "{}";|' pkgs/by-name/ju/jules/package.nix


### PR DESCRIPTION
Google Jules CLI

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
