### PR TITLE
authsock-filter: init at 0.1.39

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13502,6 +13502,12 @@
     github = "katrinafyi";
     githubId = 39479354;
   };
+  kawaz = {
+    email = "kawazzz@gmail.com";
+    github = "kawaz";
+    githubId = 156236;
+    name = "Yoshiaki Kawazu";
+  };
   kaweees = {
     github = "kaweees";
     githubId = 49963287;

--- a/pkgs/by-name/au/authsock-filter/package.nix
+++ b/pkgs/by-name/au/authsock-filter/package.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "authsock-filter";
+  version = "0.1.39";
+
+  src = fetchFromGitHub {
+    owner = "kawaz";
+    repo = "authsock-filter";
+    tag = "v${version}";
+    hash = "sha256-jr5i25PZZwDwik7EB5Npxe4e6xS7hk8+hMdhFZ1+lGg=";
+  };
+
+  cargoHash = "sha256-qTEhsUeWF56ttAuUHaRACT1/Ed4TQBO2DW4cyQuIa4U=";
+
+  meta = {
+    description = "SSH agent proxy with filtering and logging";
+    homepage = "https://github.com/kawaz/authsock-filter";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kawaz ];
+    mainProgram = "authsock-filter";
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/by-name/au/authsock-filter/package.nix
+++ b/pkgs/by-name/au/authsock-filter/package.nix
@@ -4,14 +4,14 @@
   rustPlatform,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "authsock-filter";
   version = "0.1.39";
 
   src = fetchFromGitHub {
     owner = "kawaz";
     repo = "authsock-filter";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-jr5i25PZZwDwik7EB5Npxe4e6xS7hk8+hMdhFZ1+lGg=";
   };
 
@@ -20,9 +20,10 @@ rustPlatform.buildRustPackage rec {
   meta = {
     description = "SSH agent proxy with filtering and logging";
     homepage = "https://github.com/kawaz/authsock-filter";
+    changelog = "https://github.com/kawaz/authsock-filter/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ kawaz ];
     mainProgram = "authsock-filter";
     platforms = lib.platforms.unix;
   };
-}
+})


### PR DESCRIPTION
## Description

Add authsock-filter, an SSH agent proxy with filtering and logging capabilities.

**Homepage**: https://github.com/kawaz/authsock-filter

## Features

- Filter SSH keys by fingerprint, key type, or comment patterns
- Logging of SSH agent operations
- Support for launchd (macOS) and systemd (Linux) service management

## Maintainer

I am the author of this software and will maintain this package.