### PR TITLE
zsnes: fix the build against `gcc-15`

### DIFF
--- a/pkgs/applications/emulators/zsnes/default.nix
+++ b/pkgs/applications/emulators/zsnes/default.nix
@@ -71,6 +71,8 @@ stdenv.mkDerivation {
 
   configureFlags = [ "--enable-release" ];
 
+  enableParallelBuilding = true;
+
   postInstall = ''
     function installIcon () {
         mkdir -p $out/share/icons/hicolor/$1/apps/

--- a/pkgs/applications/emulators/zsnes/default.nix
+++ b/pkgs/applications/emulators/zsnes/default.nix
@@ -60,7 +60,8 @@ stdenv.mkDerivation {
   # Workaround build failure on -fno-common toolchains:
   #   ld: initc.o:(.bss+0x28): multiple definition of `HacksDisable'; cfg.o:(.bss+0x59e3): first defined here
   # Use pre-c++17 standard (c++17 forbids throw annotations)
-  env.NIX_CFLAGS_COMPILE = "-fcommon -std=c++14";
+  # Use pre-c23: chips/dsp3emu.c:31:23: error: 'bool' cannot be defined via 'typedef'
+  env.NIX_CFLAGS_COMPILE = "-fcommon -std=c++14 -std=gnu17";
 
   preConfigure = ''
     cd src


### PR DESCRIPTION
Without the change the build fails on `master` at `x86_640linux` as:

        chips/dsp3emu.c:31:23: error: 'bool' cannot be defined via 'typedef'
          31 | typedef unsigned char bool;
             |                       ^~~~

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
