### PR TITLE
aseprite: add darwin support

### DIFF
--- a/pkgs/by-name/as/aseprite/package.nix
+++ b/pkgs/by-name/as/aseprite/package.nix
@@ -11,6 +11,7 @@
   gitUpdater,
   glib,
   harfbuzzFull,
+  libicns,
   lib,
   libGL,
   libjpeg,
@@ -68,6 +69,9 @@ clangStdenv.mkDerivation (finalAttrs: {
     cmake
     ninja
     pkg-config
+  ]
+  ++ lib.optionals clangStdenv.hostPlatform.isDarwin [
+    libicns
   ];
 
   buildInputs = [
@@ -108,10 +112,10 @@ clangStdenv.mkDerivation (finalAttrs: {
     substituteInPlace src/ver/CMakeLists.txt \
       --replace-fail '"1.x-dev"' '"${finalAttrs.version}"'
 
-    # Using substituteInPlace because no upstream patch for GCC 15 was found for this bundled library.
-    substituteInPlace third_party/json11/json11.cpp \
-      --replace-fail "#include <cmath>" "#include <cmath>
-    #include <cstdint>"
+    # Fix build on Darwin with `-Werror=format-security`
+    # (NSLog requires a string-literal format)
+    substituteInPlace laf/os/osx/logger.mm \
+      --replace-fail 'NSLog([NSString stringWithUTF8String:error]);' 'NSLog(@"%@", [NSString stringWithUTF8String:error]);'
   '';
 
   cmakeFlags = [
@@ -139,6 +143,10 @@ clangStdenv.mkDerivation (finalAttrs: {
     "-DSKIA_LIBRARY_DIR=${skia-aseprite}/lib"
   ];
 
+  # `libskia.a` is static, so its deps must be linked explicitly on Darwin
+  # (otherwise we hit undefined `_jpeg_*`/`_WebP*` symbols, e.g. in the thumbnailer).
+  env.NIX_LDFLAGS = lib.optionalString clangStdenv.hostPlatform.isDarwin "-ljpeg -lwebp -lwebpdemux -lwebpmux";
+
   postInstall = ''
     # Install desktop icons.
     src="$out/share/aseprite/data/icons"
@@ -149,6 +157,30 @@ clangStdenv.mkDerivation (finalAttrs: {
     done
     # Delete unneeded artifacts of bundled libraries.
     rm -rf "$out"/{include,lib,man}
+  ''
+  + lib.optionalString clangStdenv.hostPlatform.isDarwin ''
+    install -d "$out/Applications"
+    if [ -d "$out/bin/aseprite.app" ]; then
+      rm -rf "$out/Applications/Aseprite.app"
+      mv "$out/bin/aseprite.app" "$out/Applications/Aseprite.app"
+    fi
+    # Generate the `.icns` files referenced by Info.plist from the shipped PNGs.
+    res="$out/Applications/Aseprite.app/Contents/Resources"
+    icons="$res/data/icons"
+    if [ -d "$icons" ] && command -v png2icns >/dev/null; then
+      for spec in "Aseprite ase" "Document doc" "Extension ext"; do
+        set -- $spec
+        name="$1"
+        prefix="$2"
+        png2icns "$res/$name.icns" \
+          "$icons/''${prefix}16.png" \
+          "$icons/''${prefix}32.png" \
+          "$icons/''${prefix}128.png" \
+          "$icons/''${prefix}256.png"
+      done
+    fi
+    # Keep $out/bin clean on Darwin; the bundle lives under $out/Applications.
+    rmdir "$out/bin" 2>/dev/null || true
   '';
 
   passthru.updateScript = gitUpdater { rev-prefix = "v"; };
@@ -159,20 +191,19 @@ clangStdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.unfree;
     longDescription = ''
       Aseprite is a program to create animated sprites. Its main features are:
-
-                - Sprites are composed by layers & frames (as separated concepts).
-                - Supported color modes: RGBA, Indexed (palettes up to 256 colors), and Grayscale.
-                - Load/save sequence of PNG files and GIF animations (and FLC, FLI, JPG, BMP, PCX, TGA).
-                - Export/import animations to/from Sprite Sheets.
-                - Tiled drawing mode, useful to draw patterns and textures.
-                - Undo/Redo for every operation.
-                - Real-time animation preview.
-                - Multiple editors support.
-                - Pixel-art specific tools like filled Contour, Polygon, Shading mode, etc.
-                - Onion skinning.
+        - Sprites are composed by layers & frames (as separated concepts).
+        - Supported color modes: RGBA, Indexed (palettes up to 256 colors), and Grayscale.
+        - Load/save sequence of PNG files and GIF animations (and FLC, FLI, JPG, BMP, PCX, TGA).
+        - Export/import animations to/from Sprite Sheets.
+        - Tiled drawing mode, useful to draw patterns and textures.
+        - Undo/Redo for every operation.
+        - Real-time animation preview.
+        - Multiple editors support.
+        - Pixel-art specific tools like filled Contour, Polygon, Shading mode, etc.
+        - Onion skinning.
     '';
     maintainers = [ lib.maintainers.iamanaws ];
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
     mainProgram = "aseprite";
   };
 })

--- a/pkgs/by-name/as/aseprite/package.nix
+++ b/pkgs/by-name/as/aseprite/package.nix
@@ -171,7 +171,7 @@ clangStdenv.mkDerivation (finalAttrs: {
                 - Pixel-art specific tools like filled Contour, Polygon, Shading mode, etc.
                 - Onion skinning.
     '';
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.iamanaws ];
     platforms = lib.platforms.linux;
     mainProgram = "aseprite";
   };

--- a/pkgs/by-name/sk/skia-aseprite/package.nix
+++ b/pkgs/by-name/sk/skia-aseprite/package.nix
@@ -2,6 +2,7 @@
   aseprite,
   clangStdenv,
   expat,
+  cctools,
   fetchFromGitHub,
   fetchgit,
   fontconfig,
@@ -38,6 +39,10 @@ clangStdenv.mkDerivation (finalAttrs: {
     gn
     ninja
     python3
+  ]
+  ++ lib.optionals clangStdenv.hostPlatform.isDarwin [
+    # Skia's build invokes `libtool -static` on Darwin to create `.a` archives.
+    cctools.libtool
   ];
 
   # Using substituteInPlace because no clean upstream backport for GCC 15 exists for this version of Skia, newer versions fix this with large refactorings.
@@ -68,13 +73,15 @@ clangStdenv.mkDerivation (finalAttrs: {
     expat
     fontconfig
     harfbuzzFull
-    libglvnd
     libjpeg
     libpng
     libwebp
+    zlib
+  ]
+  ++ lib.optionals clangStdenv.hostPlatform.isLinux [
+    libglvnd
     libX11
     libgbm
-    zlib
   ];
 
   buildPhase = ''


### PR DESCRIPTION
- Fix skia-aseprite build for darwin (close https://github.com/NixOS/nixpkgs/issues/332312) 
- Add initial darwin support for aseprite. 
- Add myself as maintainer. I didn't initially intend to adopt this package, but after handling the last version bump from an almost year-old version, I realized I could help to at least keep it in better shape than it has been recently.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
