### PR TITLE
jello-lang: init at 0-unstable-2025-01-07, jellyfish: init at 0-unstable-2024-05-27

### DIFF
--- a/pkgs/by-name/je/jello-lang/package.nix
+++ b/pkgs/by-name/je/jello-lang/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  fetchpatch2,
+  jellyfish,
+  nix-update-script,
+}:
+
+python3Packages.buildPythonApplication {
+  pname = "jello-lang";
+  version = "0-unstable-2025-01-07";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "codereport";
+    repo = "jello";
+    rev = "462c48d0613d3ef5e2c2c9771b3db64f0747ac89";
+    hash = "sha256-5pyJYV6UITtsjHUsyqdiyTXw3dK1ibZQpi8Z3E/L+xo=";
+  };
+
+  patches = [
+    (fetchpatch2 {
+      # https://github.com/codereport/jello/pull/43
+      url = "https://github.com/codereport/jello/commit/16ea477b302a810d161303539c4145130b90544c.patch";
+      hash = "sha256-6ZbytV6jUPAoPbV4IAbP5YsgPcjZZ+chGo3Z1h3hg1E=";
+    })
+  ];
+
+  build-system = [ python3Packages.setuptools ];
+
+  dependencies = [
+    python3Packages.colorama
+    python3Packages.prompt-toolkit
+  ];
+
+  # there are no tests
+  doCheck = false;
+
+  makeWrapperArgs = [ "--suffix PATH : ${lib.makeBinPath [ jellyfish ]}" ];
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
+
+  meta = {
+    description = "Wrapper for Jellyfish (a fork of the Jelly programming language)";
+    homepage = "https://github.com/codereport/jello";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ defelo ];
+    mainProgram = "jello";
+  };
+}

--- a/pkgs/by-name/je/jellyfish/package.nix
+++ b/pkgs/by-name/je/jellyfish/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+python3Packages.buildPythonApplication {
+  pname = "jellyfish";
+  version = "0-unstable-2024-05-27";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "codereport";
+    repo = "jellyfish";
+    rev = "611fdf45c8950dfc06d22c2638aa73f9560203b4";
+    hash = "sha256-IwqXR7oeQjFV4MGadqg1Y6a5tUYb3MdT2L6kDs5JvTo=";
+  };
+
+  build-system = [ python3Packages.setuptools ];
+
+  dependencies = [ python3Packages.sympy ];
+
+  # there are no tests
+  doCheck = false;
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
+
+  meta = {
+    description = "Extension of the Jelly programming language created by Dennis Mitchell";
+    homepage = "https://github.com/codereport/jellyfish";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ defelo ];
+    mainProgram = "jelly";
+  };
+}


### PR DESCRIPTION
> A Python script for wrapping the Jellyfish (a fork of Jelly) executable so you can more easily play with the language.

https://github.com/codereport/jello

> Jellyfish is an extension of the [Jelly programming language](https://github.com/DennisMitchell/jellylanguage/) created by Dennis Mitchell.

https://github.com/codereport/jellyfish

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
