### PR TITLE
maintainers: drop coloquinte

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5263,12 +5263,6 @@
     githubId = 244239;
     name = "Mauricio Collares";
   };
-  coloquinte = {
-    email = "gabriel.gouvine_nix@m4x.org";
-    github = "Coloquinte";
-    githubId = 4102525;
-    name = "Gabriel Gouvine";
-  };
   commandodev = {
     email = "ben@perurbis.com";
     github = "commandodev";

--- a/pkgs/by-name/co/coloquinte/package.nix
+++ b/pkgs/by-name/co/coloquinte/package.nix
@@ -34,6 +34,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/Coloquinte/PlaceRoute";
     license = lib.licenses.mit;
     platforms = lib.platforms.linux;
-    maintainers = [ lib.maintainers.coloquinte ];
+    maintainers = [ ];
   };
 })


### PR DESCRIPTION
## Reasons

- Last commented in [July 2023](https://github.com/NixOS/nixpkgs/issues?q=commenter%3AColoquinte)
- Hasn't created any PRs / Issues since [July 2023](https://github.com/NixOS/nixpkgs/issues?q=author%3AColoquinte)
- About 3 [unanswered ](https://github.com/NixOS/nixpkgs/issues?q=involves%3AColoquinte%20-commenter%3AColoquinte%20-author%3AColoquinte%20-reviewed-by%3AColoquinte) PRs / Issues

See [lossing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs. You have one week to respond to this.

## Packages 

Those packages only have them as their maintainer and would need at least one new maintainer.

- [ ] coloquinte


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
