### PR TITLE
ossim: init at 2.12.0

### DIFF
--- a/pkgs/by-name/os/ossim/package.nix
+++ b/pkgs/by-name/os/ossim/package.nix
@@ -1,0 +1,80 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchpatch,
+  cmake,
+  makeWrapper,
+  curl,
+  freetype,
+  geos,
+  jsoncpp,
+  libgeotiff,
+  libjpeg,
+  libtiff,
+  proj,
+  sqlite,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ossim";
+  version = "2.12.0";
+
+  src = fetchFromGitHub {
+    owner = "ossimlabs";
+    repo = "ossim";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-nVQN+XnCYpVQSkgKsolqbR3KtPGTkvpym4cDl7IqjUc=";
+  };
+
+  patches = [
+    # Fixed build error gcc version 15.0.1
+    (fetchpatch {
+      url = "https://github.com/ossimlabs/ossim/commit/13b9fa9ae54f79a7e7728408de6246e00d38f399.patch";
+      hash = "sha256-AKzOT+JurB/54gvzn2a5amw+uIupaNxssnEhc8CSfPM=";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail 'GET_GIT_REVISION()' "" \
+      --replace-fail 'OSSIM_GIT_REVISION_NUMBER "UNKNOWN"' 'OSSIM_GIT_REVISION_NUMBER "${finalAttrs.version}"'
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    makeWrapper
+  ];
+
+  buildInputs = [
+    curl
+    freetype
+    geos
+    jsoncpp
+    libgeotiff
+    libjpeg
+    libtiff
+    proj
+    sqlite
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_OSSIM_TESTS" false)
+    (lib.cmakeFeature "CMAKE_POLICY_VERSION_MINIMUM" "3.10")
+  ];
+
+  postInstall = ''
+    for binary in $out/bin/ossim-*; do
+      wrapProgram $binary \
+        --prefix LD_LIBRARY_PATH ":" $out/lib
+    done
+  '';
+
+  meta = {
+    description = "Open Source Software Image Map library";
+    homepage = "https://github.com/ossimlabs/ossim";
+    license = lib.licenses.mit;
+    teams = [ lib.teams.geospatial ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
https://www.osgeo.org/projects/ossim/
> OSSIM is an open source, C++ (mostly), geospatial image processing library

[![Packaging status](https://repology.org/badge/tiny-repos/ossim.svg)](https://repology.org/project/ossim/versions)

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
