### PR TITLE
dtach: cleanup

### DIFF
--- a/pkgs/by-name/dt/dtach/package.nix
+++ b/pkgs/by-name/dt/dtach/package.nix
@@ -1,17 +1,21 @@
 {
+  fetchFromGitHub,
+  fetchpatch2,
   lib,
   stdenv,
-  fetchurl,
-  fetchpatch2,
+  versionCheckHook,
+  nix-update-script,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "dtach";
   version = "0.9";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/project/dtach/dtach/${version}/dtach-${version}.tar.gz";
-    sha256 = "1wwj2hlngi8qn2pisvhyfxxs8gyqjlgrrv5lz91w8ly54dlzvs9j";
+  src = fetchFromGitHub {
+    owner = "crigler";
+    repo = "dtach";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-os6jC3Wh0fiafQEUFlIHvC+F7xtlH3hQFDLcdTYYYyU=";
   };
 
   patches = [
@@ -22,14 +26,22 @@ stdenv.mkDerivation rec {
   ];
 
   installPhase = ''
-    mkdir -p $out/bin
-    cp dtach $out/bin/dtach
+    runHook preInstall
+
+    install -D dtach $out/bin/${finalAttrs.meta.mainProgram}
+
+    runHook postInstall
   '';
 
-  meta = {
-    homepage = "https://dtach.sourceforge.net/";
-    description = "Program that emulates the detach feature of screen";
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
 
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    homepage = "https://dtach.sourceforge.net";
+    description = "Program that emulates the detach feature of screen";
     longDescription = ''
       dtach is a tiny program that emulates the detach feature of
       screen, allowing you to run a program in an environment that is
@@ -38,11 +50,9 @@ stdenv.mkDerivation rec {
       thus works best with programs that know how to redraw
       themselves.
     '';
-
     license = lib.licenses.gpl2Plus;
-
     platforms = lib.platforms.unix;
     maintainers = [ ];
     mainProgram = "dtach";
   };
-}
+})

--- a/pkgs/by-name/dt/dtach/package.nix
+++ b/pkgs/by-name/dt/dtach/package.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.unix;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ yiyu ];
     mainProgram = "dtach";
   };
 })


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
