### PR TITLE
smartmontools: update drivedb; move to github; support auto updates

### DIFF
--- a/pkgs/by-name/sm/smartmontools/package.nix
+++ b/pkgs/by-name/sm/smartmontools/package.nix
@@ -90,7 +90,10 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Tools for monitoring the health of hard drives";
     homepage = "https://www.smartmontools.org/";
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [ Frostman ];
+    maintainers = with lib.maintainers; [
+      Frostman
+      samasaur
+    ];
     platforms = with lib.platforms; linux ++ darwin;
     mainProgram = "smartctl";
   };

--- a/pkgs/by-name/sm/smartmontools/package.nix
+++ b/pkgs/by-name/sm/smartmontools/package.nix
@@ -1,23 +1,18 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
   autoreconfHook,
   enableMail ? false,
   gnused,
   hostname,
   mailutils,
   systemdLibs,
+  writeShellScript,
+  nix-update,
 }:
 
 let
-  dbrev = "5714";
-  drivedbBranch = "RELEASE_7_5_DRIVEDB";
-  driverdb = fetchurl {
-    url = "https://sourceforge.net/p/smartmontools/code/${dbrev}/tree/branches/${drivedbBranch}/smartmontools/drivedb.h?format=raw";
-    sha256 = "sha256-DndzUHpZex3F9WXYq+kNDWvkLNc1OZX3KR0mby5cKbA=";
-    name = "smartmontools-drivedb.h";
-  };
   scriptPath = lib.makeBinPath (
     [
       gnused
@@ -27,21 +22,26 @@ let
   );
 
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "smartmontools";
   version = "7.5";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/smartmontools/${pname}-${version}.tar.gz";
-    hash = "sha256-aQuDyjMTeNqeoNnWEAjEsi3eOROHubutfyk4fyWV924=";
+  src = fetchFromGitHub {
+    owner = "smartmontools";
+    repo = "smartmontools";
+    tag = "RELEASE_${lib.replaceString "." "_" finalAttrs.version}";
+    hash = "sha256-/2J73F97yiPlUnGkzewWzU+sARaeqgVc/3ScjVlHhQE=";
   };
 
+  prePatch = ''
+    cd smartmontools
+  '';
   patches = [
     # fixes darwin build
     ./smartmontools.patch
   ];
   postPatch = ''
-    cp -v ${driverdb} drivedb.h
+    ln -sf "$drivedb" drivedb.h
   '';
 
   configureFlags = [
@@ -54,6 +54,38 @@ stdenv.mkDerivation rec {
   buildInputs = lib.optionals (lib.meta.availableOn stdenv.hostPlatform systemdLibs) [ systemdLibs ];
   enableParallelBuilding = true;
 
+  drivedb = fetchFromGitHub {
+    owner = "smartmontools";
+    repo = "smartmontools";
+    rev = "794fa5069ee298c82f93ff0a7f7ef6a5fdd10e5e";
+    hash = "sha256-WBed5elI+WsIiIJ1YVkdVGJ4XMrGRFIFWqk6ffVl0bU=";
+    postFetch = ''
+      mv "$out/smartmontools/drivedb.h" "$TMPDIR/drivedb.h"
+      rm -rf "$out"
+      mv "$TMPDIR/drivedb.h" "$out"
+    '';
+    passthru = {
+      # Necessary so that nix-update can update the drivedb
+      src = finalAttrs.drivedb;
+      pname = "smartmontools-drivedb";
+      version = "${finalAttrs.version}-drivedb-unstable";
+    };
+  };
+
+  passthru.updateScript = writeShellScript "update-smartmontools" ''
+    # Set a default attribute path
+    # When running maintainers/scripts/update.nix this is set automatically,
+    # but this allows running this update script directly.
+    UPDATE_NIX_ATTR_PATH="''${UPDATE_NIX_ATTR_PATH:-smartmontools}"
+
+    # Update smartmontools
+    ${lib.getExe nix-update} "$UPDATE_NIX_ATTR_PATH" --version-regex 'RELEASE_(\d+)_(\d+)(?:_(\d+))?'
+
+    # Update drivedb.h
+    branch="origin/$(nix-instantiate --eval --raw --attr "$UPDATE_NIX_ATTR_PATH.src.tag")_DRIVEDB"
+    ${lib.getExe nix-update} "$UPDATE_NIX_ATTR_PATH.drivedb" "--version=branch=$branch"
+  '';
+
   meta = {
     description = "Tools for monitoring the health of hard drives";
     homepage = "https://www.smartmontools.org/";
@@ -62,4 +94,4 @@ stdenv.mkDerivation rec {
     platforms = with lib.platforms; linux ++ darwin;
     mainProgram = "smartctl";
   };
-}
+})

--- a/pkgs/by-name/sm/smartmontools/smartmontools.patch
+++ b/pkgs/by-name/sm/smartmontools/smartmontools.patch
@@ -1,19 +1,6 @@
-diff --git a/../smartmontools-6.5/configure b/./configure
-index acb028a..5e2c7a1 100755
---- a/../smartmontools-6.5/configure
-+++ b/./configure
-@@ -6703,7 +6703,7 @@ fi
-     ;;
-   *-*-darwin*)
-     os_deps='os_darwin.o'
--    os_libs='-framework CoreFoundation -framework IOKit'
-+    os_libs='-framework ApplicationServices -framework IOKit'
-     os_darwin=yes
-     os_man_filter=Darwin
-     ;;
-diff --git a/../smartmontools-6.5/configure.ac b/./configure.ac
+diff --git a/./configure.ac b/./configure.ac
 index 6bd61d7..32ff50c 100644
---- a/../smartmontools-6.5/configure.ac
+--- a/./configure.ac
 +++ b/./configure.ac
 @@ -508,7 +508,7 @@ case "${host}" in
      ;;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Fetches from GitHub instead of SourceForge. This allows getting the latest version of the drive database (also done in this PR). I've also restructured the package a little to enable auto-updates of both the main package and the drivedb. While making these changes I also dropped part of the patch (since it no longer applied after swapping to GitHub) and converted the package to use `finalAttrs`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
