### PR TITLE
tyrolienne: 1.1.0 -> 1.2.0, add darwin support

### DIFF
--- a/pkgs/by-name/ty/tyrolienne/package.nix
+++ b/pkgs/by-name/ty/tyrolienne/package.nix
@@ -14,17 +14,17 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "tyrolienne";
-  version = "1.1.0";
+  version = "1.2.0";
 
   src = fetchFromGitea {
     domain = "git.uku3lig.net";
     owner = "uku";
     repo = "tyrolienne";
     tag = finalAttrs.version;
-    hash = "sha256-LJZxQLATVGEhb0HK8PO3Fe+N+GjJdwX1Z7mOCIwQkqo=";
+    hash = "sha256-jl1h7L+Ae28A7YFoIsQqxbx2XmxxjUHebD5Xba0cB5o=";
   };
 
-  cargoHash = "sha256-ax8Akv26XFFxKVstUIAHUDKypzkJOS8mpBDIT3NfBbE=";
+  cargoHash = "sha256-J/gS8tyy+5ZG1xl4NrYCU26lD0yvsVyRUoOXntCgVSE=";
 
   nativeBuildInputs = [
     copyDesktopItems

--- a/pkgs/by-name/ty/tyrolienne/package.nix
+++ b/pkgs/by-name/ty/tyrolienne/package.nix
@@ -1,6 +1,8 @@
 {
   lib,
+  stdenv,
   rustPlatform,
+  cargo-bundle,
   copyDesktopItems,
   fetchFromGitea,
   ffmpeg,
@@ -10,7 +12,6 @@
   nix-update-script,
   pkg-config,
   wrapGAppsHook4,
-  zenity,
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "tyrolienne";
@@ -27,10 +28,15 @@ rustPlatform.buildRustPackage (finalAttrs: {
   cargoHash = "sha256-J/gS8tyy+5ZG1xl4NrYCU26lD0yvsVyRUoOXntCgVSE=";
 
   nativeBuildInputs = [
-    copyDesktopItems
-    imagemagick
     pkg-config
     wrapGAppsHook4
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    copyDesktopItems
+    imagemagick
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    cargo-bundle
   ];
 
   buildInputs = [ libadwaita ];
@@ -38,7 +44,22 @@ rustPlatform.buildRustPackage (finalAttrs: {
   # Tests are disabled because there are none, avoids having to recompile everything twice
   doCheck = false;
 
-  postInstall = ''
+  installPhase = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    runHook preInstall
+
+    # cargo-bundle expects the binary in target/release
+    release_target="target/${stdenv.hostPlatform.rust.cargoShortTarget}/release"
+    mv $release_target/tyrolienne target/release/tyrolienne
+
+    export CARGO_BUNDLE_SKIP_BUILD=true
+    app_path=$(cargo bundle --release | xargs)
+    mkdir -p $out/Applications
+    mv $app_path $out/Applications/
+
+    runHook postInstall
+  '';
+
+  postInstall = lib.optionalString stdenv.hostPlatform.isLinux ''
     for size in 16 32 48 128 256; do
       dir="$out/share/icons/hicolor/''${size}x''${size}/apps"
       mkdir -p "$dir"
@@ -46,14 +67,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
     done
   '';
 
-  preFixup = ''
+  preFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
     gappsWrapperArgs+=(
-      --prefix PATH : ${
-        lib.makeBinPath [
-          ffmpeg
-          zenity
-        ]
-      }
+      --prefix PATH : ${lib.makeBinPath [ ffmpeg ]}
     )
   '';
 
@@ -75,7 +91,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     description = "Simple tool to convert, upload, and embed videos to Zipline";
     homepage = "https://git.uku3lig.net/uku/tyrolienne";
     license = lib.licenses.mpl20;
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
     maintainers = with lib.maintainers; [ uku3lig ];
     mainProgram = "tyrolienne";
   };


### PR DESCRIPTION
Changelog: https://git.uku3lig.net/uku/tyrolienne/releases/tag/1.2.0

Darwin support added to be in line with upstream

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
