### PR TITLE
astwar: init at 0.4.5

### DIFF
--- a/pkgs/by-name/as/astwar/package.nix
+++ b/pkgs/by-name/as/astwar/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  stdenv,
+  autoreconfHook,
+  fetchcvs,
+  ncurses,
+  texinfo,
+  versionCheckHook,
+}:
+
+stdenv.mkDerivation {
+  pname = "astwar";
+  version = "0.4.5";
+
+  src = fetchcvs {
+    cvsRoot = ":pserver:anonymous@cvs.savannah.nongnu.org:/sources/astwar";
+    module = "astwar";
+    date = "2002-07-21";
+    hash = "sha256-/9logwWAOtXfUQpcWw6zSsWQ3q983+E+K33+yHulCA0=";
+  };
+
+  NIX_CFLAGS_COMPILE = [
+    "-include"
+    "stdlib.h"
+    "-include"
+    "string.h"
+    "-DHAVE_VPRINTF=1"
+  ];
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+    texinfo
+  ];
+
+  buildInputs = [ ncurses ];
+
+  postInstall = ''
+    install -Dm644 AUTHORS ChangeLog NEWS README astwar.pdf -t "$out/share/doc/astwar"
+    install -Dm644 COPYING -t "$out/share/licenses/astwar"
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  meta = {
+    description = "2D Space Shooter";
+    homepage = "https://savannah.nongnu.org/projects/astwar";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ Zaczero ];
+    mainProgram = "astwar";
+    platforms = lib.platforms.unix;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/NixOS/nixpkgs/issues/380688

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
