### PR TITLE
angr-management: init at 9.2.154

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5336,6 +5336,11 @@
     name = "Connor Baker";
     githubId = 3880346;
   };
+  connornelson = {
+    github = "ConnorNelson";
+    githubId = 5953003;
+    name = "Connor Nelson";
+  };
   conradmearns = {
     email = "conradmearns+github@pm.me";
     github = "ConradMearns";

--- a/pkgs/by-name/an/angr-management/package.nix
+++ b/pkgs/by-name/an/angr-management/package.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  python3,
+  fetchFromGitHub,
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "angr-management";
+  version = "9.2.137";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "angr";
+    repo = "angr-management";
+    rev = "v${version}";
+    hash = "sha256-2ZKCTgQUcCSmg1/tm8n+3IfDw6Eey4reYgyWYlc7+4w=";
+  };
+
+  build-system = with python3.pkgs; [ setuptools ];
+
+  dependencies =
+    with python3.pkgs;
+    (
+      [
+        # requirements from setup.cfg
+        pyside6
+        pyside6-qtads
+        qtawesome
+        qtpy
+        angr
+        bidict
+        ipython
+        pyqodeng
+        requests
+        tomlkit
+        thefuzz
+        binsync
+        rpyc
+        # requirements from setup.cfg -- vendorized qtconsole package
+        traitlets
+        jupyter-core
+        jupyter-client
+        pygments
+        ipykernel
+        pyzmq
+        packaging
+      ]
+      ++ angr.optional-dependencies.AngrDB
+      ++ requests.optional-dependencies.socks
+    );
+
+  pythonImportsCheck = [ "angrmanagement" ];
+
+  meta = {
+    description = "The official angr GUI";
+    homepage = "https://github.com/angr/angr-management";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ scoder12 ];
+    mainProgram = "angr-management";
+  };
+}

--- a/pkgs/by-name/an/angr-management/package.nix
+++ b/pkgs/by-name/an/angr-management/package.nix
@@ -1,20 +1,22 @@
 {
   lib,
-  python3,
   fetchFromGitHub,
+  python3,
 }:
 
 python3.pkgs.buildPythonApplication rec {
   pname = "angr-management";
-  version = "9.2.137";
+  version = "9.2.147";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "angr";
     repo = "angr-management";
-    rev = "v${version}";
-    hash = "sha256-2ZKCTgQUcCSmg1/tm8n+3IfDw6Eey4reYgyWYlc7+4w=";
+    tag = "v${version}";
+    hash = "sha256-WPnrLgYae8rRwdhciGrc+z+OjYtkGFslODmBZx+3KPU=";
   };
+
+  pythonRelaxDeps = [ "binsync" ];
 
   build-system = with python3.pkgs; [ setuptools ];
 
@@ -23,30 +25,31 @@ python3.pkgs.buildPythonApplication rec {
     (
       [
         # requirements from setup.cfg
+        angr
+        bidict
+        binsync
+        ipython
+        pyqodeng-angr
         pyside6
         pyside6-qtads
         qtawesome
         qtpy
-        angr
-        bidict
-        ipython
-        pyqodeng
         requests
-        tomlkit
-        thefuzz
-        binsync
         rpyc
+        thefuzz
+        tomlkit
         # requirements from setup.cfg -- vendorized qtconsole package
-        traitlets
-        jupyter-core
-        jupyter-client
-        pygments
         ipykernel
-        pyzmq
+        jupyter-client
+        jupyter-core
         packaging
+        pygments
+        pyzmq
+        traitlets
       ]
       ++ angr.optional-dependencies.AngrDB
       ++ requests.optional-dependencies.socks
+      ++ thefuzz.optional-dependencies.speedup
     );
 
   pythonImportsCheck = [ "angrmanagement" ];
@@ -54,6 +57,7 @@ python3.pkgs.buildPythonApplication rec {
   meta = {
     description = "The official angr GUI";
     homepage = "https://github.com/angr/angr-management";
+    changelog = "https://github.com/angr/angr-management/releases/tag/${src.tag}";
     license = lib.licenses.bsd2;
     maintainers = with lib.maintainers; [ scoder12 ];
     mainProgram = "angr-management";

--- a/pkgs/by-name/an/angr-management/package.nix
+++ b/pkgs/by-name/an/angr-management/package.nix
@@ -1,27 +1,34 @@
 {
   lib,
   fetchFromGitHub,
-  python3,
+  python312,
+  xorg,
 }:
 
-python3.pkgs.buildPythonApplication rec {
+python312.pkgs.buildPythonApplication rec {
   pname = "angr-management";
-  version = "9.2.147";
+  version = "9.2.154";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "angr";
     repo = "angr-management";
     tag = "v${version}";
-    hash = "sha256-WPnrLgYae8rRwdhciGrc+z+OjYtkGFslODmBZx+3KPU=";
+    hash = "sha256-ZaQRXCt6u5FGApiXTToJdIXBnBLv3emo13YG5ip0lJA=";
   };
 
-  pythonRelaxDeps = [ "binsync" ];
+  pythonRelaxDeps = [
+    "angr"
+    "binsync"
+    "qtawesome"
+  ];
 
-  build-system = with python3.pkgs; [ setuptools ];
+  buildInputs = [ xorg.xcbutilcursor ];
+
+  build-system = with python312.pkgs; [ setuptools ];
 
   dependencies =
-    with python3.pkgs;
+    with python312.pkgs;
     (
       [
         # requirements from setup.cfg
@@ -47,7 +54,7 @@ python3.pkgs.buildPythonApplication rec {
         pyzmq
         traitlets
       ]
-      ++ angr.optional-dependencies.AngrDB
+      ++ angr.optional-dependencies.angrdb
       ++ requests.optional-dependencies.socks
       ++ thefuzz.optional-dependencies.speedup
     );
@@ -55,11 +62,14 @@ python3.pkgs.buildPythonApplication rec {
   pythonImportsCheck = [ "angrmanagement" ];
 
   meta = {
-    description = "The official angr GUI";
+    description = "Graphical binary analysis tool powered by the angr binary analysis platform";
     homepage = "https://github.com/angr/angr-management";
     changelog = "https://github.com/angr/angr-management/releases/tag/${src.tag}";
     license = lib.licenses.bsd2;
-    maintainers = with lib.maintainers; [ scoder12 ];
+    maintainers = with lib.maintainers; [
+      connornelson
+      scoder12
+    ];
     mainProgram = "angr-management";
   };
 }


### PR DESCRIPTION
https://github.com/angr/angr-management

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
