### PR TITLE
nss_pam_ldapd: fix C23 compatibility

### DIFF
--- a/pkgs/by-name/ns/nss_pam_ldapd/fix-bool-c23-keyword.patch
+++ b/pkgs/by-name/ns/nss_pam_ldapd/fix-bool-c23-keyword.patch
@@ -1,0 +1,31 @@
+From 8ddb983a546f632986a84a784c4625110f7782a2 Mon Sep 17 00:00:00 2001
+From: Arthur de Jong <arthur@arthurdejong.org>
+Date: Sun, 23 Feb 2025 15:22:38 +0100
+Subject: Fix variable name (bool) which is a keyword in C23
+
+Closes https://bugs.debian.org/1097481
+---
+ nslcd/cfg.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/nslcd/cfg.c b/nslcd/cfg.c
+index ded797a..b984b0e 100644
+--- a/nslcd/cfg.c
++++ b/nslcd/cfg.c
+@@ -207,10 +207,10 @@ static int get_boolean(const char *filename, int lnr,
+   return parse_boolean(filename, lnr, token);
+ }
+ 
+-static const char *print_boolean(int bool)
++static const char *print_boolean(int value)
+ {
+-  if (bool) return "yes";
+-  else      return "no";
++  if (value) return "yes";
++  else       return "no";
+ }
+ 
+ #define TIME_MINUTES 60
+-- 
+cgit v1.2.3
+

--- a/pkgs/by-name/ns/nss_pam_ldapd/package.nix
+++ b/pkgs/by-name/ns/nss_pam_ldapd/package.nix
@@ -19,6 +19,11 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-4BeE4Xy1M7tmvQYB4gXnhSY0RcPC33pvkCMqtBMccW0=";
   };
 
+  patches = [
+    # Fix C23 compatibility: rename 'bool' variable which is now a keyword
+    ./fix-bool-c23-keyword.patch
+  ];
+
   nativeBuildInputs = [
     pkg-config
     makeWrapper


### PR DESCRIPTION
Rename 'bool' variable to 'value' in print_boolean() function since 'bool' is now a reserved keyword in C23.

Patch taken from Debian: https://bugs.debian.org/1097481

This is related to issue #475479, it fails to build with GCC 15.

Build error:

```
Jan 07 23:01:12 wthack nixos-upgrade-start[482398]: error: Cannot build '/nix/store/7bmdb82cr5rg5qqj3s60kspq8d9qjpqx-nss-pam-ldapd-0.9.13.drv'.
Jan 07 23:01:12 wthack nixos-upgrade-start[482398]:        Reason: builder failed with exit code 2.
Jan 07 23:01:12 wthack nixos-upgrade-start[482398]:        Output paths:
Jan 07 23:01:12 wthack nixos-upgrade-start[482398]:          /nix/store/74v9rc8ql309iw755cgj34dqs1x6knhl-nss-pam-ldapd-0.9.13
Jan 07 23:01:12 wthack nixos-upgrade-start[482398]:        Last 25 log lines:
Jan 07 23:01:12 wthack nixos-upgrade-start[482398]:        > daemonize.c:233:13: warning: ignoring return value of 'write' declared with attribute 'warn_unused_result' [-Wunused-result]
Jan 07 23:01:12 wthack nixos-upgrade-start[482398]:        >   233 |       (void)write(daemonizefd, &l, sizeof(int));
Jan 07 23:01:12 wthack nixos-upgrade-start[482398]:        >       |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Jan 07 23:01:12 wthack nixos-upgrade-start[482398]:        > daemonize.c:234:13: warning: ignoring return value of 'write' declared with attribute 'warn_unused_result' [-Wunused-result]
Jan 07 23:01:12 wthack nixos-upgrade-start[482398]:        >   234 |       (void)write(daemonizefd, message, l);
Jan 07 23:01:12 wthack nixos-upgrade-start[482398]:        >       |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Jan 07 23:01:12 wthack nixos-upgrade-start[482398]:        > gcc -DHAVE_CONFIG_H -I. -I..  -I..   -g -O2 -c -o common.o common.c
Jan 07 23:01:12 wthack nixos-upgrade-start[482398]:        > gcc -DHAVE_CONFIG_H -I. -I..  -I..   -g -O2 -c -o myldap.o myldap.c
Jan 07 23:01:12 wthack nixos-upgrade-start[482398]:        > gcc -DHAVE_CONFIG_H -I. -I..  -I..   -g -O2 -c -o cfg.o cfg.c
Jan 07 23:01:12 wthack nixos-upgrade-start[482398]:        > cfg.c:210:38: error: 'bool' cannot be used here
Jan 07 23:01:12 wthack nixos-upgrade-start[482398]:        >   210 | static const char *print_boolean(int bool)
Jan 07 23:01:12 wthack nixos-upgrade-start[482398]:        >       |                                      ^~~~
Jan 07 23:01:12 wthack nixos-upgrade-start[482398]:        > cfg.c:210:38: note: 'bool' is a keyword with '-std=c23' onwards
Jan 07 23:01:12 wthack nixos-upgrade-start[482398]:        > cfg.c: In function 'print_boolean':
Jan 07 23:01:12 wthack nixos-upgrade-start[482398]:        > cfg.c:212:11: error: expected identifier or '(' before ')' token
Jan 07 23:01:12 wthack nixos-upgrade-start[482398]:        >   212 |   if (bool) return "yes";
Jan 07 23:01:12 wthack nixos-upgrade-start[482398]:        >       |           ^
Jan 07 23:01:12 wthack nixos-upgrade-start[482398]:        > cfg.c:212:7: error: declaration in the controlling expression must have an initializer
Jan 07 23:01:12 wthack nixos-upgrade-start[482398]:        >   212 |   if (bool) return "yes";
Jan 07 23:01:12 wthack nixos-upgrade-start[482398]:        >       |       ^~~~
Jan 07 23:01:12 wthack nixos-upgrade-start[482398]:        > make[2]: *** [Makefile:515: cfg.o] Error 1
Jan 07 23:01:12 wthack nixos-upgrade-start[482398]:        > make[2]: Leaving directory '/build/nss-pam-ldapd-0.9.13/nslcd'
Jan 07 23:01:12 wthack nixos-upgrade-start[482398]:        > make[1]: *** [Makefile:450: all-recursive] Error 1
Jan 07 23:01:12 wthack nixos-upgrade-start[482398]:        > make[1]: Leaving directory '/build/nss-pam-ldapd-0.9.13'
Jan 07 23:01:12 wthack nixos-upgrade-start[482398]:        > make: *** [Makefile:391: all] Error 2
```

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
