### PR TITLE
fuzpad: init at 2.05.00

### DIFF
--- a/pkgs/by-name/fu/fuzpad/package.nix
+++ b/pkgs/by-name/fu/fuzpad/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fzf,
+  git,
+  coreutils,
+  findutils,
+  gnused,
+  gnugrep,
+  bash,
+  makeWrapper,
+}:
+
+let
+  wrapperPath = lib.makeBinPath [
+    fzf
+    git
+    coreutils
+    findutils
+    gnused
+    gnugrep
+  ];
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "fuzpad";
+  version = "2.05.00";
+
+  src = fetchFromGitHub {
+    owner = "JianZcar";
+    repo = "FuzPad";
+    tag = "${finalAttrs.version}";
+    hash = "sha256-cqZvJtQbSEMoXVbAOy+aE33IUfwUuzvNIzNuOLf4pwU=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  buildInputs = [ bash ];
+
+  installPhase = ''
+    install -m 755 -Dt $out/bin $src/bin/fuzpad
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/fuzpad \
+      --prefix PATH : "${wrapperPath}"
+  '';
+
+  meta = {
+    description = "Minimalistic note taking solution powered by fzf";
+    homepage = "https://github.com/JianZcar/FuzPad";
+    changelog = "https://github.com/JianZcar/FuzPad/releases/tag/${finalAttrs.version}";
+    maintainers = with lib.maintainers; [
+      nicknb
+    ];
+    mainProgram = "fuzpad";
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/fu/fuzpad/package.nix
+++ b/pkgs/by-name/fu/fuzpad/package.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  fzf,
+  git,
+  coreutils,
+  findutils,
+  gnused,
+  gnugrep,
+  bash,
+  makeWrapper,
+}:
+
+let
+  wrapperPath = lib.makeBinPath [
+    fzf
+    git
+    coreutils
+    findutils
+    gnused
+    gnugrep
+  ];
+in
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "fuzpad";
+  version = "2.05.00";
+
+  src = fetchFromGitHub {
+    owner = "JianZcar";
+    repo = "FuzPad";
+    tag = "${finalAttrs.version}";
+    hash = "sha256-cqZvJtQbSEMoXVbAOy+aE33IUfwUuzvNIzNuOLf4pwU=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  buildInputs = [ bash ];
+
+  patches = [
+    ./remove-hardcoded-shell-variable.patch
+  ];
+
+  installPhase = ''
+    install -m755 -Dt $out/bin bin/fuzpad
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/fuzpad --prefix PATH : "${wrapperPath}"
+  '';
+
+  meta = {
+    description = "Minimalistic note taking solution powered by fzf";
+    homepage = "https://github.com/JianZcar/FuzPad";
+    changelog = "https://github.com/JianZcar/FuzPad/releases/tag/${finalAttrs.version}";
+    maintainers = with lib.maintainers; [
+      nicknb
+    ];
+    mainProgram = "fuzpad";
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/fu/fuzpad/remove-hardcoded-shell-variable.patch
+++ b/pkgs/by-name/fu/fuzpad/remove-hardcoded-shell-variable.patch
@@ -1,0 +1,12 @@
+diff --git a/bin/fuzpad b/bin/fuzpad
+index 8dd33a6..be90e34 100755
+--- a/bin/fuzpad
++++ b/bin/fuzpad
+@@ -1,7 +1,5 @@
+ #!/bin/bash
+ 
+-SHELL=/bin/bash # Set the SHELL environment variable, fixes POSIX-incompatible shells
+-
+ # Set where notes are stored
+ # By default, will store at $FUZPAD_DIR if the variable is already set
+ # else will try to store under the $XDG_DATA_HOME directory if it is set,


### PR DESCRIPTION
Adds [fuzpad](https://github.com/JianZcar/FuzPad), a minimalistic note taking solution powered by fzf.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
