### PR TITLE
regal: Update regal package source to OPA org

### DIFF
--- a/pkgs/by-name/re/regal/package.nix
+++ b/pkgs/by-name/re/regal/package.nix
@@ -6,29 +6,32 @@
 
 buildGoModule rec {
   name = "regal";
-  version = "0.34.1";
+  version = "0.37.0";
 
   src = fetchFromGitHub {
-    owner = "StyraInc";
+    owner = "open-policy-agent";
     repo = "regal";
     rev = "v${version}";
-    hash = "sha256-gdoQ+u9YbwTq28b3gYsNA0SxYFigeKK2JUd0paz8WYQ=";
+    hash = "sha256-zAp4v1bKz+q+29jlhEccl7o9RWLA+Hn3Kp/UGBQlmA8=";
   };
 
-  vendorHash = "sha256-FycDMCfvpUkW7KcTLMUBOjbU4JnKCJrWQalNKSY1RkM=";
+  vendorHash = "sha256-yvUvv8EL3WrsyBnzaGQK4DR+O5Ner9ehkZYCMnfRwRU=";
+
+  # Only build the main binary, exclude build/lsp/main.go
+  subPackages = [ "." ];
 
   ldflags = [
     "-s"
     "-w"
-    "-X github.com/styrainc/regal/pkg/version.Version=${version}"
-    "-X github.com/styrainc/regal/pkg/version.Commit=${version}"
+    "-X github.com/open-policy-agent/regal/pkg/version.Version=${version}"
+    "-X github.com/open-policy-agent/regal/pkg/version.Commit=${version}"
   ];
 
   meta = {
     description = "Linter and language server for Rego";
     mainProgram = "regal";
-    homepage = "https://github.com/StyraInc/regal";
-    changelog = "https://github.com/StyraInc/regal/releases/tag/${src.rev}";
+    homepage = "https://github.com/open-policy-agent/regal";
+    changelog = "https://github.com/open-policy-agent/regal/releases/tag/${src.rev}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ rinx ];
   };


### PR DESCRIPTION
Regal has been donated to the Open Policy Agent GitHub organization. Update package to fetch from new upstream location and enable automatic updates going forward.

For more info regarding the donation, please see:
https://blog.openpolicyagent.org/note-from-teemu-tim-and-torin-to-the-open-policy-agent-community-2dbbfe494371




## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
