### PR TITLE
audible-cli: Remove fish completion generation

### DIFF
--- a/pkgs/by-name/au/audible-cli/package.nix
+++ b/pkgs/by-name/au/audible-cli/package.nix
@@ -50,7 +50,6 @@ python3Packages.buildPythonApplication rec {
   postInstall = ''
     installShellCompletion --cmd audible \
       --bash <(source utils/code_completion/audible-complete-bash.sh) \
-      --fish <(source utils/code_completion/audible-complete-zsh-fish.sh) \
       --zsh <(source utils/code_completion/audible-complete-zsh-fish.sh)
   '';
 


### PR DESCRIPTION
`audible-cli` does not produce a valid fish script when sourcing `utils/code_completion/audible-complete-zsh-fish.sh`.  Produced zsh script only produces syntax errors when sourced by fish.

See here: https://github.com/mkb79/audible-cli/issues/253

A newer release of `audible-cli` may include correct fish completion, at which point, completion can be provided for fish as well.

See here: https://github.com/mkb79/audible-cli/pull/252


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
- Tested: Built the package and verified that the fish completion is no longer produced

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
