### PR TITLE
ankiAddons.syntax-highlighting: init at version 2.0.2

### DIFF
--- a/pkgs/by-name/an/anki/addons/default.nix
+++ b/pkgs/by-name/an/anki/addons/default.nix
@@ -22,5 +22,7 @@
 
   review-heatmap = callPackage ./review-heatmap { };
 
+  syntax-highlighting-ng = callPackage ./syntax-highlighting-ng { };
+
   yomichan-forvo-server = callPackage ./yomichan-forvo-server { };
 }

--- a/pkgs/by-name/an/anki/addons/syntax-highlighting-ng/0001-Change-language.patch
+++ b/pkgs/by-name/an/anki/addons/syntax-highlighting-ng/0001-Change-language.patch
@@ -1,0 +1,204 @@
+From 17ca6e7bb19f0907bbc521aab39ff692457f40ca Mon Sep 17 00:00:00 2001
+From: Alan Du <alanhdu@gmail.com>
+Date: Fri, 23 May 2025 18:47:26 -0400
+Subject: [PATCH] Fix plugin for anki 25.02.1
+
+Closes https://github.com/cav71/syntax-highlighting-ng/issues/16
+
+In https://github.com/ankitects/anki/issues/3935, Anki no longer
+supports inline scripts in the editor page -- that means that the
+`pycmd` Javascript would never trigger and would instead
+raise an error like:
+
+```
+JS error :3057 Refused to execute inline event handler because it violates the following Content Security Policy directive: "script-src http://127.0.0.1:33359/_anki/ http://127.0.0.1:33359/_addons/". Either the 'unsafe-inline' keyword, a hash ('sha256-...'), or a nonce ('nonce-...') is required to enable inline execution. Note that hashes do not apply to event handlers, style attributes and javascript: navigations unless the 'unsafe-hashes' keyword is present.
+```
+
+This updates the code to dynamically retrieve the value of
+the language using the webview instead of via the `pycmd` bridge.
+
+This does lead to one change in behavior though: now, the "previous
+lang" value will only be set when users actually trigger the syntax
+highlighting, rather than when they select a new language.
+---
+ src/syntax_highlighting_ng/main.py | 111 +++++++++++------------------
+ 1 file changed, 42 insertions(+), 69 deletions(-)
+
+diff --git a/src/syntax_highlighting_ng/main.py b/src/syntax_highlighting_ng/main.py
+index 741714a..88f3253 100644
+--- a/src/syntax_highlighting_ng/main.py
++++ b/src/syntax_highlighting_ng/main.py
+@@ -19,7 +19,6 @@
+ import logging
+ import functools
+ import os
+-import sys
+ import re
+ import json
+ import traceback
+@@ -36,7 +35,7 @@
+ from aqt.main import AnkiQt
+ from aqt.editor import Editor
+ from aqt.utils import showWarning
+-from anki.hooks import addHook, wrap
++from anki.hooks import addHook
+
+ log = getattr(mw.addonManager, "get_logger", logging.getLogger)(__name__)
+
+@@ -45,6 +44,7 @@
+     getattr(pygments, "__version__", "N/A"),
+ )
+
++LANG_ID = "syntax_highlighting_select"
+ HOTKEY = config.local_conf["hotkey"]
+ STYLE = config.local_conf["style"]
+ LIMITED_LANGS = config.local_conf["limitToLangs"]
+@@ -202,19 +202,6 @@ def onOptionsCall(mw: AnkiQt) -> None:
+ mw.form.menuTools.addAction(options_action)
+
+
+-# Highlighter initialization
+-
+-
+-def init_highlighter(ed: Editor, *args, **kwargs):
+-    # Get the last selected language (or the default language if the user
+-    # has never chosen any)
+-
+-    previous_lang = get_default_lang(mw)
+-    ed.codeHighlightLangAlias = LANGUAGES_MAP.get(previous_lang, "")
+-
+-
+-# Highlighter widgets
+-
+ # button icon
+ standardHeight = 20
+ standardWidth = 20
+@@ -295,28 +282,7 @@ def add_code_langs_combobox(self, func, previous_lang):
+ QSplitter.add_code_langs_combobox = add_code_langs_combobox  # type: ignore
+
+
+-@ui_code
+-def onCodeHighlightLangSelect(ed, lang):
+-    from . import html_render
+-
+-    try:
+-        alias = LANGUAGES_MAP[lang]
+-    except KeyError:
+-        ed.codeHighlightLangAlias = ""
+-        raise html_render.LanguageNotFound(lang)
+-    set_default_lang(mw, lang)
+-    ed.codeHighlightLangAlias = alias
+-
+-
+ # Editor widgets in Anki 2.1
+-
+-select_elm = (
+-    """<select onchange='pycmd("shLang:" +"""
+-    """ this.selectedOptions[0].text)' """
+-    """style='vertical-align: top;'>{}</select>"""
+-)
+-
+-
+ def onSetupButtons21(buttons, ed):
+     """Add buttons to Editor for Anki 2.1.x"""
+     # no need for a lambda since onBridgeCmd passes current editor instance
+@@ -345,7 +311,8 @@ def onSetupButtons21(buttons, ed):
+     for lang in selection:
+         options.append(option_str.format(lang))
+
+-    combo = select_elm.format("".join(options))
++    select_elm = "<select id='{}' style='vertical-align: top;'>{}</select>"
++    combo = select_elm.format(LANG_ID, "".join(options))
+     buttons.append(combo)
+
+     return buttons
+@@ -386,41 +353,52 @@ def highlight_code(ed):
+         # '\u00A0' (non-breaking space). This character messes with the
+         # formatter for highlighted code. To correct this, we replace all
+         # '\u00A0' characters with regular space characters
+-        code = selected_text.replace("\u00A0", " ")
++        code = selected_text.replace("\u00a0", " ")
+     else:
+         clipboard = QApplication.clipboard()
+         # Get the code from the clipboard
+         code = clipboard.text()
+
+-    # Select the lexer for the correct language
+-    style = html_render.Style(
+-        # NOTE: we specify the language to highlight for
+-        language=ed.codeHighlightLangAlias,
+-        style=STYLE,
+-        linenos="inline" if linenos is True else linenos,
+-        noclasses=noclasses,
+-    )
+-
+-    processed = html_render.render_string(code, style=style)
+-
+-    if centerfragments:
+-        pretty_code = "".join(
+-            [
+-                "<center><table><tbody><tr><td>",
+-                processed,
+-                "</td></tr></tbody></table></center>",
+-            ]
+-        )
+-    else:
+-        pretty_code = "".join(
+-            ["<table><tbody><tr><td>", processed, "</td></tr></tbody></table>"]
++    def callback(lang: str) -> None:
++        try:
++            alias = LANGUAGES_MAP[lang]
++        except KeyError:
++            raise html_render.LanguageNotFound(lang)
++        set_default_lang(mw, lang)
++
++        style = html_render.Style(
++            language=alias,
++            style=STYLE,
++            linenos="inline" if linenos is True else linenos,
++            noclasses=noclasses,
+         )
+
+-    pretty_code = process_html(pretty_code)
++        processed = html_render.render_string(code, style=style)
++
++        if centerfragments:
++            pretty_code = "".join(
++                [
++                    "<center><table><tbody><tr><td>",
++                    processed,
++                    "</td></tr></tbody></table></center>",
++                ]
++            )
++        else:
++            pretty_code = "".join(
++                ["<table><tbody><tr><td>", processed, "</td></tr></tbody></table>"]
++            )
++
++        pretty_code = process_html(pretty_code)
++
++        # These two lines insert a piece of HTML in the current cursor position
++        ed.web.eval(
++            "document.execCommand('inserthtml', false, %s);" % json.dumps(pretty_code)
++        )
+
+-    # These two lines insert a piece of HTML in the current cursor position
+-    ed.web.eval(
+-        "document.execCommand('inserthtml', false, %s);" % json.dumps(pretty_code)
++    ed.web.evalWithCallback(
++        # Select the lexer for the correct language
++        f"document.getElementById('{LANG_ID}').selectedOptions[0].text",
++        callback,
+     )
+
+
+@@ -438,9 +416,4 @@ def process_html(html):
+
+
+ # Hooks and monkey-patches
+-
+-
+ addHook("setupEditorButtons", onSetupButtons21)
+-Editor.onBridgeCmd = wrap(Editor.onBridgeCmd, onBridgeCmd, "around")
+-
+-Editor.__init__ = wrap(Editor.__init__, init_highlighter)

--- a/pkgs/by-name/an/anki/addons/syntax-highlighting-ng/default.nix
+++ b/pkgs/by-name/an/anki/addons/syntax-highlighting-ng/default.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  anki-utils,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+anki-utils.buildAnkiAddon (finalAttrs: {
+  pname = "syntax-highlighting-ng";
+  version = "0.0.7";
+  src = fetchFromGitHub {
+    owner = "cav71";
+    repo = "syntax-highlighting-ng";
+    sparseCheckout = [ "src/syntax_highlighting_ng" ];
+    tag = finalAttrs.version;
+    hash = "sha256-kNZBNf1O6CDYMilvfITCM0pC4OZSP0/rKReBnRYwUUw=";
+  };
+  sourceRoot = "${finalAttrs.src.name}/src/syntax_highlighting_ng";
+
+  patchFlags = [ "-p3" ];
+  patches = [ ./0001-Change-language.patch ];
+
+  passthru.updateScript = nix-update-script { };
+  meta = {
+    description = ''
+      Allows you to insert syntax-highlighted code snippets in Anki flashcards.
+    '';
+    homepage = "https://github.com/cav71/syntax-highlighting-ng";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ dastarruer ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Add the syntax-highlighting Anki addon, which allows you to insert syntax-highlighted code snippets in Anki flashcards.

@JuneStepp @ethancedwards8 This is unfinished because I have run into two problems. 
1. This addon uses Python 2
2. This addon also reads from a configuration file

I have solved the first issue by removing a deprecated call to `.decode()` in the `postPatch` section. It's more of a workaround, and there may be a better way of fixing this that I'm unaware of.

This is the error from the second issue:
```
Anki 25.09.2 (3890e12c) (ao)
Python 3.13.11 Qt 6.10.1 PyQt 6.9.0
Platform: Linux-6.18.2-x86_64-with-glibc2.40

When loading syntax-highlighting:
Traceback (most recent call last):
  File "/nix/store/0h314ypmpsanp3zlqxryrdcv1ij8g8rb-anki-25.09.2-lib/lib/python3.13/site-packages/aqt/addons.py", line 250, in loadAddons
    __import__(addon.dir_name)
    ~~~~~~~~~~^^^^^^^^^^^^^^^^
  File "/nix/store/k8z4ffch0qvr8n249w92qjw33hsj4nra-anki-addons/syntax-highlighting/__init__.py", line 15, in <module>
    from . import main
  File "/nix/store/k8z4ffch0qvr8n249w92qjw33hsj4nra-anki-addons/syntax-highlighting/main.py", line 37, in <module>
    from .config import local_conf
  File "/nix/store/k8z4ffch0qvr8n249w92qjw33hsj4nra-anki-addons/syntax-highlighting/config.py", line 177, in <module>
    local_conf = getConfig()
  File "/nix/store/k8z4ffch0qvr8n249w92qjw33hsj4nra-anki-addons/syntax-highlighting/config.py", line 160, in getConfig
    meta = _addonMeta()
  File "/nix/store/k8z4ffch0qvr8n249w92qjw33hsj4nra-anki-addons/syntax-highlighting/config.py", line 106, in _addonMeta
    _writeAddonMeta(meta)
    ~~~~~~~~~~~~~~~^^^^^^
  File "/nix/store/k8z4ffch0qvr8n249w92qjw33hsj4nra-anki-addons/syntax-highlighting/config.py", line 120, in _writeAddonMeta
    with io.open(meta_path, 'w', encoding="utf-8") as f:
         ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
OSError: [Errno 30] Read-only file system: '/nix/store/k8z4ffch0qvr8n249w92qjw33hsj4nra-anki-addons/syntax-highlighting/meta.json'
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
