### PR TITLE
bitcoin: 30.1 -> 29.1

### DIFF
--- a/pkgs/applications/blockchains/bitcoin/default.nix
+++ b/pkgs/applications/blockchains/bitcoin/default.nix
@@ -12,10 +12,10 @@
   libevent,
   zeromq,
   zlib,
+  db48,
   sqlite,
   qrencode,
   libsystemtap,
-  capnproto,
   qtbase ? null,
   qttools ? null,
   python3,
@@ -46,14 +46,14 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = if withGui then "bitcoin" else "bitcoind";
-  version = "30.0";
+  version = "29.1";
 
   src = fetchurl {
     urls = [
       "https://bitcoincore.org/bin/bitcoin-core-${finalAttrs.version}/bitcoin-${finalAttrs.version}.tar.gz"
     ];
     # hash retrieved from signed SHA256SUMS
-    sha256 = "9b472a4d51dfed9aa9d0ded2cb8c7bcb9267f8439a23a98f36eb509c1a5e6974";
+    sha256 = "067f624ae273b0d85a1554ffd7c098923351a647204e67034df6cc1dfacfa06b";
   };
 
   nativeBuildInputs = [
@@ -72,10 +72,11 @@ stdenv.mkDerivation (finalAttrs: {
     libevent
     zeromq
     zlib
-    capnproto
   ]
   ++ lib.optionals enableTracing [ libsystemtap ]
   ++ lib.optionals withWallet [ sqlite ]
+  # building with db48 (for legacy descriptor wallet support) is broken on Darwin
+  ++ lib.optionals (withWallet && !stdenv.hostPlatform.isDarwin) [ db48 ]
   ++ lib.optionals withGui [
     qrencode
     qtbase
@@ -93,12 +94,12 @@ stdenv.mkDerivation (finalAttrs: {
 
       checksums = fetchurl {
         url = "https://bitcoincore.org/bin/bitcoin-core-${finalAttrs.version}/SHA256SUMS";
-        hash = "sha256-v/b1wTOreKifpWkIrUEJsGaSo7LFs4pn7YgBN88dO9o=";
+        hash = "sha256-teQ02vm875Isks9sBC2HV3Zo78W+UkXGH9zgyNhOnQs=";
       };
 
       signatures = fetchurl {
         url = "https://bitcoincore.org/bin/bitcoin-core-${finalAttrs.version}/SHA256SUMS.asc";
-        hash = "sha256-MK37HyHAqp/vWLjKm/3HF0LkTXtKQwqz6cL4hY2YUPU=";
+        hash = "sha256-hyk57QyGJnrjuuGRmvfOhVAx9Nru93e8bfah5fSVcmg=";
       };
 
       verifyBuilderKeys =
@@ -151,6 +152,8 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     (lib.cmakeBool "BUILD_BENCH" false)
     (lib.cmakeBool "WITH_ZMQ" true)
+    # building with db48 (for legacy wallet support) is broken on Darwin
+    (lib.cmakeBool "WITH_BDB" (withWallet && !stdenv.hostPlatform.isDarwin))
     (lib.cmakeBool "WITH_USDT" enableTracing)
   ]
   ++ lib.optionals (!finalAttrs.doCheck) [

--- a/pkgs/applications/blockchains/bitcoin/default.nix
+++ b/pkgs/applications/blockchains/bitcoin/default.nix
@@ -30,7 +30,7 @@
   builderKeys ? [
     "152812300785C96444D3334D17565732E08E5E41" # achow101.gpg
     "9EDAFF80E080659604F4A76B2EBB056FD847F8A7" # Emzy.gpg
-    # "6B002C6EA3F91B1B0DF0C9BC8F617F1200A6D25C" # glozow.gpg (not signed 30.1)
+    "6B002C6EA3F91B1B0DF0C9BC8F617F1200A6D25C" # glozow.gpg
     "D1DBF2C4B96F2DEBF4C16654410108112E7EA81F" # hebasto.gpg
     "71A3B16735405025D447E8F274810B012346C9A6" # laanwj.gpg
     "67AA5B46E7AF78053167FE343B8F814A784218F8" # willcl-ark.gpg
@@ -46,14 +46,14 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = if withGui then "bitcoin" else "bitcoind";
-  version = "30.1";
+  version = "30.0";
 
   src = fetchurl {
     urls = [
       "https://bitcoincore.org/bin/bitcoin-core-${finalAttrs.version}/bitcoin-${finalAttrs.version}.tar.gz"
     ];
     # hash retrieved from signed SHA256SUMS
-    sha256 = "5d5518782c3000f64717ec1b4291e7e609a1f900d9729ee83c982243779c3f43";
+    sha256 = "9b472a4d51dfed9aa9d0ded2cb8c7bcb9267f8439a23a98f36eb509c1a5e6974";
   };
 
   nativeBuildInputs = [
@@ -87,18 +87,18 @@ stdenv.mkDerivation (finalAttrs: {
       publicKeys = fetchFromGitHub {
         owner = "bitcoin-core";
         repo = "guix.sigs";
-        rev = "8427342623f66a98e4b2503e5e15eb41485200d2";
-        sha256 = "sha256-X1mA1iPAb0OE9RNP9O5rFe9rzsui+BWQ2zMcV7SghXE=";
+        rev = "a788388207bd244d5ab07b31ecd6c126f213a6c6";
+        sha256 = "sha256-gbenuEWP6pqY9ywPd/yZy6QfWI7jvSObwto27DRXjGI=";
       };
 
       checksums = fetchurl {
         url = "https://bitcoincore.org/bin/bitcoin-core-${finalAttrs.version}/SHA256SUMS";
-        hash = "sha256-WdOYSEbxmpecFpThNwxKTNXbbwQvqlUuCxmCbhfhW6k";
+        hash = "sha256-v/b1wTOreKifpWkIrUEJsGaSo7LFs4pn7YgBN88dO9o=";
       };
 
       signatures = fetchurl {
         url = "https://bitcoincore.org/bin/bitcoin-core-${finalAttrs.version}/SHA256SUMS.asc";
-        hash = "sha256-yFPhf/tyotBtpx1lZAQR+C2YdZaAyaWCq/0OVdP2wR4=";
+        hash = "sha256-MK37HyHAqp/vWLjKm/3HF0LkTXtKQwqz6cL4hY2YUPU=";
       };
 
       verifyBuilderKeys =

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12414,7 +12414,7 @@ with pkgs;
     withGui = false;
   };
 
-  bitcoin = qt6Packages.callPackage ../applications/blockchains/bitcoin {
+  bitcoin = libsForQt5.callPackage ../applications/blockchains/bitcoin {
     withGui = true;
     inherit (darwin) autoSignDarwinBinariesHook;
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

See https://groups.google.com/g/bitcoindev/c/QsC_FWPNGr4/m/t6MSDT6pBQAJ

This undoes https://github.com/NixOS/nixpkgs/pull/476387 and https://github.com/NixOS/nixpkgs/pull/451606

Bitcoin 30.1 and 30.0 are affected by a rare bug in the wallet compound, which may result in a loss of funds. Rolling back to safety.

Note that code signer **willcl-ark** which we added in https://github.com/NixOS/nixpkgs/pull/476387 is still in the list. He has signed 29.1, so we should keep him.

I propose to use 29.1 and not update to 29.2, because Ava Chow mentioned in the mailing list, that version 30 will be fixed in 30.2 and we can update right to it.

Analyzing release notes for [30.0](https://github.com/bitcoin/bitcoin/blob/master/doc/release-notes/release-notes-30.0.md) and [30.1](https://github.com/bitcoin/bitcoin/blob/master/doc/release-notes/release-notes-30.1.md) I haven't found any downgrade risks. The only caveat is [coinstat index rebuilding](https://github.com/bitcoin/bitcoin/blob/master/doc/release-notes/release-notes-30.0.md#indexes), but they have accounted for it in the release notes.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
