### PR TITLE
nixfmt: 1.1.0 → 1.2.0

### DIFF
--- a/pkgs/by-name/ni/nixfmt/generated-package.nix
+++ b/pkgs/by-name/ni/nixfmt/generated-package.nix
@@ -5,6 +5,7 @@
   base,
   bytestring,
   cmdargs,
+  containers,
   directory,
   fetchzip,
   file-embed,
@@ -23,15 +24,16 @@
 }:
 mkDerivation {
   pname = "nixfmt";
-  version = "1.1.0";
+  version = "1.2.0";
   src = fetchzip {
-    url = "https://github.com/nixos/nixfmt/archive/v1.1.0.tar.gz";
-    sha256 = "19sydkdw1579qmvzx0zq06s23bm6m6l9wp1kvsfhxawk8pkz2pc2";
+    url = "https://github.com/nixos/nixfmt/archive/v1.2.0.tar.gz";
+    sha256 = "1qvj1sddh7bgggqnj7cnhvfh4iz1pwzc9a9awc1g7y349yvpwad3";
   };
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [
     base
+    containers
     megaparsec
     mtl
     parser-combinators

--- a/pkgs/by-name/ni/nixfmt/update.sh
+++ b/pkgs/by-name/ni/nixfmt/update.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p cabal2nix curl jq
+#!nix-shell --pure -i bash -p cabal2nix curl cacert jq nix
 #
 # This script will update the nixfmt derivation to the latest version using
 # cabal2nix.
@@ -23,5 +23,8 @@ EOF
 cabal2nix --jailbreak \
   "https://github.com/nixos/nixfmt/archive/${release_tag}.tar.gz" \
   >> "$derivation_file"
+
+nix-shell "$script_dir/../../../../" \
+  --run "treefmt --no-cache $derivation_file"
 
 echo "Finished."


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Update nixfmt to 1.2.0

[Changelog](https://github.com/NixOS/nixfmt/releases/tag/v1.2.0):
- Reformat indented strings, reformatting to simple strings when appropriate: <https://github.com/NixOS/nixfmt/pull/348>
- Added musl static build and nixfmt-static package: <https://github.com/NixOS/nixfmt/pull/349>
- Added auto-release GitHub Actions workflow: <https://github.com/NixOS/nixfmt/pull/354>
- Fixed empty lists/sets with comments idempotency: <https://github.com/NixOS/nixfmt/pull/363>
- Fixed language annotations inside lists on function arguments: <https://github.com/NixOS/nixfmt/pull/355>
- Fixed parser for chained prefix operators: <https://github.com/NixOS/nixfmt/pull/352>
- Fixed inconsistent comment indentation in parameter lists: <https://github.com/NixOS/nixfmt/pull/346>
- Fixed language annotations followed by multiple new lines: <https://github.com/NixOS/nixfmt/pull/347>
- Memory optimization: don't retain thunks when appending to Trivia: <https://github.com/NixOS/nixfmt/pull/350>
- Added a flake formatter (so nix fmt works): <https://github.com/NixOS/nixfmt/pull/357>
- Added link to standard.md in README: <https://github.com/NixOS/nixfmt/pull/361>
- Fixed typo in README for nixfmt installation: <https://github.com/NixOS/nixfmt/pull/345>



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
