### PR TITLE
linux-rpi: warn to drop in the future

### DIFF
--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -92,38 +92,6 @@ in
         # New vendor kernels should go to nixos-hardware instead.
         # e.g. https://github.com/NixOS/nixos-hardware/tree/master/microsoft/surface/kernel
 
-        linux_rpi1 = callPackage ../os-specific/linux/kernel/linux-rpi.nix {
-          kernelPatches = with kernelPatches; [
-            bridge_stp_helper
-            request_key_helper
-          ];
-          rpiVersion = 1;
-        };
-
-        linux_rpi2 = callPackage ../os-specific/linux/kernel/linux-rpi.nix {
-          kernelPatches = with kernelPatches; [
-            bridge_stp_helper
-            request_key_helper
-          ];
-          rpiVersion = 2;
-        };
-
-        linux_rpi3 = callPackage ../os-specific/linux/kernel/linux-rpi.nix {
-          kernelPatches = with kernelPatches; [
-            bridge_stp_helper
-            request_key_helper
-          ];
-          rpiVersion = 3;
-        };
-
-        linux_rpi4 = callPackage ../os-specific/linux/kernel/linux-rpi.nix {
-          kernelPatches = with kernelPatches; [
-            bridge_stp_helper
-            request_key_helper
-          ];
-          rpiVersion = 4;
-        };
-
         linux_5_10 = callPackage ../os-specific/linux/kernel/mainline.nix {
           branch = "5.10";
           kernelPatches = [
@@ -300,6 +268,56 @@ in
         linux_rt_5_4 = throw "linux_rt 5.4 has been removed because it will reach its end of life within 25.11";
 
         linux_ham = throw "linux_ham has been removed in favour of the standard kernel packages";
+
+        # Remove warning added on 2026-04-01
+        linux_rpi1 =
+          lib.warnOnInstantiate
+            "linux-rpi series will be removed in a future release. Please change to use nixos-hardware."
+            (
+              callPackage ../os-specific/linux/kernel/linux-rpi.nix {
+                kernelPatches = with kernelPatches; [
+                  bridge_stp_helper
+                  request_key_helper
+                ];
+                rpiVersion = 1;
+              }
+            );
+        linux_rpi2 =
+          lib.warnOnInstantiate
+            "linux-rpi series will be removed in a future release. Please change to use nixos-hardware."
+            (
+              callPackage ../os-specific/linux/kernel/linux-rpi.nix {
+                kernelPatches = with kernelPatches; [
+                  bridge_stp_helper
+                  request_key_helper
+                ];
+                rpiVersion = 2;
+              }
+            );
+        linux_rpi3 =
+          lib.warnOnInstantiate
+            "linux-rpi series will be removed in a future release. Please change to use nixos-hardware."
+            (
+              callPackage ../os-specific/linux/kernel/linux-rpi.nix {
+                kernelPatches = with kernelPatches; [
+                  bridge_stp_helper
+                  request_key_helper
+                ];
+                rpiVersion = 3;
+              }
+            );
+        linux_rpi4 =
+          lib.warnOnInstantiate
+            "linux-rpi series will be removed in a future release. Please change to use nixos-hardware."
+            (
+              callPackage ../os-specific/linux/kernel/linux-rpi.nix {
+                kernelPatches = with kernelPatches; [
+                  bridge_stp_helper
+                  request_key_helper
+                ];
+                rpiVersion = 4;
+              }
+            );
       }
     )
   );


### PR DESCRIPTION
Gradually deprecate the only vendor kernel exception in nixpkgs and move it to nixos-hardware

The proposal was made at https://github.com/NixOS/nixpkgs/pull/284391

We may need also now to copy the kernel and firmware files to nixos-hardware, so that users who already using nixos-hardware won't see the warn.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
