### PR TITLE
abe: init at 1.1

### DIFF
--- a/pkgs/by-name/ab/abe/package.nix
+++ b/pkgs/by-name/ab/abe/package.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  stdenv,
+  fetchzip,
+  SDL,
+  SDL_mixer,
+  makeWrapper,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "abe";
+  version = "1.1";
+
+  src = fetchzip {
+    url = "mirror://sourceforge/abe/abe/abe-${finalAttrs.version}/abe-${finalAttrs.version}.tar.gz";
+    hash = "sha256-Kx1DleV5tj0rzAxyHtY4dLSVY6KwUPJpD1MwV1rBp+0=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    makeWrapper
+    SDL
+  ];
+  buildInputs = [
+    SDL
+    SDL_mixer
+  ];
+
+  NIX_CFLAGS_COMPILE = [ "-std=gnu89" ];
+
+  hardeningDisable = [ "format" ];
+
+  # Needs SDL init even for --help, so force dummy drivers for a non-interactive test.
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+  checkPhase = ''
+    runHook preCheck
+
+    SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy HOME=$(mktemp -d) ./src/abe --help \
+      | grep -Fq "Show this help message."
+
+    runHook postCheck
+  '';
+
+  postInstall = ''
+    install -d "$out/share/abe"
+    cp -a images maps sounds "$out/share/abe/"
+
+    install -Dm644 README AUTHORS ChangeLog NEWS -t "$out/share/doc/abe"
+
+    install -d "$out/libexec"
+    mv "$out/bin/abe" "$out/libexec/abe"
+
+    makeWrapper "$out/libexec/abe" "$out/bin/abe" \
+      --chdir "$out/share/abe"
+  '';
+
+  meta = {
+    description = "Side-scrolling platform game written using SDL";
+    homepage = "https://abe.sourceforge.net/";
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ Zaczero ];
+    mainProgram = "abe";
+    platforms = lib.platforms.unix;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/NixOS/nixpkgs/issues/380688

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
