### PR TITLE
vtk: use gdalMinimal instead of gdal

### DIFF
--- a/pkgs/by-name/gd/gdal/package.nix
+++ b/pkgs/by-name/gd/gdal/package.nix
@@ -68,7 +68,7 @@
   pkg-config,
   poppler,
   proj,
-  python3,
+  python3Packages,
   qhull,
   rav1e,
   sqlite,
@@ -98,8 +98,8 @@ stdenv.mkDerivation (finalAttrs: {
     doxygen
     graphviz
     pkg-config
-    python3.pkgs.setuptools
-    python3.pkgs.wrapPython
+    python3Packages.setuptools
+    python3Packages.wrapPython
     swig
   ]
   ++ lib.optionals useJava [
@@ -202,8 +202,8 @@ stdenv.mkDerivation (finalAttrs: {
       libwebp
       zlib
       zstd
-      python3
-      python3.pkgs.numpy
+      python3Packages.python
+      python3Packages.numpy
     ]
     ++ tileDbDeps
     ++ libAvifDeps
@@ -219,7 +219,7 @@ stdenv.mkDerivation (finalAttrs: {
     ++ darwinDeps
     ++ nonDarwinDeps;
 
-  pythonPath = [ python3.pkgs.numpy ];
+  pythonPath = [ python3Packages.numpy ];
   postInstall = ''
     wrapPythonProgramsIn "$out/bin" "$out $pythonPath"
   ''
@@ -238,14 +238,14 @@ stdenv.mkDerivation (finalAttrs: {
     pushd autotest
 
     export HOME=$(mktemp -d)
-    export PYTHONPATH="$out/${python3.sitePackages}:$PYTHONPATH"
+    export PYTHONPATH="$out/${python3Packages.python.sitePackages}:$PYTHONPATH"
     export GDAL_DOWNLOAD_TEST_DATA=OFF
     # allows to skip tests that fail because of file handle leak
     # the issue was not investigated
     # https://github.com/OSGeo/gdal/blob/v3.9.0/autotest/gdrivers/bag.py#L54
     export CI=1
   '';
-  nativeInstallCheckInputs = with python3.pkgs; [
+  nativeInstallCheckInputs = with python3Packages; [
     pytestCheckHook
     pytest-benchmark
     pytest-env

--- a/pkgs/development/libraries/vtk/generic.nix
+++ b/pkgs/development/libraries/vtk/generic.nix
@@ -111,6 +111,8 @@ let
     adios2 = self.callPackage adios2.override { };
     cgns = self.callPackage cgns.override { };
     viskores = self.callPackage viskores.override { };
+    gdal = self.callPackage gdal.override { useMinimalFeatures = true; };
+    pdal = self.callPackage pdal.override { };
   });
   vtkBool = feature: bool: lib.cmakeFeature feature "${if bool then "YES" else "NO"}";
 in
@@ -137,8 +139,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     libLAS
-    gdal
-    pdal
     alembic
     imath
     c-blosc
@@ -152,6 +152,8 @@ stdenv.mkDerivation (finalAttrs: {
     libarchive
     libGL
     openvdb
+    vtkPackages.gdal
+    vtkPackages.pdal
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     libXfixes

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5932,7 +5932,7 @@ self: super: with self; {
 
   gcsfs = callPackage ../development/python-modules/gcsfs { };
 
-  gdal = toPythonModule (pkgs.gdal.override { python3 = python; });
+  gdal = toPythonModule (pkgs.gdal.override { python3Packages = self; });
 
   gdata = callPackage ../development/python-modules/gdata { };
 


### PR DESCRIPTION
gdalMinimal is used for vtk's IO module
this pr reduce clousure size of vtk (no loonger depend on openjdk). also helps building vtk on loongarch64

first commit should triger zero rebuild, just make sure python3Packages.vtk/gdal use the same python3Packages.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
