### PR TITLE
vimPlugins.nvim-treesitter-textobjects-legacy: init at 0-unstable-2025-10-31

### DIFF
--- a/pkgs/applications/editors/vim/plugins/generated.nix
+++ b/pkgs/applications/editors/vim/plugins/generated.nix
@@ -12189,6 +12189,19 @@ final: prev: {
     meta.hydraPlatforms = [ ];
   };
 
+  nvim-treesitter-textobjects-legacy = buildVimPlugin {
+    pname = "nvim-treesitter-textobjects-legacy";
+    version = "0-unstable-2025-10-31";
+    src = fetchFromGitHub {
+      owner = "nvim-treesitter";
+      repo = "nvim-treesitter-textobjects";
+      rev = "5ca4aaa6efdcc59be46b95a3e876300cfead05ef";
+      hash = "sha256-lf+AwSu96iKO1vWWU2D7jWHGfjXkbX9R2CX3gMZaD4M=";
+    };
+    meta.homepage = "https://github.com/nvim-treesitter/nvim-treesitter-textobjects/";
+    meta.hydraPlatforms = [ ];
+  };
+
   nvim-treesitter-textsubjects = buildVimPlugin {
     pname = "nvim-treesitter-textsubjects";
     version = "0-unstable-2025-08-14";

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -2840,6 +2840,10 @@ assertNoAdditions {
     dependencies = [ self.nvim-treesitter ];
   };
 
+  nvim-treesitter-textobjects-legacy = super.nvim-treesitter-textobjects-legacy.overrideAttrs {
+    dependencies = [ self.nvim-treesitter-legacy ];
+  };
+
   nvim-treesitter-textsubjects = super.nvim-treesitter-textsubjects.overrideAttrs {
     dependencies = [ self.nvim-treesitter-legacy ];
   };

--- a/pkgs/applications/editors/vim/plugins/vim-plugin-names
+++ b/pkgs/applications/editors/vim/plugins/vim-plugin-names
@@ -936,6 +936,7 @@ https://github.com/eddiebergman/nvim-treesitter-pyfold/,,
 https://github.com/nvim-treesitter/nvim-treesitter-refactor/,,
 https://github.com/PaterJason/nvim-treesitter-sexp/,HEAD,
 https://github.com/nvim-treesitter/nvim-treesitter-textobjects/,main,
+https://github.com/nvim-treesitter/nvim-treesitter-textobjects/,master,nvim-treesitter-textobjects-legacy
 https://github.com/RRethy/nvim-treesitter-textsubjects/,HEAD,
 https://github.com/AckslD/nvim-trevJ.lua/,HEAD,
 https://github.com/windwp/nvim-ts-autotag/,,


### PR DESCRIPTION
https://github.com/nvim-treesitter/nvim-treesitter-textobjects

I do not use this, but perchun asked me to add it

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
