### PR TITLE
signal-desktop: determine SOURCE_DATE_EPOCH via git and disable automatic updates

### DIFF
--- a/pkgs/by-name/si/signal-desktop/package.nix
+++ b/pkgs/by-name/si/signal-desktop/package.nix
@@ -61,7 +61,6 @@ let
     repo = "Signal-Desktop";
     tag = "v${version}";
     hash = "sha256-r1RB6vtG2mdRJifaKNrmQvxJxXOqkpHoWivvPPpesow=";
-    forceFetchGit = true;
     postCheckout = ''
       git -C "$out" show -s --format=%ct > "$out"/GIT_COMMIT_TIME
     '';
@@ -131,6 +130,10 @@ stdenv.mkDerivation (finalAttrs: {
     # it at runtime.
     substituteInPlace app/updateDefaultSession.main.ts \
       --replace-fail "\''${process.versions.electron}" "`jq -r '.devDependencies.electron' < package.json`"
+
+    # https://github.com/signalapp/Signal-Desktop/issues/7667
+    substituteInPlace ts/util/version.std.ts \
+      --replace-fail 'isAdhoc(version)' 'true'
   '';
 
   pnpmDeps = fetchPnpmDeps {

--- a/pkgs/by-name/si/signal-desktop/package.nix
+++ b/pkgs/by-name/si/signal-desktop/package.nix
@@ -60,7 +60,11 @@ let
     owner = "signalapp";
     repo = "Signal-Desktop";
     tag = "v${version}";
-    hash = "sha256-hzeioXrO9kdFFTGhhY4klrCxRgS1eoGY7+7fTGsN4cY=";
+    hash = "sha256-r1RB6vtG2mdRJifaKNrmQvxJxXOqkpHoWivvPPpesow=";
+    forceFetchGit = true;
+    postCheckout = ''
+      git -C "$out" show -s --format=%ct > "$out"/GIT_COMMIT_TIME
+    '';
   };
 
   sticker-creator = stdenv.mkDerivation (finalAttrs: {
@@ -148,8 +152,11 @@ stdenv.mkDerivation (finalAttrs: {
   env = {
     ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
     SIGNAL_ENV = "production";
-    SOURCE_DATE_EPOCH = 1766066770;
   };
+
+  preConfigure = ''
+    export SOURCE_DATE_EPOCH=`cat GIT_COMMIT_TIME`
+  '';
 
   preBuild = ''
     if [ "`jq -r '.engines.node' < package.json | cut -d. -f1`" != "${lib.versions.major nodejs.version}" ]

--- a/pkgs/by-name/si/signal-desktop/update.sh
+++ b/pkgs/by-name/si/signal-desktop/update.sh
@@ -13,8 +13,6 @@ releaseInfo="`curl_github \
   "https://api.github.com/repos/signalapp/Signal-Desktop/releases/latest"`"
 
 releaseTag="`jq -r ".tag_name" <<< $releaseInfo`"
-releaseDate="`jq -r ".created_at" <<< $releaseInfo`"
-releaseEpoch=`date -d $releaseDate +%s`
 
 packageJson="`curl_github "https://raw.githubusercontent.com/signalapp/Signal-Desktop/refs/tags/$releaseTag/package.json"`"
 
@@ -29,7 +27,6 @@ webrtcVersion="`grep --only-matching "^webrtc.version=.*$" <<< $ringrtcVersionPr
 
 sed -E -i "s/(nodejs_)../\1$nodeVersion/" $SCRIPT_DIR/package.nix
 sed -E -i "s/(electron_)../\1$electronVersion/" $SCRIPT_DIR/package.nix
-sed -E -i "s/(SOURCE_DATE_EPOCH = )[0-9]+/\1$releaseEpoch/" $SCRIPT_DIR/package.nix
 
 sed -E -i "s/(withAppleEmojis \? )false/\1true/" $SCRIPT_DIR/package.nix
 nix-update signal-desktop --subpackage sticker-creator --version="$latestVersion"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
