### PR TITLE
workflows/lint: require to contain a colon with a whitespace

### DIFF
--- a/ci/github-script/lint-commits.js
+++ b/ci/github-script/lint-commits.js
@@ -55,10 +55,11 @@ async function checkCommitMessages({ github, context, core }) {
 
     const logMsgStart = `Commit ${commit.sha}'s message's subject ("${firstLine}")`
 
-    if (!firstLine.includes(':')) {
+    if (!firstLine.includes(': ')) {
       core.error(
         `${logMsgStart} was detected as not meeting our guidelines because ` +
-          'it does not contain a colon. There are likely other issues as well.',
+          'it does not contain a colon followed by a whitespace.' +
+          'There are likely other issues as well.',
       )
       failures.add(commit.sha)
     }


### PR DESCRIPTION
This restricts github automatically merging master with commit message "Merge branch 'NixOS:master' into ...". Although we don't explicitly prohibit not space after colons, we don't use it in any of the examples. It's also enforced in https://www.conventionalcommits.org/en/v1.0.0/


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
