### PR TITLE
jinja2-cli: 0.8.2 -> 1.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16490,6 +16490,12 @@
     githubId = 2075353;
     name = "Matt Polzin";
   };
+  mattrobenolt = {
+    email = "m@robenolt.com";
+    github = "mattrobenolt";
+    githubId = 375744;
+    name = "Matt Robenolt";
+  };
   MattSturgeon = {
     email = "matt@sturgeon.me.uk";
     github = "MattSturgeon";

--- a/pkgs/by-name/ji/jinja2-cli/package.nix
+++ b/pkgs/by-name/ji/jinja2-cli/package.nix
@@ -5,7 +5,6 @@
   extras ? [
     "hjson"
     "json5"
-    "toml"
     "xml"
     "yaml"
   ],
@@ -13,20 +12,22 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "jinja2-cli";
-  version = "0.8.2";
-  format = "pyproject";
+  version = "1.0.0";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "mattrobenolt";
     repo = "jinja2-cli";
-    rev = version;
-    hash = "sha256-67gYt0nZX+VTVaoSxVXGzbRiXD7EMsVBFWC8wHo+Vw0=";
+    rev = "v${version}";
+    hash = "sha256-m7auOnk618sXet4paRJmQKVEp0LLi+7PIWx8P8IUQf0=";
   };
 
-  nativeBuildInputs = [
-    python3.pkgs.setuptools
-    python3.pkgs.wheel
-  ];
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail 'uv_build>=0.9.21,<0.10.0' 'uv_build>=0.9.9,<0.10.0'
+  '';
+
+  build-system = [ python3.pkgs.uv-build ];
 
   nativeCheckInputs = [
     python3.pkgs.pytestCheckHook
@@ -44,16 +45,15 @@ python3.pkgs.buildPythonApplication rec {
   optional-dependencies = with python3.pkgs; {
     hjson = [ hjson ];
     json5 = [ json5 ];
-    toml = [ toml ];
     xml = [ xmltodict ];
     yaml = [ pyyaml ];
   };
 
   meta = {
-    description = "CLI for Jinja2";
+    description = "The CLI for Jinja2";
     homepage = "https://github.com/mattrobenolt/jinja2-cli";
     license = lib.licenses.bsd2;
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.mattrobenolt ];
     mainProgram = "jinja2";
   };
 }


### PR DESCRIPTION
[jinja2-cli v1.0.0](https://github.com/mattrobenolt/jinja2-cli/releases/tag/v1.0.0)

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
