### PR TITLE
nixos/hostapd: set ieee80211w to 2 for wpa3-sae

### DIFF
--- a/nixos/modules/services/networking/hostapd.nix
+++ b/nixos/modules/services/networking/hostapd.nix
@@ -1045,11 +1045,6 @@ in
 
                           ignore_broadcast_ssid = bssCfg.ignoreBroadcastSsid;
 
-                          # IEEE 802.11i (authentication) related configuration
-                          # Encrypt management frames to protect against deauthentication and similar attacks
-                          ieee80211w = mkDefault 1;
-                          sae_require_mfp = mkDefault 1;
-
                           # Only allow WPA by default and disable insecure WEP
                           auth_algs = mkDefault 1;
                           # Always enable QoS, which is required for 802.11n and above
@@ -1079,18 +1074,23 @@ in
                           # Prevent downgrade attacks by indicating to clients that they should
                           # disable any transition modes from now on.
                           transition_disable = "0x01";
+                          # Per WPA3 spec, MFP is required.
+                          ieee80211w = 2;
                         }
                         // optionalAttrs (bssCfg.authentication.mode == "wpa3-sae-transition") {
                           wpa = 2;
                           wpa_key_mgmt = "WPA-PSK-SHA256 SAE";
+                          ieee80211w = 1;
                         }
                         // optionalAttrs (bssCfg.authentication.mode == "wpa2-sha1") {
                           wpa = 2;
                           wpa_key_mgmt = "WPA-PSK";
+                          ieee80211w = 1;
                         }
                         // optionalAttrs (bssCfg.authentication.mode == "wpa2-sha256") {
                           wpa = 2;
                           wpa_key_mgmt = "WPA-PSK-SHA256";
+                          ieee80211w = 1;
                         }
                         // optionalAttrs (bssCfg.authentication.mode != "none") {
                           wpa_pairwise = pairwiseCiphers;

--- a/nixos/modules/services/networking/hostapd.nix
+++ b/nixos/modules/services/networking/hostapd.nix
@@ -1047,7 +1047,6 @@ in
 
                           # IEEE 802.11i (authentication) related configuration
                           # Encrypt management frames to protect against deauthentication and similar attacks
-                          ieee80211w = mkDefault 1;
                           sae_require_mfp = mkDefault 1;
 
                           # Only allow WPA by default and disable insecure WEP
@@ -1079,18 +1078,23 @@ in
                           # Prevent downgrade attacks by indicating to clients that they should
                           # disable any transition modes from now on.
                           transition_disable = "0x01";
+                          # Per WPA3 spec, MFP is required.
+                          ieee80211w = 2;
                         }
                         // optionalAttrs (bssCfg.authentication.mode == "wpa3-sae-transition") {
                           wpa = 2;
                           wpa_key_mgmt = "WPA-PSK-SHA256 SAE";
+                          ieee80211w = 1;
                         }
                         // optionalAttrs (bssCfg.authentication.mode == "wpa2-sha1") {
                           wpa = 2;
                           wpa_key_mgmt = "WPA-PSK";
+                          ieee80211w = 1;
                         }
                         // optionalAttrs (bssCfg.authentication.mode == "wpa2-sha256") {
                           wpa = 2;
                           wpa_key_mgmt = "WPA-PSK-SHA256";
+                          ieee80211w = 1;
                         }
                         // optionalAttrs (bssCfg.authentication.mode != "none") {
                           wpa_pairwise = pairwiseCiphers;


### PR DESCRIPTION
Motivation: Allow Windows 10/11 machines to connect on WPA3 APs, as seen in https://github.com/NixOS/nixpkgs/pull/476695.

What is ieee80211w? From the hostapd docs:

```
# ieee80211w: Whether management frame protection (MFP) is enabled
# 0 = disabled (default)
# 1 = optional
# 2 = required
```

Per the [WPA3 spec](https://www.wi-fi.org/system/files/WPA3%20Specification%20v3.4.pdf):

* For WPA3: "The AP's BSS Configuration shall be PMF Required, i.e., AP sets MFPC to 1 and MFPR to 1 in beacons and probe responses of the BSS"
   * i.e. when [services.hostapd.radios.<name>.networks.<name>.authentication.mode](https://search.nixos.org/options?channel=25.11&show=services.hostapd.radios.%3Cname%3E.networks.%3Cname%3E.authentication.mode&query=hostapd+authentication.mode) == "wpa3-sae" (the default), MFP should be required, i.e. settings.ieee80211w should be "2"
* For WPA3-Transition: "The AP's BSS Configuration shall be PMF Capable, i.e., AP sets MFPC to 1 and MFPR to 0 in beacons and probe responses of the BSS."
    * i.e. when authentication.mode == "wpa3-sae-transition", MFP should be capable, i.e. settings.ieee80211w should be "1"

For WPA2, requiring this breaks many clients (which is presumably why WPA3-Transitional sets MFP to optional), so let's stick with that.

For open wifi, we shouldn't set MFP.

In this commit I also unset sae_require_mfp, which I had set in my previous [flawed] attempt at ensuring MFP worked across all authentication modes: https://github.com/NixOS/nixpkgs/commit/9e7c877de75835018551bbd3029ac4d83f3e31cc , which we now have a better fix for. Furthermore, the hostapd docs suggest sae_require_mfp is set in cases where SAE-capable devices are known to be MFP-capable, and I don't think we can assume this.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
