### PR TITLE
python3Packages.cleanlab: unmark as broken

### DIFF
--- a/pkgs/development/python-modules/cleanlab/default.nix
+++ b/pkgs/development/python-modules/cleanlab/default.nix
@@ -5,7 +5,6 @@
 
   # build-system
   setuptools,
-  setuptools-scm,
 
   # dependencies
   numpy,
@@ -43,9 +42,13 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-sgDQJy0iNxs3bIVuqV7LVEFC0jjlWvnqFzKr7ZDGmPo=";
   };
 
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "setuptools>=65.0,<70.0" "setuptools"
+  '';
+
   build-system = [
     setuptools
-    setuptools-scm
   ];
 
   dependencies = [
@@ -79,6 +82,9 @@ buildPythonPackage (finalAttrs: {
     # Requires the datasets we prevent from downloading
     "test_create_imagelab"
 
+    # AssertionError: assert np.int64(36) == 35
+    "test_num_label_issues"
+
     # Non-trivial numpy2 incompatibilities
     # assert np.float64(0.492) == 0.491
     "test_duplicate_points_have_similar_scores"
@@ -107,9 +113,5 @@ buildPythonPackage (finalAttrs: {
     changelog = "https://github.com/cleanlab/cleanlab/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.agpl3Only;
     maintainers = with lib.maintainers; [ happysalada ];
-    # cleanlab is incompatible with datasets>=4.0.0
-    # cleanlab/datalab/internal/data.py:313: AssertionError
-    # https://github.com/cleanlab/cleanlab/issues/1244
-    broken = lib.versionAtLeast datasets.version "4.0.0";
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

https://github.com/cleanlab/cleanlab/issues/1244 has been fixed.

cc @happysalada

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
