### PR TITLE
python3Packages.pip-tools: 7.5.1-unstable-2025-11-08 -> 7.5.2

### DIFF
--- a/pkgs/development/python-modules/home-assistant-chip-wheels/default.nix
+++ b/pkgs/development/python-modules/home-assistant-chip-wheels/default.nix
@@ -54,6 +54,7 @@
   sphinx-design,
   stdenv,
   tabulate,
+  tomli,
   tornado,
   types-pyyaml,
   types-requests,
@@ -232,6 +233,7 @@ stdenv.mkDerivation rec {
         sphinx-argparse
         sphinx-design
         tabulate
+        tomli
         tornado
         types-pyyaml
         types-requests

--- a/pkgs/development/python-modules/pins/default.nix
+++ b/pkgs/development/python-modules/pins/default.nix
@@ -18,7 +18,6 @@
   pytest-cases,
   pytest-parallel,
   pytestCheckHook,
-  pythonOlder,
   pyyaml,
   requests,
   s3fs,
@@ -33,8 +32,6 @@ buildPythonPackage rec {
   version = "0.9.1";
   pyproject = true;
 
-  disabled = pythonOlder "3.9";
-
   src = fetchFromGitHub {
     owner = "rstudio";
     repo = "pins-python";
@@ -45,6 +42,10 @@ buildPythonPackage rec {
   build-system = [
     setuptools
     setuptools-scm
+  ];
+
+  pythonRelaxDeps = [
+    "fsspec"
   ];
 
   dependencies = [

--- a/pkgs/development/python-modules/pip-tools/default.nix
+++ b/pkgs/development/python-modules/pip-tools/default.nix
@@ -5,8 +5,8 @@
   build,
   click,
   fetchFromGitHub,
-  pep517,
   pip,
+  pyproject-hooks,
   pytest-xdist,
   pytestCheckHook,
   pythonOlder,
@@ -19,29 +19,27 @@
 
 buildPythonPackage rec {
   pname = "pip-tools";
-  version = "7.5.1-unstable-2025-11-08";
+  version = "7.5.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "jazzband";
     repo = "pip-tools";
-    rev = "785ed5e30f4c86c24141898553a356402b142adf";
-    hash = "sha256-2mYUjLqrpN/sjR79t/ZIfpvVXAgpk/tpZWFcT/6e7uk=";
+    tag = "v${version}";
+    hash = "sha256-+y4oXiLWGFIzIT75EZFpcYCX5HKeEyPsk+phTOyoKl8=";
   };
 
   patches = [
     ./fix-setup-py-bad-syntax-detection.patch
   ];
 
-  env.SETUPTOOLS_SCM_PRETEND_VERSION = "7.5.1";
-
   build-system = [ setuptools-scm ];
 
   dependencies = [
     build
     click
-    pep517
     pip
+    pyproject-hooks
     setuptools
     wheel
   ]
@@ -60,12 +58,22 @@ buildPythonPackage rec {
     export no_proxy='*';
   '';
 
+  disabledTestPaths = [
+    # Most tests require network access
+    "tests/test_cli_compile.py"
+  ];
+
   disabledTests = [
     # Tests require network access
     "network"
     "test_direct_reference_with_extras"
     "test_local_duplicate_subdependency_combined"
     "test_bad_setup_file"
+    "test_get_hashes_local_repository_cache_miss"
+    "test_toggle_reuse_hashes_local_repository"
+    "test_get_hashes_from_mixed"
+    "test_toggle_reuse_hashes_local_repository"
+    "test_generate_hashes_all_platforms"
     # Assertion error
     "test_compile_recursive_extras"
     "test_compile_build_targets_setuptools_no_wheel_dep"
@@ -75,11 +83,6 @@ buildPythonPackage rec {
     # Deprecations
     "test_error_in_pyproject_toml"
 
-    # pip 25.0 compat issues
-    # https://github.com/jazzband/pip-tools/issues/2112
-    # requirement doesn't end with semicolon
-    "test_resolver"
-    "test_resolver__custom_unsafe_deps"
     # constraints.txt is now in a tmpdir
     "test_preserve_via_requirements_constrained_dependencies_when_run_twice"
     "test_annotate_option"


### PR DESCRIPTION
Diff: https://github.com/jazzband/pip-tools/compare/785ed5e30f4c86c24141898553a356402b142adf...v7.5.2

Changelog: https://github.com/jazzband/pip-tools/releases/tag/7.5.2

closes https://github.com/NixOS/nixpkgs/pull/477043
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
