### PR TITLE
docker-credential-env: init at 1.6.0

### DIFF
--- a/pkgs/by-name/do/docker-credential-env/package.nix
+++ b/pkgs/by-name/do/docker-credential-env/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  versionCheckHook,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "docker-credential-env";
+  version = "1.6.0";
+
+  src = fetchFromGitHub {
+    owner = "isometry";
+    repo = "docker-credential-env";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-PnLylYDuDg+FSZ4CUSoQ5gMk4p08FP4OKBxkeIMa+tY=";
+  };
+
+  vendorHash = "sha256-uALgz1TXTIk8UlxTaqYOXvCg9121hMIFfJoYC0jxohk=";
+
+  ldflags =
+    let
+      c = "github.com/docker/docker-credential-helpers/credentials";
+    in
+    [
+      "-s"
+      "-X=${c}.Name=docker-credential-env"
+      "-X=${c}.Package=github.com/isometry/docker-credential-env"
+      "-X=${c}.Version=${finalAttrs.version}"
+      "-X=${c}.Revision=${finalAttrs.src.tag}"
+    ];
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
+
+  meta = {
+    changelog = "https://github.com/isometry/docker-credential-env/releases/tag/${finalAttrs.src.tag}";
+    description = "Environment-driven docker credential helper";
+    homepage = "https://github.com/isometry/docker-credential-env";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ zowoq ];
+    mainProgram = "docker-credential-env";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
