### PR TITLE
cbqn: 0.9.0 -> 0.10.0

### DIFF
--- a/pkgs/development/interpreters/bqn/cbqn/default.nix
+++ b/pkgs/development/interpreters/bqn/cbqn/default.nix
@@ -113,16 +113,8 @@ stdenv.mkDerivation {
     # main test suite from mlochbaum/BQN
     $out/bin/BQN ${mbqn-source}/test/this.bqn
 
-    # CBQN tests that do not require compiling with test-only flags
-    $out/bin/BQN test/cmp.bqn
-    $out/bin/BQN test/equal.bqn
-    $out/bin/BQN test/copy.bqn
-    $out/bin/BQN test/bit.bqn
-    $out/bin/BQN test/hash.bqn
-    $out/bin/BQN test/squeezeValid.bqn
-    $out/bin/BQN test/squeezeExact.bqn
-    $out/bin/BQN test/various.bqn
-    $out/bin/BQN test/random.bqn
+    # run tests in test/cases/
+    $out/bin/BQN test/run.bqn lint
 
     runHook postInstallCheck
   '';

--- a/pkgs/development/interpreters/bqn/cbqn/sources.nix
+++ b/pkgs/development/interpreters/bqn/cbqn/sources.nix
@@ -11,13 +11,13 @@
     let
       self = {
         pname = "cbqn";
-        version = "0.9.0";
+        version = "0.10.0";
 
         src = fetchFromGitHub {
           owner = "dzaima";
           repo = "CBQN";
           rev = "v${self.version}";
-          hash = "sha256-WGQvnNVnNkz0PR/E5L05KvaaRZ9hgt9gNdzsR9OFYxA=";
+          hash = "sha256-RZIxIRlx1SSYP+WrMRvg6nUqqs4zqEaGPvFyY3WFgbU=";
         };
       };
     in
@@ -25,37 +25,37 @@
 
   cbqn-bytecode = {
     pname = "cbqn-bytecode";
-    version = "0-unstable-2025-03-16";
+    version = "0-unstable-2025-11-24";
 
     src = fetchFromGitHub {
       owner = "dzaima";
       repo = "cbqnBytecode";
-      rev = "0bdfb86d438a970b983afbca93011ebd92152b88";
-      hash = "sha256-oUM4UwLy9tusTFLlaZbbHfFqKEcqd9Mh4tTqiyvMyvo=";
+      rev = "cca48b93b2e3260d2fa371c578d94cf044e39042";
+      hash = "sha256-xBjXlzWhbsKjiknnncVRkh9VlUNzaxYVNB7BhZTI/r4=";
     };
   };
 
   replxx = {
     pname = "replxx";
-    version = "0-unstable-2023-10-31";
+    version = "0-unstable-2025-05-20";
 
     src = fetchFromGitHub {
       owner = "dzaima";
       repo = "replxx";
-      rev = "13f7b60f4f79c2f14f352a76d94860bad0fc7ce9";
-      hash = "sha256-xPuQ5YBDSqhZCwssbaN/FcTZlc3ampYl7nfl2bbsgBA=";
+      rev = "c1ce5b0bcabd96ec93ebf630a85619295ec7c2f3";
+      hash = "sha256-4TEjJdF0FAIT69uVMp0y4bFFrRda1CXC/bLX6mrUTA0=";
     };
   };
 
   singeli = {
     pname = "singeli";
-    version = "0-unstable-2025-03-13";
+    version = "0-unstable-2025-11-19";
 
     src = fetchFromGitHub {
       owner = "mlochbaum";
       repo = "Singeli";
-      rev = "53f42ce4331176d281fa577408ec5a652bdd9127";
-      hash = "sha256-NbCNd/m0SdX2/aabeOhAzEYc5CcT/r75NR5ScuYj77c=";
+      rev = "2936c66b061b9df61cafc1f8d07a7ed53bf10bee";
+      hash = "sha256-vxxGmc0eQxKZN7G0GCGx7xjOWgB1a1jJIcbfbaQd2do=";
     };
   };
 }


### PR DESCRIPTION
## Things done

Tests all now moved to `test/run.bqn`. Also updated dependencies:

+ cbqn-bytecode: 0-unstable-2025-03-16 -> 0-unstable-2025-11-24
+ replxx: 0-unstable-2023-10-31 -> 0-unstable-2025-05-20
+ singeli: 0-unstable-2025-03-13 -> 0-unstable-2025-11-19

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
