### PR TITLE
xzgv: fix build with gcc15

### DIFF
--- a/pkgs/by-name/xz/xzgv/package.nix
+++ b/pkgs/by-name/xz/xzgv/package.nix
@@ -23,6 +23,10 @@ stdenv.mkDerivation rec {
     gtk2
     libexif
   ];
+  env.NIX_CFLAGS_COMPILE = toString [
+    # gcc15 build failure
+    "-std=gnu17"
+  ];
   postPatch = ''
     substituteInPlace config.mk \
       --replace /usr/local $out


### PR DESCRIPTION
package no longer builds on master

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
