### PR TITLE
shorewall: 5.2.3.3 -> 5.2.8

### DIFF
--- a/pkgs/by-name/sh/shorewall/package.nix
+++ b/pkgs/by-name/sh/shorewall/package.nix
@@ -23,20 +23,20 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "shorewall";
-  version = "5.2.3.3";
+  version = "5.2.8";
 
   srcs = [
     (fetchurl {
-      url = "http://www.shorewall.net/pub/shorewall/5.2/shorewall-5.2.3/shorewall-core-${version}.tar.bz2";
-      sha256 = "1gg2yfxzm3y9qqjrrg5nq2ggi1c6yfxx0s7fvwjw70b185mwa5p5";
+      url = "https://shorewall.org/pub/shorewall/5.2/shorewall-5.2.8/shorewall-core-${version}.tar.bz2";
+      hash = "sha256-OZlrlpeiAXlHBJrT8DyyeOj5Of+SSyu0vyoLwXxZmI4=";
     })
     (fetchurl {
-      url = "http://www.shorewall.net/pub/shorewall/5.2/shorewall-5.2.3/shorewall-${version}.tar.bz2";
-      sha256 = "1ka70pa3s0cnvc83rlm57r05cdv9idnxnq0vmxi6nr7razak5f3b";
+      url = "https://shorewall.org/pub/shorewall/5.2/shorewall-5.2.8/shorewall-${version}.tar.bz2";
+      hash = "sha256-+7WrSS7TcuqvAoF8xzD4LEmoHFpfXO5LyPG86EbyMG0=";
     })
     (fetchurl {
-      url = "http://www.shorewall.net/pub/shorewall/5.2/shorewall-5.2.3/shorewall6-${version}.tar.bz2";
-      sha256 = "0mhs4m6agwk082h1n69gnyfsjpycdd8215r4r9rzb3czs5xi087n";
+      url = "https://shorewall.org/pub/shorewall/5.2/shorewall-5.2.8/shorewall6-${version}.tar.bz2";
+      hash = "sha256-6Cw6lTi2VIGVOY3DnIOwG89m61oigUyRWpJLmtwIjNE=";
     })
   ];
   sourceRoot = ".";
@@ -107,7 +107,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = "http://www.shorewall.net/";
+    homepage = "https://shorewall.org/";
     description = "IP gateway/firewall configuration tool for GNU/Linux";
     longDescription = ''
       Shorewall is a high-level tool for configuring Netfilter. You describe your


### PR DESCRIPTION
Releasenotes: https://shorewall.org/pub/shorewall/5.2/shorewall-5.2.8/releasenotes.txt

The source seems to have been moved as `http://www.shorewall.net` redirects to `https://shorewall.org`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
