### PR TITLE
python3Packages.pgmpy: 1.0.0 -> 1.0.0-unstable-2025-12-20 (for python 3.14 compatibility)

### DIFF
--- a/pkgs/development/python-modules/pgmpy/default.nix
+++ b/pkgs/development/python-modules/pgmpy/default.nix
@@ -24,7 +24,7 @@
   pytest-cov-stub,
   mock,
 }:
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pgmpy";
   version = "1.0.0";
   pyproject = true;
@@ -32,7 +32,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "pgmpy";
     repo = "pgmpy";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-WmRtek3lN7vEfXqoaZDiaNjMQ7R2PmJ/OEwxOV7m5sE=";
   };
 
@@ -81,8 +81,8 @@ buildPythonPackage rec {
   meta = {
     description = "Python Library for learning (Structure and Parameter), inference (Probabilistic and Causal), and simulations in Bayesian Networks";
     homepage = "https://github.com/pgmpy/pgmpy";
-    changelog = "https://github.com/pgmpy/pgmpy/releases/tag/${src.tag}";
+    changelog = "https://github.com/pgmpy/pgmpy/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ happysalada ];
   };
-}
+})

--- a/pkgs/development/python-modules/pgmpy/default.nix
+++ b/pkgs/development/python-modules/pgmpy/default.nix
@@ -12,6 +12,7 @@
   pandas,
   pyparsing,
   pyro-ppl,
+  scikit-base,
   scikit-learn,
   scipy,
   statsmodels,
@@ -23,17 +24,18 @@
   pytestCheckHook,
   pytest-cov-stub,
   mock,
+  writableTmpDirAsHomeHook,
 }:
 buildPythonPackage (finalAttrs: {
   pname = "pgmpy";
-  version = "1.0.0";
+  version = "1.0.0-unstable-2025-12-20";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pgmpy";
     repo = "pgmpy";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-WmRtek3lN7vEfXqoaZDiaNjMQ7R2PmJ/OEwxOV7m5sE=";
+    rev = "197e1e0444c77c00581a4c32763811e5b03f8503";
+    hash = "sha256-TCnn3GrITW8HCrYVeeythiULV130b6uulkijkPpJOqA=";
   };
 
   dependencies = [
@@ -45,6 +47,7 @@ buildPythonPackage (finalAttrs: {
     pandas
     pyparsing
     pyro-ppl
+    scikit-base
     scikit-learn
     scipy
     statsmodels
@@ -67,6 +70,20 @@ buildPythonPackage (finalAttrs: {
 
     # AssertionError
     "test_estimate_example_smoke_test"
+    "test_gcm"
+  ];
+
+  enabledTestPaths = [
+    "pgmpy/tests"
+  ];
+
+  disabledTestPaths = [
+    # requires network access
+    "pgmpy/tests/test_datasets"
+
+    # Very slow
+    "pgmpy/tests/test_estimators"
+    "pgmpy/tests/test_models"
   ];
 
   nativeCheckInputs = [
@@ -74,6 +91,7 @@ buildPythonPackage (finalAttrs: {
     # xdoctest
     pytest-cov-stub
     mock
+    writableTmpDirAsHomeHook
   ];
 
   pythonImportsCheck = [ "pgmpy" ];
@@ -81,7 +99,7 @@ buildPythonPackage (finalAttrs: {
   meta = {
     description = "Python Library for learning (Structure and Parameter), inference (Probabilistic and Causal), and simulations in Bayesian Networks";
     homepage = "https://github.com/pgmpy/pgmpy";
-    changelog = "https://github.com/pgmpy/pgmpy/releases/tag/${finalAttrs.src.tag}";
+    # changelog = "https://github.com/pgmpy/pgmpy/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       happysalada

--- a/pkgs/development/python-modules/pgmpy/default.nix
+++ b/pkgs/development/python-modules/pgmpy/default.nix
@@ -83,6 +83,9 @@ buildPythonPackage (finalAttrs: {
     homepage = "https://github.com/pgmpy/pgmpy";
     changelog = "https://github.com/pgmpy/pgmpy/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ happysalada ];
+    maintainers = with lib.maintainers; [
+      happysalada
+      sarahec
+    ];
   };
 })


### PR DESCRIPTION
1. Applied `finalAttrs:` fix.
2. Added self as maintainer (since this is a big change)
3. Version bump to last pushed revision.

Discovered in nixpkgs-review #478133

Tracking: #475732

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
