### PR TITLE
deja-dup: fix fusermount permission error

### DIFF
--- a/pkgs/by-name/de/deja-dup/find-fusermount-setuid.patch
+++ b/pkgs/by-name/de/deja-dup/find-fusermount-setuid.patch
@@ -1,0 +1,13 @@
+diff --git a/libdeja/find-fusermount b/libdeja/find-fusermount
+index 1b3211bb..95b35cf5 100755
+--- a/libdeja/find-fusermount
++++ b/libdeja/find-fusermount
+@@ -20,6 +20,8 @@
+ if [ ! -f /.flatpak-info ]; then
+   if [ -n "@FUSERMOUNT_CMD@" ]; then
+     echo "@FUSERMOUNT_CMD@"
++  elif [ -f /run/wrappers/bin/fusermount3 ]; then
++    echo /run/wrappers/bin/fusermount3
+   elif command -pv fusermount3 > /dev/null; then
+     command -pv fusermount3
+   elif command -pv fusermount > /dev/null; then

--- a/pkgs/by-name/de/deja-dup/package.nix
+++ b/pkgs/by-name/de/deja-dup/package.nix
@@ -21,7 +21,6 @@
   json-glib,
   borgbackup,
   duplicity,
-  fuse,
   rclone,
   restic,
   nix-update-script,
@@ -66,7 +65,6 @@ stdenv.mkDerivation (finalAttrs: {
     # Check https://gitlab.gnome.org/World/deja-dup/-/blob/main/meson.options
     (lib.mesonOption "borg_command" (lib.getExe borgbackup))
     (lib.mesonOption "duplicity_command" (lib.getExe duplicity))
-    (lib.mesonOption "fusermount_command" (lib.getExe' fuse "fusermount"))
     (lib.mesonOption "rclone_command" (lib.getExe rclone))
     (lib.mesonOption "restic_command" (lib.getExe restic))
     (lib.mesonEnable "packagekit" false) # packagekit-glib not packaged
@@ -78,6 +76,8 @@ stdenv.mkDerivation (finalAttrs: {
       --prefix PATH : "${lib.makeBinPath [ rclone ]}"
     )
   '';
+
+  patches = [ ./find-fusermount-setuid.patch ];
 
   passthru = {
     updateScript = nix-update-script { };


### PR DESCRIPTION
Currently the Meson option `fusermount_command` is set to a path in the Nix store, but `fusermount` requires setuid, so when trying to mount a restic backup, it fails with `fusermount: mount failed: Operation not permitted`. This commit instead patches deja-dup's `find-fusermount` script to use the setuid wrapper `/run/wrappers/bin/fusermount` if it exists.

I also switched the package from using fuse2 to fuse3 because both are supported and I didn't see a reason to use the older version.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
