### PR TITLE
python3Packages.flask-alembic: 3.1.1 -> 3.2.0

### DIFF
--- a/pkgs/development/python-modules/flask-alembic/default.nix
+++ b/pkgs/development/python-modules/flask-alembic/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  pythonAtLeast,
   flit-core,
   alembic,
   flask,
@@ -14,7 +13,7 @@
 
 buildPythonPackage rec {
   pname = "flask-alembic";
-  version = "3.1.1";
+  version = "3.2.0";
 
   pyproject = true;
 
@@ -22,7 +21,7 @@ buildPythonPackage rec {
     owner = "pallets-eco";
     repo = "flask-alembic";
     tag = version;
-    hash = "sha256-iHJr9l3w1WwZXDl573IV7+A7RDcawGL20sxxhAQQ628=";
+    hash = "sha256-g5xl5CEfSZUbZxCLYykjd94eVjxzBAkgoBcR4y7IYfM=";
   };
 
   build-system = [ flit-core ];
@@ -42,8 +41,6 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "flask_alembic" ];
 
   meta = {
-    # https://github.com/pallets-eco/flask-alembic/issues/47
-    broken = pythonAtLeast "3.13";
     homepage = "https://github.com/pallets-eco/flask-alembic";
     changelog = "https://github.com/pallets-eco/flask-alembic/blob/${src.tag}/CHANGES.md";
     license = lib.licenses.mit;


### PR DESCRIPTION
The update also fixes the build with python 3.13.

- Changelog: https://github.com/pallets-eco/flask-alembic/blob/3.2.0/CHANGES.md
- Diff: https://github.com/pallets-eco/flask-alembic/compare/3.1.1...3.2.0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
