### PR TITLE
http-nu: 0.5.0 -> 0.9.0

### DIFF
--- a/pkgs/by-name/ht/http-nu/package.nix
+++ b/pkgs/by-name/ht/http-nu/package.nix
@@ -9,16 +9,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "http-nu";
-  version = "0.5.0";
+  version = "0.9.0";
 
   src = fetchFromGitHub {
     owner = "cablehead";
     repo = "http-nu";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Ri0/HnTINXGrdzh26uT+JD32sbKLnbzq8ps2+LUbbI8=";
+    hash = "sha256-Tnu5Ophc20+fhAfqfRgfuJVdWojBBPThNPNlcefDVrs=";
   };
 
-  cargoHash = "sha256-C4VYE6dLHwYaJ9LI4A+R1AvK3Qu8lV2ISy+8ymFKQg8=";
+  cargoHash = "sha256-J1zGm5F+as/B7lXbiZVBWD4/axfRBFSDL0MEUOQ09GI=";
 
   nativeBuildInputs = lib.optionals stdenvNoCC.hostPlatform.isDarwin [
     rustPlatform.bindgenHook


### PR DESCRIPTION
Diff: https://github.com/cablehead/http-nu/compare/v0.5.0...v0.9.0
Changelog: https://github.com/cablehead/http-nu/blob/v0.9.0/changes/v0.9.0.md

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.