### PR TITLE
charles5: 5.0 -> 5.0.3

### DIFF
--- a/pkgs/applications/networking/charles/default.nix
+++ b/pkgs/applications/networking/charles/default.nix
@@ -98,8 +98,8 @@ in
 {
   charles5 = (
     generic {
-      version = "5.0";
-      hash = "sha256-gvspRI3uF7bjE4UBuTGS5+n2h0nKudLtW3sqs2GZIyM=";
+      version = "5.0.3";
+      hash = "sha256-SiZ15ekuAW7AyXBHN5Zel4ZFL/4oNy1td64NQ0GNUhE=";
       platform = "_x86_64";
       jdk = openjdk17-bootstrap;
 

--- a/pkgs/applications/networking/charles/default.nix
+++ b/pkgs/applications/networking/charles/default.nix
@@ -83,6 +83,7 @@ let
         maintainers = with lib.maintainers; [
           kalbasit
           kashw2
+          Misaka13514
         ];
         sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
         license = lib.licenses.unfree;

--- a/pkgs/applications/networking/charles/default.nix
+++ b/pkgs/applications/networking/charles/default.nix
@@ -7,6 +7,7 @@
   openjdk17-bootstrap,
   jdk11,
   jdk8,
+  writeScript,
 }:
 
 let
@@ -16,6 +17,7 @@ let
       hash,
       platform ? "",
       jdk,
+      updateScript ? null,
       ...
     }@attrs:
     let
@@ -89,6 +91,7 @@ let
         license = lib.licenses.unfree;
         platforms = lib.platforms.unix;
       };
+      passthru.updateScript = updateScript;
     };
 
 in
@@ -99,6 +102,17 @@ in
       hash = "sha256-gvspRI3uF7bjE4UBuTGS5+n2h0nKudLtW3sqs2GZIyM=";
       platform = "_x86_64";
       jdk = openjdk17-bootstrap;
+
+      updateScript = writeScript "update-charles" ''
+        #!/usr/bin/env nix-shell
+        #!nix-shell -i bash -p curl gnugrep common-updater-scripts
+
+        set -eu -o pipefail
+
+        version=$(curl -A "Mozilla/5.0" -s https://www.charlesproxy.com/download/ | grep -oP 'Version \K[0-9.]+' | head -n1)
+
+        update-source-version charles5 "$version"
+      '';
     }
   );
   charles4 = (


### PR DESCRIPTION
add passthru.updateScript

Tested, works on x86_64-linux

Doesn't work on aarch64-darwin as same as 5.0, didn't fix, should I drop darwin support or package it from [dmg](https://www.charlesproxy.com/assets/release/5.0.3/charles-proxy-5.0.3.dmg)?

```
./result/bin/charles 
Did not find VAppearances using application class loader
INFO     com.charlesproxy.CharlesContext                       Java version: OpenJDK 64-Bit Server VM 17.0.16+8 (Eclipse Adoptium)
INFO     com.charlesproxy.CharlesContext                       Loading Configuration
INFO     com.charlesproxy.CharlesContext                       Version 5.0.3
INFO     com.charlesproxy.CharlesContext                       Loading Settings
INFO     com.charlesproxy.ConfigurationManager                 Loading: /Users/atri/.charles.config
INFO     com.charlesproxy.CharlesContext                       Loading Tools
WARNING  com.charlesproxy.gui.utils.UIUtils                    Look and feel was not found: org.violetlib.aqua.AquaLookAndFeel
java.lang.ClassNotFoundException: org.violetlib.aqua.AquaLookAndFeel
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
        at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:525)
        at java.base/java.lang.Class.forName0(Native Method)
        at java.base/java.lang.Class.forName(Class.java:467)
        at java.desktop/javax.swing.SwingUtilities.loadSystemClass(SwingUtilities.java:2036)
        at java.desktop/javax.swing.UIManager.setLookAndFeel(UIManager.java:637)
        at com.charlesproxy/com.charlesproxy.gui.utils.UIUtils.iScI(Unknown Source)
        at com.charlesproxy/com.charlesproxy.gui.utils.OkCb.iScI(Unknown Source)
        at com.charlesproxy/com.charlesproxy.gui.utils.UIUtils.iScI(Unknown Source)
        at com.charlesproxy/com.charlesproxy.main.kRuY.run(Unknown Source)
        at java.desktop/java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:308)
        at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:773)
        at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:720)
        at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:714)
        at java.base/java.security.AccessController.doPrivileged(AccessController.java:399)
        at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:86)
        at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:742)
        at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:203)
        at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:124)
        at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:113)
        at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:109)
        at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
        at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:90)
WARNING  com.charlesproxy.gui.utils.UIUtils                    Unsupported macOS look and feel: com.apple.laf.AquaLookAndFeel
INFO     com.charlesproxy.CharlesContext                       Configuring Access Control List
INFO     com.charlesproxy.CharlesContext                       Starting Proxy Server
INFO     com.charlesproxy.CharlesContext                       Starting Tools
INFO     com.charlesproxy.CharlesContext                       Configuring Proxies
WARNING  com.charlesproxy.CharlesContext                       Uncaught exception on main
java.lang.NoClassDefFoundError: Could not initialize class com.charlesproxy.macos.MacOSNative
        at com.charlesproxy/com.charlesproxy.macos.vQtF.kJKP(Unknown Source)
        at com.charlesproxy/com.charlesproxy.macos.vQtF.iScI(Unknown Source)
        at com.charlesproxy/com.charlesproxy.Vqpi.EHwQ(Unknown Source)
        at com.charlesproxy/com.charlesproxy.Vqpi.iScI(Unknown Source)
        at com.charlesproxy/com.charlesproxy.CharlesContext.start(Unknown Source)
        at com.charlesproxy/com.charlesproxy.Main.iScI(Unknown Source)
        at com.charlesproxy/com.charlesproxy.main.Main.main(Unknown Source)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:569)
        at com.charlesproxy/com.xk72.vGmK.kRuY.iScI(Unknown Source)
        at com.charlesproxy/com.charlesproxy.main.MainWithClassLoader.main(Unknown Source)
Caused by: java.lang.ExceptionInInitializerError: Exception java.lang.UnsatisfiedLinkError: no charles in java.library.path: /nix/store/7ic82lwvhl4sh8gq1564lc4514w2m7xg-charles-5.0.3/share/java [in thread "main"]
        at java.base/java.lang.ClassLoader.loadLibrary(ClassLoader.java:2434)
        at java.base/java.lang.Runtime.loadLibrary0(Runtime.java:818)
        at java.base/java.lang.System.loadLibrary(System.java:2006)
        at com.charlesproxy/com.charlesproxy.macos.MacOSNative.<clinit>(Unknown Source)
        at com.charlesproxy/com.charlesproxy.macos.MkAr.kmft.<init>(Unknown Source)
        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77)
        at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:500)
        at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:481)
        at com.charlesproxy/com.charlesproxy.macos.hsTx.EHwQ(Unknown Source)
        at com.charlesproxy/com.charlesproxy.macos.hsTx.iScI(Unknown Source)
        ... 11 more
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
