### PR TITLE
haskellPackages: remove myself as maintainer from reflex-frp and obsidian packages

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -113,30 +113,13 @@ extra-packages:
 # keep-sorted start skip_lines=1 case=no
 package-maintainers:
   alexfmpe:
-    - aeson-gadt-th
-    - android-activity
     - basic-sop
-    - bytestring-aeson-orphans
-    - cli-extras
-    - cli-git
-    - cli-nix
     - commutative-semigroups
-    - constraints-extras
-    - dependent-map
-    - dependent-monoidal-map
-    - dependent-sum
-    - dependent-sum-aeson-orphans
-    - dependent-sum-template
-    - gargoyle
-    - gargoyle-postgresql
-    - gargoyle-postgresql-connect
-    - gargoyle-postgresql-nix
     - generics-sop
     - ghcjs-base
     - ghcjs-dom
     - ghcjs-dom-javascript
     - ghcjs-dom-jsaddle
-    - haveibeenpwned
     - jsaddle
     - jsaddle-clib
     - jsaddle-dom
@@ -147,25 +130,15 @@ package-maintainers:
     - large-records
     - lens-sop
     - linux-namespaces
-    - monoid-map
     - monoidal-containers
-    - nix-thunk
-    - patch
     - proto-lens-arbitrary
     - proto3-suite
     - proto3-wire
     - records-sop
-    - reflex
-    - reflex-dom
-    - reflex-dom-core
-    - reflex-gadt-api
-    - reflex-fsnotify
     - th-abstraction
     - universe
     - universe-some
-    - vessel
     - warp
-    - which
   Anton-Latukha:
     - hnix
     - hnix-store-core

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
@@ -1992,7 +1992,6 @@ dont-distribute-packages:
  - knit-haskell
  - koji-install
  - koji-tool
- - koji-tool_1_3_1
  - korfu
  - ks-test
  - kubernetes-client
@@ -3411,6 +3410,7 @@ dont-distribute-packages:
  - sydtest-amqp
  - sydtest-webdriver-screenshot
  - sydtest-webdriver-yesod
+ - sydtest-webdriver-yesod_0_0_1_0
  - sylvia
  - symantic-atom
  - symantic-http-demo


### PR DESCRIPTION
Life is too short for un-cooperative upstreams

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
