### PR TITLE
libedgetpu: fix building with GCC 15

### DIFF
--- a/pkgs/by-name/li/libedgetpu/cstdint.patch
+++ b/pkgs/by-name/li/libedgetpu/cstdint.patch
@@ -1,0 +1,13 @@
+diff --git a/driver/usb/usb_device_interface.h b/driver/usb/usb_device_interface.h
+index 238bca9..54f2f6e 100644
+--- a/driver/usb/usb_device_interface.h
++++ b/driver/usb/usb_device_interface.h
+@@ -15,6 +15,8 @@
+ #ifndef DARWINN_DRIVER_USB_USB_DEVICE_INTERFACE_H_
+ #define DARWINN_DRIVER_USB_USB_DEVICE_INTERFACE_H_
+ 
++#include <cstdint>
++
+ #include "port/array_slice.h"
+ #include "port/integral_types.h"
+ #include "port/status.h"

--- a/pkgs/by-name/li/libedgetpu/package.nix
+++ b/pkgs/by-name/li/libedgetpu/package.nix
@@ -42,6 +42,7 @@ stdenv.mkDerivation {
       hash = "sha256-mMODpQmikfXtsQvtgh26cy97EiykYNLngSjidOBt/3I=";
     })
     ./fix-abseil-20250512.0.patch
+    ./cstdint.patch
   ];
 
   postPatch = ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Fixes building with GCC 15 (broken due to a missing `cstdint` include).

Arch also fixes the package this way: https://aur.archlinux.org/cgit/aur.git/tree/usb_device_interface.patch?h=libedgetpu-git&id=575a48cd8f688ce7ce1b2dea35a31f5ce3d92110

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
