### PR TITLE
shaderc: move to by-name, unvendor glslang, 2025.3 -> 2025.5

### DIFF
--- a/pkgs/by-name/sh/shaderc/package.nix
+++ b/pkgs/by-name/sh/shaderc/package.nix
@@ -2,40 +2,14 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  replaceVars,
   cmake,
   python3,
   darwin,
   cctools,
+  glslang,
+  spirv-tools,
 }:
-# Like many google projects, shaderc doesn't gracefully support separately
-# compiled dependencies, so we can't easily use the versions of glslang and
-# spirv-tools used by vulkan-loader. Exact revisions are taken from
-# https://github.com/google/shaderc/blob/known-good/known_good.json
-
-# Future work: extract and fetch all revisions automatically based on a revision
-# of shaderc's known-good branch.
-let
-  glslang = fetchFromGitHub {
-    owner = "KhronosGroup";
-    repo = "glslang";
-    # No corresponding tag for efd24d75bcbc55620e759f6bf42c45a32abac5f8 on 2025-06-23
-    rev = "efd24d75bcbc55620e759f6bf42c45a32abac5f8";
-    hash = "sha256-wMd1ylwDOM/uBbhpyMAduM9X7ao08TNq3HdoNGfSjcQ=";
-  };
-  spirv-tools = fetchFromGitHub {
-    owner = "KhronosGroup";
-    repo = "SPIRV-Tools";
-    rev = "v2025.3.rc1";
-    hash = "sha256-yAdd/mXY8EJnE0vCu0n/aVxMH9059T/7cAdB9nP1vQQ=";
-  };
-  spirv-headers = fetchFromGitHub {
-    owner = "KhronosGroup";
-    repo = "SPIRV-Headers";
-    # No corresponding tag for 2a611a970fdbc41ac2e3e328802aed9985352dca on 2025-06-19
-    rev = "2a611a970fdbc41ac2e3e328802aed9985352dca";
-    hash = "sha256-LRjMy9xtOErbJbMh+g2IKXfmo/hWpegZM72F8E122oY=";
-  };
-in
 stdenv.mkDerivation (finalAttrs: {
   pname = "shaderc";
   version = "2025.3";
@@ -55,11 +29,19 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-q5Z0wER8DbkmfT/MNrmnn9J9rzur2YjzAncaO1aRNXA=";
   };
 
+  patches = [
+    (replaceVars ./unvendor-glslang.patch {
+      shaderc-version = finalAttrs.version;
+      spirv-tools-version = spirv-tools.version;
+      glslang-version = glslang.version;
+    })
+  ];
+
   postPatch = ''
-    cp -r --no-preserve=mode ${glslang} third_party/glslang
-    cp -r --no-preserve=mode ${spirv-tools} third_party/spirv-tools
-    ln -s ${spirv-headers} third_party/spirv-tools/external/spirv-headers
     patchShebangs --build utils/
+
+    substituteInPlace cmake/*.pc.in \
+      --replace-fail $'{prefix}/@CMAKE_INSTALL_' '@CMAKE_INSTALL_FULL_'
   '';
 
   nativeBuildInputs = [
@@ -71,18 +53,15 @@ stdenv.mkDerivation (finalAttrs: {
     darwin.autoSignDarwinBinariesHook
   ];
 
+  propagatedBuildInputs = [
+    glslang
+  ];
+
   postInstall = ''
     moveToOutput "lib/*.a" $static
   '';
 
   cmakeFlags = [ "-DSHADERC_SKIP_TESTS=ON" ];
-
-  # Fix the paths in .pc, even though it's unclear if all these .pc are really useful.
-  postFixup = ''
-    substituteInPlace "$dev"/lib/pkgconfig/*.pc \
-      --replace-fail '=''${prefix}//' '=/' \
-      --replace-fail "$dev/$dev/" "$dev/"
-  '';
 
   meta = {
     description = "Collection of tools, libraries and tests for shader compilation";

--- a/pkgs/by-name/sh/shaderc/package.nix
+++ b/pkgs/by-name/sh/shaderc/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitHub,
   replaceVars,
+  versionCheckHook,
   cmake,
   python3,
   darwin,
@@ -63,10 +64,17 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [ "-DSHADERC_SKIP_TESTS=ON" ];
 
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
+
   meta = {
     description = "Collection of tools, libraries and tests for shader compilation";
     inherit (finalAttrs.src.meta) homepage;
     license = lib.licenses.asl20;
     platforms = lib.platforms.all;
+    mainProgram = "glslc";
   };
 })

--- a/pkgs/by-name/sh/shaderc/package.nix
+++ b/pkgs/by-name/sh/shaderc/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   cmake,
   python3,
-  autoSignDarwinBinariesHook,
+  darwin,
   cctools,
 }:
 # Like many google projects, shaderc doesn't gracefully support separately
@@ -68,7 +68,7 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [ cctools ]
   ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) [
-    autoSignDarwinBinariesHook
+    darwin.autoSignDarwinBinariesHook
   ];
 
   postInstall = ''

--- a/pkgs/by-name/sh/shaderc/package.nix
+++ b/pkgs/by-name/sh/shaderc/package.nix
@@ -13,7 +13,7 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "shaderc";
-  version = "2025.3";
+  version = "2025.5";
 
   outputs = [
     "out"
@@ -27,7 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "google";
     repo = "shaderc";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-q5Z0wER8DbkmfT/MNrmnn9J9rzur2YjzAncaO1aRNXA=";
+    hash = "sha256-PmGRZDXblrBhZe16QfpHfRdsRhXnGsN7o+qh14nlOUQ=";
   };
 
   patches = [

--- a/pkgs/by-name/sh/shaderc/unvendor-glslang.patch
+++ b/pkgs/by-name/sh/shaderc/unvendor-glslang.patch
@@ -1,0 +1,49 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 06f5395..a23a573 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -130,7 +130,9 @@ endif(MSVC)
+ 
+ # Configure subdirectories.
+ # We depend on these for later projects, so they should come first.
+-add_subdirectory(third_party)
++find_package(glslang REQUIRED CONFIG)
++get_target_property(glslang_includes glslang::glslang INTERFACE_INCLUDE_DIRECTORIES)
++set(glslang_SOURCE_DIR "${glslang_includes}/glslang")
+ 
+ add_subdirectory(libshaderc_util)
+ add_subdirectory(libshaderc)
+@@ -142,7 +144,7 @@ endif()
+ add_custom_target(build-version
+   ${Python_EXECUTABLE}
+   ${CMAKE_CURRENT_SOURCE_DIR}/utils/update_build_version.py
+-  ${shaderc_SOURCE_DIR} ${spirv-tools_SOURCE_DIR} ${glslang_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}/build-version.inc
++  dummy dummy dummy ${CMAKE_CURRENT_BINARY_DIR}/build-version.inc
+   COMMENT "Update build-version.inc in the Shaderc build directory (if necessary).")
+ 
+ function(define_pkg_config_file NAME LIBS)
+diff --git a/utils/update_build_version.py b/utils/update_build_version.py
+index b7ce5b8..fcb0432 100755
+--- a/utils/update_build_version.py
++++ b/utils/update_build_version.py
+@@ -120,11 +120,15 @@ def get_version_string(project, directory):
+     """Returns a detailed version string for a given project with its
+     directory, which consists of software version string and git description
+     string."""
+-    detailed_version_string_lst = [project]
+-    if project != 'glslang':
+-        detailed_version_string_lst.append(deduce_software_version(directory))
+-    detailed_version_string_lst.append(describe(directory).replace('"', '\\"'))
+-    return ' '.join(detailed_version_string_lst)
++    match project:
++        case "shaderc":
++            return "shaderc v@shaderc-version@"
++        case "spirv-tools":
++            return "spirv-tools v@spirv-tools-version@"
++        case "glslang":
++            return "glslang v@glslang-version@"
++        case _:
++            sys.exit(1)
+ 
+ 
+ def main():

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10187,10 +10187,6 @@ with pkgs;
     protobuf = protobuf_21; # https://github.com/blueprint-freespeech/ricochet-refresh/issues/178
   };
 
-  shaderc = callPackage ../development/compilers/shaderc {
-    inherit (darwin) autoSignDarwinBinariesHook;
-  };
-
   scheherazade-new = scheherazade.override {
     version = "4.400";
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Depends on https://github.com/NixOS/nixpkgs/pull/477412

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
