### PR TITLE
emacsPackages.ws-butler: avoid `fetchFromSavannah`

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -1765,10 +1765,9 @@ let
           workgroups2 = ignoreCompilationError super.workgroups2; # elisp error
 
           ws-butler = super.ws-butler.overrideAttrs (old: {
-            # work around https://github.com/NixOS/nixpkgs/issues/436534
-            src = pkgs.fetchFromSavannah {
-              repo = "emacs/nongnu";
-              inherit (old.src) rev outputHash outputHashAlgo;
+            # TODO: Remove override when URL was updated in MELPA.
+            src = old.src.override {
+              url = "https://https.git.savannah.gnu.org/git/elpa/nongnu.git";
             };
           });
 


### PR DESCRIPTION
Avoid usage of `fetchFromSavannah` for `ws-butler`. (Simply remove the override; this works for me).

This may fix https://github.com/NixOS/nixpkgs/issues/436534, although I am not sure if it resolves the root cause of the issue.

@jian-lin @normalcea 

Should we remove `fetchFromSavannah` altogether? It is not used anymore after this PR (but may be used downstream).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
