### PR TITLE
musescore-evolution: init at 3.7.0 

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18690,6 +18690,11 @@
     githubId = 50854675;
     name = "Nelson Jeppesen";
   };
+  nemeott = {
+    github = "nemeott";
+    githubId = 123220311;
+    name = "Nathan Emeott";
+  };
   nemin = {
     name = "Nemin";
     github = "Nemin32";

--- a/pkgs/by-name/mu/musescore-evolution/musescore-evolution-pch-fix.patch
+++ b/pkgs/by-name/mu/musescore-evolution/musescore-evolution-pch-fix.patch
@@ -1,0 +1,63 @@
+diff --git a/main/CMakeLists.txt b/main/CMakeLists.txt
+index e67e5c8f5c..a4c6dd61fd 100644
+--- a/main/CMakeLists.txt
++++ b/main/CMakeLists.txt
+@@ -499,15 +499,6 @@ if (APPLE)
+       ../fonts/finalebroadway/FinaleBroadwayText.otf
+      DESTINATION ${Mscore_SHARE_NAME}${Mscore_INSTALL_NAME}fonts
+      )
+-     install(DIRECTORY
+-      ${QT_INSTALL_QML}
+-      DESTINATION ${Mscore_SHARE_NAME}${Mscore_INSTALL_NAME}
+-      REGEX ".*QtWebkit.*" EXCLUDE
+-      REGEX ".*QtTest.*" EXCLUDE
+-      REGEX ".*QtSensors.*" EXCLUDE
+-      REGEX ".*QtMultimedia.*" EXCLUDE
+-      REGEX ".*QtAudioEngine.*" EXCLUDE
+-      REGEX ".*_debug\\.dylib" EXCLUDE)
+ endif (APPLE)
+ 
+ if (MSCORE_OUTPUT_NAME)
+diff --git a/mscore/CMakeLists.txt b/mscore/CMakeLists.txt
+index 8daa49b517..471cedf06d 100644
+--- a/mscore/CMakeLists.txt
++++ b/mscore/CMakeLists.txt
+@@ -142,6 +142,7 @@ if (APPLE)
+          cocoabridge STATIC
+          macos/cocoabridge.mm
+          )
++      set_source_files_properties(macos/cocoabridge.mm PROPERTIES SKIP_PRECOMPILE_HEADERS ON)
+ else (APPLE)
+       set(INCS "")
+       set(COCOABRIDGE "")
+diff --git a/mscore/macos/cocoabridge.h b/mscore/macos/cocoabridge.h
+index d6a217ad99..0c61197bbb 100644
+--- a/mscore/macos/cocoabridge.h
++++ b/mscore/macos/cocoabridge.h
+@@ -20,6 +20,10 @@
+ #ifndef __COCOABRIDGE_H__
+ #define __COCOABRIDGE_H__
+ 
++#include <functional>
++
++#include <QString>
++
+ class CocoaBridge {
+       CocoaBridge() {};
+    public:
+diff --git a/mscore/qml/msqmlengine.cpp b/mscore/qml/msqmlengine.cpp
+index 77c94b593c..ffd066d41d 100644
+--- a/mscore/qml/msqmlengine.cpp
++++ b/mscore/qml/msqmlengine.cpp
+@@ -37,9 +37,9 @@ MsQmlEngine::MsQmlEngine(QObject* parent)
+       setImportPathList(importPaths);
+ #endif
+ #ifdef Q_OS_MAC
+-      QStringList importPaths;
++      QStringList importPaths = importPathList();
+       QDir dir(mscoreGlobalShare + QString("/qml"));
+-      importPaths.append(dir.absolutePath());
++      importPaths.prepend(dir.absolutePath());
+       setImportPathList(importPaths);
+ #endif
+       }

--- a/pkgs/by-name/mu/musescore-evolution/package.nix
+++ b/pkgs/by-name/mu/musescore-evolution/package.nix
@@ -1,0 +1,218 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  cmake,
+  wrapGAppsHook3,
+  pkg-config,
+  ninja,
+  alsa-lib,
+  alsa-plugins,
+  freetype,
+  libjack2,
+  lame,
+  libogg,
+  libpulseaudio,
+  libsndfile,
+  libvorbis,
+  portaudio,
+  portmidi,
+  flac,
+  libopusenc,
+  libopus,
+  tinyxml-2,
+  qt5, # Needed for musescore 3.X
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "musescore-evolution";
+  version = "3.7.0-unstable-2026-01-12";
+
+  src = fetchFromGitHub {
+    owner = "Jojo-Schmitz";
+    repo = "MuseScore";
+    rev = "0b4543baca9b1b70d54cecb33cbf846dabc073d1";
+    hash = "sha256-piOXHKlnfCO1n0kAgeszqa6JVoHgF8B2OF7agpadGKQ=";
+  };
+
+  patches = [
+    ./musescore-evolution-pch-fix.patch
+  ];
+
+  # From top-level CMakeLists.txt:
+  # - DOWNLOAD_SOUNDFONT defaults ON and tries to fetch from the network.
+  # Download manually at Help > Manage Resources
+  cmakeFlags = [
+    "-DDOWNLOAD_SOUNDFONT=OFF"
+  ];
+
+  qtWrapperArgs = [
+    # MuseScore JACK backend loads libjack at runtime.
+    "--prefix ${lib.optionalString stdenv.hostPlatform.isDarwin "DY"}LD_LIBRARY_PATH : ${
+      lib.makeLibraryPath [ libjack2 ]
+    }"
+  ]
+  ++ lib.optionals (stdenv.hostPlatform.isLinux) [
+    "--set ALSA_PLUGIN_DIR ${alsa-plugins}/lib/alsa-lib"
+  ]
+  ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
+    # There are some issues with using the wayland backend, see:
+    # https://musescore.org/en/node/321936
+    "--set-default QT_QPA_PLATFORM xcb"
+  ];
+
+  preFixup = ''
+    qtWrapperArgs+=("''${gappsWrapperArgs[@]}")
+
+    # Recreate correct symlinks (let fixupPhase handle compression)
+    if [ -e "$manDir/mscore-evo.1" ]; then
+      ln -sf "mscore-evo.1" "$manDir/musescore-evo.1"
+    fi
+  '';
+
+  dontWrapGApps = true;
+
+  nativeBuildInputs = [
+    qt5.wrapQtAppsHook
+    cmake
+    qt5.qttools
+    pkg-config
+    ninja
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    # Since https://github.com/musescore/MuseScore/pull/13847/commits/685ac998
+    # GTK3 is needed for file dialogs. Fixes crash with No GSettings schemas error.
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    libjack2
+    freetype
+    lame
+    libogg
+    libpulseaudio
+    libsndfile
+    libvorbis
+    portaudio
+    portmidi
+    flac
+    libopusenc
+    libopus
+    tinyxml-2
+    qt5.qtbase
+    qt5.qtdeclarative
+    qt5.qtsvg
+    qt5.qtxmlpatterns
+    qt5.qtquickcontrols2
+    qt5.qtgraphicaleffects
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    alsa-lib
+  ];
+
+  # Avoid depending on insecure QtWebEngine (and having to compile it (huge))
+  # Because we don't use this, we need to patch the CMakeLists and install scripts to not try to bundle it.
+  postPatch = ''
+    # Disable Qt bundling logic in the source CMakeLists.
+    sed -i '/QT_INSTALL_PREFIX/d' main/CMakeLists.txt
+    sed -i '/QtWebEngineProcess/d' main/CMakeLists.txt
+  '';
+
+  # Patch the generated install script to drop Qt resource / QtWebEngine installs.
+  preInstall = ''
+    sed -i '
+      /QtWebEngineProcess/d
+      /resources\"/d
+      /qtwebengine_locales/d
+      /qtwebengine/d
+      /QT_INSTALL_PREFIX/d
+    ' main/cmake_install.cmake
+  '';
+
+  # On macOS, move the .app into Applications/ and symlink the binary to bin/
+  postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    mkdir -p "$out/Applications"
+    mv "$out/mscore.app" "$out/Applications/mscore-evo.app"
+    mkdir -p $out/bin
+    ln -s $out/Applications/mscore-evo.app/Contents/MacOS/mscore $out/bin/mscore-evo
+  '';
+
+  # On Linux, let CMake + wrapQtAppsHook install/wrap "mscore", then rename it
+  # and adjust the .desktop file so it doesn't clash with the main musescore package.
+  postFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
+    mv "$out/bin/mscore" "$out/bin/mscore-evo"
+
+    # 2) Fix desktop entry to point to mscore-evo and avoid ID clash
+    desktop="$out/share/applications/mscore.desktop"
+    substitute "$desktop" "$out/share/applications/mscore-evo.desktop" \
+      --replace "Exec=mscore" "Exec=mscore-evo" \
+      --replace "Name=MuseScore 3.7" "Name=MuseScore 3.7 (Evolution)" \
+      --replace "Icon=mscore" "Icon=mscore-evo"
+    rm $desktop
+
+    # 3) Rename app icons (apps/)
+    for sizeDir in "$out"/share/icons/hicolor/*/apps/; do
+      for ext in png svg xpm; do
+        if [ -f "$sizeDir/mscore.$ext" ]; then
+          mv "$sizeDir/mscore.$ext" "$sizeDir/mscore-evo.$ext"
+        fi
+      done
+    done
+
+    # 3b) Rename mimetype icons (mimetypes/) to unique names
+    for icon in "$out"/share/icons/hicolor/*/mimetypes/application-x-musescore.* \
+                "$out"/share/icons/hicolor/*/mimetypes/application-x-musescore+xml.*; do
+      dir="''${icon%/*}"; base="''${icon##*/}"; ext="''${base##*.}"
+      case "$base" in
+        application-x-musescore.*) mv "$icon" "$dir/application-x-musescore-evo.$ext" ;;
+        application-x-musescore+xml.*) mv "$icon" "$dir/application-x-musescore-evo+xml.$ext" ;;
+      esac
+    done
+
+    # 4) Rename MIME XML and point icons to the new names
+    mv "$out/share/mime/packages/musescore.xml" "$out/share/mime/packages/musescore-evo.xml"
+    sed -i \
+      -e 's|<icon>application-x-musescore\(\+xml\)\?</icon>|<icon>application-x-musescore-evo\1</icon>|g' \
+      -e 's|<icon>musescore</icon>|<icon>mscore-evo</icon>|g' \
+      "$out/share/mime/packages/musescore-evo.xml"
+
+    # 5) Rename man pages to match mscore-evo and remove legacy symlinks
+    manDir="$out/share/man/man1"
+
+    # Remove all old musescore/mscore symlinks first (gzip may have created them)
+    find "$manDir" -type l \
+      \( -name 'mscore.1*' -o -name 'musescore.1*' \) \
+      -exec rm -f {} +
+
+    # Rename real files
+    find "$manDir" \( -name 'mscore.1*' -o -name 'musescore.1*' \) -type f |
+    while IFS= read -r man; do
+      base="$(basename "$man")"
+      newname=$(echo "$base" | sed -e 's/^mscore/mscore-evo/' -e 's/^musescore/mscore-evo/')
+      mv "$man" "$manDir/$newname"
+    done
+
+    # 6) Rename AppStream metadata and its IDs
+    meta="$out/share/metainfo/org.musescore.MuseScore.appdata.xml"
+    new="$out/share/metainfo/org.musescore.MuseScoreEvolution.appdata.xml"
+    mv "$meta" "$new"
+    sed -i \
+      -e 's|<id>org\.musescore\.MuseScore</id>|<id>org.musescore.MuseScoreEvolution</id>|' \
+      -e 's|mscore\.desktop|mscore-evo.desktop|' \
+      "$new"
+  '';
+
+  # Don't run bundled upstreams tests, as they require a running X window system.
+  doCheck = false;
+
+  passthru.updateScript.command = [ ./update.sh ];
+
+  meta = {
+    description = "Music notation and composition software";
+    homepage = "https://github.com/Jojo-Schmitz/MuseScore";
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ nemeott ];
+    mainProgram = "mscore-evo";
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/mu/musescore-evolution/update.sh
+++ b/pkgs/by-name/mu/musescore-evolution/update.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p jq nix-update coreutils
+
+set -euo pipefail
+
+# Run nix-update on the default branch (updates rev and sha256)
+nix-update musescore-evolution --version=branch
+
+# Now we need to update the version name
+
+# Find the new version generated from the nix-update command (e.g. "0-unstable-2026-01-12")
+generated_version=$(nix eval --raw -f . ${UPDATE_NIX_ATTR_PATH}.version)
+
+# Extract only the date part (after the last dash) (e.g. 0-unstable-2026-01-12)
+parts=(${generated_version//-/ }) # Split up by dashes
+clean_date="${parts[2]}-${parts[3]}-${parts[4]}" # Get clean date in YYYY-MM-DD format (e.g. "2026-01-12")
+
+# Compute version prefix based on previous version
+old_version="$UPDATE_NIX_OLD_VERSION"
+prefix="${old_version%-*}" # e.g. "3.7.0-unstable"
+
+new_version="${prefix}-${clean_date}"
+
+# Patch version in nix file
+# Strip any existing version line and replace with new one
+sed -i "s/version = \".*\"/version = \"${new_version}\"/" $(nix eval --raw -f . ${UPDATE_NIX_ATTR_PATH}.meta.position | cut -d: -f1)


### PR DESCRIPTION
Added package for Musescore Evolution, an unoffical fork of MuseScore 3.6.2. It provides extra patches, fixes, features. One notable feature is the ability to import files saved in Musescore 4.X versions. There are also a few other back-ported features. It's pretty much a better version of 3.6.2, which many people still use.

Also added myself to the maintainers list.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
