### PR TITLE
insync: Make system tray icons work

### DIFF
--- a/pkgs/by-name/in/insync/package.nix
+++ b/pkgs/by-name/in/insync/package.nix
@@ -74,6 +74,9 @@ buildFHSEnv {
     pkgs: with pkgs; [
       libudev0-shim
       insync-pkg
+      # Qt requires usr/share/icons/hicolor/index.theme file (provided by hicolor-icon-theme) to be
+      # present to successfully find the system tray icons.
+      hicolor-icon-theme
     ];
 
   extraInstallCommands = ''
@@ -117,10 +120,6 @@ buildFHSEnv {
       and built in sharing.
 
       There is a 15-day free trial, and it is a paid application after that.
-
-      Known bug(s):
-
-      1) Currently the system try icon does not render correctly.
     '';
     mainProgram = "insync";
   };


### PR DESCRIPTION
This fixes the (known) issue that system tray icon uses a "blank" icon (i.e., cannot find the Insync icons). Qt requires the `index.theme` file to be present in the icon theme directory (`share/icons/hicolor/index.theme`). This is provided by `pkgs.hicolor-icon-theme`, so this is an easy fix.

I have tested this with `nix run '.#insync' -- start` and the icon now shows properly.

Partially addresses #264124.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
