### PR TITLE
nixos/switchable-system: improve switch inhibitors

### DIFF
--- a/nixos/modules/services/system/dbus.nix
+++ b/nixos/modules/services/system/dbus.nix
@@ -104,6 +104,8 @@ in
 
   config = mkIf cfg.enable (mkMerge [
     {
+      system.switch.inhibitors.dbus-implementation = cfg.implementation;
+
       environment.etc."dbus-1".source = configDir;
 
       environment.pathsToLink = [

--- a/nixos/modules/system/activation/switchable-system.nix
+++ b/nixos/modules/system/activation/switchable-system.nix
@@ -32,12 +32,12 @@
     };
 
     inhibitors = lib.mkOption {
-      type = lib.types.listOf lib.types.pathInStore;
-      default = [ ];
+      type = lib.types.attrsOf lib.types.str;
+      default = { };
       description = ''
-        List of derivations that will prevent switching into a configuration when
+        Attribute set of strings that will prevent switching into a configuration when
         they change.
-        This can be manually overridden on the command line if required.
+        The switch can be manually forced on the command line if required.
       '';
     };
   };
@@ -67,80 +67,86 @@
         ln -s ${config.system.build.inhibitSwitch} $out/switch-inhibitors
       '';
 
-      build.inhibitSwitch = pkgs.writeTextFile {
-        name = "switch-inhibitors";
-        text = lib.concatMapStringsSep "\n" (drv: drv.outPath) config.system.switch.inhibitors;
-      };
+      build.inhibitSwitch = pkgs.writers.writeJSON "switch-inhibitors" config.system.switch.inhibitors;
 
       preSwitchChecks.switchInhibitors =
         let
           realpath = lib.getExe' pkgs.coreutils "realpath";
-          sha256sum = lib.getExe' pkgs.coreutils "sha256sum";
-          diff = lib.getExe' pkgs.diffutils "diff";
+          mktemp = lib.getExe' pkgs.coreutils "mktemp";
+          rm = lib.getExe' pkgs.coreutils "rm";
+          jq = lib.getExe' pkgs.jq "jq";
         in
-        lib.mkIf (lib.length config.system.switch.inhibitors > 0)
-          # bash
-          ''
-            incoming="''${1-}"
-            action="''${2-}"
+        # bash
+        ''
+          incoming="''${1-}"
+          action="''${2-}"
 
-            if [ "$action" == "boot" ]; then
-              echo "Not checking switch inhibitors (action = $action)"
-              exit
-            fi
+          if [ "$action" == "boot" ]; then
+            echo "Not checking switch inhibitors (action = $action)"
+            exit
+          fi
 
-            echo -n "Checking switch inhibitors..."
+          echo -n "Checking switch inhibitors..."
 
-            booted_inhibitors="$(${realpath} /run/booted-system)/switch-inhibitors"
-            booted_inhibitors_sha="$(
-              if [ -f "$booted_inhibitors" ]; then
-                ${sha256sum} - < "$booted_inhibitors"
-              else
-                echo 'none'
-              fi
-            )"
+          # Create a temporary file that we use in case a generation does not have
+          # the switch-inhibitors file.
+          empty="$(${mktemp} -t switch_inhibit.XXXX)"
+          # shellcheck disable=SC2329
+          clean_up() {
+            ${rm} -f "$empty"
+          }
+          trap clean_up EXIT
+          echo "{}" > "$empty"
 
-            if [ "$booted_inhibitors_sha" == "none" ]; then
-              echo
-              echo "The previous configuration did not specify switch inhibitors, nothing to check."
-              exit
-            fi
+          current_inhibitors="$(${realpath} /run/current-system)/switch-inhibitors"
+          if [ ! -f "$current_inhibitors" ]; then
+            current_inhibitors="$empty"
+          fi
 
-            new_inhibitors="$(${realpath} "$incoming")/switch-inhibitors"
-            new_inhibitors_sha="$(
-              if [ -f "$new_inhibitors" ]; then
-                ${sha256sum} - < "$new_inhibitors"
-              else
-                echo 'none'
-              fi
-            )"
+          new_inhibitors="$(${realpath} "$incoming")/switch-inhibitors"
+          if [ ! -f "$new_inhibitors" ]; then
+            new_inhibitors="$empty"
+          fi
 
-            if [ "$new_inhibitors_sha" == "none" ]; then
-              echo
-              echo "The new configuration does not specify switch inhibitors, nothing to check."
-              exit
-            fi
+          diff="$(
+            ${jq} \
+              --raw-output \
+              --null-input \
+              --rawfile current "$current_inhibitors" \
+              --rawfile newgen "$new_inhibitors" \
+            '
+              $current | try fromjson catch {} as $old |
+              $newgen | try fromjson catch {} as $new |
+              $old |
+              to_entries |
+              map(
+                select(.key | in ($new)) |
+                select(.value != $new.[.key]) |
+                [ .key, ":", .value, "->", $new.[.key] ] | join(" ")
+              ) |
+              join("\n")
+            ' \
+          )"
 
-            if [ "$new_inhibitors_sha" != "$booted_inhibitors_sha" ]; then
-              echo
-              echo "Found diff in switch inhibitors:"
-              echo
-              ${diff} --color "$booted_inhibitors" "$new_inhibitors"
-              echo
-              echo "The new configuration contains changes to packages that were"
-              echo "listed as switch inhibitors."
-              echo "You probably want to run 'nixos-rebuild boot' and reboot your system."
-              echo
-              echo "If you really want to switch into this configuration directly, then"
-              echo "you can set NIXOS_NO_CHECK=1 to ignore pre-switch checks."
-              echo
-              echo "WARNING: doing so might cause the switch to fail or your system to become unstable."
-              echo
-              exit 1
-            else
-              echo " done"
-            fi
-          '';
+          if [ -n "$diff" ]; then
+            echo
+            echo "There are changes to critical components of the system:"
+            echo
+            echo "$diff"
+            echo
+            echo "Switching into this system is not recommended."
+            echo "You probably want to run 'nixos-rebuild boot' and reboot your system instead."
+            echo
+            echo "If you really want to switch into this configuration directly, then"
+            echo "you can set NIXOS_NO_CHECK=1 to ignore pre-switch checks."
+            echo
+            echo "WARNING: doing so might cause the switch to fail or your system to become unstable."
+            echo
+            exit 1
+          else
+            echo " done"
+          fi
+        '';
     };
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Improvements:
1. Turn the nix value into an attrset so that every inhibitor has a name that we can match between generations
2. Write the attrset to a file as JSON
3. When checking, we load the JSON files from both the current and the new generation into a jq pipeline and match up the keys. We output a dict with a value for every key that is present in both generations with a different value.
4. Build in error handling for different corner cases (missing files, non-JSON content)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
