### PR TITLE
nixos/zoxide: ensure zoxide last in shell init

### DIFF
--- a/nixos/modules/programs/zoxide.nix
+++ b/nixos/modules/programs/zoxide.nix
@@ -52,16 +52,22 @@ in
     environment.systemPackages = [ cfg.package ];
 
     programs = {
-      zsh.interactiveShellInit = mkIf cfg.enableZshIntegration ''
-        eval "$(${getExe cfg.package} init zsh ${cfgFlags} )"
-      '';
-      bash.interactiveShellInit = mkIf cfg.enableBashIntegration ''
-        eval "$(${getExe cfg.package} init bash ${cfgFlags} )"
-      '';
-      fish.interactiveShellInit = mkIf cfg.enableFishIntegration ''
-        ${getExe cfg.package} init fish ${cfgFlags} | source
-      '';
-      xonsh.config = ''
+      zsh.interactiveShellInit = mkIf cfg.enableZshIntegration (
+        lib.mkAfter ''
+          eval "$(${getExe cfg.package} init zsh ${cfgFlags} )"
+        ''
+      );
+      bash.interactiveShellInit = mkIf cfg.enableBashIntegration (
+        lib.mkAfter ''
+          eval "$(${getExe cfg.package} init bash ${cfgFlags} )"
+        ''
+      );
+      fish.interactiveShellInit = mkIf cfg.enableFishIntegration (
+        lib.mkAfter ''
+          ${getExe cfg.package} init fish ${cfgFlags} | source
+        ''
+      );
+      xonsh.config = lib.mkAfter ''
         execx($(${getExe cfg.package} init xonsh ${cfgFlags}), 'exec', __xonsh__.ctx, filename='zoxide')
       '';
     };


### PR DESCRIPTION
this is required by zoxide, otherwise warning emitted

discovered this issue when I used starship and zoxide together.

the warning looks like:
```
zoxide: detected a possible configuration issue.
Please ensure that zoxide is initialized right at the end of your shell configuration file (usually ~/.bashrc).

If the issue persists, consider filing an issue at:
https://github.com/ajeetdsouza/zoxide/issues

Disable this message by setting _ZO_DOCTOR=0.
```

after this change, no warning emitted.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
