### PR TITLE
bilibili-tui: init at 1.0.6

### DIFF
--- a/pkgs/by-name/bi/bilibili-tui/package.nix
+++ b/pkgs/by-name/bi/bilibili-tui/package.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  stdenv,
+  pkg-config,
+  makeWrapper,
+  openssl,
+  mpv-unwrapped,
+  yt-dlp-light,
+
+  withMpv ? true,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "bilibili-tui";
+  version = "1.0.6";
+
+  src = fetchFromGitHub {
+    owner = "MareDevi";
+    repo = "bilibili-tui";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-nWUFcKQgUNaiVU0zgSB8LTdvUruc8fovCAembQz5w3I=";
+  };
+
+  cargoHash = "sha256-KvJpMQuvZM/s3b4/Pzmeucb95KeuuUx4bz3sJsKyLc8=";
+
+  nativeBuildInputs = [ makeWrapper ] ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [ pkg-config ];
+
+  buildInputs = lib.optionals (!stdenv.hostPlatform.isDarwin) [ openssl ];
+
+  env.OPENSSL_NO_VENDOR = true;
+
+  # Wrap mpv as fallback; users should prefer their system's mpv in PATH
+  postInstall = lib.optionalString withMpv ''
+    wrapProgram $out/bin/bilibili-tui \
+      --suffix PATH : ${
+        lib.makeBinPath [
+          mpv-unwrapped
+          yt-dlp-light
+        ]
+      }
+  '';
+
+  meta = {
+    description = "Terminal user interface (TUI) client for Bilibili";
+    homepage = "https://maredevi.moe/projects/bilibili-tui/";
+    downloadPage = "https://github.com/MareDevi/bilibili-tui/releases";
+    changelog = "https://github.com/MareDevi/bilibili-tui/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ puiyq ];
+    mainProgram = "bilibili-tui";
+  };
+})


### PR DESCRIPTION
https://github.com/MareDevi/bilibili-tui

This PR adds bilibili-tui, a terminal-based Bilibili client written in Rust. It provides basic functionality for interacting with Bilibili, including browsing videos, viewing comments, playing content via mpv, etc.. The project is licensed under MIT.

Although it is a young project, it is actively developed. It is expected to have adoption within the Chinese Linux community, as it fills the niche of a TUI client for Bilibili.

I am willing to maintain this package in nixpkgs and keep it up to date with upstream changes.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
