### PR TITLE
ocamlPackages_latest: 5.3 -> 5.4, add recurseIntoAttrs to all-packages

### DIFF
--- a/pkgs/development/ocaml-modules/morbig/default.nix
+++ b/pkgs/development/ocaml-modules/morbig/default.nix
@@ -9,35 +9,32 @@
   visitors,
 }:
 
-lib.throwIf (lib.versionAtLeast ocaml.version "5.4")
-  "morbig is not available for OCaml ${ocaml.version}"
+buildDunePackage rec {
+  pname = "morbig";
+  version = "0.11.0";
 
-  buildDunePackage
-  rec {
-    pname = "morbig";
-    version = "0.11.0";
+  src = fetchFromGitHub {
+    owner = "colis-anr";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-fOBaJHHP/Imi9UDLflI52OdKDcmMxpl+NH3pfofmv/o=";
+  };
 
-    src = fetchFromGitHub {
-      owner = "colis-anr";
-      repo = pname;
-      rev = "v${version}";
-      hash = "sha256-fOBaJHHP/Imi9UDLflI52OdKDcmMxpl+NH3pfofmv/o=";
-    };
+  nativeBuildInputs = [
+    menhir
+  ];
 
-    nativeBuildInputs = [
-      menhir
-    ];
+  propagatedBuildInputs = [
+    menhirLib
+    ppx_deriving_yojson
+    visitors
+  ];
 
-    propagatedBuildInputs = [
-      menhirLib
-      ppx_deriving_yojson
-      visitors
-    ];
-
-    meta = {
-      homepage = "https://github.com/colis-anr/${pname}";
-      description = "Static parser for POSIX Shell";
-      license = lib.licenses.gpl3Plus;
-      maintainers = with lib.maintainers; [ niols ];
-    };
-  }
+  meta = {
+    homepage = "https://github.com/colis-anr/${pname}";
+    description = "Static parser for POSIX Shell";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ niols ];
+    broken = lib.versionAtLeast ocaml.version "5.4";
+  };
+}

--- a/pkgs/development/tools/ocaml/camlp4/default.nix
+++ b/pkgs/development/tools/ocaml/camlp4/default.nix
@@ -9,7 +9,7 @@
   findlib,
 }:
 
-if lib.versionAtLeast ocaml.version "5.4" then
+if lib.versionAtLeast ocaml.version "5.5" then
   throw "camlp4 is not available for OCaml ${ocaml.version}"
 else
 
@@ -83,6 +83,10 @@ else
         "5.3" = {
           version = "5.3";
           sha256 = "sha256-V/kKhTP9U4jWDFuQKuB7BS3XICg1lq/2Avj7UJR55+k=";
+        };
+        "5.4" = {
+          version = "5.4";
+          sha256 = "sha256-7FsKEr0cRVF4LIOvROWMyXBefRTBaS66ZqwtP2VLefM=";
         };
       }
       .${ocaml.meta.branch};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4968,6 +4968,7 @@ with pkgs;
   ocaml = ocamlPackages.ocaml;
 
   ocamlPackages = recurseIntoAttrs ocaml-ng.ocamlPackages;
+  ocamlPackages_latest = recurseIntoAttrs ocaml-ng.ocamlPackages_latest;
 
   ocaml-crunch = ocamlPackages.crunch.bin;
 

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -2321,7 +2321,7 @@ rec {
 
   ocamlPackages_5_4 = mkOcamlPackages (callPackage ../development/compilers/ocaml/5.4.nix { });
 
-  ocamlPackages_latest = ocamlPackages_5_3;
+  ocamlPackages_latest = ocamlPackages_5_4;
 
   ocamlPackages = ocamlPackages_5_3;
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Updates the latest package set to 5.4 and adds a recurse so hydra will build this set. I am hoping to get the newest version of ocaml, and at least a few of the development tools, building in hydra. This is one way to accomplish such, but will obviously bring the entire package set into scope. My initial thought is this could be acceptable, but I'm not attached to this implementation, so if you have alternative ideas please let me know.

ocamlPackages_latest doesn't seem to be used in tree.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
