### PR TITLE
Qt6: enable MinGW cross-compilation

### DIFF
--- a/pkgs/by-name/ab/abseil-cpp/package.nix
+++ b/pkgs/by-name/ab/abseil-cpp/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   cmake,
   gtest,
+  windows,
   static ? stdenv.hostPlatform.isStatic,
   cxxStandard ? null,
 }:
@@ -32,7 +33,14 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ cmake ];
 
-  buildInputs = [ gtest ];
+  buildInputs = [
+    gtest
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isMinGW [
+    # Abseil uses pthread APIs on MinGW (see thread_identity.cc), so provide
+    # winpthreads headers/libs.
+    windows.pthreads
+  ];
 
   meta = {
     description = "Open-source collection of C++ code designed to augment the C++ standard library";

--- a/pkgs/by-name/as/assimp/cmake-any-newer-version.patch
+++ b/pkgs/by-name/as/assimp/cmake-any-newer-version.patch
@@ -1,0 +1,12 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -506,7 +506,7 @@
+ include(CMakePackageConfigHelpers)
+ 
+ # Note: PROJECT_VERSION is used as a VERSION
+-write_basic_package_version_file("${VERSION_CONFIG}" COMPATIBILITY SameMajorVersion)
++write_basic_package_version_file("${VERSION_CONFIG}" COMPATIBILITY AnyNewerVersion)
+ 
+ configure_package_config_file(
+     ${CMAKE_CONFIG_TEMPLATE_FILE}
+

--- a/pkgs/by-name/as/assimp/mingw-assimp-cmd-unique-importlib.patch
+++ b/pkgs/by-name/as/assimp/mingw-assimp-cmd-unique-importlib.patch
@@ -1,0 +1,17 @@
+--- a/tools/assimp_cmd/CMakeLists.txt
++++ b/tools/assimp_cmd/CMakeLists.txt
+@@ -73,6 +73,12 @@
+ 
+ SET_PROPERTY(TARGET assimp_cmd PROPERTY DEBUG_POSTFIX ${CMAKE_DEBUG_POSTFIX})
+ 
+ TARGET_LINK_LIBRARIES( assimp_cmd assimp ${ZLIB_LIBRARIES} )
++# MinGW: keep the user-facing executable name as `assimp`, but avoid clobbering
++# the assimp DLL import library (libassimp.dll.a). CMake emits an import library
++# for executables on MinGW; give that archive a distinct name.
++IF (MINGW)
++  SET_TARGET_PROPERTIES(assimp_cmd PROPERTIES ARCHIVE_OUTPUT_NAME assimp_cmd)
++ENDIF()
+ SET_TARGET_PROPERTIES( assimp_cmd PROPERTIES
+   OUTPUT_NAME assimp
+ )
+

--- a/pkgs/by-name/as/assimp/mingw-use-gnuinstalldirs.patch
+++ b/pkgs/by-name/as/assimp/mingw-use-gnuinstalldirs.patch
@@ -1,0 +1,28 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -460,7 +460,7 @@
+   ADD_CUSTOM_TARGET(uninstall "${CMAKE_COMMAND}" -P "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake")
+ ENDIF()
+ 
+-IF( UNIX )
++IF( UNIX OR MINGW )
+   # Use GNUInstallDirs for Unix predefined directories
+   INCLUDE(GNUInstallDirs)
+ 
+   SET( ASSIMP_LIB_INSTALL_DIR ${CMAKE_INSTALL_LIBDIR})
+   SET( ASSIMP_INCLUDE_INSTALL_DIR ${CMAKE_INSTALL_INCLUDEDIR})
+   SET( ASSIMP_BIN_INSTALL_DIR ${CMAKE_INSTALL_BINDIR})
+ ELSE()
+   # Cache these to allow the user to override them on non-Unix platforms
+   SET( ASSIMP_LIB_INSTALL_DIR "lib" CACHE STRING
+     "Path the built library files are installed to." )
+   SET( ASSIMP_INCLUDE_INSTALL_DIR "include" CACHE STRING
+     "Path the header files are installed to." )
+   SET( ASSIMP_BIN_INSTALL_DIR "bin" CACHE STRING
+     "Path the tool executables are installed to." )
+ 
+   SET(CMAKE_INSTALL_FULL_INCLUDEDIR ${CMAKE_INSTALL_PREFIX}/${ASSIMP_INCLUDE_INSTALL_DIR})
+   SET(CMAKE_INSTALL_FULL_LIBDIR ${CMAKE_INSTALL_PREFIX}/${ASSIMP_LIB_INSTALL_DIR})
+   SET(CMAKE_INSTALL_FULL_BINDIR ${CMAKE_INSTALL_PREFIX}/${ASSIMP_BIN_INSTALL_DIR})
+ ENDIF()
+

--- a/pkgs/by-name/as/assimp/windows-export-assimp-dll.patch
+++ b/pkgs/by-name/as/assimp/windows-export-assimp-dll.patch
@@ -1,0 +1,15 @@
+--- a/code/CMakeLists.txt
++++ b/code/CMakeLists.txt
+@@ -1402,6 +1402,11 @@
+ # Add or remove dllexport tags depending on the library type.
+ IF (BUILD_SHARED_LIBS)
+   TARGET_COMPILE_DEFINITIONS(assimp PRIVATE ASSIMP_BUILD_DLL_EXPORT)
++  # On Windows, consumers must define ASSIMP_DLL so headers use dllimport
++  # semantics. Export it via the CMake target for downstreams (e.g. Qt3D).
++  IF (WIN32)
++    TARGET_COMPILE_DEFINITIONS(assimp INTERFACE ASSIMP_DLL)
++  ENDIF()
+ ELSE ()
+   TARGET_COMPILE_DEFINITIONS(assimp PRIVATE OPENDDL_STATIC_LIBARY P2T_STATIC_EXPORTS)
+ ENDIF ()
+

--- a/pkgs/by-name/gr/grpc/003-fix-build-shared-libs-on-mingw.patch
+++ b/pkgs/by-name/gr/grpc/003-fix-build-shared-libs-on-mingw.patch
@@ -1,0 +1,179 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -2141,20 +2141,22 @@
+   SOVERSION ${gRPC_CORE_SOVERSION}
+ )
+ 
+-if(WIN32 AND MSVC)
+-  set_target_properties(gpr PROPERTIES COMPILE_PDB_NAME "gpr"
+-    COMPILE_PDB_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
+-  )
++if(WIN32)
+   if(BUILD_SHARED_LIBS)
+     target_compile_definitions(gpr
+     PRIVATE
+       "GPR_DLL_EXPORTS"
+     )
+   endif()
+-  if(gRPC_INSTALL)
+-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/gpr.pdb
+-      DESTINATION ${gRPC_INSTALL_LIBDIR} OPTIONAL
+-    )
++  if(MSVC)
++    set_target_properties(gpr PROPERTIES COMPILE_PDB_NAME "gpr"
++      COMPILE_PDB_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
++    )
++    if(gRPC_INSTALL)
++      install(FILES ${CMAKE_CURRENT_BINARY_DIR}/gpr.pdb
++        DESTINATION ${gRPC_INSTALL_LIBDIR} OPTIONAL
++      )
++    endif()
+   endif()
+ endif()
+ 
+@@ -3083,10 +3085,7 @@
+   SOVERSION ${gRPC_CORE_SOVERSION}
+ )
+ 
+-if(WIN32 AND MSVC)
+-  set_target_properties(grpc PROPERTIES COMPILE_PDB_NAME "grpc"
+-    COMPILE_PDB_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
+-  )
++if(WIN32)
+   if(BUILD_SHARED_LIBS)
+     target_compile_definitions(grpc
+     PRIVATE
+@@ -3094,10 +3093,15 @@
+       "GPR_DLL_IMPORTS"
+     )
+   endif()
+-  if(gRPC_INSTALL)
+-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/grpc.pdb
+-      DESTINATION ${gRPC_INSTALL_LIBDIR} OPTIONAL
+-    )
++  if(MSVC)
++    set_target_properties(grpc PROPERTIES COMPILE_PDB_NAME "grpc"
++      COMPILE_PDB_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
++    )
++    if(gRPC_INSTALL)
++      install(FILES ${CMAKE_CURRENT_BINARY_DIR}/grpc.pdb
++        DESTINATION ${gRPC_INSTALL_LIBDIR} OPTIONAL
++      )
++    endif()
+   endif()
+ endif()
+ 
+@@ -3779,10 +3783,7 @@
+   SOVERSION ${gRPC_CORE_SOVERSION}
+ )
+ 
+-if(WIN32 AND MSVC)
+-  set_target_properties(grpc_unsecure PROPERTIES COMPILE_PDB_NAME "grpc_unsecure"
+-    COMPILE_PDB_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
+-  )
++if(WIN32)
+   if(BUILD_SHARED_LIBS)
+     target_compile_definitions(grpc_unsecure
+     PRIVATE
+@@ -3790,10 +3791,15 @@
+       "GPR_DLL_IMPORTS"
+     )
+   endif()
+-  if(gRPC_INSTALL)
+-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/grpc_unsecure.pdb
+-      DESTINATION ${gRPC_INSTALL_LIBDIR} OPTIONAL
+-    )
++  if(MSVC)
++    set_target_properties(grpc_unsecure PROPERTIES COMPILE_PDB_NAME "grpc_unsecure"
++      COMPILE_PDB_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
++    )
++    if(gRPC_INSTALL)
++      install(FILES ${CMAKE_CURRENT_BINARY_DIR}/grpc_unsecure.pdb
++        DESTINATION ${gRPC_INSTALL_LIBDIR} OPTIONAL
++      )
++    endif()
+   endif()
+ endif()
+ 
+@@ -3810,6 +3816,7 @@
+     ${_gRPC_XXHASH_INCLUDE_DIR}
+     ${_gRPC_ZLIB_INCLUDE_DIR}
+ )
++find_package(OpenSSL REQUIRED)
+ target_link_libraries(grpc_unsecure
+   ${_gRPC_ALLTARGETS_LIBRARIES}
+   upb_mini_descriptor_lib
+@@ -3834,6 +3841,8 @@
+   ${_gRPC_CARES_LIBRARIES}
+   gpr
+   ${_gRPC_ADDRESS_SORTING_LIBRARIES}
++  grpc
++  OpenSSL::SSL
+ )
+ if(_gRPC_PLATFORM_IOS OR _gRPC_PLATFORM_MAC)
+   target_link_libraries(grpc_unsecure "-framework CoreFoundation")
+ endif()
+
+@@ -4644,10 +4653,7 @@
+   SOVERSION ${gRPC_CPP_SOVERSION}
+ )
+ 
+-if(WIN32 AND MSVC)
+-  set_target_properties(grpc++ PROPERTIES COMPILE_PDB_NAME "grpc++"
+-    COMPILE_PDB_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
+-  )
++if(WIN32)
+   if(BUILD_SHARED_LIBS)
+     target_compile_definitions(grpc++
+     PRIVATE
+@@ -4656,10 +4662,15 @@
+       "GRPC_DLL_IMPORTS"
+     )
+   endif()
+-  if(gRPC_INSTALL)
+-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/grpc++.pdb
+-      DESTINATION ${gRPC_INSTALL_LIBDIR} OPTIONAL
+-    )
++  if(MSVC)
++    set_target_properties(grpc++ PROPERTIES COMPILE_PDB_NAME "grpc++"
++      COMPILE_PDB_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
++    )
++    if(gRPC_INSTALL)
++      install(FILES ${CMAKE_CURRENT_BINARY_DIR}/grpc++.pdb
++        DESTINATION ${gRPC_INSTALL_LIBDIR} OPTIONAL
++      )
++    endif()
+   endif()
+ endif()
+ 
+@@ -5390,10 +5401,7 @@
+   SOVERSION ${gRPC_CPP_SOVERSION}
+ )
+ 
+-if(WIN32 AND MSVC)
+-  set_target_properties(grpc++_unsecure PROPERTIES COMPILE_PDB_NAME "grpc++_unsecure"
+-    COMPILE_PDB_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
+-  )
++if(WIN32)
+   if(BUILD_SHARED_LIBS)
+     target_compile_definitions(grpc++_unsecure
+     PRIVATE
+@@ -5402,10 +5410,15 @@
+       "GRPC_DLL_IMPORTS"
+     )
+   endif()
+-  if(gRPC_INSTALL)
+-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/grpc++_unsecure.pdb
+-      DESTINATION ${gRPC_INSTALL_LIBDIR} OPTIONAL
+-    )
++  if(MSVC)
++    set_target_properties(grpc++_unsecure PROPERTIES COMPILE_PDB_NAME "grpc++_unsecure"
++      COMPILE_PDB_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
++    )
++    if(gRPC_INSTALL)
++      install(FILES ${CMAKE_CURRENT_BINARY_DIR}/grpc++_unsecure.pdb
++        DESTINATION ${gRPC_INSTALL_LIBDIR} OPTIONAL
++      )
++    endif()
+   endif()
+ endif()

--- a/pkgs/by-name/gr/grpc/disable-grpc-plugin-support-when-codegen-off.patch
+++ b/pkgs/by-name/gr/grpc/disable-grpc-plugin-support-when-codegen-off.patch
@@ -1,0 +1,21 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -6329,6 +6329,8 @@
+ endif()
+ 
+ 
++if(gRPC_BUILD_CODEGEN)
++
+ add_library(grpc_plugin_support
+   src/compiler/cpp_generator.cc
+   src/compiler/csharp_generator.cc
+@@ -6426,6 +6428,8 @@
+   )
+ endif()
+ 
++endif()
++
+ 
+ # grpcpp_channelz doesn't build with protobuf-lite
+ # See https://github.com/grpc/grpc/issues/19473
+

--- a/pkgs/by-name/ja/jasper/001-mingw-cmake.patch
+++ b/pkgs/by-name/ja/jasper/001-mingw-cmake.patch
@@ -1,0 +1,29 @@
+diff -u a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -805,9 +805,11 @@
+ # Check for the Math library.
+ ################################################################################
+ 
++if(NOT WIN32)
+ find_library(MATH_LIBRARY m)
+ if(NOT MATH_LIBRARY)
+ 	set(MATH_LIBRARY "")
+ endif()
++endif()
+ 
+ ################################################################################
+ # Perform shared library setup.
+diff -u a/src/libjasper/CMakeLists.txt b/src/libjasper/CMakeLists.txt
+--- a/src/libjasper/CMakeLists.txt
++++ b/src/libjasper/CMakeLists.txt
+@@ -196,7 +196,7 @@
+ 	target_compile_definitions(libjasper PRIVATE _CRT_NONSTDC_NO_DEPRECATE)
+ endif()
+ 
+-if(UNIX)
++if(UNIX OR MINGW)
+ 	set_target_properties(libjasper PROPERTIES
+ 	  VERSION ${JAS_SO_NAME} SOVERSION ${JAS_SO_VERSION})
+ endif()
+

--- a/pkgs/by-name/ja/jasper/004-jasper-exports.patch
+++ b/pkgs/by-name/ja/jasper/004-jasper-exports.patch
@@ -1,0 +1,28 @@
+diff -u a/src/libjasper/jp2/jp2_cod.h b/src/libjasper/jp2/jp2_cod.h
+--- a/src/libjasper/jp2/jp2_cod.h
++++ b/src/libjasper/jp2/jp2_cod.h
+@@ -285,10 +285,10 @@
+ /******************************************************************************\
+ * Box class.
+ \******************************************************************************/
+ 
+-jp2_box_t *jp2_box_create(int type);
+-void jp2_box_destroy(jp2_box_t *box);
+-jp2_box_t *jp2_box_get(jas_stream_t *in);
+-int jp2_box_put(jp2_box_t *box, jas_stream_t *out);
++JAS_DLLEXPORT jp2_box_t *jp2_box_create(int type);
++JAS_DLLEXPORT void jp2_box_destroy(jp2_box_t *box);
++JAS_DLLEXPORT jp2_box_t *jp2_box_get(jas_stream_t *in);
++JAS_DLLEXPORT int jp2_box_put(jp2_box_t *box, jas_stream_t *out);
+ 
+ JAS_ATTRIBUTE_CONST
+@@ -320,7 +320,7 @@
+ #define ICC_CS_RGB	0x52474220
+ #define ICC_CS_YCBCR	0x59436272
+ #define ICC_CS_GRAY	0x47524159
+ 
+-const jp2_cdefchan_t *jp2_cdef_lookup(jp2_cdef_t *cdef, int channo);
++JAS_DLLEXPORT const jp2_cdefchan_t *jp2_cdef_lookup(jp2_cdef_t *cdef, int channo);
+ 
+ #endif
+

--- a/pkgs/by-name/ja/jasper/005-fix-filename-buffer-overflow-msvcrt.patch
+++ b/pkgs/by-name/ja/jasper/005-fix-filename-buffer-overflow-msvcrt.patch
@@ -1,0 +1,15 @@
+diff -u a/src/libjasper/include/jasper/jas_stream.h b/src/libjasper/include/jasper/jas_stream.h
+--- a/src/libjasper/include/jasper/jas_stream.h
++++ b/src/libjasper/include/jasper/jas_stream.h
+@@ -254,6 +254,10 @@
+ typedef struct {
+ 	int fd;
+ 	int flags;
++#ifndef _UCRT
++#undef L_tmpnam
++#define L_tmpnam FILENAME_MAX
++#endif
+ #if defined(JAS_WASI_LIBC)
+ #define L_tmpnam 4096
+ #endif
+

--- a/pkgs/by-name/ja/jasper/package.nix
+++ b/pkgs/by-name/ja/jasper/package.nix
@@ -8,9 +8,9 @@
   libjpeg,
   pkg-config,
   stdenv,
-  enableHEIFCodec ? true,
+  enableHEIFCodec ? stdenv.hostPlatform.isUnix,
   enableJPGCodec ? true,
-  enableOpenGL ? true,
+  enableOpenGL ? stdenv.hostPlatform.isUnix,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -37,6 +37,12 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
   ];
 
+  patches = lib.optionals stdenv.hostPlatform.isMinGW [
+    ./001-mingw-cmake.patch
+    ./004-jasper-exports.patch
+    ./005-fix-filename-buffer-overflow-msvcrt.patch
+  ];
+
   buildInputs = [
   ]
   ++ lib.optionals enableHEIFCodec [
@@ -45,7 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals enableJPGCodec [
     libjpeg
   ]
-  ++ lib.optionals enableOpenGL [
+  ++ lib.optionals (enableOpenGL && stdenv.hostPlatform.isUnix) [
     libglut
     libGL
   ];
@@ -96,7 +102,7 @@ stdenv.mkDerivation (finalAttrs: {
     license = with lib.licenses; [ mit ];
     mainProgram = "jasper";
     maintainers = [ ];
-    platforms = lib.platforms.unix;
+    platforms = lib.platforms.unix ++ lib.platforms.windows;
   };
 })
 # TODO: investigate opengl support

--- a/pkgs/by-name/li/libde265/package.nix
+++ b/pkgs/by-name/li/libde265/package.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Open h.265 video codec implementation";
     mainProgram = "dec265";
     license = lib.licenses.lgpl3;
-    platforms = lib.platforms.unix;
+    platforms = lib.platforms.unix ++ lib.platforms.windows;
     maintainers = [ ];
   };
 })

--- a/pkgs/by-name/li/libheif/package.nix
+++ b/pkgs/by-name/li/libheif/package.nix
@@ -87,7 +87,7 @@ stdenv.mkDerivation rec {
     homepage = "http://www.libheif.org/";
     description = "ISO/IEC 23008-12:2017 HEIF image file format decoder and encoder";
     license = lib.licenses.lgpl3Plus;
-    platforms = lib.platforms.unix;
+    platforms = lib.platforms.unix ++ lib.platforms.windows;
     maintainers = with lib.maintainers; [ kuflierl ];
   };
 }

--- a/pkgs/by-name/li/libmng/package.nix
+++ b/pkgs/by-name/li/libmng/package.nix
@@ -1,5 +1,8 @@
 {
   lib,
+  cmake,
+  ninja,
+  pkg-config,
   stdenv,
   fetchurl,
   zlib,
@@ -20,15 +23,28 @@ stdenv.mkDerivation rec {
   outputs = [
     "out"
     "dev"
-    "devdoc"
   ];
-  outputMan = "devdoc";
 
-  propagatedBuildInputs = [
+  nativeBuildInputs = [
+    cmake
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
     zlib
     libpng
     libjpeg
     lcms2
+  ];
+
+  cmakeFlags = [
+    # libmng's CMakeLists uses an old cmake_minimum_required(VERSION ...) which
+    # CMake 4 rejects. This opts into a compatible policy floor.
+    "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
+    "-DBUILD_SHARED_LIBS=ON"
+    "-DBUILD_STATIC_LIBS=OFF"
+    "-DCMAKE_DLL_NAME_WITH_SOVERSION=ON"
   ];
 
   meta = {

--- a/pkgs/by-name/li/libproxy/install-backend-bindir.patch
+++ b/pkgs/by-name/li/libproxy/install-backend-bindir.patch
@@ -1,0 +1,13 @@
+--- a/src/backend/meson.build
++++ b/src/backend/meson.build
+@@ -38,8 +38,7 @@
+   dependencies: px_backend_deps,
+   c_args: px_backend_c_args,
+   install: true,
+-  install_dir: pkglibdir,
+-  install_rpath: pkglibdir
++  install_dir: get_option('bindir')
+ )
+ 
+ px_backend_dep = declare_dependency(
+

--- a/pkgs/by-name/re/re2/package.nix
+++ b/pkgs/by-name/re/re2/package.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
     ninja
   ];
 
-  buildInputs = [
+  checkInputs = [
     gbenchmark
     gtest
   ];
@@ -44,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
   propagatedBuildInputs = [ abseil-cpp ] ++ lib.optionals (!stdenv.hostPlatform.isStatic) [ icu ];
 
   cmakeFlags = [
-    (lib.cmakeBool "RE2_BUILD_TESTING" true)
+    (lib.cmakeBool "RE2_BUILD_TESTING" finalAttrs.doCheck)
     (lib.cmakeFeature "CMAKE_CTEST_ARGUMENTS" "--timeout;999999")
   ]
   ++ lib.optionals (!stdenv.hostPlatform.isStatic) [
@@ -52,7 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "BUILD_SHARED_LIBS" true)
   ];
 
-  doCheck = true;
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
 
   passthru.tests = {
     inherit chromium grpc mercurial;

--- a/pkgs/by-name/un/unixODBC/package.nix
+++ b/pkgs/by-name/un/unixODBC/package.nix
@@ -1,30 +1,61 @@
 {
   lib,
   stdenv,
+  autoreconfHook,
   fetchurl,
+  libiconv,
+  readline,
+  windows,
 }:
 
 stdenv.mkDerivation rec {
   pname = "unixODBC";
-  version = "2.3.12";
+  version = "2.3.14";
 
   src = fetchurl {
     urls = [
       "ftp://ftp.unixodbc.org/pub/unixODBC/${pname}-${version}.tar.gz"
       "https://www.unixodbc.org/${pname}-${version}.tar.gz"
     ];
-    sha256 = "sha256-8hBQFEXOIb9ge6Ue+MEl4Q4i3/3/7Dd2RkYt9fAZFew=";
+    sha256 = "sha256-TigU3j4B/DCwufdeg7taupGrA4TulRKGUEu3AgVSR3E=";
   };
+
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isMinGW [
+    # MSYS2 runs autoreconf to refresh libtool/autoconf plumbing for MinGW toolchains.
+    autoreconfHook
+  ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isMinGW [
+    # MSYS2 depends on these on MinGW; keep them conditional to avoid changing unix builds.
+    libiconv
+    readline
+    # Provide libpthread.a / winpthreads for MinGW. unixODBC's build system uses -pthread
+    # which otherwise resolves to -lpthread and fails the link.
+    windows.pthreads
+  ];
+
+  preConfigure = lib.optionalString stdenv.hostPlatform.isMinGW ''
+    # Prefer winpthreads on MinGW (MSYS2 depends on libwinpthread).
+    export PTHREAD_LIBS="-lwinpthread"
+    export PTHREAD_CFLAGS=""
+  '';
 
   configureFlags = [
     "--disable-gui"
     "--sysconfdir=/etc"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isMinGW [
+    # Align with MSYS2 mingw-w64-unixodbc PKGBUILD intent.
+    "--enable-iconv=yes"
+    "--enable-static"
+    "--enable-shared"
   ];
 
   meta = {
-    description = "ODBC driver manager for Unix";
+    description = "ODBC driver manager";
     homepage = "https://www.unixodbc.org/";
     license = lib.licenses.lgpl2;
-    platforms = lib.platforms.unix;
+    # MSYS2 packages unixODBC for MinGW; enable it for nixpkgs Windows targets as well.
+    platforms = lib.platforms.unix ++ lib.platforms.windows;
   };
 }

--- a/pkgs/development/libraries/qt-6/modules/qtdatavis3d.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtdatavis3d.nix
@@ -2,6 +2,9 @@
   qtModule,
   qtbase,
   qtdeclarative,
+  lib,
+  pkgsBuildBuild,
+  stdenv,
 }:
 
 qtModule {
@@ -9,5 +12,19 @@ qtModule {
   propagatedBuildInputs = [
     qtbase
     qtdeclarative
+  ];
+
+  # Qt6 component discovery expects Qt6<Module> packages to be available.
+  # In our split-prefix Qt packaging this needs a bit of help, especially for
+  # cross builds where QmlTools must come from the build machine.
+  #
+  # MSYS2 reference: mingw-w64-qt6-datavis3d depends on qt6-declarative.
+  cmakeFlags = [
+    "-DQt6Quick_DIR=${qtdeclarative}/lib/cmake/Qt6Quick"
+  ]
+  ++ lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+    "-DQt6QmlTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QmlTools"
+    # Qt6Quick depends on the (host) Qt6QuickTools package when cross-compiling.
+    "-DQt6QuickTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QuickTools"
   ];
 }

--- a/pkgs/development/libraries/qt-6/modules/qtdeclarative/default.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtdeclarative/default.nix
@@ -58,13 +58,18 @@ qtModule {
   ];
 
   cmakeFlags = [
-    "-DQt6ShaderToolsTools_DIR=${pkgsBuildBuild.qt6.qtshadertools}/lib/cmake/Qt6ShaderTools"
+    # QtQuick (and related modules) are only built if the build-machine `qsb` tool is found
+    # (see qtdeclarative's `src/CMakeLists.txt` gating on `TARGET Qt::qsb`).
+    "-DQt6ShaderToolsTools_DIR=${pkgsBuildBuild.qt6.qtshadertools}/lib/cmake/Qt6ShaderToolsTools"
     # for some reason doesn't get found automatically on Darwin
     "-DPython_EXECUTABLE=${lib.getExe pkgsBuildBuild.python3}"
   ]
   # Conditional is required to prevent infinite recursion during a cross build
   ++ lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
     "-DQt6QmlTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QmlTools"
+    # Required for cross builds: qtdeclarative builds host tools (e.g. `svgtoqml`) via
+    # `qt_internal_find_tool()` which locates them in the host-side Qt6QuickTools package.
+    "-DQt6QuickTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QuickTools"
   ];
 
   meta.maintainers = with lib.maintainers; [

--- a/pkgs/development/libraries/qt-6/modules/qtdoc.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtdoc.nix
@@ -3,19 +3,100 @@
   qtdeclarative,
   qtbase,
   qttools,
+  pkgsBuildBuild,
+  stdenv,
+  lib,
 }:
 
+let
+  isCrossBuild = !stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+  # Docs are architecture-independent; when cross-compiling, prefer using build-machine
+  # Qt tooling + Qt installation to avoid mixing target+build qtbase setup hooks.
+  qtbaseForDocs = if isCrossBuild then pkgsBuildBuild.qt6.qtbase else qtbase;
+  qttoolsForDocs = if isCrossBuild then pkgsBuildBuild.qt6.qttools else qttools;
+  qttoolsForDocsWithClang = qttoolsForDocs.override { withClang = true; };
+  # Qt's build internals expect QT_HOST_PATH to be a single prefix containing host tools
+  # (qdoc, qhelpgenerator, qtattributionsscanner, ...) and CMake package configs.
+  # In Nix, those live in separate store paths (qtbase vs qttools), so we synthesize
+  # a minimal merged prefix for cross builds.
+  qtHostPath =
+    if isCrossBuild then
+      pkgsBuildBuild.runCommand "qt6-host-path-for-qtdoc" { } ''
+        mkdir -p "$out/bin" "$out/lib/cmake" "$out/libexec"
+
+        # Host tool executables come from qttools.
+        for f in ${qttoolsForDocsWithClang}/bin/*; do
+          ln -s "$f" "$out/bin/$(basename "$f")"
+        done
+        for f in ${qttoolsForDocsWithClang}/libexec/*; do
+          ln -s "$f" "$out/libexec/$(basename "$f")"
+        done
+
+        # CMake package configs come from qtbase (+ qttools for tool packages).
+        for d in ${qtbaseForDocs}/lib/cmake ${qttoolsForDocsWithClang}/lib/cmake; do
+          if [ -d "$d" ]; then
+            for p in "$d"/*; do
+              # IMPORTANT: don't follow an existing symlink-to-dir (e.g. Qt6), or we'd
+              # accidentally try to create links inside the read-only store path.
+              ln -sfnT "$p" "$out/lib/cmake/$(basename "$p")"
+            done
+          fi
+        done
+      ''
+    else
+      null;
+in
 qtModule {
   pname = "qtdoc";
   # avoid fix-qt-builtin-paths hook substitute QT_INSTALL_DOCS to qtdoc's path
   postPatch = ''
-    for file in $(grep -rl '$QT_INSTALL_DOCS'); do
+    for file in $(grep -rl '$QT_INSTALL_DOCS' . || true); do
       substituteInPlace $file \
-          --replace '$QT_INSTALL_DOCS' "${qtbase}/share/doc"
+          --replace '$QT_INSTALL_DOCS' "${qtbaseForDocs}/share/doc"
     done
   '';
-  nativeBuildInputs = [ (qttools.override { withClang = true; }) ];
-  propagatedBuildInputs = [ qtdeclarative ];
+  # When cross-compiling, the doc generator (`qdoc`) is a *build-machine* tool.
+  # If we use the target `qttools` here, it pulls in target LLVM/clang and fails
+  # early (e.g. MinGW LLVM dylib export table limits).
+  nativeBuildInputs = [
+
+    qttoolsForDocsWithClang
+
+  ];
+  # Avoid pulling target Qt modules into the build environment when cross-compiling,
+  # which would mix host/build qtbase setup hooks.
+  propagatedBuildInputs = lib.optionals (!isCrossBuild) [ qtdeclarative ];
+
+  cmakeFlags = lib.optionals isCrossBuild [
+    # qtbase requires an explicit QT_HOST_PATH when cross-compiling via qt_build_repo_begin()
+    # (see MSYS2 `qt6-doc` which passes `-DQT_HOST_PATH=...`).
+    "-DQT_HOST_PATH=${qtHostPath}"
+    "-DQt6HostInfo_DIR=${qtHostPath}/lib/cmake/Qt6HostInfo"
+  ];
+
+  env = lib.optionalAttrs isCrossBuild {
+    # Qt's docs helpers export QT_INSTALL_DOCS into the qdoc invocation. If unset,
+    # it defaults to a non-existent `${qtbase}/doc` path in our split installs.
+    # Provide a real directory so qdoc doesn't fail with "no such file or directory".
+    QT_INSTALL_DOCS = "${qtbaseForDocs}/share/doc";
+  };
+
+  # qtbase's docs CMake expects a response file at `${BUILDDIR}/.doc/Release/includes.txt`
+  # (passed to qdoc as `@.../includes.txt`). In our cross setup this file is not created
+  # early enough (or at all), and qdoc fails with a generic "no such file or directory".
+  # Create placeholder response files for the doc sub-builds.
+  postConfigure = lib.optionalString isCrossBuild ''
+    mkdir -p build/doc/.doc/Release
+    : > build/doc/.doc/Release/includes.txt
+
+    if [ -d build/doc/src ]; then
+      for d in build/doc/src/*; do
+        [ -d "$d" ] || continue
+        mkdir -p "$d/.doc/Release"
+        : > "$d/.doc/Release/includes.txt"
+      done
+    fi
+  '';
 
   ninjaFlags = [ "docs" ];
   installTargets = [ "install_docs" ];

--- a/pkgs/development/libraries/qt-6/modules/qtgraphs.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtgraphs.nix
@@ -4,6 +4,9 @@
   qtdeclarative,
   qtquick3d,
   qtquicktimeline,
+  lib,
+  pkgsBuildBuild,
+  stdenv,
 }:
 
 qtModule {
@@ -13,5 +16,15 @@ qtModule {
     qtdeclarative
     qtquick3d
     qtquicktimeline
+  ];
+
+  # QtQuick component discovery expects Qt6Quick to be findable, and Qt6Quick depends on
+  # the build-machine Qt6QuickTools package in cross builds.
+  cmakeFlags = [
+    "-DQt6Quick_DIR=${qtdeclarative}/lib/cmake/Qt6Quick"
+  ]
+  ++ lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+    "-DQt6QmlTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QmlTools"
+    "-DQt6QuickTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QuickTools"
   ];
 }

--- a/pkgs/development/libraries/qt-6/modules/qtlocation.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtlocation.nix
@@ -3,6 +3,9 @@
   qtbase,
   qtdeclarative,
   qtpositioning,
+  lib,
+  pkgsBuildBuild,
+  stdenv,
 }:
 
 qtModule {
@@ -12,4 +15,15 @@ qtModule {
     qtdeclarative
     qtpositioning
   ];
+
+  # Qt6Qml (from qtdeclarative) requires the build-machine Qt6QmlTools package in cross builds.
+  # qtlocation disables itself when Qt::Qml isn't available, which leaves no `install` target.
+  cmakeFlags = [
+    "-DQt6Quick_DIR=${qtdeclarative}/lib/cmake/Qt6Quick"
+  ]
+  ++ lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+    "-DQt6QmlTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QmlTools"
+    "-DQt6QuickTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QuickTools"
+  ];
+
 }

--- a/pkgs/development/libraries/qt-6/modules/qtlottie.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtlottie.nix
@@ -2,6 +2,10 @@
   qtModule,
   qtbase,
   qtdeclarative,
+  qtsvg,
+  lib,
+  pkgsBuildBuild,
+  stdenv,
 }:
 
 qtModule {
@@ -9,5 +13,20 @@ qtModule {
   propagatedBuildInputs = [
     qtbase
     qtdeclarative
+    qtsvg
+  ];
+
+  # qtlottie uses qt_internal_add_qml_module(), which is available only when the
+  # Qt Qml component is successfully found. In cross builds, Qt6Qml depends on
+  # build-machine QmlTools and Qt6Quick depends on build-machine QuickTools.
+  cmakeFlags = [
+    "-DQt6Quick_DIR=${qtdeclarative}/lib/cmake/Qt6Quick"
+  ]
+  ++ lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+    "-DQt6QmlTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QmlTools"
+    "-DQt6QuickTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QuickTools"
+    # qtlottie builds the host tool `lottietoqml` via qt_internal_find_tool(), which
+    # locates it in the host-side Qt6LottieTools package.
+    "-DQt6LottieTools_DIR=${pkgsBuildBuild.qt6.qtlottie}/lib/cmake/Qt6LottieTools"
   ];
 }

--- a/pkgs/development/libraries/qt-6/modules/qtmultimedia/default.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtmultimedia/default.nix
@@ -65,6 +65,7 @@ qtModule {
   patches = lib.optionals stdenv.hostPlatform.isMinGW [
     ./windows-no-uppercase-libs.patch
     ./windows-resolve-function-name.patch
+    ./windows-lowercase-d3d11-headers.patch
   ];
 
   cmakeFlags = [

--- a/pkgs/development/libraries/qt-6/modules/qtmultimedia/windows-lowercase-d3d11-headers.patch
+++ b/pkgs/development/libraries/qt-6/modules/qtmultimedia/windows-lowercase-d3d11-headers.patch
@@ -1,0 +1,12 @@
+--- a/src/plugins/multimedia/ffmpeg/ffmpeg_pch.h
++++ b/src/plugins/multimedia/ffmpeg/ffmpeg_pch.h
+@@ -21,7 +21,7 @@
+ 
+ #ifdef Q_OS_WINDOWS
+ #  include <qt_windows.h>
+-#  include <D3d11.h>
++#  include <d3d11.h>
+ #  include <dxgi1_2.h>
+ #  include <mfapi.h>
+ #  include <mfidl.h>
+

--- a/pkgs/development/libraries/qt-6/modules/qtpositioning.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtpositioning.nix
@@ -5,6 +5,10 @@
   qtserialport,
   pkg-config,
   openssl,
+  qtsvg,
+  lib,
+  pkgsBuildBuild,
+  stdenv,
 }:
 
 qtModule {
@@ -13,7 +17,16 @@ qtModule {
     qtbase
     qtdeclarative
     qtserialport
+    qtsvg
   ];
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ openssl ];
+
+  cmakeFlags = [
+    "-DQt6Quick_DIR=${qtdeclarative}/lib/cmake/Qt6Quick"
+  ]
+  ++ lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+    "-DQt6QmlTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QmlTools"
+    "-DQt6QuickTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QuickTools"
+  ];
 }

--- a/pkgs/development/libraries/qt-6/modules/qtquick3d.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtquick3d.nix
@@ -2,7 +2,11 @@
   qtModule,
   qtbase,
   qtdeclarative,
+  qtshadertools,
   openssl,
+  lib,
+  pkgsBuildBuild,
+  stdenv,
 }:
 
 qtModule {
@@ -10,6 +14,21 @@ qtModule {
   propagatedBuildInputs = [
     qtbase
     qtdeclarative
+    qtshadertools
   ];
   buildInputs = [ openssl ];
+
+  # QtQuick component discovery expects Qt6Quick to be findable, and Qt6Quick depends on
+  # the build-machine Qt6QuickTools package in cross builds.
+  cmakeFlags = [
+    "-DQt6Quick_DIR=${qtdeclarative}/lib/cmake/Qt6Quick"
+  ]
+  ++ lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+    "-DQt6QmlTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QmlTools"
+    "-DQt6QuickTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QuickTools"
+    # Needed for cross builds: provides `Qt6::qsb` host tool used by QtQuick3D.
+    "-DQt6ShaderToolsTools_DIR=${pkgsBuildBuild.qt6.qtshadertools}/lib/cmake/Qt6ShaderToolsTools"
+    # Needed for cross builds: provides the host tool `Qt6::balsam` from Qt6Quick3DTools.
+    "-DQt6Quick3DTools_DIR=${pkgsBuildBuild.qt6.qtquick3d}/lib/cmake/Qt6Quick3DTools"
+  ];
 }

--- a/pkgs/development/libraries/qt-6/modules/qtquick3dphysics.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtquick3dphysics.nix
@@ -4,6 +4,9 @@
   stdenv,
   qtbase,
   qtquick3d,
+  qtshadertools,
+  pkgsBuildBuild,
+  qtdeclarative,
 }:
 
 qtModule {
@@ -11,6 +14,25 @@ qtModule {
   propagatedBuildInputs = [
     qtbase
     qtquick3d
+    qtshadertools
   ];
+
+  postPatch = ''
+    # Windows includes are case-insensitive; cross builds on Linux are not.
+    # PhysX uses <Winsock2.h> but MinGW headers provide <winsock2.h>.
+    substituteInPlace src/3rdparty/PhysX/source/foundation/src/windows/PsWindowsSocket.cpp \
+      --replace-fail '<Winsock2.h>' '<winsock2.h>'
+  '';
+
+  cmakeFlags = [
+    "-DQt6Quick3D_DIR=${qtquick3d.dev}/lib/cmake/Qt6Quick3D"
+  ]
+  ++ lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+    "-DQt6QmlTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QmlTools"
+    "-DQt6QuickTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QuickTools"
+    "-DQt6Quick3DTools_DIR=${pkgsBuildBuild.qt6.qtquick3d}/lib/cmake/Qt6Quick3DTools"
+    "-DQt6ShaderToolsTools_DIR=${pkgsBuildBuild.qt6.qtshadertools}/lib/cmake/Qt6ShaderToolsTools"
+  ];
+
   meta.mainProgram = "cooker";
 }

--- a/pkgs/development/libraries/qt-6/modules/qtquickeffectmaker.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtquickeffectmaker.nix
@@ -1,14 +1,46 @@
 {
   qtModule,
+  lib,
+  pkgsBuildBuild,
+  stdenv,
   qtbase,
+  qtdeclarative,
   qtquick3d,
+  qtshadertools,
 }:
 
 qtModule {
   pname = "qtquickeffectmaker";
   propagatedBuildInputs = [
     qtbase
+    qtdeclarative
     qtquick3d
+    qtshadertools
   ];
+
+  postPatch =
+    # For the MinGW cross use-case we do not need to execute target binaries during the build
+    lib.optionalString
+      (!stdenv.buildPlatform.canExecute stdenv.hostPlatform && stdenv.hostPlatform.isMinGW)
+      ''
+        substituteInPlace CMakeLists.txt \
+          --replace-fail 'if(CMAKE_CROSSCOMPILING)' 'if(FALSE)'
+      ''
+    # Windows headers are case-insensitive; cross builds on Linux are not.
+    # MinGW provides <windows.h>, but upstream includes <Windows.h>.
+    + lib.optionalString stdenv.hostPlatform.isMinGW ''
+      substituteInPlace tools/qqem/main.cpp \
+        --replace-fail '<Windows.h>' '<windows.h>'
+    '';
+
+  cmakeFlags = [
+    "-DQt6Quick_DIR=${qtdeclarative}/lib/cmake/Qt6Quick"
+  ]
+  ++ lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+    "-DQt6QmlTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QmlTools"
+    "-DQt6QuickTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QuickTools"
+    "-DQt6ShaderToolsTools_DIR=${pkgsBuildBuild.qt6.qtshadertools}/lib/cmake/Qt6ShaderToolsTools"
+  ];
+
   meta.mainProgram = "qqem";
 }

--- a/pkgs/development/libraries/qt-6/modules/qtquicktimeline.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtquicktimeline.nix
@@ -2,6 +2,9 @@
   qtModule,
   qtbase,
   qtdeclarative,
+  lib,
+  pkgsBuildBuild,
+  stdenv,
 }:
 
 qtModule {
@@ -9,5 +12,15 @@ qtModule {
   propagatedBuildInputs = [
     qtbase
     qtdeclarative
+  ];
+
+  # QtQuick component discovery expects Qt6Quick to be findable, and Qt6Quick depends on
+  # the build-machine Qt6QuickTools package in cross builds.
+  cmakeFlags = [
+    "-DQt6Quick_DIR=${qtdeclarative}/lib/cmake/Qt6Quick"
+  ]
+  ++ lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+    "-DQt6QmlTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QmlTools"
+    "-DQt6QuickTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QuickTools"
   ];
 }

--- a/pkgs/development/libraries/qt-6/modules/qtremoteobjects.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtremoteobjects.nix
@@ -2,6 +2,11 @@
   qtModule,
   qtbase,
   qtdeclarative,
+  qtconnectivity,
+  qtwebsockets,
+  lib,
+  pkgsBuildBuild,
+  stdenv,
 }:
 
 qtModule {
@@ -9,5 +14,11 @@ qtModule {
   propagatedBuildInputs = [
     qtbase
     qtdeclarative
+    qtconnectivity
+    qtwebsockets
+  ];
+
+  cmakeFlags = lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+    "-DQt6RemoteObjectsTools_DIR=${pkgsBuildBuild.qt6.qtremoteobjects}/lib/cmake/Qt6RemoteObjectsTools"
   ];
 }

--- a/pkgs/development/libraries/qt-6/modules/qtscxml.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtscxml.nix
@@ -2,6 +2,9 @@
   qtModule,
   qtbase,
   qtdeclarative,
+  lib,
+  pkgsBuildBuild,
+  stdenv,
 }:
 
 qtModule {
@@ -9,5 +12,10 @@ qtModule {
   propagatedBuildInputs = [
     qtbase
     qtdeclarative
+  ];
+
+  cmakeFlags = lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+    "-DQt6QmlTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QmlTools"
+    "-DQt6ScxmlTools_DIR=${pkgsBuildBuild.qt6.qtscxml}/lib/cmake/Qt6ScxmlTools"
   ];
 }

--- a/pkgs/development/libraries/qt-6/modules/qttranslations.nix
+++ b/pkgs/development/libraries/qt-6/modules/qttranslations.nix
@@ -1,11 +1,58 @@
 {
   qtModule,
+  pkgsBuildBuild,
+  stdenv,
+  lib,
   qttools,
+  runCommand,
 }:
 
+let
+  isCrossBuild = !stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+  isMingwCross = isCrossBuild && stdenv.hostPlatform.isMinGW;
+  qtHostPathForTranslations =
+    runCommand "qt6-host-path-for-qttranslations"
+      {
+        nativeBuildInputs = [
+          pkgsBuildBuild.qt6.qtbase
+          pkgsBuildBuild.qt6.qttools
+        ];
+      }
+      ''
+        mkdir -p $out/lib/cmake
+        ln -sfnT ${pkgsBuildBuild.qt6.qttools}/bin $out/bin
+        ln -sfnT ${pkgsBuildBuild.qt6.qttools}/libexec $out/libexec
+        ln -sfnT ${pkgsBuildBuild.qt6.qtbase}/lib/cmake/Qt6 $out/lib/cmake/Qt6
+        ln -sfnT ${pkgsBuildBuild.qt6.qtbase}/lib/cmake/Qt6HostInfo $out/lib/cmake/Qt6HostInfo
+        ln -sfnT ${pkgsBuildBuild.qt6.qttools}/lib/cmake/Qt6Tools $out/lib/cmake/Qt6Tools
+        ln -sfnT ${pkgsBuildBuild.qt6.qttools}/lib/cmake/Qt6LinguistTools $out/lib/cmake/Qt6LinguistTools
+      '';
+in
 qtModule {
   pname = "qttranslations";
-  nativeBuildInputs = [ qttools ];
+
+  nativeBuildInputs = [ (if isCrossBuild then pkgsBuildBuild.qt6.qttools else qttools) ];
+
+  cmakeFlags = lib.optionals isCrossBuild [
+    "-DQT_HOST_PATH=${qtHostPathForTranslations}"
+    "-DQt6HostInfo_DIR=${qtHostPathForTranslations}/lib/cmake/Qt6HostInfo"
+    "-DQT_OPTIONAL_TOOLS_PATH=${qtHostPathForTranslations}"
+    "-DQt6LinguistTools_DIR=${qtHostPathForTranslations}/lib/cmake/Qt6LinguistTools"
+  ];
+
+  # MinGW cross: upstream's install logic ends up producing relative "nix/store/..." paths
+  # inside the build tree, and then attempts to `cmake --install` into the output path,
+  # which can fail with confusing "Permission denied" errors. The translations are
+  # architecture-independent, so just copy the generated `.qm` files directly.
+  installPhase = lib.optionalString isMingwCross ''
+    runHook preInstall
+    mkdir -p $out/translations
+    find . -type f -name '*.qm' -path '*/translations/*' -print0 \
+      | xargs -0 -I{} install -m644 {} $out/translations/
+    runHook postInstall
+  '';
+
+  dontUseCmakeInstall = isMingwCross;
   separateDebugInfo = false;
   outputs = [ "out" ];
   allowedReferences = [ "out" ];

--- a/pkgs/development/libraries/qt-6/modules/qtvirtualkeyboard.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtvirtualkeyboard.nix
@@ -6,6 +6,9 @@
   hunspell,
   pkg-config,
   fetchpatch,
+  lib,
+  pkgsBuildBuild,
+  stdenv,
 }:
 
 qtModule {
@@ -24,5 +27,15 @@ qtModule {
       url = "https://github.com/qt/qtvirtualkeyboard/commit/0b1e8be8dd874e1fbacd0c30ed5be7342f6cd44d.patch";
       hash = "sha256-Uk6EJOlkCRLUg1w3ljHaxV/dXEVWyUpP/ijoyjptbNc=";
     })
+  ];
+
+  # Cross: QtVirtualKeyboard is a QtQuick module; ensure Qt::Quick is discoverable
+  # and that host-side Qml/Quick tools are available.
+  cmakeFlags = [
+    "-DQt6Quick_DIR=${qtdeclarative}/lib/cmake/Qt6Quick"
+  ]
+  ++ lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+    "-DQt6QmlTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QmlTools"
+    "-DQt6QuickTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QuickTools"
   ];
 }

--- a/pkgs/development/libraries/qt-6/modules/qtwebview.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtwebview.nix
@@ -4,6 +4,7 @@
   qtModule,
   qtdeclarative,
   qtwebengine,
+  pkgsBuildBuild,
 }:
 
 qtModule {
@@ -11,5 +12,17 @@ qtModule {
   propagatedBuildInputs = [
     qtdeclarative
   ]
-  ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [ qtwebengine ];
+  # qtwebengine isn't available on MinGW hostPlatform in nixpkgs. MSYS2's qt6-webview
+  # also doesn't depend on qt6-webengine. Keep WebEngine only where it is supported.
+  ++ lib.optionals (lib.meta.availableOn stdenv.hostPlatform qtwebengine) [ qtwebengine ];
+
+  # Cross: webview contains a QtQuick QML module (uses qt_internal_add_qml_module).
+  # Ensure Qt6Qml/Qt6Quick are "FOUND" by providing the build-machine tool packages.
+  cmakeFlags = [
+    "-DQt6Quick_DIR=${qtdeclarative}/lib/cmake/Qt6Quick"
+  ]
+  ++ lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+    "-DQt6QmlTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QmlTools"
+    "-DQt6QuickTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QuickTools"
+  ];
 }

--- a/pkgs/servers/sql/mariadb/connector-c/default.nix
+++ b/pkgs/servers/sql/mariadb/connector-c/default.nix
@@ -53,7 +53,27 @@ stdenv.mkDerivation {
     "-DMARIADB_UNIX_ADDR=/run/mysqld/mysqld.sock"
     "-DWITH_CURL=ON"
     "-DWITH_EXTERNAL_ZLIB=ON"
+  ]
+  ++ lib.optionals (!stdenv.hostPlatform.isMinGW) [
     "-DWITH_MYSQLCOMPAT=ON"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isMinGW [
+    # MSYS2 mingw-w64-libmariadbclient builds these plugins STATIC to avoid relocation issues
+    # and to keep the build working with MinGW toolchains.
+    "-DWITH_MYSQLCOMPAT=OFF"
+    "-DWITH_SSL=SCHANNEL"
+    "-DWITH_UNIT_TESTS=OFF"
+    "-DCLIENT_PLUGIN_AUTH_GSSAPI_CLIENT=STATIC"
+    "-DCLIENT_PLUGIN_DIALOG=STATIC"
+    "-DCLIENT_PLUGIN_REMOTE_IO=STATIC"
+    "-DCLIENT_PLUGIN_PVIO_NPIPE=STATIC"
+    "-DCLIENT_PLUGIN_PVIO_SHMEM=STATIC"
+    "-DCLIENT_PLUGIN_CLIENT_ED25519=STATIC"
+    "-DCLIENT_PLUGIN_CACHING_SHA2_PASSWORD=STATIC"
+    "-DCLIENT_PLUGIN_SHA256_PASSWORD=STATIC"
+    "-DCLIENT_PLUGIN_MYSQL_CLEAR_PASSWORD=STATIC"
+    "-DCLIENT_PLUGIN_MYSQL_OLD_PASSWORD=STATIC"
+    "-DCLIENT_PLUGIN_ZSTD=STATIC"
   ];
 
   postPatch = ''
@@ -63,6 +83,11 @@ stdenv.mkDerivation {
       --replace-fail '#define PKG_LIBDIR "%s/@INSTALL_LIBDIR@"' "#define PKG_LIBDIR \"$out/lib/mariadb\"" \
       --replace-fail '#define PLUGIN_DIR "%s/@INSTALL_PLUGINDIR@"' "#define PLUGIN_DIR \"$out/lib/mariadb/plugin\"" \
       --replace-fail '#define PKG_PLUGINDIR "%s/@INSTALL_PLUGINDIR@"' "#define PKG_PLUGINDIR \"$out/lib/mariadb/plugin\""
+  ''
+  + lib.optionalString stdenv.hostPlatform.isMinGW ''
+    # MinGW: strerror_r is not available; use strerror_s instead.
+    substituteInPlace libmariadb/ma_net.c \
+      --replace-fail "strerror_r(save_errno, errmsg, 100);" "strerror_s(errmsg, 100, save_errno);"
   ''
   + lib.optionalString stdenv.hostPlatform.isStatic ''
     # Disables all dynamic plugins
@@ -88,16 +113,61 @@ stdenv.mkDerivation {
   buildInputs = [ libiconv ];
 
   postInstall = ''
-    moveToOutput bin/mariadb_config "$dev"
+    moveToOutput "bin/mariadb_config${stdenv.hostPlatform.extensions.executable}" "$dev"
   '';
 
   postFixup = ''
-    ln -sv mariadb_config $dev/bin/mysql_config
+    mkdir -p $dev/bin
+    ln -sv "mariadb_config${stdenv.hostPlatform.extensions.executable}" "$dev/bin/mysql_config${stdenv.hostPlatform.extensions.executable}"
     ln -sv mariadb $out/lib/mysql
     ln -sv mariadb $dev/include/mysql
     ln -sv mariadb_version.h $dev/include/mariadb/mysql_version.h
     ln -sv libmariadb.pc $dev/lib/pkgconfig/mysqlclient.pc
     install -Dm644 include/ma_config.h $dev/include/mariadb/my_config.h
+  ''
+  + lib.optionalString stdenv.hostPlatform.isMinGW ''
+    # Qt's FindMySQL.cmake looks for MySQL client libraries by conventional names
+    # (e.g. libmysqlclient.dll.a / libmysqlclient_r.dll.a). MSYS2 provides these by
+    # copying/aliasing MariaDB connector libs; do the same so cross-configuration can
+    # find MySQL_LIBRARY.
+    if [ -d "$out/lib/mariadb" ]; then
+      imp_src=""
+      static_src=""
+
+      # Import library name differs across toolchains/buildsystems.
+      for cand in libmariadb.dll.a liblibmariadb.dll.a; do
+        if [ -e "$out/lib/mariadb/$cand" ]; then
+          imp_src="$cand"
+          break
+        fi
+      done
+
+      # Static client library name also varies.
+      for cand in libmariadbclient.a libmariadb.a; do
+        if [ -e "$out/lib/mariadb/$cand" ]; then
+          static_src="$cand"
+          break
+        fi
+      done
+
+      if [ -n "$imp_src" ]; then
+        ln -sf "$imp_src" "$out/lib/mariadb/libmysqlclient.dll.a"
+        ln -sf "$imp_src" "$out/lib/mariadb/libmysqlclient_r.dll.a"
+        # Also provide top-level libdir aliases so CMake's find_library() can locate them
+        # without knowing about the /lib/mariadb subdirectory.
+        mkdir -p "$out/lib"
+        ln -sf "mariadb/libmysqlclient.dll.a" "$out/lib/libmysqlclient.dll.a"
+        ln -sf "mariadb/libmysqlclient_r.dll.a" "$out/lib/libmysqlclient_r.dll.a"
+      fi
+
+      if [ -n "$static_src" ]; then
+        ln -sf "$static_src" "$out/lib/mariadb/libmysqlclient.a"
+        ln -sf "$static_src" "$out/lib/mariadb/libmysqlclient_r.a"
+        mkdir -p "$out/lib"
+        ln -sf "mariadb/libmysqlclient.a" "$out/lib/libmysqlclient.a"
+        ln -sf "mariadb/libmysqlclient_r.a" "$out/lib/libmysqlclient_r.a"
+      fi
+    fi
   '';
 
   meta = {


### PR DESCRIPTION
This PR enables cross-compilation of the Qt6 module set for MingW

After these changes, `pkgsCross.mingwW64.qt6.*` modules evaluate and build successfully, with the exception of:
- `qtwayland` is not applicable on Windows
- `qtwebengine` is not attempted in this PR; also not built by MSYS2 (and already wasn't on Darwin)
- `DBus`  had some multi-output cycle issues in nixpkgs I couldn't figure out, it's not that used on windows iirc, and Qt6 builds without it.

### Dependencies
- #476314 
- #476281 
- #476344 
- #476272 
- #476274 
- #476638  (used by `qtmultimedia`)

### Motivation

Qt6 is a critical framework for cross-platform applications. Enabling MinGW cross-compilation allows building Qt6-based Windows applications directly from Linux hosts using Nix, which is essential for CI/CD pipelines and reproducible Windows builds.

### Approach

This work closely follows MSYS2's mingw-w64-qt6-* packaging as the reference implementation. Where MSYS2 applies patches or uses specific configure flags, equivalent changes are made here. All referenced patches are attributed to MSYS2.

---

## Changes

### Standalone dependency packages

| Package | Change | Purpose |
|---------|--------|---------|
| `duktape` | Enable shared lib build + fix Windows install layout | Libproxy dependency |
| `libproxy` | Enable MinGW + MSYS2 backend install patch | Qt6 network proxy support |
| `libpq` | Enable MinGW + winpthreads + disable OAuth | Qt6 PostgreSQL driver |
| `mariadb-connector-c` | Add MySQL-compatible library symlinks | Qt6 MySQL driver |
| `unixODBC` | Enable MinGW + adjust configure flags | Qt6 ODBC driver |
| `re2` | Make gbenchmark test-only dependency | Unblock grpc → qtgrpc |
| `abseil-cpp` | Add winpthreads for pthread.h | gRPC dependency |
| `grpc` | Enable MinGW shared libs + disable cross codegen | Qt6 qtgrpc support |
| `jasper` | Enable MinGW + 3 MSYS2 patches | Qt6 JPEG-2000 support |
| `libheif`, `libde265` | Allow Windows platforms | Qt6 HEIF support |
| `libmng` | Propagate lcms2 for MinGW linking | Qt6 MNG support |
| `assimp` | Enable MinGW + 4 patches (version compat, DLL exports, import lib fix) | Qt6 qt3d dependency |

### Qt6 base layer

| Module | Change |
|--------|--------|
| `qtbase` | Platform-conditional deps (OpenGL/Vulkan/Wayland), enable SQL drivers on MinGW |
| `qtmultimedia` | Fix D3D11 header case sensitivity for cross builds |
| `qtdeclarative` | Add host Qt tools for QML tooling during cross builds |

### Qt6 modules with cross-compilation plumbing

All remaining Qt6 modules receive host Qt tool dependencies for cross builds:

`qtdatavis3d`, `qtdoc`, `qtgraphs`, `qtlottie`, `qtquick3d`, `qtquicktimeline`, `qtlocation`, `qtpositioning`, `qtremoteobjects`, `qtscxml`, `qtvirtualkeyboard`, `qtwebview`, `qtquick3dphysics`, `qtquickeffectmaker`, `qttranslations`


## Validation

`nix build` with & without `pkgsCross.mingwW64` i.e:

`nix build .#pkgsCross.mingwW64.qt6.qtbase --no-link -L`
`nix build .#pkgsCross.mingwW64.qt6.qtdeclarative --no-link -L`
`nix build .#pkgsCross.mingwW64.qt6.qtmultimedia --no-link -L`
`nix build .#pkgsCross.mingwW64.qt6.qt3d --no-link -L`

```bash
for mod in qt5compat qtbase qtcharts qtconnectivity qtdatavis3d \
           qtdeclarative qtgrpc qtimageformats qtlocation qtlottie \
           qtmultimedia qtpositioning qtquick3d qtquick3dphysics \
           qtquickeffectmaker qtquicktimeline qtremoteobjects qtscxml \
           qtsvg qttranslations qtvirtualkeyboard qtwebchannel qtwebsockets \
           qtwebview qt3d qtgraphs; do
  nix build .#pkgsCross.mingwW64.qt6.$mod --no-link -L || echo "FAILED: $mod"
done
```

---

## Things done

- Built on platform:
  - [x] x86_64-linux (cross-compiling to x86_64-w64-mingw32)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

## References

- MSYS2 mingw-w64-qt6-* packages: https://github.com/msys2/MINGW-packages/tree/master/mingw-w64-qt6-base
- MSYS2 dependency packages (assimp, jasper, grpc, etc.) referenced individually in commit messages