### PR TITLE
fzf-zsh-plugin: init at 1.0.0-unstable-2025-12-15

### DIFF
--- a/pkgs/by-name/fz/fzf-zsh-plugin/package.nix
+++ b/pkgs/by-name/fz/fzf-zsh-plugin/package.nix
@@ -1,0 +1,43 @@
+{
+  bash,
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  zsh,
+}:
+
+stdenv.mkDerivation {
+  pname = "fzf-zsh-plugin";
+  version = "1.0.0-unstable-2025-12-15";
+
+  src = fetchFromGitHub {
+    owner = "unixorn";
+    repo = "fzf-zsh-plugin";
+    rev = "cdd9d5cc3b41a3a390a0fb8605c40de652da6309";
+    hash = "sha256-i6qoaMWVofhD3K6/RaaNatzA2aokiNQ5ilqmahprJFU=";
+  };
+
+  strictDeps = true;
+
+  buildInputs = [
+    bash
+    zsh
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    install -D fzf-settings.zsh $out/share/zsh/fzf-zsh-plugin/fzf-settings.zsh
+    install -D fzf-zsh-plugin.plugin.zsh $out/share/zsh/fzf-zsh-plugin/fzf-zsh-plugin.plugin.zsh
+    mkdir -p $out/bin
+    cp -r bin/* $out/bin/
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://github.com/unixorn/fzf-zsh-plugin";
+    description = "ZSH plugin to enable fzf searches of a lot more stuff - docker, tmux, homebrew and more";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.eymeric ];
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`. (https://github.com/hatch01/flake/commit/d7621e6f96508dd8ec39dbc50fb7c5c6356dcf72)
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
