### PR TITLE
pocket-id: 1.16.0 -> 2.1.0

### DIFF
--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -81,6 +81,8 @@
   - If you previously used `configFile`, migrate your configuration to the `settings` option and extract the private key to a separate file referenced by `PrivateKeyPath`.
   - If you previously used `persistentKeys`, convert your keys to PEM format and store them in a secure location accessible only to root, then reference them via `PrivateKeyPath`.
 
+- `pocket-id` has been updated to version 2 that contains [breaking changes](https://pocket-id.org/docs/setup/major-releases/migrate-v2).
+
 - `asio` (standalone version of `boost::asio`) has been updated from 1.24.0 to 1.36.0. Some breaking changes were introduced between these
   two versions, and the one affected most was the removal of `asio::io_service` in favor of `asio::io_context` in 1.33.0. `asio_1_32_0` is
   retained for packages that have not completed migration. `asio_1_10` has been removed as no packages depend on it anymore.

--- a/nixos/modules/services/security/pocket-id.nix
+++ b/nixos/modules/services/security/pocket-id.nix
@@ -143,6 +143,29 @@ in
   };
 
   config = mkIf cfg.enable {
+    assertions = (
+      map
+        (
+          # Converted to assert 2026-01-08
+          setting: {
+            assertion = !(cfg.settings ? "${setting}");
+            message = ''
+              `services.pocket-id.settings.${setting}` is deprecated.
+              See [v1 migration guide](https://pocket-id.org/docs/setup/major-releases/migrate-v1).
+            '';
+          })
+        [
+          "PUBLIC_APP_URL"
+          "PUBLIC_UI_CONFIG_DISABLED"
+          "CADDY_DISABLED"
+          "CADDY_PORT"
+          "BACKEND_PORT"
+          "POSTGRES_CONNECTION_STRING"
+          "SQLITE_DB_PATH"
+          "INTERNAL_BACKEND_URL"
+        ]
+    );
+
     warnings =
       (concatMap
         (
@@ -156,26 +179,6 @@ in
           "MAXMIND_LICENSE_KEY"
           "SMTP_PASSWORD"
           "LDAP_BIND_PASSWORD"
-        ]
-      )
-      ++ (concatMap
-        (
-          # Added 2025-05-27
-          setting:
-          optional (cfg.settings ? "${setting}") ''
-            `services.pocket-id.settings.${setting}` is deprecated.
-            See [v1 migration guide](https://pocket-id.org/docs/setup/major-releases/migrate-v1).
-          ''
-        )
-        [
-          "PUBLIC_APP_URL"
-          "PUBLIC_UI_CONFIG_DISABLED"
-          "CADDY_DISABLED"
-          "CADDY_PORT"
-          "BACKEND_PORT"
-          "POSTGRES_CONNECTION_STRING"
-          "SQLITE_DB_PATH"
-          "INTERNAL_BACKEND_URL"
         ]
       )
       ++ (concatMap

--- a/nixos/modules/services/security/pocket-id.nix
+++ b/nixos/modules/services/security/pocket-id.nix
@@ -177,6 +177,22 @@ in
           "SQLITE_DB_PATH"
           "INTERNAL_BACKEND_URL"
         ]
+      )
+      ++ (concatMap
+        (
+          # Added 2026-01-08
+          setting:
+          optional (cfg.settings ? "${setting}") ''
+            `services.pocket-id.settings.${setting}` is deprecated.
+            See [v2 migration guide](https://pocket-id.org/docs/setup/major-releases/migrate-v2).
+          ''
+        )
+        [
+          "DB_PROVIDER"
+          "KEYS_PATH"
+          "KEYS_STORAGE"
+          "LDAP_ATTRIBUTE_ADMIN_GROUP"
+        ]
       );
 
     systemd.tmpfiles.rules = [

--- a/nixos/modules/services/security/pocket-id.nix
+++ b/nixos/modules/services/security/pocket-id.nix
@@ -144,28 +144,40 @@ in
 
   config = mkIf cfg.enable {
     warnings =
-      optional (cfg.settings ? MAXMIND_LICENSE_KEY)
-        "`services.pocket-id.settings.MAXMIND_LICENSE_KEY` will be stored as plaintext in the Nix store. Use `services.pocket-id.credentials.MAXMIND_LICENSE_KEY` or `services.pocket-id.environmentFile` instead."
-      ++
-        concatMap
-          (
-            # Added 2025-05-27
-            setting:
-            optional (cfg.settings ? "${setting}") ''
-              `services.pocket-id.settings.${setting}` is deprecated.
-              See [v1 migration guide](https://pocket-id.org/docs/setup/major-releases/migrate-v1).
-            ''
-          )
-          [
-            "PUBLIC_APP_URL"
-            "PUBLIC_UI_CONFIG_DISABLED"
-            "CADDY_DISABLED"
-            "CADDY_PORT"
-            "BACKEND_PORT"
-            "POSTGRES_CONNECTION_STRING"
-            "SQLITE_DB_PATH"
-            "INTERNAL_BACKEND_URL"
-          ];
+      (concatMap
+        (
+          setting:
+          optional (cfg.settings ? "${setting}") ''
+            `services.pocket-id.settings.${setting}` will be stored as plaintext in the Nix store. Use `services.pocket-id.credentials.${setting}` or `services.pocket-id.environmentFile` instead.
+          ''
+        )
+        [
+          "ENCRYPTION_KEY"
+          "MAXMIND_LICENSE_KEY"
+          "SMTP_PASSWORD"
+          "LDAP_BIND_PASSWORD"
+        ]
+      )
+      ++ (concatMap
+        (
+          # Added 2025-05-27
+          setting:
+          optional (cfg.settings ? "${setting}") ''
+            `services.pocket-id.settings.${setting}` is deprecated.
+            See [v1 migration guide](https://pocket-id.org/docs/setup/major-releases/migrate-v1).
+          ''
+        )
+        [
+          "PUBLIC_APP_URL"
+          "PUBLIC_UI_CONFIG_DISABLED"
+          "CADDY_DISABLED"
+          "CADDY_PORT"
+          "BACKEND_PORT"
+          "POSTGRES_CONNECTION_STRING"
+          "SQLITE_DB_PATH"
+          "INTERNAL_BACKEND_URL"
+        ]
+      );
 
     systemd.tmpfiles.rules = [
       "d ${cfg.dataDir} 0755 ${cfg.user} ${cfg.group}"

--- a/nixos/modules/services/security/pocket-id.nix
+++ b/nixos/modules/services/security/pocket-id.nix
@@ -44,9 +44,10 @@ in
     environmentFile = mkOption {
       type = path;
       description = ''
-        Path to an environment file loaded for the Pocket ID service.
-
+        Path to an environment file to be loaded.
         This can be used to securely store tokens and secrets outside of the world-readable Nix store.
+
+        See [PocketID environment variables](https://pocket-id.org/docs/configuration/environment-variables).
 
         Example contents of the file:
         MAXMIND_LICENSE_KEY=your-license-key
@@ -81,7 +82,7 @@ in
             description = ''
               Whether to disable analytics.
 
-              See [docs page](https://pocket-id.org/docs/configuration/analytics/).
+              See the [analytics documentation](https://pocket-id.org/docs/configuration/analytics/).
             '';
             default = false;
           };
@@ -91,9 +92,9 @@ in
       default = { };
 
       description = ''
-        Environment variables that will be passed to Pocket ID, see
-        [configuration options](https://pocket-id.org/docs/configuration/environment-variables)
-        for supported values.
+        Environment variables to be passed.
+
+        See [PocketID environment variables](https://pocket-id.org/docs/configuration/environment-variables).
       '';
     };
 
@@ -101,7 +102,7 @@ in
       type = path;
       default = "/var/lib/pocket-id";
       description = ''
-        The directory where Pocket ID will store its data, such as the database.
+        The directory where Pocket ID will store its data, such as the database when using SQLite.
       '';
     };
 
@@ -121,15 +122,15 @@ in
   config = mkIf cfg.enable {
     warnings =
       optional (cfg.settings ? MAXMIND_LICENSE_KEY)
-        "config.services.pocket-id.settings.MAXMIND_LICENSE_KEY will be stored as plaintext in the Nix store. Use config.services.pocket-id.environmentFile instead."
+        "`services.pocket-id.settings.MAXMIND_LICENSE_KEY` will be stored as plaintext in the Nix store. Use `services.pocket-id.environmentFile` instead."
       ++
         concatMap
           (
             # Added 2025-05-27
             setting:
             optional (cfg.settings ? "${setting}") ''
-              config.services.pocket-id.settings.${setting} is deprecated.
-              See https://pocket-id.org/docs/setup/migrate-to-v1/ for migration instructions.
+              `services.pocket-id.settings.${setting}` is deprecated.
+              See [v1 migration guide](https://pocket-id.org/docs/setup/major-releases/migrate-v1).
             ''
           )
           [

--- a/nixos/tests/pocket-id.nix
+++ b/nixos/tests/pocket-id.nix
@@ -1,5 +1,9 @@
-{ lib, ... }:
+{ pkgs, lib, ... }:
 
+let
+  # !!! Don't do this with real keys. The /nix store is world-readable!
+  ENCRYPTION_KEY = pkgs.writeText "pocket-id-encryption-key" "SUeAyRRFZ1uf03ClOE+o++BVENSE/Ptb9YFRF2Sk+zM=";
+in
 {
   name = "pocket-id";
   meta.maintainers = with lib.maintainers; [
@@ -16,6 +20,9 @@
           settings = {
             PORT = 10001;
           };
+          credentials = {
+            inherit ENCRYPTION_KEY;
+          };
         };
       };
 
@@ -31,6 +38,9 @@
             PORT = 10001;
             DB_PROVIDER = "postgres";
             DB_CONNECTION_STRING = "host=/run/postgresql user=${username} database=${username}";
+          };
+          credentials = {
+            inherit ENCRYPTION_KEY;
           };
         };
 

--- a/nixos/tests/pocket-id.nix
+++ b/nixos/tests/pocket-id.nix
@@ -36,7 +36,6 @@ in
           enable = true;
           settings = {
             PORT = 10001;
-            DB_PROVIDER = "postgres";
             DB_CONNECTION_STRING = "host=/run/postgresql user=${username} database=${username}";
           };
           credentials = {

--- a/pkgs/by-name/po/pocket-id/package.nix
+++ b/pkgs/by-name/po/pocket-id/package.nix
@@ -12,18 +12,18 @@
 }:
 buildGo125Module (finalAttrs: {
   pname = "pocket-id";
-  version = "1.16.0";
+  version = "2.1.0";
 
   src = fetchFromGitHub {
     owner = "pocket-id";
     repo = "pocket-id";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-2tGd/gl0Pm5b5GfkTsChvZoWov4dwljwqDcitX5NKCY=";
+    hash = "sha256-tBjo5evQVRG0oembk1VfAfM3M/FJ4zPWV/9vgAWH9Kc=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/backend";
 
-  vendorHash = "sha256-ttbiuYRWbn8KRZtg499R4NF/E9+B+fOylxZcMwNg69M=";
+  vendorHash = "sha256-hMhOG/2xnI/adjg8CnA0tRBD8/OFDsTloFXC8iwxlV0=";
 
   env.CGO_ENABLED = 0;
   ldflags = [
@@ -56,8 +56,8 @@ buildGo125Module (finalAttrs: {
     pnpmDeps = fetchPnpmDeps {
       inherit (finalAttrs) pname version src;
       pnpm = pnpm_10;
-      fetcherVersion = 1;
-      hash = "sha256-drXGcUHP7J7keGra7/x1tr9Pfh/wjzmtUE1yAybYXLQ=";
+      fetcherVersion = 3;
+      hash = "sha256-jhlHrekVk0sNLwo8LFQY6bgX9Ic0xbczM6UTzmZTnPI=";
     };
 
     env.BUILD_OUTPUT_PATH = "dist";


### PR DESCRIPTION
Releases:
- https://github.com/pocket-id/pocket-id/releases/tag/v2.0.0: [breaking changes](https://pocket-id.org/docs/setup/major-releases/migrate-v2)
- https://github.com/pocket-id/pocket-id/releases/tag/v2.0.1
- https://github.com/pocket-id/pocket-id/releases/tag/v2.0.2
- https://github.com/pocket-id/pocket-id/releases/tag/v2.1.0

Closes https://github.com/NixOS/nixpkgs/pull/476394.

~~I'll test it soon on our server.~~ Done

My reason for adding a `credentials` option is it has a nicer interface than `environmentFile`. I think we should keep both options and let the user choose, for example `environmentFile` could be easier to use with agenix as everything is in one file, but `credentials` is slightly better with sops-nix.
In the future we can also add warnings/assertions for deprecated credentials. If we didn't already have `environmentFile`, adding an assert for `credentials.ENCRYPTION_KEY` not being set would definitely save people some painful minutes when they realize pocket-id is failing (assuming they didn't set this already and weren't notified of the breaking changes). 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
