### PR TITLE
python3Packages.pyzstd: 0.18.0 → 0.19.1

### DIFF
--- a/pkgs/development/python-modules/pyzstd/default.nix
+++ b/pkgs/development/python-modules/pyzstd/default.nix
@@ -1,59 +1,39 @@
 {
+  backports-zstd,
   buildPythonPackage,
   fetchFromGitHub,
+  hatch-vcs,
+  hatchling,
   lib,
   pytestCheckHook,
   pythonOlder,
-  setuptools,
   typing-extensions,
-  zstd-c,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pyzstd";
-  version = "0.18.0";
+  version = "0.19.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Rogdham";
     repo = "pyzstd";
-    tag = version;
-    hash = "sha256-15+GqJ/AMYs1R9ywo+muNVVbPkkzTMj//Zn/PPI+MCI=";
+    tag = finalAttrs.version;
+    hash = "sha256-1oUqnZCBJYu8haFIQ+T2KaSQaa1xnZyJHLzOQg4Fdw8=";
   };
 
-  postPatch = ''
-    # pyzst specifies setuptools<74 because 74+ drops `distutils.msvc9compiler`,
-    # required for Python 3.9 under Windows
-    substituteInPlace pyproject.toml \
-        --replace-fail '"setuptools>=64,<74"' '"setuptools"'
-
-    # pyzst needs a copy of upstream zstd's license
-    ln -s ${zstd-c.src}/LICENSE zstd
-  '';
-
-  nativeBuildInputs = [
-    setuptools
-  ];
-
   build-system = [
-    setuptools
+    hatchling
+    hatch-vcs
   ];
 
-  dependencies = lib.optionals (pythonOlder "3.13") [
-    typing-extensions
-  ];
-
-  pythonRelaxDeps = [
-    "typing-extensions"
-  ];
-
-  buildInputs = [
-    zstd-c
-  ];
-
-  pypaBuildFlags = [
-    "--config-setting=--global-option=--dynamic-link-zstd"
-  ];
+  dependencies =
+    lib.optionals (pythonOlder "3.13") [
+      typing-extensions
+    ]
+    ++ lib.optionals (pythonOlder "3.14") [
+      backports-zstd
+    ];
 
   nativeCheckInputs = [
     pytestCheckHook
@@ -66,7 +46,7 @@ buildPythonPackage rec {
   meta = {
     description = "Python bindings to Zstandard (zstd) compression library";
     homepage = "https://pyzstd.readthedocs.io";
-    changelog = "https://github.com/Rogdham/pyzstd/blob/${version}/CHANGELOG.md";
+    changelog = "https://github.com/Rogdham/pyzstd/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [
       MattSturgeon
@@ -74,4 +54,4 @@ buildPythonPackage rec {
       PopeRigby
     ];
   };
-}
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15940,7 +15940,7 @@ self: super: with self; {
 
   pyzmq = callPackage ../development/python-modules/pyzmq { };
 
-  pyzstd = callPackage ../development/python-modules/pyzstd { zstd-c = pkgs.zstd; };
+  pyzstd = callPackage ../development/python-modules/pyzstd { };
 
   pyzx = callPackage ../development/python-modules/pyzx { };
 


### PR DESCRIPTION
## Changelog

https://github.com/Rogdham/pyzstd/blob/0.19.1/CHANGELOG.md

#### 0.19.1 (November 13, 2025)

- Fix `SeekableZstdFile` write table entries on 32-bits architectures when there is a huge number of entries

#### 0.19.0 (November 7, 2025)

- The project has been completely refactored to use the Zstandard implementation from the standard library ([PEP-784](https://peps.python.org/pep-0784/))
- The refactor has some minor impact on public APIs, such as changing the exception raised on invalid input
- Add `backports.zstd` dependency for Python before 3.14
- Changes in build dependency: remove `setuptools` and C build toolchain, add `hatchling` and `hatch-vcs`
- Remove git submodule usage
- Drop support for Python 3.9 and below
- Use `ruff` as formatter and linter
- Embed type hints in Python code, and check with `mypy`

----

Also switched to the newly supported fixpoint-arg `finalAttrs` pattern.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
