### PR TITLE
libamplsolver: fix build on non-trapping FP architectures

### DIFF
--- a/pkgs/by-name/li/libamplsolver/package.nix
+++ b/pkgs/by-name/li/libamplsolver/package.nix
@@ -25,9 +25,15 @@ stdenv.mkDerivation {
     })
   ];
 
-  # Allow install_name_tool rewrite paths on darwin.
-  #   error: install_name_tool: changing install names or rpaths can't be redone for: /nix/store/...-libamplsolver-.../lib/libamplsolver.dylib (for architecture arm64) because larger updated load commands do not fit (the program must be relinked, and you may need to use -headerpad or -headerpad_max_install_names)
-  NIX_LDFLAGS = lib.optional stdenv.hostPlatform.isDarwin "-headerpad_max_install_names";
+  env = {
+    # For non-trapping FP architectures like loongarch64 and riscv64
+    NIX_CFLAGS_COMPILE = lib.optionalString (
+      stdenv.hostPlatform.isRiscV64 || stdenv.hostPlatform.isLoongArch64
+    ) "-DNO_fpu_control";
+    # Allow install_name_tool rewrite paths on darwin.
+    #   error: install_name_tool: changing install names or rpaths can't be redone for: /nix/store/...-libamplsolver-.../lib/libamplsolver.dylib (for architecture arm64) because larger updated load commands do not fit (the program must be relinked, and you may need to use -headerpad or -headerpad_max_install_names)
+    NIX_LDFLAGS = lib.optionalString stdenv.hostPlatform.isDarwin "-headerpad_max_install_names";
+  };
 
   installPhase = ''
     runHook preInstall


### PR DESCRIPTION
This code snippet will fail to compile on loongarch64 (see https://github.com/ampl/asl/blob/master/src/solvers/fpinit.c#L1437-L148)
```
#if defined(_FPU_IEEE) && defined(_FPU_EXTENDED) && defined(_FPU_DOUBLE)
	__fpu_control = _FPU_IEEE - _FPU_EXTENDED + _FPU_DOUBLE;
	_FPU_SETCW(__fpu_control);
#elif defined(__i386__) || defined(__x86_64__)
	__fpu_control = 0x27f;
	_FPU_SETCW(__fpu_control);
#elif defined(FE_ALL_EXCEPT)
	fedisableexcept(FE_ALL_EXCEPT);
#else
	!!!! How does this system work?
	!!!! Either figure it out (and modify this text),
	!!!! or compile fpinit.c with -DNO_fpu_control .
```
cause having macro FE_ALL_EXCEPT does not mean we have func fedisableexcept

according to chatgpt

架构 | FE_ALL_EXCEPT | fedisableexcept()
-- | -- | --
x86_64 | ✔ | ✔
i386 | ✔ | ✔
aarch64 | ✔ | ✔
armv7 | ✔ | ✔
riscv64 | ✔ | ✘
loongarch64 | ✔ | ✘
musl (any) | ✔ | ✘

cc @wegank should we do the same for riscv and musl? i can only valid this pr on loongarch64.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
