### PR TITLE
cargo: fix for structuredAttrs

### DIFF
--- a/pkgs/development/compilers/rust/cargo.nix
+++ b/pkgs/development/compilers/rust/cargo.nix
@@ -55,19 +55,19 @@ rustPlatform.buildRustPackage.override
       zlib
     ];
 
-    # cargo uses git-rs which is made for a version of libgit2 from recent master that
-    # is not compatible with the current version in nixpkgs.
-    #LIBGIT2_SYS_USE_PKG_CONFIG = 1;
+    env = {
+      # cargo uses git-rs which is made for a version of libgit2 from recent master that
+      # is not compatible with the current version in nixpkgs.
+      #LIBGIT2_SYS_USE_PKG_CONFIG = 1;
 
-    # fixes: the cargo feature `edition` requires a nightly version of Cargo, but this is the `stable` channel
-    RUSTC_BOOTSTRAP = 1;
+      # fixes: the cargo feature `edition` requires a nightly version of Cargo, but this is the `stable` channel
+      RUSTC_BOOTSTRAP = 1;
 
-    RUSTFLAGS =
-      if stdenv.hostPlatform.rust.rustcTargetSpec == "x86_64-unknown-linux-gnu" then
-        # Upstream defaults to lld on x86_64-unknown-linux-gnu, we want to use our linker
-        "-Clinker-features=-lld -Clink-self-contained=-linker"
-      else
-        null;
+    }
+    // lib.optionalAttrs (stdenv.hostPlatform.rust.rustcTargetSpec == "x86_64-unknown-linux-gnu") {
+      # Upstream defaults to lld on x86_64-unknown-linux-gnu, we want to use our linker
+      RUSTFLAGS = "-Clinker-features=-lld -Clink-self-contained=-linker";
+    };
 
     postInstall = ''
       wrapProgram "$out/bin/cargo" --suffix PATH : "${rustc}/bin"


### PR DESCRIPTION
Putting the mass-rebuildy part of https://github.com/NixOS/nixpkgs/pull/472376 onto staging.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
