### PR TITLE
lazyworktree: init at 1.17.0

### DIFF
--- a/pkgs/by-name/la/lazyworktree/package.nix
+++ b/pkgs/by-name/la/lazyworktree/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "lazyworktree";
+  version = "1.17.0";
+
+  src = fetchFromGitHub {
+    owner = "chmouel";
+    repo = "lazyworktree";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-5e/GnGpNCK/Tqs71UKei2sbnQ5c3MRuNod3VTNodKGM=";
+  };
+
+  vendorHash = "sha256-6TVCpD7xKN7giFhZXInKkohoML+usnzAJ5+4yDBjzJA=";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  # Tests require git and are integration tests
+  doCheck = false;
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${finalAttrs.version}"
+  ];
+
+  postInstall = ''
+    install -Dm444 shell/functions.shell -t $out/share/lazyworktree
+    installManPage lazyworktree.1
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "BubbleTea-based Terminal User Interface for efficient Git worktree management";
+    homepage = "https://github.com/chmouel/lazyworktree";
+    changelog = "https://github.com/chmouel/lazyworktree/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      chmouel
+      vdemeester
+    ];
+    mainProgram = "lazyworktree";
+  };
+})


### PR DESCRIPTION
BubbleTea-based Terminal User Interface for efficient Git worktree management, written in go.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
