### PR TITLE
python3Packages.starlette-compress: only use brotlicffi with PyPy

### DIFF
--- a/pkgs/development/python-modules/starlette-compress/default.nix
+++ b/pkgs/development/python-modules/starlette-compress/default.nix
@@ -7,6 +7,7 @@
   brotli,
   brotlicffi,
   starlette,
+  pythonOlder,
   zstandard,
   pytestCheckHook,
   httpx,
@@ -30,6 +31,8 @@ buildPythonPackage rec {
   dependencies = [
     (if isPyPy then brotlicffi else brotli)
     starlette
+  ]
+  ++ lib.optionals (pythonOlder "3.14") [
     zstandard
   ];
 

--- a/pkgs/development/python-modules/starlette-compress/default.nix
+++ b/pkgs/development/python-modules/starlette-compress/default.nix
@@ -3,6 +3,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   hatchling,
+  isPyPy,
   brotli,
   brotlicffi,
   starlette,
@@ -27,8 +28,7 @@ buildPythonPackage rec {
   build-system = [ hatchling ];
 
   dependencies = [
-    brotli
-    brotlicffi
+    (if isPyPy then brotlicffi else brotli)
     starlette
     zstandard
   ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
