### PR TITLE
sd-image: mark the firmware partition as bootable, not root

### DIFF
--- a/nixos/modules/installer/sd-card/sd-image.nix
+++ b/nixos/modules/installer/sd-card/sd-image.nix
@@ -300,8 +300,8 @@ in
               label: dos
               label-id: ${config.sdImage.firmwarePartitionID}
 
-              start=''${gap}M, size=$firmwareSizeBlocks, type=b
-              start=$((gap + ${toString config.sdImage.firmwareSize}))M, type=83, bootable
+              start=''${gap}M, size=$firmwareSizeBlocks, type=b, bootable
+              start=$((gap + ${toString config.sdImage.firmwareSize}))M, type=83
           EOF
 
           # Copy the rootfs into the SD image


### PR DESCRIPTION
I changed the sd card image creation script so that the firmware (/boot) partition is marked as bootable, and not root partition. The current code creates sd images with non-bootable firmware partition, and u-boot can't find it.

The code I changed is old reads as if it was marking rootfs as bootable on purpose, so I may be misunderstading something. I discovered this issue when my Orange Pi image failed to boot, and after applying this patch it boots successfully.

Steps to reproduce:

1. Take the minimal [flake.nix](https://gist.github.com/gnull/fdb9f4f6e05c80f904bb98dbb169a700), run `nix build .#sdImage`. We do not intend to boot it, so it intentionally leaves some fields blank — the key goal is to trigger sd-image.nix.
2. Decompress and open the resulting image with fdisk, press `p` to print partitions. See that rootfs is bootable:
   ```
   Device                                                        Boot  Start     End Sectors  Size Id Type
   nixos-image-sd-card-26.05.20260105.9f0c42f-aarch64-linux.img1       65536  475135  409600  200M  b W95 FAT32
   nixos-image-sd-card-26.05.20260105.9f0c42f-aarch64-linux.img2 *    475136 5736231 5261096  2.5G 83 Linux
   ```
3. Uncomment `# nixpkgs.url = "github:gnull/nixpkgs/patch-1";` in flake.nix. Build and check partitions again, find that /boot is bootable:
   ```
   Device                                                        Boot  Start     End Sectors  Size Id Type
   nixos-image-sd-card-26.05.20260107.0085041-aarch64-linux.img1 *     65536  475135  409600  200M  b W95 FAT32
   nixos-image-sd-card-26.05.20260107.0085041-aarch64-linux.img2      475136 5736223 5261088  2.5G 83 Linux
   ```

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
  - [x] Manualy booted an SD card image for Orange Pi 5 Plus (built with the patched module).
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
