### PR TITLE
python313Packages.tuya-device-sharing-sdk: 0.2.7 -> 0.2.8

### DIFF
--- a/pkgs/development/python-modules/tuya-device-sharing-sdk/default.nix
+++ b/pkgs/development/python-modules/tuya-device-sharing-sdk/default.nix
@@ -9,7 +9,7 @@
 }:
 let
   pname = "tuya-device-sharing-sdk";
-  version = "0.2.7";
+  version = "0.2.8";
 in
 buildPythonPackage {
   inherit pname version;

--- a/pkgs/development/python-modules/tuya-device-sharing-sdk/default.nix
+++ b/pkgs/development/python-modules/tuya-device-sharing-sdk/default.nix
@@ -1,44 +1,42 @@
 {
   lib,
   buildPythonPackage,
-  fetchFromGitHub,
-  setuptools,
-  requests,
-  paho-mqtt,
   cryptography,
+  fetchFromGitHub,
+  paho-mqtt,
+  requests,
+  setuptools,
 }:
-let
+
+buildPythonPackage (finalAttrs: {
   pname = "tuya-device-sharing-sdk";
   version = "0.2.8";
-in
-buildPythonPackage {
-  inherit pname version;
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "tuya";
     repo = "tuya-device-sharing-sdk";
-    # no tags on GitHub: https://github.com/tuya/tuya-device-sharing-sdk/issues/2
-    # no sdist on PyPI: https://github.com/tuya/tuya-device-sharing-sdk/issues/41
-    # check the dev branch for new changes
-    rev = "86c0510e7229b9cf41b2bae57f3557a4d83c1928";
-    hash = "sha256-nL7lr6HC+YpvmAdTnR6hzzn+9MEgzHkyzZuwjzsFHV0=";
+    tag = finalAttrs.version;
+    hash = "sha256-uD2Lzs08i/01iEksXpYRGB2lU7I15sQrJLfJZ93+oeY=";
   };
 
   build-system = [ setuptools ];
 
   dependencies = [
-    requests
-    paho-mqtt
     cryptography
+    paho-mqtt
+    requests
   ];
 
   doCheck = false; # no tests
 
+  pythonImportsCheck = [ "tuya_sharing" ];
+
   meta = {
     description = "Tuya Device Sharing SDK";
     homepage = "https://github.com/tuya/tuya-device-sharing-sdk";
+    changelog = "https://github.com/tuya/tuya-device-sharing-sdk/releases/tag/${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ aciceri ];
   };
-}
+})


### PR DESCRIPTION
Changelog: https://github.com/tuya/tuya-device-sharing-sdk/releases/tag/0.2.8

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
