### PR TITLE
prettier-plugin-tailwindcss: init at 0.7.2

### DIFF
--- a/pkgs/by-name/pr/prettier-plugin-tailwindcss/package.nix
+++ b/pkgs/by-name/pr/prettier-plugin-tailwindcss/package.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  prettier,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "prettier-plugin-tailwindcss";
+  version = "0.7.2";
+
+  src = fetchFromGitHub {
+    owner = "tailwindlabs";
+    repo = "prettier-plugin-tailwindcss";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-/zRz0mP2P8xX8n0UQmzWt0eYNYA5S4RrD0lRzQYt03M=";
+  };
+
+  npmDepsHash = "sha256-J2TTD4rsEG2CYtGWfksbGdTD/yFOX/WeVwaUdlyjuPQ=";
+
+  # Prettier plugin for Tailwind CSS fail to resolve prettier dependency
+  postInstall = ''
+    mkdir -p $out/lib/node_modules/prettier-plugin-tailwindcss/node_modules
+    ln -s ${prettier}/lib/node_modules/prettier $out/lib/node_modules/prettier-plugin-tailwindcss/node_modules/prettier
+  '';
+
+  meta = with lib; {
+    description = "Prettier plugin for Tailwind CSS";
+    homepage = "https://github.com/tailwindlabs/prettier-plugin-tailwindcss";
+    changelog = "https://github.com/tailwindlabs/prettier-plugin-tailwindcss/releases/tag/v${finalAttrs.version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ shikanime ];
+  };
+})


### PR DESCRIPTION
Change-Id: Ib88035aaba36de489e8007d001eb6d676a6a6964


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
