### PR TITLE
plasticscm-{client-{core,gui}-unwrapped,theme}: fix reproducibility

### DIFF
--- a/pkgs/by-name/pl/plasticscm-client-core-unwrapped/package.nix
+++ b/pkgs/by-name/pl/plasticscm-client-core-unwrapped/package.nix
@@ -16,11 +16,18 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "https://www.plasticscm.com/plasticrepo/stable/debian/amd64/plasticscm-client-core_${finalAttrs.version}_amd64.deb";
-    hash = "sha256-NuMY75JnnWVRKBSh/1XYipqc0m+O0vt7lJMVkQyTaNA=";
+    hash = "sha256-9K4pvl+hxB3+bQwC3HYaEOq5nQlCyTQQuYsuqT4BbRg=";
+    nativeBuildInputs = [ dpkg ];
+    downloadToTemp = true;
+    recursiveHash = true;
+    postFetch = ''
+      mkdir -p $out
+      dpkg-deb --fsys-tarfile $downloadedFile | tar --extract --directory=$out
+      rm -rf $out/usr/share/doc
+    '';
   };
 
   nativeBuildInputs = [
-    dpkg
     makeWrapper
   ];
 
@@ -40,15 +47,16 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runtimeInputs = [
       common-updater-scripts
       curl
+      dpkg
       jc
       jq
     ];
     text = ''
-      eval "$(curl -sSL https://www.plasticscm.com/plasticrepo/stable/debian/Packages |
+      version="$(curl -sSL https://www.plasticscm.com/plasticrepo/stable/debian/Packages |
         jc --pkg-index-deb |
-        jq -r '[.[] | select(.package == "plasticscm-client-core")] | sort_by(.version) | last | @sh "version=\(.version) hash=\(.sha256)"')"
-      # shellcheck disable=SC2154
-      update-source-version plasticscm-client-core-unwrapped "$version" "sha256-$(xxd -r -p <<<"$hash" | base64)"
+        jq -r '[.[] | select(.package == "plasticscm-client-core")] | sort_by(.version) | last | .version')"
+
+      update-source-version --ignore-same-hash plasticscm-client-core-unwrapped "$version"
     '';
   });
 

--- a/pkgs/by-name/pl/plasticscm-client-gui-unwrapped/package.nix
+++ b/pkgs/by-name/pl/plasticscm-client-gui-unwrapped/package.nix
@@ -15,12 +15,16 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "https://www.plasticscm.com/plasticrepo/stable/debian/amd64/plasticscm-client-gui_${finalAttrs.version}_amd64.deb";
-    hash = "sha256-sSabW3j9h9uNQSwWKvAH+3D9lRWvMRYcuITDonD7Inw=";
+    hash = "sha256-jqU4nfRtobdXiNIx9pjceje5Y+m+xFYdWQwWgEXxW+k=";
+    nativeBuildInputs = [ dpkg ];
+    downloadToTemp = true;
+    recursiveHash = true;
+    postFetch = ''
+      mkdir -p $out
+      dpkg-deb --fsys-tarfile $downloadedFile | tar --extract --directory=$out
+      rm -rf $out/usr/share/doc
+    '';
   };
-
-  nativeBuildInputs = [
-    dpkg
-  ];
 
   dontFixup = true;
 
@@ -38,15 +42,16 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runtimeInputs = [
       common-updater-scripts
       curl
+      dpkg
       jc
       jq
     ];
     text = ''
-      eval "$(curl -sSL https://www.plasticscm.com/plasticrepo/stable/debian/Packages |
+      version="$(curl -sSL https://www.plasticscm.com/plasticrepo/stable/debian/Packages |
         jc --pkg-index-deb |
-        jq -r '[.[] | select(.package == "plasticscm-client-gui")] | sort_by(.version) | last | @sh "version=\(.version) hash=\(.sha256)"')"
-      # shellcheck disable=SC2154
-      update-source-version plasticscm-client-gui-unwrapped "$version" "sha256-$(xxd -r -p <<<"$hash" | base64)"
+        jq -r '[.[] | select(.package == "plasticscm-client-gui")] | sort_by(.version) | last | .version')"
+
+      update-source-version --ignore-same-hash plasticscm-client-gui-unwrapped "$version"
     '';
   });
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

`usr/share/doc` was causing reproducibility issues, so that directory is now removed before the hash is calculated.

Fix: https://github.com/NixOS/nixpkgs/issues/476860

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
