### PR TITLE
prettier-plugin-astro: init at 0.14.1

### DIFF
--- a/pkgs/by-name/pr/prettier-plugin-astro/package.nix
+++ b/pkgs/by-name/pr/prettier-plugin-astro/package.nix
@@ -1,0 +1,63 @@
+{
+  fetchFromGitHub,
+  lib,
+  nodejs,
+  fetchPnpmDeps,
+  pnpm_9,
+  pnpmConfigHook,
+  stdenv,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "prettier-plugin-astro";
+  version = "0.14.1";
+
+  src = fetchFromGitHub {
+    owner = "withastro";
+    repo = "prettier-plugin-astro";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-XGPz4D2UKOonet0tX3up5mCxw3/69XYPScxb9l7nzpE=";
+  };
+
+  nativeBuildInputs = [
+    nodejs
+    pnpmConfigHook
+    pnpm_9
+  ];
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    fetcherVersion = 2;
+    hash = finalAttrs.pnpmDepsHash;
+  };
+
+  pnpmDepsHash = "sha256-K7pIWLkIIbUKDIcysfEtcf/eVMX9ZgyFHdqcuycHCNE=";
+
+  passthru.update-script = nix-update-script { };
+
+  buildPhase = ''
+    runHook preBuild
+    pnpm build
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/lib/node_modules/prettier-plugin-astro/dist
+    cp -r dist/* $out/lib/node_modules/prettier-plugin-astro/dist
+    cp -r node_modules $out/lib/node_modules/prettier-plugin-astro/node_modules
+    cp package.json $out/lib/node_modules/prettier-plugin-astro/package.json
+    cp README.md $out/lib/node_modules/prettier-plugin-astro/README.md
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Prettier plugin for Astro";
+    homepage = "https://github.com/withastro/prettier-plugin-astro";
+    changelog = "https://github.com/withastro/prettier-plugin-astro/releases/tag/v${finalAttrs.version}";
+    license = licenses.mit;
+    platforms = lib.platforms.unix;
+    maintainers = with maintainers; [ shikanime ];
+  };
+})


### PR DESCRIPTION
Change-Id: I0c49b829d11d79181ab3042c973208916a6a6964


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
