### PR TITLE
python3Packages.typed-settings: 25.0.0 -> 25.3.0

### DIFF
--- a/pkgs/development/python-modules/typed-settings/default.nix
+++ b/pkgs/development/python-modules/typed-settings/default.nix
@@ -3,8 +3,8 @@
   attrs,
   buildPythonPackage,
   cattrs,
-  click,
   click-option-group,
+  click,
   fetchPypi,
   hatch-vcs,
   hatchling,
@@ -13,6 +13,8 @@
   pydantic,
   pytest-cov-stub,
   pytestCheckHook,
+  python-dotenv,
+  pythonAtLeast,
   pythonOlder,
   rich-click,
   sybil,
@@ -21,15 +23,15 @@
 }:
 buildPythonPackage rec {
   pname = "typed-settings";
-  version = "25.0.0";
+  version = "25.3.0";
   pyproject = true;
 
-  disabled = pythonOlder "3.9";
+  disabled = pythonOlder "3.10";
 
   src = fetchPypi {
     pname = "typed_settings";
     inherit version;
-    hash = "sha256-Kbr9Mc1PXgD+OAw/ADp3HXC+rnAJcFEqjlXxQq/1wRM=";
+    hash = "sha256-hl61LDGE9GdwVkWh5Y251xngi515V0SKKtjLvCLtIaY=";
   };
 
   build-system = [ hatchling ];
@@ -62,6 +64,7 @@ buildPythonPackage rec {
     hypothesis
     pytest-cov-stub
     pytestCheckHook
+    python-dotenv
     rich-click
     sybil
   ]
@@ -79,6 +82,10 @@ buildPythonPackage rec {
   disabledTestPaths = [
     # 1Password CLI is not available
     "tests/test_onepassword.py"
+  ]
+  ++ lib.optionals (pythonAtLeast "3.14") [
+    # All the CLI help messages begin with python3.14 instead of python3
+    "tests/test_cli_argparse.py"
   ];
 
   pythonImportsCheck = [ "typed_settings" ];


### PR DESCRIPTION
Includes fixes for CLI test failures under Python 3.14

Tracking: #475732

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
