### PR TITLE
oxfmt: 0.18.0 -> 0.23.0, oxlint: 1.35.0 -> 1.38.0 

### DIFF
--- a/pkgs/by-name/ox/oxfmt/package.nix
+++ b/pkgs/by-name/ox/oxfmt/package.nix
@@ -6,12 +6,14 @@
   cargo,
   cmake,
   makeBinaryWrapper,
+  nodejs_24,
   nodejs-slim,
   pnpmConfigHook,
   pnpm_10,
   rustPlatform,
   rustc,
   versionCheckHook,
+  nix-update-script,
 }:
 
 # Build with pnpm instead of buildRustPackage because Prettier integration
@@ -19,13 +21,13 @@
 # A pure Rust build would lack the Prettier plugin functionality.
 stdenv.mkDerivation (finalAttrs: {
   pname = "oxfmt";
-  version = "0.18.0";
+  version = "0.23.0";
 
   src = fetchFromGitHub {
     owner = "oxc-project";
     repo = "oxc";
     tag = "oxfmt_v${finalAttrs.version}";
-    hash = "sha256-AatmbW8UE8UbV533I2nhijHNlqIsgvtlE7X98uT7aTA=";
+    hash = "sha256-kMCGKbc7qaY0KUOR+67mLvKW4J5CuvYUmC6Aj9xlzSk=";
   };
 
   # Remove patchedDependencies from both workspace and lockfile
@@ -37,14 +39,14 @@ stdenv.mkDerivation (finalAttrs: {
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-4G52/8WZgNFM/vcHXBbtWabBZwWo3ZBVadFjOI2SmUk=";
+    hash = "sha256-cesj9jwWHIFxpFV62QDgYl22EUE8qVjIbb2nRObAyLo=";
   };
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_10;
     fetcherVersion = 2;
-    hash = "sha256-Do2sFEK/8Axj9B9M/W9zqMboPrAo5Zm/zdrMXZvmFg0=";
+    hash = "sha256-cPswWCksQ5TyR9M2Maj5mg9I+UltR0WN3U4ClBvwG68=";
     prePnpmInstall = finalAttrs.postPatch;
   };
 
@@ -52,7 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
     cargo
     cmake
     makeBinaryWrapper
-    nodejs-slim
+    nodejs_24
     pnpmConfigHook
     pnpm_10
     rustPlatform.cargoSetupHook
@@ -94,6 +96,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version-regex=^oxfmt_v([0-9.]+)$" ];
+  };
 
   meta = {
     description = "JavaScript formatter with Prettier integration";

--- a/pkgs/by-name/ox/oxlint/package.nix
+++ b/pkgs/by-name/ox/oxlint/package.nix
@@ -10,16 +10,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "oxlint";
-  version = "1.35.0";
+  version = "1.38.0";
 
   src = fetchFromGitHub {
     owner = "oxc-project";
     repo = "oxc";
     tag = "oxlint_v${finalAttrs.version}";
-    hash = "sha256-WHSdT4IMl/TUnMJycL3sYfA8aVLtag54dOYSXrDuN9g=";
+    hash = "sha256-kMCGKbc7qaY0KUOR+67mLvKW4J5CuvYUmC6Aj9xlzSk=";
   };
 
-  cargoHash = "sha256-OTxSxDjNDN8MZV7hVg914xQDl199+yjAMukN9jTmQsU=";
+  cargoHash = "sha256-cesj9jwWHIFxpFV62QDgYl22EUE8qVjIbb2nRObAyLo=";
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [
@@ -30,7 +30,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoBuildFlags = [
     "--bin=oxlint"
-    "--bin=oxc_language_server"
   ];
   cargoTestFlags = finalAttrs.cargoBuildFlags;
 


### PR DESCRIPTION
# Things done

This PR bumps both `oxfmt` and `oxlint` to the latest released versions, as seen in the following release: https://github.com/oxc-project/oxc/releases/tag/apps_v1.38.0

In `oxfmt`, I added configuration for the `nix-update-script`, and also had to introduce `nodejs_24` in the build process since `npm` is now invoked somewhere in the build, which is not included in `nodejs-slim` (which is still used at runtime).

In `oxlint`, a more simple version bump, but the language server target was dropped (from the upstream, [it seems](https://github.com/oxc-project/oxc/releases/tag/apps_v1.37.0))

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
