### PR TITLE
glslang: modernize

### DIFF
--- a/pkgs/by-name/gl/glslang/package.nix
+++ b/pkgs/by-name/gl/glslang/package.nix
@@ -9,14 +9,14 @@
   spirv-headers,
   spirv-tools,
 }:
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "glslang";
   version = "16.1.0";
 
   src = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "glslang";
-    rev = version;
+    rev = finalAttrs.version;
     hash = "sha256-cEREniYgSd62mnvKaQkgs69ETL5pLl5Gyv3hKOtSv3w=";
   };
 
@@ -50,10 +50,10 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    inherit (src.meta) homepage;
+    inherit (finalAttrs.src.meta) homepage;
     description = "Khronos reference front-end for GLSL and ESSL";
     license = lib.licenses.asl20;
     platforms = lib.platforms.unix;
     maintainers = [ lib.maintainers.ralith ];
   };
-}
+})

--- a/pkgs/by-name/gl/glslang/package.nix
+++ b/pkgs/by-name/gl/glslang/package.nix
@@ -39,7 +39,9 @@ stdenv.mkDerivation rec {
     jq
   ];
 
-  cmakeFlags = [ "-DBUILD_SHARED_LIBS=ON" ];
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
+  ];
 
   postPatch = ''
     cp --no-preserve=mode -r "${spirv-tools.src}" External/spirv-tools

--- a/pkgs/by-name/gl/glslang/package.nix
+++ b/pkgs/by-name/gl/glslang/package.nix
@@ -6,6 +6,7 @@
   python3,
   spirv-headers,
   spirv-tools,
+  config,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "glslang";
@@ -44,6 +45,14 @@ stdenv.mkDerivation (finalAttrs: {
     # add a symlink for backwards compatibility
     ln -s $bin/bin/glslang $bin/bin/glslangValidator
   '';
+
+  passthru = lib.optionalAttrs config.allowAliases {
+    # Added 2026-01-06, https://github.com/NixOS/nixpkgs/pull/477412
+    spirv-tools = throw "'glslang' no longer pins to specific 'spirv-tools'";
+
+    # Added 2026-01-06, https://github.com/NixOS/nixpkgs/pull/477412
+    spirv-headers = throw "'glslang' no longer pins to specific 'spirv-headers'";
+  };
 
   meta = {
     inherit (finalAttrs.src.meta) homepage;

--- a/pkgs/by-name/gl/glslang/package.nix
+++ b/pkgs/by-name/gl/glslang/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "glslang";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-cEREniYgSd62mnvKaQkgs69ETL5pLl5Gyv3hKOtSv3w=";
   };
 

--- a/pkgs/by-name/gl/glslang/package.nix
+++ b/pkgs/by-name/gl/glslang/package.nix
@@ -2,9 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  bison,
   cmake,
-  jq,
   python3,
   spirv-headers,
   spirv-tools,
@@ -29,8 +27,6 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     cmake
     python3
-    bison
-    jq
   ];
 
   propagatedBuildInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Tested by building `shader-slang.tests.hello`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
