### PR TITLE
postgresqlPackages.pg_search: init at 0.21.8

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/pg_search.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_search.nix
@@ -1,0 +1,110 @@
+{
+  buildPgrxExtension,
+  cargo-pgrx_0_16_1,
+  fetchFromGitHub,
+  fetchurl,
+  lib,
+  nix-update-script,
+  pkg-config,
+  postgresql,
+  stdenv,
+}:
+
+let
+  # https://github.com/paradedb/paradedb/blob/v0.21.8/Cargo.lock#L3316-L3346
+  linderaVersion = "1.4.1";
+  linderaWebsite = "https://lindera.dev";
+
+  # pg_search's tokenizer uses several language dictionaries used by the Lindera crate
+  dictionaries = {
+    # https://github.com/lindera/lindera/blob/v1.4.1/lindera-ko-dic/build.rs#L15-L22
+    lindera-ko-dic = rec {
+      language = "Korean";
+      filename = "mecab-ko-dic-2.1.1-20180720.tar.gz";
+      source = fetchurl {
+        url = "${linderaWebsite}/${filename}";
+        hash = "sha256-cCztIcYWfp2a68Z0q17lSvWNREOXXylA030FZ8AgWRo=";
+      };
+    };
+
+    # https://github.com/lindera/lindera/blob/v1.4.1/lindera-cc-cedict/build.rs#L15-L22
+    lindera-cc-cedict = rec {
+      language = "Chinese";
+      filename = "CC-CEDICT-MeCab-0.1.0-20200409.tar.gz";
+      source = fetchurl {
+        url = "${linderaWebsite}/${filename}";
+        hash = "sha256-7Tz54+yKgGR/DseD3Ana1DuMytLplPXqtv8TpB0JFsg=";
+      };
+    };
+
+    # https://github.com/lindera/lindera/blob/v1.4.1/lindera-ipadic/build.rs#L15-L22
+    lindera-ipadic = rec {
+      language = "Japanese";
+      filename = "mecab-ipadic-2.7.0-20250920.tar.gz";
+      source = fetchurl {
+        url = "${linderaWebsite}/${filename}";
+        hash = "sha256-p7qfZF/+cJTlauHEqB0QDfj7seKLvheSYi6XKOFi2z0=";
+      };
+    };
+  };
+in
+buildPgrxExtension (finalAttrs: {
+  pname = "pg_search";
+  version = "0.21.8";
+
+  src = fetchFromGitHub {
+    owner = "paradedb";
+    repo = "paradedb";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-gvQOfyFU8SVtAJTGw0EuRatfDVZRqpv7WhIqYYZYbgc=";
+  };
+
+  cargoHash = "sha256-NRrDmswQ+oiVNeIbhfhDA7k4wOxotTLsOuT7WMewX6Y=";
+
+  inherit postgresql;
+
+  # Lindera dictionaries are copied to a temporary directory and the
+  # LINDERA_CACHE environment variable prevents the build.rs files in
+  # the Lindera crates from downloading their dictionary from an
+  # external URL, which doesn't work in the Nix sandbox
+  preConfigure = ''
+    export LINDERA_CACHE=$TMPDIR/lindera-cache
+    mkdir -p $LINDERA_CACHE/${linderaVersion}
+
+    ${lib.concatMapStringsSep "\n" (dict: ''
+      echo "Copying ${dict.language} dictionary to Lindera cache"
+      cp ${dict.source} $LINDERA_CACHE/${linderaVersion}/${dict.filename}
+    '') (lib.attrValues dictionaries)}
+
+    echo "Lindera cache prepared at $LINDERA_CACHE"
+  '';
+
+  # https://github.com/paradedb/paradedb/blob/v0.21.8/Cargo.toml#L38-L39
+  cargo-pgrx = cargo-pgrx_0_16_1;
+
+  # https://github.com/paradedb/paradedb/tree/v0.21.8/pg_search
+  cargoPgrxFlags = [
+    "--package"
+    "pg_search"
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  # pgrx tests try to install the extension into postgresql nix store
+  doCheck = false;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Transactional Elasticsearch alternative as a PostgreSQL extension";
+    homepage = "https://paradedb.com";
+    changelog = "https://github.com/paradedb/paradedb/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.agpl3Only;
+    maintainers = [ lib.maintainers.lucperkins ];
+    # https://github.com/paradedb/paradedb/blob/v0.21.8/pg_search/Cargo.toml#L14-L18
+    broken = lib.versionOlder postgresql.version "14";
+    platforms = postgresql.meta.platforms;
+  };
+})


### PR DESCRIPTION
Adds the [pg_search](https://github.com/paradedb/paradedb/tree/main/pg_search) Postgres extension to Nixpkgs.

Built on macOS with `sandbox = true`.

In addition to the standard test items listed below, I've used this extension successfully in Postgres inside a Nix dev shell.

**Note**: this was originally attempted in #460095 but there was a bug in one of `pg_search`'s dependencies (Lindera) that made it un-buildable in the Nix sandbox (namely `build.rs` files that fetched tarballs from the open Internet in a way that couldn't be turned off). That bug has been fixed, and so I'm re-attempting.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
