### PR TITLE
python3Packages.blosc2: 3.11.1 -> 3.12.2; python3Package.mne: disable failing test on Python 3.14

### DIFF
--- a/pkgs/development/python-modules/blosc2/default.nix
+++ b/pkgs/development/python-modules/blosc2/default.nix
@@ -3,6 +3,7 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
+  pythonAtLeast,
 
   # build-system
   cmake,
@@ -32,14 +33,14 @@
 
 buildPythonPackage rec {
   pname = "blosc2";
-  version = "3.11.1";
+  version = "3.12.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Blosc";
     repo = "python-blosc2";
     tag = "v${version}";
-    hash = "sha256-n+DSBzb3XXzMEqx8ApFLymU1/IPZTcEFgRarvmYkZVY=";
+    hash = "sha256-t2tf8s2WwG4vEQbh8HACMtUjVrwmGby1yKd+IlL39PY=";
   };
 
   nativeBuildInputs = [
@@ -78,6 +79,10 @@ buildPythonPackage rec {
   disabledTests = [
     # attempts external network requests
     "test_with_remote"
+  ]
+  ++ lib.optionals (pythonAtLeast "3.14") [
+    # https://github.com/Blosc/python-blosc2/issues/551
+    "test_expand_dims"
   ];
 
   passthru.c-blosc2 = c-blosc2;

--- a/pkgs/development/python-modules/mne/default.nix
+++ b/pkgs/development/python-modules/mne/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  pythonAtLeast,
   hatchling,
   hatch-vcs,
   numpy,
@@ -90,6 +91,10 @@ buildPythonPackage rec {
     # flaky
     "test_fine_cal_systems"
     "test_simulate_raw_bem"
+  ]
+  ++ lib.optionals (pythonAtLeast "3.14") [
+    #https://github.com/mne-tools/mne-python/issues/13577
+    "test_set_montage_artinis_basic"
   ];
 
   pytestFlag = [


### PR DESCRIPTION
### blosc2

Includes disabled tests on Python 3.14
Filed https://github.com/Blosc/python-blosc2/issues/551

CHANGELOG: https://github.com/Blosc/python-blosc2/releases/tag/v3.12.2
DIFF: https://github.com/Blosc/python-blosc2/compare/v3.11.1...v3.12.2

Supersedes #467949

### mne

Disable broken test on python 3.14
Filed https://github.com/mne-tools/mne-python/issues/13577

Tracking: #475732

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
