### PR TITLE
androguard: remove networkx optional dependencies

### DIFF
--- a/pkgs/development/python-modules/androguard/default.nix
+++ b/pkgs/development/python-modules/androguard/default.nix
@@ -70,8 +70,6 @@ buildPythonPackage rec {
     pygments
     pyyaml
   ]
-  ++ networkx.optional-dependencies.default
-  ++ networkx.optional-dependencies.extra
   ++ lib.optionals withGui [
     pyqt5
   ];

--- a/pkgs/development/python-modules/androguard/default.nix
+++ b/pkgs/development/python-modules/androguard/default.nix
@@ -27,6 +27,7 @@
   # This is usually used as a library, and it'd be a shame to force the GUI
   # libraries to the closure if GUI is not desired.
   withGui ? false,
+  withFrida ? false,
   # Deprecated in 24.11.
   doCheck ? true,
 }:
@@ -35,14 +36,14 @@ assert lib.warnIf (!doCheck) "python3Packages.androguard: doCheck is deprecated"
 
 buildPythonPackage rec {
   pname = "androguard";
-  version = "4.1.3";
+  version = "4.1.4";
   pyproject = true;
 
   src = fetchFromGitHub {
     repo = "androguard";
     owner = "androguard";
     tag = "v${version}";
-    sha256 = "sha256-qz6x7UgYXal1DbQGzi4iKnSGEn873rKibKme/pF7tLk=";
+    sha256 = "sha256-WajRUquDEzs0NanOLpb0gxnreqM8Jm/SxI2LYEifWxg=";
   };
 
   build-system = [
@@ -58,11 +59,9 @@ buildPythonPackage rec {
     colorama
     cryptography
     dataset
-    frida-python
     ipython
     loguru
     lxml
-    matplotlib
     mutf8
     networkx
     oscrypto
@@ -71,7 +70,11 @@ buildPythonPackage rec {
     pyyaml
   ]
   ++ lib.optionals withGui [
+    matplotlib
     pyqt5
+  ]
+  ++ lib.optionals withFrida [
+    frida-python
   ];
 
   nativeCheckInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

The networkx deps were added in https://github.com/NixOS/nixpkgs/issues/326513 but @emilazy didn't provide a reason. These deps pulls in large packages, e.g., scipy. I can't see why they are needed and the cg command works without them. I thought they are not really needed so I remove them.

The matplotlib is only used to show the image and this function also requires pyqt.

With this PR the closure size of androguard is decreased from 1.1 GiB to 461.2 MiB.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
