### PR TITLE
nixos/scx: don't escape service args in `SCX_FLAGS`

### DIFF
--- a/nixos/modules/services/scheduling/scx.nix
+++ b/nixos/modules/services/scheduling/scx.nix
@@ -109,7 +109,7 @@ in
       };
       environment = {
         SCX_SCHEDULER = cfg.scheduler;
-        SCX_FLAGS = lib.escapeShellArgs cfg.extraArgs;
+        SCX_FLAGS = toString cfg.extraArgs;
       };
 
       wantedBy = [ "multi-user.target" ];


### PR DESCRIPTION
Before, escaping shell args was necessary because they were part of `ExecStart`, but after switching to environment vars for runtime overriding, this is no longer necessary and can even cause issues (see https://github.com/NixOS/nixpkgs/pull/453196#discussion_r2658944826).

<details><summary>Testing arguments</summary>
<p>

Since not all schedulers have the same arguments, I only tested `extraArgs` with `bpfland`, but I imagine the result would be the same for the others.

```nix
  nodes.machine =
    { lib, config, ... }:
    {
      boot.kernelPackages = pkgs.linuxPackages_latest;
      services.scx.enable = true;
      services.scx.extraArgs = lib.optionals (config.services.scx.scheduler == "scx_bpfland") [
        "--slice-us 5000"
        "--slice-us-lag 40000"
        "--pin-root-path \"/sys/fs/bpf\""
        "--cpufreq"
        "--verbose"
      ];

      specialisation = {
        beerland.configuration.services.scx.scheduler = "scx_beerland";
        bpfland.configuration.services.scx.scheduler = "scx_bpfland";
        cosmos.configuration.services.scx.scheduler = "scx_cosmos";
        flash.configuration.services.scx.scheduler = "scx_flash";
        flatcg.configuration.services.scx.scheduler = "scx_flatcg";
        lavd.configuration.services.scx.scheduler = "scx_lavd";
        nest.configuration.services.scx.scheduler = "scx_nest";
        p2dq.configuration.services.scx.scheduler = "scx_p2dq";
        rlfifo.configuration.services.scx.scheduler = "scx_rlfifo";
        rustland.configuration.services.scx.scheduler = "scx_rustland";
        rusty.configuration.services.scx.scheduler = "scx_rusty";
        simple.configuration.services.scx.scheduler = "scx_simple";
      };
    };
```

```nix
nix-repl> nixosTests.scx.nodes.machine.specialisation.bpfland.configuration.systemd.services.scx.environment.SCX_FLAGS
"--slice-us 5000 --slice-us-lag 40000 --pin-root-path \"/sys/fs/bpf\" --cpufreq --verbose"
```

And the `bpfland` specialisation is passing.

```shellSession
(finished: run the VM test script, in 62.72 seconds)
machine # [   61.783985] sched_ext: BPF scheduler "simple" enabled
machine # [   61.575420] bash[2895]: local=0 global=4
test script finished in 62.82s
cleanup
kill machine (pid 9)
qemu-system-x86_64: terminating on signal 15 from pid 6 (/nix/store/qzc04a3npl70cyyy6flnnrb2ig3kayxm-python3-3.13.11/bin/python3.13)
vde_switch: EOF data port: Interrupted system call
kill vlan (pid 7)
vde_switch: EOF on stdin, cleaning up and exiting
vde_switch: Caught signal 15, cleaning up and exiting
(finished: cleanup, in 0.01 seconds)
/nix/store/ci0y01ab7mmpl8263s1kkmknaf6y1xib-vm-test-run-scx_ful
```

</p>
</details> 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
