### PR TITLE
openjfx17: build with gradle_8

### DIFF
--- a/pkgs/by-name/op/openjfx/package.nix
+++ b/pkgs/by-name/op/openjfx/package.nix
@@ -6,7 +6,6 @@
   pkgs,
 
   gradle_8,
-  gradle_7,
   perl,
   pkg-config,
   cmake,
@@ -23,6 +22,7 @@
   ffmpeg_7,
   ffmpeg_7-headless,
 
+  fetchpatch2,
   writeText,
 
   _experimental-update-script-combinators,
@@ -54,8 +54,6 @@ let
 
   atLeast21 = lib.versionAtLeast featureVersion "21";
   atLeast23 = lib.versionAtLeast featureVersion "23";
-
-  gradle_openjfx = if atLeast21 then gradle_8 else gradle_7;
 in
 
 assert lib.assertMsg (lib.pathExists sourceFile)
@@ -76,11 +74,28 @@ stdenv.mkDerivation {
       [
         ./17/patches/backport-ffmpeg-6-support-jfx11.patch
         ./17/patches/backport-ffmpeg-7-support-jfx11.patch
+
+        # Build with Gradle 8
+        (fetchpatch2 {
+          # Yes, this patch taken from the jfx21u repo is intended to be
+          # applied to jfx17.
+          url = "https://github.com/openjdk/jfx21u/commit/7f704c24c2238f9d7bb744a20667a8c1337decc6.patch?full_index=1";
+          excludes = [
+            # The patch fails to apply to these files, but with the exception
+            # of build.properties (which is patched in postPatch), none of them
+            # matter.
+            "build.properties"
+            "gradle/legal/gradle.md"
+            "gradle/wrapper/gradle-wrapper.properties"
+            "gradlew"
+          ];
+          hash = "sha256-WuJtzPy0IV4xvn+i5xeDqekWO0VR2GIfsYKkEmh8KKU=";
+        })
       ]
   );
 
   nativeBuildInputs = [
-    gradle_openjfx
+    gradle_8
     perl
     pkg-config
     cmake
@@ -99,7 +114,7 @@ stdenv.mkDerivation {
     (if atLeast21 then ffmpeg_7 else ffmpeg_7-headless)
   ];
 
-  mitmCache = gradle_openjfx.fetchDeps {
+  mitmCache = gradle_8.fetchDeps {
     attrPath = "openjfx${featureVersion}";
     pkg = pkgs."openjfx${featureVersion}".override { withWebKit = true; };
     data = ./. + "/${featureVersion}/deps.json";
@@ -132,6 +147,10 @@ stdenv.mkDerivation {
            modules/javafx.web/src/main/native/Source/bmalloc/bmalloc/IsoSharedPageInlines.h
 
     ''
+    + lib.optionalString (!atLeast21) ''
+      substituteInPlace build.properties \
+        --replace-fail jfx.gradle.version=7.3 jfx.gradle.version=8.4
+    ''
     + ''
       ln -s $config gradle.properties
     '';
@@ -156,7 +175,7 @@ stdenv.mkDerivation {
 
   disallowedReferences = [
     jdk-bootstrap
-    gradle_openjfx.jdk
+    gradle_8.jdk
   ];
 
   passthru.updateScript = _experimental-update-script-combinators.sequence [


### PR DESCRIPTION
Part of #358845.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
