### PR TITLE
hypothesis-jsonschema: init at 0.23.1 

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14899,6 +14899,12 @@
     githubId = 22010764;
     name = "Liam Weitzel";
   };
+  liamdevoe = {
+    email = "orionldevoe@gmail.com";
+    github = "Liam-Devoe";
+    githubId = 31628143;
+    name = "Liam DeVoe";
+  };
   liamdiprose = {
     email = "liam@liamdiprose.com";
     github = "liamdiprose";

--- a/pkgs/development/python-modules/hypothesis-jsonschema/default.nix
+++ b/pkgs/development/python-modules/hypothesis-jsonschema/default.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  hypothesis,
+  jsonschema,
+  pytestCheckHook,
+  pytest-xdist,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "hypothesis-jsonschema";
+  version = "0.23.1";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-9KwDICQ0KkFJoQJTmE9aVza4Kz/ir7CIjzg0oxFT8hU=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    hypothesis
+    jsonschema
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-xdist
+  ];
+
+  # tox.ini has pytest coverage flags that require pytest-cov; remove it
+  preCheck = ''
+    rm tox.ini
+  '';
+
+  pytestFlags = [
+    # some hypothesis-jsonschema tests depend on -Werror turning warnings into
+    # errors. In the repo itself, this is set by tox.ini, which we removed above.
+    "-Werror"
+  ];
+
+  disabledTestPaths = [
+    # The pypi sdist does not include CHANGELOG.md or the schema json files
+    # required by these tests.
+    "tests/test_version.py"
+    "tests/test_canonicalise.py"
+    "tests/test_from_schema.py"
+  ];
+
+  pythonImportsCheck = [ "hypothesis_jsonschema" ];
+
+  meta = {
+    description = "Generate test data from JSON schemata with Hypothesis";
+    homepage = "https://github.com/python-jsonschema/hypothesis-jsonschema";
+    license = lib.licenses.mpl20;
+    maintainers = [
+      lib.maintainers.liamdevoe
+    ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7137,6 +7137,8 @@ self: super: with self; {
 
   hypothesis-auto = callPackage ../development/python-modules/hypothesis-auto { };
 
+  hypothesis-jsonschema = callPackage ../development/python-modules/hypothesis-jsonschema { };
+
   hypothesmith = callPackage ../development/python-modules/hypothesmith { };
 
   hyppo = callPackage ../development/python-modules/hyppo { };


### PR DESCRIPTION
Adding hypothesis-jsonschema: https://github.com/python-jsonschema/hypothesis-jsonschema

First-time nix contributor, guide me if I did something wrong :slightly_smiling_face: 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
