### PR TITLE
lua5_5: update tests

### DIFF
--- a/pkgs/development/interpreters/lua-5/tests/default.nix
+++ b/pkgs/development/interpreters/lua-5/tests/default.nix
@@ -47,9 +47,11 @@ let
       ";${lua}/share/lua/5.2/?.lua;${lua}/share/lua/5.2/?/init.lua;${lua}/lib/lua/5.2/?.lua;${lua}/lib/lua/5.2/?/init.lua;./?.lua;";
     "5.3" =
       ";${lua}/share/lua/5.3/?.lua;${lua}/share/lua/5.3/?/init.lua;${lua}/lib/lua/5.3/?.lua;${lua}/lib/lua/5.3/?/init.lua;./?.lua;./?/init.lua;";
-    # lua5.4 seems to be smarter about it and dont add the lua separators when nothing left or right
+    # lua > 5.4 seems to be smarter about it and dont add the lua separators when nothing left or right
     "5.4" =
       "${lua}/share/lua/5.4/?.lua;${lua}/share/lua/5.4/?/init.lua;${lua}/lib/lua/5.4/?.lua;${lua}/lib/lua/5.4/?/init.lua;./?.lua;./?/init.lua";
+    "5.5" =
+      "${lua}/share/lua/5.5/?.lua;${lua}/share/lua/5.5/?/init.lua;${lua}/lib/lua/5.5/?.lua;${lua}/lib/lua/5.5/?/init.lua;./?.lua;./?/init.lua";
 
     # luajit versions
     "2.0" =
@@ -80,19 +82,19 @@ lib.recurseIntoAttrs {
 
   # checks that lua's setup-hook adds dependencies to LUA_PATH
   # Prevents the following regressions
-  # $ env NIX_PATH=nixpkgs=. nix-shell --pure -Q -p luajitPackages.lua luajitPackages.http
+  # $ env NIX_PATH=nixpkgs=. nix-shell --pure -Q -p luajitPackages.lua luajitPackages.alt-getopt
   # nix-shell$ luajit
-  # > require('http.request')
-  # stdin:1: module 'http.request' not found:
+  # > require('alt-getopt')
+  # stdin:1: module 'alt-getopt' not found:
   checkSetupHook =
     pkgs.runCommandLocal "test-${lua.name}-setup-hook"
       {
         nativeBuildInputs = [ lua ];
-        buildInputs = [ lua.pkgs.http ];
+        buildInputs = [ lua.pkgs.alt-getopt ];
         meta.platforms = lua.meta.platforms;
       }
       ''
-        ${lua}/bin/lua -e "require'http.request'"
+        ${lua}/bin/lua -e "require'alt_getopt'"
         touch $out
       '';
 
@@ -115,11 +117,11 @@ lib.recurseIntoAttrs {
   checkPropagatedBuildInputs =
     pkgs.runCommandLocal "test-${lua.name}-setup-hook"
       {
-        buildInputs = [ lua.pkgs.rest-nvim ];
+        buildInputs = [ lua.pkgs.luacov ];
       }
-      # `xml2lua` is a propagatedBuildInput of rest-nvim
+      # `datafile` is a propagatedBuildInput of luacov
       ''
-        ${lua}/bin/lua -e "require'xml2lua'"
+        ${lua}/bin/lua -e "require'datafile'"
         touch $out
       '';
 


### PR DESCRIPTION
A follow-up to #473564.
See https://github.com/NixOS/nixpkgs/pull/473564#issuecomment-3720829931.

- Adds interpreter path golden test cases for Lua 5.5
- Replaces `http` with `alt_getopt` in the `checkSetupHook`, because `bit32` (a `http` dependency) has a `lua < 5.5` version constraint, causing evaluation to fail.
  `alt_getopt` just has a `lua >= 5.1` constraint, so it should work with all Lua versions.
- Modifies the `checkPropagatedBuildInputs` test to use `luacov`, as `rest-nvim` has a dependency that doesn't build with Lua 5.5.

Todo:

- [x] Test with `nix build --no-link -f. lua5_5.tests`

cc @trofi

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
