### PR TITLE
python3Packages.cleanlab: 2.7.1 -> 2.8.0

### DIFF
--- a/pkgs/development/python-modules/cleanlab/default.nix
+++ b/pkgs/development/python-modules/cleanlab/default.nix
@@ -5,6 +5,7 @@
 
   # build-system
   setuptools,
+  setuptools-scm,
 
   # dependencies
   numpy,
@@ -30,22 +31,21 @@
   pythonAtLeast,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "cleanlab";
-  version = "2.7.1";
+  version = "2.8.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "cleanlab";
     repo = "cleanlab";
-    tag = "v${version}";
-    hash = "sha256-KzVqBOLTxxkgvoGPYMeYb7zMuG8VwQwX6SYR/FUhfBw=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-sgDQJy0iNxs3bIVuqV7LVEFC0jjlWvnqFzKr7ZDGmPo=";
   };
 
-  build-system = [ setuptools ];
-
-  pythonRelaxDeps = [
-    "numpy"
+  build-system = [
+    setuptools
+    setuptools-scm
   ];
 
   dependencies = [
@@ -55,13 +55,6 @@ buildPythonPackage rec {
     tqdm
     pandas
   ];
-
-  # This is ONLY turned off when we have testing enabled.
-  # The reason we do this is because of duplicate packages in the enclosure
-  # when using the packages in nativeCheckInputs.
-  # Affected packages: grpcio protobuf tensorboard tensorboard-plugin-profile
-  catchConflicts = (!doCheck);
-  doCheck = true;
 
   nativeCheckInputs = [
     cleanvision
@@ -111,7 +104,7 @@ buildPythonPackage rec {
   meta = {
     description = "Standard data-centric AI package for data quality and machine learning with messy, real-world data and labels";
     homepage = "https://github.com/cleanlab/cleanlab";
-    changelog = "https://github.com/cleanlab/cleanlab/releases/tag/v${version}";
+    changelog = "https://github.com/cleanlab/cleanlab/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.agpl3Only;
     maintainers = with lib.maintainers; [ happysalada ];
     # cleanlab is incompatible with datasets>=4.0.0
@@ -119,4 +112,4 @@ buildPythonPackage rec {
     # https://github.com/cleanlab/cleanlab/issues/1244
     broken = lib.versionAtLeast datasets.version "4.0.0";
   };
-}
+})


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/cleanlab/cleanlab/compare/v2.7.1...v2.8.0
Changelog: https://github.com/cleanlab/cleanlab/releases/tag/v2.8.0

cc @happysalada

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc