### PR TITLE
xf86-video-{apm,ast,ati,chips,cirrus}: refactor, move to pkgs/by-name & rename from xorg namespace

### DIFF
--- a/pkgs/by-name/xf/xf86-video-apm/package.nix
+++ b/pkgs/by-name/xf/xf86-video-apm/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  autoreconfHook,
+  pkg-config,
+  util-macros,
+  xorg-server,
+  xorgproto,
+  libpciaccess,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xf86-video-apm";
+  version = "1.3.0";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    group = "xorg";
+    owner = "driver";
+    repo = "xf86-video-apm";
+    tag = "xf86-video-apm-${finalAttrs.version}";
+    hash = "sha256-Q10YmtxgWiFvMqvS0RKBhWPVqyFoWNjTe1RLvt7Kxlg=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+    util-macros
+    xorg-server # for some autoconf macros
+  ];
+
+  buildInputs = [
+    xorg-server
+    xorgproto
+    libpciaccess
+  ];
+
+  passthru = {
+    updateScript = nix-update-script { extraArgs = [ "--version-regex=xf86-video-apm-(.*)" ]; };
+  };
+
+  meta = {
+    description = "Alliance Promotion video driver for the Xorg X server";
+    homepage = "https://gitlab.freedesktop.org/xorg/driver/xf86-video-apm";
+    license = with lib.licenses; [
+      x11
+      mit
+    ];
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+    broken = stdenv.hostPlatform.isAarch64;
+  };
+})

--- a/pkgs/by-name/xf/xf86-video-ast/package.nix
+++ b/pkgs/by-name/xf/xf86-video-ast/package.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  autoreconfHook,
+  pkg-config,
+  util-macros,
+  xorg-server,
+  xorgproto,
+  libpciaccess,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xf86-video-ast";
+  version = "1.2.0";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    group = "xorg";
+    owner = "driver";
+    repo = "xf86-video-ast";
+    tag = "xf86-video-ast-${finalAttrs.version}";
+    hash = "sha256-5fZ0+6Jf/QBuR9l2lOsh4RQEGKrR9XttEvwOVO8w3t4=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+    util-macros
+    xorg-server # for some autoconf macros
+  ];
+
+  buildInputs = [
+    xorg-server
+    xorgproto
+    libpciaccess
+  ];
+
+  passthru = {
+    updateScript = nix-update-script { extraArgs = [ "--version-regex=xf86-video-ast-(.*)" ]; };
+  };
+
+  meta = {
+    description = "ASpeed Technologies graphics driver for the Xorg X server";
+    homepage = "https://gitlab.freedesktop.org/xorg/driver/xf86-video-ast";
+    license = lib.licenses.hpndSellVariant;
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+    broken = stdenv.hostPlatform.isAarch64;
+  };
+})

--- a/pkgs/by-name/xf/xf86-video-ati/package.nix
+++ b/pkgs/by-name/xf/xf86-video-ati/package.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  autoreconfHook,
+  pkg-config,
+  util-macros,
+  xorg-server,
+  xorgproto,
+  libdrm,
+  libgbm,
+  libGL,
+  libpciaccess,
+  udev,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xf86-video-ati";
+  version = "22.0.0";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    group = "xorg";
+    owner = "driver";
+    repo = "xf86-video-ati";
+    tag = "xf86-video-ati-${finalAttrs.version}";
+    hash = "sha256-q8+lMYS9tfO64xT7t6PYIqsARX8Dv/8uMTMeP1JCt08=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+    util-macros
+    xorg-server # for some autoconf macros
+  ];
+
+  buildInputs = [
+    xorg-server
+    xorgproto
+    libdrm
+    libgbm
+    libGL
+    libpciaccess
+    udev
+  ];
+
+  passthru = {
+    updateScript = nix-update-script { extraArgs = [ "--version-regex=xf86-video-ati-(.*)" ]; };
+  };
+
+  meta = {
+    description = "ATI/AMD Radeon video driver for the Xorg X server";
+    homepage = "https://gitlab.freedesktop.org/xorg/driver/xf86-video-ati";
+    license = with lib.licenses; [
+      mit
+      x11
+      hpndSellVariant
+    ];
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+    broken = stdenv.hostPlatform.isAarch64;
+  };
+})

--- a/pkgs/by-name/xf/xf86-video-chips/package.nix
+++ b/pkgs/by-name/xf/xf86-video-chips/package.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  autoreconfHook,
+  pkg-config,
+  util-macros,
+  xorg-server,
+  xorgproto,
+  libpciaccess,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xf86-video-chips";
+  version = "1.5.0";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    group = "xorg";
+    owner = "driver";
+    repo = "xf86-video-chips";
+    tag = "xf86-video-chips-${finalAttrs.version}";
+    hash = "sha256-MQ6aT+fWKFtpdzV40LzMrr046h0ZRmHi2sgWjuYUMq8=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+    util-macros
+    xorg-server # for some autoconf macros
+  ];
+
+  buildInputs = [
+    xorgproto
+    libpciaccess
+    xorg-server
+  ];
+
+  passthru = {
+    updateScript = nix-update-script { extraArgs = [ "--version-regex=xf86-video-chips-(.*)" ]; };
+  };
+
+  meta = {
+    description = "Chips & Technologies video driver for the Xorg X server";
+    homepage = "https://gitlab.freedesktop.org/xorg/driver/xf86-video-chips";
+    license = with lib.licenses; [
+      hpndSellVariant
+      bsd3
+      dec3Clause
+      mit
+      x11
+    ];
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+    broken = stdenv.hostPlatform.isAarch64;
+  };
+})

--- a/pkgs/by-name/xf/xf86-video-cirrus/package.nix
+++ b/pkgs/by-name/xf/xf86-video-cirrus/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  autoreconfHook,
+  pkg-config,
+  util-macros,
+  xorg-server,
+  xorgproto,
+  libpciaccess,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xf86-video-cirrus";
+  version = "1.6.0";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    group = "xorg";
+    owner = "driver";
+    repo = "xf86-video-cirrus";
+    tag = "xf86-video-cirrus-${finalAttrs.version}";
+    hash = "sha256-7V3czOujUIKFe9UqNX4FwpDWq9XsZeaLRu9ALnZyRMw=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+    util-macros
+    xorg-server # for some autoconf macros
+  ];
+
+  buildInputs = [
+    xorg-server
+    xorgproto
+    libpciaccess
+  ];
+
+  passthru = {
+    updateScript = nix-update-script { extraArgs = [ "--version-regex=xf86-video-cirrus-(.*)" ]; };
+  };
+
+  meta = {
+    description = "Cirrus Logic video driver for the Xorg X server";
+    homepage = "https://gitlab.freedesktop.org/xorg/driver/xf86-video-cirrus";
+    license = with lib.licenses; [
+      x11
+      hpndSellVariant
+      mit
+    ];
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -132,6 +132,7 @@
   xf86-input-synaptics,
   xf86-input-vmmouse,
   xf86-input-void,
+  xf86-video-apm,
   xf86-video-ark,
   xf86-video-geode,
   xf86-video-nouveau,
@@ -347,6 +348,7 @@ self: with self; {
   xf86inputsynaptics = xf86-input-synaptics;
   xf86inputvmmouse = xf86-input-vmmouse;
   xf86inputvoid = xf86-input-void;
+  xf86videoapm = xf86-video-apm;
   xf86videoark = xf86-video-ark;
   xf86videogeode = xf86-video-geode;
   xf86videonouveau = xf86-video-nouveau;
@@ -584,44 +586,6 @@ self: with self; {
         libGL
         libdrm
         udev
-        xorgserver
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xf86videoapm = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      xorgproto,
-      libpciaccess,
-      xorgserver,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xf86-video-apm";
-      version = "1.3.0";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/driver/xf86-video-apm-1.3.0.tar.bz2";
-        sha256 = "0znwqfc8abkiha98an8hxsngnz96z6cd976bc4bsvz1km6wqk0c0";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        xorgproto
-        libpciaccess
         xorgserver
       ];
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -135,6 +135,7 @@
   xf86-video-apm,
   xf86-video-ark,
   xf86-video-ast,
+  xf86-video-ati,
   xf86-video-geode,
   xf86-video-nouveau,
   xf86-video-s3virge,
@@ -352,6 +353,7 @@ self: with self; {
   xf86videoapm = xf86-video-apm;
   xf86videoark = xf86-video-ark;
   xf86videoast = xf86-video-ast;
+  xf86videoati = xf86-video-ati;
   xf86videogeode = xf86-video-geode;
   xf86videonouveau = xf86-video-nouveau;
   xf86videos3virge = xf86-video-s3virge;
@@ -588,52 +590,6 @@ self: with self; {
         libGL
         libdrm
         udev
-        xorgserver
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xf86videoati = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      xorgproto,
-      libgbm,
-      libGL,
-      libdrm,
-      udev,
-      libpciaccess,
-      xorgserver,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xf86-video-ati";
-      version = "22.0.0";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/driver/xf86-video-ati-22.0.0.tar.xz";
-        sha256 = "0vdznwx78alhbb05paw2xd65hcsila2kqflwwnbpq8pnsdbbpj68";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        xorgproto
-        libgbm
-        libGL
-        libdrm
-        udev
-        libpciaccess
         xorgserver
       ];
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -136,6 +136,7 @@
   xf86-video-ark,
   xf86-video-ast,
   xf86-video-ati,
+  xf86-video-chips,
   xf86-video-geode,
   xf86-video-nouveau,
   xf86-video-s3virge,
@@ -354,6 +355,7 @@ self: with self; {
   xf86videoark = xf86-video-ark;
   xf86videoast = xf86-video-ast;
   xf86videoati = xf86-video-ati;
+  xf86videochips = xf86-video-chips;
   xf86videogeode = xf86-video-geode;
   xf86videonouveau = xf86-video-nouveau;
   xf86videos3virge = xf86-video-s3virge;
@@ -590,44 +592,6 @@ self: with self; {
         libGL
         libdrm
         udev
-        xorgserver
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xf86videochips = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      xorgproto,
-      libpciaccess,
-      xorgserver,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xf86-video-chips";
-      version = "1.5.0";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/driver/xf86-video-chips-1.5.0.tar.xz";
-        sha256 = "1cyljd3h2hjv42ldqimf4lllqhb8cma6p3n979kr8nn81rjdkhw4";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        xorgproto
-        libpciaccess
         xorgserver
       ];
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -137,6 +137,7 @@
   xf86-video-ast,
   xf86-video-ati,
   xf86-video-chips,
+  xf86-video-cirrus,
   xf86-video-geode,
   xf86-video-nouveau,
   xf86-video-s3virge,
@@ -356,6 +357,7 @@ self: with self; {
   xf86videoast = xf86-video-ast;
   xf86videoati = xf86-video-ati;
   xf86videochips = xf86-video-chips;
+  xf86videocirrus = xf86-video-cirrus;
   xf86videogeode = xf86-video-geode;
   xf86videonouveau = xf86-video-nouveau;
   xf86videos3virge = xf86-video-s3virge;
@@ -592,44 +594,6 @@ self: with self; {
         libGL
         libdrm
         udev
-        xorgserver
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xf86videocirrus = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      xorgproto,
-      libpciaccess,
-      xorgserver,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xf86-video-cirrus";
-      version = "1.6.0";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/driver/xf86-video-cirrus-1.6.0.tar.xz";
-        sha256 = "00b468w01hqjczfqz42v2vqhb14db4wazcqi1w29lgfyhc0gmwqf";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        xorgproto
-        libpciaccess
         xorgserver
       ];
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -134,6 +134,7 @@
   xf86-input-void,
   xf86-video-apm,
   xf86-video-ark,
+  xf86-video-ast,
   xf86-video-geode,
   xf86-video-nouveau,
   xf86-video-s3virge,
@@ -350,6 +351,7 @@ self: with self; {
   xf86inputvoid = xf86-input-void;
   xf86videoapm = xf86-video-apm;
   xf86videoark = xf86-video-ark;
+  xf86videoast = xf86-video-ast;
   xf86videogeode = xf86-video-geode;
   xf86videonouveau = xf86-video-nouveau;
   xf86videos3virge = xf86-video-s3virge;
@@ -586,44 +588,6 @@ self: with self; {
         libGL
         libdrm
         udev
-        xorgserver
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xf86videoast = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      xorgproto,
-      libpciaccess,
-      xorgserver,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xf86-video-ast";
-      version = "1.2.0";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/driver/xf86-video-ast-1.2.0.tar.xz";
-        sha256 = "14sx6dm0nmbf1fs8cazmak0aqjpjpv9wv7v09w86ff04m7f4gal6";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        xorgproto
-        libpciaccess
         xorgserver
       ];
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -464,6 +464,7 @@ print OUT <<EOF;
   xf86-input-synaptics,
   xf86-input-vmmouse,
   xf86-input-void,
+  xf86-video-apm,
   xf86-video-ark,
   xf86-video-geode,
   xf86-video-nouveau,
@@ -679,6 +680,7 @@ self: with self; {
   xf86inputsynaptics = xf86-input-synaptics;
   xf86inputvmmouse = xf86-input-vmmouse;
   xf86inputvoid = xf86-input-void;
+  xf86videoapm = xf86-video-apm;
   xf86videoark = xf86-video-ark;
   xf86videogeode = xf86-video-geode;
   xf86videonouveau = xf86-video-nouveau;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -467,6 +467,7 @@ print OUT <<EOF;
   xf86-video-apm,
   xf86-video-ark,
   xf86-video-ast,
+  xf86-video-ati,
   xf86-video-geode,
   xf86-video-nouveau,
   xf86-video-s3virge,
@@ -684,6 +685,7 @@ self: with self; {
   xf86videoapm = xf86-video-apm;
   xf86videoark = xf86-video-ark;
   xf86videoast = xf86-video-ast;
+  xf86videoati = xf86-video-ati;
   xf86videogeode = xf86-video-geode;
   xf86videonouveau = xf86-video-nouveau;
   xf86videos3virge = xf86-video-s3virge;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -468,6 +468,7 @@ print OUT <<EOF;
   xf86-video-ark,
   xf86-video-ast,
   xf86-video-ati,
+  xf86-video-chips,
   xf86-video-geode,
   xf86-video-nouveau,
   xf86-video-s3virge,
@@ -686,6 +687,7 @@ self: with self; {
   xf86videoark = xf86-video-ark;
   xf86videoast = xf86-video-ast;
   xf86videoati = xf86-video-ati;
+  xf86videochips = xf86-video-chips;
   xf86videogeode = xf86-video-geode;
   xf86videonouveau = xf86-video-nouveau;
   xf86videos3virge = xf86-video-s3virge;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -466,6 +466,7 @@ print OUT <<EOF;
   xf86-input-void,
   xf86-video-apm,
   xf86-video-ark,
+  xf86-video-ast,
   xf86-video-geode,
   xf86-video-nouveau,
   xf86-video-s3virge,
@@ -682,6 +683,7 @@ self: with self; {
   xf86inputvoid = xf86-input-void;
   xf86videoapm = xf86-video-apm;
   xf86videoark = xf86-video-ark;
+  xf86videoast = xf86-video-ast;
   xf86videogeode = xf86-video-geode;
   xf86videonouveau = xf86-video-nouveau;
   xf86videos3virge = xf86-video-s3virge;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -469,6 +469,7 @@ print OUT <<EOF;
   xf86-video-ast,
   xf86-video-ati,
   xf86-video-chips,
+  xf86-video-cirrus,
   xf86-video-geode,
   xf86-video-nouveau,
   xf86-video-s3virge,
@@ -688,6 +689,7 @@ self: with self; {
   xf86videoast = xf86-video-ast;
   xf86videoati = xf86-video-ati;
   xf86videochips = xf86-video-chips;
+  xf86videocirrus = xf86-video-cirrus;
   xf86videogeode = xf86-video-geode;
   xf86videonouveau = xf86-video-nouveau;
   xf86videos3virge = xf86-video-s3virge;

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -8,7 +8,6 @@ mirror://xorg/individual/driver/xf86-input-joystick-1.6.4.tar.xz
 mirror://xorg/individual/driver/xf86-input-keyboard-2.1.0.tar.xz
 mirror://xorg/individual/driver/xf86-input-libinput-1.5.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-amdgpu-23.0.0.tar.xz
-mirror://xorg/individual/driver/xf86-video-chips-1.5.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-cirrus-1.6.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-dummy-0.4.1.tar.xz
 mirror://xorg/individual/driver/xf86-video-fbdev-0.5.1.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -8,7 +8,6 @@ mirror://xorg/individual/driver/xf86-input-joystick-1.6.4.tar.xz
 mirror://xorg/individual/driver/xf86-input-keyboard-2.1.0.tar.xz
 mirror://xorg/individual/driver/xf86-input-libinput-1.5.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-amdgpu-23.0.0.tar.xz
-mirror://xorg/individual/driver/xf86-video-ast-1.2.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-ati-22.0.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-chips-1.5.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-cirrus-1.6.0.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -8,7 +8,6 @@ mirror://xorg/individual/driver/xf86-input-joystick-1.6.4.tar.xz
 mirror://xorg/individual/driver/xf86-input-keyboard-2.1.0.tar.xz
 mirror://xorg/individual/driver/xf86-input-libinput-1.5.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-amdgpu-23.0.0.tar.xz
-mirror://xorg/individual/driver/xf86-video-apm-1.3.0.tar.bz2
 mirror://xorg/individual/driver/xf86-video-ast-1.2.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-ati-22.0.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-chips-1.5.0.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -8,7 +8,6 @@ mirror://xorg/individual/driver/xf86-input-joystick-1.6.4.tar.xz
 mirror://xorg/individual/driver/xf86-input-keyboard-2.1.0.tar.xz
 mirror://xorg/individual/driver/xf86-input-libinput-1.5.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-amdgpu-23.0.0.tar.xz
-mirror://xorg/individual/driver/xf86-video-cirrus-1.6.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-dummy-0.4.1.tar.xz
 mirror://xorg/individual/driver/xf86-video-fbdev-0.5.1.tar.xz
 mirror://xorg/individual/driver/xf86-video-i128-1.4.1.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -8,7 +8,6 @@ mirror://xorg/individual/driver/xf86-input-joystick-1.6.4.tar.xz
 mirror://xorg/individual/driver/xf86-input-keyboard-2.1.0.tar.xz
 mirror://xorg/individual/driver/xf86-input-libinput-1.5.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-amdgpu-23.0.0.tar.xz
-mirror://xorg/individual/driver/xf86-video-ati-22.0.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-chips-1.5.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-cirrus-1.6.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-dummy-0.4.1.tar.xz


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux + cross to aarch64 where possible
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- ran:
  - [x] nixpkgs-hammering 
  - [x] nix-check-deps
  - [x] passthru.updateScript
    - left updates to r-ryantm
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
