### PR TITLE
keyd: add pygobject3 and dbus-python to keyd-application-mapper script dependencies

### DIFF
--- a/pkgs/by-name/ke/keyd/package.nix
+++ b/pkgs/by-name/ke/keyd/package.nix
@@ -27,7 +27,11 @@ let
         --replace-fail /bin/sh ${runtimeShell}
     '';
 
-    propagatedBuildInputs = with python3Packages; [ xlib ];
+    propagatedBuildInputs = with python3Packages; [
+      xlib
+      pygobject3.out
+      dbus-python.out
+    ];
 
     dontBuild = true;
 


### PR DESCRIPTION
The script imports dbus (dbus-python) and gi (pygobject3) modules in its KDE support section: https://github.com/rvaiya/keyd/blob/7c0aecb8bfd34dc8642bf4eefd2e59c89e61cec3/scripts/keyd-application-mapper#L177

Add these modules to dependencies to fix KDE support failing silently
