### PR TITLE
koreader: fix Japanese text selection with patched luajit

### DIFF
--- a/pkgs/by-name/ko/koreader/package.nix
+++ b/pkgs/by-name/ko/koreader/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  fetchpatch,
   makeWrapper,
   fetchFromGitHub,
   dpkg,
@@ -14,10 +15,20 @@
   openssl,
   writeScript,
 }:
-let
-  luajit_lua52 = luajit.override { enable52Compat = true; };
 
+let
   version = "2025.10";
+
+  # LuaJIT with table.pack/unpack support for KOReader
+  # https://github.com/koreader/koreader-base/tree/master/thirdparty/luajit
+  luajit_koreader = luajit.overrideAttrs (old: {
+    patches = (old.patches or [ ]) ++ [
+      (fetchpatch {
+        url = "https://raw.githubusercontent.com/koreader/koreader-base/master/thirdparty/luajit/koreader-luajit-enable-table_pack.patch";
+        hash = "sha256-tvx7eRoSwnumqK6H7+2RCAKRDFJtaRY/2mRPjy30fJA=";
+      })
+    ];
+  });
 
   src_repo = fetchFromGitHub {
     repo = "koreader";
@@ -52,14 +63,15 @@ stdenv.mkDerivation {
     };
 
   nativeBuildInputs = [
-    makeWrapper
     dpkg
+    makeWrapper
   ];
+
   buildInputs = [
     glib
     gnutar
     gtk3-x11
-    luajit_lua52
+    luajit_koreader
     sdcv
     SDL2
     openssl
@@ -72,7 +84,7 @@ stdenv.mkDerivation {
   ''
   # Link required binaries
   + ''
-    ln -sf ${luajit_lua52}/bin/luajit $out/lib/koreader/luajit
+    ln -sf ${luajit_koreader}/bin/luajit $out/lib/koreader/luajit
     ln -sf ${sdcv}/bin/sdcv $out/lib/koreader/sdcv
     ln -sf ${gnutar}/bin/tar $out/lib/koreader/tar
   ''
@@ -83,7 +95,7 @@ stdenv.mkDerivation {
   ''
   # Copy fonts
   + ''
-    find ${src_repo}/resources/fonts -type d -execdir cp -r '{}' $out/lib/koreader/fonts \;
+    cp -r ${src_repo}/resources/fonts/* $out/lib/koreader/fonts/
   ''
   # Remove broken symlinks
   + ''
@@ -104,7 +116,7 @@ stdenv.mkDerivation {
   '';
 
   passthru = {
-    inherit src_repo;
+    inherit src_repo luajit_koreader;
     updateScript = writeScript "update-koreader" ''
       #!/usr/bin/env nix-shell
       #!nix-shell -i bash -p nix curl jq nix-update common-updater-scripts


### PR DESCRIPTION
Fix : https://github.com/NixOS/nixpkgs/issues/467723

Fix fonts issue & japan support issue.

Koreader use specific version of luajit with patchs.
And I think the best solution is to have the same version with the same patch to avoid compatibility issues and other problems.
I remembered openresty and I think it's the best approach for koreader.


```
01/09/26-16:45:16 ERROR An error occurred while executing handler japanese:onWordSelection:
 frontend/ui/trapper.lua:416: attempt to yield across C-call boundary 
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
