### PR TITLE
m32edit.deps.buildCommand: fix the eval

### DIFF
--- a/pkgs/applications/audio/midas/generic.nix
+++ b/pkgs/applications/audio/midas/generic.nix
@@ -62,7 +62,7 @@ stdenv.mkDerivation rec {
     vmTools.debClosureGenerator {
       name = "x32edit-dependencies";
       inherit (distro) urlPrefix;
-      packagesLists = [ distro.packagesList ];
+      packagesLists = [ distro.packagesLists ];
       packages = [
         "libstdc++6"
         "libcurl4"


### PR DESCRIPTION
Without the change the eval fails as:

    $ nix eval --impure --expr 'with import ./. {}; m32edit.deps.buildCommand'
    error:
       … while evaluating the attribute 'deps.buildCommand'
         at pkgs/build-support/trivial-builders/default.nix:80:17:
           79|         enableParallelBuilding = true;
           80|         inherit buildCommand name;
             |                 ^
           81|         passAsFile = [ "buildCommand" ] ++ (derivationArgs.passAsFile or [ ]);

       … while calling the 'toString' builtin
         at /home/slyfox/dev/git/nixpkgs-master/pkgs/build-support/vm/default.nix:951:20:
          950|       ''
          951|         for i in ${toString packagesLists}; do
             |                    ^
          952|           echo "adding $i..."

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: attribute 'packagesList' missing
       at pkgs/applications/audio/midas/generic.nix:65:25:
           64|       inherit (distro) urlPrefix;
           65|       packagesLists = [ distro.packagesList ];
             |                         ^
           66|       packages = [
       Did you mean packagesLists?

After the change the eval succeeds as expected:

    $ nix eval --impure --expr 'with import ./. {}; m32edit.deps.buildCommand'
    "for i in /nix/store/2zznbnkcn08fy1hsfjrz2zyh2bsk5v56-Packages.xz /nix/store/nagl6k96w1pwdglf8dwhvv8kh9hqn7d9-Packages.xz; do\n  echo \"adding $i...\"\n  case $i in\n    *.xz | *.lzma)\n      xz -d < $i >> ./Packages\n      ;;\n    *.bz2)\n      bunzip2 < $i >> ./Packages\n      ;;\n    *.gz)\n      gzip -dc < $i >> ./Packages\n      ;;\n  esac\ndone\n\nperl -w /nix/store/jiv4hmh6ckp2kzsn2wy17ylmrwfkc7zi-deb-closure.pl \\\n  ./Packages https://snapshot.debian.org/archive/debian/20260105T082626Z libstdc++6 libcurl4 libfreetype6 libasound2 libx11-6 libxext6 > $out\nnixfmt $out\n"


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
