### PR TITLE
sssd: fix pac support

### DIFF
--- a/pkgs/os-specific/linux/sssd/default.nix
+++ b/pkgs/os-specific/linux/sssd/default.nix
@@ -74,6 +74,9 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   patches = [
+    # Fix Kerberos Support version for PAC responder
+    ./fix-kerberos-version.patch
+
     (replaceVars ./fix-ldb-modules-path.patch {
       inherit ldb;
       out = null; # will be replaced in postPatch https://github.com/NixOS/nixpkgs/pull/446589#discussion_r2384899857

--- a/pkgs/os-specific/linux/sssd/fix-kerberos-version.patch
+++ b/pkgs/os-specific/linux/sssd/fix-kerberos-version.patch
@@ -1,0 +1,14 @@
+diff --git a/src/external/pac_responder.m4 b/src/external/pac_responder.m4
+index 9072718..3501b6b 100644
+--- a/src/external/pac_responder.m4
++++ b/src/external/pac_responder.m4
+@@ -23,7 +23,8 @@ then
+         Kerberos\ 5\ release\ 1.18* | \
+         Kerberos\ 5\ release\ 1.19* | \
+         Kerberos\ 5\ release\ 1.20* | \
+-        Kerberos\ 5\ release\ 1.21*)
++        Kerberos\ 5\ release\ 1.21* | \
++        Kerberos\ 5\ release\ 1.22*)
+             krb5_version_ok=yes
+             AC_MSG_RESULT([yes])
+             ;;


### PR DESCRIPTION
- Fix PAC Responder support

Tested & Validated

nixosTests.sssd-ldap OK

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
