### PR TITLE
audible-cli: 0.3.2 -> 0.3.3

### DIFF
--- a/pkgs/by-name/au/audible-cli/package.nix
+++ b/pkgs/by-name/au/audible-cli/package.nix
@@ -9,20 +9,20 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "audible-cli";
-  version = "0.3.2";
+  version = "0.3.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "mkb79";
     repo = "audible-cli";
     tag = "v${version}";
-    hash = "sha256-DGOOMjP6dxIwbIhzRKf0+oy/2Cs+00tpwHkcmrukatw=";
+    hash = "sha256-ckI6nZUggIMvjJtN1zWXvTlVdiog0uJy6YR110A+JxM=";
   };
 
   nativeBuildInputs =
     with python3Packages;
     [
-      setuptools
+      hatchling
     ]
     ++ [
       addBinToPathHook
@@ -37,7 +37,6 @@ python3Packages.buildPythonApplication rec {
     packaging
     pillow
     questionary
-    setuptools
     tabulate
     toml
     tqdm


### PR DESCRIPTION
Just a version bump.

0.3.3 replaces `setuptools` with `hatchling` for the build process.

Full upstream changes between 0.3.2 and 0.3.3 are here: https://github.com/mkb79/audible-cli/compare/v0.3.2...v0.3.3

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
