### PR TITLE
libui-ng: fix tests with cmocka 2

### DIFF
--- a/pkgs/by-name/li/libui-ng/0001-Remove-cm_print_error-declaration.patch
+++ b/pkgs/by-name/li/libui-ng/0001-Remove-cm_print_error-declaration.patch
@@ -1,0 +1,32 @@
+From 5bfab42bc531e40d99ea88a1fb7662c8388ee833 Mon Sep 17 00:00:00 2001
+From: Marcin Serwin <marcin@serwin.dev>
+Date: Fri, 9 Jan 2026 21:23:39 +0100
+Subject: [PATCH] Remove cm_print_error declaration
+
+With CMocka 2.0.0 this `cm_print_error` is now a macro so using it as
+a function name causes syntax errors. I've checked that 1.1.8 has this
+declaration in `cmocka.h` header so it seems to no longer be needed even
+with the older version.
+
+Signed-off-by: Marcin Serwin <marcin@serwin.dev>
+---
+ test/unit/drawmatrix.c | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/test/unit/drawmatrix.c b/test/unit/drawmatrix.c
+index 2e263fc0..49623388 100644
+--- a/test/unit/drawmatrix.c
++++ b/test/unit/drawmatrix.c
+@@ -15,9 +15,6 @@ static int compareDouble(double a, double b, double epsilon)
+ 	return diff <= epsilon * eps_scale;
+ }
+ 
+-// It's not defined in cmocka.h but exists in cmocka.c
+-void cm_print_error(const char * const format, ...);
+-
+ // Check if a == b without aborting the test.
+ static int expectDoubleEqual(double a, double b, int first_error, const char* error_prefix)
+ {
+-- 
+2.52.0
+

--- a/pkgs/by-name/li/libui-ng/package.nix
+++ b/pkgs/by-name/li/libui-ng/package.nix
@@ -23,6 +23,9 @@ stdenv.mkDerivation {
 
   patches = [
     ./darwin-no-universal.patch
+
+    # https://github.com/libui-ng/libui-ng/pull/348
+    ./0001-Remove-cm_print_error-declaration.patch
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
Related to: https://github.com/NixOS/nixpkgs/pull/467954


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
