### PR TITLE
curv: 0.5-unstable-2025-01-20 -> 0.5-unstable-2026-01-17; enable jit; bump to eigen_5

### DIFF
--- a/pkgs/by-name/cu/curv/package.nix
+++ b/pkgs/by-name/cu/curv/package.nix
@@ -20,14 +20,14 @@
 
 stdenv.mkDerivation {
   pname = "curv";
-  version = "0.5-unstable-2025-01-20";
+  version = "0.5-unstable-2026-01-17";
 
   src = fetchFromGitea {
     domain = "codeberg.org";
     owner = "doug-moen";
     repo = "curv";
-    rev = "ef082c6612407dd8abce06015f9a16b1ebf661b8";
-    hash = "sha256-BGL07ZBA+ao3fg3qp56sVTe+3tM2SOp8TGu/jF7SVlM=";
+    rev = "1c2eb68e47e3c61a98e39cd3c50f90691c5a268d";
+    hash = "sha256-PuRBnJswrg+PjtU6ize+PjoBpQSSEzO2CeCx9mQF+3w=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/by-name/cu/curv/package.nix
+++ b/pkgs/by-name/cu/curv/package.nix
@@ -6,7 +6,7 @@
   git,
   pkg-config,
   boost,
-  eigen_3_4_0,
+  eigen_5,
   glm,
   gcc,
   libGL,
@@ -43,7 +43,7 @@ stdenv.mkDerivation {
 
   buildInputs = [
     boost
-    eigen_3_4_0
+    eigen_5
     glm
     libGL
     libpng

--- a/pkgs/by-name/cu/curv/package.nix
+++ b/pkgs/by-name/cu/curv/package.nix
@@ -8,8 +8,10 @@
   boost,
   eigen_3_4_0,
   glm,
+  gcc,
   libGL,
   libpng,
+  makeWrapper,
   openexr,
   onetbb,
   xorg,
@@ -36,6 +38,7 @@ stdenv.mkDerivation {
     cmake
     git
     pkg-config
+    makeWrapper
   ];
 
   buildInputs = [
@@ -73,6 +76,18 @@ stdenv.mkDerivation {
   postPatch = ''
     substituteInPlace extern/googletest/googletest/CMakeLists.txt \
       --replace-fail "cmake_minimum_required(VERSION 2.6.2)" "cmake_minimum_required(VERSION 3.10)"
+  '';
+
+  ## support runtime compilation with -Ojit
+  fixupPhase = ''
+    wrapProgram $out/bin/curv \
+      --set NIX_CFLAGS_COMPILE_${gcc.suffixSalt} "$NIX_CFLAGS_COMPILE" \
+      --set NIX_LDFLAGS_${gcc.suffixSalt} "$NIX_LDFLAGS" \
+      --prefix PATH : "${
+        lib.makeBinPath [
+          gcc
+        ]
+      }"
   '';
 
   passthru.updateScript = unstableGitUpdater { };


### PR DESCRIPTION
add wrapper with gcc, in order to enable -Ojit

bump `eigen` dependency to version 5

~~build with gcc 14. upstream issue: https://codeberg.org/doug-moen/curv/issues/269~~

closes https://github.com/NixOS/nixpkgs/pull/461788

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
