### PR TITLE
python3Packages.systembridgeconnector: 5.2.4 -> 5.3.1

### DIFF
--- a/pkgs/development/python-modules/systembridgeconnector/default.nix
+++ b/pkgs/development/python-modules/systembridgeconnector/default.nix
@@ -15,14 +15,14 @@
 
 buildPythonPackage rec {
   pname = "systembridgeconnector";
-  version = "5.2.4";
+  version = "5.3.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "timmo001";
     repo = "system-bridge-connector";
     tag = version;
-    hash = "sha256-2ExuhxaN0qfmiHruDM+/3VIKxVOH62iGN/TB3eflJvQ=";
+    hash = "sha256-VM5Or2IiLN+ceUyCaCRxys9B12JSaSfDwaoII2X6q/A=";
   };
 
   build-system = [
@@ -49,6 +49,7 @@ buildPythonPackage rec {
 
   disabledTests = [
     "test_execute_command"
+    "test_get_commands"
     "test_get_data"
     "test_get_directories"
     "test_get_file"


### PR DESCRIPTION
Diff: https://github.com/timmo001/system-bridge-connector/compare/5.2.4...5.3.1

Changelog: https://github.com/timmo001/system-bridge-connector/releases/tag/5.3.1


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
