### PR TITLE
python3Packages.obspy: 1.4.2 -> 1.4.3-unstable-2025-08-21

### DIFF
--- a/pkgs/development/python-modules/obspy/default.nix
+++ b/pkgs/development/python-modules/obspy/default.nix
@@ -18,14 +18,15 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "obspy";
-  version = "1.4.2";
+  version = "1.4.2-unstable-2025-08-21";
   pyproject = true;
 
+  # Applies a gcc fix that can't be applied as a patch due to other repo changes
   src = fetchFromGitHub {
     owner = "obspy";
     repo = "obspy";
-    tag = finalAttrs.version;
-    hash = "sha256-QBV9FRvUUy8/5KK5RdAXXLB8SK9llFy1XRnQ9T5bgcU=";
+    rev = "75bac0c96aa04a0e233e72a7c89ebe97a3b48954";
+    hash = "sha256-B55tVae8NRZZclekTvnxiFUk/bVijk7GpaccPFh15Xc=";
   };
 
   build-system = [ setuptools ];
@@ -50,7 +51,7 @@ buildPythonPackage (finalAttrs: {
   meta = {
     description = "Python framework for seismological observatories";
     homepage = "https://www.obspy.org";
-    changelog = "https://github.com/obspy/obspy/releases/tag/${finalAttrs.src.tag}";
+    changelog = "https://github.com/obspy/obspy/releases/tag/v1.4.2";
     license = lib.licenses.lgpl3Only;
     maintainers = [ lib.maintainers.ametrine ];
   };

--- a/pkgs/development/python-modules/obspy/default.nix
+++ b/pkgs/development/python-modules/obspy/default.nix
@@ -16,7 +16,7 @@
   sqlalchemy,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "obspy";
   version = "1.4.2";
   pyproject = true;
@@ -24,7 +24,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "obspy";
     repo = "obspy";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-QBV9FRvUUy8/5KK5RdAXXLB8SK9llFy1XRnQ9T5bgcU=";
   };
 
@@ -50,8 +50,8 @@ buildPythonPackage rec {
   meta = {
     description = "Python framework for seismological observatories";
     homepage = "https://www.obspy.org";
-    changelog = "https://github.com/obspy/obspy/releases/tag/${src.tag}";
+    changelog = "https://github.com/obspy/obspy/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.lgpl3Only;
     maintainers = [ lib.maintainers.ametrine ];
   };
-}
+})


### PR DESCRIPTION
Incorporates https://github.com/obspy/obspy/pull/3587 to fix gcc build error

~~Build on Python 3.14 depends on #477340~~

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
