### PR TITLE
Headscale: Add a way to specify externalConfig using configPath option

### DIFF
--- a/nixos/modules/services/networking/headscale.nix
+++ b/nixos/modules/services/networking/headscale.nix
@@ -31,6 +31,18 @@ in
     services.headscale = {
       enable = lib.mkEnableOption "headscale, Open Source coordination server for Tailscale";
 
+      configPath = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
+        description = ''
+          Speficy path to the Config file, doing so will ignore most of the settings defined.
+          ::: {.note}
+          Example of the file can be found here: https://github.com/juanfont/headscale/blob/main/config-example.yaml
+          :::
+        '';
+        example = "/etc/headscale_config.yaml";
+        default = null;
+      };
+
       package = lib.mkPackageOption pkgs "headscale" { };
 
       configFile = lib.mkOption {
@@ -683,15 +695,19 @@ in
   config = lib.mkIf cfg.enable {
     assertions = [
       {
-        assertion = with cfg.settings; dns.magic_dns -> dns.base_domain != "";
+        assertion = cfg.configPath != null || (with cfg.settings; dns.magic_dns -> dns.base_domain != "");
         message = "dns.base_domain must be set when using MagicDNS";
       }
       {
-        assertion = with cfg.settings; dns.override_local_dns -> dns.nameservers.global != [ ];
+        assertion =
+          cfg.configPath != null
+          || (with cfg.settings; dns.override_local_dns -> dns.nameservers.global != [ ]);
         message = "dns.nameservers.global must be set when overriding local DNS";
       }
       {
-        assertion = with cfg.settings; dns.extra_records_path == null || dns.extra_records == null;
+        assertion =
+          cfg.configPath != null
+          || (with cfg.settings; dns.extra_records_path == null || dns.extra_records == null);
         message = "dns.extra_records and dns.extra_records_path are mutually exclusive";
       }
       (assertRemovedOption [ "settings" "acl_policy_path" ] "Use `policy.path` instead.")
@@ -756,7 +772,9 @@ in
           export HEADSCALE_DATABASE_POSTGRES_PASS="$(head -n1 ${lib.escapeShellArg cfg.settings.database.postgres.password_file})"
         ''}
 
-        exec ${lib.getExe cfg.package} serve --config ${cfg.configFile}
+        exec ${lib.getExe cfg.package} serve --config ${
+          if cfg.configPath != null then cfg.configPath else cfg.configFile
+        }
       '';
 
       serviceConfig =


### PR DESCRIPTION
This adds a `configPath` option that allows users to add an external config
Reason for this is 2 fold, allows for easier migration to/from nix based service as only the yaml file is necessary and changes to the file can be made on the host without having to rebuild the configuration

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
