### PR TITLE
azure-sdk-for-cpp: use finalAttrs.src.name for sourceRoot

### DIFF
--- a/pkgs/development/libraries/azure-sdk-for-cpp/core-amqp.nix
+++ b/pkgs/development/libraries/azure-sdk-for-cpp/core-amqp.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation (finalAttrs: {
     tag = "azure-core-amqp_1.0.0-beta.11";
     hash = "sha256-MQsz5Dmv1BwfUaN1VXMC3hPdMHihlgOBaukp5wgTNJc=";
   };
-  sourceRoot = "source/sdk/core/azure-core-amqp";
+  sourceRoot = "${finalAttrs.src.name}/sdk/core/azure-core-amqp";
 
   postPatch = ''
     sed -i '/CMAKE_CXX_STANDARD/d' CMakeLists.txt

--- a/pkgs/development/libraries/azure-sdk-for-cpp/core-tracing-opentelemetry.nix
+++ b/pkgs/development/libraries/azure-sdk-for-cpp/core-tracing-opentelemetry.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
     tag = "azure-core-tracing-opentelemetry_1.0.0-beta.4";
     hash = "sha256-3PqHpoi7zlTUYJ4A4APKp2yPg9nVwgGiyOZ+bng4Crk=";
   };
-  sourceRoot = "source/sdk/core/azure-core-tracing-opentelemetry";
+  sourceRoot = "${finalAttrs.src.name}/sdk/core/azure-core-tracing-opentelemetry";
 
   postPatch = ''
     sed -i '/CMAKE_CXX_STANDARD/d' CMakeLists.txt

--- a/pkgs/development/libraries/azure-sdk-for-cpp/core.nix
+++ b/pkgs/development/libraries/azure-sdk-for-cpp/core.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
     tag = "azure-core_1.16.1";
     hash = "sha256-gMINz3bH80l0QYX3iKJlL962WIMujR1wuN+t4t7g7qg=";
   };
-  sourceRoot = "source/sdk/core/azure-core";
+  sourceRoot = "${finalAttrs.src.name}/sdk/core/azure-core";
 
   postPatch = ''
     sed -i '/CMAKE_CXX_STANDARD/d' CMakeLists.txt

--- a/pkgs/development/libraries/azure-sdk-for-cpp/data-tables.nix
+++ b/pkgs/development/libraries/azure-sdk-for-cpp/data-tables.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
     tag = "azure-data-tables_1.0.0-beta.6";
     hash = "sha256-gfkjoA16UP6ToIueYPfhQFh+LEhlVtvTk3qRJoHR5OY=";
   };
-  sourceRoot = "source/sdk/tables/azure-data-tables";
+  sourceRoot = "${finalAttrs.src.name}/sdk/tables/azure-data-tables";
 
   postPatch = ''
     sed -i '/CMAKE_CXX_STANDARD/d' CMakeLists.txt

--- a/pkgs/development/libraries/azure-sdk-for-cpp/identity.nix
+++ b/pkgs/development/libraries/azure-sdk-for-cpp/identity.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
     tag = "azure-identity_1.13.2";
     hash = "sha256-864fU7BkVWXE0vVEYniXQUbrNRvLhhv6aR3wwdnjbQo=";
   };
-  sourceRoot = "source/sdk/identity/azure-identity";
+  sourceRoot = "${finalAttrs.src.name}/sdk/identity/azure-identity";
 
   postPatch = ''
     sed -i '/CMAKE_CXX_STANDARD/d' CMakeLists.txt

--- a/pkgs/development/libraries/azure-sdk-for-cpp/messaging-eventhubs-checkpointstore-blob.nix
+++ b/pkgs/development/libraries/azure-sdk-for-cpp/messaging-eventhubs-checkpointstore-blob.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
     tag = "azure-messaging-eventhubs-checkpointstore-blob_1.0.0-beta.1";
     hash = "sha256-487IwzlxnKd09ztf9NQESbp/kZzsT18JXKgMwsG5W/Y=";
   };
-  sourceRoot = "source/sdk/eventhubs/azure-messaging-eventhubs-checkpointstore-blob";
+  sourceRoot = "${finalAttrs.src.name}/sdk/eventhubs/azure-messaging-eventhubs-checkpointstore-blob";
 
   postPatch = ''
     sed -i '/CMAKE_CXX_STANDARD/d' CMakeLists.txt

--- a/pkgs/development/libraries/azure-sdk-for-cpp/messaging-eventhubs.nix
+++ b/pkgs/development/libraries/azure-sdk-for-cpp/messaging-eventhubs.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
     tag = "azure-messaging-eventhubs_1.0.0-beta.10";
     hash = "sha256-qGYfvRFnesI+oIp3jCRo53v66aR2qrcummSNpc5sCOw=";
   };
-  sourceRoot = "source/sdk/eventhubs/azure-messaging-eventhubs";
+  sourceRoot = "${finalAttrs.src.name}/sdk/eventhubs/azure-messaging-eventhubs";
 
   postPatch = ''
     sed -i '/CMAKE_CXX_STANDARD/d' CMakeLists.txt

--- a/pkgs/development/libraries/azure-sdk-for-cpp/security-attestation.nix
+++ b/pkgs/development/libraries/azure-sdk-for-cpp/security-attestation.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
     tag = "azure-security-attestation_1.1.0";
     hash = "sha256-RXCMB7MMIe5x5YgMAqAf306E/1vuRXweAlN5uDHumjA=";
   };
-  sourceRoot = "source/sdk/attestation/azure-security-attestation";
+  sourceRoot = "${finalAttrs.src.name}/sdk/attestation/azure-security-attestation";
 
   postPatch = ''
     sed -i '/CMAKE_CXX_STANDARD/d' CMakeLists.txt

--- a/pkgs/development/libraries/azure-sdk-for-cpp/security-keyvault-administration.nix
+++ b/pkgs/development/libraries/azure-sdk-for-cpp/security-keyvault-administration.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation (finalAttrs: {
     tag = "azure-security-keyvault-administration_4.0.0-beta.5";
     hash = "sha256-EaiJ2Q6c1VsL+RRF0MvS8jdcHwrKLeTJ0fBlySFt/+w=";
   };
-  sourceRoot = "source/sdk/keyvault/azure-security-keyvault-administration";
+  sourceRoot = "${finalAttrs.src.name}/sdk/keyvault/azure-security-keyvault-administration";
 
   postPatch = ''
     sed -i '/CMAKE_CXX_STANDARD/d' CMakeLists.txt

--- a/pkgs/development/libraries/azure-sdk-for-cpp/security-keyvault-certificates.nix
+++ b/pkgs/development/libraries/azure-sdk-for-cpp/security-keyvault-certificates.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation (finalAttrs: {
     tag = "azure-security-keyvault-certificates_4.3.0-beta.4";
     hash = "sha256-6LvqeSqSz5oDxXoR/vD7Pbxc2ksQflFhIrN7DzmMoaE=";
   };
-  sourceRoot = "source/sdk/keyvault/azure-security-keyvault-certificates";
+  sourceRoot = "${finalAttrs.src.name}/sdk/keyvault/azure-security-keyvault-certificates";
 
   postPatch = ''
     sed -i '/CMAKE_CXX_STANDARD/d' CMakeLists.txt

--- a/pkgs/development/libraries/azure-sdk-for-cpp/security-keyvault-keys.nix
+++ b/pkgs/development/libraries/azure-sdk-for-cpp/security-keyvault-keys.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation (finalAttrs: {
     tag = "azure-security-keyvault-keys_4.5.0-beta.3";
     hash = "sha256-NSstk0cpgWBOhi50eiFSHDYiJjel2a4l8xxgfIPKSsU=";
   };
-  sourceRoot = "source/sdk/keyvault/azure-security-keyvault-keys";
+  sourceRoot = "${finalAttrs.src.name}/sdk/keyvault/azure-security-keyvault-keys";
 
   postPatch = ''
     sed -i '/CMAKE_CXX_STANDARD/d' CMakeLists.txt

--- a/pkgs/development/libraries/azure-sdk-for-cpp/security-keyvault-secrets.nix
+++ b/pkgs/development/libraries/azure-sdk-for-cpp/security-keyvault-secrets.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation (finalAttrs: {
     tag = "azure-security-keyvault-secrets_4.3.0-beta.4";
     hash = "sha256-NSstk0cpgWBOhi50eiFSHDYiJjel2a4l8xxgfIPKSsU=";
   };
-  sourceRoot = "source/sdk/keyvault/azure-security-keyvault-secrets";
+  sourceRoot = "${finalAttrs.src.name}/sdk/keyvault/azure-security-keyvault-secrets";
 
   postPatch = ''
     sed -i '/CMAKE_CXX_STANDARD/d' CMakeLists.txt

--- a/pkgs/development/libraries/azure-sdk-for-cpp/storage-blobs.nix
+++ b/pkgs/development/libraries/azure-sdk-for-cpp/storage-blobs.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation (finalAttrs: {
     tag = "azure-storage-blobs_12.15.0";
     hash = "sha256-u+zaMoX64GcTKE7QIF5WyENTogLBMTCenoI8hPY7m08=";
   };
-  sourceRoot = "source/sdk/storage/azure-storage-blobs";
+  sourceRoot = "${finalAttrs.src.name}/sdk/storage/azure-storage-blobs";
 
   postPatch = ''
     sed -i '/CMAKE_CXX_STANDARD/d' CMakeLists.txt

--- a/pkgs/development/libraries/azure-sdk-for-cpp/storage-common.nix
+++ b/pkgs/development/libraries/azure-sdk-for-cpp/storage-common.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
     tag = "azure-storage-common_12.11.0";
     hash = "sha256-u+zaMoX64GcTKE7QIF5WyENTogLBMTCenoI8hPY7m08=";
   };
-  sourceRoot = "source/sdk/storage/azure-storage-common";
+  sourceRoot = "${finalAttrs.src.name}/sdk/storage/azure-storage-common";
 
   postPatch = ''
     sed -i '/CMAKE_CXX_STANDARD/d' CMakeLists.txt

--- a/pkgs/development/libraries/azure-sdk-for-cpp/storage-files-datalake.nix
+++ b/pkgs/development/libraries/azure-sdk-for-cpp/storage-files-datalake.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
     tag = "azure-storage-files-datalake_12.13.0";
     hash = "sha256-u+zaMoX64GcTKE7QIF5WyENTogLBMTCenoI8hPY7m08=";
   };
-  sourceRoot = "source/sdk/storage/azure-storage-files-datalake";
+  sourceRoot = "${finalAttrs.src.name}/sdk/storage/azure-storage-files-datalake";
 
   postPatch = ''
     sed -i '/CMAKE_CXX_STANDARD/d' CMakeLists.txt

--- a/pkgs/development/libraries/azure-sdk-for-cpp/storage-files-shares.nix
+++ b/pkgs/development/libraries/azure-sdk-for-cpp/storage-files-shares.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation (finalAttrs: {
     tag = "azure-storage-files-shares_12.15.0";
     hash = "sha256-u+zaMoX64GcTKE7QIF5WyENTogLBMTCenoI8hPY7m08=";
   };
-  sourceRoot = "source/sdk/storage/azure-storage-files-shares";
+  sourceRoot = "${finalAttrs.src.name}/sdk/storage/azure-storage-files-shares";
 
   postPatch = ''
     sed -i '/CMAKE_CXX_STANDARD/d' CMakeLists.txt

--- a/pkgs/development/libraries/azure-sdk-for-cpp/storage-queues.nix
+++ b/pkgs/development/libraries/azure-sdk-for-cpp/storage-queues.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation (finalAttrs: {
     tag = "azure-storage-queues_12.5.0";
     hash = "sha256-u+zaMoX64GcTKE7QIF5WyENTogLBMTCenoI8hPY7m08=";
   };
-  sourceRoot = "source/sdk/storage/azure-storage-queues";
+  sourceRoot = "${finalAttrs.src.name}/sdk/storage/azure-storage-queues";
 
   postPatch = ''
     sed -i '/CMAKE_CXX_STANDARD/d' CMakeLists.txt


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I don't think `source` should be hard coded. This breaks when setting `config.fetchedSourceNameDefault = "full"`.

It's a similar situation to #468444

Here's how I'm testing:

```
  nix-build --expr '
      let
        pkgs = import /home/jrestivo/dev/nixpkgs {
          config = {
            fetchedSourceNameDefault = "full";
          };
        };
        azure = pkgs.azure-sdk-for-cpp;
      in
      [
        azure.core
        azure.core-amqp
        azure.core-tracing-opentelemetry
        azure.data-tables
        azure.identity
        azure.messaging-eventhubs
        azure.messaging-eventhubs-checkpointstore-blob
        azure.security-attestation
        azure.security-keyvault-administration
        azure.security-keyvault-certificates
        azure.security-keyvault-keys
        azure.security-keyvault-secrets
        azure.storage-blobs
        azure.storage-common
        azure.storage-files-datalake
        azure.storage-files-shares
        azure.storage-queues
      ]
    '
```

`azure.security-attestation` is broken for me with this change, but I don't think that's caused by the change. The rest build for me.

`azure.security-attestation`'s error:
```
error: Cannot build '/nix/store/gy90g8i5rmr7rgfbia4k9927wvc55j8n-azure-sdk-for-cpp-security-attestation-1.2.0-beta.1-unreleased-2025-03-12.drv'.
       Reason: builder failed with exit code 1.
       Output paths:
         /nix/store/183mgb7g5hm2v5vjb2c1vg9pqj0wmw2z-azure-sdk-for-cpp-security-attestation-1.2.0-beta.1-unreleased-2025-03-12
         /nix/store/348k25kh91skx79gci848kwvmqfmg08i-azure-sdk-for-cpp-security-attestation-1.2.0-beta.1-unreleased-2025-03-12-dev
       Last 25 log lines:
       >       |                                                                               ^~~~~~~~~~~~~~~~~~
       > [9/11] Building CXX object CMakeFiles/azure-security-attestation.dir/src/private/attestation_deserializers_private.cpp.o
       > In file included from /build/azure-sdk-for-cpp-1.1.0-github-source/sdk/attestation/azure-security-attestation/src/private/attestation_deserializers_private.hpp:17,
       >                  from /build/azure-sdk-for-cpp-1.1.0-github-source/sdk/attestation/azure-security-attestation/src/private/attestation_deserializers_private.cpp:14:
       > /build/azure-sdk-for-cpp-1.1.0-github-source/sdk/attestation/azure-security-attestation/inc/azure/attestation/attestation_client.hpp:179:69: warning: 'Azure::Core::Context::ApplicationContext' is deprecated: ApplicationCont
ext is no longer supported. Instead customers should create their own root context objects. [-Wdeprecated-declarations]
       >   179 |         Azure::Core::Context const& context = Azure::Core::Context::ApplicationContext) const;
       >       |                                                                     ^~~~~~~~~~~~~~~~~~
       > In file included from /build/azure-sdk-for-cpp-1.1.0-github-source/sdk/attestation/azure-security-attestation/inc/azure/attestation/attestation_client_models.hpp:13,
       >                  from /build/azure-sdk-for-cpp-1.1.0-github-source/sdk/attestation/azure-security-attestation/src/private/attestation_client_models_private.hpp:13,
       >                  from /build/azure-sdk-for-cpp-1.1.0-github-source/sdk/attestation/azure-security-attestation/src/private/attestation_deserializers_private.hpp:16:
       > /nix/store/ngr5iqnal61fxjlwiv6gbqdf3dpb0kin-azure-sdk-for-cpp-core-1.16.1-dev/include/azure/core/context.hpp:381:79: note: declared here
       >   381 |         "own root context objects.")]] static const AZ_CORE_DLLEXPORT Context ApplicationContext;
       >       |                                                                               ^~~~~~~~~~~~~~~~~~
       > [10/11] Building CXX object CMakeFiles/azure-security-attestation.dir/src/attestation_administration_client.cpp.o
       > In file included from /build/azure-sdk-for-cpp-1.1.0-github-source/sdk/attestation/azure-security-attestation/src/attestation_administration_client.cpp:5:
       > /build/azure-sdk-for-cpp-1.1.0-github-source/sdk/attestation/azure-security-attestation/inc/azure/attestation/attestation_client.hpp:179:69: warning: 'Azure::Core::Context::ApplicationContext' is deprecated: ApplicationCont
ext is no longer supported. Instead customers should create their own root context objects. [-Wdeprecated-declarations]
       >   179 |         Azure::Core::Context const& context = Azure::Core::Context::ApplicationContext) const;
       >       |                                                                     ^~~~~~~~~~~~~~~~~~
       > In file included from /build/azure-sdk-for-cpp-1.1.0-github-source/sdk/attestation/azure-security-attestation/inc/azure/attestation/attestation_client_models.hpp:13,
       >                  from /build/azure-sdk-for-cpp-1.1.0-github-source/sdk/attestation/azure-security-attestation/inc/azure/attestation/attestation_administration_client.hpp:6,
       >                  from /build/azure-sdk-for-cpp-1.1.0-github-source/sdk/attestation/azure-security-attestation/src/attestation_administration_client.cpp:4:
       > /nix/store/ngr5iqnal61fxjlwiv6gbqdf3dpb0kin-azure-sdk-for-cpp-core-1.16.1-dev/include/azure/core/context.hpp:381:79: note: declared here
       >   381 |         "own root context objects.")]] static const AZ_CORE_DLLEXPORT Context ApplicationContext;
       >       |                                                                               ^~~~~~~~~~~~~~~~~~
       > ninja: build stopped: subcommand failed.
       For full logs, run:
         nix log /nix/store/gy90g8i5rmr7rgfbia4k9927wvc55j8n-azure-sdk-for-cpp-security-attestation-1.2.0-beta.1-unreleased-2025-03-12.drv
error: build of '/nix/store/00q1m79i9xy1f4al25bbg5gixqclng7g-azure-sdk-for-cpp-security-keyvault-secrets-4.3.0-beta.4.drv', '/nix/store/0ld3sq2nyr8mh3k4vp13fpq0w05da6wg-azure-sdk-for-cpp-core-amqp-1.0.0-beta.11.drv', '/nix/store/6i5
8dlzwnvqxjg105f47a1f0q42kdp52-azure-sdk-for-cpp-core-tracing-opentelemetry-1.0.0-beta.4.drv', '/nix/store/6y0d67mcxs7lvsk0g9cs70mrfayxl6fy-azure-sdk-for-cpp-keyvault-keys-4.5.0-beta.3.drv', '/nix/store/8mxsacx0pj5ra4mcrx9d1hq1nfzwcx
ms-azure-sdk-for-cpp-messaging-eventhubs-checkpointstore-blob-1.0.0-beta.1.drv', '/nix/store/bvnwy59qvfns8a33pl4jnnz6kwsw00n8-azure-sdk-for-cpp-storage-blobs-12.15.0.drv', '/nix/store/cgc0jlwnzm89k6xksyd52z53jqmb9sn4-azure-sdk-for-c
pp-storage-queues-12.5.0.drv', '/nix/store/gy90g8i5rmr7rgfbia4k9927wvc55j8n-azure-sdk-for-cpp-security-attestation-1.2.0-beta.1-unreleased-2025-03-12.drv', '/nix/store/lsf5d1wkvqj3r93z6snjfl48w48n7rqy-azure-sdk-for-cpp-security-keyv
ault-certificates-4.3.0-beta.4.drv', '/nix/store/lvbcn9i9i3llc44vy36vlz5dgvw6lmk4-azure-sdk-for-cpp-messaging-eventhubs-1.0.0-beta.10.drv', '/nix/store/nxskmamypqncv92d4iaij94pa2hfq1q5-azure-sdk-for-cpp-keyvault-administration-4.0.0
-beta.5.drv', '/nix/store/sc2kd5bay6qz37pfh2265fn7kmzb0lr8-azure-sdk-for-cpp-storage-files-datalake-12.13.0.drv', '/nix/store/y8pbyxr14fx8kl4b6iiivbzlwf3n7yc8-azure-sdk-for-cpp-storage-files-shares-12.15.0.drv' failed
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
