### PR TITLE
xcursor-viewer: init at 0-unstable-2026-01-05

### DIFF
--- a/pkgs/by-name/xc/xcursor-viewer/package.nix
+++ b/pkgs/by-name/xc/xcursor-viewer/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  qt5,
+  unstableGitUpdater,
+}:
+
+stdenv.mkDerivation {
+  pname = "xcursor-viewer";
+  version = "0-unstable-2026-01-05";
+
+  src = fetchFromGitHub {
+    owner = "drizt";
+    repo = "xcursor-viewer";
+    rev = "216ed3b6b4694f75fc424862874dc5e2b66fb685";
+    hash = "sha256-faQuxHrUAqqSODDKZrRlMnWRj0NeM8hSHSbec7KSo50=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    qt5.wrapQtAppsHook
+  ];
+
+  buildInputs = [ qt5.qtbase ];
+
+  passthru.updateScript = unstableGitUpdater { };
+
+  meta = {
+    description = "A preview application for cursors in xcurosr format built in QT5";
+    homepage = "https://github.com/drizt/xcursor-viewer/";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ atemu ];
+    mainProgram = "xcursor-viewer";
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
I ran this to preview a cursor theme on wayland and it worked as expected.

The updater also works.

cc @wineee who contributed upstream before.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
