### PR TITLE
neovimUtils.makeVimPackageInfo: follow up fixes

### DIFF
--- a/pkgs/applications/editors/neovim/utils.nix
+++ b/pkgs/applications/editors/neovim/utils.nix
@@ -68,10 +68,14 @@ let
   */
   makeVimPackageInfo =
     # a list of neovim plugin derivations, for instance
-    #  plugins = [
-    # { plugin=vimPlugins.far-vim; config = "let g:far#source='rg'"; optional = false; }
-    # vimPlugins.vim-fugitive
-    # ]
+    #  [
+    #     {
+    #       plugin   = vimPlugins.grug-far-nvim;
+    #       config   = "let g:grug_far = { 'startInInsertMode': v:false }";
+    #       optional = false;
+    #     }
+    #     vimPlugins.vim-fugitive
+    #  ]
     plugins:
 
     let
@@ -79,7 +83,7 @@ let
 
       vimPackage = normalizedPluginsToVimPackage pluginsNormalized;
 
-      userPluginLua = lib.foldl (
+      userPluginViml = lib.foldl (
         acc: p: if p.config != null then acc ++ [ p.config ] else acc
       ) [ ] pluginsNormalized;
 
@@ -103,8 +107,8 @@ let
       # plugins' python dependencies
       inherit pluginPython3Packages;
 
-      # lua config set by the user along with the plugin
-      inherit userPluginLua;
+      # viml config set by the user along with the plugin
+      inherit userPluginViml;
 
       # recommanded configuration set in vim plugins ".passthru.initLua"
       inherit pluginAdvisedLua;

--- a/pkgs/applications/editors/neovim/wrapper.nix
+++ b/pkgs/applications/editors/neovim/wrapper.nix
@@ -98,7 +98,7 @@ let
 
         # we call vimrcContent without 'packages' to avoid the init.vim generation
         neovimRcContent' = lib.concatStringsSep "\n" (
-          vimPackageInfo.userPluginLua ++ lib.optional (neovimRcContent != null) neovimRcContent
+          vimPackageInfo.userPluginViml ++ lib.optional (neovimRcContent != null) neovimRcContent
         );
 
         packpathDirs.myNeovimPackages = vimPackageInfo.vimPackage;


### PR DESCRIPTION
Not sure what I've done but seems like I merged an old version of my PR in https://github.com/NixOS/nixpkgs/pull/474920, missing some fixes mentioned in reviews, notably
- `userPluginLua` -> `userPluginViml`
- formatted doc for 'plugins'

I had made sure tests passed so it's not a problem for users but it was misleading for consumers. I realized it while preparing
https://github.com/nix-community/home-manager/pull/8433
Sadly HM makes it a bit annoying to work with a fork of nixpkgs.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
