### PR TITLE
espup: port rustup/0001-dynamically-patchelf-binaries.patch

### DIFF
--- a/pkgs/by-name/es/espup/0001-dynamically-patchelf-binaries.patch
+++ b/pkgs/by-name/es/espup/0001-dynamically-patchelf-binaries.patch
@@ -1,0 +1,176 @@
+diff --git a/src/toolchain/mod.rs b/src/toolchain/mod.rs
+index b268916..4f22267 100644
+--- a/src/toolchain/mod.rs
++++ b/src/toolchain/mod.rs
+@@ -210,6 +210,7 @@ pub async fn download_file(
+                 return Err(Error::UnsuportedFileExtension(extension.to_string()));
+             }
+         }
++        nix_patchelf_directory_if_needed(Path::new(output_directory));
+     } else {
+         debug!("Creating file: '{file_path}'");
+         let mut out = File::create(&file_path)?;
+@@ -218,6 +219,163 @@ pub async fn download_file(
+     Ok(file_path)
+ }
+ 
++fn nix_patchelf_directory_if_needed(directory: &Path) {
++    use std::fs::read_dir;
++
++    fn walk_dir(dir: &Path, callback: &mut dyn FnMut(&Path)) {
++        if let Ok(entries) = read_dir(dir) {
++            for entry in entries.flatten() {
++                let path = entry.path();
++                if path.is_dir() {
++                    walk_dir(&path, callback);
++                } else {
++                    callback(&path);
++                }
++            }
++        }
++    }
++
++    let mut patch_count = 0;
++    walk_dir(directory, &mut |path| {
++        if nix_patchelf_if_needed(path) {
++            patch_count += 1;
++        }
++    });
++
++    if patch_count > 0 {
++        debug!("Patched {patch_count} ELF files in {}", directory.display());
++    }
++}
++
++fn nix_patchelf_if_needed(dest_path: &Path) -> bool {
++    use std::fs::File;
++    use std::os::unix::fs::FileExt;
++
++    struct ELFReader<'a> {
++        file: &'a mut File,
++        is_32bit: bool,
++        is_little_end: bool,
++    }
++
++    impl<'a> ELFReader<'a> {
++        const MAGIC_NUMBER: &'static [u8] = &[0x7F, 0x45, 0x4c, 0x46];
++        const ET_EXEC: u16 = 0x2;
++        const ET_DYN: u16 = 0x3;
++        const PT_INTERP: u32 = 0x3;
++
++        fn new(file: &'a mut File) -> Option<Self> {
++            use std::io::Read;
++            let mut magic_number = [0; 4];
++            file.read_exact(&mut magic_number).ok()?;
++            if Self::MAGIC_NUMBER != magic_number {
++                return None;
++            }
++            let mut ei_class = [0; 1];
++            file.read_exact_at(&mut ei_class, 0x4).ok()?;
++            let is_32bit = ei_class[0] == 1;
++            let mut ei_data = [0; 1];
++            file.read_exact_at(&mut ei_data, 0x5).ok()?;
++            let is_little_end = ei_data[0] == 1;
++            Some(Self {
++                file,
++                is_32bit,
++                is_little_end,
++            })
++        }
++
++        fn is_exec_or_dyn(&self) -> bool {
++            let e_type = self.read_u16_at(0x10);
++            e_type == Self::ET_EXEC || e_type == Self::ET_DYN
++        }
++
++        fn e_phoff(&self) -> u64 {
++            if self.is_32bit {
++                self.read_u32_at(0x1C) as u64
++            } else {
++                self.read_u64_at(0x20)
++            }
++        }
++
++        fn e_phentsize(&self) -> u64 {
++            let offset = if self.is_32bit { 0x2A } else { 0x36 };
++            self.read_u16_at(offset) as u64
++        }
++
++        fn e_phnum(&self) -> u64 {
++            let offset = if self.is_32bit { 0x2C } else { 0x38 };
++            self.read_u16_at(offset) as u64
++        }
++
++        fn has_interp(&self) -> bool {
++            let e_phoff = self.e_phoff();
++            let e_phentsize = self.e_phentsize();
++            let e_phnum = self.e_phnum();
++            for i in 0..e_phnum {
++                let p_type = self.read_u32_at(e_phoff + i * e_phentsize);
++                if p_type == Self::PT_INTERP {
++                    return true;
++                }
++            }
++            false
++        }
++
++        fn read_u16_at(&self, offset: u64) -> u16 {
++            let mut data = [0; 2];
++            self.file.read_exact_at(&mut data, offset).unwrap();
++            if self.is_little_end {
++                u16::from_le_bytes(data)
++            } else {
++                u16::from_be_bytes(data)
++            }
++        }
++
++        fn read_u32_at(&self, offset: u64) -> u32 {
++            let mut data = [0; 4];
++            self.file.read_exact_at(&mut data, offset).unwrap();
++            if self.is_little_end {
++                u32::from_le_bytes(data)
++            } else {
++                u32::from_be_bytes(data)
++            }
++        }
++
++        fn read_u64_at(&self, offset: u64) -> u64 {
++            let mut data = [0; 8];
++            self.file.read_exact_at(&mut data, offset).unwrap();
++            if self.is_little_end {
++                u64::from_le_bytes(data)
++            } else {
++                u64::from_be_bytes(data)
++            }
++        }
++    }
++
++    let Some(mut dest_file) = File::open(dest_path).ok() else {
++        return false;
++    };
++    let Some(elf) = ELFReader::new(&mut dest_file) else {
++        return false;
++    };
++    if !elf.is_exec_or_dyn() {
++        return false;
++    }
++    let mut patch_command = std::process::Command::new("@patchelf@/bin/patchelf");
++    if elf.has_interp() {
++        patch_command
++            .arg("--set-interpreter")
++            .arg("@dynamicLinker@");
++    }
++    // Always add rpath for libstdc++ and other libs
++    patch_command.arg("--add-rpath").arg("@libPath@");
++
++    debug!("patching {dest_path:?} using patchelf");
++    if let Err(err) = patch_command.arg(dest_path).output() {
++        warn!("failed to execute patchelf: {err:?}");
++        return false;
++    }
++    true
++}
++
+ /// Installs or updates the Espressif Rust ecosystem.
+ pub async fn install(args: InstallOpts, install_mode: InstallMode) -> Result<()> {
+     match install_mode {


### PR DESCRIPTION
Ports the rustup package's patch https://github.com/NixOS/nixpkgs/blob/e078bbb383dbd10828e3b49a7504c23e16a7553f/pkgs/development/tools/rust/rustup/0001-dynamically-patchelf-binaries.patch to espup, allowing downloaded binaries to work on nixos systems properly, avoiding the need to use nix-ld or setup a complicated FHS environment.

The patch differs from the rustup version in 3 ways:
1. Integration: Rustup patches files one-by-one during move_file(); espup walks the directory after archive.unpack() and patches all ELF files
2. LLD wrapper: Rustup wraps ld.lld with a shell script for nix's ld-wrapper; espup doesn't need this (no linkers installed)
3. Rpath: Rustup only adds rpath for rust-lld or interpreter-less binaries; espup adds rpath to all ELF binaries (pre-built toolchains need libstdc++)

Resolves #372653

Tested by doing the following:

1. Generating a project for an esp32-s3 using `esp-generate`
```
$ esp-generate
> Select your target chip: esp32s3
> Enter project name: photopainter
[2026-01-06T20:43:49Z WARN ] `rustc +nightly-2025-10-02-x86_64-unknown-linux-gnu --print target-list` exited with status Some(1)
[2026-01-06T20:43:50Z WARN ] `rustc +1.87.0-x86_64-unknown-linux-gnu --print target-list` exited with status Some(1)
Selected options: --chip esp32s3 -o unstable-hal -o alloc -o wifi -o embassy -o log -o esp-backtrace

Checking installed versions
🆗 Rust (esp): 1.90.0
🆗 espflash: 4.3.0
```
2. Adding a flake:
```nix
{
  inputs = {
    nixpkgs.url = "github:ozwaldorf/nixpkgs/espup/patchelf";
    flake-utils.url = "github:numtide/flake-utils";
  };

  outputs =
    { nixpkgs, flake-utils, ... }:
    flake-utils.lib.eachDefaultSystem (
      system:
      let
        pkgs = import nixpkgs { inherit system; };
      in
      {
        devShell = pkgs.mkShell {
          buildInputs = with pkgs; [
            rustup
            espup
            espflash
          ];
        };
      }
    );
}
```
3. Enabling the dev shell with espup and rustup:
```bash
nix develop
```
4. Running `espup install`
```
$ espup install
[info]: Installing the Espressif Rust ecosystem
[info]: Checking Rust installation
...
[info]: Installation successfully completed!

	To get started, you need to set up some environment variables by running: '. /home/oz/export-esp.sh'
	This step must be done every time you open a new terminal.
	    See other methods for setting the environment in https://esp-rs.github.io/book/installation/riscv-and-xtensa.html#3-set-up-the-environment-variables
```
5. Sourcing the environment variables required by the toolchain:
```
. ~/export_esp.sh
```
6. Finally, successfully building the project boilerplate:
```
$ cargo build
...
   Compiling usb-device v0.3.2
   Compiling crypto-common v0.1.7
   Compiling digest v0.10.7
   Compiling embassy-embedded-hal v0.5.0
   Compiling embassy-usb-synopsys-otg v0.3.1
   Compiling embassy-net v0.7.1
    Finished `dev` profile [optimized + debuginfo] target(s) in 16.64s
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc