### PR TITLE
python313Packages.beets-alternatives: 0.13.4 -> 0.14.0

### DIFF
--- a/pkgs/development/python-modules/beets-alternatives/default.nix
+++ b/pkgs/development/python-modules/beets-alternatives/default.nix
@@ -5,7 +5,7 @@
   buildPythonPackage,
 
   # build-system
-  poetry-core,
+  hatchling,
 
   # nativeBuildInputs
   beets-minimal,
@@ -22,29 +22,18 @@
 
 buildPythonPackage rec {
   pname = "beets-alternatives";
-  version = "0.13.4";
+  version = "0.14.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     repo = "beets-alternatives";
     owner = "geigerzaehler";
     tag = "v${version}";
-    hash = "sha256-jGHRoBBXqJq0r/Gbp7gkuaEFPVMGE6cqQRi84AHTXxQ=";
+    hash = "sha256-leZYXf6Oo/jAKbnJbP+rTnuRsh9P1BQXYAbthMNT60A=";
   };
 
-  patches = [
-    # Fixes build failure by ignoring DeprecationWarning during tests.
-    (fetchpatch {
-      url = "https://github.com/geigerzaehler/beets-alternatives/commit/3c15515edfe62d5d6c8f3fb729bf3dcef41c1ffa.patch";
-      hash = "sha256-gZXftDI5PXJ0c65Z1HLABJ2SlDnXU78xxIEt7IGp8RQ=";
-      excludes = [
-        "poetry.lock"
-      ];
-    })
-  ];
-
   build-system = [
-    poetry-core
+    hatchling
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Closes https://github.com/NixOS/nixpkgs/issues/476419

Changelog https://github.com/geigerzaehler/beets-alternatives/releases/tag/v0.14.0

The upstream switched the build system from poetry to hatchling, and the package definition has been updated accordingly.

Note that building it with Python 3.14 causes a failure because `numba` is disabled under this version of Python.

```bash
$ nom-build -A python314Packages.beets-alternatives --show-trace                                                                                     
error:
       … while evaluating the attribute 'drvPath'
         at /home/starryreverie/userdata/development/nixpkgs/lib/customisation.nix:446:7:
          445|     // {
          446|       drvPath =
             |       ^
          447|         assert condition;

       … while evaluating the attribute 'drvPath'
         at /home/starryreverie/userdata/development/nixpkgs/lib/customisation.nix:446:7:
          445|     // {
          446|       drvPath =
             |       ^
          447|         assert condition;

       … while evaluating an expression to select 'drvPath' on it
         at «internal»:1:552:
       … while evaluating strict
         at «internal»:1:552:
       … while calling the 'derivationStrict' builtin
         at «internal»:1:208:
       … while evaluating derivation 'python3.14-beets-alternatives-0.14.0'
         whose name attribute is located at /home/starryreverie/userdata/development/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:541:13
         at /home/starryreverie/userdata/development/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:541:13:
          540|           // {
          541|             ${if (attrs ? name || (attrs ? pname && attrs ? version)) then "name" else null} =
             |             ^
          542|               let

       … while evaluating attribute 'nativeBuildInputs' of derivation 'python3.14-beets-alternatives-0.14.0'
         at /home/starryreverie/userdata/development/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:590:13:
          589|             depsBuildBuild = elemAt (elemAt dependencies 0) 0;
          590|             nativeBuildInputs = elemAt (elemAt dependencies 0) 1;
             |             ^
          591|             depsBuildTarget = elemAt (elemAt dependencies 0) 2;

       … while evaluating the attribute 'out.outPath'
         at /home/starryreverie/userdata/development/nixpkgs/lib/customisation.nix:428:13:
          427|               drv.${outputName}.drvPath;
          428|             outPath =
             |             ^
          429|               assert condition;

       … while calling the 'getAttr' builtin
         at «internal»:1:500:
       … while calling the 'derivationStrict' builtin
         at «internal»:1:208:
       … while evaluating derivation 'python3.14-beets-2.5.1'
         whose name attribute is located at /home/starryreverie/userdata/development/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:541:13
         at /home/starryreverie/userdata/development/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:541:13:
          540|           // {
          541|             ${if (attrs ? name || (attrs ? pname && attrs ? version)) then "name" else null} =
             |             ^
          542|               let

       … while evaluating attribute 'propagatedBuildInputs' of derivation 'python3.14-beets-2.5.1'
         at /home/starryreverie/userdata/development/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:600:13:
          599|             depsHostHostPropagated = elemAt (elemAt propagatedDependencies 1) 0;
          600|             propagatedBuildInputs = elemAt (elemAt propagatedDependencies 1) 1;
             |             ^
          601|             depsTargetTargetPropagated = elemAt (elemAt propagatedDependencies 2) 0;

       … while evaluating the attribute 'out.outPath'
         at /home/starryreverie/userdata/development/nixpkgs/lib/customisation.nix:428:13:
          427|               drv.${outputName}.drvPath;
          428|             outPath =
             |             ^
          429|               assert condition;

       … while calling the 'getAttr' builtin
         at «internal»:1:500:
       … while calling the 'derivationStrict' builtin
         at «internal»:1:208:
       … while evaluating derivation 'python3.14-librosa-0.11.0'
         whose name attribute is located at /home/starryreverie/userdata/development/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:541:13
         at /home/starryreverie/userdata/development/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:541:13:
          540|           // {
          541|             ${if (attrs ? name || (attrs ? pname && attrs ? version)) then "name" else null} =
             |             ^
          542|               let

       … while evaluating attribute 'nativeBuildInputs' of derivation 'python3.14-librosa-0.11.0'
         at /home/starryreverie/userdata/development/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:590:13:
          589|             depsBuildBuild = elemAt (elemAt dependencies 0) 0;
          590|             nativeBuildInputs = elemAt (elemAt dependencies 0) 1;
             |             ^
          591|             depsBuildTarget = elemAt (elemAt dependencies 0) 2;

       … while evaluating the attribute 'out.outPath'
         at /home/starryreverie/userdata/development/nixpkgs/lib/customisation.nix:428:13:
          427|               drv.${outputName}.drvPath;
          428|             outPath =
             |             ^
          429|               assert condition;

       … while calling the 'getAttr' builtin
         at «internal»:1:500:
       … while calling the 'derivationStrict' builtin
         at «internal»:1:208:
       … while evaluating derivation 'python3.14-resampy-0.4.3'
         whose name attribute is located at /home/starryreverie/userdata/development/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:541:13
         at /home/starryreverie/userdata/development/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:541:13:
          540|           // {
          541|             ${if (attrs ? name || (attrs ? pname && attrs ? version)) then "name" else null} =
             |             ^
          542|               let

       … while evaluating attribute 'propagatedBuildInputs' of derivation 'python3.14-resampy-0.4.3'
         at /home/starryreverie/userdata/development/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:600:13:
          599|             depsHostHostPropagated = elemAt (elemAt propagatedDependencies 1) 0;
          600|             propagatedBuildInputs = elemAt (elemAt propagatedDependencies 1) 1;
             |             ^
          601|             depsTargetTargetPropagated = elemAt (elemAt propagatedDependencies 2) 0;

       … while evaluating condition
         at /home/starryreverie/userdata/development/nixpkgs/lib/customisation.nix:429:22:
          428|             outPath =
          429|               assert condition;
             |                      ^
          430|               drv.${outputName}.outPath;

       … caused by explicit throw
         at /home/starryreverie/userdata/development/nixpkgs/pkgs/development/interpreters/python/mk-python-derivation.nix:463:14:
          462|           drv.disabled
          463|           -> throw "${removePrefix namePrefix drv.name} not supported for interpreter ${python.executable}"
             |              ^
          464|         ) { } drv

       error: numba-0.62.0 not supported for interpreter python3.14

       note: trace involved the following derivations:
       derivation 'python3.14-beets-alternatives-0.14.0'
       derivation 'python3.14-beets-2.5.1'
       derivation 'python3.14-librosa-0.11.0'
       derivation 'python3.14-resampy-0.4.3'
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
