### PR TITLE
mpvScripts.cut: init at 2.2.0-unstable-2023-11-21

### DIFF
--- a/pkgs/by-name/mp/mpv/scripts/cut.nix
+++ b/pkgs/by-name/mp/mpv/scripts/cut.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "mpv-cut";
+  version = "2.2.0-unstable-2023-11-21";
+
+  src = fetchFromGitHub {
+    owner = "familyfriendlymikey";
+    repo = "mpv-cut";
+    rev = "3b18f1161ffb2ff822c88cb97e099772d4b3c26d";
+    hash = "sha256-c4NHJM1qeXXBz8oyGUzS9QiAzRYiNKjmArM1K0Q2Xo0=";
+  };
+
+  dontBuild = true;
+  dontCheck = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 main.lua $out/share/mpv/scripts/cut.lua
+    install -Dm644 utils $out/share/mpv/scripts/cut/utils
+
+    runHook postInstall
+  '';
+
+  passthru.scriptName = "cut.lua";
+
+  meta = with lib; {
+    description = "An mpv plugin for cutting videos incredibly quickly";
+    homepage = "https://github.com/familyfriendlymikey/mpv-cut";
+    license = licenses.unfree; # the repository doesn't have a license
+    maintainers = with maintainers; [ ncfavier ];
+  };
+}


### PR DESCRIPTION
https://github.com/familyfriendlymikey/mpv-cut


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
