### PR TITLE
treewide: cleanup fetchFromGitLab default value

### DIFF
--- a/pkgs/by-name/bi/bisoncpp/package.nix
+++ b/pkgs/by-name/bi/bisoncpp/package.nix
@@ -13,7 +13,6 @@ stdenv.mkDerivation rec {
   version = "6.04.00";
 
   src = fetchFromGitLab {
-    domain = "gitlab.com";
     owner = "fbb-git";
     repo = "bisoncpp";
     rev = "6.04.00";

--- a/pkgs/by-name/bo/bobcat/package.nix
+++ b/pkgs/by-name/bo/bobcat/package.nix
@@ -16,7 +16,6 @@ stdenv.mkDerivation (finalAttrs: {
   version = "5.11.01";
 
   src = fetchFromGitLab {
-    domain = "gitlab.com";
     owner = "fbb-git";
     repo = "bobcat";
     tag = finalAttrs.version;

--- a/pkgs/by-name/ca/callaudiod/package.nix
+++ b/pkgs/by-name/ca/callaudiod/package.nix
@@ -15,7 +15,6 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.1.10";
 
   src = fetchFromGitLab {
-    domain = "gitlab.com";
     owner = "mobian1";
     repo = "callaudiod";
     tag = finalAttrs.version;

--- a/pkgs/by-name/fl/flare-signal/package.nix
+++ b/pkgs/by-name/fl/flare-signal/package.nix
@@ -26,7 +26,6 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.18.3";
 
   src = fetchFromGitLab {
-    domain = "gitlab.com";
     owner = "schmiddi-on-mobile";
     repo = "flare";
     tag = finalAttrs.version;

--- a/pkgs/by-name/fr/frotz/package.nix
+++ b/pkgs/by-name/fr/frotz/package.nix
@@ -32,7 +32,6 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.55";
 
   src = fetchFromGitLab {
-    domain = "gitlab.com";
     owner = "DavidGriffith";
     repo = "frotz";
     tag = finalAttrs.version;

--- a/pkgs/by-name/ju/jumpnbump/package.nix
+++ b/pkgs/by-name/ju/jumpnbump/package.nix
@@ -25,7 +25,6 @@ stdenv.mkDerivation {
 
   # By targeting the development version, we can omit the patches Arch uses
   src = fetchFromGitLab {
-    domain = "gitlab.com";
     owner = "LibreGames";
     repo = "jumpnbump";
     rev = "5744738211ca691444f779aafee3537fb3562516";

--- a/pkgs/by-name/ne/networkd-dispatcher/package.nix
+++ b/pkgs/by-name/ne/networkd-dispatcher/package.nix
@@ -16,7 +16,6 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.2.4";
 
   src = fetchFromGitLab {
-    domain = "gitlab.com";
     owner = "craftyguy";
     repo = "networkd-dispatcher";
     rev = finalAttrs.version;

--- a/pkgs/by-name/pa/pagsuite/package.nix
+++ b/pkgs/by-name/pa/pagsuite/package.nix
@@ -12,7 +12,6 @@ stdenv.mkDerivation {
   version = "1.80-unstable-2025-05-03";
 
   src = fetchFromGitLab {
-    domain = "gitlab.com";
     owner = "kumm";
     repo = "pagsuite";
     rev = "1cc657765658cb2eb622d4a9c656ab9854150e7d";

--- a/pkgs/by-name/pr/process-cpp/package.nix
+++ b/pkgs/by-name/pr/process-cpp/package.nix
@@ -21,7 +21,6 @@ stdenv.mkDerivation (finalAttrs: {
   version = "3.0.3";
 
   src = fetchFromGitLab {
-    domain = "gitlab.com";
     owner = "ubports";
     repo = "development/core/lib-cpp/process-cpp";
     rev = finalAttrs.version;

--- a/pkgs/by-name/qw/qwertone/package.nix
+++ b/pkgs/by-name/qw/qwertone/package.nix
@@ -14,7 +14,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.5.0";
 
   src = fetchFromGitLab {
-    domain = "gitlab.com";
     owner = "azymohliad";
     repo = "qwertone";
     tag = "v${finalAttrs.version}";

--- a/pkgs/by-name/so/sord/package.nix
+++ b/pkgs/by-name/so/sord/package.nix
@@ -17,7 +17,6 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.16.20";
 
   src = fetchFromGitLab {
-    domain = "gitlab.com";
     owner = "drobilla";
     repo = "sord";
     tag = "v${finalAttrs.version}";

--- a/pkgs/tools/security/gnupg/24.nix
+++ b/pkgs/tools/security/gnupg/24.nix
@@ -84,7 +84,6 @@ stdenv.mkDerivation rec {
   # compatibility with OpenPGP.
   #
   freepgPatches = fetchFromGitLab {
-    domain = "gitlab.com";
     owner = "freepg";
     repo = "gnupg";
     rev = "361c223eb00ca372fbf9506f5150ddbec193936f";


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
