### PR TITLE
librespot-ma: 0.7.1-unstable-2025-11-06 -> 0.8.0-unstable-2025-12-05

### DIFF
--- a/pkgs/by-name/li/librespot-ma/package.nix
+++ b/pkgs/by-name/li/librespot-ma/package.nix
@@ -8,16 +8,16 @@
 
 rustPlatform.buildRustPackage {
   pname = "librespot-ma";
-  version = "0.7.1-unstable-2025-11-06";
+  version = "0.8.0-unstable-2025-12-05";
 
   src = fetchFromGitHub {
     owner = "music-assistant";
     repo = "librespot";
-    rev = "2af61256649d6c1ed149791a53a20a595b617704";
-    hash = "sha256-sarxS6YArK5luX4TRXJUKhreMqhZbsS/3fCVWHxPNpY=";
+    rev = "1d68d603027d89d1a60bf5a15f180e28382e2cfc";
+    hash = "sha256-quKAiXqTwf6cgKi9qqksQRaGqV9UZjerHQZfqDVHCIs=";
   };
 
-  cargoHash = "sha256-CI2BFmQNK1+J2qaKg6u6WM83jwBuWjeh9dROnrF3Kv0=";
+  cargoHash = "sha256-Kf3w6tD/MQaXXegtiCkFbUcYwr4OMw6ipLxNLxJ2NTQ=";
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
Fixes:
```
Valid `--volume-ctrl` / `-E` values: cubic, fixed, linear, log
[2026-01-06T09:37:31Z ERROR librespot] Invalid `--volume-ctrl` / `-E`: "passthrough"
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
