### PR TITLE
kiro-cli: init at 1.24.0

### DIFF
--- a/pkgs/by-name/ki/kiro-cli/package.nix
+++ b/pkgs/by-name/ki/kiro-cli/package.nix
@@ -1,0 +1,107 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  makeBinaryWrapper,
+  undmg,
+  versionCheckHook,
+  xz,
+  bzip2,
+}:
+
+let
+  inherit (stdenv.hostPlatform) system;
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "kiro-cli";
+  version = "1.24.0";
+
+  src =
+    let
+      darwinDmg = fetchurl {
+        url = "https://desktop-release.q.us-east-1.amazonaws.com/${finalAttrs.version}/Kiro%20CLI.dmg";
+        hash = "sha256-V/akA/fcQZFULlBgGNibQRrhiBpGOr2s+jdPrAGOtnY=";
+      };
+    in
+    {
+      x86_64-linux = fetchurl {
+        url = "https://desktop-release.q.us-east-1.amazonaws.com/${finalAttrs.version}/kirocli-x86_64-linux.tar.gz";
+        hash = "sha256-kDvM5OVKaB7RYmYySRNyMMMPllGPXuO27/E4/SN3onY=";
+      };
+      aarch64-linux = fetchurl {
+        url = "https://desktop-release.q.us-east-1.amazonaws.com/${finalAttrs.version}/kirocli-aarch64-linux.tar.gz";
+        hash = "sha256-gprO84khQoRPCeNqZny3TP2ndQgJrtRm0xcpSjzrYHI=";
+      };
+      x86_64-darwin = darwinDmg;
+      aarch64-darwin = darwinDmg;
+    }
+    .${system} or (throw "Unsupported system: ${system}");
+
+  sourceRoot = if stdenv.hostPlatform.isDarwin then "Kiro CLI.app" else "kirocli";
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    makeBinaryWrapper
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    autoPatchelfHook
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    undmg
+  ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    stdenv.cc.cc.lib
+    xz
+    bzip2
+  ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+  ''
+  + lib.optionalString stdenv.hostPlatform.isLinux ''
+    install -Dm755 bin/kiro-cli $out/bin/.kiro-wrapped
+    install -Dm755 bin/kiro-cli-chat $out/bin/kiro-cli-chat
+    install -Dm755 bin/kiro-cli-term $out/bin/kiro-cli-term
+    makeBinaryWrapper $out/bin/.kiro-wrapped $out/bin/kiro \
+      --prefix PATH : $out/bin
+  ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    mkdir -p $out/bin $out/Applications
+    cp -r "../Kiro CLI.app" "$out/Applications/"
+    ln -s "$out/Applications/Kiro CLI.app/Contents/MacOS/kiro-cli" $out/bin/kiro
+    for bin in kiro-cli-chat kiro-cli-term; do
+      if [[ -e "$out/Applications/Kiro CLI.app/Contents/MacOS/$bin" ]]; then
+        ln -s "$out/Applications/Kiro CLI.app/Contents/MacOS/$bin" "$out/bin/$bin"
+      fi
+    done
+  ''
+  + ''
+    runHook postInstall
+  '';
+
+  passthru.updateScript = ./update.sh;
+
+  meta = {
+    description = "Command-line interface for Kiro, an agentic IDE";
+    homepage = "https://kiro.dev";
+    license = lib.licenses.unfree;
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    maintainers = [ lib.maintainers.jamesward ];
+    mainProgram = "kiro";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+  };
+})

--- a/pkgs/by-name/ki/kiro-cli/update.sh
+++ b/pkgs/by-name/ki/kiro-cli/update.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq nix coreutils
+
+set -euo pipefail
+
+MANIFEST_URL="https://desktop-release.q.us-east-1.amazonaws.com/latest/manifest.json"
+PACKAGE_DIR="$(dirname "$0")"
+PACKAGE_NIX="$PACKAGE_DIR/package.nix"
+
+manifest=$(curl -fsSL "$MANIFEST_URL")
+latest_version=$(echo "$manifest" | jq -r '.version')
+current_version=$(grep -Po '^\s+version\s*=\s*"\K[0-9.]+' "$PACKAGE_NIX" | head -1)
+
+if [[ "$latest_version" == "$current_version" ]]; then
+    echo "kiro-cli is already up to date at version $current_version"
+    exit 0
+fi
+
+echo "Updating kiro-cli from $current_version to $latest_version"
+
+get_linux_hash() {
+    local arch="$1"
+    echo "$manifest" | jq -r --arg arch "$arch" '
+        .packages[] |
+        select(.os == "linux" and .fileType == "tarGz" and .variant == "headless" and .architecture == $arch and (.targetTriple | contains("musl") | not)) |
+        .sha256
+    '
+}
+
+get_darwin_hash() {
+    echo "$manifest" | jq -r '
+        .packages[] |
+        select(.os == "macos" and .fileType == "dmg") |
+        .sha256
+    '
+}
+
+hex_to_sri() {
+    local hex="$1"
+    nix hash convert --to sri --hash-algo sha256 "$hex"
+}
+
+x86_64_linux_hex=$(get_linux_hash "x86_64")
+aarch64_linux_hex=$(get_linux_hash "aarch64")
+darwin_hex=$(get_darwin_hash)
+
+if [[ -z "$x86_64_linux_hex" || -z "$aarch64_linux_hex" || -z "$darwin_hex" ]]; then
+    echo "Error: Could not find all hashes in manifest"
+    echo "  x86_64-linux: $x86_64_linux_hex"
+    echo "  aarch64-linux: $aarch64_linux_hex"
+    echo "  darwin: $darwin_hex"
+    exit 1
+fi
+
+x86_64_linux_hash=$(hex_to_sri "$x86_64_linux_hex")
+aarch64_linux_hash=$(hex_to_sri "$aarch64_linux_hex")
+darwin_hash=$(hex_to_sri "$darwin_hex")
+
+echo "x86_64-linux hash: $x86_64_linux_hash"
+echo "aarch64-linux hash: $aarch64_linux_hash"
+echo "darwin hash: $darwin_hash"
+
+# Get current hashes from package.nix
+current_x86_hash=$(grep -A2 'x86_64-linux = fetchurl' "$PACKAGE_NIX" | grep -Po 'hash = "\K[^"]+')
+current_aarch64_hash=$(grep -A2 'aarch64-linux = fetchurl' "$PACKAGE_NIX" | grep -Po 'hash = "\K[^"]+')
+current_darwin_hash=$(grep -A2 'darwinDmg = fetchurl' "$PACKAGE_NIX" | grep -Po 'hash = "\K[^"]+')
+
+# Update version and hashes
+sed -i "s|version = \"$current_version\"|version = \"$latest_version\"|" "$PACKAGE_NIX"
+sed -i "s|$current_x86_hash|$x86_64_linux_hash|" "$PACKAGE_NIX"
+sed -i "s|$current_aarch64_hash|$aarch64_linux_hash|" "$PACKAGE_NIX"
+sed -i "s|$current_darwin_hash|$darwin_hash|" "$PACKAGE_NIX"
+
+echo "Updated kiro-cli to version $latest_version"


### PR DESCRIPTION
## Things done

New [kiro-cli](https://kiro.dev/cli) package

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
