### PR TITLE
python3Packages.myst-parser: fix build, cleanup

### DIFF
--- a/pkgs/development/python-modules/myst-parser/default.nix
+++ b/pkgs/development/python-modules/myst-parser/default.nix
@@ -2,9 +2,11 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+
+  # build-system
   flit-core,
-  pythonOlder,
-  defusedxml,
+
+  # dependencies
   docutils,
   jinja2,
   markdown-it-py,
@@ -12,23 +14,24 @@
   pyyaml,
   sphinx,
   typing-extensions,
+
+  # tests
   beautifulsoup4,
+  defusedxml,
   pytest-param-files,
   pytest-regressions,
-  sphinx-pytest,
   pytestCheckHook,
+  sphinx-pytest,
 }:
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "myst-parser";
   version = "4.0.1";
   pyproject = true;
 
-  disabled = pythonOlder "3.10";
-
   src = fetchFromGitHub {
     owner = "executablebooks";
     repo = "myst-parser";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-/Prauz4zuJY39EK2BmgBbH1uwjF4K38e5X5hPYwRBl0=";
   };
 
@@ -40,8 +43,8 @@ buildPythonPackage rec {
   dependencies = [
     docutils
     jinja2
-    mdit-py-plugins
     markdown-it-py
+    mdit-py-plugins
     pyyaml
     sphinx
     typing-extensions
@@ -52,20 +55,20 @@ buildPythonPackage rec {
     defusedxml
     pytest-param-files
     pytest-regressions
-    sphinx-pytest
     pytestCheckHook
+    sphinx-pytest
   ]
   ++ markdown-it-py.optional-dependencies.linkify;
 
   disabledTests = [
     # sphinx 8.2 compat
     # https://github.com/executablebooks/MyST-Parser/issues/1030
-    "test_sphinx_directives"
-    "test_references_singlehtml"
+    "test_commonmark"
     "test_extended_syntaxes"
     "test_fieldlist_extension"
     "test_includes"
-    "test_commonmark"
+    "test_references_singlehtml"
+    "test_sphinx_directives"
   ];
 
   pythonImportsCheck = [ "myst_parser" ];
@@ -73,8 +76,8 @@ buildPythonPackage rec {
   meta = {
     description = "Sphinx and Docutils extension to parse MyST";
     homepage = "https://myst-parser.readthedocs.io/";
-    changelog = "https://raw.githubusercontent.com/executablebooks/MyST-Parser/v${version}/CHANGELOG.md";
+    changelog = "https://raw.githubusercontent.com/executablebooks/MyST-Parser/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ loicreynier ];
   };
-}
+})

--- a/pkgs/development/python-modules/myst-parser/default.nix
+++ b/pkgs/development/python-modules/myst-parser/default.nix
@@ -34,6 +34,9 @@ buildPythonPackage rec {
 
   build-system = [ flit-core ];
 
+  pythonRelaxDeps = [
+    "markdown-it-py"
+  ];
   dependencies = [
     docutils
     jinja2
@@ -62,11 +65,10 @@ buildPythonPackage rec {
     "test_extended_syntaxes"
     "test_fieldlist_extension"
     "test_includes"
+    "test_commonmark"
   ];
 
   pythonImportsCheck = [ "myst_parser" ];
-
-  pythonRelaxDeps = [ "docutils" ];
 
   meta = {
     description = "Sphinx and Docutils extension to parse MyST";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- **python3Packages.myst-parser: fix build**
- **python3Packages.myst-parser: cleanup**

cc @loicreynier

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
