### PR TITLE
dokuwiki: fix caddy route rewrite for /_detail

### DIFF
--- a/nixos/modules/services/web-apps/dokuwiki.nix
+++ b/nixos/modules/services/web-apps/dokuwiki.nix
@@ -609,9 +609,9 @@ in
               rewrite @allow_media /lib/exe/fetch.php?media=/{http.regexp.path.1}
 
               @allow_detail   {
-                path /_detail*
+                path_regexp path ^/_detail/(.*)$
               }
-              rewrite @allow_detail /lib/exe/detail.php?media={path}
+              rewrite @allow_detail /lib/exe/detail.php?media=/{http.regexp.path.1}
 
               @allow_export   {
                 path /_export*


### PR DESCRIPTION
this change fixes a bug in the Caddy configuration for the `dokuwiki` NixOS module. the route rewrite rule for paths containing `/_detail` was incorrect, causing issues when viewing image links when using Caddy as the web server.

tested manually by patching the module via `disabledModules = []`:

<img width="911" height="501" alt="image" src="https://github.com/user-attachments/assets/e1a5c05f-8cf0-4dcb-aa4f-c43dcbed60f5" />

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
