### PR TITLE
onnx: 1.20.0 -> 1.20.1

### DIFF
--- a/pkgs/by-name/on/onnx/package.nix
+++ b/pkgs/by-name/on/onnx/package.nix
@@ -1,12 +1,18 @@
 {
-  cmake,
-  fetchFromGitHub,
-  gtest,
   lib,
-  ninja,
-  protobuf,
-  python3Packages,
   stdenv,
+  python3Packages,
+  fetchFromGitHub,
+
+  # nativeBuildInputs
+  cmake,
+  ninja,
+
+  # buildInputs
+  protobuf,
+
+  # checkInputs
+  gtest,
 }:
 let
   inherit (lib)
@@ -27,13 +33,13 @@ stdenv.mkDerivation (finalAttrs: {
   strictDeps = true;
 
   pname = "onnx";
-  version = "1.20.0";
+  version = "1.20.1";
 
   src = fetchFromGitHub {
     owner = "onnx";
     repo = "onnx";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-oWbrBx1jWznzeT2N+VrFH8LIqdzY/aXH5N0kb/vbg2M=";
+    hash = "sha256-XZJXD6sBvVJ6cLPyDkKOW8oSkjqcw9whUqDWd7dxY3c=";
   };
 
   outputs = [
@@ -49,18 +55,6 @@ stdenv.mkDerivation (finalAttrs: {
     python
     setuptools
   ];
-
-  # NOTE: Darwin requires a static build, so this patch is unnecessary on that platform.
-  prePatch = lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
-    nixLog "patching $PWD/CMakeLists.txt to fix symbol visibility"
-    substituteInPlace "$PWD/CMakeLists.txt" \
-      --replace-fail \
-        'set_target_properties(onnx_object PROPERTIES CXX_VISIBILITY_PRESET hidden)' \
-        '# set_target_properties(onnx_object PROPERTIES CXX_VISIBILITY_PRESET hidden)' \
-      --replace-fail \
-        'set_target_properties(onnx_object PROPERTIES VISIBILITY_INLINES_HIDDEN ON)' \
-        '# set_target_properties(onnx_object PROPERTIES VISIBILITY_INLINES_HIDDEN ON)'
-  '';
 
   # NOTE: python3Packages.protobuf does not propagate a dependency on protobuf's dev output, so we must bring it in
   # for the CMake files.


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/onnx/onnx/compare/v1.20.0...v1.20.1
Changelog: https://github.com/onnx/onnx/releases/tag/v1.20.1

cc @acairncross @ConnorBaker

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc