### PR TITLE
coreutils: use finalAttrs, fix .passthru.binlore

### DIFF
--- a/pkgs/tools/misc/coreutils/default.nix
+++ b/pkgs/tools/misc/coreutils/default.nix
@@ -2,14 +2,11 @@
   lib,
   stdenv,
   fetchurl,
-  autoreconfHook,
   buildPackages,
   libiconv,
   perl,
-  texinfo,
   xz,
   binlore,
-  coreutils,
   gmpSupport ? true,
   gmp,
   aclSupport ? lib.meta.availableOn stdenv.hostPlatform acl,
@@ -46,12 +43,12 @@ let
     ;
   isCross = (stdenv.hostPlatform != stdenv.buildPlatform);
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "coreutils" + (optionalString (!minimal) "-full");
   version = "9.9";
 
   src = fetchurl {
-    url = "mirror://gnu/coreutils/coreutils-${version}.tar.xz";
+    url = "mirror://gnu/coreutils/coreutils-${finalAttrs.version}.tar.xz";
     hash = "sha256-Gby2yoZxg8V9dxVerpRsXs7YgYMUO0XKUa19JsYoynU=";
   };
 
@@ -232,7 +229,7 @@ stdenv.mkDerivation rec {
       #
       # binlore only spots exec in runcon on some platforms (i.e., not
       # darwin; see comment on inverse case below)
-      binlore.out = binlore.synthesize coreutils ''
+      binlore.out = binlore.synthesize finalAttrs.finalPackage ''
         execer can bin/{chroot,env,install,nice,nohup,runcon,sort,split,stdbuf,timeout}
         execer cannot bin/{[,b2sum,base32,base64,basename,basenc,cat,chcon,chgrp,chmod,chown,cksum,comm,cp,csplit,cut,date,dd,df,dir,dircolors,dirname,du,echo,expand,expr,factor,false,fmt,fold,groups,head,hostid,id,join,kill,link,ln,logname,ls,md5sum,mkdir,mkfifo,mknod,mktemp,mv,nl,nproc,numfmt,od,paste,pathchk,pinky,pr,printenv,printf,ptx,pwd,readlink,realpath,rm,rmdir,seq,sha1sum,sha224sum,sha256sum,sha384sum,sha512sum,shred,shuf,sleep,stat,stty,sum,sync,tac,tail,tee,test,touch,tr,true,truncate,tsort,tty,uname,unexpand,uniq,unlink,uptime,users,vdir,wc,who,whoami,yes}
       '';
@@ -242,7 +239,7 @@ stdenv.mkDerivation rec {
       # darwin; I have a note that the behavior may need selinux?).
       # hard-set it so people working on macOS don't miss cases of
       # runcon until ofBorg fails.
-      binlore.out = binlore.synthesize coreutils ''
+      binlore.out = binlore.synthesize finalAttrs.finalPackage ''
         execer can bin/runcon
       '';
     };
@@ -263,4 +260,4 @@ stdenv.mkDerivation rec {
     platforms = with lib.platforms; unix ++ windows;
     priority = 10;
   };
-}
+})

--- a/pkgs/tools/misc/coreutils/default.nix
+++ b/pkgs/tools/misc/coreutils/default.nix
@@ -229,19 +229,27 @@ stdenv.mkDerivation (finalAttrs: {
       #
       # binlore only spots exec in runcon on some platforms (i.e., not
       # darwin; see comment on inverse case below)
-      binlore.out = binlore.synthesize finalAttrs.finalPackage ''
-        execer can bin/{chroot,env,install,nice,nohup,runcon,sort,split,stdbuf,timeout}
-        execer cannot bin/{[,b2sum,base32,base64,basename,basenc,cat,chcon,chgrp,chmod,chown,cksum,comm,cp,csplit,cut,date,dd,df,dir,dircolors,dirname,du,echo,expand,expr,factor,false,fmt,fold,groups,head,hostid,id,join,kill,link,ln,logname,ls,md5sum,mkdir,mkfifo,mknod,mktemp,mv,nl,nproc,numfmt,od,paste,pathchk,pinky,pr,printenv,printf,ptx,pwd,readlink,realpath,rm,rmdir,seq,sha1sum,sha224sum,sha256sum,sha384sum,sha512sum,shred,shuf,sleep,stat,stty,sum,sync,tac,tail,tee,test,touch,tr,true,truncate,tsort,tty,uname,unexpand,uniq,unlink,uptime,users,vdir,wc,who,whoami,yes}
-      '';
+      binlore.out = binlore.synthesize finalAttrs.finalPackage (
+        ''
+          execer can bin/{chroot,env,install,nice,nohup,sort,split,stdbuf,timeout}
+          execer cannot bin/{[,b2sum,base32,base64,basename,basenc,cat,chgrp,chmod,chown,cksum,comm,cp,csplit,cut,date,dd,df,dir,dircolors,dirname,du,echo,expand,expr,factor,false,fmt,fold,groups,head,hostid,id,join,kill,link,ln,logname,ls,md5sum,mkdir,mkfifo,mknod,mktemp,mv,nl,nproc,numfmt,od,paste,pathchk,pinky,pr,printenv,printf,ptx,pwd,readlink,realpath,rm,rmdir,seq,sha1sum,sha224sum,sha256sum,sha384sum,sha512sum,shred,shuf,sleep,stat,stty,sum,sync,tac,tail,tee,test,touch,tr,true,truncate,tsort,tty,uname,unexpand,uniq,unlink,uptime,users,vdir,wc,who,whoami,yes}
+        ''
+        + optionalString selinuxSupport ''
+          execer can bin/runcon
+          execer cannot bin/chcon
+        ''
+      );
     }
     // optionalAttrs (singleBinary == false) {
       # binlore only spots exec in runcon on some platforms (i.e., not
       # darwin; I have a note that the behavior may need selinux?).
       # hard-set it so people working on macOS don't miss cases of
       # runcon until ofBorg fails.
-      binlore.out = binlore.synthesize finalAttrs.finalPackage ''
-        execer can bin/runcon
-      '';
+      binlore.out = binlore.synthesize finalAttrs.finalPackage (
+        optionalString selinuxSupport ''
+          execer can bin/runcon
+        ''
+      );
     };
 
   meta = {


### PR DESCRIPTION
@trofi this should fix the breakage you identified in https://github.com/NixOS/nixpkgs/pull/460517#issuecomment-3730562500.

Notes:
* I'm not familiar with binlore, so checking that it's actually fixed now, and that I didn't break it further, would be appreciated. :)
* The breakage was due to the second-to-last item in https://lists.gnu.org/archive/html/coreutils-announce/2025-11/msg00000.html (which I hadn't thought would break anything... oops). But we cannot just add `--with-selinux` to `configureFlags`: that flag does not actually work when `selinuxSupport` is disabled, because gnulib will switch it back to off once it notices that selinux/selinux.h is missing. I sent a patch their way, but we cannot actually apply that patch now, because we can't use autoreconf and the replacement ./bootstrap script doesn't seem to work on their tarball.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of <s>all</s> some binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
