### PR TITLE
llama-cpp.service: add support for --models-dir flag

### DIFF
--- a/nixos/modules/services/misc/llama-cpp.nix
+++ b/nixos/modules/services/misc/llama-cpp.nix
@@ -22,12 +22,14 @@ in
         type = lib.types.nullOr lib.types.path;
         example = "/models/mistral-instruct-7b/ggml-model-q4_0.gguf";
         description = "Model path.";
+        default = null;
       };
 
       modelsDir = lib.mkOption {
         type = lib.types.nullOr lib.types.path;
         example = "/models/";
         description = "Models directory.";
+        default = null;
       };
 
       extraFlags = lib.mkOption {

--- a/nixos/modules/services/misc/llama-cpp.nix
+++ b/nixos/modules/services/misc/llama-cpp.nix
@@ -85,15 +85,25 @@ in
       serviceConfig = {
         Type = "idle";
         KillSignal = "SIGINT";
-        ExecStart = let
-          args = [
-            "--host" cfg.host
-            "--port" (toString cfg.port)
-          ]
-          ++ lib.optionals (cfg.model != null) [ "-m" cfg.model ]
-          ++ lib.optionals (cfg.modelsDir != null) [ "--models-dir" cfg.modelsDir ]
-          ++ cfg.extraFlags;
-        in "${cfg.package}/bin/llama-server ${utils.escapeSystemdExecArgs args}";
+        ExecStart =
+          let
+            args = [
+              "--host"
+              cfg.host
+              "--port"
+              (toString cfg.port)
+            ]
+            ++ lib.optionals (cfg.model != null) [
+              "-m"
+              cfg.model
+            ]
+            ++ lib.optionals (cfg.modelsDir != null) [
+              "--models-dir"
+              cfg.modelsDir
+            ]
+            ++ cfg.extraFlags;
+          in
+          "${cfg.package}/bin/llama-server ${utils.escapeSystemdExecArgs args}";
         Restart = "on-failure";
         RestartSec = 300;
 

--- a/nixos/modules/services/misc/llama-cpp.nix
+++ b/nixos/modules/services/misc/llama-cpp.nix
@@ -69,14 +69,6 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    # Enforce that either model or modelDir is set
-    assertions = [
-      {
-        assertion = cfg.model != null || cfg.modelsDir != null;
-        message = "services.llama-cpp: Either 'model' or 'modelDir' must be set.";
-      }
-    ];
-
     systemd.services.llama-cpp = {
       description = "LLaMA C++ server";
       after = [ "network.target" ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
* Add a new `modelsDir` option to services.llama-cpp. The `modelsDir` option is of type path or null, and its value is passed to `llama-server` with the `--models-dir` flag.
* Change the `models` option of services.llama-cpp to type path or null.
* Assert that either one of `models` or `modelsDir` is not null.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
