### PR TITLE
Revert "python314Packages.llm: disable failing tests"

### DIFF
--- a/pkgs/development/python-modules/llm/default.nix
+++ b/pkgs/development/python-modules/llm/default.nix
@@ -6,7 +6,6 @@
   fetchFromGitHub,
   fetchpatch,
   pytestCheckHook,
-  pythonAtLeast,
   pythonOlder,
   replaceVars,
   setuptools,
@@ -250,13 +249,6 @@ let
       # TypeError: CliRunner.__init__() got an unexpected keyword argument 'mix_stderr
       # https://github.com/simonw/llm/issues/1293
       "test_embed_multi_files_encoding"
-    ]
-    ++ lib.optionals (pythonAtLeast "3.14") [
-      # Index out of range
-      # https://github.com/simonw/llm/issues/1335
-      "test_logs_fragments"
-      "test_expand_fragment_json"
-      "test_expand_fragment_markdown"
     ];
 
     pythonImportsCheck = [ "llm" ];


### PR DESCRIPTION
This reverts commit b28eb85200dd9abf93f46012c4cfc31cc0430989 from https://github.com/NixOS/nixpkgs/pull/477241. It was already fixed in https://github.com/NixOS/nixpkgs/pull/477234.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test