### PR TITLE
python3Packages.py-key-value-shared: init at 0.3.0; python3Packages.py-key-value-aio: init at 0.3.0; python3Packages.pydocket: init at 0.16.3; python3Packages.fastmcp: 2.12.5 -> 2.14.2

### DIFF
--- a/pkgs/development/python-modules/fastmcp/default.nix
+++ b/pkgs/development/python-modules/fastmcp/default.nix
@@ -160,6 +160,9 @@ buildPythonPackage rec {
     changelog = "https://github.com/jlowin/fastmcp/releases/tag/${src.tag}";
     homepage = "https://github.com/jlowin/fastmcp";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ GaetanLepage ];
+    maintainers = with lib.maintainers; [
+      amadejkastelic
+      GaetanLepage
+    ];
   };
 }

--- a/pkgs/development/python-modules/fastmcp/default.nix
+++ b/pkgs/development/python-modules/fastmcp/default.nix
@@ -18,13 +18,17 @@
   openai,
   openapi-core,
   openapi-pydantic,
+  platformdirs,
   pydantic,
+  pydocket,
   pyperclip,
   python-dotenv,
+  py-key-value-aio,
   rich,
   websockets,
 
   # tests
+  anthropic,
   dirty-equals,
   email-validator,
   fastapi,
@@ -37,14 +41,14 @@
 
 buildPythonPackage rec {
   pname = "fastmcp";
-  version = "2.12.5";
+  version = "2.14.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "jlowin";
     repo = "fastmcp";
     tag = "v${version}";
-    hash = "sha256-F8NCp1Ku1EeI/YjbHuHcDYytTgqOFyLp+sZGBqayv6s=";
+    hash = "sha256-JqDsHmhuRom4CPmQd0sMaBtgypHDtwVJ4I3fnOLjnd8=";
   };
 
   build-system = [
@@ -60,13 +64,19 @@ buildPythonPackage rec {
     mcp
     openapi-core
     openapi-pydantic
+    platformdirs
     pydantic
+    pydocket
     pyperclip
     python-dotenv
+    py-key-value-aio
     rich
     websockets
   ]
-  ++ pydantic.optional-dependencies.email;
+  ++ pydantic.optional-dependencies.email
+  ++ py-key-value-aio.optional-dependencies.disk
+  ++ py-key-value-aio.optional-dependencies.keyring
+  ++ py-key-value-aio.optional-dependencies.memory;
 
   optional-dependencies = {
     openai = [ openai ];
@@ -75,6 +85,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "fastmcp" ];
 
   nativeCheckInputs = [
+    anthropic
     dirty-equals
     email-validator
     fastapi
@@ -109,6 +120,9 @@ buildPythonPackage rec {
     "test_uv_transport"
     "test_uv_transport_module"
     "test_github_api_schema_performance"
+    "test_log_file_captures_stderr_output_with_path"
+    "test_log_file_captures_stderr_output_with_textio"
+    "test_log_file_none_uses_default_behavior"
 
     # RuntimeError: Client failed to connect: Timed out while waiting for response
     "test_timeout"
@@ -133,8 +147,6 @@ buildPythonPackage rec {
   disabledTestPaths = lib.optionals stdenv.hostPlatform.isDarwin [
     # RuntimeError: Server failed to start after 10 attempts
     "tests/client/auth/test_oauth_client.py"
-    "tests/client/test_openapi_experimental.py"
-    "tests/client/test_openapi_legacy.py"
     "tests/client/test_sse.py"
     "tests/client/test_streamable_http.py"
     "tests/server/auth/test_jwt_provider.py"

--- a/pkgs/development/python-modules/py-key-value-aio/default.nix
+++ b/pkgs/development/python-modules/py-key-value-aio/default.nix
@@ -1,0 +1,123 @@
+{
+  aioboto3,
+  aiofile,
+  aiohttp,
+  aiomcache,
+  anyio,
+  beartype,
+  buildPythonPackage,
+  cachetools,
+  cryptography,
+  dbus-python,
+  dirty-equals,
+  diskcache,
+  docker,
+  duckdb,
+  elasticsearch,
+  fetchFromGitHub,
+  inline-snapshot,
+  keyring,
+  lib,
+  pathvalidate,
+  pydantic,
+  pymongo,
+  py-key-value-shared,
+  pytest-asyncio,
+  pytest-xdist,
+  pytestCheckHook,
+  pytz,
+  redis,
+  types-aiobotocore-dynamodb,
+  uv-build,
+}:
+
+buildPythonPackage rec {
+  pname = "py-key-value-aio";
+  version = "0.3.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "strawgate";
+    repo = "py-key-value";
+    tag = version;
+    hash = "sha256-4ji+GzJTv1QnC5n/OaL9vR65j8BQmJsVGGnjjuulDiU=";
+  };
+
+  sourceRoot = "${src.name}/key-value/key-value-aio";
+
+  build-system = [ uv-build ];
+
+  dependencies = [
+    beartype
+    py-key-value-shared
+  ];
+
+  optional-dependencies = {
+    disk = [
+      diskcache
+      pathvalidate
+    ];
+    duckdb = [
+      duckdb
+      pytz
+    ];
+    dynamodb = [
+      aioboto3
+      types-aiobotocore-dynamodb
+    ];
+    elasticsearch = [
+      aiohttp
+      elasticsearch
+    ];
+    filetree = [
+      aiofile
+      anyio
+    ];
+    keyring = [ keyring ];
+    keyring-linux = [
+      dbus-python
+      keyring
+    ];
+    memcached = [ aiomcache ];
+    memory = [ cachetools ];
+    mongodb = [ pymongo ];
+    pydantic = [ pydantic ];
+    redis = [ redis ];
+    wrappers-encryption = [ cryptography ];
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml --replace-fail "uv_build>=0.8.2,<0.9.0" "uv_build"
+  '';
+
+  nativeCheckInputs = [
+    aiofile
+    aiomcache
+    anyio
+    cachetools
+    dirty-equals
+    diskcache
+    docker
+    inline-snapshot
+    pathvalidate
+    pydantic
+    pytestCheckHook
+    pytest-asyncio
+    pytest-xdist
+  ];
+
+  disabledTestPaths = [
+    # Require key_value.shared_test module
+    "tests/stores"
+  ];
+
+  pythonImportsCheck = [ "key_value.aio" ];
+
+  meta = {
+    description = "Async key-value store library";
+    homepage = "https://strawgate.com/py-key-value/";
+    changelog = "https://github.com/strawgate/py-key-value/releases/tag/${src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.amadejkastelic ];
+  };
+}

--- a/pkgs/development/python-modules/py-key-value-shared/default.nix
+++ b/pkgs/development/python-modules/py-key-value-shared/default.nix
@@ -1,0 +1,58 @@
+{
+  beartype,
+  buildPythonPackage,
+  fetchFromGitHub,
+  inline-snapshot,
+  lib,
+  pytestCheckHook,
+  pytest-xdist,
+  typing-extensions,
+  uv-build,
+}:
+
+buildPythonPackage rec {
+  pname = "py-key-value-shared";
+  version = "0.3.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "strawgate";
+    repo = "py-key-value";
+    tag = version;
+    hash = "sha256-4ji+GzJTv1QnC5n/OaL9vR65j8BQmJsVGGnjjuulDiU=";
+  };
+
+  sourceRoot = "${src.name}/key-value/key-value-shared";
+
+  build-system = [ uv-build ];
+
+  dependencies = [
+    beartype
+    typing-extensions
+  ];
+
+  postPatch = ''
+    substituteInPlace pyproject.toml --replace-fail "uv_build>=0.8.2,<0.9.0" "uv_build"
+  '';
+
+  nativeCheckInputs = [
+    inline-snapshot
+    pytestCheckHook
+    pytest-xdist
+  ];
+
+  disabledTestPaths = [
+    # Missing key_value.sharedtest module
+    "tests/utils/test_managed_entry.py"
+  ];
+
+  pythonImportsCheck = [ "key_value.shared" ];
+
+  meta = {
+    description = "Shared module for py-key-value packages";
+    homepage = "https://strawgate.com/py-key-value/";
+    changelog = "https://github.com/strawgate/py-key-value/releases/tag/${src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.amadejkastelic ];
+  };
+}

--- a/pkgs/development/python-modules/pydocket/default.nix
+++ b/pkgs/development/python-modules/pydocket/default.nix
@@ -1,0 +1,101 @@
+{
+  buildPythonPackage,
+  cloudpickle,
+  docker,
+  fakeredis,
+  fetchFromGitHub,
+  hatchling,
+  hatch-vcs,
+  lib,
+  opentelemetry-api,
+  opentelemetry-exporter-prometheus,
+  opentelemetry-instrumentation,
+  opentelemetry-instrumentation-redis,
+  prometheus-client,
+  pytestCheckHook,
+  py-key-value-aio,
+  pytest-asyncio,
+  pytest-cov,
+  pytest-timeout,
+  pytest-xdist,
+  python-json-logger,
+  redis,
+  rich,
+  typer,
+  typing-extensions,
+}:
+
+buildPythonPackage rec {
+  pname = "pydocket";
+  version = "0.16.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "chrisguidry";
+    repo = "docket";
+    tag = version;
+    hash = "sha256-DNq+PUbh6SfazxkM7tbjEOXbh1VSJPM3jEkgn64XQ5g=";
+  };
+
+  build-system = [
+    hatchling
+    hatch-vcs
+  ];
+
+  dependencies = [
+    cloudpickle
+    fakeredis
+    opentelemetry-api
+    opentelemetry-exporter-prometheus
+    opentelemetry-instrumentation
+    prometheus-client
+    py-key-value-aio
+    python-json-logger
+    redis
+    rich
+    typer
+    typing-extensions
+  ]
+  ++ fakeredis.optional-dependencies.lua
+  ++ py-key-value-aio.optional-dependencies.memory
+  ++ py-key-value-aio.optional-dependencies.redis;
+
+  pythonRelaxDeps = [
+    "fakeredis"
+    "opentelemetry-exporter-prometheus"
+    "opentelemetry-instrumentation"
+  ];
+
+  nativeCheckInputs = [
+    docker
+    opentelemetry-instrumentation-redis
+    pytest-asyncio
+    pytest-cov
+    pytest-timeout
+    pytest-xdist
+    pytestCheckHook
+  ];
+
+  preCheck = ''
+    export REDIS_VERSION=memory
+  '';
+
+  disabledTests = [
+    # Require network socket binding
+    "test_healthcheck_server_returns_ok"
+    "test_exports_metrics_as_prometheus_metrics"
+    # These tests fail when using fakeredis instead of real Redis
+    "test_internal_redis_polling_spans_suppressed_by_default"
+    "test_docket_strike_xread_spans_suppressed_by_default"
+  ];
+
+  pythonImportsCheck = [ "docket" ];
+
+  meta = {
+    description = "A distributed background task system for Python";
+    homepage = "https://chrisguidry.github.io/docket/";
+    changelog = "https://github.com/chrisguidry/docket/releases/tag/${src.tag}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.amadejkastelic ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12802,6 +12802,8 @@ self: super: with self; {
 
   py-improv-ble-client = callPackage ../development/python-modules/py-improv-ble-client { };
 
+  py-key-value-aio = callPackage ../development/python-modules/py-key-value-aio { };
+
   py-key-value-shared = callPackage ../development/python-modules/py-key-value-shared { };
 
   py-libnuma = callPackage ../development/python-modules/py-libnuma { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13265,6 +13265,8 @@ self: super: with self; {
 
   pydo = callPackage ../development/python-modules/pydo { };
 
+  pydocket = callPackage ../development/python-modules/pydocket { };
+
   pydocstyle = callPackage ../development/python-modules/pydocstyle { };
 
   pydocumentdb = callPackage ../development/python-modules/pydocumentdb { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12802,6 +12802,8 @@ self: super: with self; {
 
   py-improv-ble-client = callPackage ../development/python-modules/py-improv-ble-client { };
 
+  py-key-value-shared = callPackage ../development/python-modules/py-key-value-shared { };
+
   py-libnuma = callPackage ../development/python-modules/py-libnuma { };
 
   py-libzfs = callPackage ../development/python-modules/py-libzfs { };


### PR DESCRIPTION
https://github.com/jlowin/fastmcp/compare/v2.12.5..v2.14.2

Bumped `python3Packages.fastmcp` and packaged missing deps:
- `py-key-value-shared`
- `py-key-value-aio`
- `pydocket`

Closes #476673

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
