### PR TITLE
rumdl: 0.0.203 -> 0.0.213

### DIFF
--- a/pkgs/by-name/ru/rumdl/package.nix
+++ b/pkgs/by-name/ru/rumdl/package.nix
@@ -10,25 +10,20 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rumdl";
-  version = "0.0.210";
+  version = "0.0.211";
 
   src = fetchFromGitHub {
     owner = "rvben";
     repo = "rumdl";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-AxJzCRZCfm8DbybWgYnAb8kQEYXA0FCfvI8OxQwrcgI=";
+    hash = "sha256-EW/JQlzve46eKCuDqXmvdeU1X3khtuk/WiUD5XoD+N4=";
   };
 
-  cargoHash = "sha256-4PNacVB31uVtyNfQbYpgUmu8RxXbbXvaWS0bzYEAaOI=";
+  cargoHash = "sha256-dres1qO4YqmGwnjFDp6alh5+QTQa4liDBv6iMXFBlck=";
 
   cargoBuildFlags = [
     "--bin=rumdl"
   ];
-
-  postPatch = ''
-    substituteInPlace tests/cli_alias_test.rs --replace-fail \
-      'target/debug' "target/${stdenvNoCC.hostPlatform.rust.rustcTargetSpec}/$cargoCheckType"
-  '';
 
   # Non-specific tests often fail on Darwin (especially aarch64-darwin),
   # on both Hydra and GitHub-hosted runners, even with __darwinAllowLocalNetworking enabled.

--- a/pkgs/by-name/ru/rumdl/package.nix
+++ b/pkgs/by-name/ru/rumdl/package.nix
@@ -3,30 +3,40 @@
   fetchFromGitHub,
   rustPlatform,
   stdenvNoCC,
+  gitMinimal,
   versionCheckHook,
   nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rumdl";
-  version = "0.0.203";
+  version = "0.0.210";
 
   src = fetchFromGitHub {
     owner = "rvben";
     repo = "rumdl";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-co+DlgUUxHR77wXCapzCSScImL3NPzFXM5d1YFPZxgk=";
+    hash = "sha256-AxJzCRZCfm8DbybWgYnAb8kQEYXA0FCfvI8OxQwrcgI=";
   };
 
-  cargoHash = "sha256-gZw1DsKsIh4xeovJYj3lgQ+2cqqy8GfkEhtDfgq7LWs=";
+  cargoHash = "sha256-4PNacVB31uVtyNfQbYpgUmu8RxXbbXvaWS0bzYEAaOI=";
 
   cargoBuildFlags = [
     "--bin=rumdl"
   ];
 
+  postPatch = ''
+    substituteInPlace tests/cli_alias_test.rs --replace-fail \
+      'target/debug' "target/${stdenvNoCC.hostPlatform.rust.rustcTargetSpec}/$cargoCheckType"
+  '';
+
   # Non-specific tests often fail on Darwin (especially aarch64-darwin),
   # on both Hydra and GitHub-hosted runners, even with __darwinAllowLocalNetworking enabled.
   doCheck = !stdenvNoCC.hostPlatform.isDarwin;
+
+  nativeCheckInputs = [
+    gitMinimal
+  ];
 
   useNextest = true;
 

--- a/pkgs/by-name/ru/rumdl/package.nix
+++ b/pkgs/by-name/ru/rumdl/package.nix
@@ -10,16 +10,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rumdl";
-  version = "0.0.211";
+  version = "0.0.213";
 
   src = fetchFromGitHub {
     owner = "rvben";
     repo = "rumdl";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-EW/JQlzve46eKCuDqXmvdeU1X3khtuk/WiUD5XoD+N4=";
+    hash = "sha256-YUo6WU3r9phIrM8g3qfGAVaj1oSAOqgTfCoghsFU/Ng=";
   };
 
-  cargoHash = "sha256-dres1qO4YqmGwnjFDp6alh5+QTQa4liDBv6iMXFBlck=";
+  cargoHash = "sha256-JSHS1/H5jiB4NvQV5qMrui118JGxVLqOfjRLUB/cPTQ=";
 
   cargoBuildFlags = [
     "--bin=rumdl"


### PR DESCRIPTION
Diff: https://github.com/rvben/rumdl/compare/v0.0.203...v0.0.210

* nixpkgs-update has stopped after 0.0.207 because upstream added some test code which hardcoded `target/debug`.
  * https://nixpkgs-update-logs.nix-community.org/rumdl/2026-01-01.log
  * https://github.com/rvben/rumdl/blob/v0.0.207/tests/cli_alias_test.rs#L647
* Required `git` inputs for checkPhase since 0.0.209
  * https://github.com/rvben/rumdl/blame/v0.0.209/tests/cli_respect_gitignore_test.rs#L41

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

cc @Hasnep

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
