### PR TITLE
constrict: init at 25.12.1

### DIFF
--- a/pkgs/by-name/co/constrict/package.nix
+++ b/pkgs/by-name/co/constrict/package.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  pkg-config,
+  blueprint-compiler,
+  gobject-introspection,
+  wrapGAppsHook4,
+  desktop-file-utils,
+  libadwaita,
+  libglycin,
+  libva-utils,
+  ffmpeg,
+  gst-thumbnailers,
+  glycin-loaders,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "constrict";
+  version = "25.12.1";
+  pyproject = false; # Built with meson
+
+  src = fetchFromGitHub {
+    owner = "Wartybix";
+    repo = "Constrict";
+    tag = finalAttrs.version;
+    hash = "sha256-ZSiBlejNFakz+/3qj3n+ekB5l9JOk3MiQ8PRZOdxtLQ=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    blueprint-compiler
+    gobject-introspection
+    wrapGAppsHook4
+    desktop-file-utils
+  ];
+
+  buildInputs = [
+    libadwaita
+    libglycin
+  ];
+
+  dependencies = [
+    python3Packages.pygobject3
+  ];
+
+  # Search for use of subprocess
+  runtimeDeps = [
+    libva-utils
+    ffmpeg
+    gst-thumbnailers
+  ];
+
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=(
+      ''${gappsWrapperArgs[@]}
+      --prefix XDG_DATA_DIRS : "${glycin-loaders}/share"
+      --prefix PATH : ${lib.makeBinPath finalAttrs.runtimeDeps}
+    )
+  '';
+
+  meta = {
+    description = "Compresses your videos to your chosen file size";
+    homepage = "https://github.com/Wartybix/Constrict";
+    changelog = "https://github.com/Wartybix/Constrict/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.gpl3Plus;
+    mainProgram = "constrict";
+    teams = [ lib.teams.gnome-circle ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/gs/gst-thumbnailers/package.nix
+++ b/pkgs/by-name/gs/gst-thumbnailers/package.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  rustPlatform,
+  meson,
+  ninja,
+  pkg-config,
+  cargo,
+  rustc,
+  wrapGAppsNoGuiHook,
+  gst_all_1,
+  fontconfig,
+  libglycin,
+  glycin-loaders,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "gst-thumbnailers";
+  version = "1.0.alpha.1";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "GNOME";
+    repo = "gst-thumbnailers";
+    tag = finalAttrs.version;
+    hash = "sha256-LOdD8ECSK+QuXkE8jjIg5IfZSQ5FcIi3hmZ2vAaaBKI=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-PIqEEijKe+wsX6idqoIB591h1Yj4mixwXDKDN4caO9I=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    rustPlatform.cargoSetupHook
+    cargo
+    rustc
+    wrapGAppsNoGuiHook
+  ];
+
+  buildInputs = [
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good
+    gst_all_1.gst-plugins-bad
+    gst_all_1.gst-plugins-ugly
+    fontconfig
+    libglycin
+  ];
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix XDG_DATA_DIRS : "${glycin-loaders}/share"
+    )
+  '';
+
+  meta = {
+    description = "Generate thumbnailer for video and audio files";
+    homepage = "https://gitlab.gnome.org/GNOME/gst-thumbnailers";
+    license = lib.licenses.gpl3Plus;
+    maintainers = [ lib.maintainers.aleksana ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
This is a gnome circle application.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
