### PR TITLE
mozhi: 0-unstable-2025-09-19 -> 0-unstable-2026-01-10

### DIFF
--- a/pkgs/by-name/mo/mozhi/package.nix
+++ b/pkgs/by-name/mo/mozhi/package.nix
@@ -6,17 +6,17 @@
 }:
 buildGoModule {
   pname = "mozhi";
-  version = "0-unstable-2025-09-19";
+  version = "0-unstable-2026-01-10";
 
   src = fetchFromGitea {
     domain = "codeberg.org";
     owner = "aryak";
     repo = "mozhi";
-    rev = "67f216b3fa9edb3b3ec995a4a6fb6777ea934177";
-    hash = "sha256-fQkOyfuBbRLvCzwv7kT1AEJUAWQshWOZDTYfp7plkag=";
+    rev = "6b3f675b8d4c8fb852e88f0696d0c4d72516e618";
+    hash = "sha256-O+heptNxkckcYxUi1QZUBun0F3zquGp5gPVsuWThajQ=";
   };
 
-  vendorHash = "sha256-ptwP+ZuuzxRpIuNDoXnAML1KYEh9zTBcOs9YTI8z63A=";
+  vendorHash = "sha256-PiduR6mEATCKMi1lvKx4lpuSvNAyMhdeI/pRrsgGNx8=";
 
   passthru.updateScript = unstableGitUpdater { };
 


### PR DESCRIPTION
https://codeberg.org/aryak/mozhi/compare/67f216b3fa9edb3b3ec995a4a6fb6777ea934177...6b3f675b8d4c8fb852e88f0696d0c4d72516e618

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
