### PR TITLE
lemon-graph: fix build with GCC 15 and C++20

### DIFF
--- a/pkgs/by-name/le/lemon-graph/package.nix
+++ b/pkgs/by-name/le/lemon-graph/package.nix
@@ -27,6 +27,9 @@ stdenv.mkDerivation rec {
 
     # fix cmake compatibility. vendored from https://github.com/The-OpenROAD-Project/lemon-graph/pull/2
     ./cmake_version.patch
+
+    # fix C++20 compatibility. vendored from https://github.com/The-OpenROAD-Project/lemon-graph/commit/f871b10396270cfd09ffddc4b6ead07722e9c232
+    ./update_cxx20.patch
   ];
 
   meta = {

--- a/pkgs/by-name/le/lemon-graph/update_cxx20.patch
+++ b/pkgs/by-name/le/lemon-graph/update_cxx20.patch
@@ -1,0 +1,127 @@
+From f871b10396270cfd09ffddc4b6ead07722e9c232 Mon Sep 17 00:00:00 2001
+From: Matt Liberty <mliberty@precisioninno.com>
+Date: Wed, 13 Nov 2024 03:48:00 +0000
+Subject: [PATCH] Update for c++20
+
+Signed-off-by: Matt Liberty <mliberty@precisioninno.com>
+---
+ lemon/bits/array_map.h | 27 ++++++++++++++-------------
+ 1 file changed, 14 insertions(+), 13 deletions(-)
+
+diff --git a/lemon/bits/array_map.h b/lemon/bits/array_map.h
+index 355ee00..f8a7133 100644
+--- a/lemon/bits/array_map.h
++++ b/lemon/bits/array_map.h
+@@ -75,6 +75,7 @@ namespace lemon {
+     typedef typename Notifier::ObserverBase Parent;
+ 
+     typedef std::allocator<Value> Allocator;
++    typedef std::allocator_traits<Allocator> AllocatorTraits;
+ 
+   public:
+ 
+@@ -88,7 +89,7 @@ namespace lemon {
+       Item it;
+       for (nf->first(it); it != INVALID; nf->next(it)) {
+         int id = nf->id(it);;
+-        allocator.construct(&(values[id]), Value());
++        AllocatorTraits::construct(allocator, &(values[id]), Value());
+       }
+     }
+ 
+@@ -102,7 +103,7 @@ namespace lemon {
+       Item it;
+       for (nf->first(it); it != INVALID; nf->next(it)) {
+         int id = nf->id(it);;
+-        allocator.construct(&(values[id]), value);
++        AllocatorTraits::construct(allocator, &(values[id]), value);
+       }
+     }
+ 
+@@ -121,7 +122,7 @@ namespace lemon {
+       Item it;
+       for (nf->first(it); it != INVALID; nf->next(it)) {
+         int id = nf->id(it);;
+-        allocator.construct(&(values[id]), copy.values[id]);
++        AllocatorTraits::construct(allocator, &(values[id]), copy.values[id]);
+       }
+     }
+ 
+@@ -218,15 +219,15 @@ namespace lemon {
+         for (nf->first(it); it != INVALID; nf->next(it)) {
+           int jd = nf->id(it);;
+           if (id != jd) {
+-            allocator.construct(&(new_values[jd]), values[jd]);
+-            allocator.destroy(&(values[jd]));
++            AllocatorTraits::construct(allocator, &(new_values[jd]), values[jd]);
++            AllocatorTraits::destroy(allocator, &(values[jd]));
+           }
+         }
+         if (capacity != 0) allocator.deallocate(values, capacity);
+         values = new_values;
+         capacity = new_capacity;
+       }
+-      allocator.construct(&(values[id]), Value());
++      AllocatorTraits::construct(allocator, &(values[id]), Value());
+     }
+ 
+     // \brief Adds more new keys to the map.
+@@ -260,8 +261,8 @@ namespace lemon {
+             }
+           }
+           if (found) continue;
+-          allocator.construct(&(new_values[id]), values[id]);
+-          allocator.destroy(&(values[id]));
++          AllocatorTraits::construct(allocator, &(new_values[id]), values[id]);
++          AllocatorTraits::destroy(allocator, &(values[id]));
+         }
+         if (capacity != 0) allocator.deallocate(values, capacity);
+         values = new_values;
+@@ -269,7 +270,7 @@ namespace lemon {
+       }
+       for (int i = 0; i < int(keys.size()); ++i) {
+         int id = nf->id(keys[i]);
+-        allocator.construct(&(values[id]), Value());
++        AllocatorTraits::construct(allocator, &(values[id]), Value());
+       }
+     }
+ 
+@@ -279,7 +280,7 @@ namespace lemon {
+     // and it overrides the erase() member function of the observer base.
+     virtual void erase(const Key& key) {
+       int id = Parent::notifier()->id(key);
+-      allocator.destroy(&(values[id]));
++      AllocatorTraits::destroy(allocator, &(values[id]));
+     }
+ 
+     // \brief Erase more keys from the map.
+@@ -289,7 +290,7 @@ namespace lemon {
+     virtual void erase(const std::vector<Key>& keys) {
+       for (int i = 0; i < int(keys.size()); ++i) {
+         int id = Parent::notifier()->id(keys[i]);
+-        allocator.destroy(&(values[id]));
++        AllocatorTraits::destroy(allocator, &(values[id]));
+       }
+     }
+ 
+@@ -303,7 +304,7 @@ namespace lemon {
+       Item it;
+       for (nf->first(it); it != INVALID; nf->next(it)) {
+         int id = nf->id(it);;
+-        allocator.construct(&(values[id]), Value());
++        AllocatorTraits::construct(allocator, &(values[id]), Value());
+       }
+     }
+ 
+@@ -317,7 +318,7 @@ namespace lemon {
+         Item it;
+         for (nf->first(it); it != INVALID; nf->next(it)) {
+           int id = nf->id(it);
+-          allocator.destroy(&(values[id]));
++          AllocatorTraits::destroy(allocator, &(values[id]));
+         }
+         allocator.deallocate(values, capacity);
+         capacity = 0;
+-- 
+2.52.0
+


### PR DESCRIPTION
- Fix 'std::iterator' deprecation warnings by defining iterator traits explicitly.
- Fix 'std::allocator::construct' removal in C++20 using std::allocator_traits.
- Resolve uninitialized variable warnings in dim2::Point.
- Add [[fallthrough]] attributes to intentional switch case transitions.
