### PR TITLE
lightway: 0-unstable-2025-09-19 -> 0-unstable-2026-01-02

### DIFF
--- a/pkgs/by-name/li/lightway/backport-darwin-address-calc-fix.patch
+++ b/pkgs/by-name/li/lightway/backport-darwin-address-calc-fix.patch
@@ -1,0 +1,398 @@
+From 9228741450f627da1dba800b44da03db8df44b32 Mon Sep 17 00:00:00 2001
+From: Samuel Tam <samuel.tam@expressvpn.com>
+Date: Fri, 9 Jan 2026 18:12:12 +0800
+Subject: [PATCH] ARM64 ASM: Darwin specific address calc fix
+
+Don't use ':lo12:' in Darwin specific address calculation code.
+@PAGEOFF is indicating this.
+---
+ wolfcrypt/src/port/arm/armv8-mlkem-asm.S  | 74 +++++++++++------------
+ wolfcrypt/src/port/arm/armv8-sha3-asm.S   |  4 +-
+ wolfcrypt/src/port/arm/armv8-sha512-asm.S |  8 +--
+ 3 files changed, 43 insertions(+), 43 deletions(-)
+
+diff --git a/wolfcrypt/src/port/arm/armv8-mlkem-asm.S b/wolfcrypt/src/port/arm/armv8-mlkem-asm.S
+index a45475c..1ded4af 100644
+--- a/wolfcrypt/src/port/arm/armv8-mlkem-asm.S
++++ b/wolfcrypt/src/port/arm/armv8-mlkem-asm.S
+@@ -168,21 +168,21 @@ _mlkem_ntt:
+ 	add  x2, x2, :lo12:L_mlkem_aarch64_zetas
+ #else
+ 	adrp x2, L_mlkem_aarch64_zetas@PAGE
+-	add  x2, x2, :lo12:L_mlkem_aarch64_zetas@PAGEOFF
++	add  x2, x2, L_mlkem_aarch64_zetas@PAGEOFF
+ #endif /* __APPLE__ */
+ #ifndef __APPLE__
+ 	adrp x3, L_mlkem_aarch64_zetas_qinv
+ 	add  x3, x3, :lo12:L_mlkem_aarch64_zetas_qinv
+ #else
+ 	adrp x3, L_mlkem_aarch64_zetas_qinv@PAGE
+-	add  x3, x3, :lo12:L_mlkem_aarch64_zetas_qinv@PAGEOFF
++	add  x3, x3, L_mlkem_aarch64_zetas_qinv@PAGEOFF
+ #endif /* __APPLE__ */
+ #ifndef __APPLE__
+ 	adrp x4, L_mlkem_aarch64_consts
+ 	add  x4, x4, :lo12:L_mlkem_aarch64_consts
+ #else
+ 	adrp x4, L_mlkem_aarch64_consts@PAGE
+-	add  x4, x4, :lo12:L_mlkem_aarch64_consts@PAGEOFF
++	add  x4, x4, L_mlkem_aarch64_consts@PAGEOFF
+ #endif /* __APPLE__ */
+ 	add	x1, x0, #0x100
+ 	ldr	q4, [x4]
+@@ -1562,21 +1562,21 @@ _mlkem_invntt:
+ 	add  x2, x2, :lo12:L_mlkem_aarch64_zetas_inv
+ #else
+ 	adrp x2, L_mlkem_aarch64_zetas_inv@PAGE
+-	add  x2, x2, :lo12:L_mlkem_aarch64_zetas_inv@PAGEOFF
++	add  x2, x2, L_mlkem_aarch64_zetas_inv@PAGEOFF
+ #endif /* __APPLE__ */
+ #ifndef __APPLE__
+ 	adrp x3, L_mlkem_aarch64_zetas_inv_qinv
+ 	add  x3, x3, :lo12:L_mlkem_aarch64_zetas_inv_qinv
+ #else
+ 	adrp x3, L_mlkem_aarch64_zetas_inv_qinv@PAGE
+-	add  x3, x3, :lo12:L_mlkem_aarch64_zetas_inv_qinv@PAGEOFF
++	add  x3, x3, L_mlkem_aarch64_zetas_inv_qinv@PAGEOFF
+ #endif /* __APPLE__ */
+ #ifndef __APPLE__
+ 	adrp x4, L_mlkem_aarch64_consts
+ 	add  x4, x4, :lo12:L_mlkem_aarch64_consts
+ #else
+ 	adrp x4, L_mlkem_aarch64_consts@PAGE
+-	add  x4, x4, :lo12:L_mlkem_aarch64_consts@PAGEOFF
++	add  x4, x4, L_mlkem_aarch64_consts@PAGEOFF
+ #endif /* __APPLE__ */
+ 	add	x1, x0, #0x100
+ 	ldr	q8, [x4]
+@@ -3013,21 +3013,21 @@ _mlkem_ntt_sqrdmlsh:
+ 	add  x2, x2, :lo12:L_mlkem_aarch64_zetas
+ #else
+ 	adrp x2, L_mlkem_aarch64_zetas@PAGE
+-	add  x2, x2, :lo12:L_mlkem_aarch64_zetas@PAGEOFF
++	add  x2, x2, L_mlkem_aarch64_zetas@PAGEOFF
+ #endif /* __APPLE__ */
+ #ifndef __APPLE__
+ 	adrp x3, L_mlkem_aarch64_zetas_qinv
+ 	add  x3, x3, :lo12:L_mlkem_aarch64_zetas_qinv
+ #else
+ 	adrp x3, L_mlkem_aarch64_zetas_qinv@PAGE
+-	add  x3, x3, :lo12:L_mlkem_aarch64_zetas_qinv@PAGEOFF
++	add  x3, x3, L_mlkem_aarch64_zetas_qinv@PAGEOFF
+ #endif /* __APPLE__ */
+ #ifndef __APPLE__
+ 	adrp x4, L_mlkem_aarch64_consts
+ 	add  x4, x4, :lo12:L_mlkem_aarch64_consts
+ #else
+ 	adrp x4, L_mlkem_aarch64_consts@PAGE
+-	add  x4, x4, :lo12:L_mlkem_aarch64_consts@PAGEOFF
++	add  x4, x4, L_mlkem_aarch64_consts@PAGEOFF
+ #endif /* __APPLE__ */
+ 	add	x1, x0, #0x100
+ 	ldr	q4, [x4]
+@@ -4195,21 +4195,21 @@ _mlkem_invntt_sqrdmlsh:
+ 	add  x2, x2, :lo12:L_mlkem_aarch64_zetas_inv
+ #else
+ 	adrp x2, L_mlkem_aarch64_zetas_inv@PAGE
+-	add  x2, x2, :lo12:L_mlkem_aarch64_zetas_inv@PAGEOFF
++	add  x2, x2, L_mlkem_aarch64_zetas_inv@PAGEOFF
+ #endif /* __APPLE__ */
+ #ifndef __APPLE__
+ 	adrp x3, L_mlkem_aarch64_zetas_inv_qinv
+ 	add  x3, x3, :lo12:L_mlkem_aarch64_zetas_inv_qinv
+ #else
+ 	adrp x3, L_mlkem_aarch64_zetas_inv_qinv@PAGE
+-	add  x3, x3, :lo12:L_mlkem_aarch64_zetas_inv_qinv@PAGEOFF
++	add  x3, x3, L_mlkem_aarch64_zetas_inv_qinv@PAGEOFF
+ #endif /* __APPLE__ */
+ #ifndef __APPLE__
+ 	adrp x4, L_mlkem_aarch64_consts
+ 	add  x4, x4, :lo12:L_mlkem_aarch64_consts
+ #else
+ 	adrp x4, L_mlkem_aarch64_consts@PAGE
+-	add  x4, x4, :lo12:L_mlkem_aarch64_consts@PAGEOFF
++	add  x4, x4, L_mlkem_aarch64_consts@PAGEOFF
+ #endif /* __APPLE__ */
+ 	add	x1, x0, #0x100
+ 	ldr	q8, [x4]
+@@ -5532,14 +5532,14 @@ _mlkem_basemul_mont:
+ 	add  x3, x3, :lo12:L_mlkem_aarch64_zetas_mul
+ #else
+ 	adrp x3, L_mlkem_aarch64_zetas_mul@PAGE
+-	add  x3, x3, :lo12:L_mlkem_aarch64_zetas_mul@PAGEOFF
++	add  x3, x3, L_mlkem_aarch64_zetas_mul@PAGEOFF
+ #endif /* __APPLE__ */
+ #ifndef __APPLE__
+ 	adrp x4, L_mlkem_aarch64_consts
+ 	add  x4, x4, :lo12:L_mlkem_aarch64_consts
+ #else
+ 	adrp x4, L_mlkem_aarch64_consts@PAGE
+-	add  x4, x4, :lo12:L_mlkem_aarch64_consts@PAGEOFF
++	add  x4, x4, L_mlkem_aarch64_consts@PAGEOFF
+ #endif /* __APPLE__ */
+ 	ldr	q1, [x4]
+ 	ldp	q2, q3, [x1]
+@@ -6230,14 +6230,14 @@ _mlkem_basemul_mont_add:
+ 	add  x3, x3, :lo12:L_mlkem_aarch64_zetas_mul
+ #else
+ 	adrp x3, L_mlkem_aarch64_zetas_mul@PAGE
+-	add  x3, x3, :lo12:L_mlkem_aarch64_zetas_mul@PAGEOFF
++	add  x3, x3, L_mlkem_aarch64_zetas_mul@PAGEOFF
+ #endif /* __APPLE__ */
+ #ifndef __APPLE__
+ 	adrp x4, L_mlkem_aarch64_consts
+ 	add  x4, x4, :lo12:L_mlkem_aarch64_consts
+ #else
+ 	adrp x4, L_mlkem_aarch64_consts@PAGE
+-	add  x4, x4, :lo12:L_mlkem_aarch64_consts@PAGEOFF
++	add  x4, x4, L_mlkem_aarch64_consts@PAGEOFF
+ #endif /* __APPLE__ */
+ 	ldr	q1, [x4]
+ 	ldp	q2, q3, [x1]
+@@ -6991,7 +6991,7 @@ _mlkem_csubq_neon:
+ 	add  x1, x1, :lo12:L_mlkem_aarch64_q
+ #else
+ 	adrp x1, L_mlkem_aarch64_q@PAGE
+-	add  x1, x1, :lo12:L_mlkem_aarch64_q@PAGEOFF
++	add  x1, x1, L_mlkem_aarch64_q@PAGEOFF
+ #endif /* __APPLE__ */
+ 	ldr	q20, [x1]
+ 	ld4	{v0.8h, v1.8h, v2.8h, v3.8h}, [x0], #0x40
+@@ -7172,7 +7172,7 @@ _mlkem_add_reduce:
+ 	add  x2, x2, :lo12:L_mlkem_aarch64_consts
+ #else
+ 	adrp x2, L_mlkem_aarch64_consts@PAGE
+-	add  x2, x2, :lo12:L_mlkem_aarch64_consts@PAGEOFF
++	add  x2, x2, L_mlkem_aarch64_consts@PAGEOFF
+ #endif /* __APPLE__ */
+ 	ldr	q0, [x2]
+ 	ld4	{v1.8h, v2.8h, v3.8h, v4.8h}, [x0], #0x40
+@@ -7363,7 +7363,7 @@ _mlkem_add3_reduce:
+ 	add  x3, x3, :lo12:L_mlkem_aarch64_consts
+ #else
+ 	adrp x3, L_mlkem_aarch64_consts@PAGE
+-	add  x3, x3, :lo12:L_mlkem_aarch64_consts@PAGEOFF
++	add  x3, x3, L_mlkem_aarch64_consts@PAGEOFF
+ #endif /* __APPLE__ */
+ 	ldr	q0, [x3]
+ 	ld4	{v1.8h, v2.8h, v3.8h, v4.8h}, [x0], #0x40
+@@ -7594,7 +7594,7 @@ _mlkem_rsub_reduce:
+ 	add  x2, x2, :lo12:L_mlkem_aarch64_consts
+ #else
+ 	adrp x2, L_mlkem_aarch64_consts@PAGE
+-	add  x2, x2, :lo12:L_mlkem_aarch64_consts@PAGEOFF
++	add  x2, x2, L_mlkem_aarch64_consts@PAGEOFF
+ #endif /* __APPLE__ */
+ 	ldr	q0, [x2]
+ 	ld4	{v1.8h, v2.8h, v3.8h, v4.8h}, [x0], #0x40
+@@ -7785,7 +7785,7 @@ _mlkem_to_mont:
+ 	add  x1, x1, :lo12:L_mlkem_aarch64_consts
+ #else
+ 	adrp x1, L_mlkem_aarch64_consts@PAGE
+-	add  x1, x1, :lo12:L_mlkem_aarch64_consts@PAGEOFF
++	add  x1, x1, L_mlkem_aarch64_consts@PAGEOFF
+ #endif /* __APPLE__ */
+ 	ldr	q0, [x1]
+ 	ld4	{v1.8h, v2.8h, v3.8h, v4.8h}, [x0], #0x40
+@@ -7999,7 +7999,7 @@ _mlkem_to_mont_sqrdmlsh:
+ 	add  x1, x1, :lo12:L_mlkem_aarch64_consts
+ #else
+ 	adrp x1, L_mlkem_aarch64_consts@PAGE
+-	add  x1, x1, :lo12:L_mlkem_aarch64_consts@PAGEOFF
++	add  x1, x1, L_mlkem_aarch64_consts@PAGEOFF
+ #endif /* __APPLE__ */
+ 	ldr	q0, [x1]
+ 	ld4	{v1.8h, v2.8h, v3.8h, v4.8h}, [x0], #0x40
+@@ -8226,21 +8226,21 @@ _mlkem_to_msg_neon:
+ 	add  x2, x2, :lo12:L_mlkem_to_msg_low
+ #else
+ 	adrp x2, L_mlkem_to_msg_low@PAGE
+-	add  x2, x2, :lo12:L_mlkem_to_msg_low@PAGEOFF
++	add  x2, x2, L_mlkem_to_msg_low@PAGEOFF
+ #endif /* __APPLE__ */
+ #ifndef __APPLE__
+ 	adrp x3, L_mlkem_to_msg_high
+ 	add  x3, x3, :lo12:L_mlkem_to_msg_high
+ #else
+ 	adrp x3, L_mlkem_to_msg_high@PAGE
+-	add  x3, x3, :lo12:L_mlkem_to_msg_high@PAGEOFF
++	add  x3, x3, L_mlkem_to_msg_high@PAGEOFF
+ #endif /* __APPLE__ */
+ #ifndef __APPLE__
+ 	adrp x4, L_mlkem_to_msg_bits
+ 	add  x4, x4, :lo12:L_mlkem_to_msg_bits
+ #else
+ 	adrp x4, L_mlkem_to_msg_bits@PAGE
+-	add  x4, x4, :lo12:L_mlkem_to_msg_bits@PAGEOFF
++	add  x4, x4, L_mlkem_to_msg_bits@PAGEOFF
+ #endif /* __APPLE__ */
+ 	ldr	q0, [x2]
+ 	ldr	q1, [x3]
+@@ -8506,14 +8506,14 @@ _mlkem_from_msg_neon:
+ 	add  x2, x2, :lo12:L_mlkem_from_msg_q1half
+ #else
+ 	adrp x2, L_mlkem_from_msg_q1half@PAGE
+-	add  x2, x2, :lo12:L_mlkem_from_msg_q1half@PAGEOFF
++	add  x2, x2, L_mlkem_from_msg_q1half@PAGEOFF
+ #endif /* __APPLE__ */
+ #ifndef __APPLE__
+ 	adrp x3, L_mlkem_from_msg_bits
+ 	add  x3, x3, :lo12:L_mlkem_from_msg_bits
+ #else
+ 	adrp x3, L_mlkem_from_msg_bits@PAGE
+-	add  x3, x3, :lo12:L_mlkem_from_msg_bits@PAGEOFF
++	add  x3, x3, L_mlkem_from_msg_bits@PAGEOFF
+ #endif /* __APPLE__ */
+ 	ld1	{v2.16b, v3.16b}, [x1]
+ 	ldr	q1, [x2]
+@@ -9517,28 +9517,28 @@ _mlkem_rej_uniform_neon:
+ 	add  x4, x4, :lo12:L_mlkem_rej_uniform_mask
+ #else
+ 	adrp x4, L_mlkem_rej_uniform_mask@PAGE
+-	add  x4, x4, :lo12:L_mlkem_rej_uniform_mask@PAGEOFF
++	add  x4, x4, L_mlkem_rej_uniform_mask@PAGEOFF
+ #endif /* __APPLE__ */
+ #ifndef __APPLE__
+ 	adrp x5, L_mlkem_aarch64_q
+ 	add  x5, x5, :lo12:L_mlkem_aarch64_q
+ #else
+ 	adrp x5, L_mlkem_aarch64_q@PAGE
+-	add  x5, x5, :lo12:L_mlkem_aarch64_q@PAGEOFF
++	add  x5, x5, L_mlkem_aarch64_q@PAGEOFF
+ #endif /* __APPLE__ */
+ #ifndef __APPLE__
+ 	adrp x6, L_mlkem_rej_uniform_bits
+ 	add  x6, x6, :lo12:L_mlkem_rej_uniform_bits
+ #else
+ 	adrp x6, L_mlkem_rej_uniform_bits@PAGE
+-	add  x6, x6, :lo12:L_mlkem_rej_uniform_bits@PAGEOFF
++	add  x6, x6, L_mlkem_rej_uniform_bits@PAGEOFF
+ #endif /* __APPLE__ */
+ #ifndef __APPLE__
+ 	adrp x7, L_mlkem_rej_uniform_indices
+ 	add  x7, x7, :lo12:L_mlkem_rej_uniform_indices
+ #else
+ 	adrp x7, L_mlkem_rej_uniform_indices@PAGE
+-	add  x7, x7, :lo12:L_mlkem_rej_uniform_indices@PAGEOFF
++	add  x7, x7, L_mlkem_rej_uniform_indices@PAGEOFF
+ #endif /* __APPLE__ */
+ 	eor	v1.16b, v1.16b, v1.16b
+ 	eor	v12.16b, v12.16b, v12.16b
+@@ -9754,7 +9754,7 @@ _mlkem_sha3_blocksx3_neon:
+ 	add  x27, x27, :lo12:L_sha3_aarch64_r
+ #else
+ 	adrp x27, L_sha3_aarch64_r@PAGE
+-	add  x27, x27, :lo12:L_sha3_aarch64_r@PAGEOFF
++	add  x27, x27, L_sha3_aarch64_r@PAGEOFF
+ #endif /* __APPLE__ */
+ 	str	x0, [x29, #40]
+ 	ld4	{v0.d, v1.d, v2.d, v3.d}[0], [x0], #32
+@@ -10079,7 +10079,7 @@ _mlkem_shake128_blocksx3_seed_neon:
+ 	add  x28, x28, :lo12:L_sha3_aarch64_r
+ #else
+ 	adrp x28, L_sha3_aarch64_r@PAGE
+-	add  x28, x28, :lo12:L_sha3_aarch64_r@PAGEOFF
++	add  x28, x28, L_sha3_aarch64_r@PAGEOFF
+ #endif /* __APPLE__ */
+ 	str	x0, [x29, #40]
+ 	add	x0, x0, #32
+@@ -10426,7 +10426,7 @@ _mlkem_shake256_blocksx3_seed_neon:
+ 	add  x28, x28, :lo12:L_sha3_aarch64_r
+ #else
+ 	adrp x28, L_sha3_aarch64_r@PAGE
+-	add  x28, x28, :lo12:L_sha3_aarch64_r@PAGEOFF
++	add  x28, x28, L_sha3_aarch64_r@PAGEOFF
+ #endif /* __APPLE__ */
+ 	str	x0, [x29, #40]
+ 	add	x0, x0, #32
+@@ -10774,7 +10774,7 @@ _mlkem_sha3_blocksx3_neon:
+ 	add  x27, x27, :lo12:L_sha3_aarch64_r
+ #else
+ 	adrp x27, L_sha3_aarch64_r@PAGE
+-	add  x27, x27, :lo12:L_sha3_aarch64_r@PAGEOFF
++	add  x27, x27, L_sha3_aarch64_r@PAGEOFF
+ #endif /* __APPLE__ */
+ 	str	x0, [x29, #40]
+ 	ld4	{v0.d, v1.d, v2.d, v3.d}[0], [x0], #32
+@@ -11184,7 +11184,7 @@ _mlkem_shake128_blocksx3_seed_neon:
+ 	add  x28, x28, :lo12:L_sha3_aarch64_r
+ #else
+ 	adrp x28, L_sha3_aarch64_r@PAGE
+-	add  x28, x28, :lo12:L_sha3_aarch64_r@PAGEOFF
++	add  x28, x28, L_sha3_aarch64_r@PAGEOFF
+ #endif /* __APPLE__ */
+ 	str	x0, [x29, #40]
+ 	add	x0, x0, #32
+@@ -11616,7 +11616,7 @@ _mlkem_shake256_blocksx3_seed_neon:
+ 	add  x28, x28, :lo12:L_sha3_aarch64_r
+ #else
+ 	adrp x28, L_sha3_aarch64_r@PAGE
+-	add  x28, x28, :lo12:L_sha3_aarch64_r@PAGEOFF
++	add  x28, x28, L_sha3_aarch64_r@PAGEOFF
+ #endif /* __APPLE__ */
+ 	str	x0, [x29, #40]
+ 	add	x0, x0, #32
+diff --git a/wolfcrypt/src/port/arm/armv8-sha3-asm.S b/wolfcrypt/src/port/arm/armv8-sha3-asm.S
+index 411349f..6089f8c 100644
+--- a/wolfcrypt/src/port/arm/armv8-sha3-asm.S
++++ b/wolfcrypt/src/port/arm/armv8-sha3-asm.S
+@@ -95,7 +95,7 @@ _BlockSha3_crypto:
+ 	add  x1, x1, :lo12:L_SHA3_transform_crypto_r
+ #else
+ 	adrp x1, L_SHA3_transform_crypto_r@PAGE
+-	add  x1, x1, :lo12:L_SHA3_transform_crypto_r@PAGEOFF
++	add  x1, x1, L_SHA3_transform_crypto_r@PAGEOFF
+ #endif /* __APPLE__ */
+ 	ld4	{v0.d, v1.d, v2.d, v3.d}[0], [x0], #32
+ 	ld4	{v4.d, v5.d, v6.d, v7.d}[0], [x0], #32
+@@ -268,7 +268,7 @@ _BlockSha3_base:
+ 	add  x27, x27, :lo12:L_SHA3_transform_base_r
+ #else
+ 	adrp x27, L_SHA3_transform_base_r@PAGE
+-	add  x27, x27, :lo12:L_SHA3_transform_base_r@PAGEOFF
++	add  x27, x27, L_SHA3_transform_base_r@PAGEOFF
+ #endif /* __APPLE__ */
+ 	ldp	x1, x2, [x0]
+ 	ldp	x3, x4, [x0, #16]
+diff --git a/wolfcrypt/src/port/arm/armv8-sha512-asm.S b/wolfcrypt/src/port/arm/armv8-sha512-asm.S
+index 514e5de..ee64e6e 100644
+--- a/wolfcrypt/src/port/arm/armv8-sha512-asm.S
++++ b/wolfcrypt/src/port/arm/armv8-sha512-asm.S
+@@ -165,14 +165,14 @@ _Transform_Sha512_Len_neon:
+ 	add  x3, x3, :lo12:L_SHA512_transform_neon_len_k
+ #else
+ 	adrp x3, L_SHA512_transform_neon_len_k@PAGE
+-	add  x3, x3, :lo12:L_SHA512_transform_neon_len_k@PAGEOFF
++	add  x3, x3, L_SHA512_transform_neon_len_k@PAGEOFF
+ #endif /* __APPLE__ */
+ #ifndef __APPLE__
+ 	adrp x27, L_SHA512_transform_neon_len_r8
+ 	add  x27, x27, :lo12:L_SHA512_transform_neon_len_r8
+ #else
+ 	adrp x27, L_SHA512_transform_neon_len_r8@PAGE
+-	add  x27, x27, :lo12:L_SHA512_transform_neon_len_r8@PAGEOFF
++	add  x27, x27, L_SHA512_transform_neon_len_r8@PAGEOFF
+ #endif /* __APPLE__ */
+ 	ld1	{v11.16b}, [x27]
+ 	# Load digest into working vars
+@@ -1070,7 +1070,7 @@ L_sha512_len_neon_start:
+ 	add  x3, x3, :lo12:L_SHA512_transform_neon_len_k
+ #else
+ 	adrp x3, L_SHA512_transform_neon_len_k@PAGE
+-	add  x3, x3, :lo12:L_SHA512_transform_neon_len_k@PAGEOFF
++	add  x3, x3, L_SHA512_transform_neon_len_k@PAGEOFF
+ #endif /* __APPLE__ */
+ 	subs	w2, w2, #0x80
+ 	bne	L_sha512_len_neon_begin
+@@ -1211,7 +1211,7 @@ _Transform_Sha512_Len_crypto:
+ 	add  x4, x4, :lo12:L_SHA512_trans_crypto_len_k
+ #else
+ 	adrp x4, L_SHA512_trans_crypto_len_k@PAGE
+-	add  x4, x4, :lo12:L_SHA512_trans_crypto_len_k@PAGEOFF
++	add  x4, x4, L_SHA512_trans_crypto_len_k@PAGEOFF
+ #endif /* __APPLE__ */
+ 	# Load first 16 64-bit words of K permanently
+ 	ld1	{v8.2d, v9.2d, v10.2d, v11.2d}, [x4], #0x40
+-- 
+2.51.2
+

--- a/pkgs/by-name/li/lightway/package.nix
+++ b/pkgs/by-name/li/lightway/package.nix
@@ -10,16 +10,25 @@
 
 rustPlatform.buildRustPackage {
   pname = "lightway";
-  version = "0-unstable-2025-09-19";
+  version = "0-unstable-2026-01-02";
 
   src = fetchFromGitHub {
     owner = "expressvpn";
     repo = "lightway";
-    rev = "dac72eb8af0994de020d71d24114717ecfb9804d";
-    hash = "sha256-oHxHJ4D/Xg/zAFiI0bMX3Dc05HXIjk+ZHuGY03cwY+c=";
+    rev = "8e21da7ab3a97ab75235264e85fa8615f7b0f33b";
+    hash = "sha256-1YpXaxPm1BMALhRU25FH5PLJ1IIRfcYA3W6e4c8Si+w=";
   };
 
-  cargoHash = "sha256-RFlac10XFJXT3Giayy31kZ3Nn1Q+YsPt/zCdkSV0Atk=";
+  cargoHash = "sha256-4SIE/kGRd2I3sqO+IgItO1PBQHeFv9N4erfVe/9re7A=";
+
+  # Backport fix for Darwin address calculation to vendored wolfSSL 5.8.2.
+  # https://github.com/wolfSSL/wolfssl/pull/9537
+  # Drop when Lightway bumps wolfSSL past commit 5c2c459, or > 5.8.4.
+  postPatch = ''
+    patch -Np1 \
+      -d $cargoDepsCopy/wolfssl-sys-2.0.0/wolfssl-src \
+      -i ${./backport-darwin-address-calc-fix.patch}
+  '';
 
   cargoBuildFlags = lib.cli.toCommandLineGNU { } {
     package = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Update lightway to latest git master, also backport a fix from wolfSSL upstream to fix, to fix the failing `aarch64-darwin` builds using a newer clang in nixpkgs.

- https://github.com/wolfSSL/wolfssl/pull/9537
- Failing builds: https://hydra.nixos.org/job/nixpkgs/unstable/lightway.aarch64-darwin

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
