### PR TITLE
Revert "treewide: prepare Rust packages for structuredAttrs by putting variables in env"

### DIFF
--- a/pkgs/by-name/ai/airshipper/package.nix
+++ b/pkgs/by-name/ai/airshipper/package.nix
@@ -87,7 +87,7 @@ rustPlatform.buildRustPackage {
     makeWrapper
   ];
 
-  env.RUSTC_BOOTSTRAP = 1; # We need rust unstable features
+  RUSTC_BOOTSTRAP = 1; # We need rust unstable features
 
   postInstall = ''
     install -Dm444 -t "$out/share/applications" "client/assets/net.veloren.airshipper.desktop"

--- a/pkgs/by-name/ce/celeste/package.nix
+++ b/pkgs/by-name/ce/celeste/package.nix
@@ -54,7 +54,7 @@ rustPlatform.buildRustPackage rec {
       --replace-warn 'edition = "2021"' 'edition = "2024"'
   '';
 
-  env.RUSTC_BOOTSTRAP = 1;
+  RUSTC_BOOTSTRAP = 1;
 
   nativeBuildInputs = [
     just

--- a/pkgs/by-name/cn/cnsprcy/package.nix
+++ b/pkgs/by-name/cn/cnsprcy/package.nix
@@ -22,7 +22,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   passthru.updateScript = ./update.sh;
 
-  env.RUSTC_BOOTSTRAP = true;
+  RUSTC_BOOTSTRAP = true;
   buildInputs = [ sqlite ];
 
   meta = {

--- a/pkgs/by-name/ew/eww/package.nix
+++ b/pkgs/by-name/ew/eww/package.nix
@@ -47,7 +47,7 @@ rustPlatform.buildRustPackage rec {
   cargoTestFlags = cargoBuildFlags;
 
   # requires unstable rust features
-  env.RUSTC_BOOTSTRAP = 1;
+  RUSTC_BOOTSTRAP = 1;
 
   postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd eww \

--- a/pkgs/by-name/fr/freshfetch/package.nix
+++ b/pkgs/by-name/fr/freshfetch/package.nix
@@ -18,7 +18,7 @@ rustPlatform.buildRustPackage rec {
   cargoHash = "sha256-LKltHVig33zUSWoRgCb1BgeKiJsDnlYEuPfQfrnhafI=";
 
   # freshfetch depends on rust nightly features
-  env.RUSTC_BOOTSTRAP = 1;
+  RUSTC_BOOTSTRAP = 1;
 
   meta = {
     description = "Fresh take on neofetch";

--- a/pkgs/by-name/fu/fuc/package.nix
+++ b/pkgs/by-name/fu/fuc/package.nix
@@ -19,7 +19,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-OoTWGeF96BpPDx1Y9AEVOIBK7kCz6pjw24pLiNcKmOc=";
 
-  env.RUSTC_BOOTSTRAP = 1;
+  RUSTC_BOOTSTRAP = 1;
 
   cargoBuildFlags = [
     "--workspace"

--- a/pkgs/by-name/hi/highlight-assertions/package.nix
+++ b/pkgs/by-name/hi/highlight-assertions/package.nix
@@ -18,7 +18,7 @@ rustPlatform.buildRustPackage rec {
   cargoHash = "sha256-egrxcnDVKKgk1sL5WNMIR2FPwQbjjMy20VWizcTBEtM=";
 
   # requires nightly features
-  env.RUSTC_BOOTSTRAP = 1;
+  RUSTC_BOOTSTRAP = 1;
 
   meta = {
     description = "Tool for unit testing tree sitter highlights for nvim-treesitter";

--- a/pkgs/by-name/ho/holo-cli/package.nix
+++ b/pkgs/by-name/ho/holo-cli/package.nix
@@ -24,7 +24,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
 
   # Use rust nightly features
-  env.RUSTC_BOOTSTRAP = 1;
+  RUSTC_BOOTSTRAP = 1;
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/by-name/ho/holo-daemon/package.nix
+++ b/pkgs/by-name/ho/holo-daemon/package.nix
@@ -25,7 +25,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   cargoHash = "sha256-YZ2c6W6CCqgyN+6i7Vh5fWLKw8L4pUqvq/tDO/Q/kf0=";
 
   # Use rust nightly features
-  env.RUSTC_BOOTSTRAP = 1;
+  RUSTC_BOOTSTRAP = 1;
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/by-name/id/idmail/package.nix
+++ b/pkgs/by-name/id/idmail/package.nix
@@ -34,10 +34,8 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-UcS2gAoa2fzPu6hh8I5sXSHHbAmzsecT44Ju2CVsK0Q=";
 
-  env = {
-    RUSTC_BOOTSTRAP = 1;
-    RUSTFLAGS = "--cfg=web_sys_unstable_apis";
-  };
+  RUSTC_BOOTSTRAP = 1;
+  RUSTFLAGS = "--cfg=web_sys_unstable_apis";
 
   nativeBuildInputs = [
     wasm-bindgen-cli_0_2_100

--- a/pkgs/by-name/ki/kind2/package.nix
+++ b/pkgs/by-name/ki/kind2/package.nix
@@ -23,7 +23,7 @@ rustPlatform.buildRustPackage rec {
   '';
 
   # requires nightly features
-  env.RUSTC_BOOTSTRAP = true;
+  RUSTC_BOOTSTRAP = true;
 
   meta = {
     description = "Functional programming language and proof assistant";

--- a/pkgs/by-name/ko/kord/package.nix
+++ b/pkgs/by-name/ko/kord/package.nix
@@ -13,7 +13,7 @@ rustPlatform.buildRustPackage rec {
   version = "0.6.1";
 
   # kord depends on nightly features
-  env.RUSTC_BOOTSTRAP = 1;
+  RUSTC_BOOTSTRAP = 1;
 
   src = fetchFromGitHub {
     owner = "twitchax";

--- a/pkgs/by-name/ms/msedit/package.nix
+++ b/pkgs/by-name/ms/msedit/package.nix
@@ -19,18 +19,14 @@ rustPlatform.buildRustPackage (finalAttrs: {
   };
 
   cargoHash = "sha256-U8U70nzTmpY6r8J661EJ4CGjx6vWrGovu5m25dvz5sY=";
-
   # Requires nightly features
-  env = {
-    RUSTC_BOOTSTRAP = 1;
-    # Without -headerpad, the following error occurs on x86_64-darwin
-    # error: install_name_tool: changing install names or rpaths can't be redone for: ... because larger updated load commands do not fit (the program must be relinked, and you may need to use -headerpad or -headerpad_max_install_names)
-    NIX_LDFLAGS = toString (
-      lib.optionals (with stdenv.hostPlatform; isDarwin && isx86_64) [
-        "-headerpad_max_install_names"
-      ]
-    );
-  };
+  env.RUSTC_BOOTSTRAP = 1;
+
+  # Without -headerpad, the following error occurs on x86_64-darwin
+  # error: install_name_tool: changing install names or rpaths can't be redone for: ... because larger updated load commands do not fit (the program must be relinked, and you may need to use -headerpad or -headerpad_max_install_names)
+  NIX_LDFLAGS = lib.optionals (with stdenv.hostPlatform; isDarwin && isx86_64) [
+    "-headerpad_max_install_names"
+  ];
 
   buildInputs = [
     icu

--- a/pkgs/by-name/ni/nix-ld/package.nix
+++ b/pkgs/by-name/ni/nix-ld/package.nix
@@ -21,10 +21,8 @@ rustPlatform.buildRustPackage rec {
 
   hardeningDisable = [ "stackprotector" ];
 
-  env = {
-    NIX_SYSTEM = stdenv.system;
-    RUSTC_BOOTSTRAP = "1";
-  };
+  NIX_SYSTEM = stdenv.system;
+  RUSTC_BOOTSTRAP = "1";
 
   preCheck = ''
     export NIX_LD=${stdenv.cc.bintools.dynamicLinker}

--- a/pkgs/by-name/sh/shadow-tls/package.nix
+++ b/pkgs/by-name/sh/shadow-tls/package.nix
@@ -17,7 +17,7 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-1oJCdqBa1pWpQ7QvZ0vZaOd73R+SzR9OPf+yoI+RwCY=";
 
-  env.RUSTC_BOOTSTRAP = 1;
+  RUSTC_BOOTSTRAP = 1;
 
   # network required
   doCheck = false;

--- a/pkgs/by-name/sy/syndicate-server/package.nix
+++ b/pkgs/by-name/sy/syndicate-server/package.nix
@@ -25,7 +25,7 @@ rustPlatform.buildRustPackage rec {
   ];
   buildInputs = [ openssl ];
 
-  env.RUSTC_BOOTSTRAP = 1;
+  RUSTC_BOOTSTRAP = 1;
 
   doCheck = false;
   doInstallCheck = true;

--- a/pkgs/by-name/un/unpfs/package.nix
+++ b/pkgs/by-name/un/unpfs/package.nix
@@ -19,7 +19,7 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-jRe1lgzfhzBUsS6wwwlqxxomap2TIDOyF3YBv20GJ14=";
 
-  env.RUSTC_BOOTSTRAP = 1;
+  RUSTC_BOOTSTRAP = 1;
 
   postInstall = ''
     install -D -m 0444 ../../README* -t "$out/share/doc/${pname}"

--- a/pkgs/development/compilers/rust/cargo.nix
+++ b/pkgs/development/compilers/rust/cargo.nix
@@ -55,19 +55,19 @@ rustPlatform.buildRustPackage.override
       zlib
     ];
 
-    env = {
-      # cargo uses git-rs which is made for a version of libgit2 from recent master that
-      # is not compatible with the current version in nixpkgs.
-      #LIBGIT2_SYS_USE_PKG_CONFIG = 1;
+    # cargo uses git-rs which is made for a version of libgit2 from recent master that
+    # is not compatible with the current version in nixpkgs.
+    #LIBGIT2_SYS_USE_PKG_CONFIG = 1;
 
-      # fixes: the cargo feature `edition` requires a nightly version of Cargo, but this is the `stable` channel
-      RUSTC_BOOTSTRAP = 1;
+    # fixes: the cargo feature `edition` requires a nightly version of Cargo, but this is the `stable` channel
+    RUSTC_BOOTSTRAP = 1;
 
-    }
-    // lib.optionalAttrs (stdenv.hostPlatform.rust.rustcTargetSpec == "x86_64-unknown-linux-gnu") {
-      # Upstream defaults to lld on x86_64-unknown-linux-gnu, we want to use our linker
-      RUSTFLAGS = "-Clinker-features=-lld -Clink-self-contained=-linker";
-    };
+    RUSTFLAGS =
+      if stdenv.hostPlatform.rust.rustcTargetSpec == "x86_64-unknown-linux-gnu" then
+        # Upstream defaults to lld on x86_64-unknown-linux-gnu, we want to use our linker
+        "-Clinker-features=-lld -Clink-self-contained=-linker"
+      else
+        null;
 
     postInstall = ''
       wrapProgram "$out/bin/cargo" --suffix PATH : "${rustc}/bin"

--- a/pkgs/development/compilers/rust/clippy.nix
+++ b/pkgs/development/compilers/rust/clippy.nix
@@ -21,7 +21,7 @@ rustPlatform.buildRustPackage {
   buildInputs = [ rustc.llvm ];
 
   # fixes: error: the option `Z` is only accepted on the nightly compiler
-  env.RUSTC_BOOTSTRAP = 1;
+  RUSTC_BOOTSTRAP = 1;
 
   # Without disabling the test the build fails with:
   # error: failed to run custom build command for `rustc_llvm v0.0.0

--- a/pkgs/development/compilers/rust/rustfmt.nix
+++ b/pkgs/development/compilers/rust/rustfmt.nix
@@ -38,15 +38,13 @@ rustPlatform.buildRustPackage {
     install_name_tool -add_rpath "${rustc.unwrapped}/lib" "$out/bin/git-rustfmt"
   '';
 
-  env = {
-    # As of 1.0.0 and rustc 1.30 rustfmt requires a nightly compiler
-    RUSTC_BOOTSTRAP = 1;
+  # As of 1.0.0 and rustc 1.30 rustfmt requires a nightly compiler
+  RUSTC_BOOTSTRAP = 1;
 
-    # As of rustc 1.45.0, these env vars are required to build rustfmt (due to
-    # https://github.com/rust-lang/rust/pull/72001)
-    CFG_RELEASE = rustc.version;
-    CFG_RELEASE_CHANNEL = if asNightly then "nightly" else "stable";
-  };
+  # As of rustc 1.45.0, these env vars are required to build rustfmt (due to
+  # https://github.com/rust-lang/rust/pull/72001)
+  CFG_RELEASE = rustc.version;
+  CFG_RELEASE_CHANNEL = if asNightly then "nightly" else "stable";
 
   postInstall = ''
     wrapProgram $out/bin/cargo-fmt \

--- a/pkgs/development/python-modules/mitmproxy-linux/default.nix
+++ b/pkgs/development/python-modules/mitmproxy-linux/default.nix
@@ -26,10 +26,8 @@ buildPythonPackage {
     patch -p1 < tmp.diff
   '';
 
-  env = {
-    RUSTFLAGS = "-C target-feature=";
-    RUSTC_BOOTSTRAP = 1;
-  };
+  RUSTFLAGS = "-C target-feature=";
+  RUSTC_BOOTSTRAP = 1;
 
   buildAndTestSubdir = "mitmproxy-linux";
 


### PR DESCRIPTION
Reverts NixOS/nixpkgs#472376

Mass rebuild on non-x86.