### PR TITLE
pkgs/coreboot-toolchain: bump to 25.12

### DIFF
--- a/pkgs/development/tools/misc/coreboot-toolchain/default.nix
+++ b/pkgs/development/tools/misc/coreboot-toolchain/default.nix
@@ -26,19 +26,21 @@ let
 
       stdenvNoCC.mkDerivation (finalAttrs: {
         pname = "coreboot-toolchain-${arch}";
-        version = "25.09";
+        version = "25.12";
 
         src = fetchgit {
           url = "https://review.coreboot.org/coreboot";
           rev = finalAttrs.version;
-          hash = "sha256-GMLhGspaS+SsldYFwhMoxzpFgU6alm6WASv3lp/FRRY=";
+          hash = "sha256-zm1M+iveBxE/8/vIXZz1KoFkMaKW+bsQM4me5T6WqVY=";
           fetchSubmodules = false;
           leaveDotGit = true;
           postFetch = ''
             PATH=${lib.makeBinPath [ getopt ]}:$PATH ${stdenv.shell} $out/util/crossgcc/buildgcc -W > $out/.crossgcc_version
             rm -rf $out/.git
           '';
-          allowedRequisites = [ ];
+
+          ## Behavior's a bit broken.
+          # allowedRequisites = [ ];
         };
 
         archives = ./stable.nix;

--- a/pkgs/development/tools/misc/coreboot-toolchain/stable.nix
+++ b/pkgs/development/tools/misc/coreboot-toolchain/stable.nix
@@ -29,17 +29,80 @@
     };
   }
   {
-    name = "binutils-2.44.tar.xz";
+    name = "binutils-2.45.tar.xz";
     archive = fetchurl {
-      sha256 = "0dvj6zs7fcfm5bln1k9ma1h96a4wqi79s3i4p7fnfgnnb7h1f86f";
-      url = "mirror://gnu/binutils/binutils-2.44.tar.xz";
+      sha256 = "1lpmpszs3lk9mcg7yn0m312745kbc8vlazn95h79i25ikizhw365";
+      url = "mirror://gnu/binutils/binutils-2.45.tar.xz";
     };
   }
   {
-    name = "acpica-unix-20250404.tar.gz";
+    name = "acpica-unix-20250807.tar.gz";
     archive = fetchurl {
-      sha256 = "0593dicbdx5qcx13ari1c0rhsay09bwwsq6w94pcjbfbws4m92f0";
-      url = "https://downloadmirror.intel.com/852044/acpica-unix-20250404.tar.gz";
+      sha256 = "0cwfm7i5a2fqq35hznnal38pgxgmnkm0v2xkb82jm1yv9014rjpa";
+      url = "https://downloadmirror.intel.com/864114/acpica-unix-20250807.tar.gz";
+    };
+  }
+  {
+    name = "lld-18.1.8.src.tar.xz";
+    archive = fetchurl {
+      sha256 = "0scpr70lzc4v29x1asfvy9w9zhf40rnry6bsix1bhgk1zc2nh3l0";
+      url = "https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/lld-18.1.8.src.tar.xz";
+    };
+  }
+  {
+    name = "llvm-18.1.8.src.tar.xz";
+    archive = fetchurl {
+      sha256 = "13g2nawibrd5rz3fpw3g7lbbqkdk1h5qc3d7icax1iwv6q7zk37n";
+      url = "https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/llvm-18.1.8.src.tar.xz";
+    };
+  }
+  {
+    name = "clang-18.1.8.src.tar.xz";
+    archive = fetchurl {
+      sha256 = "06a5kzhq0j4gr7dgr83rzc9a445wngwd5vac21wmaz882c5gw92p";
+      url = "https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/clang-18.1.8.src.tar.xz";
+    };
+  }
+  {
+    name = "cmake-18.1.8.src.tar.xz";
+    archive = fetchurl {
+      sha256 = "0dz884dsn8qgy87iiiq55m2hp6da78r2pm0rscy8jd6xjbsxxfjr";
+      url = "https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/cmake-18.1.8.src.tar.xz";
+    };
+  }
+  {
+    name = "compiler-rt-18.1.8.src.tar.xz";
+    archive = fetchurl {
+      sha256 = "0bw9vy7yqyfzsfx8c0pgy6scifrs6r9cn9z92q374h4jkjdfjm70";
+      url = "https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/compiler-rt-18.1.8.src.tar.xz";
+    };
+  }
+  {
+    name = "clang-tools-extra-18.1.8.src.tar.xz";
+    archive = fetchurl {
+      sha256 = "1wd7y1a0db4y51swlq6dmm9hrv8pvmv158yi9f10dlayv7y7g275";
+      url = "https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/clang-tools-extra-18.1.8.src.tar.xz";
+    };
+  }
+  {
+    name = "libunwind-18.1.8.src.tar.xz";
+    archive = fetchurl {
+      sha256 = "0xv83v7r7azpflxkhjpalxcv99ck93vm3xrf8w7dmc3qd78pf5f3";
+      url = "https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/libunwind-18.1.8.src.tar.xz";
+    };
+  }
+  {
+    name = "runtimes-18.1.8.src.tar.xz";
+    archive = fetchurl {
+      sha256 = "1cvwy3ccww46imrk4mjkcys88lsvv0cm1fh66fbf4f2l3vlw55wr";
+      url = "https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/runtimes-18.1.8.src.tar.xz";
+    };
+  }
+  {
+    name = "cmake-4.0.3.tar.gz";
+    archive = fetchurl {
+      sha256 = "1yrzkwkr2nxl8hcjkk333l9ycbw9prkg363k4km609kknyvkfdcd";
+      url = "https://cmake.org/files/v4.0/cmake-4.0.3.tar.gz";
     };
   }
   {


### PR DESCRIPTION
Why is the toolchain never up to date with coreboot-utils?

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
