### PR TITLE
bacula: fix build with ncurses 6.6

### DIFF
--- a/pkgs/by-name/ba/bacula/0001-console-include-termios.h-explicitly.patch
+++ b/pkgs/by-name/ba/bacula/0001-console-include-termios.h-explicitly.patch
@@ -1,0 +1,24 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Philip Taron <philip.taron@gmail.com>
+Date: Wed, 7 Jan 2026 17:30:51 -0800
+Subject: [PATCH] console: include termios.h explicitly
+
+ncurses 6.6 moved the termios.h include inside #ifdef NCURSES_INTERNALS
+in term.h, so applications can no longer rely on term.h to provide
+termios symbols. Include termios.h explicitly.
+---
+ src/console/conio.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/console/conio.c b/src/console/conio.c
+index 2bea887..7ac61d6 100755
+--- a/src/console/conio.c
++++ b/src/console/conio.c
+@@ -56,6 +56,7 @@
+ 
+ #include <curses.h>
+ #include <term.h>
++#include <termios.h>
+ 
+ #ifdef HAVE_SUN_OS
+ #ifndef _TERM_H

--- a/pkgs/by-name/ba/bacula/package.nix
+++ b/pkgs/by-name/ba/bacula/package.nix
@@ -21,6 +21,12 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-KUr9PS651bccPQ6I/fGetRO/24Q7KNNcBVLkrgYoJ6E=";
   };
 
+  patches = [
+    # ncurses 6.6 moved the termios.h include inside #ifdef NCURSES_INTERNALS in term.h,
+    # so applications can no longer rely on term.h to provide termios symbols.
+    ./0001-console-include-termios.h-explicitly.patch
+  ];
+
   # libtool.m4 only matches macOS 10.*
   postPatch = lib.optionalString (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) ''
     substituteInPlace configure \


### PR DESCRIPTION
[ncurses 6.6](https://github.com/NixOS/nixpkgs/pull/477454) moved the termios.h include inside `#ifdef NCURSES_INTERNALS` in term.h, so applications can no longer rely on term.h to provide termios symbols. Include termios.h explicitly in conio.c.

Thanks to @trofi for the [report](https://github.com/NixOS/nixpkgs/pull/477454#issuecomment-3717535719).

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test