### PR TITLE
awkaster: init at 0-unstable-2023-01-20

### DIFF
--- a/pkgs/by-name/aw/awkaster/package.nix
+++ b/pkgs/by-name/aw/awkaster/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  gawk,
+  makeWrapper,
+  nix-update-script,
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "awkaster";
+  version = "0-unstable-2023-01-20";
+
+  src = fetchFromGitHub {
+    owner = "TheMozg";
+    repo = "awk-raycaster";
+    rev = "ac7f1b03554ca1c662ea2951cdd9f0b586075890";
+    hash = "sha256-g8jrVCQsdEASzE0HUpACQIhMslXbBpMH9Z7+rYVwEqg=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 awkaster.awk "$out/share/awkaster/awkaster.awk"
+    install -Dm644 README.md -t "$out/share/doc/awkaster"
+    install -Dm644 LICENSE -t "$out/share/licenses/awkaster"
+
+    makeWrapper ${gawk}/bin/gawk "$out/bin/awkaster" \
+      --add-flags "-f $out/share/awkaster/awkaster.awk"
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = stdenvNoCC.buildPlatform.canExecute stdenvNoCC.hostPlatform;
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    printf "q" | "$out/bin/awkaster" | grep -Fq "You quit."
+
+    runHook postInstallCheck
+  '';
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
+
+  meta = {
+    description = "Awk-based pseudo-3D dungeon game inspired by Wolfenstein 3D";
+    homepage = "https://github.com/TheMozg/awk-raycaster";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ Zaczero ];
+    mainProgram = "awkaster";
+    platforms = lib.platforms.unix;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/NixOS/nixpkgs/issues/380688

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
