### PR TITLE
lemon: 1.69 -> 1.0-unstable

### DIFF
--- a/pkgs/by-name/le/lemon/package.nix
+++ b/pkgs/by-name/le/lemon/package.nix
@@ -8,13 +8,13 @@ let
 
   srcs = {
     lemon = fetchurl {
-      sha256 = "1c5pk2hz7j9hix5mpc38rwnm8dnlr2jqswf4lan6v78ccbyqzkjx";
-      url = "http://www.sqlite.org/src/raw/tool/lemon.c?name=680980c7935bfa1edec20c804c9e5ba4b1dd96f5";
+      hash = "sha256-TXVOEtRpOhLCyi4C3RMt0lHmMp/y2K5YdL8ND6WPrOY=";
+      url = "https://www.sqlite.org/src/raw/3fdc16b23f1ea0c91c049b518fc3f75c71843dbfe2b447fcb3cd92d9e4f219f8?at=lemon.c";
       name = "lemon.c";
     };
     lempar = fetchurl {
-      sha256 = "1ba13a6yh9j2cs1aw2fh4dxqvgf399gxq1gpp4sh8q0f2w6qiw3i";
-      url = "http://www.sqlite.org/src/raw/tool/lempar.c?name=01ca97f87610d1dac6d8cd96ab109ab1130e76dc";
+      hash = "sha256-TYKrUJHtpoljeRWZq4Y1rYLlu7LeM/HuUhe3LJZZkVo=";
+      url = "https://www.sqlite.org/src/raw/b57e1780bf8098dd4a9a5bba537f994276ea825a420f6165153e5894dc2dfb07?at=lempar.c";
       name = "lempar.c";
     };
   };
@@ -22,7 +22,7 @@ let
 in
 stdenv.mkDerivation {
   pname = "lemon";
-  version = "1.69";
+  version = "1.0-unstable";
 
   dontUnpack = true;
 


### PR DESCRIPTION
The lemon parser generator out of sqlite hasn't been updated for a while, and recently broken: https://hydra.nixos.org/job/nixos/unstable/nixpkgs.lemon.x86_64-linux

The most recent version from the sqlite tree works.

This fixes antimony.

I wasn't sure how the original version number had been derived, so I put the version from the sqlite tree.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
