### PR TITLE
svt-av1-psy: move to an active fork svt-av1-psyex

### DIFF
--- a/pkgs/by-name/sv/svt-av1-psyex/package.nix
+++ b/pkgs/by-name/sv/svt-av1-psyex/package.nix
@@ -68,7 +68,10 @@ stdenv.mkDerivation (finalAttrs: {
       bsd3
     ];
     platforms = lib.platforms.unix;
-    maintainers = with lib.maintainers; [ johnrtitor ];
+    maintainers = with lib.maintainers; [
+      johnrtitor
+      ccicnce113424
+    ];
     mainProgram = "SvtAv1EncApp";
   };
 })

--- a/pkgs/by-name/sv/svt-av1-psyex/package.nix
+++ b/pkgs/by-name/sv/svt-av1-psyex/package.nix
@@ -3,22 +3,22 @@
   stdenv,
   fetchFromGitHub,
   cmake,
-  nasm,
+  yasm,
   cpuinfo,
   libdovi,
   hdr10plus,
-  unstableGitUpdater,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
-  pname = "svt-av1-psy";
-  version = "3.0.2-unstable-2025-04-21";
+  pname = "svt-av1-psyex";
+  version = "3.0.2-B";
 
   src = fetchFromGitHub {
-    owner = "psy-ex";
-    repo = "svt-av1-psy";
-    rev = "3745419c40267d294202b52f48f069aff56cdb78";
-    hash = "sha256-iAw2FiEsBGB4giWqzo1EJZok26WSlq7brq9kJubnkAQ=";
+    owner = "BlueSwordM";
+    repo = "svt-av1-psyex";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-klfrbow8UtpIPwIgt8tK7FP7Jp6In9nxfOZrdi1PsHo=";
   };
 
   cmakeBuildType = "Release";
@@ -40,7 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
     cmake
   ]
   ++ lib.optionals stdenv.hostPlatform.isx86_64 [
-    nasm
+    yasm
   ];
 
   buildInputs = [
@@ -51,17 +51,14 @@ stdenv.mkDerivation (finalAttrs: {
     cpuinfo
   ];
 
-  passthru.updateScript = unstableGitUpdater {
-    branch = "master";
-    tagPrefix = "v";
-  };
+  passthru.updateScript = nix-update-script { extraArgs = [ "--use-github-releases" ]; };
 
   meta = {
-    homepage = "https://github.com/psy-ex/svt-av1-psy";
+    homepage = "https://github.com/BlueSwordM/svt-av1-psyex";
     description = "Scalable Video Technology AV1 Encoder and Decoder";
 
     longDescription = ''
-      SVT-AV1-PSY is the Scalable Video Technology for AV1 (SVT-AV1 Encoder and Decoder)
+      SVT-AV1-PSYEX is the Scalable Video Technology for AV1 (SVT-AV1 Encoder and Decoder)
       with perceptual enhancements for psychovisually optimal AV1 encoding.
       The goal is to create the best encoding implementation for perceptual quality with AV1.
     '';

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1582,6 +1582,7 @@ mapAliases {
   sumalibs = throw "'sumalibs' has been removed as it was archived upstream and broken with GCC 14"; # Added 2025-06-14
   sumatra = throw "'sumatra' has been removed as it was archived upstream and broken with GCC 14"; # Added 2025-06-14
   sumneko-lua-language-server = throw "'sumneko-lua-language-server' has been renamed to/replaced by 'lua-language-server'"; # Converted to throw 2025-10-27
+  svt-av1-psy = warnAlias "'svt-av1-psy' has been replaced by 'svt-av1-psyex'" svt-av1-psyex; # Added 2026-01-10
   swig4 = throw "'swig4' has been renamed to/replaced by 'swig'"; # Converted to throw 2025-10-27
   swiProlog = throw "'swiProlog' has been renamed to/replaced by 'swi-prolog'"; # Converted to throw 2025-10-27
   swiPrologWithGui = throw "'swiPrologWithGui' has been renamed to/replaced by 'swi-prolog-gui'"; # Converted to throw 2025-10-27


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
The upstream repository https://github.com/psy-ex/svt-av1-psy has been archived, so I've moved to an active fork https://github.com/BlueSwordM/svt-av1-psyex listed in the README.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
