### PR TITLE
lichess-bot: add updateScript, 2025.12.23.1 -> 2026.1.11.1

### DIFF
--- a/pkgs/by-name/li/lichess-bot/package.nix
+++ b/pkgs/by-name/li/lichess-bot/package.nix
@@ -2,6 +2,7 @@
   lib,
   python3Packages,
   fetchFromGitHub,
+  versionCheckHook,
 }:
 
 python3Packages.buildPythonApplication {
@@ -42,6 +43,12 @@ python3Packages.buildPythonApplication {
 
     runHook postInstall
   '';
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgramArg = "--disable_auto_logging";
+  doInstallCheck = true;
 
   meta = {
     description = "Bridge between lichess.org and bots";

--- a/pkgs/by-name/li/lichess-bot/package.nix
+++ b/pkgs/by-name/li/lichess-bot/package.nix
@@ -11,14 +11,14 @@
 
 python3Packages.buildPythonApplication {
   pname = "lichess-bot";
-  version = "2025.12.23.1";
+  version = "2026.1.7.1";
   pyproject = false;
 
   src = fetchFromGitHub {
     owner = "lichess-bot-devs";
     repo = "lichess-bot";
-    rev = "6ea42dfaffa65efea0da09d94b058853d724a989";
-    hash = "sha256-G8DiW96mRnvmmmRALRcYDnjLilQIRqH5m6+aTluhohI=";
+    rev = "c2a71a74357386e2219a87da311950e432fcaf2d";
+    hash = "sha256-dzpU4VAuOlzBk4bn7iUxJ1hdqYfxb0XqTbtNhTjGWLI=";
   };
 
   propagatedBuildInputs = with python3Packages; [

--- a/pkgs/by-name/li/lichess-bot/package.nix
+++ b/pkgs/by-name/li/lichess-bot/package.nix
@@ -11,14 +11,14 @@
 
 python3Packages.buildPythonApplication {
   pname = "lichess-bot";
-  version = "2026.1.7.1";
+  version = "2026.1.11.1";
   pyproject = false;
 
   src = fetchFromGitHub {
     owner = "lichess-bot-devs";
     repo = "lichess-bot";
-    rev = "c2a71a74357386e2219a87da311950e432fcaf2d";
-    hash = "sha256-dzpU4VAuOlzBk4bn7iUxJ1hdqYfxb0XqTbtNhTjGWLI=";
+    rev = "96afce91316ba1243290408f2eeb6cd89778e8ff";
+    hash = "sha256-eE6b4VWhBqWjrF028om0NE/UN9+4sI7PoZp4eV6hRcE=";
   };
 
   propagatedBuildInputs = with python3Packages; [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Diff: https://github.com/lichess-bot-devs/lichess-bot/compare/6ea42dfaffa65efea0da09d94b058853d724a989...c2a71a74357386e2219a87da311950e432fcaf2d

To suppress incorrect downgrading PRs: https://github.com/NixOS/nixpkgs/pull/476085#issuecomment-3705838751

Supersedes and closes #477956

~I think `1.1.3-unstable-$date` is appropriate version format according to the guidelines.
It is based on the latest upstream tag, and nix-update-script handles the bumps correctly.~  => [Restored original version format](https://github.com/NixOS/nixpkgs/compare/e9299595a929a5bf130b0fae271d3d3a24a28303..e9eb347f3469a60ab5d1fa72678468cfc09d5579)

https://github.com/NixOS/nixpkgs/blob/0029ebec0c774c1b8d707377e50550a2831f64d8/pkgs/README.md#L460-L486

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

cc @mse63 

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
