### PR TITLE
humanshell: init at 1.0.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13138,6 +13138,12 @@
     githubId = 810075;
     name = "Juan Rodal";
   };
+  juanparati = {
+    email = "juanparati@gmail.com";
+    github = "juanparati";
+    githubId = 835173;
+    name = "Juan Lago";
+  };
   juboba = {
     email = "juboba@gmail.com";
     github = "juboba";

--- a/pkgs/by-name/hu/humanshell/package.nix
+++ b/pkgs/by-name/hu/humanshell/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "humanshell";
+  version = "1.0.3";
+
+  src = fetchFromGitHub {
+    owner = "juanparati";
+    repo = "humanshell";
+    rev = version;
+    hash = "sha256-RoH9tXgefL4woXmKrXCX19O4iVWQvgi23r4UsG6ysFc=";
+  };
+
+  cargoHash = "sha256-u2++3IgDg8xZHPDgfSODLwHvVRXsfiNKeL+E0fXpOI0=";
+
+  meta = {
+    description = "Translate human expressions into shell expressions";
+    homepage = "https://github.com/juanparati/humanshell";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ juanparati ];
+    platforms = lib.platforms.unix;
+    longDescription = ''
+      A command-line tool that translates human expressions into shell commands
+      using the Anthropic API and Open AI API.
+    '';
+    mainProgram = "hs";
+  };
+}

--- a/pkgs/by-name/hu/humanshell/package.nix
+++ b/pkgs/by-name/hu/humanshell/package.nix
@@ -29,4 +29,4 @@ rustPlatform.buildRustPackage (finalAttrs: {
     '';
     mainProgram = "hs";
   };
-}
+})

--- a/pkgs/by-name/hu/humanshell/package.nix
+++ b/pkgs/by-name/hu/humanshell/package.nix
@@ -4,7 +4,7 @@
   rustPlatform,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "humanshell";
   version = "1.0.3";
 

--- a/pkgs/by-name/hu/humanshell/package.nix
+++ b/pkgs/by-name/hu/humanshell/package.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "juanparati";
     repo = "humanshell";
-    rev = version;
+    tag = finalAttrs.version;
     hash = "sha256-RoH9tXgefL4woXmKrXCX19O4iVWQvgi23r4UsG6ysFc=";
   };
 


### PR DESCRIPTION
Humanshell is a command-line tool that translates human expressions into shell commands using the Anthropic API and Open AI API.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
