### PR TITLE
fdroidserver: 2.4.3 -> 2.4.3-unstable-2026-01-05

### DIFF
--- a/pkgs/by-name/gr/gradlew-fdroid/package.nix
+++ b/pkgs/by-name/gr/gradlew-fdroid/package.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  fetchFromGitLab,
+  python3Packages,
+}:
+
+python3Packages.buildPythonApplication {
+  pname = "gradlew-fdroid";
+  version = "0.0.1-unstable-2026-01-07";
+
+  src = fetchFromGitLab {
+    owner = "fdroid";
+    repo = "gradlew-fdroid";
+    rev = "996b7829f40f33317d33c1b6ddcffcf976bd6181";
+    hash = "sha256-aQoQ1Js5Wqj2Gp10+66c/esdEjrCNYgbh6HYVwhYiEY=";
+  };
+
+  pyproject = true;
+
+  build-system = with python3Packages; [
+    hatchling
+  ];
+
+  meta = {
+    homepage = "https://gitlab.com/fdroid/gradlew-fdroid";
+    description = "Reimplementation of gradlew script";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ linsui ];
+    mainProgram = "gradlew-fdroid";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Since F-Droid always run the buildserver on fdroidserver master, and the last release has been a little old, this PR bumps fdroidserver to the latest master. Also removes some unused deps which should have been removed long ago. Now the closure size reduces from 2.26G to 1.21G.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
