### PR TITLE
python3Packages.anyconfig: disable broken tests on python 3.14

### DIFF
--- a/pkgs/development/python-modules/anyconfig/default.nix
+++ b/pkgs/development/python-modules/anyconfig/default.nix
@@ -6,13 +6,13 @@
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "anyconfig";
   version = "0.14.0";
   format = "setuptools";
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-LN9Ur12ujpF0Pe2CxU7Z2Krvo6lyL11F6bX3S2A+AU0=";
   };
 
@@ -44,4 +44,4 @@ buildPythonPackage rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ tboerger ];
   };
-}
+})

--- a/pkgs/development/python-modules/anyconfig/default.nix
+++ b/pkgs/development/python-modules/anyconfig/default.nix
@@ -1,6 +1,6 @@
 {
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
   lib,
   pytestCheckHook,
   setuptools,
@@ -11,9 +11,11 @@ buildPythonPackage (finalAttrs: {
   version = "0.14.0";
   format = "setuptools";
 
-  src = fetchPypi {
-    inherit (finalAttrs) pname version;
-    hash = "sha256-LN9Ur12ujpF0Pe2CxU7Z2Krvo6lyL11F6bX3S2A+AU0=";
+  src = fetchFromGitHub {
+    owner = "ssato";
+    repo = "python-anyconfig";
+    tag = "RELEASE_${finalAttrs.version}";
+    hash = "sha256-ngXj/KzErz81T09j6tlV9OYDX3DqW5I8xo/ulLNokpQ=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/anyconfig/default.nix
+++ b/pkgs/development/python-modules/anyconfig/default.nix
@@ -3,6 +3,7 @@
   fetchFromGitHub,
   lib,
   pytestCheckHook,
+  pythonAtLeast,
   setuptools,
 }:
 
@@ -29,6 +30,11 @@ buildPythonPackage (finalAttrs: {
   disabledTests = [
     # OSError: /build/anyconfig-0.12.0/tests/res/cli/no_template/10/e/10.* should exists but not
     "test_runs_for_datasets"
+  ]
+  ++ lib.optionals (pythonAtLeast "3.14") [
+    # Python 3.14: output format has changed
+    "test_dumps"
+    "test_dump"
   ];
 
   disabledTestPaths = [


### PR DESCRIPTION
1. Applied `finalAttrs:` fix
2. Built from GitHub source
3. Disabled `test_dump` and `test_dumps` for a minor difference in unicode outputs.

Tracking: 475732

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
