### PR TITLE
python3Packages.pydevd: cleanup

### DIFF
--- a/pkgs/development/python-modules/pydevd/default.nix
+++ b/pkgs/development/python-modules/pydevd/default.nix
@@ -1,20 +1,24 @@
 {
-  stdenv,
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
+
+  # build-system
   cython,
   setuptools,
+
+  # tests
   numpy,
   psutil,
-  pytest-xdist,
   pytestCheckHook,
+  pytest-xdist,
   pythonAtLeast,
   trio,
   untangle,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pydevd";
   version = "3.4.1";
   pyproject = true;
@@ -22,16 +26,9 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "fabioz";
     repo = "PyDev.Debugger";
-    tag = "pydev_debugger_${lib.replaceStrings [ "." ] [ "_" ] version}";
+    tag = "pydev_debugger_${lib.replaceStrings [ "." ] [ "_" ] finalAttrs.version}";
     hash = "sha256-srcYeN4IsnX/B0AWLynr62UC5o+DcjnUrGjcTpvHTCM=";
   };
-
-  # https://github.com/fabioz/PyDev.Debugger/issues/316
-  disabled = pythonAtLeast "3.14";
-
-  postPatch = ''
-    sed -i '/addopts/d' pytest.ini
-  '';
 
   __darwinAllowLocalNetworking = true;
 
@@ -43,7 +40,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     numpy
     psutil
-    #pytest-xdist
+    pytest-xdist
     pytestCheckHook
     trio
     untangle
@@ -64,9 +61,11 @@ buildPythonPackage rec {
     "test_attach_to_pid"
     "test_terminate"
     "test_gui_event_loop_custom"
+
     # AssertionError: assert '/usr/bin/' == '/usr/bin'
     # https://github.com/fabioz/PyDev.Debugger/issues/227
     "test_to_server_and_to_client"
+
     # Times out
     "test_case_sys_exit_multiple_exception_attach"
   ]
@@ -74,6 +73,44 @@ buildPythonPackage rec {
     # raise segmentation fault
     # https://github.com/fabioz/PyDev.Debugger/issues/269
     "test_evaluate_expression"
+  ]
+  ++ lib.optionals (pythonAtLeast "3.14") [
+    # AssertionError (strings do not match)
+    "test_build_tuple"
+    "test_collect_try_except_info"
+    "test_collect_try_except_info2"
+    "test_collect_try_except_info3"
+    "test_collect_try_except_info4"
+    "test_collect_try_except_info4a"
+    "test_collect_try_except_info_in_single_line_1"
+    "test_collect_try_except_info_in_single_line_2"
+    "test_collect_try_except_info_multiple_except"
+    "test_collect_try_except_info_raise_unhandled10"
+    "test_collect_try_except_info_raise_unhandled7"
+    "test_collect_try_except_info_return_on_except"
+    "test_collect_try_except_info_with"
+    "test_separate_future_import"
+    "test_simple_code_to_bytecode_cls_method"
+    "test_simple_code_to_bytecode_repr_return_tuple"
+    "test_simple_code_to_bytecode_repr_return_tuple_with_call"
+    "test_simple_code_to_bytecode_repr_simple_method_calls"
+    "test_simple_code_to_bytecode_repr_tuple"
+    "test_smart_step_into_bytecode_info_023a"
+
+    # AssertionError: False is not true
+    "test_if_code_obj_equals"
+
+    # AssertionError: TimeoutError (note: error trying to dump threads on timeout: [Errno 9] Bad file descriptor).
+    "test_m_switch"
+    "test_module_entry_point"
+    "test_multiprocessing_simple"
+    "test_stop_on_start_entry_point"
+    "test_stop_on_start_m_switch"
+
+    # Failed: remains unmatched: 'Worked'
+    "test_run"
+    # Failed: remains unmatched: 'WorkedLocalFoo'
+    "test_run_on_local_module_without_adding_to_pythonpath"
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     "test_multiprocessing_simple"
@@ -89,4 +126,4 @@ buildPythonPackage rec {
     maintainers = with lib.maintainers; [ onny ];
     mainProgram = "pydevd";
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
