### PR TITLE
Update Exodus to latest version

### DIFF
--- a/pkgs/by-name/ex/exodus/package.nix
+++ b/pkgs/by-name/ex/exodus/package.nix
@@ -28,12 +28,12 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "exodus";
-  version = "25.28.4";
+  version = "26.1.5";
 
   src = requireFile {
     name = "exodus-linux-x64-${finalAttrs.version}.zip";
     url = "https://downloads.exodus.com/releases/exodus-linux-x64-${finalAttrs.version}.zip";
-    hash = "sha256-AGeFsMHSywC32iaIGI9/VY2YC3gR5bHu33rOWJlyFFM=";
+    hash = "sha256-BClWuL4dTc1lESyEXuDtpGp1K/AxICbpQIaWYLrme1M=";
   };
 
   nativeBuildInputs = [ unzip ];


### PR DESCRIPTION
(This is my first push request.)
This is an update to the exodus derivation to use the latest version number and respective hash. I have tested using nixos-build and it works fine.