### PR TITLE
nixos/system-path: remove more wrappers

### DIFF
--- a/nixos/modules/config/system-path.nix
+++ b/nixos/modules/config/system-path.nix
@@ -214,6 +214,7 @@ in
       postBuild = ''
         # Remove wrapped binaries, they shouldn't be accessible via PATH.
         find $out/bin -maxdepth 1 -name ".*-wrapped" -type l -delete
+        find $out/bin -maxdepth 1 -name ".*-wrapped_*" -type l -delete
 
         if [ -x $out/bin/glib-compile-schemas -a -w $out/share/glib-2.0/schemas ]; then
             $out/bin/glib-compile-schemas $out/share/glib-2.0/schemas


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
I am having  all those wrappers in my PATH
```
                                        .FreeCADCmd-wrapped_                      .koreader-wrapped_                        .obs-ffmpeg-mux-wrapped_                  .shotcut-wrapped_
.android-translation-layer-wrapped_       .FreeCAD-wrapped_                         .kritarunner-wrapped_                     .obs-nvenc-test-wrapped_                  .simple_web_server-wrapped_
.ardour8-wrapped_                         .friture-wrapped_                         .krita_version-wrapped_                   .obs-wrapped_                             .smplayer-wrapped_
.ark-wrapped_                             .gcalccmd-wrapped_                        .krita-wrapped_                           .octave-10.3.0-wrapped_                   .spectacle-wrapped_
.audacious-wrapped_                       .ghb-wrapped_                             .krita-wrapped__                   
```
Another user:
<img width="1280" height="80" alt="image" src="https://github.com/user-attachments/assets/0c880a45-b500-4d0a-9669-e43acef328e7" />


TODO: test this change

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
