### PR TITLE
sm64coopdx: 1.4 -> 1.4.1; cleanup

### DIFF
--- a/pkgs/by-name/sm/sm64coopdx/package.nix
+++ b/pkgs/by-name/sm/sm64coopdx/package.nix
@@ -40,13 +40,14 @@ in
 # note: there is a generic builder in pkgs/games/sm64ex/generic.nix that is meant to help build sm64ex and its forks; however sm64coopdx has departed significantly enough in its build that it doesn't make sense to use that other than the baseRom derivation
 stdenv.mkDerivation (finalAttrs: {
   pname = "sm64coopdx";
-  version = "1.4";
+  version = "1.4.1";
 
   src = fetchFromGitHub {
     owner = "coop-deluxe";
     repo = "sm64coopdx";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-ct7X6LCitk1QID00guvYOMfIwnZccMeXqXwUB3ioKh8=";
+    # Replace with `tag = "v${finalAttrs.version}";` in the next version. The upstream repository tagged the wrong commit.
+    rev = "6092488d1c4fc741b16a0789ef9c08ec0279333f";
+    hash = "sha256-BIdKKIp6q9Vp2DByXzT9CJzOszFhjriiWBEqFwUT28M=";
   };
 
   patches = [ ./no-update-check.patch ];

--- a/pkgs/by-name/sm/sm64coopdx/package.nix
+++ b/pkgs/by-name/sm/sm64coopdx/package.nix
@@ -143,7 +143,7 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = [ lib.maintainers.shelvacu ];
     mainProgram = "sm64coopdx";
     homepage = "https://sm64coopdx.com/";
-    changelog = "https://github.com/coop-deluxe/sm64coopdx/releases/tag/v1.3";
+    changelog = "https://github.com/coop-deluxe/sm64coopdx/releases/tag/${finalAttrs.version}";
     sourceProvenance = with lib.sourceTypes; [
       fromSource
       # The lua engine, discord sdk, and coopnet library are vendored pre-built. See https://github.com/coop-deluxe/sm64coopdx/tree/v1.0.3/lib

--- a/pkgs/by-name/sm/sm64coopdx/package.nix
+++ b/pkgs/by-name/sm/sm64coopdx/package.nix
@@ -72,7 +72,7 @@ stdenv.mkDerivation (finalAttrs: {
   desktopItems = [
     (makeDesktopItem {
       name = finalAttrs.pname;
-      desktopName = "Super Mario 64 Coop Deluxe";
+      desktopName = "sm64coopdx";
       exec = "sm64coopdx";
       icon = finalAttrs.pname;
       categories = [ "Game" ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->


Resolves #478143
https://github.com/coop-deluxe/sm64coopdx/releases/tag/v1.4.1

The upstream repository tagged the wrong commit, so I used the correct rev instead of the tag.
The rev is correct as the change from the last commit was described in the release changelog.
Linking to the upstream issue that I opened: https://github.com/coop-deluxe/sm64coopdx/issues/1074

I also updated the changelog link to use the correct version and the desktop item to the correct name (as described on their homepage).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
