### PR TITLE
yaziPlugins: update on 2026-01-07

### DIFF
--- a/pkgs/by-name/ya/yazi/plugins/compress/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/compress/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "compress.yazi";
-  version = "0-unstable-2026-01-03";
+  version = "0-unstable-2026-01-05";
 
   src = fetchFromGitHub {
     owner = "KKV9";
     repo = "compress.yazi";
-    rev = "f9208fe6c1885ff4fe9bcc890e4c96d87d91d37d";
-    hash = "sha256-teyZP1ij/T92fJx8gf9Z8/ddzcNknNC6KijaYeAzPz8=";
+    rev = "c9c16d8eb3d8f15bea5d58419229529921c58c94";
+    hash = "sha256-tllxA9rlyQGuFHMMhoTjjAAJImsCTAgawBd3c9ZGzMU=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/piper/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/piper/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "piper.yazi";
-  version = "25.5.31-unstable-2025-06-21";
+  version = "25.9.15-unstable-2025-12-31";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "3d1efb706924112daed986a4eef634e408bad65e";
-    hash = "sha256-GgEg1A5sxaH7hR1CUOO9WV21kH8B2YUGAtOapcWLP7Y=";
+    rev = "398796d88fee7bf9c99c4dc29089b865d4f47722";
+    hash = "sha256-LOQ/0LYVrXsqQjeBeERKQ2M8BwN8xo3yej1mxNHphOU=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/projects/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/projects/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "projects.yazi";
-  version = "0-unstable-2025-06-19";
+  version = "0-unstable-2025-12-31";
 
   src = fetchFromGitHub {
     owner = "MasouShizuka";
     repo = "projects.yazi";
-    rev = "a5e33db284ab580de7b549e472bba13a5ba7c7b9";
-    hash = "sha256-4VD1OlzGgyeB1jRgPpI4aWnOCHNZQ9vhh40cbU80Les=";
+    rev = "eed0657a833f56ea69f3531c89ecc7bad761d611";
+    hash = "sha256-5J0eqffUzI0GodpqwzmaQJtfh75kEbbIwbR8pFH/ZmU=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/recycle-bin/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/recycle-bin/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "recycle-bin.yazi";
-  version = "0-unstable-2025-12-04";
+  version = "0-unstable-2026-01-04";
 
   src = fetchFromGitHub {
     owner = "uhs-robert";
     repo = "recycle-bin.yazi";
-    rev = "53ad17c77746497e5146ad41fad94e6fc43e900b";
-    hash = "sha256-CasCXkE8ig2INqx1mJj0wyxUVD1WFNM7aZ0SITXEsx0=";
+    rev = "69d7d4ce9e102b9249166c8ea783cfd24bdf7bb4";
+    hash = "sha256-oGmgqe8ZUJM3cxIPw019PwcNaQjLYquFpD1awabPrPc=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/restore/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/restore/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "restore.yazi";
-  version = "25.5.31-unstable-2025-12-04";
+  version = "25.5.31-unstable-2026-01-06";
 
   src = fetchFromGitHub {
     owner = "boydaihungst";
     repo = "restore.yazi";
-    rev = "6395e52b3af3a8832f0249970a168c41fb92b31b";
-    hash = "sha256-HfXhYe3XPKkd/ivpQB85EsZyvLiflJE0tRNGVid2A9A=";
+    rev = "4eda0bf047f014622348390d8db0e2e1b6d036f0";
+    hash = "sha256-1qi7wnFAc8z9mFq1mbBQqQIsSe5uyTogmsSiNXS7F0w=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/rich-preview/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/rich-preview/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "rich-preview.yazi";
-  version = "0-unstable-2025-10-22";
+  version = "0-unstable-2026-01-05";
 
   src = fetchFromGitHub {
     owner = "AnirudhG07";
     repo = "rich-preview.yazi";
-    rev = "831234e828d292913f4b174a1ca2be2fb1080f22";
-    hash = "sha256-CK3ynjs53I1tRqARoOYMgBczBrcle+pwpUhHt3VpSXs=";
+    rev = "573b275fc0065eea3e8aa2afd07ad59e56ceff57";
+    hash = "sha256-Nla6KUHmdpW4trejrBTrh8jSDi5cu2fIGls24Cfy3pc=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/smart-filter/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/smart-filter/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "smart-filter.yazi";
-  version = "25.5.31-unstable-2025-07-23";
+  version = "25.12.29-unstable-2025-12-29";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "de53d90cb2740f84ae595f93d0c4c23f8618a9e4";
-    hash = "sha256-ixZKOtLOwLHLeSoEkk07TB3N57DXoVEyImR3qzGUzxQ=";
+    rev = "517619af126f25f3da096ff156ce46b561b54be3";
+    hash = "sha256-j7fsUmx2nK4Tyj5KCamcCmfs99K6duV+okf8NvzccsI=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/vcs-files/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/vcs-files/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "vcs-files.yazi";
-  version = "25.9.15-unstable-2025-09-15";
+  version = "25.12.29-unstable-2026-01-06";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "109b13df29f4b7d14fd8e1b38414b205e706c761";
-    hash = "sha256-u8gbZnA8xShsbH06yCZM/aXskMrSHKPcQtIMFp1Cdyo=";
+    rev = "4e5590280db0de5f130bf377e9c32a202110f575";
+    hash = "sha256-/yGS8R1YsYqqX4JTlIJeg+NfFSxGUHvSdKQZGk6KiBU=";
   };
 
   meta = {


### PR DESCRIPTION
- compress: 0-unstable-2026-01-03 → 0-unstable-2026-01-05
- piper: 25.5.31-unstable-2025-06-21 → 25.9.15-unstable-2025-12-31
- projects: 0-unstable-2025-06-19 → 0-unstable-2025-12-31
- recycle-bin: 0-unstable-2025-12-04 → 0-unstable-2026-01-04
- restore: 25.5.31-unstable-2025-12-04 → 25.5.31-unstable-2026-01-06
- rich-preview: 0-unstable-2025-10-22 → 0-unstable-2026-01-05
- smart-filter: 25.5.31-unstable-2025-07-23 → 25.12.29-unstable-2025-12-29
- vcs-files: 25.9.15-unstable-2025-09-15 → 25.12.29-unstable-2026-01-06


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
