### PR TITLE
pagmo2: modernize; drop use of gold

### DIFF
--- a/pkgs/development/python-modules/pygmo/default.nix
+++ b/pkgs/development/python-modules/pygmo/default.nix
@@ -5,9 +5,6 @@
   fetchFromGitHub,
   cmake,
   boost,
-  eigen,
-  ipopt,
-  nlopt,
   pagmo2,
   python,
   cloudpickle,
@@ -43,9 +40,6 @@ toPythonModule (
 
     buildInputs = [
       boost
-      eigen
-      ipopt
-      nlopt
       pagmo2
       pybind11
     ];


### PR DESCRIPTION
drop use of gold since it is disused by upstream official ci now:

- ubuntu: https://github.com/esa/pagmo2/blob/39b8965fa2cad6de9f609a3796b16efaf64fb2e8/tools/travis_ubuntu_ppc64.sh
- osx: https://github.com/esa/pagmo2/blob/39b8965fa2cad6de9f609a3796b16efaf64fb2e8/tools/gha_osx.sh

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
