### PR TITLE
libvpx: Fix ppc64 cross, improve ppc64le cross

### DIFF
--- a/pkgs/by-name/li/libvpx/package.nix
+++ b/pkgs/by-name/li/libvpx/package.nix
@@ -84,6 +84,8 @@ let
       "arm64"
     else if stdenv.hostPlatform.isx86_32 then
       "x86"
+    else if (stdenv.hostPlatform.isPower64 && stdenv.hostPlatform.isLittleEndian) then
+      "ppc64le"
     else
       stdenv.hostPlatform.parsed.cpu.name;
 
@@ -97,7 +99,10 @@ let
       stdenv.hostPlatform.parsed.kernel.name;
 
   isGeneric =
-    (stdenv.hostPlatform.isPower && stdenv.hostPlatform.isLittleEndian)
+    (
+      stdenv.hostPlatform.isPower
+      && !(stdenv.hostPlatform.isPower64 && stdenv.hostPlatform.isLittleEndian)
+    )
     || stdenv.hostPlatform.parsed.cpu.name == "armv6l"
     || stdenv.hostPlatform.isLoongArch64
     || stdenv.hostPlatform.isRiscV;


### PR DESCRIPTION
- ppc64le now has a corresponding target in libvgm. Adjust code to use ppc64le-linux-gnu for ppc64le cross.
- 32-bit POWER & ppc64 cross currently doesn't build, because there are no known platform targets in libvpx for these. Adjust isGeneric code to include non-ppc64le POWER.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux (unchanged)
  - [x] powerpc-linux (cross)
  - [x] powerpc64-linux (cross)
  - [x] powerpc64le-linux (cross)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
