### PR TITLE
chroma: 2.20.0 → 2.22.0

### DIFF
--- a/pkgs/by-name/ch/chroma/package.nix
+++ b/pkgs/by-name/ch/chroma/package.nix
@@ -10,7 +10,7 @@ in
 
 buildGoModule rec {
   pname = "chroma";
-  version = "2.20.0";
+  version = "2.22.0";
 
   # To update:
   # nix-prefetch-git --rev v${version} https://github.com/alecthomas/chroma.git > src.json
@@ -21,7 +21,7 @@ buildGoModule rec {
     inherit (srcInfo) sha256;
   };
 
-  vendorHash = "sha256-GiaVgqhhrexSnBWVtQ+/cwdykHVDxR95BFMkrH1s+8Q=";
+  vendorHash = "sha256-kzlXrIMSa5C4UFt+BiMh6NedelQG49OxYbreeWhCb80=";
 
   modRoot = "./cmd/chroma";
 

--- a/pkgs/by-name/ch/chroma/src.json
+++ b/pkgs/by-name/ch/chroma/src.json
@@ -1,13 +1,14 @@
 {
   "url": "https://github.com/alecthomas/chroma.git",
-  "rev": "303b65df3f2d2151cee24bcf9f9b625db474ef51",
-  "date": "2025-08-04T13:55:06+10:00",
-  "path": "/nix/store/1f8p33h1srs9knj6sn6mc5rf0wcybf4g-chroma",
-  "sha256": "05w4hnfcxqdlsz7mkc0m3jbp1aj67wzyhq5jh8ldfgnyjnlafia3",
-  "hash": "sha256-Q0WnqJXePtcogrJg6D8/RqpwlxwVsFnP17ThzpyFhBc=",
+  "rev": "467c878aa553cdb4b0d486a534ea744f6ac7ef5e",
+  "date": "2026-01-10T09:37:30+11:00",
+  "path": "/nix/store/qkfgjvpw8j5rkfgh687kxzkv8ac9apba-chroma",
+  "sha256": "1wlvxxlbwaq963rkr9fwxc6qwa77m49icq2gdzf46w7wdc3cygpm",
+  "hash": "sha256-9T7PBmv8cEPcb09gFhOp5yiODevcpTzzMAkrvmjvm/I=",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
   "fetchTags": false,
-  "leaveDotGit": false
+  "leaveDotGit": false,
+  "rootDir": ""
 }


### PR DESCRIPTION
~~Version bump + KDL support patch. Timing-wise this was perfect as I was looking for _any_ tool that supported both Nix _&_ KDL. The KDL patch was merged yesterday (which obviously a new release isn’t yet cut, but KDL was the primary motivator for doing the update). HTML output **works** for me.~~

~~I am not 100% sure the `src.json` will work with the patch as I can’t tell if my cached build made it work or not. I will let ofborg try.~~

https://github.com/alecthomas/chroma/issues/1193
https://github.com/alecthomas/chroma/commit/467c878aa553cdb4b0d486a534ea744f6ac7ef5e

<!--
^ Please summarize the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.
