### PR TITLE
ungoogled-chromium: 143.0.7499.169-1 -> 143.0.7499.192-1

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -813,7 +813,7 @@
     }
   },
   "ungoogled-chromium": {
-    "version": "143.0.7499.169",
+    "version": "143.0.7499.192",
     "deps": {
       "depot_tools": {
         "rev": "e2bb3cd55899346cc68bbfd5139e59c9d85a6984",
@@ -825,16 +825,16 @@
         "hash": "sha256-kIPhfuJBQSISdRjloe0N2JrqvuVrEkNijb92/9zSE9I="
       },
       "ungoogled-patches": {
-        "rev": "143.0.7499.169-1",
-        "hash": "sha256-6fz1xdX4o0k0Bj4+Y4Tw9h98f/zpcqikYJARtv54Unw="
+        "rev": "143.0.7499.192-1",
+        "hash": "sha256-OUdpe1flyqi2FPDzgFXBYu72CI1ZQkZ0wf3baSN+ayw="
       },
       "npmHash": "sha256-HF6B4abJJJ9JDVbovtAdaHIvqE1zHJZ2a+g2Cudx8Pw="
     },
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "164b20aab62509dad21fd46383951aeec084ad1e",
-        "hash": "sha256-WqpZXjcklOyPIvEmWi23bC8D/vVXMLkAmFrQQ13Iy6o=",
+        "rev": "be2c1f4fd451578a9ada68a0ac12d659362b44bf",
+        "hash": "sha256-YbYtW4UmlFoqXUSvPc7H+Fe0hUM+t9JwpBHKC98pY98=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {


### PR DESCRIPTION
Same underlying changes as #477563

https://chromereleases.googleblog.com/2026/01/stable-channel-update-for-desktop.html

This update includes 1 security fix.

CVEs:
CVE-2026-0628

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
