### PR TITLE
code-cursor: 2.2.44 -> 2.3.29, auto-update vscodeVersion and save to sources.json

### DIFF
--- a/pkgs/by-name/co/code-cursor/package.nix
+++ b/pkgs/by-name/co/code-cursor/package.nix
@@ -70,6 +70,7 @@ in
     maintainers = with lib.maintainers; [
       aspauldingcode
       prince213
+      qweered
     ];
     platforms = [
       "aarch64-linux"

--- a/pkgs/by-name/co/code-cursor/package.nix
+++ b/pkgs/by-name/co/code-cursor/package.nix
@@ -14,37 +14,22 @@ let
   inherit (stdenv) hostPlatform;
   finalCommandLineArgs = "--update=false " + commandLineArgs;
 
-  sources = {
-    x86_64-linux = fetchurl {
-      url = "https://downloads.cursor.com/production/20adc1003928b0f1b99305dbaf845656ff81f5d4/linux/x64/Cursor-2.2.44-x86_64.AppImage";
-      hash = "sha256-hit0L6vE893jPq4QQqteT6T08hghX5hE/NZLUWTqqvY=";
-    };
-    aarch64-linux = fetchurl {
-      url = "https://downloads.cursor.com/production/20adc1003928b0f1b99305dbaf845656ff81f5d4/linux/arm64/Cursor-2.2.44-aarch64.AppImage";
-      hash = "sha256-D2pcfwzRED/TYGABCo83YI4g77tu3xgvqjOo8XsteSA=";
-    };
-    x86_64-darwin = fetchurl {
-      url = "https://downloads.cursor.com/production/20adc1003928b0f1b99305dbaf845656ff81f5d4/darwin/x64/Cursor-darwin-x64.dmg";
-      hash = "sha256-/BD2PMcP20/SDGPCsnkv3PQW7u0FEXuORfDeG/KV0MQ=";
-    };
-    aarch64-darwin = fetchurl {
-      url = "https://downloads.cursor.com/production/20adc1003928b0f1b99305dbaf845656ff81f5d4/darwin/arm64/Cursor-darwin-arm64.dmg";
-      hash = "sha256-qehVIZipBbWOYbf6Zo3GBStS8dp+c4EtgDTGAQz1mzE=";
-    };
-  };
+  sourcesJson = lib.importJSON ./sources.json;
+  sources = lib.mapAttrs (
+    _: info:
+    fetchurl {
+      inherit (info) url hash;
+    }
+  ) sourcesJson.sources;
 
   source = sources.${hostPlatform.system};
 in
 (callPackage vscode-generic rec {
   inherit useVSCodeRipgrep;
+  inherit (sourcesJson) version vscodeVersion;
   commandLineArgs = finalCommandLineArgs;
 
-  version = "2.2.44";
   pname = "cursor";
-
-  # You can find the current VSCode version in the About dialog:
-  # workbench.action.showAboutDialog (Help: About)
-  vscodeVersion = "1.105.1";
 
   executableName = "cursor";
   longName = "Cursor";

--- a/pkgs/by-name/co/code-cursor/sources.json
+++ b/pkgs/by-name/co/code-cursor/sources.json
@@ -1,0 +1,22 @@
+{
+  "version": "2.2.44",
+  "vscodeVersion": "1.105.1",
+  "sources": {
+    "x86_64-linux": {
+      "url": "https://downloads.cursor.com/production/20adc1003928b0f1b99305dbaf845656ff81f5d4/linux/x64/Cursor-2.2.44-x86_64.AppImage",
+      "hash": "sha256-hit0L6vE893jPq4QQqteT6T08hghX5hE/NZLUWTqqvY="
+    },
+    "aarch64-linux": {
+      "url": "https://downloads.cursor.com/production/20adc1003928b0f1b99305dbaf845656ff81f5d4/linux/arm64/Cursor-2.2.44-aarch64.AppImage",
+      "hash": "sha256-D2pcfwzRED/TYGABCo83YI4g77tu3xgvqjOo8XsteSA="
+    },
+    "x86_64-darwin": {
+      "url": "https://downloads.cursor.com/production/20adc1003928b0f1b99305dbaf845656ff81f5d4/darwin/x64/Cursor-darwin-x64.dmg",
+      "hash": "sha256-/BD2PMcP20/SDGPCsnkv3PQW7u0FEXuORfDeG/KV0MQ="
+    },
+    "aarch64-darwin": {
+      "url": "https://downloads.cursor.com/production/20adc1003928b0f1b99305dbaf845656ff81f5d4/darwin/arm64/Cursor-darwin-arm64.dmg",
+      "hash": "sha256-qehVIZipBbWOYbf6Zo3GBStS8dp+c4EtgDTGAQz1mzE="
+    }
+  }
+}

--- a/pkgs/by-name/co/code-cursor/sources.json
+++ b/pkgs/by-name/co/code-cursor/sources.json
@@ -1,22 +1,22 @@
 {
-  "version": "2.2.44",
+  "version": "2.3.29",
   "vscodeVersion": "1.105.1",
   "sources": {
     "x86_64-linux": {
-      "url": "https://downloads.cursor.com/production/20adc1003928b0f1b99305dbaf845656ff81f5d4/linux/x64/Cursor-2.2.44-x86_64.AppImage",
-      "hash": "sha256-hit0L6vE893jPq4QQqteT6T08hghX5hE/NZLUWTqqvY="
+      "url": "https://downloads.cursor.com/production/4ca9b38c6c97d4243bf0c61e51426667cb964bdc/linux/x64/Cursor-2.3.29-x86_64.AppImage",
+      "hash": "sha256-uWgUCXo0MHNyiigiymr0LoMoATePp0dksI7JyR/5bRY="
     },
     "aarch64-linux": {
-      "url": "https://downloads.cursor.com/production/20adc1003928b0f1b99305dbaf845656ff81f5d4/linux/arm64/Cursor-2.2.44-aarch64.AppImage",
-      "hash": "sha256-D2pcfwzRED/TYGABCo83YI4g77tu3xgvqjOo8XsteSA="
+      "url": "https://downloads.cursor.com/production/4ca9b38c6c97d4243bf0c61e51426667cb964bdc/linux/arm64/Cursor-2.3.29-aarch64.AppImage",
+      "hash": "sha256-/oUz5wNRtPKYkEIKpHhcjWZNAAhTMvNdJLm+sXE9pDg="
     },
     "x86_64-darwin": {
-      "url": "https://downloads.cursor.com/production/20adc1003928b0f1b99305dbaf845656ff81f5d4/darwin/x64/Cursor-darwin-x64.dmg",
-      "hash": "sha256-/BD2PMcP20/SDGPCsnkv3PQW7u0FEXuORfDeG/KV0MQ="
+      "url": "https://downloads.cursor.com/production/4ca9b38c6c97d4243bf0c61e51426667cb964bdc/darwin/x64/Cursor-darwin-x64.dmg",
+      "hash": "sha256-A93Glr2bOL6zSu0XTgNj0Pmt6G2ufRgf4lPJ0xcGhow="
     },
     "aarch64-darwin": {
-      "url": "https://downloads.cursor.com/production/20adc1003928b0f1b99305dbaf845656ff81f5d4/darwin/arm64/Cursor-darwin-arm64.dmg",
-      "hash": "sha256-qehVIZipBbWOYbf6Zo3GBStS8dp+c4EtgDTGAQz1mzE="
+      "url": "https://downloads.cursor.com/production/4ca9b38c6c97d4243bf0c61e51426667cb964bdc/darwin/arm64/Cursor-darwin-arm64.dmg",
+      "hash": "sha256-cp/aTNapbwRXxdUU0fWs3HliV7rCmT/2CbNXqZPMpEs="
     }
   }
 }

--- a/pkgs/by-name/co/code-cursor/update.sh
+++ b/pkgs/by-name/co/code-cursor/update.sh
@@ -1,39 +1,44 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p curl jq coreutils common-updater-scripts
-set -eu -o pipefail
+#!nix-shell -i bash -p curl jq coreutils nix _7zz
+# shellcheck shell=bash
+set -euo pipefail
 
-currentVersion=$(nix-instantiate --eval -E "with import ./. {}; code-cursor.version or (lib.getVersion code-cursor)" | tr -d '"')
+cd -- "$(dirname "${BASH_SOURCE[0]}")"
 
-declare -A platforms=( [x86_64-linux]='linux-x64' [aarch64-linux]='linux-arm64' [x86_64-darwin]='darwin-x64' [aarch64-darwin]='darwin-arm64' )
-declare -A updates=( )
-first_version=""
+META=$(curl -fsSL "https://api2.cursor.sh/updates/api/download/stable/linux-x64/cursor")
+VERSION=$(jq -r '.version' <<< "$META")
+CURRENT=$(jq -r '.version' sources.json)
 
-for platform in ${!platforms[@]}; do
-    api_platform=${platforms[$platform]}
-    result=$(curl -s "https://api2.cursor.sh/updates/api/download/stable/$api_platform/cursor")
-    version=$(echo $result | jq -r '.version')
-    if [[ "$version" == "$currentVersion" ]]; then
-      exit 0
-    fi
-    if [[ -z "$first_version" ]]; then
-      first_version=$version
-      first_platform=$platform
-    elif [[ "$version" != "$first_version" ]]; then
-      >&2 echo "Multiple versions found: $first_version ($first_platform) and $version ($platform)"
-      exit 1
-    fi
-    url=$(echo $result | jq -r '.downloadUrl')
-    # Exits with code 22 if not downloadable
-    curl --output /dev/null --silent --head --fail "$url"
-    updates+=( [$platform]="$result" )
+[[ "$VERSION" == "$CURRENT" ]] && { echo "Already up to date ($VERSION)"; exit 0; }
+
+SOURCES="{}"
+VSCODE=""
+
+for pair in \
+  x86_64-linux:linux-x64 \
+  aarch64-linux:linux-arm64 \
+  x86_64-darwin:darwin-x64 \
+  aarch64-darwin:darwin-arm64
+do
+  IFS=: read -r sys platform <<< "$pair"
+  meta=$(curl -fsSL "https://api2.cursor.sh/updates/api/download/stable/$platform/cursor")
+  version=$(jq -r '.version' <<< "$meta")
+
+  [[ "$version" != "$VERSION" ]] && { echo "Version mismatch: $sys has $version, expected $VERSION"; exit 1; }
+
+  url=$(jq -r '.downloadUrl' <<< "$meta")
+
+  { read -r hash; read -r path; } < <(nix-prefetch-url --print-path "$url")
+
+  sri=$(nix-hash --type sha256 --to-sri "$hash")
+
+  if [[ "$sys" == "x86_64-linux" ]]; then
+    VSCODE=$(7zz x -so "$path" "usr/share/cursor/resources/app/product.json" 2>/dev/null | jq -r '.vscodeVersion')
+  fi
+
+  SOURCES=$(jq -n --argjson src "$SOURCES" --arg sys "$sys" --arg url "$url" --arg hash "$sri" \
+    '$src + {($sys): {url: $url, hash: $hash}}')
 done
 
-# Install updates
-for platform in ${!updates[@]}; do
-  result=${updates[$platform]}
-  version=$(echo $result | jq -r '.version')
-  url=$(echo $result | jq -r '.downloadUrl')
-  source=$(nix-prefetch-url "$url" --name "cursor-$version")
-  hash=$(nix-hash --to-sri --type sha256 "$source")
-  update-source-version code-cursor $version $hash "$url" --system=$platform --ignore-same-version --source-key="sources.$platform"
-done
+jq -n --arg v "$VERSION" --arg vs "$VSCODE" --argjson s "$SOURCES" \
+  '{version: $v, vscodeVersion: $vs, sources: $s}' > sources.json


### PR DESCRIPTION
Supercedes #464521 

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
