### PR TITLE
tetrd: 1.0.4 -> 1.3.1-1, modify module

### DIFF
--- a/nixos/modules/services/networking/tetrd.nix
+++ b/nixos/modules/services/networking/tetrd.nix
@@ -5,24 +5,30 @@
   ...
 }:
 
+let
+  cfg = config.services.tetrd;
+in
 {
-  options.services.tetrd.enable = lib.mkEnableOption "tetrd";
+  options.services.tetrd = {
+    enable = lib.mkEnableOption "tetrd";
+    package = lib.mkPackageOption pkgs "tetrd" { };
+  };
 
-  config = lib.mkIf config.services.tetrd.enable {
+  config = lib.mkIf cfg.enable {
     environment = {
-      systemPackages = [ pkgs.tetrd ];
-      etc."resolv.conf".source = "/etc/tetrd/resolv.conf";
+      systemPackages = [ cfg.package ];
+      # etc."resolv.conf".source = "/etc/tetrd/resolv.conf"; # Disabled overwriting of resolve.conf since otherwise tetrd disables your dns when its not connected to a device.
     };
 
     systemd = {
       tmpfiles.rules = [ "f /etc/tetrd/resolv.conf - - -" ];
 
       services.tetrd = {
-        description = pkgs.tetrd.meta.description;
+        description = cfg.package.meta.description;
         wantedBy = [ "multi-user.target" ];
 
         serviceConfig = {
-          ExecStart = "${pkgs.tetrd}/opt/Tetrd/bin/tetrd";
+          ExecStart = "${cfg.package}/opt/Tetrd/bin/tetrd";
           Restart = "always";
           RuntimeDirectory = "tetrd";
           RootDirectory = "/run/tetrd";

--- a/pkgs/by-name/te/tetrd/package.nix
+++ b/pkgs/by-name/te/tetrd/package.nix
@@ -19,15 +19,16 @@
   libappindicator,
   udev,
   libgbm,
+  libGL,
 }:
 
 stdenv.mkDerivation rec {
   pname = "tetrd";
-  version = "1.0.4";
+  version = "1.3.1-1";
 
   src = fetchurl {
-    url = "https://web.archive.org/web/20211130190525/https://download.tetrd.app/files/tetrd.linux_amd64.pkg.tar.xz";
-    sha256 = "1bxp7rg2dm9nnvkgg48xd156d0jgdf35flaw0bwzkkh3zz9ysry2";
+    url = "https://web.archive.org/web/20260108185127/https://download.tetrd.app/files/tetrd.linux_amd64.pkg.tar.xz";
+    sha256 = "0mpixs20jrxkbxvd7nl0p664jgqfp3m6qf7kmsj7frkhky697fbm";
   };
 
   sourceRoot = ".";
@@ -40,6 +41,7 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
+    libGL
     c-ares
     ffmpeg
     libevent
@@ -69,6 +71,9 @@ stdenv.mkDerivation rec {
     wrapProgram $out/opt/Tetrd/tetrd \
       --prefix LD_LIBRARY_PATH ":" ${lib.makeLibraryPath buildInputs}
 
+    mkdir $out/bin
+    ln -s $out/opt/Tetrd/tetrd $out/bin/tetrd
+
     runHook postInstall
   '';
 
@@ -82,5 +87,6 @@ stdenv.mkDerivation rec {
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.unfree;
     platforms = [ "x86_64-linux" ];
+    mainProgram = "tetrd";
   };
 }


### PR DESCRIPTION
Updated the `tetrd` package to the newest version and also added the binary to the `$out/bin` folder (idk why this wasn't done before) ((This would also close #394361)).

Also modified the service so that there is a package option, and I made it so the `/etc/resolve.conf` doesn't get overwritten by the one tetrd makes in `/etc/tetrd/resolv.conf`, since that one breaks your dns when you disconnect your phone (since it just makes the file empty). I could potentially make a option that restores this functionality but  I don't think its needed.

This is my first PR to nixpkgs, hope I did everything right :P.

Closes #451459

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
