### PR TITLE
karere: 1.1.0 -> 2.0.9

### DIFF
--- a/pkgs/by-name/ka/karere/package.nix
+++ b/pkgs/by-name/ka/karere/package.nix
@@ -59,7 +59,10 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/tobagin/karere";
     changelog = "https://github.com/tobagin/karere/blob/${finalAttrs.src.rev}/CHANGELOG.md";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ marcel ];
+    maintainers = with lib.maintainers; [
+      marcel
+      aleksana
+    ];
     mainProgram = "karere";
   };
 })

--- a/pkgs/by-name/ka/karere/package.nix
+++ b/pkgs/by-name/ka/karere/package.nix
@@ -2,10 +2,12 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  vala,
+  rustPlatform,
   meson,
   ninja,
   pkg-config,
+  cargo,
+  rustc,
   wrapGAppsHook4,
   blueprint-compiler,
   desktop-file-utils,
@@ -13,26 +15,32 @@
   gtk4,
   libadwaita,
   webkitgtk_6_0,
-  json-glib,
-  libgee,
+  glib-networking,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "karere";
-  version = "1.1.0";
+  version = "2.0.9";
 
   src = fetchFromGitHub {
     owner = "tobagin";
     repo = "karere";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-4jV2vE7KtdpA9qjKR4xj/w6g1WZD/l8ezRtuFyzJtZ8=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-roxynxGiM43VHl+ngo/EMKEJ56XaYA6qaok/SzppFlY=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-BYG1TgCbkaQlquFy/tmjzdfypc8yno7w7SdBsgqOxkU=";
   };
 
   nativeBuildInputs = [
-    vala
     meson
     ninja
     pkg-config
+    cargo
+    rustc
+    rustPlatform.cargoSetupHook
     wrapGAppsHook4
     blueprint-compiler
     desktop-file-utils
@@ -43,8 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
     gtk4
     libadwaita
     webkitgtk_6_0
-    json-glib
-    libgee
+    glib-networking
   ];
 
   meta = {


### PR DESCRIPTION
Tested. The tray icon cannot be loaded if you are just testing without installing it, because the bar needs to read it. Installed it and it looked fine.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
