### PR TITLE
maintainers: drop ingenieroariel, gbpdt

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11277,12 +11277,6 @@
     name = "Silvan Mosberger";
     keys = [ { fingerprint = "6C2B 55D4 4E04 8266 6B7D  DA1A 422E 9EDA E015 7170"; } ];
   };
-  ingenieroariel = {
-    email = "ariel@nunez.co";
-    github = "ingenieroariel";
-    githubId = 54999;
-    name = "Ariel Nunez";
-  };
   insipx = {
     email = "github@andrewplaza.dev";
     github = "insipx";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9351,12 +9351,6 @@
     githubId = 16470252;
     name = "Gemini Lasswell";
   };
-  gbpdt = {
-    email = "nix@pdtpartners.com";
-    github = "gbpdt";
-    githubId = 25106405;
-    name = "Graham Bennett";
-  };
   gbtb = {
     email = "goodbetterthebeast3@gmail.com";
     github = "gbtb";

--- a/pkgs/by-name/ap/apache-airflow/python-package.nix
+++ b/pkgs/by-name/ap/apache-airflow/python-package.nix
@@ -346,7 +346,6 @@ buildPythonPackage rec {
     changelog = "https://airflow.apache.org/docs/apache-airflow/${version}/release_notes.html";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
-      gbpdt
       taranarmo
     ];
   };

--- a/pkgs/by-name/ap/apache-airflow/python-package.nix
+++ b/pkgs/by-name/ap/apache-airflow/python-package.nix
@@ -347,7 +347,6 @@ buildPythonPackage rec {
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       gbpdt
-      ingenieroariel
       taranarmo
     ];
   };

--- a/pkgs/by-name/te/tegola/package.nix
+++ b/pkgs/by-name/te/tegola/package.nix
@@ -51,7 +51,6 @@ buildGoModule {
     homepage = "https://www.tegola.io/";
     description = "Mapbox Vector Tile server";
     mainProgram = "tegola";
-    maintainers = with lib.maintainers; [ ingenieroariel ];
     teams = [ lib.teams.geospatial ];
     license = lib.licenses.mit;
   };


### PR DESCRIPTION
Dropping both maintainers of apache airflow due to inactivity. The package is heavily outdated and insecure and both maintainers have been inactive for a few years and not responded to any maintainer pings.

This is according to the contribution guidelines in https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status. @gbpdt and @ingenieroariel if you'd like to keep maintaining please let me know within a week from now.

Of course, even if you don't respond now, you will always be welcome back later.

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
