### PR TITLE
tcardgen: init at v0.9.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18293,6 +18293,12 @@
     githubId = 1222539;
     name = "Roman Naumann";
   };
+  nanamiiiii = {
+    email = "sk@myuu.dev";
+    github = "Nanamiiiii";
+    githubId = 52265804;
+    name = "Akihiro Saiki";
+  };
   nanotwerp = {
     email = "nanotwerp@gmail.com";
     github = "nanotwerp";

--- a/pkgs/by-name/tc/tcardgen/0001-test-fix-expected-error-string-in-test-for-hugo-pack.patch
+++ b/pkgs/by-name/tc/tcardgen/0001-test-fix-expected-error-string-in-test-for-hugo-pack.patch
@@ -1,0 +1,25 @@
+From 962df00b9323b73c70ca1bfaa42c99700e56b0a0 Mon Sep 17 00:00:00 2001
+From: Akihiro Saiki <sk@myuu.dev>
+Date: Sat, 3 Jan 2026 11:52:02 +0900
+Subject: [PATCH] test: fix expected error string in test for `hugo` package
+
+---
+ pkg/hugo/frontmatter_test.go | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/pkg/hugo/frontmatter_test.go b/pkg/hugo/frontmatter_test.go
+index a8f103d..0124c0b 100644
+--- a/pkg/hugo/frontmatter_test.go
++++ b/pkg/hugo/frontmatter_test.go
+@@ -63,7 +63,7 @@ content`,
+ 			input: `---
+ title = "invalid format'
+ ---`,
+-			expectErr: errors.New("failed to unmarshal YAML: yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `title =...` into map[string]interface {}"),
++			expectErr: errors.New("\"_stream.yaml:1:1\": failed to unmarshal YAML: yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `title =...` into map[string]interface {}"),
+ 		},
+ 		{
+ 			desc: "Title is missing",
+-- 
+2.52.0
+

--- a/pkgs/by-name/tc/tcardgen/package.nix
+++ b/pkgs/by-name/tc/tcardgen/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildGoModule,
+  versionCheckHook,
+}:
+
+buildGoModule rec {
+  pname = "tcardgen";
+  version = "0.9.0";
+
+  src = fetchFromGitHub {
+    owner = "Ladicle";
+    repo = "tcardgen";
+    tag = "v${version}";
+    sha256 = "sha256-TojNst+KUbCEHf0Vbg3TyRy4F6jHidjmPL56gzL0Y1U=";
+  };
+
+  patches = [
+    ./0001-test-fix-expected-error-string-in-test-for-hugo-pack.patch
+  ];
+
+  vendorHash = "sha256-X39L1jDlgdwMALzsVIUBocqxvamrb+M5FZkDCkI5XCc=";
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  doInstallCheck = true;
+
+  meta = {
+    description = "TwitterCard(OGP) image generator for Hugo posts.";
+    homepage = "https://github.com/Ladicle/tcardgen";
+    license = lib.licenses.mit;
+    mainProgram = "tcardgen";
+    maintainers = with lib.maintainers; [ nanamiiiii ];
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add tcardgen, a CLI tool that generates OGP images for markdown-based blog posts (especially Hugo-based sites).

https://github.com/Ladicle/tcardgen

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
