### PR TITLE
linuxKernel.kernels.linux_rt_*: updates

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-rt-5.10.nix
+++ b/pkgs/os-specific/linux/kernel/linux-rt-5.10.nix
@@ -10,7 +10,7 @@
 }@args:
 
 let
-  version = "5.10.245-rt139"; # updated by ./update-rt.sh
+  version = "5.10.247-rt141"; # updated by ./update-rt.sh
   branch = lib.versions.majorMinor version;
   kversion = builtins.elemAt (lib.splitString "-" version) 0;
 in
@@ -25,7 +25,7 @@ buildLinux (
 
     src = fetchurl {
       url = "mirror://kernel/linux/kernel/v5.x/linux-${kversion}.tar.xz";
-      hash = "sha256-Ex516xTab9aDs4grzYVghc/KR8waqJzS3rG0jSLSnZ8=";
+      hash = "sha256-cMi4e6H82L+mY2YZNNyb2pLQtfPA/DGXu1Y5n2nZ/gw=";
     };
 
     kernelPatches =
@@ -34,7 +34,7 @@ buildLinux (
           name = "rt";
           patch = fetchurl {
             url = "mirror://kernel/linux/kernel/projects/rt/${branch}/older/patch-${version}.patch.xz";
-            hash = "sha256-0/8We7wtj6Y3oMDdkLzmpuOz0kiY4RlWZeUcxy7UDds=";
+            hash = "sha256-p3XNJ9f+MrxuVbxp+4ycBmLb0YiPdoMS4lGnp6u1Uts=";
           };
         };
       in

--- a/pkgs/os-specific/linux/kernel/linux-rt-5.15.nix
+++ b/pkgs/os-specific/linux/kernel/linux-rt-5.15.nix
@@ -10,7 +10,7 @@
 }@args:
 
 let
-  version = "5.15.195-rt90"; # updated by ./update-rt.sh
+  version = "5.15.197-rt91"; # updated by ./update-rt.sh
   branch = lib.versions.majorMinor version;
   kversion = builtins.elemAt (lib.splitString "-" version) 0;
 in
@@ -29,7 +29,7 @@ buildLinux (
 
     src = fetchurl {
       url = "mirror://kernel/linux/kernel/v5.x/linux-${kversion}.tar.xz";
-      hash = "sha256-I9CA3DL5nTk5w9G9ZaaO2FuPk0+SzBhBpj+Jjc25pEE=";
+      hash = "sha256-/SGN+OIQekRDtsKf73+VqtFnAx4Pvbx6hYroRxNgZoo=";
     };
 
     kernelPatches =
@@ -38,7 +38,7 @@ buildLinux (
           name = "rt";
           patch = fetchurl {
             url = "mirror://kernel/linux/kernel/projects/rt/${branch}/older/patch-${version}.patch.xz";
-            hash = "sha256-RdymUTnItL0Vi8Vt5j1lAlX/hxp6+Ka+oPBgD9agwZY=";
+            hash = "sha256-HRM/Ecbo7ZfPfq8uNXJO/XRb5I1EsjBHQPmXlVsF8lY=";
           };
         };
       in

--- a/pkgs/os-specific/linux/kernel/linux-rt-6.1.nix
+++ b/pkgs/os-specific/linux/kernel/linux-rt-6.1.nix
@@ -10,7 +10,7 @@
 }@args:
 
 let
-  version = "6.1.156-rt56"; # updated by ./update-rt.sh
+  version = "6.1.158-rt58"; # updated by ./update-rt.sh
   branch = lib.versions.majorMinor version;
   kversion = builtins.elemAt (lib.splitString "-" version) 0;
 in
@@ -29,7 +29,7 @@ buildLinux (
 
     src = fetchurl {
       url = "mirror://kernel/linux/kernel/v6.x/linux-${kversion}.tar.xz";
-      hash = "sha256-1LsUiyBOWu04aQSJc2lhza+SX+ezXPH1bEetegmgIo4=";
+      hash = "sha256-rQaL/bYE7A9PfeOFyOerlEAIqnikruypT1Mgbmcmv9o=";
     };
 
     kernelPatches =
@@ -38,7 +38,7 @@ buildLinux (
           name = "rt";
           patch = fetchurl {
             url = "mirror://kernel/linux/kernel/projects/rt/${branch}/older/patch-${version}.patch.xz";
-            hash = "sha256-kyTBYH+sQ55AJOzUER7xqnuA5KVFgEhHWC9ToniBquo=";
+            hash = "sha256-Ws250UnJ8Il9d4j5KerKwia5X19b3kM4NifMo3/ydGE=";
           };
         };
       in

--- a/pkgs/os-specific/linux/kernel/linux-rt-6.12.nix
+++ b/pkgs/os-specific/linux/kernel/linux-rt-6.12.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  buildLinux,
+  fetchurl,
+  kernelPatches ? [ ],
+  structuredExtraConfig ? { },
+  extraMeta ? { },
+  argsOverride ? { },
+  ...
+}@args:
+
+let
+  version = "6.12.57-rt14"; # updated by ./update-rt.sh
+  branch = lib.versions.majorMinor version;
+  kversion = builtins.elemAt (lib.splitString "-" version) 0;
+in
+buildLinux (
+  args
+  // {
+    inherit version;
+    pname = "linux-rt";
+
+    # modDirVersion needs a patch number, change X.Y-rtZ to X.Y.0-rtZ.
+    modDirVersion =
+      if (builtins.match "[^.]*[.][^.]*-.*" version) == null then
+        version
+      else
+        lib.replaceStrings [ "-" ] [ ".0-" ] version;
+
+    src = fetchurl {
+      url = "mirror://kernel/linux/kernel/v6.x/linux-${kversion}.tar.xz";
+      hash = "sha256-Flyhw3xGB7kOcxmWt8HjMRKFFn0T3u7fCPPx8LnSVBo=";
+    };
+
+    kernelPatches =
+      let
+        rt-patch = {
+          name = "rt";
+          patch = fetchurl {
+            url = "mirror://kernel/linux/kernel/projects/rt/${branch}/older/patch-${version}.patch.xz";
+            hash = "sha256-+mjg+g8EkSWxudBVjRf1fsW6dNO63XJ2/3y0VQqfGzQ=";
+          };
+        };
+      in
+      [ rt-patch ] ++ kernelPatches;
+
+    structuredExtraConfig =
+      with lib.kernel;
+      {
+        PREEMPT_RT = yes;
+        # Fix error: unused option: PREEMPT_RT.
+        EXPERT = yes; # PREEMPT_RT depends on it (in kernel/Kconfig.preempt)
+        # Fix error: option not set correctly: PREEMPT_VOLUNTARY (wanted 'y', got 'n').
+        PREEMPT_VOLUNTARY = lib.mkForce no; # PREEMPT_RT deselects it.
+        # Fix error: unused option: RT_GROUP_SCHED.
+        RT_GROUP_SCHED = lib.mkForce (option no); # Removed by sched-disable-rt-group-sched-on-rt.patch.
+      }
+      // structuredExtraConfig;
+
+    extraMeta = extraMeta // {
+      inherit branch;
+    };
+
+    isLTS = true;
+  }
+  // argsOverride
+)

--- a/pkgs/os-specific/linux/kernel/linux-rt-6.6.nix
+++ b/pkgs/os-specific/linux/kernel/linux-rt-6.6.nix
@@ -10,7 +10,7 @@
 }@args:
 
 let
-  version = "6.6.112-rt63"; # updated by ./update-rt.sh
+  version = "6.6.119-rt67"; # updated by ./update-rt.sh
   branch = lib.versions.majorMinor version;
   kversion = builtins.elemAt (lib.splitString "-" version) 0;
 in
@@ -29,7 +29,7 @@ buildLinux (
 
     src = fetchurl {
       url = "mirror://kernel/linux/kernel/v6.x/linux-${kversion}.tar.xz";
-      hash = "sha256-bH2SvzFqVukd5By2DaH2PZSk+Kr672oTBV3wwpETiiI=";
+      hash = "sha256-PaCbmAu0BMwoeTR5uy1sY2UiZ5IV/6ZaBMiTV1JT5eg=";
     };
 
     kernelPatches =
@@ -38,7 +38,7 @@ buildLinux (
           name = "rt";
           patch = fetchurl {
             url = "mirror://kernel/linux/kernel/projects/rt/${branch}/older/patch-${version}.patch.xz";
-            hash = "sha256-bv3jejZ2fitvGLzlpmUpWojC1TSf1o6Yd9hBUihv4gc=";
+            hash = "sha256-96iC3T7tUdyKwIG29v9VpuYOdzt6aHp/6ibmvm385gU=";
           };
         };
       in

--- a/pkgs/os-specific/linux/kernel/update-rt.sh
+++ b/pkgs/os-specific/linux/kernel/update-rt.sh
@@ -55,8 +55,8 @@ update-if-needed() {
         echo "$nixattr: $cur (up-to-date)"
         return
     fi
-    khash=$(nix-prefetch-url "$mirror/v${major}.x/linux-${kversion}.tar.xz" | nix-hash --type sha256 --to-sri)
-    phash=$(nix-prefetch-url "$mirror/projects/rt/${branch}/older/patch-${new}.patch.xz" | nix-hash --type sha256 --to-sri)
+    khash="$(nix-hash --to-sri --type sha256 "$(nix-prefetch-url --type sha256 "$mirror/v${major}.x/linux-${kversion}.tar.xz")")"
+    phash="$(nix-hash --to-sri --type sha256 "$(nix-prefetch-url --type sha256 "$mirror/projects/rt/${branch}/older/patch-${new}.patch.xz")")"
     if [ "$cur" ]; then
         msg="$nixattr: $cur -> $new"
     else


### PR DESCRIPTION
Rt version of the [6.18](https://mirrors.edge.kernel.org/pub/linux/kernel/projects/rt/6.18) kernel is not yet available, but should be added soon since most of the versions have less than a year until [EOL](https://endoflife.date/linux). 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
