### PR TITLE
python314Packages.ibis-framework: disable additional failing test

### DIFF
--- a/pkgs/development/python-modules/ibis-framework/default.nix
+++ b/pkgs/development/python-modules/ibis-framework/default.nix
@@ -97,7 +97,7 @@ let
   };
 in
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "ibis-framework";
   version = "11.0.0";
   pyproject = true;
@@ -105,7 +105,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "ibis-project";
     repo = "ibis";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-hf5guWeX9WQbKaNrs7ALwwDxV1Rgeb5Z0PedTQ4P7S0=";
   };
 
@@ -139,7 +139,7 @@ buildPythonPackage rec {
     pytest-xdist
     writableTmpDirAsHomeHook
   ]
-  ++ lib.concatMap (name: optional-dependencies.${name}) testBackends;
+  ++ lib.concatMap (name: finalAttrs.passthru.optional-dependencies.${name}) testBackends;
 
   pytestFlags = [
     "--benchmark-disable"
@@ -372,11 +372,11 @@ buildPythonPackage rec {
   meta = {
     description = "Productivity-centric Python Big Data Framework";
     homepage = "https://github.com/ibis-project/ibis";
-    changelog = "https://github.com/ibis-project/ibis/blob/${src.tag}/docs/release_notes.md";
+    changelog = "https://github.com/ibis-project/ibis/blob/${finalAttrs.src.tag}/docs/release_notes.md";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       cpcloud
       sarahec
     ];
   };
-}
+})

--- a/pkgs/development/python-modules/ibis-framework/default.nix
+++ b/pkgs/development/python-modules/ibis-framework/default.nix
@@ -186,6 +186,7 @@ buildPythonPackage (finalAttrs: {
   ]
   ++ lib.optionals (pythonAtLeast "3.14") [
     # ExceptionGroup: multiple unraisable exception warnings (4 sub-exceptions)
+    "test_non_roundtripable_str_type"
     "test_parse_dtype_roundtrip"
 
     # AssertionError: value does not match the expected value in snapshot ...


### PR DESCRIPTION
1. Builds on #475621 by disabling one additional failing test found on x86_64-linux.
2. Adds `finalAttrs` fix.

~~Note: Build breaks intermittently across all platforms due to broken uvloop test #473859.~~ Rebased over fix.

Tracking: #475732

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
