### PR TITLE
various: remove from xorg namespace

### DIFF
--- a/doc/packages/xorg.section.md
+++ b/doc/packages/xorg.section.md
@@ -16,7 +16,7 @@ cat $(PRINT_PATH=1 nix-prefetch-url $url | tail -n 1) \
 
 ## Individual Tarballs {#individual-tarballs}
 
-The upstream release process for [X11R7.8](https://x.org/wiki/Releases/7.8/) does not include a planned katamari. Instead, each component of X.org is released as its own tarball. We maintain `pkgs/servers/x11/xorg/tarballs.list` as a list of tarballs for each individual package. This list includes X.org core libraries and protocol descriptions, extra newer X11 interface libraries, like `xorg.libxcb`, and classic utilities which are largely unused but still available if needed, like `xorg.imake`.
+The upstream release process for [X11R7.8](https://x.org/wiki/Releases/7.8/) does not include a planned katamari. Instead, each component of X.org is released as its own tarball. We maintain `pkgs/servers/x11/xorg/tarballs.list` as a list of tarballs for each individual package. This list includes X.org core libraries and protocol descriptions, extra newer X11 interface libraries, like `xorg.libxcb`, and classic utilities which are largely unused but still available if needed, like `imake`.
 
 ## Generating Nix Expressions {#generating-nix-expressions}
 

--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -3,6 +3,7 @@
   lib,
   utils,
   pkgs,
+  iceauth,
   ...
 }:
 
@@ -835,7 +836,7 @@ in
         xorg.xrandr
         xorg.xrdb
         xorg.setxkbmap
-        xorg.iceauth # required for KDE applications (it's called by dcopserver)
+        iceauth # required for KDE applications (it's called by dcopserver)
         xorg.xlsclients
         xorg.xset
         xorg.xsetroot

--- a/pkgs/build-support/appimage/default.nix
+++ b/pkgs/build-support/appimage/default.nix
@@ -9,6 +9,7 @@
   squashfsTools,
   buildFHSEnv,
   pkgs,
+  libpciaccess,
 }:
 
 rec {
@@ -152,7 +153,7 @@ rec {
         gst_all_1.gst-plugins-base
         libdrm
         xorg.xkeyboardconfig
-        xorg.libpciaccess
+        libpciaccess
 
         glib
         bzip2

--- a/pkgs/by-name/ch/cherry/package.nix
+++ b/pkgs/by-name/ch/cherry/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitHub,
   xorg,
+  fonttosfnt,
 }:
 
 stdenv.mkDerivation rec {
@@ -17,7 +18,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    xorg.fonttosfnt
+    fonttosfnt
     xorg.mkfontdir
   ];
 

--- a/pkgs/by-name/cl/clearlyU/package.nix
+++ b/pkgs/by-name/cl/clearlyU/package.nix
@@ -4,6 +4,7 @@
   fetchurl,
   xorg,
   libfaketime,
+  fonttosfnt,
 }:
 
 stdenv.mkDerivation rec {
@@ -16,7 +17,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    xorg.fonttosfnt
+    fonttosfnt
     xorg.mkfontscale
     libfaketime
   ];

--- a/pkgs/by-name/cr/creep/package.nix
+++ b/pkgs/by-name/cr/creep/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   libfaketime,
   xorg,
+  fonttosfnt,
 }:
 
 stdenv.mkDerivation rec {
@@ -19,7 +20,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     libfaketime
-    xorg.fonttosfnt
+    fonttosfnt
     xorg.mkfontscale
   ];
 

--- a/pkgs/by-name/di/dina-font/package.nix
+++ b/pkgs/by-name/di/dina-font/package.nix
@@ -5,6 +5,7 @@
   fontforge,
   bdftopcf,
   xorg,
+  fonttosfnt,
 }:
 
 stdenv.mkDerivation {
@@ -27,7 +28,7 @@ stdenv.mkDerivation {
     fontforge
     bdftopcf
     xorg.mkfontscale
-    xorg.fonttosfnt
+    fonttosfnt
   ];
 
   buildPhase = ''

--- a/pkgs/by-name/ef/efont-unicode/package.nix
+++ b/pkgs/by-name/ef/efont-unicode/package.nix
@@ -5,6 +5,7 @@
   libfaketime,
   xorg,
   bdftopcf,
+  fonttosfnt,
 }:
 
 stdenv.mkDerivation rec {
@@ -19,10 +20,9 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     libfaketime
     bdftopcf
-  ] ++ (with xorg; [
     fonttosfnt
-    mkfontscale
-  ]);
+    xorg.mkfontscale
+  ];
 
   buildPhase = ''
     runHook preBuild

--- a/pkgs/by-name/ef/efont-unicode/package.nix
+++ b/pkgs/by-name/ef/efont-unicode/package.nix
@@ -4,6 +4,7 @@
   fetchurl,
   libfaketime,
   xorg,
+  bdftopcf,
 }:
 
 stdenv.mkDerivation rec {
@@ -15,12 +16,13 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-fT7SsYlV3dCQrf0IZfiNI1grj3ngDgr8IkWdg+f9m3M=";
   };
 
-  nativeBuildInputs = with xorg; [
+  nativeBuildInputs = [
     libfaketime
     bdftopcf
+  ] ++ (with xorg; [
     fonttosfnt
     mkfontscale
-  ];
+  ]);
 
   buildPhase = ''
     runHook preBuild

--- a/pkgs/by-name/en/envypn-font/package.nix
+++ b/pkgs/by-name/en/envypn-font/package.nix
@@ -4,6 +4,7 @@
   fetchurl,
   libfaketime,
   xorg,
+  fonttosfnt,
 }:
 
 stdenv.mkDerivation rec {
@@ -17,7 +18,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     libfaketime
-    xorg.fonttosfnt
+    fonttosfnt
     xorg.mkfontscale
   ];
 

--- a/pkgs/by-name/go/gohufont/package.nix
+++ b/pkgs/by-name/go/gohufont/package.nix
@@ -6,6 +6,7 @@
   bdf2psf,
   bdftopcf,
   libfaketime,
+  fonttosfnt,
 }:
 
 stdenv.mkDerivation {
@@ -23,7 +24,7 @@ stdenv.mkDerivation {
     xorg.mkfontscale
     bdf2psf
     bdftopcf
-    xorg.fonttosfnt
+    fonttosfnt
     libfaketime
   ];
 

--- a/pkgs/by-name/nx/nx-libs/package.nix
+++ b/pkgs/by-name/nx/nx-libs/package.nix
@@ -5,6 +5,7 @@
   automake,
   fetchFromGitHub,
   fetchpatch,
+  gccmakedep,
   libjpeg_turbo,
   libpng,
   libtool,
@@ -38,7 +39,7 @@ stdenv.mkDerivation rec {
     libtool
     pkg-config
     which
-    xorg.gccmakedep
+    gccmakedep
     xorg.imake
   ];
   buildInputs = [

--- a/pkgs/by-name/nx/nx-libs/package.nix
+++ b/pkgs/by-name/nx/nx-libs/package.nix
@@ -13,6 +13,7 @@
   pkg-config,
   which,
   xorg,
+  imake,
   libtirpc,
 }:
 stdenv.mkDerivation rec {
@@ -40,7 +41,7 @@ stdenv.mkDerivation rec {
     pkg-config
     which
     gccmakedep
-    xorg.imake
+    imake
   ];
   buildInputs = [
     libjpeg_turbo

--- a/pkgs/by-name/ra/radeontools/package.nix
+++ b/pkgs/by-name/ra/radeontools/package.nix
@@ -5,7 +5,7 @@
   autoreconfHook,
   pciutils,
   pkg-config,
-  xorg,
+  libpciaccess,
 }:
 
 stdenv.mkDerivation rec {
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     autoreconfHook
     pkg-config
   ];
-  buildInputs = [ xorg.libpciaccess ];
+  buildInputs = [ libpciaccess ];
 
   meta = {
     description = "Lowlevel tools to tweak register and dump state on radeon GPUs";

--- a/pkgs/by-name/si/siji/package.nix
+++ b/pkgs/by-name/si/siji/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   libfaketime,
   xorg,
+  fonttosfnt,
 }:
 
 stdenv.mkDerivation {
@@ -19,7 +20,7 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [
     libfaketime
-    xorg.fonttosfnt
+    fonttosfnt
     xorg.mkfontscale
   ];
 

--- a/pkgs/by-name/ti/tigervnc/package.nix
+++ b/pkgs/by-name/ti/tigervnc/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitHub,
   xorg,
+  libpciaccess,
   xkeyboard_config,
   zlib,
   libjpeg_turbo,
@@ -134,8 +135,8 @@ stdenv.mkDerivation (finalAttrs: {
     ffmpeg
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux (
-    with xorg;
-    [
+    [ libpciaccess ]
+    ++ (with xorg; [
       nettle
       pam
       perl
@@ -151,11 +152,10 @@ stdenv.mkDerivation (finalAttrs: {
       libXft
       libxkbfile
       libXfont2
-      libpciaccess
       libGLU
       libXrandr
       libXdamage
-    ]
+    ])
     ++ xorg.xorgserver.buildInputs
   );
 

--- a/pkgs/by-name/uc/ucs-fonts/package.nix
+++ b/pkgs/by-name/uc/ucs-fonts/package.nix
@@ -5,6 +5,7 @@
   bdftopcf,
   libfaketime,
   xorg,
+  fonttosfnt,
 }:
 
 stdenv.mkDerivation {
@@ -31,7 +32,7 @@ stdenv.mkDerivation {
   nativeBuildInputs = [
     bdftopcf
     libfaketime
-    xorg.fonttosfnt
+    fonttosfnt
     xorg.mkfontscale
   ];
 

--- a/pkgs/by-name/un/uni-vga/package.nix
+++ b/pkgs/by-name/un/uni-vga/package.nix
@@ -7,6 +7,7 @@
   bdftopcf,
   libfaketime,
   xorg,
+  fonttosfnt,
 }:
 
 stdenv.mkDerivation {
@@ -20,7 +21,7 @@ stdenv.mkDerivation {
   nativeBuildInputs = [
     bdftopcf
     libfaketime
-    xorg.fonttosfnt
+    fonttosfnt
     xorg.mkfontscale
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [

--- a/pkgs/by-name/un/unifont/package.nix
+++ b/pkgs/by-name/un/unifont/package.nix
@@ -4,6 +4,7 @@
   fetchurl,
   xorg,
   libfaketime,
+  fonttosfnt,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -27,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     libfaketime
-    xorg.fonttosfnt
+    fonttosfnt
     xorg.mkfontscale
   ];
 

--- a/pkgs/by-name/uw/uw-ttyp0/package.nix
+++ b/pkgs/by-name/uw/uw-ttyp0/package.nix
@@ -6,6 +6,7 @@
   bdftopcf,
   bdf2psf,
   xorg,
+  fonttosfnt,
   targetsDat ? null,
   variantsDat ? null,
 }:
@@ -23,7 +24,7 @@ stdenv.mkDerivation rec {
     perl
     bdftopcf
     bdf2psf
-    xorg.fonttosfnt
+    fonttosfnt
     xorg.mkfontdir
   ];
 

--- a/pkgs/by-name/xl/xlife/package.nix
+++ b/pkgs/by-name/xl/xlife/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchsvn,
   xorg,
+  gccmakedep,
 }:
 
 stdenv.mkDerivation {
@@ -15,8 +16,8 @@ stdenv.mkDerivation {
     sha256 = "1gadlcp32s179kd7ypxr8cymd6s060p6z4c2vnx94i8bmiw3nn8h";
   };
 
-  nativeBuildInputs = with xorg; [
-    imake
+  nativeBuildInputs = [
+    xorg.imake
     gccmakedep
   ];
   buildInputs = [ xorg.libX11 ];

--- a/pkgs/by-name/xl/xlife/package.nix
+++ b/pkgs/by-name/xl/xlife/package.nix
@@ -4,6 +4,7 @@
   fetchsvn,
   xorg,
   gccmakedep,
+  imake,
 }:
 
 stdenv.mkDerivation {
@@ -17,7 +18,7 @@ stdenv.mkDerivation {
   };
 
   nativeBuildInputs = [
-    xorg.imake
+    imake
     gccmakedep
   ];
   buildInputs = [ xorg.libX11 ];

--- a/pkgs/by-name/xs/xscreensaver/package.nix
+++ b/pkgs/by-name/xs/xscreensaver/package.nix
@@ -23,7 +23,7 @@
   makeWrapper,
   pam,
   perlPackages,
-  xorg,
+  appres,
   pkg-config,
   systemd,
   forceInstallAllHacks ? true,
@@ -110,7 +110,7 @@ stdenv.mkDerivation (finalAttrs: {
           lib.makeBinPath [
             coreutils
             perlPackages.perl
-            xorg.appres
+            appres
           ]
         }" \
         --prefix PERL5LIB ':' $PERL5LIB

--- a/pkgs/by-name/xt/xterm/package.nix
+++ b/pkgs/by-name/xt/xterm/package.nix
@@ -11,6 +11,7 @@
   nixosTests,
   pkgsCross,
   gitUpdater,
+  luit,
   enableDecLocator ? true,
 }:
 
@@ -47,7 +48,7 @@ stdenv.mkDerivation rec {
     ncurses
     freetype
     xorg.libXft
-    xorg.luit
+    luit
   ];
 
   configureFlags = [

--- a/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
@@ -21,6 +21,7 @@
   pkgsBuildBuild,
 
   xorg,
+  libpciaccess,
   libXcursor,
   libXScrnSaver,
   libXrandr,
@@ -381,7 +382,7 @@ qtModule (
       libXScrnSaver
       libXcursor
       libXrandr
-      xorg.libpciaccess
+      libpciaccess
       libXtst
       xorg.libXcomposite
       xorg.libXdamage

--- a/pkgs/development/libraries/qt-6/modules/qtwebengine/default.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtwebengine/default.nix
@@ -16,6 +16,7 @@
   which,
   nodejs,
   xorg,
+  libpciaccess,
   libXcursor,
   libXScrnSaver,
   libXrandr,
@@ -258,7 +259,7 @@ qtModule {
     libXScrnSaver
     libXcursor
     libXrandr
-    xorg.libpciaccess
+    libpciaccess
     libXtst
     xorg.libXcomposite
     xorg.libXdamage

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -1,7 +1,6 @@
 # THIS IS A GENERATED FILE.  DO NOT EDIT!
 {
   lib,
-  bdftopcf,
   bitmap,
   editres,
   font-adobe-100dpi,
@@ -213,7 +212,6 @@
 self: with self; {
 
   inherit
-    bdftopcf
     bitmap
     editres
     fonttosfnt

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -1,7 +1,6 @@
 # THIS IS A GENERATED FILE.  DO NOT EDIT!
 {
   lib,
-  appres,
   bdftopcf,
   bitmap,
   editres,
@@ -214,7 +213,6 @@
 self: with self; {
 
   inherit
-    appres
     bdftopcf
     bitmap
     editres

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -38,7 +38,6 @@
   font-util,
   font-winitzki-cyrillic,
   font-xfree86-type1,
-  ico,
   imake,
   libapplewm,
   libdmx,
@@ -206,7 +205,6 @@
 self: with self; {
 
   inherit
-    ico
     imake
     libdmx
     libfontenc

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -39,7 +39,6 @@
   font-winitzki-cyrillic,
   font-xfree86-type1,
   libapplewm,
-  libfontenc,
   libfs,
   libice,
   libpciaccess,
@@ -203,7 +202,6 @@
 self: with self; {
 
   inherit
-    libfontenc
     libpciaccess
     libxcb
     libxcvt

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -1,7 +1,6 @@
 # THIS IS A GENERATED FILE.  DO NOT EDIT!
 {
   lib,
-  bitmap,
   editres,
   font-adobe-100dpi,
   font-adobe-75dpi,
@@ -212,7 +211,6 @@
 self: with self; {
 
   inherit
-    bitmap
     editres
     fonttosfnt
     gccmakedep

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -41,7 +41,6 @@
   libapplewm,
   libfs,
   libice,
-  libpciaccess,
   libpthread-stubs,
   libsm,
   libwindowswm,
@@ -202,7 +201,6 @@
 self: with self; {
 
   inherit
-    libpciaccess
     libxcb
     libxcvt
     libxkbfile

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -38,7 +38,6 @@
   font-util,
   font-winitzki-cyrillic,
   font-xfree86-type1,
-  gccmakedep,
   iceauth,
   ico,
   imake,
@@ -208,7 +207,6 @@
 self: with self; {
 
   inherit
-    gccmakedep
     iceauth
     ico
     imake

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -39,7 +39,6 @@
   font-winitzki-cyrillic,
   font-xfree86-type1,
   libapplewm,
-  libdmx,
   libfontenc,
   libfs,
   libice,
@@ -204,7 +203,6 @@
 self: with self; {
 
   inherit
-    libdmx
     libfontenc
     libpciaccess
     libxcb

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -1,7 +1,6 @@
 # THIS IS A GENERATED FILE.  DO NOT EDIT!
 {
   lib,
-  editres,
   font-adobe-100dpi,
   font-adobe-75dpi,
   font-adobe-utopia-100dpi,
@@ -211,7 +210,6 @@
 self: with self; {
 
   inherit
-    editres
     fonttosfnt
     gccmakedep
     iceauth

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -93,7 +93,6 @@
   libxxf86vm,
   listres,
   lndir,
-  luit,
   makedepend,
   mkfontscale,
   oclock,
@@ -222,7 +221,6 @@ self: with self; {
     libxshmfence
     listres
     lndir
-    luit
     makedepend
     mkfontscale
     oclock

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -38,7 +38,6 @@
   font-util,
   font-winitzki-cyrillic,
   font-xfree86-type1,
-  iceauth,
   ico,
   imake,
   libapplewm,
@@ -207,7 +206,6 @@
 self: with self; {
 
   inherit
-    iceauth
     ico
     imake
     libdmx

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -38,7 +38,6 @@
   font-util,
   font-winitzki-cyrillic,
   font-xfree86-type1,
-  imake,
   libapplewm,
   libdmx,
   libfontenc,
@@ -205,7 +204,6 @@
 self: with self; {
 
   inherit
-    imake
     libdmx
     libfontenc
     libpciaccess

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -35,7 +35,6 @@
   font-screen-cyrillic,
   font-sony-misc,
   font-sun-misc,
-  fonttosfnt,
   font-util,
   font-winitzki-cyrillic,
   font-xfree86-type1,
@@ -210,7 +209,6 @@
 self: with self; {
 
   inherit
-    fonttosfnt
     gccmakedep
     iceauth
     ico

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -37,7 +37,6 @@ $pcMap{"GL"} = "libGL";
 $pcMap{"gbm"} = "libgbm";
 $pcMap{"hwdata"} = "hwdata";
 $pcMap{"dmx"} = "libdmx";
-$pcMap{"fontenc"} = "libfontenc";
 $pcMap{"fontutil"} = "fontutil";
 $pcMap{"ice"} = "libICE";
 $pcMap{"libfs"} = "libFS";
@@ -333,10 +332,6 @@ print OUT <<EOF;
 # THIS IS A GENERATED FILE.  DO NOT EDIT!
 {
   lib,
-  appres,
-  bdftopcf,
-  bitmap,
-  editres,
   font-adobe-100dpi,
   font-adobe-75dpi,
   font-adobe-utopia-100dpi,
@@ -371,20 +366,12 @@ print OUT <<EOF;
   font-screen-cyrillic,
   font-sony-misc,
   font-sun-misc,
-  fonttosfnt,
   font-util,
   font-winitzki-cyrillic,
   font-xfree86-type1,
-  gccmakedep,
-  iceauth,
-  ico,
-  imake,
   libapplewm,
-  libdmx,
-  libfontenc,
   libfs,
   libice,
-  libpciaccess,
   libpthread-stubs,
   libsm,
   libwindowswm,
@@ -430,7 +417,6 @@ print OUT <<EOF;
   libxxf86vm,
   listres,
   lndir,
-  luit,
   makedepend,
   mkfontscale,
   oclock,
@@ -546,25 +532,12 @@ print OUT <<EOF;
 self: with self; {
 
   inherit
-    appres
-    bdftopcf
-    bitmap
-    editres
-    fonttosfnt
-    gccmakedep
-    iceauth
-    ico
-    imake
-    libdmx
-    libfontenc
-    libpciaccess
     libxcb
     libxcvt
     libxkbfile
     libxshmfence
     listres
     lndir
-    luit
     makedepend
     mkfontscale
     oclock

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -113,6 +113,7 @@ self: super:
   gccmakedep = lib.warnOnInstantiate "gccmakedep has been removed from xorg namespace, use pkgs.gccmakedep instead" pkgs.gccmakedep; # added 2026-01-10
   iceauth = lib.warnOnInstantiate "iceauth has been removed from xorg namespace, use pkgs.iceauth instead" pkgs.iceauth; # added 2026-01-10
   ico = lib.warnOnInstantiate "ico has been removed from xorg namespace, use pkgs.ico instead" pkgs.ico; # added 2026-01-10
+  imake = lib.warnOnInstantiate "imake has been removed from xorg namespace, use pkgs.imake instead" pkgs.imake; # added 2026-01-10
   luit = lib.warnOnInstantiate "luit has been removed from xorg namespace, use pkgs.luit instead" pkgs.luit; # added 2026-01-10
   xf86videoglide = throw "The Xorg Glide video driver has been archived upstream due to being obsolete"; # added 2025-12-13
   xf86videoglint = throw ''

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -116,6 +116,7 @@ self: super:
   imake = lib.warnOnInstantiate "imake has been removed from xorg namespace, use pkgs.imake instead" pkgs.imake; # added 2026-01-10
   libdmx = lib.warnOnInstantiate "libdmx has been removed from xorg namespace, use pkgs.libdmx instead" pkgs.libdmx; # added 2026-01-10
   libfontenc = lib.warnOnInstantiate "libfontenc has been removed from xorg namespace, use pkgs.libfontenc instead" pkgs.libfontenc; # added 2026-01-10
+  libpciaccess = lib.warnOnInstantiate "libpciaccess has been removed from xorg namespace, use pkgs.libpciaccess instead" pkgs.libpciaccess; # added 2026-01-10
   luit = lib.warnOnInstantiate "luit has been removed from xorg namespace, use pkgs.luit instead" pkgs.luit; # added 2026-01-10
   xf86videoglide = throw "The Xorg Glide video driver has been archived upstream due to being obsolete"; # added 2025-12-13
   xf86videoglint = throw ''

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -105,6 +105,7 @@ self: super:
   # keep-sorted start
   appres = lib.warnOnInstantiate "appres has been removed from xorg namespace, use pkgs.appres instead" pkgs.appres; # added 2026-01-10
   bdftopcf = lib.warnOnInstantiate "bdftopcf has been removed from xorg namespace, use pkgs.bdftopcf instead" pkgs.bdftopcf; # added 2026-01-10
+  bitmap = lib.warnOnInstantiate "bitmap has been removed from xorg namespace, use pkgs.bitmap instead" pkgs.bitmap; # added 2026-01-10
   fontbitstreamspeedo = throw "Bitstream Speedo is an obsolete font format that hasn't been supported by Xorg since 2005"; # added 2025-09-24
   libXtrap = throw "XTrap was a proposed X11 extension that hasn't been in Xorg since X11R6 in 1994, it is deprecated and archived upstream."; # added 2025-12-13
   xf86videoglide = throw "The Xorg Glide video driver has been archived upstream due to being obsolete"; # added 2025-12-13

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -114,6 +114,7 @@ self: super:
   iceauth = lib.warnOnInstantiate "iceauth has been removed from xorg namespace, use pkgs.iceauth instead" pkgs.iceauth; # added 2026-01-10
   ico = lib.warnOnInstantiate "ico has been removed from xorg namespace, use pkgs.ico instead" pkgs.ico; # added 2026-01-10
   imake = lib.warnOnInstantiate "imake has been removed from xorg namespace, use pkgs.imake instead" pkgs.imake; # added 2026-01-10
+  libdmx = lib.warnOnInstantiate "libdmx has been removed from xorg namespace, use pkgs.libdmx instead" pkgs.libdmx; # added 2026-01-10
   luit = lib.warnOnInstantiate "luit has been removed from xorg namespace, use pkgs.luit instead" pkgs.luit; # added 2026-01-10
   xf86videoglide = throw "The Xorg Glide video driver has been archived upstream due to being obsolete"; # added 2025-12-13
   xf86videoglint = throw ''

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  pkgs,
   config,
   fetchpatch,
   automake,
@@ -102,6 +103,7 @@ self: super:
 # deprecate some packages
 // lib.optionalAttrs config.allowAliases {
   # keep-sorted start
+  appres = lib.warnOnInstantiate "appres has been removed from xorg namespace, use pkgs.appres instead" pkgs.appres; # added 2026-01-10
   fontbitstreamspeedo = throw "Bitstream Speedo is an obsolete font format that hasn't been supported by Xorg since 2005"; # added 2025-09-24
   libXtrap = throw "XTrap was a proposed X11 extension that hasn't been in Xorg since X11R6 in 1994, it is deprecated and archived upstream."; # added 2025-12-13
   xf86videoglide = throw "The Xorg Glide video driver has been archived upstream due to being obsolete"; # added 2025-12-13

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -109,6 +109,7 @@ self: super:
   editres = lib.warnOnInstantiate "editres has been removed from xorg namespace, use pkgs.editres instead" pkgs.editres; # added 2026-01-10
   fontbitstreamspeedo = throw "Bitstream Speedo is an obsolete font format that hasn't been supported by Xorg since 2005"; # added 2025-09-24
   libXtrap = throw "XTrap was a proposed X11 extension that hasn't been in Xorg since X11R6 in 1994, it is deprecated and archived upstream."; # added 2025-12-13
+  fonttosfnt = lib.warnOnInstantiate "fonttosfnt has been removed from xorg namespace, use pkgs.fonttosfnt instead" pkgs.fonttosfnt; # added 2026-01-10
   xf86videoglide = throw "The Xorg Glide video driver has been archived upstream due to being obsolete"; # added 2025-12-13
   xf86videoglint = throw ''
     The Xorg GLINT/Permedia video driver has been broken since xorg 21.

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -111,6 +111,7 @@ self: super:
   libXtrap = throw "XTrap was a proposed X11 extension that hasn't been in Xorg since X11R6 in 1994, it is deprecated and archived upstream."; # added 2025-12-13
   fonttosfnt = lib.warnOnInstantiate "fonttosfnt has been removed from xorg namespace, use pkgs.fonttosfnt instead" pkgs.fonttosfnt; # added 2026-01-10
   gccmakedep = lib.warnOnInstantiate "gccmakedep has been removed from xorg namespace, use pkgs.gccmakedep instead" pkgs.gccmakedep; # added 2026-01-10
+  iceauth = lib.warnOnInstantiate "iceauth has been removed from xorg namespace, use pkgs.iceauth instead" pkgs.iceauth; # added 2026-01-10
   luit = lib.warnOnInstantiate "luit has been removed from xorg namespace, use pkgs.luit instead" pkgs.luit; # added 2026-01-10
   xf86videoglide = throw "The Xorg Glide video driver has been archived upstream due to being obsolete"; # added 2025-12-13
   xf86videoglint = throw ''

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -110,6 +110,7 @@ self: super:
   fontbitstreamspeedo = throw "Bitstream Speedo is an obsolete font format that hasn't been supported by Xorg since 2005"; # added 2025-09-24
   libXtrap = throw "XTrap was a proposed X11 extension that hasn't been in Xorg since X11R6 in 1994, it is deprecated and archived upstream."; # added 2025-12-13
   fonttosfnt = lib.warnOnInstantiate "fonttosfnt has been removed from xorg namespace, use pkgs.fonttosfnt instead" pkgs.fonttosfnt; # added 2026-01-10
+  luit = lib.warnOnInstantiate "luit has been removed from xorg namespace, use pkgs.luit instead" pkgs.luit; # added 2026-01-10
   xf86videoglide = throw "The Xorg Glide video driver has been archived upstream due to being obsolete"; # added 2025-12-13
   xf86videoglint = throw ''
     The Xorg GLINT/Permedia video driver has been broken since xorg 21.

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -115,6 +115,7 @@ self: super:
   ico = lib.warnOnInstantiate "ico has been removed from xorg namespace, use pkgs.ico instead" pkgs.ico; # added 2026-01-10
   imake = lib.warnOnInstantiate "imake has been removed from xorg namespace, use pkgs.imake instead" pkgs.imake; # added 2026-01-10
   libdmx = lib.warnOnInstantiate "libdmx has been removed from xorg namespace, use pkgs.libdmx instead" pkgs.libdmx; # added 2026-01-10
+  libfontenc = lib.warnOnInstantiate "libfontenc has been removed from xorg namespace, use pkgs.libfontenc instead" pkgs.libfontenc; # added 2026-01-10
   luit = lib.warnOnInstantiate "luit has been removed from xorg namespace, use pkgs.luit instead" pkgs.luit; # added 2026-01-10
   xf86videoglide = throw "The Xorg Glide video driver has been archived upstream due to being obsolete"; # added 2025-12-13
   xf86videoglint = throw ''

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -103,21 +103,8 @@ self: super:
 # deprecate some packages
 // lib.optionalAttrs config.allowAliases {
   # keep-sorted start
-  appres = lib.warnOnInstantiate "appres has been removed from xorg namespace, use pkgs.appres instead" pkgs.appres; # added 2026-01-10
-  bdftopcf = lib.warnOnInstantiate "bdftopcf has been removed from xorg namespace, use pkgs.bdftopcf instead" pkgs.bdftopcf; # added 2026-01-10
-  bitmap = lib.warnOnInstantiate "bitmap has been removed from xorg namespace, use pkgs.bitmap instead" pkgs.bitmap; # added 2026-01-10
-  editres = lib.warnOnInstantiate "editres has been removed from xorg namespace, use pkgs.editres instead" pkgs.editres; # added 2026-01-10
   fontbitstreamspeedo = throw "Bitstream Speedo is an obsolete font format that hasn't been supported by Xorg since 2005"; # added 2025-09-24
   libXtrap = throw "XTrap was a proposed X11 extension that hasn't been in Xorg since X11R6 in 1994, it is deprecated and archived upstream."; # added 2025-12-13
-  fonttosfnt = lib.warnOnInstantiate "fonttosfnt has been removed from xorg namespace, use pkgs.fonttosfnt instead" pkgs.fonttosfnt; # added 2026-01-10
-  gccmakedep = lib.warnOnInstantiate "gccmakedep has been removed from xorg namespace, use pkgs.gccmakedep instead" pkgs.gccmakedep; # added 2026-01-10
-  iceauth = lib.warnOnInstantiate "iceauth has been removed from xorg namespace, use pkgs.iceauth instead" pkgs.iceauth; # added 2026-01-10
-  ico = lib.warnOnInstantiate "ico has been removed from xorg namespace, use pkgs.ico instead" pkgs.ico; # added 2026-01-10
-  imake = lib.warnOnInstantiate "imake has been removed from xorg namespace, use pkgs.imake instead" pkgs.imake; # added 2026-01-10
-  libdmx = lib.warnOnInstantiate "libdmx has been removed from xorg namespace, use pkgs.libdmx instead" pkgs.libdmx; # added 2026-01-10
-  libfontenc = lib.warnOnInstantiate "libfontenc has been removed from xorg namespace, use pkgs.libfontenc instead" pkgs.libfontenc; # added 2026-01-10
-  libpciaccess = lib.warnOnInstantiate "libpciaccess has been removed from xorg namespace, use pkgs.libpciaccess instead" pkgs.libpciaccess; # added 2026-01-10
-  luit = lib.warnOnInstantiate "luit has been removed from xorg namespace, use pkgs.luit instead" pkgs.luit; # added 2026-01-10
   xf86videoglide = throw "The Xorg Glide video driver has been archived upstream due to being obsolete"; # added 2025-12-13
   xf86videoglint = throw ''
     The Xorg GLINT/Permedia video driver has been broken since xorg 21.
@@ -128,3 +115,37 @@ self: super:
   xtrap = throw "XTrap was a proposed X11 extension that hasn't been in Xorg since X11R6 in 1994, it is deprecated and archived upstream."; # added 2025-12-13
   # keep-sorted end
 }
+
+# Packages moved to top-level (pkgs/by-name). These aliases provide a clear
+# error message when someone explicitly uses xorg.X. They are excluded from
+# pkgsForCall merge in splice.nix via the deprecatedAliases list.
+// (
+  let
+    # added 2026-01-10
+    movedToToplevel = [
+      "appres"
+      "bdftopcf"
+      "bitmap"
+      "editres"
+      "fonttosfnt"
+      "gccmakedep"
+      "iceauth"
+      "ico"
+      "imake"
+      "libdmx"
+      "libfontenc"
+      "libpciaccess"
+      "luit"
+    ];
+  in
+  lib.optionalAttrs config.allowAliases (
+    lib.genAttrs movedToToplevel (
+      name:
+      lib.warnOnInstantiate "${name} has been removed from xorg namespace, use pkgs.${name} instead"
+        pkgs.${name}
+    )
+  )
+  // {
+    deprecatedAliases = movedToToplevel;
+  }
+)

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -106,6 +106,7 @@ self: super:
   appres = lib.warnOnInstantiate "appres has been removed from xorg namespace, use pkgs.appres instead" pkgs.appres; # added 2026-01-10
   bdftopcf = lib.warnOnInstantiate "bdftopcf has been removed from xorg namespace, use pkgs.bdftopcf instead" pkgs.bdftopcf; # added 2026-01-10
   bitmap = lib.warnOnInstantiate "bitmap has been removed from xorg namespace, use pkgs.bitmap instead" pkgs.bitmap; # added 2026-01-10
+  editres = lib.warnOnInstantiate "editres has been removed from xorg namespace, use pkgs.editres instead" pkgs.editres; # added 2026-01-10
   fontbitstreamspeedo = throw "Bitstream Speedo is an obsolete font format that hasn't been supported by Xorg since 2005"; # added 2025-09-24
   libXtrap = throw "XTrap was a proposed X11 extension that hasn't been in Xorg since X11R6 in 1994, it is deprecated and archived upstream."; # added 2025-12-13
   xf86videoglide = throw "The Xorg Glide video driver has been archived upstream due to being obsolete"; # added 2025-12-13

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -1,59 +1,10 @@
 {
-  callPackage,
   lib,
   config,
-  stdenv,
-  makeWrapper,
-  fetchurl,
   fetchpatch,
-  fetchFromGitLab,
-  buildPackages,
   automake,
-  autoconf,
-  libiconv,
-  libtool,
-  intltool,
-  gettext,
-  gzip,
-  python3,
-  perl,
-  freetype,
-  tradcpp,
-  fontconfig,
-  meson,
-  ninja,
   ed,
-  fontforge,
-  libGL,
-  spice-protocol,
-  zlib,
-  libGLU,
-  dbus,
-  libunwind,
-  libdrm,
-  netbsd,
-  ncompress,
-  updateAutotoolsGnuConfigScriptsHook,
-  mesa,
-  udev,
-  bootstrap_cmds,
-  bison,
-  flex,
-  clangStdenv,
-  autoreconfHook,
-  mcpp,
-  libepoxy,
-  openssl,
-  pkg-config,
-  llvm,
-  libxslt,
-  libxcrypt,
-  hwdata,
   xorg,
-  windows,
-  libgbm,
-  mesa-gl-headers,
-  dri-pkgconfig-stub,
 }:
 self: super:
 {
@@ -150,15 +101,16 @@ self: super:
 
 # deprecate some packages
 // lib.optionalAttrs config.allowAliases {
+  # keep-sorted start
   fontbitstreamspeedo = throw "Bitstream Speedo is an obsolete font format that hasn't been supported by Xorg since 2005"; # added 2025-09-24
   libXtrap = throw "XTrap was a proposed X11 extension that hasn't been in Xorg since X11R6 in 1994, it is deprecated and archived upstream."; # added 2025-12-13
-  xtrap = throw "XTrap was a proposed X11 extension that hasn't been in Xorg since X11R6 in 1994, it is deprecated and archived upstream."; # added 2025-12-13
   xf86videoglide = throw "The Xorg Glide video driver has been archived upstream due to being obsolete"; # added 2025-12-13
   xf86videoglint = throw ''
     The Xorg GLINT/Permedia video driver has been broken since xorg 21.
-    see https://gitlab.freedesktop.org/xorg/driver/xf86-video-glint/-/issues/1
-  ''; # added 2025-12-13
+    see https://gitlab.freedesktop.org/xorg/driver/xf86-video-glint/-/issues/1''; # added 2025-12-13
   xf86videonewport = throw "The Xorg Newport video driver is broken and hasn't had a release since 2012"; # added 2025-12-13
   xf86videotga = throw "The Xorg TGA (aka DEC 21030) video driver is broken and hasn't had a release since 2012"; # added 2025-12-13
   xf86videowsfb = throw "The Xorg BSD wsdisplay framebuffer video driver is broken and hasn't had a release since 2012"; # added 2025-12-13
+  xtrap = throw "XTrap was a proposed X11 extension that hasn't been in Xorg since X11R6 in 1994, it is deprecated and archived upstream."; # added 2025-12-13
+  # keep-sorted end
 }

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -104,6 +104,7 @@ self: super:
 // lib.optionalAttrs config.allowAliases {
   # keep-sorted start
   appres = lib.warnOnInstantiate "appres has been removed from xorg namespace, use pkgs.appres instead" pkgs.appres; # added 2026-01-10
+  bdftopcf = lib.warnOnInstantiate "bdftopcf has been removed from xorg namespace, use pkgs.bdftopcf instead" pkgs.bdftopcf; # added 2026-01-10
   fontbitstreamspeedo = throw "Bitstream Speedo is an obsolete font format that hasn't been supported by Xorg since 2005"; # added 2025-09-24
   libXtrap = throw "XTrap was a proposed X11 extension that hasn't been in Xorg since X11R6 in 1994, it is deprecated and archived upstream."; # added 2025-12-13
   xf86videoglide = throw "The Xorg Glide video driver has been archived upstream due to being obsolete"; # added 2025-12-13

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -112,6 +112,7 @@ self: super:
   fonttosfnt = lib.warnOnInstantiate "fonttosfnt has been removed from xorg namespace, use pkgs.fonttosfnt instead" pkgs.fonttosfnt; # added 2026-01-10
   gccmakedep = lib.warnOnInstantiate "gccmakedep has been removed from xorg namespace, use pkgs.gccmakedep instead" pkgs.gccmakedep; # added 2026-01-10
   iceauth = lib.warnOnInstantiate "iceauth has been removed from xorg namespace, use pkgs.iceauth instead" pkgs.iceauth; # added 2026-01-10
+  ico = lib.warnOnInstantiate "ico has been removed from xorg namespace, use pkgs.ico instead" pkgs.ico; # added 2026-01-10
   luit = lib.warnOnInstantiate "luit has been removed from xorg namespace, use pkgs.luit instead" pkgs.luit; # added 2026-01-10
   xf86videoglide = throw "The Xorg Glide video driver has been archived upstream due to being obsolete"; # added 2025-12-13
   xf86videoglint = throw ''

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -110,6 +110,7 @@ self: super:
   fontbitstreamspeedo = throw "Bitstream Speedo is an obsolete font format that hasn't been supported by Xorg since 2005"; # added 2025-09-24
   libXtrap = throw "XTrap was a proposed X11 extension that hasn't been in Xorg since X11R6 in 1994, it is deprecated and archived upstream."; # added 2025-12-13
   fonttosfnt = lib.warnOnInstantiate "fonttosfnt has been removed from xorg namespace, use pkgs.fonttosfnt instead" pkgs.fonttosfnt; # added 2026-01-10
+  gccmakedep = lib.warnOnInstantiate "gccmakedep has been removed from xorg namespace, use pkgs.gccmakedep instead" pkgs.gccmakedep; # added 2026-01-10
   luit = lib.warnOnInstantiate "luit has been removed from xorg namespace, use pkgs.luit instead" pkgs.luit; # added 2026-01-10
   xf86videoglide = throw "The Xorg Glide video driver has been archived upstream due to being obsolete"; # added 2025-12-13
   xf86videoglint = throw ''

--- a/pkgs/tools/admin/turbovnc/default.nix
+++ b/pkgs/tools/admin/turbovnc/default.nix
@@ -26,6 +26,7 @@
   xkbcomp,
   xkeyboard_config,
   xorg,
+  libfontenc,
   xterm,
 }:
 
@@ -94,7 +95,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch = ''
     substituteInPlace unix/Xvnc/CMakeLists.txt --replace 'string(REGEX REPLACE "X11" "Xfont2" X11_Xfont2_LIB' 'set(X11_Xfont2_LIB ${xorg.libXfont2}/lib/libXfont2.so)  #'
-    substituteInPlace unix/Xvnc/CMakeLists.txt --replace 'string(REGEX REPLACE "X11" "fontenc" X11_Fontenc_LIB' 'set(X11_Fontenc_LIB ${xorg.libfontenc}/lib/libfontenc.so)  #'
+    substituteInPlace unix/Xvnc/CMakeLists.txt --replace 'string(REGEX REPLACE "X11" "fontenc" X11_Fontenc_LIB' 'set(X11_Fontenc_LIB ${libfontenc}/lib/libfontenc.so)  #'
     substituteInPlace unix/Xvnc/CMakeLists.txt --replace 'string(REGEX REPLACE "X11" "pixman-1" X11_Pixman_LIB' 'set(X11_Pixman_LIB ${xorg.pixman}/lib/libpixman-1.so)  #'
   '';
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9407,11 +9407,7 @@ with pkgs;
       # Use `lib.callPackageWith __splicedPackages` rather than plain `callPackage`
       # so as not to have the newly bound xorg items already in scope,  which would
       # have created a cycle.
-      overrides = lib.callPackageWith __splicedPackages ../servers/x11/xorg/overrides.nix {
-        inherit (buildPackages.darwin) bootstrap_cmds;
-        udev = if stdenv.hostPlatform.isLinux then udev else null;
-        libdrm = if stdenv.hostPlatform.isLinux then libdrm else null;
-      };
+      overrides = lib.callPackageWith __splicedPackages ../servers/x11/xorg/overrides.nix { };
 
       generatedPackages = lib.callPackageWith __splicedPackages ../servers/x11/xorg/default.nix { };
 

--- a/pkgs/top-level/splice.nix
+++ b/pkgs/top-level/splice.nix
@@ -106,23 +106,20 @@ let
         ;
     };
 
-  splicedPackagesWithXorg =
-    splicedPackages
-    // removeAttrs splicedPackages.xorg [
-      "callPackage"
-      "newScope"
-      "overrideScope"
-      "packages"
-    ];
+  # Attributes to exclude when merging xorg into pkgsForCall.
+  # deprecatedAliases are packages moved to by-name that are still present in xorg namespace.
+  xorgExcludedAttrs = [
+    "callPackage"
+    "deprecatedAliases"
+    "newScope"
+    "overrideScope"
+    "packages"
+  ]
+  ++ (splicedPackages.xorg.deprecatedAliases or [ ]);
 
-  packagesWithXorg =
-    pkgs
-    // removeAttrs pkgs.xorg [
-      "callPackage"
-      "newScope"
-      "overrideScope"
-      "packages"
-    ];
+  splicedPackagesWithXorg = splicedPackages // removeAttrs splicedPackages.xorg xorgExcludedAttrs;
+
+  packagesWithXorg = pkgs // removeAttrs pkgs.xorg xorgExcludedAttrs;
 
   pkgsForCall = if actuallySplice then splicedPackagesWithXorg else packagesWithXorg;
 


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
