### PR TITLE
xf86-video-{i128,i740,mga,neomagic}: refactor, move to pkgs/by-name & rename from xorg namespace

### DIFF
--- a/pkgs/by-name/xf/xf86-video-i128/package.nix
+++ b/pkgs/by-name/xf/xf86-video-i128/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  autoreconfHook,
+  pkg-config,
+  util-macros,
+  xorg-server,
+  xorgproto,
+  libpciaccess,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xf86-video-i128";
+  version = "1.4.1";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    group = "xorg";
+    owner = "driver";
+    repo = "xf86-video-i128";
+    tag = "xf86-video-i128-${finalAttrs.version}";
+    hash = "sha256-2yjzaJV5DIATEmByIZJXZyZ781lTUNzfafCmIlBSBRg=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+    util-macros
+    xorg-server # for some autoconf macros
+  ];
+
+  buildInputs = [
+    xorg-server
+    xorgproto
+    libpciaccess
+  ];
+
+  passthru = {
+    updateScript = nix-update-script { extraArgs = [ "--version-regex=xf86-video-i128-(.*)" ]; };
+  };
+
+  meta = {
+    description = "Number Nine I128 video driver for the Xorg X server";
+    homepage = "https://gitlab.freedesktop.org/xorg/driver/xf86-video-i128";
+    license = with lib.licenses; [
+      hpndSellVariant
+      mit
+    ];
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+    broken = stdenv.hostPlatform.isAarch64;
+  };
+})

--- a/pkgs/by-name/xf/xf86-video-i740/package.nix
+++ b/pkgs/by-name/xf/xf86-video-i740/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  autoreconfHook,
+  pkg-config,
+  util-macros,
+  xorg-server,
+  xorgproto,
+  libpciaccess,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xf86-video-i740";
+  version = "1.4.0";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    group = "xorg";
+    owner = "driver";
+    repo = "xf86-video-i740";
+    tag = "xf86-video-i740-${finalAttrs.version}";
+    hash = "sha256-wEpTkmzMjEebkPf6/69gjmDdJ0OQ3MrnosIXFIQor8A=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+    util-macros
+    xorg-server # for some autoconf macros
+  ];
+
+  buildInputs = [
+    xorg-server
+    xorgproto
+    libpciaccess
+  ];
+
+  passthru = {
+    updateScript = nix-update-script { extraArgs = [ "--version-regex=xf86-video-i740-(.*)" ]; };
+  };
+
+  meta = {
+    description = "Intel i740 video driver for the Xorg X server";
+    homepage = "https://gitlab.freedesktop.org/xorg/driver/xf86-video-i740";
+    license = with lib.licenses; [
+      mit
+      hpndSellVariant
+    ];
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+    broken = stdenv.hostPlatform.isAarch64;
+  };
+})

--- a/pkgs/by-name/xf/xf86-video-mga/package.nix
+++ b/pkgs/by-name/xf/xf86-video-mga/package.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  autoreconfHook,
+  pkg-config,
+  util-macros,
+  xorg-server,
+  xorgproto,
+  libdrm,
+  libpciaccess,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xf86-video-mga";
+  version = "2.1.0";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    group = "xorg";
+    owner = "driver";
+    repo = "xf86-video-mga";
+    tag = "xf86-video-mga-${finalAttrs.version}";
+    hash = "sha256-9DpqSyGTu4jOttZlF95/rpi2oEu+JPU3sniuHTatoRo=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+    util-macros
+    xorg-server # for some autoconf macros
+  ];
+
+  buildInputs = [
+    xorgproto
+    libdrm
+    libpciaccess
+    xorg-server
+  ];
+
+  passthru = {
+    updateScript = nix-update-script { extraArgs = [ "--version-regex=xf86-video-mga-(.*)" ]; };
+  };
+
+  meta = {
+    description = "Matrox video driver for the Xorg X server";
+    homepage = "https://gitlab.freedesktop.org/xorg/driver/xf86-video-mga";
+    license = with lib.licenses; [
+      x11
+      mitOpenGroup
+      hpndSellVariant
+      mit
+    ];
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/xf/xf86-video-neomagic/package.nix
+++ b/pkgs/by-name/xf/xf86-video-neomagic/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  autoreconfHook,
+  pkg-config,
+  util-macros,
+  xorg-server,
+  xorgproto,
+  libpciaccess,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xf86-video-neomagic";
+  version = "1.3.1";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    group = "xorg";
+    owner = "driver";
+    repo = "xf86-video-neomagic";
+    tag = "xf86-video-neomagic-${finalAttrs.version}";
+    hash = "sha256-j1zhKGYmKADZ/6WuCQTca7l+rTgqlLhGoQvYhWxWAAE=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+    util-macros
+    xorg-server # for some autoconf macros
+  ];
+  buildInputs = [
+    xorg-server
+    xorgproto
+    libpciaccess
+  ];
+
+  passthru = {
+    updateScript = nix-update-script { extraArgs = [ "--version-regex=xf86-video-neomagic-(.*)" ]; };
+  };
+
+  meta = {
+    description = "NeoMagic video driver for the Xorg X server";
+    homepage = "https://gitlab.freedesktop.org/xorg/driver/xf86-video-neomagic";
+    license = with lib.licenses; [
+      hpndSellVariant
+      mit
+      # the repo contains several copyright notices without a license
+      unfree
+    ];
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -134,6 +134,7 @@
   xf86-input-void,
   xf86-video-ark,
   xf86-video-geode,
+  xf86-video-i128,
   xf86-video-nouveau,
   xf86-video-s3virge,
   xf86-video-v4l,
@@ -349,6 +350,7 @@ self: with self; {
   xf86inputvoid = xf86-input-void;
   xf86videoark = xf86-video-ark;
   xf86videogeode = xf86-video-geode;
+  xf86videoi128 = xf86-video-i128;
   xf86videonouveau = xf86-video-nouveau;
   xf86videos3virge = xf86-video-s3virge;
   xf86videov4l = xf86-video-v4l;
@@ -846,44 +848,6 @@ self: with self; {
       src = fetchurl {
         url = "mirror://xorg/individual/driver/xf86-video-fbdev-0.5.1.tar.xz";
         sha256 = "11zk8whari4m99ad3w30xwcjkgya4xbcpmg8710q14phkbxw0aww";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        xorgproto
-        libpciaccess
-        xorgserver
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xf86videoi128 = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      xorgproto,
-      libpciaccess,
-      xorgserver,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xf86-video-i128";
-      version = "1.4.1";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/driver/xf86-video-i128-1.4.1.tar.xz";
-        sha256 = "0imwmkam09wpp3z3iaw9i4hysxicrrax7i3p0l2glgp3zw9var3h";
       };
       hardeningDisable = [
         "bindnow"

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -135,6 +135,7 @@
   xf86-video-ark,
   xf86-video-geode,
   xf86-video-i128,
+  xf86-video-i740,
   xf86-video-nouveau,
   xf86-video-s3virge,
   xf86-video-v4l,
@@ -351,6 +352,7 @@ self: with self; {
   xf86videoark = xf86-video-ark;
   xf86videogeode = xf86-video-geode;
   xf86videoi128 = xf86-video-i128;
+  xf86videoi740 = xf86-video-i740;
   xf86videonouveau = xf86-video-nouveau;
   xf86videos3virge = xf86-video-s3virge;
   xf86videov4l = xf86-video-v4l;
@@ -848,44 +850,6 @@ self: with self; {
       src = fetchurl {
         url = "mirror://xorg/individual/driver/xf86-video-fbdev-0.5.1.tar.xz";
         sha256 = "11zk8whari4m99ad3w30xwcjkgya4xbcpmg8710q14phkbxw0aww";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        xorgproto
-        libpciaccess
-        xorgserver
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xf86videoi740 = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      xorgproto,
-      libpciaccess,
-      xorgserver,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xf86-video-i740";
-      version = "1.4.0";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/driver/xf86-video-i740-1.4.0.tar.bz2";
-        sha256 = "0l3s1m95bdsg4gki943qipq8agswbb84dzcflpxa3vlckwhh3r26";
       };
       hardeningDisable = [
         "bindnow"

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -137,6 +137,7 @@
   xf86-video-i128,
   xf86-video-i740,
   xf86-video-mga,
+  xf86-video-neomagic,
   xf86-video-nouveau,
   xf86-video-s3virge,
   xf86-video-v4l,
@@ -355,6 +356,7 @@ self: with self; {
   xf86videoi128 = xf86-video-i128;
   xf86videoi740 = xf86-video-i740;
   xf86videomga = xf86-video-mga;
+  xf86videoneomagic = xf86-video-neomagic;
   xf86videonouveau = xf86-video-nouveau;
   xf86videos3virge = xf86-video-s3virge;
   xf86videov4l = xf86-video-v4l;
@@ -933,44 +935,6 @@ self: with self; {
         libxshmfence
         libXtst
         libXvMC
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xf86videoneomagic = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      xorgproto,
-      libpciaccess,
-      xorgserver,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xf86-video-neomagic";
-      version = "1.3.1";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/driver/xf86-video-neomagic-1.3.1.tar.xz";
-        sha256 = "153lzhq0vahg3875wi8hl9rf4sgizs41zmfg6hpfjw99qdzaq7xn";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        xorgproto
-        libpciaccess
-        xorgserver
       ];
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -136,6 +136,7 @@
   xf86-video-geode,
   xf86-video-i128,
   xf86-video-i740,
+  xf86-video-mga,
   xf86-video-nouveau,
   xf86-video-s3virge,
   xf86-video-v4l,
@@ -353,6 +354,7 @@ self: with self; {
   xf86videogeode = xf86-video-geode;
   xf86videoi128 = xf86-video-i128;
   xf86videoi740 = xf86-video-i740;
+  xf86videomga = xf86-video-mga;
   xf86videonouveau = xf86-video-nouveau;
   xf86videos3virge = xf86-video-s3virge;
   xf86videov4l = xf86-video-v4l;
@@ -931,46 +933,6 @@ self: with self; {
         libxshmfence
         libXtst
         libXvMC
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xf86videomga = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      xorgproto,
-      libdrm,
-      libpciaccess,
-      xorgserver,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xf86-video-mga";
-      version = "2.1.0";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/driver/xf86-video-mga-2.1.0.tar.xz";
-        sha256 = "0wxbcgg5i4yq22pbc50567877z8irxhqzgl3sk6vf5zs9szmvy3v";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        xorgproto
-        libdrm
-        libpciaccess
-        xorgserver
       ];
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -467,6 +467,7 @@ print OUT <<EOF;
   xf86-video-ark,
   xf86-video-geode,
   xf86-video-i128,
+  xf86-video-i740,
   xf86-video-nouveau,
   xf86-video-s3virge,
   xf86-video-v4l,
@@ -683,6 +684,7 @@ self: with self; {
   xf86videoark = xf86-video-ark;
   xf86videogeode = xf86-video-geode;
   xf86videoi128 = xf86-video-i128;
+  xf86videoi740 = xf86-video-i740;
   xf86videonouveau = xf86-video-nouveau;
   xf86videos3virge = xf86-video-s3virge;
   xf86videov4l = xf86-video-v4l;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -469,6 +469,7 @@ print OUT <<EOF;
   xf86-video-i128,
   xf86-video-i740,
   xf86-video-mga,
+  xf86-video-neomagic,
   xf86-video-nouveau,
   xf86-video-s3virge,
   xf86-video-v4l,
@@ -687,6 +688,7 @@ self: with self; {
   xf86videoi128 = xf86-video-i128;
   xf86videoi740 = xf86-video-i740;
   xf86videomga = xf86-video-mga;
+  xf86videoneomagic = xf86-video-neomagic;
   xf86videonouveau = xf86-video-nouveau;
   xf86videos3virge = xf86-video-s3virge;
   xf86videov4l = xf86-video-v4l;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -466,6 +466,7 @@ print OUT <<EOF;
   xf86-input-void,
   xf86-video-ark,
   xf86-video-geode,
+  xf86-video-i128,
   xf86-video-nouveau,
   xf86-video-s3virge,
   xf86-video-v4l,
@@ -681,6 +682,7 @@ self: with self; {
   xf86inputvoid = xf86-input-void;
   xf86videoark = xf86-video-ark;
   xf86videogeode = xf86-video-geode;
+  xf86videoi128 = xf86-video-i128;
   xf86videonouveau = xf86-video-nouveau;
   xf86videos3virge = xf86-video-s3virge;
   xf86videov4l = xf86-video-v4l;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -468,6 +468,7 @@ print OUT <<EOF;
   xf86-video-geode,
   xf86-video-i128,
   xf86-video-i740,
+  xf86-video-mga,
   xf86-video-nouveau,
   xf86-video-s3virge,
   xf86-video-v4l,
@@ -685,6 +686,7 @@ self: with self; {
   xf86videogeode = xf86-video-geode;
   xf86videoi128 = xf86-video-i128;
   xf86videoi740 = xf86-video-i740;
+  xf86videomga = xf86-video-mga;
   xf86videonouveau = xf86-video-nouveau;
   xf86videos3virge = xf86-video-s3virge;
   xf86videov4l = xf86-video-v4l;

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -120,12 +120,6 @@ self: super:
 
   xf86videodummy = brokenOnDarwin super.xf86videodummy; # never worked: https://hydra.nixos.org/job/nixpkgs/trunk/xorg.xf86videodummy.x86_64-darwin
 
-  xf86videoi128 = super.xf86videoi128.overrideAttrs (attrs: {
-    meta = attrs.meta // {
-      badPlatforms = lib.platforms.aarch64;
-    };
-  });
-
   xf86videoomap = super.xf86videoomap.overrideAttrs (attrs: {
     env.NIX_CFLAGS_COMPILE = toString [ "-Wno-error=format-overflow" ];
   });

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -15,7 +15,6 @@ mirror://xorg/individual/driver/xf86-video-chips-1.5.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-cirrus-1.6.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-dummy-0.4.1.tar.xz
 mirror://xorg/individual/driver/xf86-video-fbdev-0.5.1.tar.xz
-mirror://xorg/individual/driver/xf86-video-i128-1.4.1.tar.xz
 mirror://xorg/individual/driver/xf86-video-i740-1.4.0.tar.bz2
 mirror://xorg/individual/driver/xf86-video-intel-2.99.917.tar.bz2
 mirror://xorg/individual/driver/xf86-video-mga-2.1.0.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -16,7 +16,6 @@ mirror://xorg/individual/driver/xf86-video-cirrus-1.6.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-dummy-0.4.1.tar.xz
 mirror://xorg/individual/driver/xf86-video-fbdev-0.5.1.tar.xz
 mirror://xorg/individual/driver/xf86-video-intel-2.99.917.tar.bz2
-mirror://xorg/individual/driver/xf86-video-mga-2.1.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-neomagic-1.3.1.tar.xz
 mirror://xorg/individual/driver/xf86-video-nv-2.1.23.tar.xz
 mirror://xorg/individual/driver/xf86-video-omap-0.4.5.tar.bz2

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -16,7 +16,6 @@ mirror://xorg/individual/driver/xf86-video-cirrus-1.6.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-dummy-0.4.1.tar.xz
 mirror://xorg/individual/driver/xf86-video-fbdev-0.5.1.tar.xz
 mirror://xorg/individual/driver/xf86-video-intel-2.99.917.tar.bz2
-mirror://xorg/individual/driver/xf86-video-neomagic-1.3.1.tar.xz
 mirror://xorg/individual/driver/xf86-video-nv-2.1.23.tar.xz
 mirror://xorg/individual/driver/xf86-video-omap-0.4.5.tar.bz2
 mirror://xorg/individual/driver/xf86-video-openchrome-0.6.0.tar.bz2

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -15,7 +15,6 @@ mirror://xorg/individual/driver/xf86-video-chips-1.5.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-cirrus-1.6.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-dummy-0.4.1.tar.xz
 mirror://xorg/individual/driver/xf86-video-fbdev-0.5.1.tar.xz
-mirror://xorg/individual/driver/xf86-video-i740-1.4.0.tar.bz2
 mirror://xorg/individual/driver/xf86-video-intel-2.99.917.tar.bz2
 mirror://xorg/individual/driver/xf86-video-mga-2.1.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-neomagic-1.3.1.tar.xz


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux + cross to aarch64 where possible
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- ran:
  - [x] nixpkgs-hammering 
  - [x] nix-check-deps
  - [x] passthru.updateScript
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
