### PR TITLE
librttopo: change src to gitlab mirror

### DIFF
--- a/pkgs/by-name/li/librttopo/package.nix
+++ b/pkgs/by-name/li/librttopo/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitea,
+  fetchFromGitLab,
   autoreconfHook,
   validatePkgConfig,
   geos,
@@ -16,12 +16,11 @@ stdenv.mkDerivation rec {
     "dev"
   ];
 
-  src = fetchFromGitea {
-    domain = "git.osgeo.org/gitea";
+  src = fetchFromGitLab {
     owner = "rttopo";
-    repo = "librttopo";
+    repo = "rttopo";
     rev = "librttopo-${version}";
-    sha256 = "0h7lzlkn9g4xky6h81ndy0aa6dxz8wb6rnl8v3987jy1i6pr072p";
+    hash = "sha256-VxyQr4nBy4PS2IjabBZHvzejFPDNBgSNn528ZCf99EA=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

the gitea instance is returning a 404 for me. I tested this with:

```
nix build .#librttopo.src --rebuild -L
```

If I run this I get:

```
nix build .#librttopo.src --rebuild -L

source> structuredAttrs is enabled
source>
source> trying https://git.osgeo.org/gitea/rttopo/librttopo/archive/librttopo-1.1.0.tar.gz
source>   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
source>                                  Dload  Upload   Total   Spent    Left  Speed
source> 100   154 100   154   0     0   353     0  --:--:-- --:--:-- --:--:--   353
source>   0     0   0     0   0     0     0     0  --:--:-- --:--:-- --:--:--     0
source> curl: (22) SSL certificate OpenSSL verify result: unable to get local issuer certificate (20)
source> Warning: Problem (retrying all errors). Will retry in 1 second. 3 retries left.
source> 100   154 100   154   0     0  1447     0  --:--:-- --:--:-- --:--:--  1452
source>   0     0   0     0   0     0     0     0  --:--:-- --:--:-- --:--:--     0
source> curl: (22) SSL certificate OpenSSL verify result: unable to get local issuer certificate (20)
source> Warning: Problem (retrying all errors). Will retry in 2 seconds. 2 retries
source> Warning: left.
source> 100   154 100   154   0     0  1394     0  --:--:-- --:--:-- --:--:--  1387
source>   0     0   0     0   0     0     0     0  --:--:-- --:--:-- --:--:--     0
source> curl: (22) SSL certificate OpenSSL verify result: unable to get local issuer certificate (20)
source> Warning: Problem (retrying all errors). Will retry in 4 seconds. 1 retry left.
source> 100   154 100   154   0     0  1394     0  --:--:-- --:--:-- --:--:--  1400
source>   0     0   0     0   0     0     0     0  --:--:-- --:--:-- --:--:--     0
source> curl: (22) SSL certificate OpenSSL verify result: unable to get local issuer certificate (20)
source> error: cannot download source from any mirror
error: Cannot build '/nix/store/bg093xrw8m4rdzi1pwigw7rql4n7icbz-source.drv'
```

on b8aae46. I found a github mirror and moved there. There might be some finnicking we need to do with the fetchgitea to get it to work, but it wasn't clear to me how to do that. Instead of this PR we could also reach out to upstream. Just wanted mostly to flag this as a problem with this PR.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
