### PR TITLE
exodus: 25.28.4 -> 26.1.5

### DIFF
--- a/pkgs/by-name/ex/exodus/package.nix
+++ b/pkgs/by-name/ex/exodus/package.nix
@@ -28,12 +28,12 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "exodus";
-  version = "25.28.4";
+  version = "26.1.5";
 
   src = requireFile {
     name = "exodus-linux-x64-${finalAttrs.version}.zip";
     url = "https://downloads.exodus.com/releases/exodus-linux-x64-${finalAttrs.version}.zip";
-    hash = "sha256-AGeFsMHSywC32iaIGI9/VY2YC3gR5bHu33rOWJlyFFM=";
+    hash = "sha256-BClWuL4dTc1lESyEXuDtpGp1K/AxICbpQIaWYLrme1M=";
   };
 
   nativeBuildInputs = [ unzip ];


### PR DESCRIPTION
This pull request superseeds: https://github.com/NixOS/nixpkgs/pull/478411
Just a bump on the upstream version to make the package work.