### PR TITLE
pmacct: add patch for gcc15 compatability

### DIFF
--- a/pkgs/by-name/pm/pmacct/gcc15-compat.patch
+++ b/pkgs/by-name/pm/pmacct/gcc15-compat.patch
@@ -1,0 +1,56 @@
+From 6466578967d3d39c46f7ec10b308bca36568697d Mon Sep 17 00:00:00 2001
+From: Paolo Lucente <pl+github@pmacct.net>
+Date: Tue, 11 Mar 2025 23:02:05 +0000
+Subject: [PATCH] * fix, making gcc15 happy. Patch contributed by Petr Gajdos
+
+---
+
+diff --git a/src/pmacct.h b/src/pmacct.h
+index ab7b3bba5..121141a28 100644
+--- a/src/pmacct.h
++++ b/src/pmacct.h
+@@ -368,9 +368,9 @@ struct child_ctl2 {
+ #include "util.h"
+ 
+ /* prototypes */
+-void startup_handle_falling_child();
+-void handle_falling_child();
+-void ignore_falling_child();
++void startup_handle_falling_child(int);
++void handle_falling_child(int);
++void ignore_falling_child(int);
+ void PM_sigint_handler(int);
+ void PM_sigalrm_noop_handler(int);
+ void reload(int);
+diff --git a/src/signals.c b/src/signals.c
+index 94fdbd12e..ad9a627e1 100644
+--- a/src/signals.c
++++ b/src/signals.c
+@@ -29,7 +29,7 @@
+ extern struct plugins_list_entry *plugin_list;
+ 
+ /* functions */
+-void startup_handle_falling_child()
++void startup_handle_falling_child(int unused)
+ {
+   int i, j;
+ 
+@@ -42,7 +42,7 @@ void startup_handle_falling_child()
+   }
+ }
+ 
+-void handle_falling_child()
++void handle_falling_child(int unused)
+ {
+   struct plugins_list_entry *list = NULL;
+   int j, ret;
+@@ -100,7 +100,7 @@ void handle_falling_child()
+   }
+ }
+ 
+-void ignore_falling_child()
++void ignore_falling_child(int unused)
+ {
+   pid_t cpid;
+   int status;
+

--- a/pkgs/by-name/pm/pmacct/package.nix
+++ b/pkgs/by-name/pm/pmacct/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   pkg-config,
   autoreconfHook,
   libtool,
@@ -37,6 +38,14 @@ stdenv.mkDerivation (finalAttrs: {
     rev = "v${finalAttrs.version}";
     hash = "sha256-3gV6GUhTQnH09NRIJQI0xBn05Bgo3AJsE2cSxNPXITo=";
   };
+
+  patches = [
+    # Fixes GCC15 compatability
+    # Can be removed with the next release
+    # Custom version of https://github.com/pmacct/pmacct/commit/6466578967d3d39c46f7ec10b308bca36568697d.patch
+    # without the copyright date changes.
+    ./gcc15-compat.patch
+  ];
 
   nativeBuildInputs = [
     autoreconfHook


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
