### PR TITLE
aztfexport: init at 0.18.0

### DIFF
--- a/pkgs/by-name/az/aztfexport/package.nix
+++ b/pkgs/by-name/az/aztfexport/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+  versionCheckHook,
+}:
+buildGoModule (finalAttrs: {
+  pname = "aztfexport";
+  version = "0.18.0";
+
+  src = fetchFromGitHub {
+    owner = "Azure";
+    repo = "aztfexport";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-j6WdQvbxmHOMEfCvnFDxr9ZNOZg0BIOC6u1nw+n3hA0=";
+  };
+
+  vendorHash = "sha256-qb4/sUjtfw/USITTLSuB2fXWR2mAuAcvbawrNA/ilRo=";
+
+  ldflags = [
+    "-s"
+    "-X main.version=${finalAttrs.version}"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+
+  doInstallCheck = true;
+
+  meta = {
+    description = "Tool to bring existing Azure resources under Terraform's management";
+    homepage = "https://github.com/Azure/aztfexport";
+    changelog = "https://github.com/Azure/aztfexport/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mpl20;
+    maintainers = [ lib.maintainers.john-rodewald ];
+    mainProgram = "aztfexport";
+  };
+})


### PR DESCRIPTION
## Things done

A tool to bring existing Azure resources under Terraform's management.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
