### PR TITLE
python3Packages.atopile: skip failing test, cleanup

### DIFF
--- a/pkgs/development/python-modules/atopile/default.nix
+++ b/pkgs/development/python-modules/atopile/default.nix
@@ -61,7 +61,7 @@
   versionCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "atopile";
   version = "0.12.4";
   pyproject = true;
@@ -71,7 +71,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "atopile";
     repo = "atopile";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-SB6D1738t3kQJI+V9ClVsByHm6BsLl078N/wDAHJE6E=";
   };
 
@@ -228,9 +228,9 @@ buildPythonPackage rec {
     description = "Design circuit boards with code";
     homepage = "https://atopile.io";
     downloadPage = "https://github.com/atopile/atopile";
-    changelog = "https://github.com/atopile/atopile/releases/tag/${src.tag}";
+    changelog = "https://github.com/atopile/atopile/releases/tag/${finalAttrs.src.tag}";
     license = with lib.licenses; [ mit ];
     maintainers = with lib.maintainers; [ sigmanificient ];
     mainProgram = "ato";
   };
-}
+})

--- a/pkgs/development/python-modules/atopile/default.nix
+++ b/pkgs/development/python-modules/atopile/default.nix
@@ -185,6 +185,7 @@ buildPythonPackage rec {
   disabledTests = [
     # timeout
     "test_build_error_logging"
+    "test_can_evaluate_literals"
     "test_examples_build"
     "test_net_names_deterministic"
     "test_performance_mifs_bus_params"

--- a/pkgs/development/python-modules/atopile/default.nix
+++ b/pkgs/development/python-modules/atopile/default.nix
@@ -58,6 +58,7 @@
   pytest-xdist,
   hypothesis,
   writableTmpDirAsHomeHook,
+  versionCheckHook,
 }:
 
 buildPythonPackage rec {
@@ -143,7 +144,9 @@ buildPythonPackage rec {
     pytest-datafiles
     pytest-timeout
     hypothesis
+    versionCheckHook
   ];
+  versionCheckProgramArg = "--version";
 
   preCheck = ''
     # do not report worker logs to filee


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- **python3Packages.atopile: skip failing test**
- **python3Packages.atopile: add versionCheckHook**
- **python3Packages.atopile: switch to finalAttrs**

cc @Sigmanificient

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
