### PR TITLE
Update vsrocq

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -3939,6 +3939,7 @@ let
         mktplcRef = {
           publisher = "rocq-prover";
           name = "vsrocq";
+          # When updating the version here, also update the language server vsrocq-language-server
           version = "2.3.4";
           hash = "sha256-2zYoCUtyhboQt68UJEmWOvrTrIOV2QmpaXU5mUhJfsA=";
         };

--- a/pkgs/development/coq-modules/vscoq-language-server/default.nix
+++ b/pkgs/development/coq-modules/vscoq-language-server/default.nix
@@ -16,7 +16,6 @@ let
     in
     with lib.versions;
     lib.switch coq.coq-version [
-      (case (range "8.18" "9.1") "2.3.3")
       (case (range "8.18" "9.1") "2.2.6")
       (case (range "8.18" "8.20") "2.2.1")
       (case (range "8.18" "8.19") "2.1.2")
@@ -42,8 +41,7 @@ let
     release."2.2.5".sha256 = "sha256-XyIjwem/yS7UIpQATNixgKkrMOHHs74nkAOvpU5WG1k=";
     release."2.2.6".rev = "v2.2.6";
     release."2.2.6".sha256 = "sha256-J8nRTAwN6GBEYgqlXa2kkkrHPatXsSObQg9QUQoZhgE=";
-    release."2.3.3".rev = "v2.3.3";
-    release."2.3.3".sha256 = "sha256-wgn28wqWhZS4UOLUblkgXQISgLV+XdSIIEMx9uMT/ig=";
+    # This is the last version of VsCoq. Now, new versions are for VsRocq.
     inherit location;
   };
   fetched = fetch (if version != null then version else defaultVersion);

--- a/pkgs/development/coq-modules/vscoq-language-server/default.nix
+++ b/pkgs/development/coq-modules/vscoq-language-server/default.nix
@@ -23,8 +23,8 @@ let
     ] null;
   location = {
     domain = "github.com";
-    owner = "coq-community";
-    repo = "vscoq";
+    owner = "rocq-prover";
+    repo = "vsrocq";
   };
   fetch = metaFetch {
     release."2.0.3+coq8.18".sha256 = "sha256-VXhHCP6Ni5/OcsgoI1EbJfYCpXzwkuR8kbbKrl6dfjU=";
@@ -77,7 +77,7 @@ ocamlPackages.buildDunePackage {
 
   meta = {
     description = "Language server for the vscoq vscode/codium extension";
-    homepage = "https://github.com/coq-community/vscoq";
+    homepage = "https://github.com/rocq-prover/vsrocq";
     maintainers = with lib.maintainers; [ cohencyril ];
     license = lib.licenses.mit;
   }

--- a/pkgs/development/rocq-modules/vsrocq-language-server/default.nix
+++ b/pkgs/development/rocq-modules/vsrocq-language-server/default.nix
@@ -16,8 +16,8 @@ let
       case = case: out: { inherit case out; };
     in
     lib.switch rocq-core.rocq-version [
-      (case (lib.versions.range "8.18" "9.1") "2.3.3")
-      (case (lib.versions.range "8.18" "9.1") "2.3.0")
+      # When updating the default version here, also update the VsRocq VS Code extension
+      (case (lib.versions.range "8.18" "9.1") "2.3.4")
     ] null;
   location = {
     domain = "github.com";
@@ -29,6 +29,8 @@ let
     release."2.3.0".sha256 = "sha256-BZLxcCmSGFf04eUmlJXnyxmg4hTwpFaPaIik4VD444M=";
     release."2.3.3".rev = "v2.3.3";
     release."2.3.3".sha256 = "sha256-wgn28wqWhZS4UOLUblkgXQISgLV+XdSIIEMx9uMT/ig=";
+    release."2.3.4".rev = "v2.3.4";
+    release."2.3.4".sha256 = "sha256-v1hQjE8U1o2VYOlUjH0seIsNG+NrMNZ8ixt4bQNyGvI=";
     inherit location;
   };
   fetched = fetch (if version != null then version else defaultVersion);

--- a/pkgs/development/rocq-modules/vsrocq-language-server/default.nix
+++ b/pkgs/development/rocq-modules/vsrocq-language-server/default.nix
@@ -74,7 +74,6 @@ ocamlPackages.buildDunePackage {
     license = lib.licenses.mit;
   }
   // lib.optionalAttrs (fetched.broken or false) {
-    rocqFilter = true;
     broken = true;
   };
 }

--- a/pkgs/top-level/coq-packages.nix
+++ b/pkgs/top-level/coq-packages.nix
@@ -222,6 +222,7 @@ let
       Vpl = callPackage ../development/coq-modules/Vpl { };
       VplTactic = callPackage ../development/coq-modules/VplTactic { };
       vscoq-language-server = callPackage ../development/coq-modules/vscoq-language-server { };
+      vsrocq-language-server = callPackage ../development/rocq-modules/vsrocq-language-server { };
       VST = callPackage ../development/coq-modules/VST (
         (lib.optionalAttrs (lib.versionAtLeast self.coq.version "8.14") {
           compcert = self.compcert.override {


### PR DESCRIPTION
See commit messages for details of changes:

- First commit is a simple update of vsrocq-language-server (catching up with the update of the VsRocq extension already made in #467514).
- The second commit reverts the update to vscoq-language-server from #460186 which broke the package (`vscoq-language-server` should actually be kept frozen at the last version before the renaming, this will also match the version of the frozen / deprecated `maximedenes.vscoq` VS Code extension).
- The third commit is cosmetic: it updates the references to the VsCoq/VsRocq GitHub repository.
- The last commit adds `vsrocq-language-server` to the `coqPackages` collection. There is no reason for the package not to be listed there. And in fact, despite its name, it actually still depends on `coq`.

cc @CohenCyril for review

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
