### PR TITLE
nxv: enable darwin local networking for tests

### DIFF
--- a/pkgs/by-name/nx/nxv/package.nix
+++ b/pkgs/by-name/nx/nxv/package.nix
@@ -20,6 +20,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-7c1LryJvrOsSiLPYNvGIFaTONhA0c99n918/yNRKkxo=";
 
+  # Tests use mockito which needs to bind to localhost
+  __darwinAllowLocalNetworking = true;
+
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
   versionCheckProgramArg = "--version";


### PR DESCRIPTION
Fixes test failures on darwin by enabling `__darwinAllowLocalNetworking`.

The tests use mockito to create a local HTTP mock server, which needs to bind to localhost. Without this flag, the darwin sandbox blocks the connection causing 11 tests to fail.

Fixes: https://github.com/jamesbrink/nxv/issues/16