### PR TITLE
haskellPackages.gi-ostree: work around argv limit; add pkgConfigModules metadata to various packages (as a prerequisite)

### DIFF
--- a/pkgs/by-name/gp/gpgme/package.nix
+++ b/pkgs/by-name/gp/gpgme/package.nix
@@ -19,7 +19,7 @@
   python3,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "gpgme";
   version = "2.0.1";
 
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
   outputBin = "dev"; # gpgme-config; not so sure about gpgme-tool
 
   src = fetchurl {
-    url = "mirror://gnupg/gpgme/gpgme-${version}.tar.bz2";
+    url = "mirror://gnupg/gpgme/gpgme-${finalAttrs.version}.tar.bz2";
     hash = "sha256-ghqwaVyELqtRdSqBmAySsEEMfq3QQQP3kdXSpSZ4SWY=";
   };
 
@@ -99,7 +99,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = "https://gnupg.org/software/gpgme/index.html";
-    changelog = "https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gpgme.git;f=NEWS;hb=gpgme-${version}";
+    changelog = "https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gpgme.git;f=NEWS;hb=gpgme-${finalAttrs.version}";
     description = "Library for making GnuPG easier to use";
     longDescription = ''
       GnuPG Made Easy (GPGME) is a library designed to make access to GnuPG
@@ -114,4 +114,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ dotlambda ];
   };
-}
+})

--- a/pkgs/by-name/gp/gpgme/package.nix
+++ b/pkgs/by-name/gp/gpgme/package.nix
@@ -17,6 +17,7 @@
   libsForQt5,
   qt6Packages,
   python3,
+  testers,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -95,6 +96,9 @@ stdenv.mkDerivation (finalAttrs: {
     python = python3.pkgs.gpgme;
     qt5 = libsForQt5.qgpgme;
     qt6 = qt6Packages.qgpgme;
+    pkg-config = testers.hasPkgConfigModules {
+      package = finalAttrs.finalPackage;
+    };
   };
 
   meta = {
@@ -113,5 +117,9 @@ stdenv.mkDerivation (finalAttrs: {
     ];
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ dotlambda ];
+    pkgConfigModules = [
+      "gpgme-glib"
+      "gpgme"
+    ];
   };
 })

--- a/pkgs/by-name/li/libarchive/package.nix
+++ b/pkgs/by-name/li/libarchive/package.nix
@@ -23,6 +23,7 @@
   cmake,
   nix,
   samba,
+  testers,
 
   # for passthru.lore
   binlore,
@@ -140,10 +141,14 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [ jcumming ];
     platforms = lib.platforms.all;
     inherit (acl.meta) badPlatforms;
+    pkgConfigModules = [ "libarchive" ];
   };
 
   passthru.tests = {
     inherit cmake nix samba;
+    pkg-config = testers.hasPkgConfigModules {
+      package = finalAttrs.finalPackage;
+    };
   };
 
   # bsdtar is detected as "cannot" because its exec is internal to

--- a/pkgs/by-name/li/libcap/package.nix
+++ b/pkgs/by-name/li/libcap/package.nix
@@ -23,6 +23,8 @@
   squid,
   tor,
   uwsgi,
+  testers,
+  libcap,
 }:
 
 assert usePam -> pam != null;
@@ -127,6 +129,9 @@ stdenv.mkDerivation rec {
       tor
       uwsgi
       ;
+    pkg-config = testers.hasPkgConfigModules {
+      package = libcap;
+    };
   };
 
   meta = {
@@ -134,5 +139,9 @@ stdenv.mkDerivation rec {
     homepage = "https://sites.google.com/site/fullycapable";
     platforms = lib.platforms.linux;
     license = lib.licenses.bsd3;
+    pkgConfigModules = [
+      "libcap"
+      "libpsx"
+    ];
   };
 }

--- a/pkgs/by-name/os/ostree/package.nix
+++ b/pkgs/by-name/os/ostree/package.nix
@@ -43,6 +43,7 @@
   replaceVars,
   openssl,
   ostree-full,
+  testers,
 }:
 
 let
@@ -170,6 +171,9 @@ stdenv.mkDerivation (finalAttrs: {
       musl = pkgsCross.musl64.ostree;
       installedTests = nixosTests.installed-tests.ostree;
       inherit ostree-full;
+      pkg-config = testers.hasPkgConfigModules {
+        package = finalAttrs.finalPackage;
+      };
     };
   };
 
@@ -179,5 +183,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.lgpl2Plus;
     platforms = lib.platforms.linux;
     maintainers = [ ];
+    pkgConfigModules = [ "ostree-1" ];
   };
 })

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -1967,6 +1967,7 @@ builtins.intersectAttrs super {
     gi-gtksource5
     gi-gsk
     gi-adwaita
+    gi-ostree
     sdl2-ttf
     sdl2
     dear-imgui


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Due to an unfortunate Cabal quirk, we need to propagate all pkg config deps to gi-ostree for it to compile properly. We can do this selectively *if* we have accurate `pkgConfigModules` metadata, so compiler flags don't cause argv limits to be hit.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
