### PR TITLE
tests.eval: init

### DIFF
--- a/pkgs/development/interpreters/python/python-packages-base.nix
+++ b/pkgs/development/interpreters/python/python-packages-base.nix
@@ -76,7 +76,7 @@ let
               pos = attrs.__stdenvPythonCompatPos or (builtins.unsafeGetAttrPos attrName attrs);
               msg = [
                 "${name}: Passing `stdenv` directly to `buildPythonPackage` or `buildPythonApplication` is deprecated. You should use their `.override` function instead, e.g:"
-                "  buildPythonPackage.override { stdenv = customStdenv; } { }"
+                "    buildPythonPackage.override { stdenv = customStdenv; } { }"
               ]
               ++ lib.optionals (pos != null) [
                 "`stdenv` argument found at ${pos.file}:${toString pos.line}"

--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -109,6 +109,8 @@ in
       gccTests = recurseIntoAttrs gccTests;
     };
 
+  eval = callPackage ./eval { };
+
   devShellTools = callPackage ../build-support/dev-shell-tools/tests { };
 
   stdenv-inputs = callPackage ./stdenv-inputs { };

--- a/pkgs/test/eval/README.md
+++ b/pkgs/test/eval/README.md
@@ -1,0 +1,30 @@
+# Eval tests
+
+This directory contains tests for Nixpkgs eval itself.
+For example, you can test that a deprecated feature gives the expected result _and_ emits the expected warning.
+
+The test harness itself is in `default.nix` and `test.py`, which reads all other `.nix` files in the directory and evaluates their tests.
+
+A test file can accept `pkgs` and/or `lib` as inputs and should evaluate to an attrset of test attributes.
+Each test attribute can define:
+
+- `name` the assertion name printed in build logs (`string`: defaults to the attribute name)
+- `expr` the nix expression under test (any)
+- `stdout` the stdout expected from `nix-instantiate` (`string`: defaults to `"true\n"`)
+- `stderr` the stderr expected from `nix-instantiate` (`string`: optional)
+- `exit` the exit code expected from `nix-instantiate` (`int`: defaults to `0`)
+- `test` a function for custom assertions (`({ stdoutFile :: String, stderrFile :: String, exit :: Integer } → Any)`: optional, can throw)
+
+For example:
+```nix
+{ pkgs, lib }:
+{
+  example-test = {
+    name = "Example";
+    expr = lib.warn "foo" true;
+    stderr = ''
+      evaluation warning: foo
+    '';
+  };
+}
+```

--- a/pkgs/test/eval/default.nix
+++ b/pkgs/test/eval/default.nix
@@ -1,0 +1,58 @@
+/**
+  This derivation allows implementing more complex tests, such as those covering deprecated features that emit warnings.
+  These tests can evaluate or instantiate nix expressions, capture output, make assertions, etc.
+*/
+{
+  lib,
+  nix,
+  path,
+  python3,
+  runCommand,
+  writableTmpDirAsHomeHook,
+}:
+
+runCommand "nixpkgs-pkgs-tests-eval"
+  {
+    __structuredAttrs = true;
+    strictDeps = true;
+    tests = lib.pipe ./. [
+      builtins.readDir
+      (lib.filterAttrs (
+        name: type: type == "regular" && name != "default.nix" && lib.hasSuffix ".nix" name
+      ))
+      (lib.mapAttrsToList (name: type: ./. + "/${name}"))
+    ];
+    env = {
+      nixpkgs = "${path}";
+      NIX_PATH = "nixpkgs=${path}";
+      NIX_BUILD_HOOK = "";
+      PAGER = "cat";
+    };
+    nativeBuildInputs = [
+      nix
+      writableTmpDirAsHomeHook
+    ];
+    meta = {
+      # This test depends on the Nixpkgs tree itself,
+      # so any change to Nixpkgs will cause a rebuild.
+      hydraPlatforms = [ ];
+    };
+  }
+  ''
+    # Setup nix environment
+    export TEST_ROOT="$PWD/test-tmp"
+    export NIX_CONF_DIR="$TEST_ROOT/etc"
+    export NIX_LOCALSTATE_DIR="$TEST_ROOT/var"
+    export NIX_LOG_DIR="$TEST_ROOT/var/log/nix"
+    export NIX_STATE_DIR="$TEST_ROOT/var/nix"
+    export NIX_STORE_DIR="$TEST_ROOT/store"
+    nix-store --init
+
+    # Run tests
+    mkdir $out
+
+    for file in "''${tests[@]}"
+    do
+      ${python3.interpreter} ${./test.py} "$file"
+    done
+  ''

--- a/pkgs/test/eval/python-overriding.nix
+++ b/pkgs/test/eval/python-overriding.nix
@@ -1,0 +1,109 @@
+{ pkgs, lib }:
+let
+  package-stub = pkgs.python3Packages.callPackage (
+    {
+      buildPythonPackage,
+      emptyDirectory,
+    }:
+    buildPythonPackage {
+      pname = "python-package-stub";
+      version = "0.1.0";
+      pyproject = true;
+      src = emptyDirectory;
+    }
+  ) { };
+
+  package-stub-gcc = pkgs.python3Packages.callPackage (
+    {
+      buildPythonPackage,
+      emptyDirectory,
+      gccStdenv,
+    }:
+    buildPythonPackage {
+      pname = "python-package-stub";
+      version = "0.1.0";
+      pyproject = true;
+      src = emptyDirectory;
+      stdenv = gccStdenv;
+    }
+  ) { };
+
+  package-stub-fp-args-gcc = pkgs.python3Packages.callPackage (
+    {
+      buildPythonPackage,
+      emptyDirectory,
+      gccStdenv,
+    }:
+    buildPythonPackage (_: {
+      pname = "python-package-stub";
+      version = "0.1.0";
+      pyproject = true;
+      src = emptyDirectory;
+      stdenv = gccStdenv;
+    })
+  ) { };
+
+  stdenvDeprecationWarningPattern =
+    lib.escapeRegex ''
+      evaluation warning: python-package-stub: Passing `stdenv` directly to `buildPythonPackage` or `buildPythonApplication` is deprecated. You should use their `.override` function instead, e.g:
+                            buildPythonPackage.override { stdenv = customStdenv; } { }
+                          `stdenv` argument found at ${toString __curPos.file}:''
+    + "[0-9]+\n";
+
+  stdenvDeprecationWarning =
+    { stderrFile, ... }:
+    let
+      stderr = builtins.readFile stderrFile;
+      result = builtins.match stdenvDeprecationWarningPattern stderr;
+    in
+    lib.throwIf (result == null) "expected stdenv deprecation warning" true;
+in
+{
+  overridePythonAttrs-stdenv-correct = {
+    expr =
+      pkgs.clangStdenv == (package-stub.override (prev: {
+        buildPythonPackage = prev.buildPythonPackage.override {
+          stdenv = pkgs.clangStdenv;
+        };
+      })).stdenv;
+    stderr = "";
+  };
+
+  overridePythonAttrs-stdenv-deprecated = {
+    expr =
+      pkgs.clangStdenv == (package-stub.overridePythonAttrs (_: {
+        stdenv = pkgs.clangStdenv;
+      })).stdenv;
+    test = stdenvDeprecationWarning;
+  };
+
+  overridePythonAttrs-override-clangStdenv-deprecated-nested = {
+    expr =
+      pkgs.clangStdenv == (
+        (package-stub.overridePythonAttrs {
+          stdenv = pkgs.gccStdenv;
+        }).overridePythonAttrs
+        {
+          stdenv = pkgs.clangStdenv;
+        }
+      ).stdenv;
+    test =
+      { stderrFile, ... }:
+      let
+        stderr = builtins.readFile stderrFile;
+        pattern = stdenvDeprecationWarningPattern + stdenvDeprecationWarningPattern;
+        result = builtins.match pattern stderr;
+      in
+      lib.throwIf (result == null) "expected 2 stdenv deprecation warnings" true;
+  };
+
+  buildPythonPackage-stdenv-deprecated = {
+    expr = pkgs.gccStdenv == package-stub-gcc.stdenv;
+    test = stdenvDeprecationWarning;
+  };
+
+  buildPythonPackage-fp-args-stdenv-deprecated = {
+    expr = pkgs.gccStdenv == package-stub-fp-args-gcc.stdenv;
+    test = stdenvDeprecationWarning;
+  };
+}

--- a/pkgs/test/eval/python-overriding.nix
+++ b/pkgs/test/eval/python-overriding.nix
@@ -46,7 +46,7 @@ let
   stdenvDeprecationWarningPattern =
     lib.escapeRegex ''
       evaluation warning: python-package-stub: Passing `stdenv` directly to `buildPythonPackage` or `buildPythonApplication` is deprecated. You should use their `.override` function instead, e.g:
-                            buildPythonPackage.override { stdenv = customStdenv; } { }
+                              buildPythonPackage.override { stdenv = customStdenv; } { }
                           `stdenv` argument found at ${toString __curPos.file}:''
     + "[0-9]+\n";
 

--- a/pkgs/test/eval/test.py
+++ b/pkgs/test/eval/test.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from difflib import unified_diff
+from pathlib import Path
+from textwrap import indent
+from tempfile import TemporaryDirectory
+
+
+def load_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("file", type=Path, help="The test file to evaluate")
+    return parser.parse_args()
+
+
+def main():
+    args = load_args()
+    if not TestFixture.run_all(args.file):
+        sys.exit(1)
+
+
+@dataclass
+class TestFixture:
+    "A test fixture in a test file"
+
+    file: Path
+    attr: str
+    name: str
+    stdout: str | None
+    stderr: str | None
+    exit: int
+    has_test_fn: bool
+
+    def run(self) -> bool:
+        with TemporaryDirectory() as td:
+            td = Path(td)
+            stdout = td / "stdout"
+            stderr = td / "stderr"
+
+            with stdout.open("wb") as outf, stderr.open("wb") as errf:
+                result = subprocess.run(
+                    [
+                        "nix-instantiate",
+                        "--eval",
+                        self.file,
+                        "--arg",
+                        "pkgs",
+                        "import <nixpkgs> { }",
+                        "--arg",
+                        "lib",
+                        "import <nixpkgs/lib>",
+                        "--attr",
+                        f"{self.attr}.expr",
+                    ],
+                    stdout=outf,
+                    stderr=errf,
+                )
+
+            errors = []
+
+            if self.exit is not None and self.exit != result.returncode:
+                errors.append(
+                    indent(
+                        f"- Incorrect exit code. Expected {self.exit}, actual {result.returncode}",
+                        "  ",
+                    )
+                )
+
+            if self.stdout is not None:
+                text = stdout.read_text()
+                if self.stdout != text:
+                    expected = self.stdout.splitlines(keepends=True)
+                    actual = text.splitlines(keepends=True)
+                    diff = unified_diff(
+                        expected, actual, fromfile="expected", tofile="actual"
+                    )
+                    errors.append(
+                        indent(
+                            f"- Incorrect stdout:\n{indent(''.join(diff), '  ')}", "  "
+                        )
+                    )
+
+            if self.stderr is not None:
+                text = stderr.read_text()
+                if self.stderr != text:
+                    expected = self.stderr.splitlines(keepends=True)
+                    actual = text.splitlines(keepends=True)
+                    diff = unified_diff(
+                        expected, actual, fromfile="expected", tofile="actual"
+                    )
+                    errors.append(
+                        indent(
+                            f"- Incorrect stderr:\n{indent(''.join(diff), '  ')}", "  "
+                        )
+                    )
+
+            if self.has_test_fn:
+                test_result = subprocess.run(
+                    [
+                        "nix-instantiate",
+                        "--eval",
+                        self.file,
+                        "--arg",
+                        "pkgs",
+                        "import <nixpkgs> { }",
+                        "--arg",
+                        "lib",
+                        "import <nixpkgs/lib>",
+                        "--attr",
+                        f"{self.attr}.test",
+                        "--arg",
+                        "exit",
+                        f"{result.returncode}",
+                        "--argstr",
+                        "stdoutFile",
+                        stdout,
+                        "--argstr",
+                        "stderrFile",
+                        stderr,
+                    ],
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    text=True,
+                )
+                if test_result.returncode != 0:
+                    errors.append(
+                        indent(
+                            (
+                                f"- Test function failed: exit {test_result.returncode}:\n"
+                                f"{indent(test_result.stdout, '  ')}"
+                            ),
+                            "  ",
+                        )
+                    )
+
+            if errors != []:
+                print(f"- {self.name} FAILED", file=sys.stderr)
+                print("\n".join(errors), file=sys.stderr)
+                return False
+
+            print(f"- {self.name} OK", file=sys.stderr)
+            return True
+
+    @classmethod
+    def run_all(cls, file: Path) -> bool:
+        ok = True
+        print(f"Running {file.stem}", file=sys.stderr)
+        for attr, test in cls.load_all(file).items():
+            ok = test.run() and ok
+        return ok
+
+    @classmethod
+    def load_all(cls, file: Path) -> dict[str, TestFixture]:
+        expr = """
+        { file }:
+        let
+          fn = import file;
+          autoArgs = {
+            pkgs = import <nixpkgs> { };
+            lib = import <nixpkgs/lib>;
+          };
+          args = builtins.intersectAttrs (builtins.functionArgs fn) autoArgs;
+          attrs = if builtins.isFunction fn then fn args else fn;
+        in
+        builtins.mapAttrs (
+          attr:
+          {
+            name ? attr,
+            expr, # do not eval yet
+            stdout ? "true\\n",
+            stderr ? null,
+            exit ? 0,
+            test ? null,
+          }@args:
+          {
+            inherit name stdout stderr exit;
+            hasTestFn = args ? test;
+          }
+        ) attrs
+        """
+
+        with subprocess.Popen(
+            [
+                "nix-instantiate",
+                "--eval",
+                "--strict",
+                "--json",
+                "--argstr",
+                "file",
+                file,
+                "--expr",
+                expr,
+            ],
+            stdout=subprocess.PIPE,
+            stderr=sys.stderr,
+        ) as proc:
+            ok = True
+            try:
+                data = json.load(proc.stdout)
+            except json.JSONDecodeError:
+                ok = False
+
+            returncode = proc.wait()
+            if not (ok and returncode == 0):
+                raise subprocess.CalledProcessError(
+                    cmd=f"load {file}",
+                    returncode=returncode,
+                )
+
+        return {
+            attr: cls(
+                file=file,
+                attr=attr,
+                name=test["name"],
+                stdout=test["stdout"],
+                stderr=test["stderr"],
+                exit=test["exit"],
+                has_test_fn=test["hasTestFn"],
+            )
+            for attr, test in data.items()
+        }
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Introduces `pkgs/test/eval`, which allows making assertions against a nix evaluation that is run _within_ a test derivation's build script.

This is heavily inspired by [lib/tests/test-with-nix.nix](https://github.com/NixOS/nixpkgs/blob/master/lib/tests/test-with-nix.nix) and Ci's eval comparison, which use the same technique of running nix within a derivation build script.

While this may be useful for any sufficiently complex pkgs tests, adding it is initially motivated by python's deprecated `stdenv` overriding. This needs test coverage but emits warnings, so cannot be directly included in the `pkgs.tests` evaluation. By using the eval within a build technique, we can not only retain test coverage, we can also make assertion about the emitted warning itself!

This is an alternative to the `handleMsgStdenvArg` workaround proposed in https://github.com/NixOS/nixpkgs/pull/477208 - cc @ShamrockLee

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
