### PR TITLE
variety: 0.8.13 -> 0.9.0-b1

### DIFF
--- a/pkgs/by-name/va/variety/package.nix
+++ b/pkgs/by-name/va/variety/package.nix
@@ -22,14 +22,14 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "variety";
-  version = "0.8.13";
+  version = "0.9.0-b1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "varietywalls";
     repo = "variety";
     tag = version;
-    hash = "sha256-7CTJ3hWddbOX/UfZ1qX9rPNGTfkxQ4pxu23sq9ulgv4=";
+    hash = "sha256-uDQZfWY0RuTsdD/IxpjzSTMMtNq632VAwAjB+CeUIbw=";
   };
 
   nativeBuildInputs = [
@@ -47,7 +47,10 @@ python3Packages.buildPythonApplication rec {
   ]
   ++ lib.optional appindicatorSupport libayatana-appindicator;
 
-  build-system = with python3Packages; [ setuptools ];
+  build-system = with python3Packages; [
+    setuptools
+    setuptools-gettext
+  ];
 
   dependencies =
     with python3Packages;
@@ -77,12 +80,10 @@ python3Packages.buildPythonApplication rec {
   '';
 
   prePatch = ''
-    substituteInPlace variety_lib/varietyconfig.py \
-      --replace-fail "__variety_data_directory__ = \"../data\"" \
-                "__variety_data_directory__ = \"$out/share/variety\""
     substituteInPlace variety/VarietyWindow.py \
       --replace-fail '[script,' '["${runtimeShell}", script,' \
-      --replace-fail 'check_output(script)' 'check_output(["${runtimeShell}", script])'
+      --replace-fail 'check_output(script)' 'check_output(["${runtimeShell}", script])' \
+      --replace-fail 'os.stat(path).st_mode | stat.S_IEXEC' 'os.stat(path).st_mode | stat.S_IEXEC | stat.S_IWUSR'
     substituteInPlace data/variety-autostart.desktop.template \
       --replace-fail "/bin/bash" "${lib.getExe bash}" \
       --replace-fail "{VARIETY_PATH}" "variety"


### PR DESCRIPTION
Updates variety from 0.8.13 to 0.9.0-b1 (beta).

This beta release adds support for COSMIC desktop environment, which is needed for users running the new COSMIC DE. Additionally includes support for KDE Active Blur wallpaper plugin, WebP image format, and fixes Python 3.14 compatibility issues.

Release notes: https://github.com/varietywalls/variety/releases/tag/0.9.0-b1

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`?
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - NixOS test(s) (look inside nixos/tests)
  - and/or package tests
  - or, for functions and "core" functionality, tests in lib/tests or pkgs/test
  - made sure NixOS tests are linked to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- 25.05 Release Notes
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits CONTRIBUTING.md