### PR TITLE
oboete: 0.2.1 -> 0.2.2

### DIFF
--- a/pkgs/by-name/ob/oboete/package.nix
+++ b/pkgs/by-name/ob/oboete/package.nix
@@ -3,7 +3,6 @@
   stdenv,
   rustPlatform,
   fetchFromGitHub,
-  fetchpatch2,
   just,
   libcosmicAppHook,
   sqlite,
@@ -12,25 +11,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "oboete";
-  version = "0.2.1";
+  version = "0.2.2";
 
   src = fetchFromGitHub {
     owner = "mariinkys";
     repo = "oboete";
     tag = finalAttrs.version;
-    hash = "sha256-yCIZl51Etv/vXJsIMTvUDPhCnkIuenvHjcP0KZXdAiE=";
+    hash = "sha256-MBWqAQekGdJHQhyObjnR8AUV+yjM++R11ALpE5BuUHc=";
   };
 
-  cargoHash = "sha256-BWGUzGGm1u64bQLy1rg9+WYNlgeuxcHlKsdIb18yVZA=";
-
-  # TODO: Remove in the next update
-  patches = [
-    (fetchpatch2 {
-      name = "fix-oboete-justfile.patch";
-      url = "https://patch-diff.githubusercontent.com/raw/mariinkys/oboete/pull/25.diff?full_index=1";
-      hash = "sha256-GPrtL73EKQi5fIIWPYcuS3HRwJ4ZHFsHzRYN6pYuUVg=";
-    })
-  ];
+  cargoHash = "sha256-deQeX1hVwJvzwCmtACiugEpRbzVP4Z2OBi2y2PPLVCM=";
 
   nativeBuildInputs = [
     libcosmicAppHook


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/mariinkys/oboete/compare/0.2.1...0.2.2
Changelog: https://github.com/mariinkys/oboete/releases/tag/0.2.2

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
