### PR TITLE
lla: 0.5.0 -> 0.5.3, fix build

### DIFF
--- a/pkgs/by-name/ll/lla/package.nix
+++ b/pkgs/by-name/ll/lla/package.nix
@@ -9,17 +9,14 @@
   versionCheckHook,
   nix-update-script,
 }:
-let
-  version = "0.5.0";
-in
-rustPlatform.buildRustPackage {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "lla";
-  inherit version;
+  version = "0.5.0";
 
   src = fetchFromGitHub {
     owner = "chaqchase";
     repo = "lla";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-xbXTiOr3c9PX0SRfjO+3Kib5S0fruFhjHO2Mf00BVBg=";
   };
 
@@ -65,10 +62,10 @@ rustPlatform.buildRustPackage {
       Git integration, and a robust plugin system with an extensible list of plugins to add more functionality.
     '';
     homepage = "https://lla.chaqchase.com";
-    changelog = "https://github.com/chaqchase/lla/blob/refs/tags/v${version}/CHANGELOG.md";
+    changelog = "https://github.com/chaqchase/lla/blob/refs/tags/v${finalAttrs.version}/CHANGELOG.md";
     license = with lib.licenses; [ mit ];
     maintainers = with lib.maintainers; [ pluiedev ];
     platforms = lib.platforms.unix;
     mainProgram = "lla";
   };
-}
+})

--- a/pkgs/by-name/ll/lla/package.nix
+++ b/pkgs/by-name/ll/lla/package.nix
@@ -11,13 +11,13 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "lla";
-  version = "0.5.0";
+  version = "0.5.3";
 
   src = fetchFromGitHub {
     owner = "chaqchase";
     repo = "lla";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-xbXTiOr3c9PX0SRfjO+3Kib5S0fruFhjHO2Mf00BVBg=";
+    hash = "sha256-AVvng3pF68bLlJBobEDBxW7/CQADTfg1Ylm/tjQFFfQ=";
   };
 
   nativeBuildInputs = [
@@ -33,7 +33,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   # Do not vendor Oniguruma
   env.RUSTONIG_SYSTEM_LIBONIG = true;
 
-  cargoHash = "sha256-qKeNSaZMpyQpI7oGqn416pfBINMsIE+0sjzg38roxc8=";
+  cargoHash = "sha256-SQBaUaNuPUUw/bQ9UnUNCo+HpU7VVK3wzKAtSDpmTHo=";
 
   cargoBuildFlags = [ "--workspace" ];
 

--- a/pkgs/by-name/ll/lla/package.nix
+++ b/pkgs/by-name/ll/lla/package.nix
@@ -4,6 +4,8 @@
   fetchFromGitHub,
   makeBinaryWrapper,
   installShellFiles,
+  pkg-config,
+  oniguruma,
   versionCheckHook,
   nix-update-script,
 }:
@@ -24,7 +26,15 @@ rustPlatform.buildRustPackage {
   nativeBuildInputs = [
     makeBinaryWrapper
     installShellFiles
+    pkg-config
   ];
+
+  buildInputs = [
+    oniguruma
+  ];
+
+  # Do not vendor Oniguruma
+  env.RUSTONIG_SYSTEM_LIBONIG = true;
 
   cargoHash = "sha256-qKeNSaZMpyQpI7oGqn416pfBINMsIE+0sjzg38roxc8=";
 


### PR DESCRIPTION
Build was previously failing because lla was somehow vendoring and compiling Oniguruma from source, which was broken with the GCC 15 migration. Disabling vendoring makes the build work again. Also cleaned up some parts of the derivation.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
