### PR TITLE
mmlgui: Fix GCC 15 compat

### DIFF
--- a/pkgs/applications/audio/mmlgui/default.nix
+++ b/pkgs/applications/audio/mmlgui/default.nix
@@ -14,14 +14,14 @@
 
 stdenv.mkDerivation {
   pname = "mmlgui";
-  version = "210420-preview-unstable-2024-04-15";
+  version = "210420-preview-unstable-2026-01-09";
 
   src = fetchFromGitHub {
     owner = "superctr";
     repo = "mmlgui";
-    rev = "e49f225ac2b2d46056b2c45a5d31c544227c4968";
+    rev = "9803a154c5fdbe6e88956e391ea0d5c4eae18cdc";
     fetchSubmodules = true;
-    hash = "sha256-hj2k1BrE8AA2HTBEO03RammlZV2U4KW0gLJmFNiaSvI=";
+    hash = "sha256-3HMSVSgqusIhFf7jheyC2ytoJqSsJA8yYUnhxvdteq0=";
   };
 
   postPatch = ''


### PR DESCRIPTION
https://github.com/superctr/ctrmml/pull/10
https://github.com/superctr/mmlgui/pull/11

~~Draft because the UI inside the window is unresponsive for me, but I'm on an uncommon Wayland compositor. Will check at home.~~

Responsive on my desktop, prolly an issue specific to that compositor.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
