### PR TITLE
fleet: package with frontend

### DIFF
--- a/pkgs/by-name/fl/fleet/package.nix
+++ b/pkgs/by-name/fl/fleet/package.nix
@@ -1,20 +1,59 @@
 {
   lib,
   fetchFromGitHub,
+  stdenvNoCC,
+  yarnConfigHook,
+  yarnBuildHook,
+  nodejs_24,
+  fetchYarnDeps,
   buildGoModule,
+  go-bindata,
   versionCheckHook,
 }:
-
-buildGoModule (finalAttrs: {
+let
   pname = "fleet";
   version = "4.78.1";
-
   src = fetchFromGitHub {
     owner = "fleetdm";
     repo = "fleet";
-    tag = "fleet-v${finalAttrs.version}";
+    tag = "fleet-v${version}";
     hash = "sha256-3F9vzY1JAw2DMzUhMl7j9I8RGjVXulQH2JcYCFuAwDY=";
   };
+
+  frontend = stdenvNoCC.mkDerivation {
+    pname = "${pname}-frontend";
+    inherit version src;
+
+    nativeBuildInputs = [
+      yarnConfigHook
+      yarnBuildHook
+      nodejs_24
+    ];
+
+    yarnOfflineCache = fetchYarnDeps {
+      yarnLock = src + "/yarn.lock";
+      hash = "sha256-cCf0Q6g+VJaTCOZ12/7z8gcDf3+YT2LBTCJb39InJVw=";
+    };
+
+    NODE_ENV = "production";
+    yarnBuildScript = "webpack";
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/assets
+      cp -r assets/* $out/assets/
+
+      mkdir -p $out/frontend/templates
+      cp frontend/templates/react.tmpl $out/frontend/templates/react.tmpl
+
+      runHook postInstall
+    '';
+  };
+in
+buildGoModule (finalAttrs: {
+  inherit pname version src;
+
   vendorHash = "sha256-EwPbZLcqJV5J7ieoQwAJLIn4wwMlwZoTtWaXgvY3pR0=";
 
   subPackages = [
@@ -26,11 +65,28 @@ buildGoModule (finalAttrs: {
     "-X github.com/fleetdm/fleet/v4/server/version.version=${finalAttrs.version}"
   ];
 
+  nativeBuildInputs = [ go-bindata ];
+
+  preBuild = ''
+    cp -r ${frontend}/assets/* assets
+    cp -r ${frontend}/frontend/templates/react.tmpl frontend/templates/react.tmpl
+
+    go-bindata -pkg=bindata -tags full \
+      -o=server/bindata/generated.go \
+      frontend/templates/ assets/... server/mail/templates
+  '';
+
+  tags = [ "full" ];
+
   doInstallCheck = true;
   versionCheckProgramArg = "version";
   nativeInstallCheckInputs = [
     versionCheckHook
   ];
+
+  passthru = {
+    inherit frontend;
+  };
 
   meta = {
     homepage = "https://github.com/fleetdm/fleet";
@@ -40,6 +96,7 @@ buildGoModule (finalAttrs: {
     maintainers = with lib.maintainers; [
       asauzeau
       lesuisse
+      bddvlpr
     ];
     mainProgram = "fleet";
   };


### PR DESCRIPTION
Previously, when running the Fleet server, any requests that fetch templates or assets will fail as they are not included in this package. With this addition, the required files will be built using webpack and included in the go build using go-bindata (as per upstream).

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
