### PR TITLE
ncps: v0.5.2 -> v0.6.0

### DIFF
--- a/pkgs/by-name/nc/ncps/package.nix
+++ b/pkgs/by-name/nc/ncps/package.nix
@@ -3,117 +3,35 @@
   curl,
   dbmate,
   fetchFromGitHub,
+  jq,
   lib,
+  mariadb,
   minio,
   minio-client,
+  postgresql,
   python3,
+  redis,
 }:
 
 let
-
-  # Start MinIO before running tests to enable S3 integration tests
-  minioPreCheck = ''
-    echo "🚀 Starting MinIO for S3 integration tests..."
-
-    # Create temporary directories for MinIO data and config
-    export MINIO_DATA_DIR=$(mktemp -d)
-    export HOME=$(mktemp -d)
-
-    # Configure MinIO credentials (must be set before starting MinIO)
-    export MINIO_ROOT_USER=admin
-    export MINIO_ROOT_PASSWORD=password
-    export MINIO_REGION=us-east-1
-
-    # Generate random free ports using python
-    # We bind to port 0, get the assigned port, and close the socket immediately.
-    # In a Nix sandbox, the race condition risk (port being stolen between check and use) is negligible.
-    export MINIO_PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("", 0)); print(s.getsockname()[1]); s.close()')
-    export CONSOLE_PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("", 0)); print(s.getsockname()[1]); s.close()')
-
-    # Export S3 test environment variables
-    export NCPS_TEST_S3_BUCKET="test-bucket"
-    export NCPS_TEST_S3_ENDPOINT="http://127.0.0.1:$MINIO_PORT"
-    export NCPS_TEST_S3_REGION="us-east-1"
-    export NCPS_TEST_S3_ACCESS_KEY_ID="test-access-key"
-    export NCPS_TEST_S3_SECRET_ACCESS_KEY="test-secret-key"
-
-    # Start MinIO server in background
-    minio server "$MINIO_DATA_DIR" \
-      --address "127.0.0.1:$MINIO_PORT" \
-      --console-address "127.0.0.1:$CONSOLE_PORT" &
-    export MINIO_PID=$!
-
-    # Wait for MinIO to be ready
-    echo "⏳ Waiting for MinIO to be ready..."
-    for i in {1..30}; do
-      if curl -sf "$NCPS_TEST_S3_ENDPOINT/minio/health/live"; then
-        echo "✅ MinIO is ready"
-        break
-      fi
-      if [ $i -eq 30 ]; then
-        echo "❌ MinIO failed to start"
-        kill $MINIO_PID 2>/dev/null || true
-        exit 1
-      fi
-      sleep 1
-    done
-
-    # Setup admin alias
-    mc alias set local "$NCPS_TEST_S3_ENDPOINT" "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD"
-
-    # Create test bucket
-    mc mb "local/$NCPS_TEST_S3_BUCKET" || true
-
-    # Create service account for tests
-    mc admin user svcacct add \
-      --access-key "$NCPS_TEST_S3_ACCESS_KEY_ID" \
-      --secret-key "$NCPS_TEST_S3_SECRET_ACCESS_KEY" \
-      local admin || true
-
-    echo "✅ MinIO configured for S3 integration tests"
-  '';
-
-  # Stop MinIO after tests complete
-  minioPostCheck = ''
-    echo "🛑 Stopping MinIO..."
-    if [ -n "$MINIO_PID" ]; then
-      kill $MINIO_PID 2>/dev/null || true
-      # Wait for MinIO to fully shut down
-      for i in {1..30}; do
-        if ! kill -0 $MINIO_PID 2>/dev/null; then
-          break
-        fi
-        sleep 0.5
-      done
-
-      # If it's still alive, force kill it
-      if kill -0 $MINIO_PID 2>/dev/null; then
-        echo "MinIO did not shut down gracefully, force killing..."
-        kill -9 $MINIO_PID 2>/dev/null || true
-        sleep 1 # Give a moment for the OS to clean up after SIGKILL
-      fi
-    fi
-    sleep 1
-    rm -rf "$MINIO_DATA_DIR" 2>/dev/null || true
-    echo "✅ MinIO stopped and cleaned up"
-  '';
-
   finalAttrs = {
     pname = "ncps";
-    version = "0.5.2";
+    version = "0.6.0";
 
     src = fetchFromGitHub {
       owner = "kalbasit";
       repo = "ncps";
       tag = "v${finalAttrs.version}";
-      hash = "sha256-uGghoADkD2eJYZwt8QSiVzw68dRDLI+OxMa1VAQhBKQ=";
+      hash = "sha256-/Fa8cpBACbbB74W1HSQmsS06BLofnH094be6I2peX0U=";
     };
 
     ldflags = [
       "-X github.com/kalbasit/ncps/cmd.Version=v${finalAttrs.version}"
     ];
 
-    vendorHash = "sha256-3YPKlz7+x7nYCqKmOroaiUyZGKIQMGFxcNyPnrA9Tio=";
+    vendorHash = "sha256-GuUhJ0Zf2Zjfgstxcy6/DAs0Eq7PU4aiiJMSNcNqsqI=";
+
+    subPackages = [ "." ];
 
     doCheck = true;
     checkFlags = [ "-race" ];
@@ -121,20 +39,30 @@ let
     nativeBuildInputs = [
       curl # used for checking MinIO health check
       dbmate # used for testing
+      jq # used for testing by the init-minio
+      mariadb # MySQL/MariaDB for integration tests
       minio # S3-compatible storage for integration tests
       minio-client # mc CLI for MinIO setup
+      postgresql # PostgreSQL for integration tests
       python3 # used for generating the ports
+      redis # Redis for distributed locking integration tests
     ];
 
     # pre and post checks
     preCheck = ''
       # Set up cleanup trap to ensure background processes are killed even if tests fail
       cleanup() {
-        ${minioPostCheck}
+        source $src/nix/packages/ncps/post-check-minio.sh
+        source $src/nix/packages/ncps/post-check-mysql.sh
+        source $src/nix/packages/ncps/post-check-postgres.sh
+        source $src/nix/packages/ncps/post-check-redis.sh
       }
       trap cleanup EXIT
 
-      ${minioPreCheck}
+      source $src/nix/packages/ncps/pre-check-minio.sh
+      source $src/nix/packages/ncps/pre-check-mysql.sh
+      source $src/nix/packages/ncps/pre-check-postgres.sh
+      source $src/nix/packages/ncps/pre-check-redis.sh
     '';
 
     postInstall = ''


### PR DESCRIPTION
https://github.com/kalbasit/ncps/releases/tag/v0.6.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
