### PR TITLE
python313Packages.hap-python: disable failing test on Python 3.14

### DIFF
--- a/pkgs/development/python-modules/hap-python/default.nix
+++ b/pkgs/development/python-modules/hap-python/default.nix
@@ -17,7 +17,7 @@
   zeroconf,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "hap-python";
   version = "5.0.0";
   pyproject = true;
@@ -25,7 +25,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "ikalchev";
     repo = "HAP-python";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-+EhxoO5X/ANGh008WE0sJeBsu8SRnuds3hXGxNWpKnk=";
   };
 
@@ -49,7 +49,7 @@ buildPythonPackage rec {
     pytest-timeout
     pytestCheckHook
   ]
-  ++ optional-dependencies.QRCode;
+  ++ lib.flatten (builtins.attrValues finalAttrs.passthru.optional-dependencies);
 
   pythonImportsCheck = [ "pyhap" ];
 
@@ -61,8 +61,8 @@ buildPythonPackage rec {
   meta = {
     description = "HomeKit Accessory Protocol implementation";
     homepage = "https://github.com/ikalchev/HAP-python";
-    changelog = "https://github.com/ikalchev/HAP-python/blob/${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/ikalchev/HAP-python/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ oro ];
   };
-}
+})

--- a/pkgs/development/python-modules/hap-python/default.nix
+++ b/pkgs/development/python-modules/hap-python/default.nix
@@ -1,8 +1,8 @@
 {
   lib,
   async-timeout,
-  buildPythonPackage,
   base36,
+  buildPythonPackage,
   chacha20poly1305-reuseable,
   cryptography,
   fetchFromGitHub,
@@ -12,6 +12,7 @@
   pytest-asyncio,
   pytest-timeout,
   pytestCheckHook,
+  pythonAtLeast,
   pythonOlder,
   setuptools,
   zeroconf,
@@ -55,6 +56,11 @@ buildPythonPackage rec {
   ++ optional-dependencies.QRCode;
 
   pythonImportsCheck = [ "pyhap" ];
+
+  disabledTests = lib.optionals (pythonAtLeast "3.14") [
+    # https://github.com/ikalchev/HAP-python/issues/490
+    "test_start_from_sync"
+  ];
 
   meta = {
     description = "HomeKit Accessory Protocol implementation";

--- a/pkgs/development/python-modules/hap-python/default.nix
+++ b/pkgs/development/python-modules/hap-python/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  async-timeout,
   base36,
   buildPythonPackage,
   chacha20poly1305-reuseable,
@@ -38,9 +37,6 @@ buildPythonPackage rec {
     h11
     orjson
     zeroconf
-  ]
-  ++ lib.optionals (pythonOlder "3.11") [
-    async-timeout
   ];
 
   optional-dependencies.QRCode = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
