### PR TITLE
curl-impersonate: 1.2.0 -> 1.4.2

### DIFF
--- a/pkgs/by-name/cu/curl-impersonate/deps.nix
+++ b/pkgs/by-name/cu/curl-impersonate/deps.nix
@@ -7,9 +7,9 @@
     hash = "sha256-KTfK3eAHqjpSoXwhrJFT6gVHAPN5JtHZZgK/B+iIyEc=";
   };
 
-  "brotli-1.1.0.tar.gz" = fetchurl {
-    url = "https://github.com/google/brotli/archive/refs/tags/v1.1.0.tar.gz";
-    hash = "sha256-5yCmyilCi4A/StFlNxdx9TmPq6OX7fZ3iDehhZnqE/8=";
+  "brotli-1.2.0.tar.gz" = fetchurl {
+    url = "https://github.com/google/brotli/archive/refs/tags/v1.2.0.tar.gz";
+    hash = "sha256-gWyW6Ojxk7QBUdrX6P83sSIdAZ28ucNc0/rb/mR33+w=";
   };
 
   "boringssl-673e61fc215b178a90c0e67858bbf162c8158993.zip" = fetchurl {
@@ -30,5 +30,25 @@
   "nghttp3-1.9.0.tar.bz2" = fetchurl {
     url = "https://github.com/ngtcp2/nghttp3/releases/download/v1.9.0/nghttp3-1.9.0.tar.bz2";
     hash = "sha256-TTCmjxfnKhOStghdr6qfxzLaHX0m7sVUuyFnCDMvzxo=";
+  };
+
+  "zlib-1.3.1.tar.gz" = fetchurl {
+    url = "https://github.com/madler/zlib/releases/download/v1.3.1/zlib-1.3.1.tar.gz";
+    hash = "sha256-mpOyt9/ax3zrpaVYpYDnRmfdb+3kWFuR7vtg8Dty3yM=";
+  };
+
+  "zstd-1.5.6.tar.gz" = fetchurl {
+    url = "https://github.com/facebook/zstd/releases/download/v1.5.6/zstd-1.5.6.tar.gz";
+    hash = "sha256-jCngbPQqrMHq/EB3ri7Gxvy5amJhV+BZPV6Co0/UA8E=";
+  };
+
+  "libunistring-1.1.tar.gz" = fetchurl {
+    url = "https://ftp.gnu.org/gnu/libunistring/libunistring-1.1.tar.gz";
+    hash = "sha256-oiUr7uyDCsREufaNazitiD2xmRnbNbUiIs+CfDhb22o=";
+  };
+
+  "libidn2-2.3.7.tar.gz" = fetchurl {
+    url = "https://ftp.gnu.org/gnu/libidn/libidn2-2.3.7.tar.gz";
+    hash = "sha256-TCGnkbYQuVGbnQ4SuAl78vNZsS+N2SZHYRqSnmv9fWQ=";
   };
 }

--- a/pkgs/by-name/cu/curl-impersonate/package.nix
+++ b/pkgs/by-name/cu/curl-impersonate/package.nix
@@ -26,7 +26,7 @@
 }:
 stdenv.mkDerivation rec {
   pname = "curl-impersonate";
-  version = "1.2.0";
+  version = "1.4.2";
 
   outputs = [
     "out"
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
     owner = "lexiforest";
     repo = "curl-impersonate";
     tag = "v${version}";
-    hash = "sha256-tAQdTRGAOD2rpLZvoLQ2YL0wrohXEcmChMZBvYjsMhE=";
+    hash = "sha256-c24KaYc0cH6b+92kg02mMtTp7ZVu36LeDpW5xjxuzk4=";
   };
 
   # Disable blanket -Werror to fix build on `gcc-13` related to minor
@@ -157,6 +157,7 @@ stdenv.mkDerivation rec {
     let
       libext = stdenv.hostPlatform.extensions.sharedLibrary;
     in
+    # sh
     ''
       # If libnssckbi.so is needed, link libnssckbi.so without needing nss in closure
       if grep -F nssckbi $out/lib/libcurl-impersonate${libext} &>/dev/null; then
@@ -165,6 +166,9 @@ stdenv.mkDerivation rec {
           patchelf --add-needed libnssckbi${libext} $out/lib/libcurl-impersonate${libext}
         ''}
       fi
+
+      # installPhase already installs curl headers in $dev, better to override those
+      rm -rf "$dev/include/curl"
     '';
 
   disallowedReferences = [ go ];
@@ -197,7 +201,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     changelog = "https://github.com/lexiforest/curl-impersonate/releases/tag/${src.tag}";
-    description = "Special build of curl that can impersonate Chrome & Firefox";
+    description = "Special build of curl that can impersonate Chrome, Edge, Safari and Firefox";
     homepage = "https://github.com/lexiforest/curl-impersonate";
     license = with lib.licenses; [
       curl

--- a/pkgs/by-name/cu/curl-impersonate/update.sh
+++ b/pkgs/by-name/cu/curl-impersonate/update.sh
@@ -99,6 +99,26 @@ cat >"$(dirname "$pkgpath")"/deps.nix <<EOF
     url = "$(evalvar NGHTTP3_URL "$vars")";
     hash = "$(narhash "$(evalvar NGHTTP3_URL "$vars")")";
   };
+
+  "zlib-$(getvar ZLIB_VERSION "$vars").tar.gz" = fetchurl {
+    url = "$(evalvar ZLIB_URL "$vars")";
+    hash = "$(narhash "$(evalvar ZLIB_URL "$vars")")";
+  };
+
+  "zstd-$(getvar ZSTD_VERSION "$vars").tar.gz" = fetchurl {
+    url = "$(evalvar ZSTD_URL "$vars")";
+    hash = "$(narhash "$(evalvar ZSTD_URL "$vars")")";
+  };
+
+  "libunistring-$(getvar LIBUNISTRING_VERSION "$vars").tar.gz" = fetchurl {
+    url = "$(evalvar LIBUNISTRING_URL "$vars")";
+    hash = "$(narhash "$(evalvar LIBUNISTRING_URL "$vars")")";
+  };
+
+  "libidn2-$(getvar LIBIDN2_VERSION "$vars").tar.gz" = fetchurl {
+    url = "$(evalvar LIBIDN2_URL "$vars")";
+    hash = "$(narhash "$(evalvar LIBIDN2_URL "$vars")")";
+  };
 }
 EOF
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Changelogs: https://github.com/lexiforest/curl-impersonate/releases
Diff: https://github.com/lexiforest/curl-impersonate/compare/v1.2.0...v1.4.2

Notable changes:
- A few new dependencies
- Support for `chrome142` and `firefox144`
- Support for building on Android and iOS

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
