### PR TITLE
checkmake: 0.2.2 -> 0.3.1

### DIFF
--- a/pkgs/by-name/ch/checkmake/package.nix
+++ b/pkgs/by-name/ch/checkmake/package.nix
@@ -3,22 +3,23 @@
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
+  nix-update-script,
   pandoc,
   go,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "checkmake";
-  version = "0.2.2";
+  version = "0.3.1";
 
   src = fetchFromGitHub {
-    owner = "mrtazz";
+    owner = "checkmake";
     repo = "checkmake";
-    tag = version;
-    hash = "sha256-Ql8XSQA/w7wT9GbmYOM2vG15GVqj9LxOGIu8Wqp9Wao=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-W+4bKERQL4nsPxrcCP19uYAwSw+tK9mAQp/fufzYcYg=";
   };
 
-  vendorHash = null;
+  vendorHash = "sha256-Iv3MFhHnwDLIuUH7G6NYyQUSAaivBYqYDWephHnBIho=";
 
   nativeBuildInputs = [
     installShellFiles
@@ -28,11 +29,13 @@ buildGoModule rec {
   ldflags = [
     "-s"
     "-w"
-    "-X=main.version=${version}"
+    "-X=main.version=${finalAttrs.version}"
     "-X=main.buildTime=1970-01-01T00:00:00Z"
     "-X=main.builder=nixpkgs"
     "-X=main.goversion=go${go.version}"
   ];
+
+  passthru.updateScript = nix-update-script { };
 
   postPatch = ''
     substituteInPlace man/man1/checkmake.1.md \
@@ -48,14 +51,14 @@ buildGoModule rec {
   '';
 
   meta = {
-    description = "Experimental tool for linting and checking Makefiles";
+    description = "Linter and analyzer for Makefiles";
     mainProgram = "checkmake";
-    homepage = "https://github.com/mrtazz/checkmake";
-    changelog = "https://github.com/mrtazz/checkmake/releases/tag/${src.rev}";
+    homepage = "https://github.com/checkmake/checkmake";
+    changelog = "https://github.com/checkmake/checkmake/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     longDescription = ''
-      checkmake is an experimental tool for linting and checking
-      Makefiles. It may not do what you want it to.
+      checkmake is a linter for Makefiles. It scans Makefiles for potential issues based on configurable rules.
     '';
+    maintainers = with lib.maintainers; [ lafrenierejm ];
   };
-}
+})


### PR DESCRIPTION
The project's changelog is at https://github.com/checkmake/checkmake/blob/HEAD/CHANGELOG.md.

Changes in this PR:

- Updated the package's source to reflect its new home in a dedicated GitHub organization.
- Added myself as the package's maintainer.
- Migrated the package to the `finalAttrs` pattern.
- Updated the package description since upstream considers the project ["no longer experimental"](https://github.com/checkmake/checkmake/blob/HEAD/CHANGELOG.md#v030-8th-january-2026) as of 0.3.0.

---

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
