### PR TITLE
xf86-video-{qxl,r128}: refactor, move to pkgs/by-name & rename from xorg namespace

### DIFF
--- a/pkgs/by-name/xf/xf86-video-qxl/package.nix
+++ b/pkgs/by-name/xf/xf86-video-qxl/package.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  autoreconfHook,
+  pkg-config,
+  util-macros,
+  xorg-server,
+  xorgproto,
+  libdrm,
+  libpciaccess,
+  spice-protocol,
+  udev,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xf86-video-qxl";
+  version = "0.1.6";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    group = "xorg";
+    owner = "driver";
+    repo = "xf86-video-qxl";
+    tag = "xf86-video-qxl-${finalAttrs.version}";
+    hash = "sha256-g7NvAjmvPjyqUTXnZREDDs18O2e9Zl5hZeAza2a/1Jw=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+    util-macros
+    xorg-server # for some autoconf macros
+  ];
+
+  buildInputs = [
+    xorg-server
+    xorgproto
+    libdrm
+    libpciaccess
+    spice-protocol
+    udev
+  ];
+
+  passthru = {
+    updateScript = nix-update-script { extraArgs = [ "--version-regex=xf86-video-qxl-(.*)" ]; };
+  };
+
+  meta = {
+    description = "Xorg video driver for the QXL virtual GPU";
+    homepage = "https://gitlab.freedesktop.org/xorg/driver/xf86-video-qxl";
+    license = lib.licenses.mit;
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+    broken = stdenv.hostPlatform.isAarch64;
+  };
+})

--- a/pkgs/by-name/xf/xf86-video-r128/package.nix
+++ b/pkgs/by-name/xf/xf86-video-r128/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  autoreconfHook,
+  pkg-config,
+  util-macros,
+  xorg-server,
+  xorgproto,
+  libdrm,
+  libpciaccess,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xf86-video-r128";
+  version = "6.13.0";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    group = "xorg";
+    owner = "driver";
+    repo = "xf86-video-r128";
+    tag = "xf86-video-r128-${finalAttrs.version}";
+    hash = "sha256-f75PQ3pmWtyqeEfrMQpO31U0QOydlmQ49gJuvneRoso=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+    util-macros
+    xorg-server # for some autoconf macros
+  ];
+
+  buildInputs = [
+    xorg-server
+    xorgproto
+    libdrm
+    libpciaccess
+  ];
+
+  passthru = {
+    updateScript = nix-update-script { extraArgs = [ "--version-regex=xf86-video-r128-(.*)" ]; };
+  };
+
+  meta = {
+    description = "ATI Rage 128 video driver for the Xorg X server";
+    homepage = "https://gitlab.freedesktop.org/xorg/driver/xf86-video-r128";
+    license = with lib.licenses; [
+      mit
+      hpndSellVariant
+    ];
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -135,6 +135,7 @@
   xf86-video-ark,
   xf86-video-geode,
   xf86-video-nouveau,
+  xf86-video-qxl,
   xf86-video-s3virge,
   xf86-video-v4l,
   xfd,
@@ -350,6 +351,7 @@ self: with self; {
   xf86videoark = xf86-video-ark;
   xf86videogeode = xf86-video-geode;
   xf86videonouveau = xf86-video-nouveau;
+  xf86videoqxl = xf86-video-qxl;
   xf86videos3virge = xf86-video-s3virge;
   xf86videov4l = xf86-video-v4l;
   xkeyboardconfig = xkeyboard-config;
@@ -1205,48 +1207,6 @@ self: with self; {
         libXext
         xorgserver
         libXvMC
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xf86videoqxl = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      xorgproto,
-      libdrm,
-      udev,
-      libpciaccess,
-      xorgserver,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xf86-video-qxl";
-      version = "0.1.6";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/driver/xf86-video-qxl-0.1.6.tar.xz";
-        sha256 = "0pwncx60r1xxk8kpp9a46ga5h7k7hjqf14726v0gra27vdc9blra";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        xorgproto
-        libdrm
-        udev
-        libpciaccess
-        xorgserver
       ];
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -136,6 +136,7 @@
   xf86-video-geode,
   xf86-video-nouveau,
   xf86-video-qxl,
+  xf86-video-r128,
   xf86-video-s3virge,
   xf86-video-v4l,
   xfd,
@@ -352,6 +353,7 @@ self: with self; {
   xf86videogeode = xf86-video-geode;
   xf86videonouveau = xf86-video-nouveau;
   xf86videoqxl = xf86-video-qxl;
+  xf86videor128 = xf86-video-r128;
   xf86videos3virge = xf86-video-s3virge;
   xf86videov4l = xf86-video-v4l;
   xkeyboardconfig = xkeyboard-config;
@@ -1207,46 +1209,6 @@ self: with self; {
         libXext
         xorgserver
         libXvMC
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xf86videor128 = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      xorgproto,
-      libdrm,
-      libpciaccess,
-      xorgserver,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xf86-video-r128";
-      version = "6.13.0";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/driver/xf86-video-r128-6.13.0.tar.xz";
-        sha256 = "0igpfgls5nx4sz8a7yppr42qi37prqmxsy08zqbxbv81q9dfs2zj";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        xorgproto
-        libdrm
-        libpciaccess
-        xorgserver
       ];
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -468,6 +468,7 @@ print OUT <<EOF;
   xf86-video-geode,
   xf86-video-nouveau,
   xf86-video-qxl,
+  xf86-video-r128,
   xf86-video-s3virge,
   xf86-video-v4l,
   xfd,
@@ -684,6 +685,7 @@ self: with self; {
   xf86videogeode = xf86-video-geode;
   xf86videonouveau = xf86-video-nouveau;
   xf86videoqxl = xf86-video-qxl;
+  xf86videor128 = xf86-video-r128;
   xf86videos3virge = xf86-video-s3virge;
   xf86videov4l = xf86-video-v4l;
   xkeyboardconfig = xkeyboard-config;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -467,6 +467,7 @@ print OUT <<EOF;
   xf86-video-ark,
   xf86-video-geode,
   xf86-video-nouveau,
+  xf86-video-qxl,
   xf86-video-s3virge,
   xf86-video-v4l,
   xfd,
@@ -682,6 +683,7 @@ self: with self; {
   xf86videoark = xf86-video-ark;
   xf86videogeode = xf86-video-geode;
   xf86videonouveau = xf86-video-nouveau;
+  xf86videoqxl = xf86-video-qxl;
   xf86videos3virge = xf86-video-s3virge;
   xf86videov4l = xf86-video-v4l;
   xkeyboardconfig = xkeyboard-config;

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -162,10 +162,6 @@ self: super:
     };
   });
 
-  xf86videoqxl = super.xf86videoqxl.overrideAttrs (attrs: {
-    buildInputs = attrs.buildInputs ++ [ spice-protocol ];
-  });
-
   xf86videosiliconmotion = super.xf86videosiliconmotion.overrideAttrs (attrs: {
     meta = attrs.meta // {
       platforms = [

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -23,7 +23,6 @@ mirror://xorg/individual/driver/xf86-video-neomagic-1.3.1.tar.xz
 mirror://xorg/individual/driver/xf86-video-nv-2.1.23.tar.xz
 mirror://xorg/individual/driver/xf86-video-omap-0.4.5.tar.bz2
 mirror://xorg/individual/driver/xf86-video-openchrome-0.6.0.tar.bz2
-mirror://xorg/individual/driver/xf86-video-r128-6.13.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-savage-2.4.1.tar.xz
 mirror://xorg/individual/driver/xf86-video-siliconmotion-1.7.10.tar.xz
 mirror://xorg/individual/driver/xf86-video-sis-0.12.0.tar.gz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -23,7 +23,6 @@ mirror://xorg/individual/driver/xf86-video-neomagic-1.3.1.tar.xz
 mirror://xorg/individual/driver/xf86-video-nv-2.1.23.tar.xz
 mirror://xorg/individual/driver/xf86-video-omap-0.4.5.tar.bz2
 mirror://xorg/individual/driver/xf86-video-openchrome-0.6.0.tar.bz2
-mirror://xorg/individual/driver/xf86-video-qxl-0.1.6.tar.xz
 mirror://xorg/individual/driver/xf86-video-r128-6.13.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-savage-2.4.1.tar.xz
 mirror://xorg/individual/driver/xf86-video-siliconmotion-1.7.10.tar.xz


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] nixpkgs-hammering
- [x] nix-check-deps
- [x] ran passtrhu.updateScript
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
