### PR TITLE
krita-plugin-gmic: 3.2.4.1 -> 3.6.4.1

### DIFF
--- a/pkgs/by-name/kr/krita-plugin-gmic/package.nix
+++ b/pkgs/by-name/kr/krita-plugin-gmic/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitHub,
+  fetchurl,
   cmake,
   extra-cmake-modules,
   fftw,
@@ -11,15 +11,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "krita-plugin-gmic";
-  version = "3.2.4.1";
+  version = "3.6.4.1";
 
-  src = fetchFromGitHub {
-    owner = "amyspark";
-    repo = "gmic";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-SYE8kGvN7iD5OqiEEZpB/eRle67PrB5DojMC79qAQtg=";
+  src = fetchurl {
+    url = "https://files.kde.org/krita/build/dependencies/gmic-${finalAttrs.version}.tar.gz";
+    hash = "sha256-prbGkwFWC+LqK1WDqOwZvX5Q5LQal3dFUXzpILwF+v4=";
   };
-  sourceRoot = "${finalAttrs.src.name}/gmic-qt";
+  sourceRoot = "gmic-v${finalAttrs.version}/gmic-qt";
   dontWrapQtApps = true;
 
   postPatch = ''
@@ -49,7 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   meta = {
-    homepage = "https://github.com/amyspark/gmic";
+    homepage = "https://krita.org";
     description = "GMic plugin for Krita";
     license = lib.licenses.cecill21;
     maintainers = with lib.maintainers; [ lelgenio ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The [old repository](https://github.com/amyspark/gmic) for krita's gmic-qt fork has been archived. Following what is done in [krita's source code](https://invent.kde.org/graphics/krita/-/blob/fa234b48deddbd3072d42a1bf85d159af851d228/3rdparty_plugins/ext_gmic/CMakeLists.txt), we now fetch the code from their archive.

For reference, on Archilinux's [PKGBUILD](https://gitlab.archlinux.org/archlinux/packaging/packages/krita-plugin-gmic/-/blob/main/PKGBUILD) a similar process is done, but using a [github repository](https://github.com/vanyossi/gmic) as a proxy.

I have no idea what to do with `meta.homepage`, since there appears to be none.

fixes: https://github.com/NixOS/nixpkgs/issues/475789

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
