### PR TITLE
weechatScripts.wee-slack: 2.11.0 -> 2.11.0-unstable-2026-01-07

### DIFF
--- a/pkgs/applications/networking/irc/weechat/scripts/wee-slack/default.nix
+++ b/pkgs/applications/networking/irc/weechat/scripts/wee-slack/default.nix
@@ -7,15 +7,15 @@
   python3Packages,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "wee-slack";
-  version = "2.11.0";
+  version = "2.11.0-unstable-2026-01-07";
 
   src = fetchFromGitHub {
     repo = "wee-slack";
     owner = "wee-slack";
-    rev = "v${version}";
-    sha256 = "sha256-xQO/yi4pJSnO/ldzVQkC7UhAfpy57xzO58NV7KZm4E8=";
+    rev = "08a9cd05d482772e79d879e0b99ddd66a94d979d";
+    hash = "sha256-9S8XI+ZSzXcWOQbH6hxZ3N8VEczRE0+xxh5w9dqTL00=";
   };
 
   patches = [
@@ -25,7 +25,6 @@ stdenv.mkDerivation rec {
           name = "wee-slack-env";
           paths = with python3Packages; [
             websocket-client
-            six
           ];
         }
       }/${python3Packages.python.sitePackages}";


### PR DESCRIPTION
https://github.com/wee-slack/wee-slack/compare/v2.11.0...08a9cd05d482772e79d879e0b99ddd66a94d979d

Fixes compat with Slack APIs after yesterdays breaking changes, patches would not apply cleanly.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
