### PR TITLE
treewide: fetchPypi: stop inheriting format from the main package

### DIFF
--- a/pkgs/by-name/cm/cmake-format/package.nix
+++ b/pkgs/by-name/cm/cmake-format/package.nix
@@ -11,7 +11,8 @@ python3Packages.buildPythonApplication rec {
   format = "wheel";
 
   src = fetchPypi {
-    inherit version format;
+    inherit version;
+    format = "wheel";
     pname = "cmakelang";
     sha256 = "0kmggnfbv6bba75l3zfzqwk0swi90brjka307m2kcz2w35kr8jvn";
   };

--- a/pkgs/by-name/hp/hpp2plantuml/package.nix
+++ b/pkgs/by-name/hp/hpp2plantuml/package.nix
@@ -10,7 +10,8 @@ python3Packages.buildPythonApplication rec {
   format = "wheel";
 
   src = fetchPypi {
-    inherit pname version format;
+    inherit pname version;
+    format = "wheel";
     hash = "sha256-9FggDDOxWr4z1DBbvYLyvgs3CCguFjq3I4E9ULwL0+Q=";
   };
 

--- a/pkgs/by-name/so/sourcery/package.nix
+++ b/pkgs/by-name/so/sourcery/package.nix
@@ -28,7 +28,8 @@ python3Packages.buildPythonApplication rec {
   format = "wheel";
 
   src = fetchPypi {
-    inherit pname version format;
+    inherit pname version;
+    format = "wheel";
     inherit (platformInfo) platform hash;
   };
 

--- a/pkgs/development/python-modules/array-record/default.nix
+++ b/pkgs/development/python-modules/array-record/default.nix
@@ -21,7 +21,8 @@ buildPythonPackage rec {
       pyShortVersion = "cp${builtins.replaceStrings [ "." ] [ "" ] python.pythonVersion}";
     in
     fetchPypi {
-      inherit version format;
+      inherit version;
+      format = "wheel";
       pname = "array_record";
       dist = pyShortVersion;
       python = pyShortVersion;

--- a/pkgs/development/python-modules/fontawesomefree/default.nix
+++ b/pkgs/development/python-modules/fontawesomefree/default.nix
@@ -11,7 +11,8 @@ buildPythonPackage rec {
 
   # they only provide a wheel
   src = fetchPypi {
-    inherit pname version format;
+    inherit pname version;
+    format = "wheel";
     dist = "py3";
     python = "py3";
     hash = "sha256-WZtXRDHJvZLtX8BU0QRaB8QjNdo2wXiE8rk0dV7vkIk=";

--- a/pkgs/development/python-modules/gviz-api/default.nix
+++ b/pkgs/development/python-modules/gviz-api/default.nix
@@ -11,7 +11,8 @@ buildPythonPackage rec {
   format = "wheel";
 
   src = fetchPypi {
-    inherit pname version format;
+    inherit pname version;
+    format = "wheel";
     sha256 = "a05055fed8c279f34f4b496eace7648c7fe9c1b06851e8a36e748541f1adbb05";
   };
 

--- a/pkgs/development/python-modules/ipympl/default.nix
+++ b/pkgs/development/python-modules/ipympl/default.nix
@@ -20,7 +20,8 @@ buildPythonPackage rec {
   disabled = pythonOlder "3.5";
 
   src = fetchPypi {
-    inherit pname version format;
+    inherit pname version;
+    format = "wheel";
     hash = "sha256-NpjufqoLBHp2A1F9eqG3GzIRil9RdUyrRexdmU9nII8=";
     dist = "py3";
     python = "py3";

--- a/pkgs/development/python-modules/paddle2onnx/default.nix
+++ b/pkgs/development/python-modules/paddle2onnx/default.nix
@@ -14,7 +14,8 @@ let
   format = "wheel";
   pyShortVersion = "cp${builtins.replaceStrings [ "." ] [ "" ] python.pythonVersion}";
   src = fetchPypi {
-    inherit pname version format;
+    inherit pname version;
+    format = "wheel";
     dist = pyShortVersion;
     python = pyShortVersion;
     abi = pyShortVersion;

--- a/pkgs/development/python-modules/panel/default.nix
+++ b/pkgs/development/python-modules/panel/default.nix
@@ -24,7 +24,8 @@ buildPythonPackage rec {
   # artifacts using npm, the bundling invoked in setup.py
   # tries to fetch even more artifacts
   src = fetchPypi {
-    inherit pname version format;
+    inherit pname version;
+    format = "wheel";
     hash = "sha256-HDtKM11W1aoM9dbhw2hKKX4kpiz5k0XF6euFUoN7l8M=";
     dist = "py3";
     python = "py3";

--- a/pkgs/development/python-modules/pydata-sphinx-theme/default.nix
+++ b/pkgs/development/python-modules/pydata-sphinx-theme/default.nix
@@ -20,7 +20,8 @@ buildPythonPackage rec {
   disabled = pythonOlder "3.8";
 
   src = fetchPypi {
-    inherit version format;
+    inherit version;
+    format = "wheel";
     dist = "py3";
     python = "py3";
     pname = "pydata_sphinx_theme";

--- a/pkgs/development/python-modules/pyttsx3/default.nix
+++ b/pkgs/development/python-modules/pyttsx3/default.nix
@@ -10,7 +10,8 @@ buildPythonPackage rec {
   format = "wheel";
 
   src = fetchPypi {
-    inherit pname version format;
+    inherit pname version;
+    format = "wheel";
     sha256 = "sha256-/z5P91bCTXK58/LzBODtqv0PWK2w5vS5DZMEQM2osgc=";
     dist = "py3";
     python = "py3";

--- a/pkgs/development/python-modules/ray/default.nix
+++ b/pkgs/development/python-modules/ray/default.nix
@@ -114,7 +114,8 @@ buildPythonPackage rec {
       };
     in
     fetchPypi {
-      inherit pname version format;
+      inherit pname version;
+      format = "wheel";
       dist = pyShortVersion;
       python = pyShortVersion;
       abi = pyShortVersion;

--- a/pkgs/development/python-modules/requests-download/default.nix
+++ b/pkgs/development/python-modules/requests-download/default.nix
@@ -18,7 +18,8 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     pname = "requests_download";
-    inherit version format;
+    inherit version;
+    format = "wheel";
     sha256 = "1ballx1hljpdpyvqzqn79m0dc21z2smrnxk2ylb6dbpg5crrskcr";
   };
 

--- a/pkgs/development/python-modules/sphinx-book-theme/default.nix
+++ b/pkgs/development/python-modules/sphinx-book-theme/default.nix
@@ -17,7 +17,8 @@ buildPythonPackage rec {
   disabled = pythonOlder "3.9";
 
   src = fetchPypi {
-    inherit version format;
+    inherit version;
+    format = "wheel";
     dist = "py3";
     python = "py3";
     pname = "sphinx_book_theme";

--- a/pkgs/development/python-modules/tensorboard-data-server/default.nix
+++ b/pkgs/development/python-modules/tensorboard-data-server/default.nix
@@ -13,7 +13,8 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     pname = "tensorboard_data_server";
-    inherit version format;
+    inherit version;
+    format = "wheel";
     dist = "py3";
     python = "py3";
     hash = "sha256-fgYQ0gWIlYiYODbsBdwJjoD5e357v/fplOu3j1eNDds=";

--- a/pkgs/development/python-modules/tensorboard/default.nix
+++ b/pkgs/development/python-modules/tensorboard/default.nix
@@ -27,7 +27,8 @@ buildPythonPackage rec {
   # tensorflow/tensorboard is built from a downloaded wheel, because
   # https://github.com/tensorflow/tensorboard/issues/719 blocks buildBazelPackage.
   src = fetchPypi {
-    inherit pname version format;
+    inherit pname version;
+    format = "wheel";
     dist = "py3";
     python = "py3";
     hash = "sha256-ncn5eMuEwHI6z5o0XZbBhPApPRjxZruNWe4Jjmz6q6Y=";

--- a/pkgs/development/python-modules/tensorflow-estimator/bin.nix
+++ b/pkgs/development/python-modules/tensorflow-estimator/bin.nix
@@ -14,7 +14,8 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     pname = "tensorflow_estimator";
-    inherit version format;
+    inherit version;
+    format = "wheel";
     hash = "sha256-rt8h7sf7LckRUPyRoc4SvETbtyJ4oItY55/4fJ4o8VM=";
   };
 

--- a/pkgs/servers/home-assistant/frontend.nix
+++ b/pkgs/servers/home-assistant/frontend.nix
@@ -12,7 +12,8 @@ buildPythonPackage rec {
   format = "wheel";
 
   src = fetchPypi {
-    inherit version format;
+    inherit version;
+    format = "wheel";
     pname = "home_assistant_frontend";
     dist = "py3";
     python = "py3";


### PR DESCRIPTION
The `format` of `buildPythonPackage` has differed from `fetchPypi`.

Decouple to facilitate `finalAttrs` migration.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
