### PR TITLE
lib.systems: add uefi support

### DIFF
--- a/lib/systems/doubles.nix
+++ b/lib/systems/doubles.nix
@@ -109,6 +109,10 @@ let
     "aarch64-windows"
     "x86_64-windows"
     "i686-windows"
+
+    # UEFI
+    "aarch64-uefi"
+    "x86_64-uefi"
   ];
 
   allParsed = map parse.mkSystemFromString all;
@@ -189,6 +193,7 @@ in
   redox = filterDoubles predicates.isRedox;
   windows = filterDoubles predicates.isWindows;
   genode = filterDoubles predicates.isGenode;
+  uefi = filterDoubles predicates.isUefi;
 
   embedded = filterDoubles predicates.isNone;
 }

--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -338,6 +338,24 @@ rec {
   };
 
   #
+  # UEFI
+  #
+
+  x86_64-unknown-uefi = {
+    config = "x86_64-unknown-uefi";
+    libc = null;
+    useLLVM = true;
+    linker = "lld";
+  };
+
+  aarch64-unknown-uefi = {
+    config = "aarch64-unknown-uefi";
+    libc = null;
+    useLLVM = true;
+    linker = "lld";
+  };
+
+  #
   # Windows
   #
 

--- a/lib/systems/inspect.nix
+++ b/lib/systems/inspect.nix
@@ -431,6 +431,10 @@ rec {
       }
     ];
 
+    isUefi = [
+      { kernel = kernels.uefi; }
+    ];
+
     isElf = {
       kernel.execFormat = execFormats.elf;
     };

--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -634,6 +634,10 @@ rec {
         execFormat = unknown;
         families = { };
       };
+      uefi = {
+        execFormat = pe;
+        families = { };
+      };
     }
     // {
       # aliases
@@ -849,6 +853,7 @@ rec {
             "mmixware"
             "ghcjs"
             "mingw32"
+            "uefi"
           ]
           || hasPrefix "freebsd" (elemAt l 2)
           || hasPrefix "netbsd" (elemAt l 2)

--- a/lib/tests/systems.nix
+++ b/lib/tests/systems.nix
@@ -55,6 +55,7 @@ lib.runTests (
       ++ js
       ++ genode
       ++ redox
+      ++ uefi
     );
 
     testarm = mseteq arm [
@@ -136,6 +137,7 @@ lib.runTests (
       "x86_64-solaris"
       "x86_64-windows"
       "x86_64-none"
+      "x86_64-uefi"
     ];
 
     testcygwin = mseteq cygwin [


### PR DESCRIPTION
Add uefi build support based on #353050.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
