### PR TITLE
lib.lists.replaceElemAt: init

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -295,6 +295,7 @@ let
         elemAt
         isList
         concatAttrValues
+        replaceElemAt
         ;
       inherit (self.strings)
         concatStrings

--- a/lib/lists.nix
+++ b/lib/lists.nix
@@ -2019,4 +2019,41 @@ rec {
     :::
   */
   concatAttrValues = set: concatLists (attrValues set);
+
+  /**
+    Replaces a list's nth element with a new element
+
+    # Inputs
+
+    `list`
+    : Input list
+
+    `idx`
+    : index to replace
+
+    `newElem`
+    : new element to replace with
+
+    # Type
+
+    ```
+    replaceElemAt :: [a] -> int - b -> [a]
+    ```
+
+    # Examples
+    :::{.example}
+    ## `replaceElemAt` usage example
+
+    ```nix
+    lib.replaceElemAt` [1 2 3] 0 "a"
+    => ["a" 2 3]
+    ```
+
+    :::
+  */
+  replaceElemAt =
+    list: idx: newElem:
+    assert lib.assertMsg (idx >= 0 && idx < length list)
+      "'lists.replaceElemAt' called with index ${toString idx} on a list of size ${toString (length list)}";
+    genList (i: if i == idx then newElem else elemAt list i) (length list);
 }

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -4909,4 +4909,17 @@ runTests {
       targetTarget = "prefix-tt";
     };
   };
+
+  testReplaceElemAt = {
+    expr = lib.replaceElemAt [ 1 2 3 ] 1 "a";
+    expected = [
+      1
+      "a"
+      3
+    ];
+  };
+
+  testReplaceElemAtOutOfRange = testingThrow (lib.replaceElemAt [ 1 2 3 ] 5 "a");
+
+  testReplaceElemAtNegative = testingThrow (lib.replaceElemAt [ 1 2 3 ] (-1) "a");
 }


### PR DESCRIPTION
It's very easy to resort to lib.drop + lib.take to accomplish this, but it's not obvious that it actually performs quite badly.

Replacing an item in a list should be a relative common operation.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
