### PR TITLE
nixos/flaresolverr: add systemd hardening

### DIFF
--- a/nixos/modules/services/misc/flaresolverr.nix
+++ b/nixos/modules/services/misc/flaresolverr.nix
@@ -117,4 +117,6 @@ in
 
     networking.firewall = lib.mkIf cfg.openFirewall { allowedTCPPorts = [ cfg.port ]; };
   };
+
+  meta.maintainers = with lib.maintainers; [ diogotcorreia ];
 }

--- a/nixos/modules/services/misc/flaresolverr.nix
+++ b/nixos/modules/services/misc/flaresolverr.nix
@@ -46,10 +46,72 @@ in
         RestartSec = 5;
         Type = "simple";
         DynamicUser = true;
+        UMask = "0077";
         RuntimeDirectory = "flaresolverr";
         WorkingDirectory = "/run/flaresolverr";
         ExecStart = lib.getExe cfg.package;
         TimeoutStopSec = 30;
+
+        # Systemd hardening
+        LockPersonality = true;
+        PrivateDevices = true;
+        PrivateMounts = true;
+        PrivateUsers = true;
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        RestrictRealtime = true;
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_UNIX"
+        ];
+        RestrictNamespaces = [
+          "net"
+          "pid"
+          "user"
+        ];
+        CapabilityBoundingSet = [
+          "~CAP_BLOCK_SUSPEND"
+          "~CAP_BPF"
+          "~CAP_CHOWN"
+          "~CAP_IPC_LOCK"
+          "~CAP_MKNOD"
+          "~CAP_NET_ADMIN"
+          "~CAP_NET_RAW"
+          "~CAP_PERFMON"
+          "~CAP_SYSLOG"
+          "~CAP_SYS_ADMIN"
+          "~CAP_SYS_BOOT"
+          "~CAP_SYS_MODULE"
+          "~CAP_SYS_PACCT"
+          "~CAP_SYS_PTRACE"
+          "~CAP_SYS_TIME"
+          "~CAP_WAKE_ALARM"
+        ];
+        SystemCallFilter = [
+          "~@chown"
+          "~@clock"
+          "~@cpu-emulation"
+          "~@debug"
+          "~@keyring"
+          "~@memlock"
+          "~@module"
+          "~@obsolete"
+          "~@pkey"
+          "~@raw-io"
+          "~@reboot"
+          "~@setuid"
+          "~@swap"
+          "~@timer"
+        ];
+        SystemCallErrorNumber = "EPERM";
+        SystemCallArchitectures = "native";
       };
     };
 

--- a/nixos/tests/flaresolverr.nix
+++ b/nixos/tests/flaresolverr.nix
@@ -1,7 +1,7 @@
 { lib, ... }:
 {
   name = "flaresolverr";
-  meta.maintainers = [ ];
+  meta.maintainers = with lib.maintainers; [ diogotcorreia ];
 
   nodes.machine =
     { pkgs, ... }:

--- a/pkgs/by-name/fl/flaresolverr/package.nix
+++ b/pkgs/by-name/fl/flaresolverr/package.nix
@@ -71,7 +71,7 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/FlareSolverr/FlareSolverr/blob/${finalAttrs.src.rev}/CHANGELOG.md";
     license = lib.licenses.mit;
     mainProgram = "flaresolverr";
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ diogotcorreia ];
     inherit (undetected-chromedriver.meta) platforms;
   };
 })


### PR DESCRIPTION
Add systemd hardening to the flaresolverr service.

I've tested this on my server and it appears to work: https://github.com/diogotcorreia/dotfiles/commit/b2ee2569b2251dfb63a8dd3696832b0f87d875da

Also added myself as maintainer of the package, module, and test, since they currently do not have any (as of https://github.com/NixOS/nixpkgs/pull/424788).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
