### PR TITLE
moon-buggy: fix build with GCC 15

### DIFF
--- a/pkgs/by-name/mo/moon-buggy/fix-signal-handler.patch
+++ b/pkgs/by-name/mo/moon-buggy/fix-signal-handler.patch
@@ -1,0 +1,26 @@
+diff --git a/configure b/configure
+index 536fc31..13622e7 100755
+--- a/configure
++++ b/configure
+@@ -4559,7 +4559,7 @@ else
+   echo "$as_me: failed program was:" >&5
+ sed 's/^/| /' conftest.$ac_ext >&5
+ 
+-ac_cv_type_signal=int
++ac_cv_type_signal=void
+ fi
+ rm -f conftest.err conftest.$ac_objext conftest.$ac_ext
+ fi
+diff --git a/signal.c b/signal.c
+index 8cbb774..2f16e30 100644
+--- a/signal.c
++++ b/signal.c
+@@ -47,7 +47,7 @@ unblock (void)
+ }
+ 
+ static void
+-install_signal (int signum, RETSIGTYPE (*handler) ())
++install_signal (int signum, RETSIGTYPE (*handler) (int))
+ /* Emulate the `signal' function via `sigaction'.  */
+ {
+   struct sigaction  action;

--- a/pkgs/by-name/mo/moon-buggy/package.nix
+++ b/pkgs/by-name/mo/moon-buggy/package.nix
@@ -17,6 +17,11 @@ stdenv.mkDerivation rec {
     sha256 = "0gyjwlpx0sd728dwwi7pwks4zfdy9rm1w1xbhwg6zip4r9nc2b9m";
   };
 
+  patches = [
+    # Newer GCC rejects assigning signal handlers to incompatible function pointers
+    ./fix-signal-handler.patch
+  ];
+
   meta = {
     description = "Simple character graphics game where you drive some kind of car across the moon's surface";
     mainProgram = "moon-buggy";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Closes https://github.com/NixOS/nixpkgs/issues/476707

Tracks https://github.com/NixOS/nixpkgs/issues/475479

The incompatible assignment of signal handler functions to pointers have been rejected by GCC 15. This PR adds a patch to fix this issue.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
