### PR TITLE
[Backport release-25.11] k3s: update all packages

### DIFF
--- a/pkgs/applications/networking/cluster/k3s/1_31/versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_31/versions.nix
@@ -11,5 +11,11 @@
   k3sCNISha256 = "04xig5spp81l81781ixmk99ghiz8lk0p16zhcbja5mslfdjmc7vg";
   containerdVersion = "2.1.5-k3s1.32";
   containerdSha256 = "1fzld9q0ycfg9b3054qg70mif1p6i7xqikcbabrmxapk81fy83kn";
+  containerdPackage = "github.com/k3s-io/containerd/v2";
   criCtlVersion = "1.31.0-k3s2";
+  flannelVersion = "v0.27.4";
+  flannelPluginVersion = "v1.8.0-flannel1";
+  kubeRouterVersion = "v2.6.1-k3s3";
+  criDockerdVersion = "v0.3.19-k3s2.31";
+  helmJobVersion = "";
 }

--- a/pkgs/applications/networking/cluster/k3s/1_32/images-versions.json
+++ b/pkgs/applications/networking/cluster/k3s/1_32/images-versions.json
@@ -1,26 +1,26 @@
 {
   "airgap-images-amd64-tar-gz": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.32.10%2Bk3s1/k3s-airgap-images-amd64.tar.gz",
-    "sha256": "0bad9ede6ecd09461f9f73c44073e97f20e45c59556c0db61be93f8695fdf901"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.32.11%2Bk3s1/k3s-airgap-images-amd64.tar.gz",
+    "sha256": "6dfe83a7d8984a5fe6be63a429698ce3fc61761ce68e3f4f2c6f3ff96a349f37"
   },
   "airgap-images-amd64-tar-zst": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.32.10%2Bk3s1/k3s-airgap-images-amd64.tar.zst",
-    "sha256": "4217e7a36bfecc66cd678e854175f740f6b97dda44b094a132bf751c7198bba9"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.32.11%2Bk3s1/k3s-airgap-images-amd64.tar.zst",
+    "sha256": "9b6a7ea64b7b14a6c43613e4e170902e99c600857265875282f8d4b9dfefa6f4"
   },
   "airgap-images-arm-tar-gz": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.32.10%2Bk3s1/k3s-airgap-images-arm.tar.gz",
-    "sha256": "7c21cafa273e4cf30fd43c7fccb147897084bb7eba21c9e99b3ae0246eef7a55"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.32.11%2Bk3s1/k3s-airgap-images-arm.tar.gz",
+    "sha256": "cbda428d59a8593267343fb32ad985bf2125f45860425f9b7b31bbea9d305046"
   },
   "airgap-images-arm-tar-zst": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.32.10%2Bk3s1/k3s-airgap-images-arm.tar.zst",
-    "sha256": "a52d31f6dbc756ffe8a1701d3ad52d432a904d7b34932049d411f16bc3bb4e2c"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.32.11%2Bk3s1/k3s-airgap-images-arm.tar.zst",
+    "sha256": "b1a253aab260beabea305517d8d57cce4594d2e071320d5700d389b29eb3c196"
   },
   "airgap-images-arm64-tar-gz": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.32.10%2Bk3s1/k3s-airgap-images-arm64.tar.gz",
-    "sha256": "d35f436ed082ccde1b3712617b05da4464832747bb41dcd14261237834d91296"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.32.11%2Bk3s1/k3s-airgap-images-arm64.tar.gz",
+    "sha256": "0f6e598bf90b9ced4f1f758db6b0d7f8afbf9b5973d801d8a743c5b27ac3b748"
   },
   "airgap-images-arm64-tar-zst": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.32.10%2Bk3s1/k3s-airgap-images-arm64.tar.zst",
-    "sha256": "a32df1ffd86eb63e5f91e1c69438ff4074020ca76976a293321e524bc1562fc0"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.32.11%2Bk3s1/k3s-airgap-images-arm64.tar.zst",
+    "sha256": "297beda34a0a2a7ff727fced94dba6f999636a4e9b2cdd6e30840cc0e746a4ee"
   }
 }

--- a/pkgs/applications/networking/cluster/k3s/1_32/versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_32/versions.nix
@@ -1,8 +1,8 @@
 {
-  k3sVersion = "1.32.10+k3s1";
-  k3sCommit = "1c5d65cec8e24f5238e2e0b21f0dac8c2f8d5db5";
-  k3sRepoSha256 = "0wfh2m55dxfvf3m74jrwvpc21xxc17gwbifnkl9nyd8kha271876";
-  k3sVendorHash = "sha256-PedpbkyP3XZ8yLlFo/VGjPlImYGOk5ebPYGivPR2Izg=";
+  k3sVersion = "1.32.11+k3s1";
+  k3sCommit = "8119508834f2503e3c7bace3125f5db6b038d377";
+  k3sRepoSha256 = "0fni4sh3a5flyrli7xxd9zxj9sh75kv79msy3zkfbgjxqz7rg4v9";
+  k3sVendorHash = "sha256-8gzvad5Cpkatc8158m9FBGnkGEbajn30alSPlzhor0E=";
   chartVersions = import ./chart-versions.nix;
   imagesVersions = builtins.fromJSON (builtins.readFile ./images-versions.json);
   k3sRootVersion = "0.15.0";
@@ -11,11 +11,11 @@
   k3sCNISha256 = "04xig5spp81l81781ixmk99ghiz8lk0p16zhcbja5mslfdjmc7vg";
   containerdVersion = "2.1.5-k3s1.32";
   containerdSha256 = "1fzld9q0ycfg9b3054qg70mif1p6i7xqikcbabrmxapk81fy83kn";
-  containerdPackage = "";
+  containerdPackage = "github.com/k3s-io/containerd/v2";
   criCtlVersion = "1.31.0-k3s2";
-  flannelVersion = "";
-  flannelPluginVersion = "";
-  kubeRouterVersion = "";
-  criDockerdVersion = "";
-  helmJobVersion = "";
+  flannelVersion = "v0.27.4";
+  flannelPluginVersion = "v1.8.0-flannel1";
+  kubeRouterVersion = "v2.6.3-k3s1";
+  criDockerdVersion = "v0.3.19-k3s2.32";
+  helmJobVersion = "v0.9.12-build20251215";
 }

--- a/pkgs/applications/networking/cluster/k3s/1_32/versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_32/versions.nix
@@ -11,5 +11,11 @@
   k3sCNISha256 = "04xig5spp81l81781ixmk99ghiz8lk0p16zhcbja5mslfdjmc7vg";
   containerdVersion = "2.1.5-k3s1.32";
   containerdSha256 = "1fzld9q0ycfg9b3054qg70mif1p6i7xqikcbabrmxapk81fy83kn";
+  containerdPackage = "";
   criCtlVersion = "1.31.0-k3s2";
+  flannelVersion = "";
+  flannelPluginVersion = "";
+  kubeRouterVersion = "";
+  criDockerdVersion = "";
+  helmJobVersion = "";
 }

--- a/pkgs/applications/networking/cluster/k3s/1_33/images-versions.json
+++ b/pkgs/applications/networking/cluster/k3s/1_33/images-versions.json
@@ -1,26 +1,26 @@
 {
   "airgap-images-amd64-tar-gz": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.6%2Bk3s1/k3s-airgap-images-amd64.tar.gz",
-    "sha256": "9cc46db774c51e4195dfe3c2dafe1ecc18c7293bf08e7a81258aec07e60fc26d"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.7%2Bk3s1/k3s-airgap-images-amd64.tar.gz",
+    "sha256": "47644f3141878535a1951fdaf03bc485001b50a58b8fb58d97c75c49ea38a1f0"
   },
   "airgap-images-amd64-tar-zst": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.6%2Bk3s1/k3s-airgap-images-amd64.tar.zst",
-    "sha256": "1a852774a4cf27b24b1c60fc8fdc88e1f31841955dad99dfedd492a4ccfb6c08"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.7%2Bk3s1/k3s-airgap-images-amd64.tar.zst",
+    "sha256": "9b6a7ea64b7b14a6c43613e4e170902e99c600857265875282f8d4b9dfefa6f4"
   },
   "airgap-images-arm-tar-gz": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.6%2Bk3s1/k3s-airgap-images-arm.tar.gz",
-    "sha256": "4026e1da9f3f184e4d66474d278785c50276867e057376073504b63f06d48e7c"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.7%2Bk3s1/k3s-airgap-images-arm.tar.gz",
+    "sha256": "ee76f65f39a0ca12bbaa6bf9fdd5dc161b553b15a5746d47795cf0113916c063"
   },
   "airgap-images-arm-tar-zst": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.6%2Bk3s1/k3s-airgap-images-arm.tar.zst",
-    "sha256": "c1f1dc4e3a3f42ec1aad051b0d7a6ecb4853f5f428f043c318d1aab5ab73728d"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.7%2Bk3s1/k3s-airgap-images-arm.tar.zst",
+    "sha256": "b1a253aab260beabea305517d8d57cce4594d2e071320d5700d389b29eb3c196"
   },
   "airgap-images-arm64-tar-gz": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.6%2Bk3s1/k3s-airgap-images-arm64.tar.gz",
-    "sha256": "7bbe0b76621debfeaf8f50a931e833102d7cade1a65b7fd8ff83027aa8f5add5"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.7%2Bk3s1/k3s-airgap-images-arm64.tar.gz",
+    "sha256": "a2f534291abd4d6491dc669b46e437df1fe0cd7b573485ec30aa813510b22635"
   },
   "airgap-images-arm64-tar-zst": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.6%2Bk3s1/k3s-airgap-images-arm64.tar.zst",
-    "sha256": "059a3595138d019c676b2753b144dab613c4ee1d3892a115a95e74d665009b1b"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.7%2Bk3s1/k3s-airgap-images-arm64.tar.zst",
+    "sha256": "87db88828e43179ef30a17ba66b416a3e398c4a00673908bd8d39ae4996ce300"
   }
 }

--- a/pkgs/applications/networking/cluster/k3s/1_33/versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_33/versions.nix
@@ -1,8 +1,8 @@
 {
-  k3sVersion = "1.33.6+k3s1";
-  k3sCommit = "b5847677be5afdc431f70afec6780679c3845d16";
-  k3sRepoSha256 = "0pm8x121pb6pyn9rq9c5pbr7y293rzyp0q3c5mc1gb4glqwx7f8g";
-  k3sVendorHash = "sha256-Cjacx5i1ahZ9RBXBTsUtmNDyyofw1fedpExTHuU8grA=";
+  k3sVersion = "1.33.7+k3s1";
+  k3sCommit = "0b396d3f7f26e0c2ae5b6a114383830f533938c2";
+  k3sRepoSha256 = "0jkvm7c333zazabsxrjl6wkdsni1m5g5gamriyyf53lly9935wsf";
+  k3sVendorHash = "sha256-HpgcO/mUo64mkH38sAURnLOmXdXmHh3o6iDKtQeUt/E=";
   chartVersions = import ./chart-versions.nix;
   imagesVersions = builtins.fromJSON (builtins.readFile ./images-versions.json);
   k3sRootVersion = "0.15.0";
@@ -11,11 +11,11 @@
   k3sCNISha256 = "04xig5spp81l81781ixmk99ghiz8lk0p16zhcbja5mslfdjmc7vg";
   containerdVersion = "2.1.5-k3s1.33";
   containerdSha256 = "15iw6px3710rlsx7j933i07qd4a2r7caagfjbhhfcp33m9k19v7h";
-  containerdPackage = "";
+  containerdPackage = "github.com/k3s-io/containerd/v2";
   criCtlVersion = "1.33.0-k3s2";
-  flannelVersion = "";
-  flannelPluginVersion = "";
-  kubeRouterVersion = "";
-  criDockerdVersion = "";
-  helmJobVersion = "";
+  flannelVersion = "v0.27.4";
+  flannelPluginVersion = "v1.8.0-flannel1";
+  kubeRouterVersion = "v2.6.3-k3s1";
+  criDockerdVersion = "v0.3.19-k3s2";
+  helmJobVersion = "v0.9.12-build20251215";
 }

--- a/pkgs/applications/networking/cluster/k3s/1_33/versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_33/versions.nix
@@ -11,5 +11,11 @@
   k3sCNISha256 = "04xig5spp81l81781ixmk99ghiz8lk0p16zhcbja5mslfdjmc7vg";
   containerdVersion = "2.1.5-k3s1.33";
   containerdSha256 = "15iw6px3710rlsx7j933i07qd4a2r7caagfjbhhfcp33m9k19v7h";
+  containerdPackage = "";
   criCtlVersion = "1.33.0-k3s2";
+  flannelVersion = "";
+  flannelPluginVersion = "";
+  kubeRouterVersion = "";
+  criDockerdVersion = "";
+  helmJobVersion = "";
 }

--- a/pkgs/applications/networking/cluster/k3s/1_34/images-versions.json
+++ b/pkgs/applications/networking/cluster/k3s/1_34/images-versions.json
@@ -1,26 +1,26 @@
 {
   "airgap-images-amd64-tar-gz": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.34.2%2Bk3s1/k3s-airgap-images-amd64.tar.gz",
-    "sha256": "4bfa596bec42e8752d6f90e69e724ee438c2a8c3ba7827c3d4f30ca8ca30de35"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.34.3%2Bk3s1/k3s-airgap-images-amd64.tar.gz",
+    "sha256": "499d7fb0b2eab200e9bf9b3935ce787a7fa0597933dce25ad091703933d6ecc8"
   },
   "airgap-images-amd64-tar-zst": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.34.2%2Bk3s1/k3s-airgap-images-amd64.tar.zst",
-    "sha256": "24359781bd775f513691e98031853d79eac53e265f7d72d1e7325df4f3b18eb0"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.34.3%2Bk3s1/k3s-airgap-images-amd64.tar.zst",
+    "sha256": "b8dff3265568e1be66ab72ac0ded68bd266fa37a32c010f1253dba6547a49ce8"
   },
   "airgap-images-arm-tar-gz": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.34.2%2Bk3s1/k3s-airgap-images-arm.tar.gz",
-    "sha256": "ee792ad7b22a03567fd2dea4e16bf239667df50367f6b65070d5daf76e6054f8"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.34.3%2Bk3s1/k3s-airgap-images-arm.tar.gz",
+    "sha256": "170db25228c873741f895fced05f0e5bdbbddb8ffeb5e0342a5b8e44f3c28757"
   },
   "airgap-images-arm-tar-zst": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.34.2%2Bk3s1/k3s-airgap-images-arm.tar.zst",
-    "sha256": "ae43b262c9d739a7b693670825160e9afab6b10fdb975659679de576b84ae286"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.34.3%2Bk3s1/k3s-airgap-images-arm.tar.zst",
+    "sha256": "27407fd1553c89b8ccd3b45ad0fbdcd483c1a010e7b28b60b24a8e73b58aa783"
   },
   "airgap-images-arm64-tar-gz": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.34.2%2Bk3s1/k3s-airgap-images-arm64.tar.gz",
-    "sha256": "2e0383744babd5e801acdb2c6bd9cced8cf2d60c7b4a699ecf3311e200aeacdb"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.34.3%2Bk3s1/k3s-airgap-images-arm64.tar.gz",
+    "sha256": "e67cddf839571cd489aef44acb2aca82285a9789a170c1a44d51b7f8b6129883"
   },
   "airgap-images-arm64-tar-zst": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.34.2%2Bk3s1/k3s-airgap-images-arm64.tar.zst",
-    "sha256": "41b34aab92bc5166135dc73217ead65766688fd3543166ce32ffff7e101bef46"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.34.3%2Bk3s1/k3s-airgap-images-arm64.tar.zst",
+    "sha256": "b6cb3c06f19859d3a5fba54b305097e89d2a86b5bce9e8360a46b9d2e67da565"
   }
 }

--- a/pkgs/applications/networking/cluster/k3s/1_34/versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_34/versions.nix
@@ -1,8 +1,8 @@
 {
-  k3sVersion = "1.34.2+k3s1";
-  k3sCommit = "8dac81b2a24e78ce4cf951c7788ea6a8d4a59aa7";
-  k3sRepoSha256 = "1nwh1aggxvjv99kz1zkklim7jqsn0d44g8905653gkfpk0givghq";
-  k3sVendorHash = "sha256-IJi5gVxBsAjeQHi5rQpNRvWOXuNPx2Rtsy18VL+2Yxo=";
+  k3sVersion = "1.34.3+k3s1";
+  k3sCommit = "48ffa7b6893f21b919b3029d54c9d9838ae426a1";
+  k3sRepoSha256 = "1177kzbhp6ihb7dzfdi1a0idgp69y1hwh6wnwvdx1fnivg2gj7aw";
+  k3sVendorHash = "sha256-dp8SU24nuy3WmG1Zln/J2nVHnVQmVyN78FBOSxNjbF8=";
   chartVersions = import ./chart-versions.nix;
   imagesVersions = builtins.fromJSON (builtins.readFile ./images-versions.json);
   k3sRootVersion = "0.15.0";
@@ -11,11 +11,11 @@
   k3sCNISha256 = "04xig5spp81l81781ixmk99ghiz8lk0p16zhcbja5mslfdjmc7vg";
   containerdVersion = "2.1.5-k3s1";
   containerdSha256 = "0n0g58d352i8wz0bqn87vgrd7z54j268cbmbp19fz68wmifm7fl8";
-  containerdPackage = "";
+  containerdPackage = "github.com/k3s-io/containerd/v2";
   criCtlVersion = "1.34.0-k3s2";
-  flannelVersion = "";
-  flannelPluginVersion = "";
-  kubeRouterVersion = "";
-  criDockerdVersion = "";
-  helmJobVersion = "";
+  flannelVersion = "v0.27.4";
+  flannelPluginVersion = "v1.8.0-flannel1";
+  kubeRouterVersion = "v2.6.3-k3s1";
+  criDockerdVersion = "v0.3.19-k3s3";
+  helmJobVersion = "v0.9.12-build20251215";
 }

--- a/pkgs/applications/networking/cluster/k3s/1_34/versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_34/versions.nix
@@ -11,5 +11,11 @@
   k3sCNISha256 = "04xig5spp81l81781ixmk99ghiz8lk0p16zhcbja5mslfdjmc7vg";
   containerdVersion = "2.1.5-k3s1";
   containerdSha256 = "0n0g58d352i8wz0bqn87vgrd7z54j268cbmbp19fz68wmifm7fl8";
+  containerdPackage = "";
   criCtlVersion = "1.34.0-k3s2";
+  flannelVersion = "";
+  flannelPluginVersion = "";
+  kubeRouterVersion = "";
+  criDockerdVersion = "";
+  helmJobVersion = "";
 }

--- a/pkgs/applications/networking/cluster/k3s/builder.nix
+++ b/pkgs/applications/networking/cluster/k3s/builder.nix
@@ -6,7 +6,7 @@ lib:
   k3sCommit,
   k3sRepoSha256 ? lib.fakeHash,
   k3sVendorHash ? lib.fakeHash,
-  # taken from ./scripts/version.sh VERSION_ROOT https://github.com/k3s-io/k3s/blob/v1.23.3%2Bk3s1/scripts/version.sh#L47
+  # taken from ./scripts/version.sh VERSION_ROOT
   k3sRootVersion,
   k3sRootSha256 ? lib.fakeHash,
   # Based on the traefik charts here: https://github.com/k3s-io/k3s/blob/d71ab6317e22dd34673faa307a412a37a16767f6/scripts/download#L29-L32
@@ -14,15 +14,27 @@ lib:
   chartVersions,
   # Air gap container images that are released as assets with every k3s release
   imagesVersions,
-  # taken from ./scripts/version.sh VERSION_CNIPLUGINS https://github.com/k3s-io/k3s/blob/v1.23.3%2Bk3s1/scripts/version.sh#L45
+  # taken from ./scripts/version.sh VERSION_CNIPLUGINS
   k3sCNIVersion,
   k3sCNISha256 ? lib.fakeHash,
   # taken from ./scripts/version.sh VERSION_CONTAINERD
   containerdVersion,
   containerdSha256 ? lib.fakeHash,
+  # taken from ./scripts/version.sh PKG_CONTAINERD_K3S
+  containerdPackage,
   # run `grep github.com/kubernetes-sigs/cri-tools go.mod | head -n1 | awk '{print $4}'` in the k3s repo at the tag
   criCtlVersion,
   updateScript ? null,
+  # taken from ./scripts/version.sh VERSION_FLANNEL
+  flannelVersion,
+  # taken from ./scripts/version.sh VERSION_FLANNEL_PLUGIN
+  flannelPluginVersion,
+  # taken from ./scripts/version.sh VERSION_KUBE_ROUTER
+  kubeRouterVersion,
+  # taken from ./scripts/version.sh VERSION_CRI_DOCKERD
+  criDockerdVersion,
+  # taken from ./scripts/version.sh VERSION_HELM_JOB
+  helmJobVersion,
 }@attrs:
 
 # builder.nix contains a "builder" expression that, given k3s version and hash
@@ -109,23 +121,58 @@ let
     priority = 5;
   };
 
-  # https://github.com/k3s-io/k3s/blob/5fb370e53e0014dc96183b8ecb2c25a61e891e76/scripts/build#L19-L40
-  versionldflags = [
-    "-X github.com/k3s-io/k3s/pkg/version.Version=v${k3sVersion}"
-    "-X github.com/k3s-io/k3s/pkg/version.GitCommit=${lib.substring 0 8 k3sCommit}"
-    "-X github.com/k3s-io/k3s/pkg/version.UpstreamGolang=go${go.version}"
-    "-X k8s.io/client-go/pkg/version.gitVersion=v${k3sVersion}"
-    "-X k8s.io/client-go/pkg/version.gitCommit=${k3sCommit}"
-    "-X k8s.io/client-go/pkg/version.gitTreeState=clean"
-    "-X k8s.io/client-go/pkg/version.buildDate=1970-01-01T01:01:01Z"
-    "-X k8s.io/component-base/version.gitVersion=v${k3sVersion}"
-    "-X k8s.io/component-base/version.gitCommit=${k3sCommit}"
-    "-X k8s.io/component-base/version.gitTreeState=clean"
-    "-X k8s.io/component-base/version.buildDate=1970-01-01T01:01:01Z"
-    "-X github.com/kubernetes-sigs/cri-tools/pkg/version.Version=v${criCtlVersion}"
-    "-X github.com/containerd/containerd/version.Version=v${containerdVersion}"
-    "-X github.com/containerd/containerd/version.Package=github.com/k3s-io/containerd"
-  ];
+  # https://github.com/k3s-io/k3s/blob/fd48cd623340a4a6e3b2717dede368283cedec1a/scripts/build#L23-L59
+  versionldflags =
+    let
+      PKG = "github.com/k3s-io/k3s";
+      PKG_CONTAINERD = "github.com/containerd/containerd/v2";
+      PKG_CRICTL = "sigs.k8s.io/cri-tools/pkg";
+      PKG_K8S_BASE = "k8s.io/component-base";
+      PKG_K8S_CLIENT = "k8s.io/client-go/pkg";
+      PKG_CNI_PLUGINS = "github.com/containernetworking/plugins";
+      PKG_KUBE_ROUTER = "github.com/cloudnativelabs/kube-router/v2";
+      PKG_CRI_DOCKERD = "github.com/Mirantis/cri-dockerd";
+      PKG_ETCD = "go.etcd.io/etcd";
+      PKG_HELM_CONTROLLER = "github.com/k3s-io/helm-controller";
+      buildDate = "1970-01-01T01:01:01Z";
+    in
+    [
+      "-X ${PKG}/pkg/version.Version=${k3sVersion}"
+      "-X ${PKG}/pkg/version.GitCommit=${lib.substring 0 8 k3sCommit}"
+      "-X ${PKG}/pkg/version.UpstreamGolang=go${go.version}"
+
+      "-X ${PKG_K8S_CLIENT}/version.gitVersion=v${k3sVersion}"
+      "-X ${PKG_K8S_CLIENT}/version.gitCommit=${k3sCommit}"
+      "-X ${PKG_K8S_CLIENT}/version.gitTreeState=clean"
+      "-X ${PKG_K8S_CLIENT}/version.buildDate=${buildDate}"
+
+      "-X ${PKG_K8S_BASE}/version.gitVersion=v${k3sVersion}"
+      "-X ${PKG_K8S_BASE}/version.gitCommit=${k3sCommit}"
+      "-X ${PKG_K8S_BASE}/version.gitTreeState=clean"
+      "-X ${PKG_K8S_BASE}/version.buildDate=${buildDate}"
+
+      "-X ${PKG_CRICTL}/version.Version=${criCtlVersion}"
+
+      "-X ${PKG_CONTAINERD}/version.Version=${containerdVersion}"
+      "-X ${PKG_CONTAINERD}/version.Package=${containerdPackage}"
+
+      "-X ${PKG_CNI_PLUGINS}/pkg/utils/buildversion.BuildVersion=${k3sCNIVersion}"
+      "-X ${PKG_CNI_PLUGINS}/plugins/meta/flannel.Program=flannel"
+      "-X ${PKG_CNI_PLUGINS}/plugins/meta/flannel.Version=${flannelPluginVersion}+${flannelVersion}"
+      "-X ${PKG_CNI_PLUGINS}/plugins/meta/flannel.Commit=HEAD"
+      "-X ${PKG_CNI_PLUGINS}/plugins/meta/flannel.buildDate=${buildDate}"
+
+      "-X ${PKG_KUBE_ROUTER}/pkg/version.Version=${kubeRouterVersion}"
+      "-X ${PKG_KUBE_ROUTER}/pkg/version.BuildDate=${buildDate}"
+
+      "-X ${PKG_CRI_DOCKERD}/cmd/version.Version=${criDockerdVersion}"
+      "-X ${PKG_CRI_DOCKERD}/cmd/version.GitCommit=HEAD"
+      "-X ${PKG_CRI_DOCKERD}/cmd/version.BuildTime=${buildDate}"
+
+      "-X ${PKG_ETCD}/api/v3/version.GitSHA=HEAD"
+
+      "-X ${PKG_HELM_CONTROLLER}/pkg/controllers/chart.DefaultJobImage=rancher/klipper-helm:${helmJobVersion}"
+    ];
 
   # bundled into the k3s binary
   traefik = {

--- a/pkgs/applications/networking/cluster/k3s/builder.nix
+++ b/pkgs/applications/networking/cluster/k3s/builder.nix
@@ -346,16 +346,6 @@ buildGoModule (finalAttrs: {
       --replace-fail '"$LDFLAGS $STATIC" -o' \
                 '"$LDFLAGS" -o'
 
-    # Upstream codegen fails with trimpath set. Removes "trimpath" for 'go generate':
-
-    substituteInPlace scripts/package-cli \
-      --replace-fail '"''${GO}" generate' \
-                'GOFLAGS="" \
-                 GOOS="${pkgsBuildBuild.go.GOOS}" \
-                 GOARCH="${pkgsBuildBuild.go.GOARCH}" \
-                 CC="${pkgsBuildBuild.stdenv.cc}/bin/cc" \
-                 "''${GO}" generate'
-
     # Add the -e flag to process "errornous" packages. We need to modify this because the upstream
     # build-time version detection doesn't work with a vendor directory.
     substituteInPlace scripts/version.sh \

--- a/pkgs/applications/networking/cluster/k3s/builder.nix
+++ b/pkgs/applications/networking/cluster/k3s/builder.nix
@@ -426,8 +426,8 @@ buildGoModule (finalAttrs: {
     rsync -a --no-perms --chmod u=rwX ${k3sRoot}/etc/ ./etc/
 
     export ARCH=$GOARCH
-    export DRONE_TAG="v${k3sVersion}"
-    export DRONE_COMMIT="${k3sCommit}"
+    export TAG="v${k3sVersion}"
+    export GITHUB_SHA="${k3sCommit}"
     # use ./scripts/package-cli to run 'go generate' + 'go build'
 
     ./scripts/package-cli

--- a/pkgs/applications/networking/cluster/k3s/default.nix
+++ b/pkgs/applications/networking/cluster/k3s/default.nix
@@ -23,6 +23,10 @@ in
       }
     ) extraArgs).overrideAttrs
       {
+        # versionCheckHook fails with updated k3s builder
+        nativeInstallCheckInputs = [ ];
+        # limited functionality due to missing version data
+        meta.broken = true;
         meta.knownVulnerabilities = [ "k3s_1_31 has reached end-of-life on 2025-11-11" ];
       };
 

--- a/pkgs/applications/networking/cluster/k3s/update-script.sh
+++ b/pkgs/applications/networking/cluster/k3s/update-script.sh
@@ -35,8 +35,8 @@ K3S_REPO_SHA256=${PREFETCH_META%$'\n'*}
 
 cd "$K3S_STORE_PATH"
 # Set the DRONE variables as they are expected to be set in version.sh
-DRONE_TAG="$LATEST_TAG_NAME"
-DRONE_COMMIT="$K3S_COMMIT"
+TAG="$LATEST_TAG_NAME"
+GITHUB_SHA="$K3S_COMMIT"
 NO_DAPPER="" # Source git_version.sh in scripts/version.sh#L8
 source "${K3S_STORE_PATH}/scripts/version.sh"
 

--- a/pkgs/applications/networking/cluster/k3s/update-script.sh
+++ b/pkgs/applications/networking/cluster/k3s/update-script.sh
@@ -119,7 +119,13 @@ cat >versions.nix <<EOF
   k3sCNISha256 = "${CNIPLUGINS_SHA256}";
   containerdVersion = "${VERSION_CONTAINERD:1}";
   containerdSha256 = "${CONTAINERD_SHA256}";
+  containerdPackage = "${PKG_CONTAINERD_K3S}";
   criCtlVersion = "${VERSION_CRICTL:1}";
+  flannelVersion = "${VERSION_FLANNEL}";
+  flannelPluginVersion = "${VERSION_FLANNEL_PLUGIN}";
+  kubeRouterVersion = "${VERSION_KUBE_ROUTER}";
+  criDockerdVersion = "${VERSION_CRI_DOCKERD}";
+  helmJobVersion = "${VERSION_HELM_JOB}";
 }
 EOF
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Manual backport of https://github.com/NixOS/nixpkgs/pull/476287. The changes to the builder lead to eval errors for the EOL package `k3s_1_31`. This adds variables to make the build theoretically work, however, the version check hook also fails with the new builder.

As a result, `k3s_1_31` is now also marked as broken. The package can be built if the version check hook is removed from `builder.nix`.

Replaces https://github.com/NixOS/nixpkgs/pull/477079

@NixOS/k3s 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
