### PR TITLE
nixos/console: ensure colors list is empty or contains 16 elements

### DIFF
--- a/nixos/modules/config/console.nix
+++ b/nixos/modules/config/console.nix
@@ -77,7 +77,9 @@ in
     };
 
     colors = lib.mkOption {
-      type = with lib.types; listOf (strMatching "[[:xdigit:]]{6}");
+      type =
+        with lib.types;
+        addCheck (listOf (strMatching "[[:xdigit:]]{6}")) (list: list == [ ] || builtins.length list == 16);
       default = [ ];
       example = [
         "002b36"

--- a/nixos/modules/config/console.nix
+++ b/nixos/modules/config/console.nix
@@ -103,7 +103,6 @@ in
         Colors must be in hexadecimal format and listed in
         order from color 0 to color 15.
       '';
-
     };
 
     packages = lib.mkOption {


### PR DESCRIPTION
```
commit f3c7eafb2ebff7634c57c3f3df53d290b0feeec0
Author: NAHO <90870942+trueNAHO@users.noreply.github.com>
Date:   2026-01-09 15:08:22 +0100

    nixos/console: remove empty line to improve readability

 nixos/modules/config/console.nix | 1 -
 1 file changed, 1 deletion(-)

commit 9ac5c603435520a2a7097e7d84f45675a62694e0
Author: NAHO <90870942+trueNAHO@users.noreply.github.com>
Date:   2026-01-09 15:13:41 +0100

    nixos/console: ensure colors list is empty or contains 16 elements

    Ensure the console.colors list is empty or contains exactly 16 elements
    to catch run time bugs at build time.

 nixos/modules/config/console.nix | 4 +++-
 1 file changed, 3 insertions(+), 1 deletion(-)
```

This is to prevent confusing run time errors mentioned in https://github.com/nix-community/stylix/issues/2127.

This PR was tested in Stylix and properly errors at build time when the list does not contain 0 or 16 elements:

```console
$ nix eval .#testbed:fish-nixos:dark
«error: A definition for option `virtualisation.vmVariant.console.colors' is not of type `list of string matching the pattern [[:xdigit:]]{6}'. TypeError: Definition values:
- In `/nix/store/55nybdhfsjxdml1sszb0rr9jzbl2pili-source/modules/console/nixos.nix':
    [
      "24273a"
      "ed8796"
      "a6da95"
      "eed49f"
    ...»
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
