### PR TITLE
Revert "python3Packages.dataset: use sqlalchemy_1_4"

### DIFF
--- a/pkgs/by-name/an/androguard/package.nix
+++ b/pkgs/by-name/an/androguard/package.nix
@@ -1,0 +1,12 @@
+{
+  python3Packages,
+}:
+
+let
+  pythonPackages = python3Packages.overrideScope (
+    self: super: {
+      sqlalchemy = self.sqlalchemy_1_4;
+    }
+  );
+in
+pythonPackages.toPythonApplication pythonPackages.androguard

--- a/pkgs/by-name/di/diffoscope/package.nix
+++ b/pkgs/by-name/di/diffoscope/package.nix
@@ -84,6 +84,8 @@ let
   python = python3.override {
     self = python;
     packageOverrides = final: prev: {
+      # version 2 breaks dataset and thus androguard
+      sqlalchemy = prev.sqlalchemy_1_4;
       # version 4 or newer would log the following error but tests currently don't fail because radare2 is disabled
       # ValueError: argument TNULL is not a TLSH hex string
       tlsh = prev.tlsh.overridePythonAttrs (

--- a/pkgs/by-name/fd/fdroidserver/package.nix
+++ b/pkgs/by-name/fd/fdroidserver/package.nix
@@ -2,13 +2,19 @@
   lib,
   fetchFromGitLab,
   python3Packages,
-  python3,
   fetchPypi,
   apksigner,
   installShellFiles,
 }:
 
-python3Packages.buildPythonApplication rec {
+let
+  pythonPackages = python3Packages.overrideScope (
+    self: super: {
+      sqlalchemy = self.sqlalchemy_1_4;
+    }
+  );
+in
+pythonPackages.buildPythonApplication rec {
   pname = "fdroidserver";
   version = "2.4.3";
 
@@ -37,7 +43,7 @@ python3Packages.buildPythonApplication rec {
   '';
 
   preConfigure = ''
-    ${python3.pythonOnBuildForHost.interpreter} setup.py compile_catalog
+    ${pythonPackages.python.pythonOnBuildForHost.interpreter} setup.py compile_catalog
   '';
 
   postInstall = ''
@@ -49,12 +55,12 @@ python3Packages.buildPythonApplication rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  build-system = with python3Packages; [
+  build-system = with pythonPackages; [
     setuptools
     babel
   ];
 
-  dependencies = with python3Packages; [
+  dependencies = with pythonPackages; [
     androguard
     biplist
     clint

--- a/pkgs/by-name/qu/quark-engine/package.nix
+++ b/pkgs/by-name/qu/quark-engine/package.nix
@@ -2,10 +2,20 @@
   lib,
   fetchFromGitHub,
   gitMinimal,
-  python3,
+  python3Packages,
 }:
 
-python3.pkgs.buildPythonApplication rec {
+let
+  pythonPackages = python3Packages.overrideScope (
+    self: super: {
+      pytest-randomly = super.pytest-randomly.overridePythonAttrs {
+        doCheck = false;
+      };
+      sqlalchemy = self.sqlalchemy_1_4;
+    }
+  );
+in
+pythonPackages.buildPythonApplication rec {
   pname = "quark-engine";
   version = "25.6.1";
   pyproject = true;
@@ -17,9 +27,9 @@ python3.pkgs.buildPythonApplication rec {
     hash = "sha256-DAD37fzswY3c0d+ubOCYImxs4qyD4fhC3m2l0iD977A=";
   };
 
-  build-system = with python3.pkgs; [ setuptools ];
+  build-system = with pythonPackages; [ setuptools ];
 
-  dependencies = with python3.pkgs; [
+  dependencies = with pythonPackages; [
     androguard
     click
     colorama

--- a/pkgs/development/python-modules/dataset/default.nix
+++ b/pkgs/development/python-modules/dataset/default.nix
@@ -45,6 +45,6 @@ buildPythonPackage rec {
     maintainers = with lib.maintainers; [ xfnw ];
     # SQLAlchemy >= 2.0.0 is unsupported
     # https://github.com/pudo/dataset/issues/411
-    broken = true;
+    broken = lib.versionAtLeast sqlalchemy.version "2.0.0";
   };
 }

--- a/pkgs/development/python-modules/dataset/default.nix
+++ b/pkgs/development/python-modules/dataset/default.nix
@@ -6,7 +6,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   pythonOlder,
-  sqlalchemy_1_4,
+  sqlalchemy,
 }:
 
 buildPythonPackage rec {
@@ -28,11 +28,9 @@ buildPythonPackage rec {
   ];
 
   dependencies = [
-    (alembic.override { sqlalchemy = sqlalchemy_1_4; })
+    alembic
     banal
-    # SQLAlchemy >= 2.0.0 is unsupported
-    # https://github.com/pudo/dataset/issues/411
-    sqlalchemy_1_4
+    sqlalchemy
   ];
 
   # checks attempt to import nonexistent module 'test.test' and fail
@@ -45,5 +43,8 @@ buildPythonPackage rec {
     homepage = "https://dataset.readthedocs.io";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ xfnw ];
+    # SQLAlchemy >= 2.0.0 is unsupported
+    # https://github.com/pudo/dataset/issues/411
+    broken = true;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10048,8 +10048,6 @@ with pkgs;
     useQt6 = true;
   };
 
-  androguard = with python3.pkgs; toPythonApplication androguard;
-
   dejavu_fonts = lowPrio (callPackage ../data/fonts/dejavu-fonts { });
 
   # solve collision for nix-env before https://github.com/NixOS/nix/pull/815


### PR DESCRIPTION
This partially reverts https://github.com/NixOS/nixpkgs/pull/380276 because only unversioned attributes may be included in dependencies.[^1]

[^1]: https://nixos.org/manual/nixpkgs/stable/#contributing-guidelines

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
