### PR TITLE
python314Packages.kantoku: disable broken tests for python >= 3.14

### DIFF
--- a/pkgs/development/python-modules/kantoku/default.nix
+++ b/pkgs/development/python-modules/kantoku/default.nix
@@ -14,7 +14,7 @@
   tornado,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "kantoku";
   version = "0.18.3";
   pyproject = true;
@@ -22,7 +22,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "bentoml";
     repo = "kantoku";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-pI79B7TDZwL4Jz5e7PDPIf8iIGiwCOKFI2jReUt8UNg=";
   };
 
@@ -59,8 +59,8 @@ buildPythonPackage rec {
   meta = {
     description = "A Process & Socket Manager built with zmq";
     homepage = "https://github.com/bentoml/kantoku";
-    changelog = "https://github.com/bentoml/kantoku/releases/tag/${version}";
+    changelog = "https://github.com/bentoml/kantoku/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ fab ];
   };
-}
+})

--- a/pkgs/development/python-modules/kantoku/default.nix
+++ b/pkgs/development/python-modules/kantoku/default.nix
@@ -3,6 +3,7 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
+  pythonAtLeast,
   flit-core,
   gevent,
   mock,
@@ -52,6 +53,13 @@ buildPythonPackage (finalAttrs: {
     # Assertion error when test_socketstats hits a permission error
     "test_resource_watcher_max_mem"
     "test_resource_watcher_max_mem_abs"
+  ]
+  ++ lib.optionals (pythonAtLeast "3.14") [
+    "test_help_invalid_command"
+    "test_venv"
+    "test_venv_site_packages"
+    # Times out
+    "test_handler"
   ];
 
   __darwinAllowLocalNetworking = true;


### PR DESCRIPTION
1. The command line output has changed from `python3` to `python3.14`, breaking three tests. Disabled.
2. Added `finalAttrs` fix.

Tracking: #475732

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
