### PR TITLE
python3Packages.snappy: 3.2 -> 3.3.2, modernise

### DIFF
--- a/pkgs/by-name/tk/tkgl/package.nix
+++ b/pkgs/by-name/tk/tkgl/package.nix
@@ -10,13 +10,13 @@
 
 tcl.mkTclDerivation {
   pname = "tkgl";
-  version = "1.2.1-unstable-2025-06-01";
+  version = "1.2.1-unstable-2026-01-07";
 
   src = fetchFromGitHub {
     owner = "3-manifolds";
     repo = "TkGL";
-    rev = "45bf16e6c28a070c70fc9a0eb8c47a0b6ff8a2e3";
-    hash = "sha256-AA5LZGhMTWmTZqI/wtycUYLsUe9BwO3voGMS7vGlCM0=";
+    rev = "e47636bc56f02ddca503f98abc65e31a0f0f0a7c";
+    hash = "sha256-Y5NIKWUjbtVn9qiVzc8TsKCm4M3KbNPiBjVTBWf7ALA=";
   };
 
   postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''

--- a/pkgs/by-name/tk/tkgl/package.nix
+++ b/pkgs/by-name/tk/tkgl/package.nix
@@ -46,6 +46,9 @@ tcl.mkTclDerivation {
     description = "OpenGL drawing surface for Tk 8 and 9";
     homepage = "https://github.com/3-manifolds/TkGL";
     license = lib.licenses.tcltk;
-    maintainers = with lib.maintainers; [ noiioiu ];
+    maintainers = with lib.maintainers; [
+      noiioiu
+      alejo7797
+    ];
   };
 }

--- a/pkgs/development/python-modules/cypari/default.nix
+++ b/pkgs/development/python-modules/cypari/default.nix
@@ -1,14 +1,33 @@
 {
   lib,
+  fetchFromGitHub,
   python,
   buildPythonPackage,
-  fetchFromGitHub,
+  fetchurl,
   fetchpatch,
+
+  # build-time dependencies
   setuptools,
   cython,
-  gmp,
-  pari,
   perl,
+
+  # static libraries
+  pkgsStatic,
+  gmpStatic ? pkgsStatic.gmp,
+  pari,
+  pariStatic_2_15 ? pari.overrideAttrs (
+    finalAttrs: oldAttrs: {
+      version = "2.15.4";
+      src = fetchurl {
+        url = "https://pari.math.u-bordeaux.fr/pub/pari/OLD/${lib.versions.majorMinor finalAttrs.version}/pari-${finalAttrs.version}.tar.gz";
+        hash = "sha256-w1Rb/uDG37QLd/tLurr5mdguYAabn20ovLbPAEyMXA8=";
+      };
+      installTargets = [
+        "install"
+        "install-lib-sta"
+      ];
+    }
+  ),
 }:
 
 buildPythonPackage rec {
@@ -38,8 +57,8 @@ buildPythonPackage rec {
 
   preBuild = ''
     mkdir libcache
-    ln -s ${gmp} libcache/gmp
-    ln -s ${pari} libcache/pari
+    ln -s ${gmpStatic} libcache/gmp
+    ln -s ${pariStatic_2_15} libcache/pari
   '';
 
   build-system = [
@@ -62,11 +81,11 @@ buildPythonPackage rec {
   meta = {
     description = "Sage's PARI extension, modified to stand alone";
     homepage = "https://github.com/3-manifolds/CyPari";
+    changelog = "https://github.com/3-manifolds/CyPari/releases/tag/${src.tag}";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [
       noiioiu
       alejo7797
     ];
-    changelog = "https://github.com/3-manifolds/CyPari/releases/tag/${src.tag}";
   };
 }

--- a/pkgs/development/python-modules/cypari/default.nix
+++ b/pkgs/development/python-modules/cypari/default.nix
@@ -33,26 +33,21 @@
 
 buildPythonPackage rec {
   pname = "cypari";
-  version = "2.5.5";
+  version = "2.5.6";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "3-manifolds";
     repo = "CyPari";
     tag = "${version}_as_released";
-    hash = "sha256-RJ9O1KsDHmMkTCIFUrcSUkA5ijTsxmoI939QCsCib0Y=";
+    hash = "sha256-pzxnrWkoPW7fpxLbUQ+drIrdrjqaAiNnDfe9ky2IxaA=";
   };
 
   patches = [
     (fetchpatch {
-      name = "support-aarch64-linux.patch";
-      url = "https://github.com/3-manifolds/CyPari/commit/6197171b52ee4f44a4954ddd0e2e36769b189dee.patch";
-      hash = "sha256-j2P7DEGD2B8q9Hh4G2mQng76fQdUpeAdFYoTD7Ui/Dk=";
-    })
-    (fetchpatch {
       name = "fix-build-with-cython-3_1.patch";
-      url = "https://github.com/3-manifolds/CyPari/compare/622e112ffcf0383e2110954ff3ac3c42c006ebe1...50bcbd2b39177f5e4c5a3551a8a14f75ab05a5d6.patch";
-      hash = "sha256-6ayvtHMS3YtzzklHaaLzl9d4zHJhm0lVZQZFS9ykFY4=";
+      url = "https://github.com/3-manifolds/CyPari/compare/17bf39dc4508f2e46de75b95c65982c627652b60...d6cb914d2bdc74a51cc2a9136204ebf47b3e7369.diff";
+      hash = "sha256-c8sq80mYSMMvgFh7RXYwKcqwI7iVRQsm/8yaIL0+PHQ=";
     })
   ];
 

--- a/pkgs/development/python-modules/cypari/default.nix
+++ b/pkgs/development/python-modules/cypari/default.nix
@@ -3,6 +3,7 @@
   fetchFromGitHub,
   python,
   buildPythonPackage,
+  nix-update-script,
   fetchurl,
   fetchpatch,
 
@@ -77,6 +78,13 @@ buildPythonPackage rec {
     ${python.interpreter} -P -m cypari.test
     runHook postCheck
   '';
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "(.*)_as_released"
+    ];
+  };
 
   meta = {
     description = "Sage's PARI extension, modified to stand alone";

--- a/pkgs/development/python-modules/plink/default.nix
+++ b/pkgs/development/python-modules/plink/default.nix
@@ -10,14 +10,14 @@
 
 buildPythonPackage rec {
   pname = "plink";
-  version = "2.4.6";
+  version = "2.4.9";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "3-manifolds";
     repo = "plink";
     tag = "${version}_as_released";
-    hash = "sha256-+WUyQvQY9Fx47GikzJ4gcCpSIjvk5756FP0bDdF6Ack=";
+    hash = "sha256-+O371oWfvRvMfjXX6qZj91c7+4MBneZFNcfdrJQNCY8=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/plink/default.nix
+++ b/pkgs/development/python-modules/plink/default.nix
@@ -5,6 +5,7 @@
   setuptools,
   sphinx,
   tkinter,
+  nix-update-script,
 }:
 
 buildPythonPackage rec {
@@ -27,6 +28,13 @@ buildPythonPackage rec {
   dependencies = [ tkinter ];
 
   pythonImportsCheck = [ "plink" ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "(.*)_as_released"
+    ];
+  };
 
   meta = {
     description = "Full featured Tk-based knot and link editor";

--- a/pkgs/development/python-modules/snappy-manifolds/default.nix
+++ b/pkgs/development/python-modules/snappy-manifolds/default.nix
@@ -3,6 +3,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   setuptools,
+  nix-update-script,
 }:
 
 buildPythonPackage rec {
@@ -20,6 +21,13 @@ buildPythonPackage rec {
   build-system = [ setuptools ];
 
   pythonImportsCheck = [ "snappy_manifolds" ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "(.*)_as_released"
+    ];
+  };
 
   meta = {
     description = "Database of snappy manifolds";

--- a/pkgs/development/python-modules/snappy-manifolds/default.nix
+++ b/pkgs/development/python-modules/snappy-manifolds/default.nix
@@ -8,14 +8,14 @@
 
 buildPythonPackage rec {
   pname = "snappy-manifolds";
-  version = "1.2.1";
+  version = "1.4";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "3-manifolds";
     repo = "snappy_manifolds";
     tag = "${version}_as_released";
-    hash = "sha256-vxG3z6zWzG4S11fBxYGn4/c2f2sWOCIrzT+R27TR144=";
+    hash = "sha256-e+BoPvg0cuEqLq2f9ZPgqFMEYw7eeSEDkY42+l+kDCk=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/snappy/default.nix
+++ b/pkgs/development/python-modules/snappy/default.nix
@@ -1,16 +1,22 @@
 {
   lib,
   stdenv,
-  fetchpatch,
+  fetchFromGitHub,
   python,
   buildPythonPackage,
-  fetchFromGitHub,
+  fetchpatch,
+
+  # build-time dependencies
   setuptools,
-  cypari,
   cython,
+
+  # non-Python runtime dependencies
+  libGL,
+
+  # Python runtime dependencies
+  cypari,
   fxrays,
   ipython,
-  libGL,
   low-index,
   packaging,
   pickleshare,
@@ -20,9 +26,16 @@
   snappy-15-knots,
   snappy-manifolds,
   spherogram,
+  tkinter-gl,
+
+  # documentation
   sphinxHook,
   sphinx-rtd-theme,
-  tkinter-gl,
+
+  # tests
+  runCommand,
+  sage,
+  writableTmpDirAsHomeHook,
 }:
 
 buildPythonPackage rec {
@@ -58,7 +71,7 @@ buildPythonPackage rec {
   postPatch =
     lib.optionalString stdenv.hostPlatform.isLinux ''
       substituteInPlace setup.py \
-        --replace-fail "/usr/include/GL" "${libGL.dev}/include/GL"
+        --replace-fail "/usr/include/GL" "${lib.getDev libGL}/include/GL"
       substituteInPlace freedesktop/share/applications/snappy.desktop \
         --replace-fail "Exec=/usr/bin/env python3 -m snappy.app" "Exec=SnapPy"
     ''
@@ -116,6 +129,25 @@ buildPythonPackage rec {
     ${python.interpreter} -m snappy.test --skip-gui
     runHook postCheck
   '';
+
+  passthru.tests.sage =
+    let
+      sage' = sage.override {
+        extraPythonPackages = ps: [ ps.snappy ];
+        requireSageTests = false;
+      };
+    in
+    runCommand "snappy-sage-tests"
+      {
+        nativeBuildInputs = [
+          sage'
+          writableTmpDirAsHomeHook
+        ];
+      }
+      ''
+        sage -python -m snappy.test --skip-gui
+        touch $out
+      '';
 
   meta = {
     description = "Studying the topology and geometry of 3-manifolds, with a focus on hyperbolic structures";

--- a/pkgs/development/python-modules/snappy/default.nix
+++ b/pkgs/development/python-modules/snappy/default.nix
@@ -41,7 +41,7 @@
 
 buildPythonPackage rec {
   pname = "snappy";
-  version = "3.2";
+  version = "3.3.2";
   pyproject = true;
 
   outputs = [
@@ -53,7 +53,7 @@ buildPythonPackage rec {
     owner = "3-manifolds";
     repo = "SnapPy";
     tag = "${version}_as_released";
-    hash = "sha256-IwPxuyVDsL5yML+J06HTKlz52sYrPkohLJ0XDXDwTlo=";
+    hash = "sha256-Pl4Nl0LXNvdtQ/EFVQy0QdUA/Fqoz2QAFWW5nz0bv78=";
   };
 
   patches = [
@@ -61,11 +61,6 @@ buildPythonPackage rec {
       name = "no-copy-doc.patch";
       url = "https://github.com/3-manifolds/SnapPy/commit/c6aeeaaec7010a54e4ebdf2e8dad7b384c2ce8e5.patch";
       hash = "sha256-OV3Qr5wO5UHNzVFTPTujIpp5ptel6gvAlcMgrJ8C0KY=";
-    })
-    (fetchpatch {
-      name = "fix-test-aarch64.patch";
-      url = "https://github.com/3-manifolds/SnapPy/commit/a8d57db39bc8f486746dc61027779168d0bc316a.patch";
-      hash = "sha256-RsuwaR+7UrVTKlPwQeHblTAN++La7b9BSMdFcJSiX5Q=";
     })
   ];
 

--- a/pkgs/development/python-modules/snappy/default.nix
+++ b/pkgs/development/python-modules/snappy/default.nix
@@ -5,6 +5,7 @@
   python,
   buildPythonPackage,
   fetchpatch,
+  nix-update-script,
 
   # build-time dependencies
   setuptools,
@@ -148,6 +149,13 @@ buildPythonPackage rec {
         sage -python -m snappy.test --skip-gui
         touch $out
       '';
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "(.*)_as_released"
+    ];
+  };
 
   meta = {
     description = "Studying the topology and geometry of 3-manifolds, with a focus on hyperbolic structures";

--- a/pkgs/development/python-modules/spherogram/default.nix
+++ b/pkgs/development/python-modules/spherogram/default.nix
@@ -1,14 +1,19 @@
 {
   lib,
-  buildPythonPackage,
   fetchFromGitHub,
+  python,
+  buildPythonPackage,
+
+  # build-time dependencies
   setuptools,
   cython,
-  networkx,
+
+  # runtime dependencies
   decorator,
   knot-floer-homology,
-  snappy-manifolds,
+  networkx,
   snappy-15-knots,
+  snappy-manifolds,
 }:
 
 buildPythonPackage rec {
@@ -38,6 +43,12 @@ buildPythonPackage rec {
   optional-dependencies.snappy-15-knots = [ snappy-15-knots ];
 
   pythonImportsCheck = [ "spherogram" ];
+
+  checkPhase = ''
+    runHook preCheck
+    ${python.interpreter} -m spherogram.test
+    runHook postCheck
+  '';
 
   meta = {
     description = "Spherical diagrams for 3-manifold topology";

--- a/pkgs/development/python-modules/spherogram/default.nix
+++ b/pkgs/development/python-modules/spherogram/default.nix
@@ -24,14 +24,14 @@
 
 buildPythonPackage rec {
   pname = "spherogram";
-  version = "2.3";
+  version = "2.4.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "3-manifolds";
     repo = "spherogram";
     tag = "${version}_as_released";
-    hash = "sha256-uqc+3xS4xulXR0tZlNuyC5Zz5OztR6c4PZWpsvU+4Pw=";
+    hash = "sha256-zQoNuy2rj02GAuRNDufMwA/wQ4U8ZeIADb8LpIvMFOY=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/spherogram/default.nix
+++ b/pkgs/development/python-modules/spherogram/default.nix
@@ -14,6 +14,11 @@
   networkx,
   snappy-15-knots,
   snappy-manifolds,
+
+  # tests
+  runCommand,
+  sage,
+  writableTmpDirAsHomeHook,
 }:
 
 buildPythonPackage rec {
@@ -49,6 +54,25 @@ buildPythonPackage rec {
     ${python.interpreter} -m spherogram.test
     runHook postCheck
   '';
+
+  passthru.tests.sage =
+    let
+      sage' = sage.override {
+        extraPythonPackages = ps: [ ps.spherogram ];
+        requireSageTests = false;
+      };
+    in
+    runCommand "spherogram-sage-tests"
+      {
+        nativeBuildInputs = [
+          sage'
+          writableTmpDirAsHomeHook
+        ];
+      }
+      ''
+        sage -python -m spherogram.test
+        touch $out
+      '';
 
   meta = {
     description = "Spherical diagrams for 3-manifold topology";

--- a/pkgs/development/python-modules/spherogram/default.nix
+++ b/pkgs/development/python-modules/spherogram/default.nix
@@ -3,6 +3,7 @@
   fetchFromGitHub,
   python,
   buildPythonPackage,
+  nix-update-script,
 
   # build-time dependencies
   setuptools,
@@ -73,6 +74,13 @@ buildPythonPackage rec {
         sage -python -m spherogram.test
         touch $out
       '';
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "(.*)_as_released"
+    ];
+  };
 
   meta = {
     description = "Spherical diagrams for 3-manifold topology";

--- a/pkgs/development/python-modules/tkinter-gl/default.nix
+++ b/pkgs/development/python-modules/tkinter-gl/default.nix
@@ -1,11 +1,12 @@
 {
   lib,
+  fetchFromGitHub,
   python,
   buildPythonPackage,
-  fetchFromGitHub,
+  setuptools,
   setuptools-scm,
-  tkinter,
   tkgl,
+  tkinter,
 }:
 
 buildPythonPackage rec {
@@ -29,7 +30,10 @@ buildPythonPackage rec {
                      "pkg_dir = os.path.join(__path__[0], 'tk')"
   '';
 
-  build-system = [ setuptools-scm ];
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
 
   dependencies = [ tkinter ];
 

--- a/pkgs/development/python-modules/tkinter-gl/default.nix
+++ b/pkgs/development/python-modules/tkinter-gl/default.nix
@@ -12,14 +12,14 @@
 
 buildPythonPackage rec {
   pname = "tkinter-gl";
-  version = "1.0";
+  version = "1.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "3-manifolds";
     repo = "tkinter_gl";
     tag = "v${version}_as_released";
-    hash = "sha256-ObI8EEQ7mAOAuV6f+Ld4HH0xkFzqiAZqHDvzjwPA/wM";
+    hash = "sha256-PNxxjyVGoMw4J/SXWvVITuGMq/HypxUwDkSxeFy2Vag=";
   };
 
   postPatch = ''
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     rm -r src/tkinter_gl/tk
     # Platform-specific directories are only necessary when using compiled TkGL
     substituteInPlace src/tkinter_gl/__init__.py \
-      --replace-fail "pkg_dir = os.path.join(__path__[0], 'tk', sys.platform,)" \
+      --replace-fail "pkg_dir = os.path.join(__path__[0], 'tk', target)" \
                      "pkg_dir = os.path.join(__path__[0], 'tk')"
   '';
 

--- a/pkgs/development/python-modules/tkinter-gl/default.nix
+++ b/pkgs/development/python-modules/tkinter-gl/default.nix
@@ -7,6 +7,7 @@
   setuptools-scm,
   tkgl,
   tkinter,
+  nix-update-script,
 }:
 
 buildPythonPackage rec {
@@ -47,6 +48,13 @@ buildPythonPackage rec {
     '';
 
   pythonImportsCheck = [ "tkinter_gl" ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "v(.*)_as_released"
+    ];
+  };
 
   meta = {
     description = "Base class for GL rendering surfaces in tkinter";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3476,23 +3476,7 @@ self: super: with self; {
 
   cynthion = callPackage ../development/python-modules/cynthion { };
 
-  cypari = callPackage ../development/python-modules/cypari {
-
-    inherit (pkgs.pkgsStatic) gmp;
-
-    pari = pkgs.pari.overrideAttrs rec {
-      version = "2.15.4";
-      src = pkgs.fetchurl {
-        url = "https://pari.math.u-bordeaux.fr/pub/pari/OLD/${lib.versions.majorMinor version}/pari-${version}.tar.gz";
-        hash = "sha256-w1Rb/uDG37QLd/tLurr5mdguYAabn20ovLbPAEyMXA8=";
-      };
-      installTargets = [
-        "install"
-        "install-lib-sta"
-      ];
-    };
-
-  };
+  cypari = callPackage ../development/python-modules/cypari { };
 
   cypari2 = callPackage ../development/python-modules/cypari2 { };
 


### PR DESCRIPTION
https://github.com/3-manifolds/SnapPy/releases/tag/3.3_as_released
https://github.com/3-manifolds/SnapPy/releases/tag/3.3.1_as_released
https://github.com/3-manifolds/SnapPy/releases/tag/3.3.2_as_released

### See also
- https://github.com/3-manifolds/CyPari/releases/tag/2.5.6_as_released
- https://github.com/3-manifolds/PLink/releases/tag/2.4.8_as_released
- https://github.com/3-manifolds/snappy_manifolds/releases/tag/1.4_as_released
- https://github.com/3-manifolds/Spherogram/releases/tag/2.4_as_released
- https://github.com/3-manifolds/tkinter_gl/releases/tag/v1.1_as_released

### Notes
- Adds tests under `passthru.tests` which test extra functionality of SnapPy and Spherogram when run within Sage.
- Adds `updateScript`s to SnapPy and many of its dependencies.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
