### PR TITLE
ocamlPackages.{camlpdf,cpdf}: 2.8 → 2.8.1

### DIFF
--- a/pkgs/development/ocaml-modules/camlpdf/default.nix
+++ b/pkgs/development/ocaml-modules/camlpdf/default.nix
@@ -6,15 +6,15 @@
   findlib,
 }:
 
-stdenv.mkDerivation rec {
-  version = "2.8";
+stdenv.mkDerivation (finalAttrs: {
+  version = "2.8.1";
   pname = "ocaml${ocaml.version}-camlpdf";
 
   src = fetchFromGitHub {
     owner = "johnwhitington";
     repo = "camlpdf";
-    rev = "v${version}";
-    hash = "sha256-+SFuFqlrP0nwm199y0QFWYvlwD+Cbh0PHA5bmXIWdNk=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ZExQtcFBPiS7c6v+WEjZYQ6zXtqRTNLV0hYzYSB/eLE=";
   };
 
   nativeBuildInputs = [
@@ -35,4 +35,4 @@ stdenv.mkDerivation rec {
     maintainers = with lib.maintainers; [ vbgl ];
     broken = lib.versionOlder ocaml.version "4.10";
   };
-}
+})

--- a/pkgs/development/ocaml-modules/cpdf/default.nix
+++ b/pkgs/development/ocaml-modules/cpdf/default.nix
@@ -7,15 +7,15 @@
   camlpdf,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "ocaml${ocaml.version}-cpdf";
-  version = "2.8";
+  version = "2.8.1";
 
   src = fetchFromGitHub {
     owner = "johnwhitington";
     repo = "cpdf-source";
-    rev = "v${version}";
-    hash = "sha256-DvTY5EQcvnL76RlQTcVqBiycqbCdGQCXzarSMH2P/pg=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-MK48ajZmpXibbaJ4x2vaHhh2N+OBRqj7zT8eaVenxDY=";
   };
 
   nativeBuildInputs = [
@@ -44,4 +44,4 @@ stdenv.mkDerivation rec {
     inherit (ocaml.meta) platforms;
     broken = lib.versionOlder ocaml.version "4.10";
   };
-}
+})


### PR DESCRIPTION
Fixes & improvements:
 - https://github.com/johnwhitington/camlpdf/blob/v2.8.1/Changes
 - https://github.com/johnwhitington/cpdf-source/blob/v2.8.1/Changes

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
