### PR TITLE
python314Packages.pyecharts: disable failing test

### DIFF
--- a/pkgs/development/python-modules/pyecharts/default.nix
+++ b/pkgs/development/python-modules/pyecharts/default.nix
@@ -8,6 +8,7 @@
   pillow,
   prettytable,
   pytestCheckHook,
+  pythonAtLeast,
   requests,
   setuptools,
   simplejson,
@@ -52,6 +53,10 @@ buildPythonPackage rec {
     "test_render_embed_js"
     "test_display_javascript_v2"
     "test_lines3d_base"
+  ]
+  ++ lib.optionals (pythonAtLeast "3.14") [
+    # https://github.com/pyecharts/pyecharts/issues/2452
+    "test_wordcloud_encode_image_to_base64_os_error"
   ];
 
   meta = {


### PR DESCRIPTION
1. Discovered and disabled a failing test on Python 3.14 only
2. Filed https://github.com/pyecharts/pyecharts/issues/2452

Tracking #475732

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
