### PR TITLE
tic-80: 1.1-unstable-2025-10-21 -> 1.1-unstable-2025-12-30

### DIFF
--- a/pkgs/by-name/ti/tic-80/package.nix
+++ b/pkgs/by-name/ti/tic-80/package.nix
@@ -21,7 +21,7 @@
 }:
 let
   # git rev-list HEAD --count
-  revision = "3042";
+  revision = "3049";
   year = "2025";
 in
 
@@ -29,18 +29,18 @@ stdenv.mkDerivation {
   pname = "tic-80";
   # use an untagged version until upstream tags a new version. We want
   # 'PREFER_SYSTEM_LIBRARIES', and without it tic-80 won't build
-  version = "1.1-unstable-2025-10-21";
+  version = "1.1-unstable-2025-12-30";
 
   src = fetchFromGitHub {
     owner = "nesbox";
     repo = "TIC-80";
-    rev = "a2c875f7275541e7724199ce8e504fb578b819a6";
+    rev = "881828910e77c799c1a6894cadc2d05a5c2f3f70";
     # TIC-80 vendors its dependencies as submodules. For the following dependencies,
     # there are no (or no compatible) packages in nixpkgs yet, so we use the vendored
     # ones as a fill-in: wasm, squirrel, pocketpy, argparse, naett,
     # sdlgpu, mruby.
     fetchSubmodules = true;
-    hash = "sha256-S/v1WHrvVndW4qHFWRJc3dcQkjw5vCU1/mN0PW9Wfkc=";
+    hash = "sha256-bqLVoLJpT62k9d+WZUgIu4ClcJNUvURB7j+NE/fzWNk=";
   };
 
   # TIC-80 tries to determine the revision part of the version using its Git history.


### PR DESCRIPTION
Changes: https://github.com/nesbox/TIC-80/compare/a2c875f7275541e7724199ce8e504fb578b819a6...881828910e77c799c1a6894cadc2d05a5c2f3f70

Resolves #465083 by including nesbox/TIC-80#2869.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
