### PR TITLE
amazing-qr: init at 0-unstable-2021-05-07

### DIFF
--- a/pkgs/by-name/am/amazing-qr/package.nix
+++ b/pkgs/by-name/am/amazing-qr/package.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+}:
+
+python3Packages.buildPythonApplication {
+  pname = "amazing-qr";
+  version = "0-unstable-2021-05-07";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "x-hw";
+    repo = "amazing-qr";
+    rev = "a773916dcf5bed8fdcd9c492dd552d4044ff568f";
+    hash = "sha256-KNGXedVharD/vsAebe9qeG4yFZwZyF77LjPy/LgUF3Y=";
+  };
+
+  build-system = with python3Packages; [ setuptools ];
+
+  dependencies = with python3Packages; [
+    imageio
+    numpy
+    pillow
+  ];
+
+  meta = {
+    description = "QR code generator";
+    mainProgram = "amzqr";
+    maintainers = with lib.maintainers; [ nicknb ];
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION
Adds [amazing-qr](https://github.com/x-hw/amazing-qr), a QR code generator written in Python.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
