### PR TITLE
prometheus: 3.8.1 → 3.9.1

### DIFF
--- a/pkgs/by-name/pr/prometheus/package.nix
+++ b/pkgs/by-name/pr/prometheus/package.nix
@@ -24,6 +24,7 @@
   enableOVHCloud ? true,
   enablePuppetDB ? true,
   enableScaleway ? true,
+  enableSTACKIT ? true,
   enableTriton ? true,
   enableUyuni ? true,
   enableVultr ? true,
@@ -127,6 +128,7 @@ buildGoModule (finalAttrs: {
     ${lib.optionalString enableOVHCloud "echo - github.com/prometheus/prometheus/discovery/ovhcloud"}
     ${lib.optionalString enablePuppetDB "echo - github.com/prometheus/prometheus/discovery/puppetdb"}
     ${lib.optionalString enableScaleway "echo - github.com/prometheus/prometheus/discovery/scaleway"}
+    ${lib.optionalString enableSTACKIT "echo - github.com/prometheus/prometheus/discovery/stackit"}
     ${lib.optionalString enableTriton "echo - github.com/prometheus/prometheus/discovery/triton"}
     ${lib.optionalString enableUyuni "echo - github.com/prometheus/prometheus/discovery/uyuni"}
     ${lib.optionalString enableVultr "echo - github.com/prometheus/prometheus/discovery/vultr"}

--- a/pkgs/by-name/pr/prometheus/source.nix
+++ b/pkgs/by-name/pr/prometheus/source.nix
@@ -1,6 +1,6 @@
 {
-  version = "3.8.1";
-  hash = "sha256-mb1aMWpIELyZaqjYX1teYdtAK/+W9jzdPwzgbT7AVj4=";
-  npmDepsHash = "sha256-wmxvlQWQO2gP2apupMJssqAPr1ntWWIazduQU3AuodU=";
-  vendorHash = "sha256-35pVMl1Hu970BQE6jMzT1xaz/3FaIFWUtel0cl/uBdw=";
+  version = "3.9.0";
+  hash = "sha256-80EkJaH7NMQOCHWKz19c/8c2ncBE+qAFJ5fp1mbK+tU=";
+  npmDepsHash = "sha256-Y4874LZjj48y5eeByhhMAJp3NtX0QAehYvjzxkK2B2E=";
+  vendorHash = "sha256-CGec9hR/BpO3rXNGYm0V9AESsGIR6a0734e8t9oMOpA=";
 }

--- a/pkgs/by-name/pr/prometheus/source.nix
+++ b/pkgs/by-name/pr/prometheus/source.nix
@@ -1,6 +1,6 @@
 {
-  version = "3.9.0";
-  hash = "sha256-80EkJaH7NMQOCHWKz19c/8c2ncBE+qAFJ5fp1mbK+tU=";
-  npmDepsHash = "sha256-Y4874LZjj48y5eeByhhMAJp3NtX0QAehYvjzxkK2B2E=";
+  version = "3.9.1";
+  hash = "sha256-kqqWFvzEfpG+e+7ils9KE/RNs0eadLqrzMQJsSunQOM=";
+  npmDepsHash = "sha256-Z+EaIDQLgJ1YQ9tmGZLtvOVaDvZX1qeJJxsCAd/h41k=";
   vendorHash = "sha256-CGec9hR/BpO3rXNGYm0V9AESsGIR6a0734e8t9oMOpA=";
 }


### PR DESCRIPTION
* https://github.com/prometheus/prometheus/releases/tag/v3.9.0
* https://github.com/prometheus/prometheus/releases/tag/v3.9.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
