### PR TITLE
ego: 1.1.7 -> 1.2.0

### DIFF
--- a/pkgs/by-name/eg/ego/package.nix
+++ b/pkgs/by-name/eg/ego/package.nix
@@ -4,33 +4,43 @@
   fetchFromGitHub,
   makeBinaryWrapper,
   acl,
+  libxcb,
   xhost,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "ego";
-  version = "1.1.7";
+  version = "1.2.0";
 
   src = fetchFromGitHub {
     owner = "intgr";
     repo = "ego";
-    rev = finalAttrs.version;
-    hash = "sha256-613RM7Ldye0wHAH3VMhzhyT5WVTybph3gS/WNMrsgGI=";
+    tag = finalAttrs.version;
+    hash = "sha256-TO0jyi6XGPfuF7s4vTV8uT43SjCGUx6cVZONyb5e93Q=";
   };
 
-  buildInputs = [ acl ];
+  buildInputs = [
+    acl
+    libxcb
+  ];
 
   nativeBuildInputs = [ makeBinaryWrapper ];
 
-  cargoHash = "sha256-GwWDH3np/YKUx7BLmKxUui2CXLYbHjivWC1av9jaccA=";
+  cargoHash = "sha256-MmcZrjjNvc3C/RRMCQsuaJT4sf+gTAaxVDtKGHjKqc8=";
 
   # requires access to /root
   checkFlags = [
     "--skip=tests::test_check_user_homedir"
   ];
 
+  preCheck = ''
+    export LD_LIBRARY_PATH="${lib.makeLibraryPath [ libxcb ]}:$LD_LIBRARY_PATH"
+  '';
+
   postInstall = ''
-    wrapProgram $out/bin/ego --prefix PATH : ${lib.makeBinPath [ xhost ]}
+    wrapProgram $out/bin/ego \
+      --prefix PATH : ${lib.makeBinPath [ xhost ]} \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libxcb ]}
   '';
 
   meta = {


### PR DESCRIPTION
@dit7ya



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
