### PR TITLE
hdapsd: fix build, modernize, adpot, 20141203 -> 20250908

### DIFF
--- a/pkgs/by-name/hd/hdapsd/package.nix
+++ b/pkgs/by-name/hd/hdapsd/package.nix
@@ -6,13 +6,15 @@
   udevCheckHook,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "hdapsd";
   version = "20250908";
 
-  src = fetchurl {
-    url = "https://github.com/evgeni/hdapsd/releases/download/${version}/hdapsd-${version}.tar.gz";
-    sha256 = "sha256-qENcOFJ9x5CkN72ZkTx/OL+gpwAYJlJomKvAjTklDYQ=";
+  src = fetchFromGitHub {
+    owner = "linux-thinkpad";
+    repo = "hdapsd";
+    tag = finalAttrs.version;
+    hash = "sha256-/62E10fmv8idQFLVLgKkDomhBQk+DOc9167lkVBiRns=";
   };
 
   nativeBuildInputs = [
@@ -31,4 +33,4 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/hd/hdapsd/package.nix
+++ b/pkgs/by-name/hd/hdapsd/package.nix
@@ -1,20 +1,22 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
+  pkg-config,
   udevCheckHook,
 }:
 
 stdenv.mkDerivation rec {
   pname = "hdapsd";
-  version = "20141203";
+  version = "20250908";
 
   src = fetchurl {
     url = "https://github.com/evgeni/hdapsd/releases/download/${version}/hdapsd-${version}.tar.gz";
-    sha256 = "0ppgrfabd0ivx9hyny3c3rv4rphjyxcdsd5svx5pgfai49mxnl36";
+    sha256 = "sha256-qENcOFJ9x5CkN72ZkTx/OL+gpwAYJlJomKvAjTklDYQ=";
   };
 
   nativeBuildInputs = [
+    pkg-config
     udevCheckHook
   ];
 

--- a/pkgs/by-name/hd/hdapsd/package.nix
+++ b/pkgs/by-name/hd/hdapsd/package.nix
@@ -32,5 +32,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "http://hdaps.sf.net/";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ starryreverie ];
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Closes https://github.com/NixOS/nixpkgs/issues/477614

Tracks https://github.com/NixOS/nixpkgs/issues/475479

~~The upstream code contains an outdated function call which wasn't aligned with the corresponding declaration, which has been rejected by GCC 15.~~

Updating the package to the latest version fixes build failure. Note that the upstream repository has been moved to [linux-thinkpad/hdapsd](https://github.com/linux-thinkpad/hdapsd/).

Release: <https://github.com/linux-thinkpad/hdapsd/releases/tag/20250908>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
