### PR TITLE
setup-hooks/multiple-outputs: remove pkg-config file patching

### DIFF
--- a/pkgs/build-support/setup-hooks/multiple-outputs.sh
+++ b/pkgs/build-support/setup-hooks/multiple-outputs.sh
@@ -172,11 +172,6 @@ _multioutDevs() {
     moveToOutput lib/cmake "${!outputDev}"
     moveToOutput share/aclocal "${!outputDev}"
     # don't move *.la, as libtool needs them in the directory of the library
-
-    for f in "${!outputDev}"/{lib,share}/pkgconfig/*.pc; do
-        echo "Patching '$f' includedir to output ${!outputInclude}"
-        sed -i "/^includedir=/s,=\${prefix},=${!outputInclude}," "$f"
-    done
 }
 
 # Make the "dev" propagate other outputs needed for development.


### PR DESCRIPTION
This was added with initial implemention of multiple outputs: <https://github.com/NixOS/nixpkgs/pull/7701>.

Problems with the generated pkg-config modules should be addressed at the package level through correct configuration. The current approach hides problems that resurface later (e.g., incorrectly generated cmake config files in <https://github.com/NixOS/nixpkgs/pull/477258>) and is sometimes not enough, requiring further patching (e.g., see the removed `postFixup` in <https://github.com/NixOS/nixpkgs/pull/477412>).

Depends on:
- https://github.com/NixOS/nixpkgs/pull/477412
- https://github.com/NixOS/nixpkgs/pull/477258
- https://github.com/NixOS/nixpkgs/pull/476830
- https://github.com/NixOS/nixpkgs/pull/477464
- https://github.com/NixOS/nixpkgs/pull/478215
- https://github.com/NixOS/nixpkgs/pull/490753
- https://github.com/NixOS/nixpkgs/pull/490770
- https://github.com/NixOS/nixpkgs/pull/490803

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
