### PR TITLE
nixos/switchable-system: improvements to switch inhibitors

### DIFF
--- a/nixos/modules/system/activation/switchable-system.nix
+++ b/nixos/modules/system/activation/switchable-system.nix
@@ -128,9 +128,10 @@
             echo
             echo "The new configuration contains changes to packages that were"
             echo "listed as switch inhibitors."
+            echo "You probably want to run 'nixos-rebuild boot' and reboot your system."
             echo
             echo "If you really want to switch into this configuration directly, then"
-            echo "you can set NIXOS_NO_CHECK=1 to ignore these pre-switch checks."
+            echo "you can set NIXOS_NO_CHECK=1 to ignore pre-switch checks."
             echo
             echo "WARNING: doing so might cause the switch to fail or your system to become unstable."
             echo

--- a/nixos/modules/system/activation/switchable-system.nix
+++ b/nixos/modules/system/activation/switchable-system.nix
@@ -78,68 +78,69 @@
           sha256sum = lib.getExe' pkgs.coreutils "sha256sum";
           diff = lib.getExe' pkgs.diffutils "diff";
         in
-        # bash
-        ''
-          incoming="''${1-}"
-          action="''${2-}"
+        lib.mkIf (lib.length config.system.switch.inhibitors > 0)
+          # bash
+          ''
+            incoming="''${1-}"
+            action="''${2-}"
 
-          if [ "$action" == "boot" ]; then
-            echo "Not checking switch inhibitors (action = $action)"
-            exit
-          fi
-
-          echo -n "Checking switch inhibitors..."
-
-          booted_inhibitors="$(${realpath} /run/booted-system)/switch-inhibitors"
-          booted_inhibitors_sha="$(
-            if [ -f "$booted_inhibitors" ]; then
-              ${sha256sum} - < "$booted_inhibitors"
-            else
-              echo 'none'
+            if [ "$action" == "boot" ]; then
+              echo "Not checking switch inhibitors (action = $action)"
+              exit
             fi
-          )"
 
-          if [ "$booted_inhibitors_sha" == "none" ]; then
-            echo
-            echo "The previous configuration did not specify switch inhibitors, nothing to check."
-            exit
-          fi
+            echo -n "Checking switch inhibitors..."
 
-          new_inhibitors="$(${realpath} "$incoming")/switch-inhibitors"
-          new_inhibitors_sha="$(
-            if [ -f "$new_inhibitors" ]; then
-              ${sha256sum} - < "$new_inhibitors"
-            else
-              echo 'none'
+            booted_inhibitors="$(${realpath} /run/booted-system)/switch-inhibitors"
+            booted_inhibitors_sha="$(
+              if [ -f "$booted_inhibitors" ]; then
+                ${sha256sum} - < "$booted_inhibitors"
+              else
+                echo 'none'
+              fi
+            )"
+
+            if [ "$booted_inhibitors_sha" == "none" ]; then
+              echo
+              echo "The previous configuration did not specify switch inhibitors, nothing to check."
+              exit
             fi
-          )"
 
-          if [ "$new_inhibitors_sha" == "none" ]; then
-            echo
-            echo "The new configuration does not specify switch inhibitors, nothing to check."
-            exit
-          fi
+            new_inhibitors="$(${realpath} "$incoming")/switch-inhibitors"
+            new_inhibitors_sha="$(
+              if [ -f "$new_inhibitors" ]; then
+                ${sha256sum} - < "$new_inhibitors"
+              else
+                echo 'none'
+              fi
+            )"
 
-          if [ "$new_inhibitors_sha" != "$booted_inhibitors_sha" ]; then
-            echo
-            echo "Found diff in switch inhibitors:"
-            echo
-            ${diff} --color "$booted_inhibitors" "$new_inhibitors"
-            echo
-            echo "The new configuration contains changes to packages that were"
-            echo "listed as switch inhibitors."
-            echo "You probably want to run 'nixos-rebuild boot' and reboot your system."
-            echo
-            echo "If you really want to switch into this configuration directly, then"
-            echo "you can set NIXOS_NO_CHECK=1 to ignore pre-switch checks."
-            echo
-            echo "WARNING: doing so might cause the switch to fail or your system to become unstable."
-            echo
-            exit 1
-          else
-            echo " done"
-          fi
-        '';
+            if [ "$new_inhibitors_sha" == "none" ]; then
+              echo
+              echo "The new configuration does not specify switch inhibitors, nothing to check."
+              exit
+            fi
+
+            if [ "$new_inhibitors_sha" != "$booted_inhibitors_sha" ]; then
+              echo
+              echo "Found diff in switch inhibitors:"
+              echo
+              ${diff} --color "$booted_inhibitors" "$new_inhibitors"
+              echo
+              echo "The new configuration contains changes to packages that were"
+              echo "listed as switch inhibitors."
+              echo "You probably want to run 'nixos-rebuild boot' and reboot your system."
+              echo
+              echo "If you really want to switch into this configuration directly, then"
+              echo "you can set NIXOS_NO_CHECK=1 to ignore pre-switch checks."
+              echo
+              echo "WARNING: doing so might cause the switch to fail or your system to become unstable."
+              echo
+              exit 1
+            else
+              echo " done"
+            fi
+          '';
     };
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
- **nixos/switchable-system: improve error message in case switch inhibitors changed**
- **nixos/switchable-system: only include the switch-inhibitors check when we have inhibitors**

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
