### PR TITLE
buildNpmPackage: derive default inputs for `npmDeps` from `finalAttrs`

### DIFF
--- a/pkgs/build-support/node/build-npm-package/default.nix
+++ b/pkgs/build-support/node/build-npm-package/default.nix
@@ -13,14 +13,7 @@ lib.extendMkDerivation {
   extendDrvArgs =
     finalAttrs:
     {
-      name ? "${args.pname}-${args.version}",
-      src ? null,
-      srcs ? null,
-      sourceRoot ? null,
-      prePatch ? "",
-      patches ? [ ],
-      postPatch ? "",
-      patchFlags ? [ ],
+      name ? "${finalAttrs.pname}-${finalAttrs.version}",
       nativeBuildInputs ? [ ],
       buildInputs ? [ ],
       # The output hash of the dependencies for this project.
@@ -53,19 +46,18 @@ lib.extendMkDerivation {
       npmWorkspace ? null,
       nodejs ? topLevelArgs.nodejs,
       npmDeps ? fetchNpmDeps {
-        inherit
-          forceGitDeps
-          forceEmptyCache
-          src
-          srcs
-          sourceRoot
-          prePatch
-          patches
-          postPatch
-          patchFlags
-          ;
         name = "${name}-npm-deps";
-        hash = npmDepsHash;
+        hash = finalAttrs.npmDepsHash;
+
+        forceEmptyCache = finalAttrs.forceEmptyCache or false;
+        forceGitDeps = finalAttrs.forceGitDeps or false;
+        patchFlags = finalAttrs.patchFlags or [ ];
+        patches = finalAttrs.patches or [ ];
+        postPatch = finalAttrs.postPatch or "";
+        prePatch = finalAttrs.prePatch or "";
+        sourceRoot = finalAttrs.sourceRoot or null;
+        src = finalAttrs.src or null;
+        srcs = finalAttrs.srcs or null;
       },
       # Custom npmConfigHook
       npmConfigHook ? null,


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Currently, `buildNpmPackage` provides a default for its `npmDeps` argument, derived from its `npmDepsHash` argument.

However, the way this is implemented prevents downstream overlays from overriding `npmDeps` by only using `npmDepsHash` (one needs to override `npmDeps` itself instead).

For example, the following currently does _not_ work / has no effect:

```nix
# random package making use of `buildNpmPackage`
bruno.overrideAttrs (old: {
  npmDepsHash = lib.fakeHash;
});

# this does work, but is not intuitive:
bruno.overrideAttrs (old: {
  npmDeps = old.npmDeps.overrideAttrs (old: {
    outputHash = lib.fakeHash;
  });
});
```

Method 2 will also get increasingly cumbersome the more changes are made. For example, if one wants to backport a package update, `src` needs to be overridden in both the main derivation, as well as the input for `fetchNpmDeps`.

With this patch, the inputs for `fetchNpmDeps` are derived from the derivation's `finalAttrs` instead, so one can simply use the first technique to override `npmDepsHash` and have it be propagated to `npmDeps`, which is useful for e.g. manually backporting package updates.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
