### PR TITLE
programs.fish: default useBabelfish to true

### DIFF
--- a/nixos/tests/fish.nix
+++ b/nixos/tests/fish.nix
@@ -15,6 +15,21 @@
       documentation.man.enable = false;
     };
 
+  # Test babelfish (default) with shell hooks that use bash `source` command.
+  # This previously failed with "Unknown command: babelfish" because babelfish
+  # wasn't invoked with an absolute path.
+  nodes.babelfish =
+    { pkgs, ... }:
+
+    {
+      programs.fish.enable = true;
+      programs.git.enable = true;
+      programs.git.prompt.enable = true;
+
+      # Avoid slow man cache build
+      documentation.man.enable = false;
+    };
+
   testScript =
     #python
     ''
@@ -30,5 +45,9 @@
       )
       machine.wait_for_file("/etc/fish/config.fish")
       config = machine.succeed("fish_indent -c /etc/fish/config.fish")
+
+      # Test babelfish with git prompt (the fix for "Unknown command: babelfish")
+      babelfish.wait_for_file("/etc/fish/config.fish")
+      babelfish.succeed("fish -ic 'echo babelfish test passed'")
     '';
 }


### PR DESCRIPTION
## Problem

`foreign-env` (fenv) runs on **every shell startup**, even when sourcing empty bash scripts. It has O(n²) environment diffing overhead - running `not contains -- "$environment" $before` for every environment variable.

This causes ~130ms startup penalty on every fish shell, with zero benefit when there are no bash scripts to source (which is the common case).

## Solution

- Add new `useForeignEnv` option (default: `false`) for users who actually need foreign-env
- Keep `useBabelfish` for backwards compatibility (now effectively deprecated)
- Default behavior now uses babelfish, which is faster

**Before (fenv by default):** `contains checks` ~130ms  
**After (babelfish by default):** `contains checks` ~0.4ms

## Migration

- Users with `useBabelfish = true`: no change needed (still works)
- Users with default config: automatically get faster startup
- Users who need fenv: set `useForeignEnv = true`

Fixes #477301