### PR TITLE
nixVersions.nix_2_31: 2.31.2 -> 2.31.3

### DIFF
--- a/nixos/modules/installer/tools/nix-fallback-paths.nix
+++ b/nixos/modules/installer/tools/nix-fallback-paths.nix
@@ -1,8 +1,8 @@
 {
-  x86_64-linux = "/nix/store/x30lnlgk1s16rynrfslbf8phr6h6rqf2-nix-2.31.2";
-  i686-linux = "/nix/store/ix94q6rrdg6cr4893cjpzdbmibhlm0dv-nix-2.31.2";
-  aarch64-linux = "/nix/store/xnybj9lk0kwvmr2va253avanq7m3cpyg-nix-2.31.2";
-  riscv64-linux = "/nix/store/33as1vqp8mq36nr5bb5gr7ziw1nf4q1v-nix-riscv64-unknown-linux-gnu-2.31.2";
-  x86_64-darwin = "/nix/store/b9dvary8rcljj7ajv1x64hwwch4cvyvp-nix-2.31.2";
-  aarch64-darwin = "/nix/store/lvv1j8qbrvlnl3aagcjrhf42d458zgb5-nix-2.31.2";
+  x86_64-linux = "/nix/store/mxn3vxpvk2b42kgd08aw4bn27qhf434w-nix-2.31.3";
+  i686-linux = "/nix/store/b7d35ifww9683l74ydkb0qhrq6lqcisi-nix-2.31.3";
+  aarch64-linux = "/nix/store/ysz7dwmy4zd1zm3wzx5dh9g999xv7pbm-nix-2.31.3";
+  riscv64-linux = "/nix/store/avfv2lqbnphj2ap8y5ihg1l0sqhpjll7-nix-riscv64-unknown-linux-gnu-2.31.3";
+  x86_64-darwin = "/nix/store/s8lcl6nrd5ia7nr4zx9mg720i9f8qm37-nix-2.31.3";
+  aarch64-darwin = "/nix/store/vfjzbcl3kf9jjwh0g2x03cvz2x5hg8py-nix-2.31.3";
 }

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -167,34 +167,17 @@ lib.makeExtensible (
 
       nix_2_30 = addTests "nix_2_30" self.nixComponents_2_30.nix-everything;
 
-      nixComponents_2_31 =
-        (nixDependencies.callPackage ./modular/packages.nix rec {
-          version = "2.31.2";
-          inherit (self.nix_2_30.meta) teams;
-          otherSplices = generateSplicesForNixComponents "nixComponents_2_31";
-          src = fetchFromGitHub {
-            owner = "NixOS";
-            repo = "nix";
-            tag = version;
-            hash = "sha256-NLGXPLjENLeKVOg3OZgHXZ+1x6sPIKq9FHH8pxbCrDI=";
-          };
-        }).appendPatches
-          (
-            [
-              (fetchpatch2 {
-                name = "nix-2.31-14692-mdbook-0.5-support.patch";
-                url = "https://github.com/NixOS/nix/commit/a4f5f365090980a6eeb2ef483e49c04bdefd71a8.patch";
-                hash = "sha256-GOWZtHSzHovnD8iUknr61bo7y85i0BKdw3kVBGDfBX0=";
-              })
-            ]
-            ++
-              # issues on darwin: https://github.com/NixOS/nixpkgs/pull/468208#issuecomment-3626314109
-              lib.optional stdenv.isLinux (fetchpatch2 {
-                name = "nix-2.31-14240-sri-error-message.patch";
-                url = "https://github.com/NixOS/nix/commit/56751b1cd2c4700c71c545f2246adf602c97fdf5.patch";
-                hash = "sha256-CerSBAI+H2RqPp9jsCP0QIM2rZYx3yBZHVVUAztgc18=";
-              })
-          );
+      nixComponents_2_31 = nixDependencies.callPackage ./modular/packages.nix rec {
+        version = "2.31.3";
+        inherit (self.nix_2_30.meta) teams;
+        otherSplices = generateSplicesForNixComponents "nixComponents_2_31";
+        src = fetchFromGitHub {
+          owner = "NixOS";
+          repo = "nix";
+          tag = version;
+          hash = "sha256-oe0YWe8f+pwQH4aYD2XXLW5iEHyXNUddurqJ5CUVCIk=";
+        };
+      };
 
       nix_2_31 = addTests "nix_2_31" self.nixComponents_2_31.nix-everything;
 


### PR DESCRIPTION
This PR targets staging-nixos due to needing to rebuild all NixOS tests.

Small changelog:

## Bug fixes (crashes)

- Fix segfaults from `toView()` when compiled with newer nixpkgs (NixOS/nix#14154)
- Fix use-after-move in `DerivationGoal::repairClosure` and `SampleStack` (NixOS/nix#14086)
- Fix assertion failure on partially valid derivation outputs (NixOS/nix#14137)
- Fix `RestrictedStore::addDependency` recursion causing crashes (NixOS/nix#14729)
- Fix crash on flakerefs containing newlines (NixOS/nix#14491)

## Bug fixes (functionality)

- Fix fakeSSH check breaking SSH copies with `user@host` format (NixOS/nix#14150)
- Fix `builtins.dirOf` regression from Nix 2.23 (NixOS/nix#14515)
- Restore missing `isAllowed` check in `ChrootLinuxDerivationBuilder` (NixOS/nix#14531)
- Fix curl with c-ares failing to resolve DNS in sandbox on macOS (NixOS/nix#14792)
- Fix tarball percent decoding for `file://` URIs (NixOS/nix#14909)
- `exportReferencesGraph`: Handle heterogeneous arrays (NixOS/nix#14189)
- Fix filesystem ops in store optimization (NixOS/nix#14676)

## Bug fixes (output)

- Fix double-quoting of paths in logs (NixOS/nix#14210)
- Include path in world-writable error messages (NixOS/nix#14785)

## Improvements

- Better git refnames validation (NixOS/nix#14253)
- Use pure/restricted eval for help pages (NixOS/nix#14086)
- Improve store-reference compatibility with IPv6 ZoneId literals (NixOS/nix#14437)
- Correct `build-dir` error in manual (NixOS/nix#14745)

## Build system

- Add mdbook 0.5 support (NixOS/nix#14690)
- Drop legacy Apple SDK pattern (NixOS/nix#13976)

https://github.com/NixOS/nix/releases/tag/2.31.3

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test