### PR TITLE
treewide: juce_recommended_lto_flags -> ffat-lto-objects

### DIFF
--- a/pkgs/by-name/de/dexed/package.nix
+++ b/pkgs/by-name/de/dexed/package.nix
@@ -33,11 +33,6 @@ stdenv.mkDerivation (finalAttrs: {
 
     substituteInPlace Source/CMakeLists.txt \
       --replace-fail 'COPY_PLUGIN_AFTER_BUILD TRUE' 'COPY_PLUGIN_AFTER_BUILD FALSE'
-  ''
-  # LTO needs special setup on Linux
-  + lib.optionalString stdenv.hostPlatform.isLinux ''
-    substituteInPlace Source/CMakeLists.txt \
-      --replace-fail 'juce::juce_recommended_lto_flags' '# Not forcing LTO'
   '';
 
   strictDeps = true;
@@ -66,6 +61,17 @@ stdenv.mkDerivation (finalAttrs: {
     "-lXinerama"
     "-lXrandr"
     "-ljack"
+  ]);
+
+  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isLinux (toString [
+    # juce, compiled in this build as part of a Git submodule, uses `-flto` as
+    # a Link Time Optimization flag, and instructs the plugin compiled here to
+    # use this flag to. This breaks the build for us. Using _fat_ LTO allows
+    # successful linking while still providing LTO benefits. If our build of
+    # `juce` was used as a dependency, we could have patched that `-flto` line
+    # in our juce's source, but that is not possible because it is used as a
+    # Git Submodule.
+    "-ffat-lto-objects"
   ]);
 
   installPhase =

--- a/pkgs/by-name/pr/proteus/package.nix
+++ b/pkgs/by-name/pr/proteus/package.nix
@@ -50,7 +50,13 @@ stdenv.mkDerivation rec {
   env.NIX_CFLAGS_COMPILE = toString [
     # Support JACK output in the standalone application:
     "-DJUCE_JACK"
-    # Accommodate -flto:
+    # juce, compiled in this build as part of a Git submodule, uses `-flto` as
+    # a Link Time Optimization flag, and instructs the plugin compiled here to
+    # use this flag to. This breaks the build for us. Using _fat_ LTO allows
+    # successful linking while still providing LTO benefits. If our build of
+    # `juce` was used as a dependency, we could have patched that `-flto` line
+    # in our juce's source, but that is not possible because it is used as a
+    # Git Submodule.
     "-ffat-lto-objects"
   ];
 

--- a/pkgs/by-name/qd/qdelay/package.nix
+++ b/pkgs/by-name/qd/qdelay/package.nix
@@ -61,10 +61,16 @@ stdenv.mkDerivation (finalAttrs: {
     "-DCMAKE_OSX_ARCHITECTURES=${stdenv.hostPlatform.darwinArch}"
   ];
 
-  postPatch = ''
-    substituteInPlace CMakeLists.txt \
-      --replace-fail 'juce::juce_recommended_lto_flags' '# Not forcing LTO'
-  '';
+  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isLinux (toString [
+    # juce, compiled in this build as part of a Git submodule, uses `-flto` as
+    # a Link Time Optimization flag, and instructs the plugin compiled here to
+    # use this flag to. This breaks the build for us. Using _fat_ LTO allows
+    # successful linking while still providing LTO benefits. If our build of
+    # `juce` was used as a dependency, we could have patched that `-flto` line
+    # in our juce's source, but that is not possible because it is used as a
+    # Git Submodule.
+    "-ffat-lto-objects"
+  ]);
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/by-name/ri/ripplerx/package.nix
+++ b/pkgs/by-name/ri/ripplerx/package.nix
@@ -61,14 +61,19 @@ stdenv.mkDerivation (finalAttrs: {
     "-lXrandr"
   ];
 
+  env.NIX_CFLAGS_COMPILE = toString [
+    # juce, compiled in this build as part of a Git submodule, uses `-flto` as
+    # a Link Time Optimization flag, and instructs the plugin compiled here to
+    # use this flag to. This breaks the build for us. Using _fat_ LTO allows
+    # successful linking while still providing LTO benefits. If our build of
+    # `juce` was used as a dependency, we could have patched that `-flto` line
+    # in our juce's source, but that is not possible because it is used as a
+    # Git Submodule.
+    "-ffat-lto-objects"
+  ];
+
   # Fontconfig error: Cannot load default config file: No such file: (null)
   env.FONTCONFIG_FILE = "${fontconfig.out}/etc/fonts/fonts.conf";
-
-  # LTO needs special setup on Linux
-  postPatch = ''
-    substituteInPlace CMakeLists.txt \
-      --replace-fail 'juce::juce_recommended_lto_flags' '# Not forcing LTO'
-  '';
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/by-name/sg/sg-323/package.nix
+++ b/pkgs/by-name/sg/sg-323/package.nix
@@ -52,10 +52,16 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
-  postPatch = ''
-    substituteInPlace CMakeLists.txt \
-      --replace-fail 'juce::juce_recommended_lto_flags' '# Not forcing LTO'
-  '';
+  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isLinux (toString [
+    # juce, compiled in this build as part of a Git submodule, uses `-flto` as
+    # a Link Time Optimization flag, and instructs the plugin compiled here to
+    # use this flag to. This breaks the build for us. Using _fat_ LTO allows
+    # successful linking while still providing LTO benefits. If our build of
+    # `juce` was used as a dependency, we could have patched that `-flto` line
+    # in our juce's source, but that is not possible because it is used as a
+    # Git Submodule.
+    "-ffat-lto-objects"
+  ]);
 
   installPhase =
     let

--- a/pkgs/by-name/va/vaporizer2/package.nix
+++ b/pkgs/by-name/va/vaporizer2/package.nix
@@ -31,10 +31,6 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   postPatch = ''
-    # LTO needs special setup on Linux
-    substituteInPlace CMakeLists.txt \
-      --replace-fail 'juce::juce_recommended_lto_flags' '# Not forcing LTO'
-
     rm -rf clap-juce-extensions
     ln -s ${finalAttrs.passthru.clapJuceExtensions} clap-juce-extensions
   '';
@@ -63,6 +59,17 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     (lib.cmakeFeature "USE_SYSTEM_JUCE" "ON")
+  ];
+
+  env.NIX_CFLAGS_COMPILE = toString [
+    # juce, compiled in this build as part of a Git submodule, uses `-flto` as
+    # a Link Time Optimization flag, and instructs the plugin compiled here to
+    # use this flag to. This breaks the build for us. Using _fat_ LTO allows
+    # successful linking while still providing LTO benefits. If our build of
+    # `juce` was used as a dependency, we could have patched that `-flto` line
+    # in our juce's source, but that is not possible because it is used as a
+    # Git Submodule.
+    "-ffat-lto-objects"
   ];
 
   passthru.clapJuceExtensions = fetchFromGitHub {

--- a/pkgs/by-name/zl/zlequalizer/package.nix
+++ b/pkgs/by-name/zl/zlequalizer/package.nix
@@ -75,11 +75,16 @@ clangStdenv.mkDerivation (finalAttrs: {
     "-lXrandr"
   ]);
 
-  # LTO needs special setup on Linux
-  postPatch = lib.optionalString clangStdenv.hostPlatform.isLinux ''
-    substituteInPlace CMakeLists.txt \
-      --replace-fail 'juce::juce_recommended_lto_flags' '# Not forcing LTO'
-  '';
+  env.NIX_CFLAGS_COMPILE = lib.optionalString clangStdenv.hostPlatform.isLinux (toString [
+    # juce, compiled in this build as part of a Git submodule, uses `-flto` as
+    # a Link Time Optimization flag, and instructs the plugin compiled here to
+    # use this flag to. This breaks the build for us. Using _fat_ LTO allows
+    # successful linking while still providing LTO benefits. If our build of
+    # `juce` was used as a dependency, we could have patched that `-flto` line
+    # in our juce's source, but that is not possible because it is used as a
+    # Git Submodule.
+    "-ffat-lto-objects"
+  ]);
 
   cmakeFlags = [
     # see: https://github.com/ZL-Audio/ZLEqualizer#clone-and-build


### PR DESCRIPTION
A lot of juce based audio packages disable lto because they don't build otherwise.
By using ``-ffat-lto-objects`` instead, we should get faster binaries.
I've also compared the size of the resulting store paths for most of these packages, and each one I checked was smaller with ``-ffat-lto-objects``; so win-win.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
