### PR TITLE
e-imzo: fix missing libudev & system on boot error message

### DIFF
--- a/nixos/modules/services/security/e-imzo.nix
+++ b/nixos/modules/services/security/e-imzo.nix
@@ -38,6 +38,13 @@ in
         Type = "simple";
         Restart = "always";
         RestartSec = 1;
+        ExecStartPre = [
+          (pkgs.writeShellScript "e-imzo-check-port-availability" ''
+            until [ -z "$(${pkgs.iproute2}/bin/ss -tuln | grep -E ':(64646|64443)\>')" ]; do
+              sleep 1
+            done
+          '')
+        ];
         ExecStart = lib.getExe cfg.package;
 
         NoNewPrivileges = true;

--- a/pkgs/by-name/e-/e-imzo/package.nix
+++ b/pkgs/by-name/e-/e-imzo/package.nix
@@ -37,7 +37,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
           pcsclite
         ]
       }" \
-      --add-flags "-Dsun.security.smartcardio.library=${pcsclite.lib}/lib/libpcsclite.${stdenvNoCC.hostPlatform.extensions.sharedLibrary}" \
+      --add-flags "-Dsun.security.smartcardio.library=${pcsclite.lib}/lib/libpcsclite${stdenvNoCC.hostPlatform.extensions.sharedLibrary}" \
       --add-flags "-jar $out/lib/e-imzo/E-IMZO.jar"
 
     runHook postInstall

--- a/pkgs/by-name/e-/e-imzo/package.nix
+++ b/pkgs/by-name/e-/e-imzo/package.nix
@@ -3,21 +3,10 @@
   stdenvNoCC,
   fetchurl,
   jre8,
-  curl,
-  ccid,
   pcsclite,
-  pcsc-tools,
-  writeShellScript,
+  udev,
+  makeWrapper,
 }:
-let
-  exec = writeShellScript "e-imzo" ''
-    cd "$(dirname "$0")/../lib/e-imzo"
-
-    ${jre8}/bin/java -Dsun.security.smartcardio.library=${pcsclite.lib}/lib/libpcsclite.${stdenvNoCC.hostPlatform.extensions.sharedLibrary} -jar E-IMZO.jar
-
-    exit 0
-  '';
-in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "e-imzo";
   version = "5.00";
@@ -26,6 +15,10 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     url = "https://cdn.xinux.uz/e-imzo/E-IMZO-v${finalAttrs.version}.tar.gz";
     hash = "sha256-jPAZu98prkC4NQlfA8/kJuw9qdCrSSSyzySSWPlIXpY=";
   };
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
 
   installPhase = ''
     runHook preInstall
@@ -37,7 +30,15 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     install -m 644 ./truststore.jks $out/lib/e-imzo/
     cp -r ./lib $out/lib/e-imzo/
 
-    install -m 755 "${exec}" $out/bin/e-imzo
+    makeWrapper ${jre8}/bin/java $out/bin/e-imzo \
+      --set LD_LIBRARY_PATH "${
+        lib.makeLibraryPath [
+          udev
+          pcsclite
+        ]
+      }" \
+      --add-flags "-Dsun.security.smartcardio.library=${pcsclite.lib}/lib/libpcsclite.${stdenvNoCC.hostPlatform.extensions.sharedLibrary}" \
+      --add-flags "-jar $out/lib/e-imzo/E-IMZO.jar"
 
     runHook postInstall
   '';


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Previous problem which e-imzo package ran twice:
<img width="1778" height="498" alt="image" src="https://github.com/user-attachments/assets/07d5c08a-d9f6-4eb4-9a60-61210be0187b" />

Prevent by not running e-imzo deamon when user log in to system while 64646, 64443 in use. With this e-imzo will run once on system startup

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
