### PR TITLE
ocamlPackages.ppxlib: 0.33.0 → 0.34.0

### DIFF
--- a/pkgs/by-name/fl/flow/package.nix
+++ b/pkgs/by-name/fl/flow/package.nix
@@ -10,7 +10,7 @@
 let
   ocamlPackages = ocaml-ng.ocamlPackages.overrideScope (
     self: super: {
-      ppxlib = super.ppxlib.override { version = "0.33.0"; };
+      ppxlib = super.ppxlib.override { version = "0.34.0"; };
     }
   );
 in

--- a/pkgs/development/ocaml-modules/landmarks-ppx/default.nix
+++ b/pkgs/development/ocaml-modules/landmarks-ppx/default.nix
@@ -8,14 +8,13 @@
 
 buildDunePackage {
   pname = "landmarks-ppx";
-  minimalOCamlVersion = "4.08";
 
   inherit (landmarks) src version;
 
   buildInputs = [ ppxlib ];
   propagatedBuildInputs = [ landmarks ];
 
-  doCheck = lib.versionAtLeast ocaml.version "4.08" && lib.versionOlder ocaml.version "5.0";
+  doCheck = lib.versionAtLeast ocaml.version "5.1";
 
   meta = landmarks.meta // {
     description = "Preprocessor instrumenting code using the landmarks library";

--- a/pkgs/development/ocaml-modules/ocaml-lsp/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-lsp/default.nix
@@ -85,5 +85,6 @@ buildDunePackage rec {
   meta = lsp.meta // {
     description = "OCaml Language Server Protocol implementation";
     mainProgram = "ocamllsp";
+    broken = lib.versions.majorMinor ocaml.version == "4.13";
   };
 }

--- a/pkgs/development/ocaml-modules/ppxlib/default.nix
+++ b/pkgs/development/ocaml-modules/ppxlib/default.nix
@@ -11,7 +11,7 @@
           if lib.versionAtLeast ocaml.version "5.03" then
             if lib.versionAtLeast ocaml.version "5.04" then "0.37.0" else "0.36.2"
           else
-            "0.33.0"
+            "0.34.0"
         else
           "0.24.0"
       else
@@ -90,6 +90,9 @@ let
       "0.33.0" = {
         sha256 = "sha256-/6RO9VHyO3XiHb1pijAxBDE4Gq8UC5/kuBwucKLSxjo=";
         min_version = "4.07";
+      };
+      "0.34.0" = {
+        sha256 = "sha256-132XFloVjXrla3wDh80E6ZJ9fn55fKEDn/tbsXpmYac=";
       };
       "0.36.2" = {
         sha256 = "sha256-yHVgB9jKwTeahGEUYQDB1hHH327MGpoKqb3ewNbk5xs=";


### PR DESCRIPTION
Note that this does not affect the default version of `ocamlPackages`.

The first two commits are not directly related but avoid build failures:
- landmark-ppx has been failing due to GCC 15
- ocaml-lsp has been broken by a dune update, some time ago

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
