### PR TITLE
mistral-vibe: nuke store reference in comment

### DIFF
--- a/pkgs/by-name/mi/mistral-vibe/package.nix
+++ b/pkgs/by-name/mi/mistral-vibe/package.nix
@@ -72,7 +72,7 @@ python3Packages.buildPythonApplication rec {
   pytestFlags = [ "tests/cli/test_clipboard.py" ];
 
   disabledTests = [
-    # AssertionError: assert '/nix/store/rlq03x4cwf8zn73hxaxnx0zn5q9kifls-bash-5.3p3/bin/sh:
+    # AssertionError: assert '/nix/store/00000000000000000000000000000000-bash-5.3p3/bin/sh:
     # warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8): No such file or directory\n' == ''
     "test_decodes_non_utf8_bytes"
     "test_runs_echo_successfully"


### PR DESCRIPTION
The hardcoded store path caused fetchFromGitHub to fail when fetching nixpkgs with the error:

```
error: the fixed-output derivation '/nix/store/k9blc69hymk2mhl0fyhbhr8rgv4rcn84-source.drv' must not reference store paths but 1 such references were found:
         /nix/store/rlq03x4cwf8zn73hxaxnx0zn5q9kifls-bash-5.3p3
```

See https://github.com/NixOS/nixpkgs/pull/474854#discussion_r2663391139