### PR TITLE
python3Packages.altair: 5.5.0 -> 6.0.0

### DIFF
--- a/pkgs/development/python-modules/altair/default.nix
+++ b/pkgs/development/python-modules/altair/default.nix
@@ -3,10 +3,12 @@
   buildPythonPackage,
   fetchFromGitHub,
   hatchling,
+  anywidget,
   ipython,
   ipywidgets,
   jinja2,
   jsonschema,
+  mistune,
   narwhals,
   numpy,
   packaging,
@@ -17,21 +19,20 @@
   pythonOlder,
   toolz,
   typing-extensions,
-  vega-datasets,
+  vl-convert-python,
+  writableTmpDirAsHomeHook,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "altair";
-  version = "5.5.0";
+  version = "6.0.0";
   pyproject = true;
-
-  disabled = pythonOlder "3.9";
 
   src = fetchFromGitHub {
     owner = "altair-viz";
     repo = "altair";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-lrKC4FYRQEax5E0lQNhO9FLk5UOJ0TnYzqZjndlRpGI=";
+    hash = "sha256-+Qc51L4tL1pRDpWwadxPpTE4tDH3FTO/wH67FtXMN7k=";
   };
 
   build-system = [ hatchling ];
@@ -48,15 +49,22 @@ buildPythonPackage (finalAttrs: {
   ++ lib.optional (pythonOlder "3.14") typing-extensions;
 
   nativeCheckInputs = [
+    anywidget
     ipython
     ipywidgets
+    mistune
     polars
     pytest-xdist
     pytestCheckHook
-    vega-datasets
+    vl-convert-python
+    writableTmpDirAsHomeHook
   ];
 
   pythonImportsCheck = [ "altair" ];
+
+  enabledTestPaths = [
+    "tests/"
+  ];
 
   disabledTests = [
     # ValueError: Saving charts in 'svg' format requires the vl-convert-python or altair_saver package: see http://github.com/altair-viz/altair_saver/
@@ -66,13 +74,17 @@ buildPythonPackage (finalAttrs: {
     "test_dataframe_to_csv[pandas]"
     # Network access
     "test_theme_remote_lambda"
+    "test_chart_validation_errors"
+    "test_multiple_field_strings_in_condition"
   ];
 
   disabledTestPaths = [
     # Disabled because it requires internet connectivity
     "tests/test_examples.py"
+    "tests/test_datasets.py"
+    "altair/datasets/_data.py"
     # TODO: Disabled because of missing altair_viewer package
-    "tests/vegalite/v5/test_api.py"
+    "tests/vegalite/v6/test_api.py"
     # avoid updating files and dependency on black
     "tests/test_toplevel.py"
     # require vl-convert package

--- a/pkgs/development/python-modules/altair/default.nix
+++ b/pkgs/development/python-modules/altair/default.nix
@@ -20,7 +20,7 @@
   vega-datasets,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "altair";
   version = "5.5.0";
   pyproject = true;
@@ -30,7 +30,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "altair-viz";
     repo = "altair";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-lrKC4FYRQEax5E0lQNhO9FLk5UOJ0TnYzqZjndlRpGI=";
   };
 
@@ -90,4 +90,4 @@ buildPythonPackage rec {
       vinetos
     ];
   };
-}
+})


### PR DESCRIPTION
In short what is included with the version 6 release of Altair.

* we now compile against Vega-Lite version 6 (to be specific, version 6.1.0) and provide support for Python 3.14.
* we have a new datasets module, altair.datasets, lazily access to datasets from https://github.com/vega/vega-datasets.
* we are now thread-safe, altair specifications should be stable after re-running.
* we improved docs and included new examples, eg. this faceted choropleth of habitat species across geographical counties https://altair-viz.github.io/gallery/maps_faceted_species.html.
* we improved the typing experiences.
* we migrated to uv as part of the infrastructure modernization and now have automated weekly builds.

CHANGELOG: https://github.com/vega/altair/releases/tag/v6.0.0
DIFF: https://github.com/vega/altair/compare/v5.5.0...v6.0.0

Tracking: #475732 (python 3.14 support)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin -- requires other package fixes in order to build
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
