### PR TITLE
apple-sdk: add license to be in complaince

### DIFF
--- a/pkgs/by-name/ap/apple-sdk/package.nix
+++ b/pkgs/by-name/ap/apple-sdk/package.nix
@@ -107,6 +107,9 @@ stdenvNoCC.mkDerivation (
     meta = {
       description = "Frameworks and libraries required for building packages on Darwin";
       homepage = "https://developer.apple.com";
+      # NOTE: We only strip the SDK to only symbol lists & header files for interoperability all encumbered binary code is removed.
+      # Please see ....
+      license = lib.licenses.free;
       teams = [ lib.teams.darwin ];
       platforms = lib.platforms.darwin;
       badPlatforms = [ lib.systems.inspect.patterns.is32bit ];


### PR DESCRIPTION
This pr adds the apple sdk license to be in compliance that has been missed. 

[See this comment for issues around why it needs to be added](https://github.com/NixOS/nixpkgs/pull/477742#issuecomment-3718942454)

I did a simple nix eval and found it missing: 
```
nix eval --json --impure --expr '
  let 
    pkgs = import <nixpkgs> { 
      config = { 
        allowUnfree = true; 
        allowBroken = true; 
      }; 
    };
    lib = pkgs.lib;
    
    # Safely check for meta.name and the absence of meta.license
    checkMissingLicense = name: value: 
      let 
        res = builtins.tryEval (
          # Check if it is a derivation and has meta.name but NO license
          lib.isDerivation value && 
          (value ? meta.name) && 
          !(value ? meta.license)
        );
      in 
        res.success && res.value;

    # Filter the entire package set
    missingLicense = lib.filterAttrs checkMissingLicense pkgs;
  in 
    builtins.attrNames missingLicense
'
```

Link to license: https://developer.apple.com/support/terms/apple-developer-program-license-agreement/

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

CC @NixOS/darwin-core

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
