### PR TITLE
Cinnamon updates 2026-01-09

### DIFF
--- a/pkgs/applications/backup/timeshift/unwrapped.nix
+++ b/pkgs/applications/backup/timeshift/unwrapped.nix
@@ -18,7 +18,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "timeshift";
-  version = "25.12.3";
+  version = "25.12.4";
   outputs = [
     "out"
     "man"
@@ -28,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "linuxmint";
     repo = "timeshift";
     tag = finalAttrs.version;
-    hash = "sha256-yrPeaGdt32bmP8lV+eYZb2H3OmVl3G5AH7eeGZ3LM3k=";
+    hash = "sha256-4iK9RngcqwR0sYo9AXcTwEQ1eoPQPbAmwM5k/rcgU9s=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/fo/folder-color-switcher/package.nix
+++ b/pkgs/by-name/fo/folder-color-switcher/package.nix
@@ -8,14 +8,14 @@
 
 stdenvNoCC.mkDerivation {
   pname = "folder-color-switcher";
-  version = "1.7.0";
+  version = "1.7.1";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "folder-color-switcher";
     # They don't really do tags, this is just a named commit.
-    rev = "c528788f05697d1e176df4f869d64bcebbab1528";
-    hash = "sha256-RSIiNjoU2Qk+0ACirUeo+VSfpjQ8NNJqmKKASD7RZXs=";
+    rev = "856f6f27dfa48ee1ac8d7ec40333e3f892458067";
+    hash = "sha256-nNH8/MIgVk7Y9YyGfN1jjdGJ4DruXu2Lg8+GjQnIggM=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/hy/hypnotix/package.nix
+++ b/pkgs/by-name/hy/hypnotix/package.nix
@@ -16,13 +16,13 @@
 
 stdenv.mkDerivation rec {
   pname = "hypnotix";
-  version = "5.5";
+  version = "5.6";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "hypnotix";
     tag = version;
-    hash = "sha256-/bFqPar/Ey48e+KG1EN0IuTF4HX+2jeMcFkqcEcOKMs=";
+    hash = "sha256-7CPrRMoVM1FaU8aJlnZigTkHa97bDPdwcu4JY7sERJQ=";
   };
 
   patches = [

--- a/pkgs/by-name/pi/pix/package.nix
+++ b/pkgs/by-name/pi/pix/package.nix
@@ -35,13 +35,13 @@
 
 stdenv.mkDerivation rec {
   pname = "pix";
-  version = "3.4.9";
+  version = "3.4.10";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "pix";
     rev = version;
-    hash = "sha256-cuNggVsNNqACWttPy1Tt8MfPFQKiuYhaMnh8TTHCi74=";
+    hash = "sha256-IrRE2Bv2+DZMLI48at7npcAd3TSJRuZNzU/YbNK8x3k=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/st/sticky/package.nix
+++ b/pkgs/by-name/st/sticky/package.nix
@@ -17,13 +17,13 @@
 
 stdenv.mkDerivation rec {
   pname = "sticky";
-  version = "1.29";
+  version = "1.30";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "sticky";
     rev = version;
-    hash = "sha256-5KDjvohmdw8j5G8V+uFXPzRSRo/C2HgeRodWfguQjYg=";
+    hash = "sha256-8Y6PoQQHS8h1AT+4DMbExd9y7ScDMig0M9BJQjq09Uc=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/wa/warpinator/package.nix
+++ b/pkgs/by-name/wa/warpinator/package.nix
@@ -42,13 +42,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "warpinator";
-  version = "2.0.2";
+  version = "2.0.3";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "warpinator";
     rev = version;
-    hash = "sha256-bVK60fSIWp02qrKCJ68awyPcZhMTW5bjRPI7YHmmScc=";
+    hash = "sha256-3ZkufMZFTn8BQO9DHr3s9ELRuDrTflE4Ym73dO7rrKs=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/xa/xapp/package.nix
+++ b/pkgs/by-name/xa/xapp/package.nix
@@ -24,7 +24,7 @@
 
 stdenv.mkDerivation rec {
   pname = "xapp";
-  version = "3.2.1";
+  version = "3.2.2";
 
   outputs = [
     "out"
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     owner = "linuxmint";
     repo = "xapp";
     rev = version;
-    hash = "sha256-Uc3vMcWVzT0N9FCDxxI2e4yk1fg6FJiC7XXpY80mV0c=";
+    hash = "sha256-xVGIrK7koqX6xKoanVHWQMBUusUjtvHzQg2OV0E0b78=";
   };
 
   # Recommended by upstream, which enables the build of xapp-debug.

--- a/pkgs/by-name/xe/xed-editor/package.nix
+++ b/pkgs/by-name/xe/xed-editor/package.nix
@@ -23,13 +23,13 @@
 
 stdenv.mkDerivation rec {
   pname = "xed-editor";
-  version = "3.8.8";
+  version = "3.8.9";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "xed";
     rev = version;
-    hash = "sha256-BbakdZwigC/im9Il5sCeRF0SJuLCPtqe7/mcYmPcCRI=";
+    hash = "sha256-ZTrTCyyyUDbt+/kjb1+I/bOjwXcsYGYd5K9ebPjJTA8=";
   };
 
   patches = [

--- a/pkgs/by-name/xr/xreader/package.nix
+++ b/pkgs/by-name/xr/xreader/package.nix
@@ -37,13 +37,13 @@
 
 stdenv.mkDerivation rec {
   pname = "xreader";
-  version = "4.6.2";
+  version = "4.6.3";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "xreader";
     rev = version;
-    hash = "sha256-LUpP4gBxe5kxH3OdCFWPx3APMqVMfJy/r3FGHrGxPqI=";
+    hash = "sha256-lVJFNOiayAai/Lg4tl8lNaK5fdTlZ0ptzstUzciH1mA=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--

xed-editor: 3.8.8 -> 3.8.9
timeshift: 25.12.3 -> 25.12.4
timeshift-unwrapped: 25.12.3 -> 25.12.4
sticky: 1.29 -> 1.30
hypnotix: 5.5 -> 5.6
xreader: 4.6.2 -> 4.6.3
xapp: 3.2.1 -> 3.2.2
warpinator: 2.0.2 -> 2.0.3
pix: 3.4.9 -> 3.4.10
folder-color-switcher: 1.7.0 -> 1.7.1


-->

Only translation updates.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

