### PR TITLE
usbutils: 018 -> 019

### DIFF
--- a/pkgs/by-name/us/usbutils/fix-paths.patch
+++ b/pkgs/by-name/us/usbutils/fix-paths.patch
@@ -1,12 +1,13 @@
 diff --git a/lsusb.py b/lsusb.py
-index bbc4dbb..8af1b1f 100755
+index 8f19ec4..ae81134 100755
 --- a/lsusb.py
 +++ b/lsusb.py
-@@ -27,8 +27,7 @@ showwakeup = False
+@@ -27,9 +27,7 @@ showwakeup = False
  
  prefix = "/sys/bus/usb/devices/"
  usbids = [
 -	"/usr/share/hwdata/usb.ids",
+-	"/usr/share/misc/usb.ids",
 -	"/usr/share/usb.ids",
 +	"@hwdata@/share/hwdata/usb.ids",
  ]

--- a/pkgs/by-name/us/usbutils/package.nix
+++ b/pkgs/by-name/us/usbutils/package.nix
@@ -14,11 +14,11 @@
 
 stdenv.mkDerivation rec {
   pname = "usbutils";
-  version = "018";
+  version = "019";
 
   src = fetchurl {
     url = "mirror://kernel/linux/utils/usb/usbutils/usbutils-${version}.tar.xz";
-    hash = "sha256-g/aLWbWFR1icACZugmcYZGJ1k6tDYtjIB/UO6pI8rZM=";
+    hash = "sha256-ZZ9AxEDjG6hlxSyBijPTumqXNJ4zU/ixmFF5yyqnHsU=";
   };
 
   patches = [
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     (fetchpatch {
-      url = "https://raw.githubusercontent.com/Homebrew/formula-patches/24a6945778381a62ecdcc1d78bcc16b9f86778c1/usbutils/portable.patch";
+      url = "https://raw.githubusercontent.com/Homebrew/homebrew-core/1cf441a09f572566b1b7c4695a4d169d1177248a/Patches/usbutils/portable.patch";
       hash = "sha256-spTkWURij4sPLoWtDaWVMIk81AS5W+qUUOQL1pAZEvs=";
     })
   ];


### PR DESCRIPTION
- Rebase `fix-paths.patch` to accomodate upstream changes in `lsusb.py`
- Update Darwin patch URL to homebrew-core as the old formula-patches repo is deprecated (hash unchanged).


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
