### PR TITLE
[Backport release-25.11] changelogger: 0.6.1 -> 0.7.0, modernize, adopt

### DIFF
--- a/pkgs/by-name/ch/changelogger/package.nix
+++ b/pkgs/by-name/ch/changelogger/package.nix
@@ -40,7 +40,7 @@ buildGoModule rec {
     homepage = "https://github.com/MarkusFreitag/changelogger";
     changelog = "https://github.com/MarkusFreitag/changelogger/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ tomsiewert ];
+    maintainers = [ ];
     mainProgram = "changelogger";
   };
 }

--- a/pkgs/by-name/ch/changelogger/package.nix
+++ b/pkgs/by-name/ch/changelogger/package.nix
@@ -8,16 +8,16 @@
 
 buildGoModule rec {
   pname = "changelogger";
-  version = "0.6.1";
+  version = "0.7.0";
 
   src = fetchFromGitHub {
     owner = "MarkusFreitag";
     repo = "changelogger";
     rev = "v${version}";
-    sha256 = "sha256-XDiO8r1HpdsfBKzFLnsWdxte2EqL1blPH21137fNm5M=";
+    sha256 = "sha256-Glup2Y3sGO2hNKFeZXOrffHct2F4Ebn9+f6yOy3pekY=";
   };
 
-  vendorHash = "sha256-E6J+0tZriskBnXdhQOQA240c3z+laXM5honoREjHPfM=";
+  vendorHash = "sha256-f6ojMri3m3pwLXbLnNbS/Xl2lqo0eEHLGbbT5KR1Clc=";
 
   ldflags = [
     "-s"
@@ -25,6 +25,12 @@ buildGoModule rec {
     "-X github.com/MarkusFreitag/changelogger/cmd.BuildVersion=${version}"
     "-X github.com/MarkusFreitag/changelogger/cmd.BuildDate=1970-01-01T00:00:00"
   ];
+
+  preCheck = ''
+    # Test needs gitconfig
+    substituteInPlace pkg/gitconfig/gitconfig_test.go \
+      --replace-fail "TestGetGitAuthor" "SkipGetGitAuthor"
+  '';
 
   nativeBuildInputs = [ installShellFiles ];
 

--- a/pkgs/by-name/ch/changelogger/package.nix
+++ b/pkgs/by-name/ch/changelogger/package.nix
@@ -42,11 +42,11 @@ buildGoModule (finalAttrs: {
   '';
 
   meta = {
+    changelog = "https://github.com/MarkusFreitag/changelogger/blob/v${finalAttrs.version}/CHANGELOG.md";
     description = "Tool to manage your changelog file in Markdown";
     homepage = "https://github.com/MarkusFreitag/changelogger";
-    changelog = "https://github.com/MarkusFreitag/changelogger/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.mit;
-    maintainers = [ ];
     mainProgram = "changelogger";
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/ch/changelogger/package.nix
+++ b/pkgs/by-name/ch/changelogger/package.nix
@@ -6,14 +6,14 @@
   installShellFiles,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "changelogger";
   version = "0.7.0";
 
   src = fetchFromGitHub {
     owner = "MarkusFreitag";
     repo = "changelogger";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     sha256 = "sha256-Glup2Y3sGO2hNKFeZXOrffHct2F4Ebn9+f6yOy3pekY=";
   };
 
@@ -22,7 +22,7 @@ buildGoModule rec {
   ldflags = [
     "-s"
     "-w"
-    "-X github.com/MarkusFreitag/changelogger/cmd.BuildVersion=${version}"
+    "-X github.com/MarkusFreitag/changelogger/cmd.BuildVersion=${finalAttrs.version}"
     "-X github.com/MarkusFreitag/changelogger/cmd.BuildDate=1970-01-01T00:00:00"
   ];
 
@@ -44,9 +44,9 @@ buildGoModule rec {
   meta = {
     description = "Tool to manage your changelog file in Markdown";
     homepage = "https://github.com/MarkusFreitag/changelogger";
-    changelog = "https://github.com/MarkusFreitag/changelogger/blob/v${version}/CHANGELOG.md";
+    changelog = "https://github.com/MarkusFreitag/changelogger/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = [ ];
     mainProgram = "changelogger";
   };
-}
+})

--- a/pkgs/by-name/ch/changelogger/package.nix
+++ b/pkgs/by-name/ch/changelogger/package.nix
@@ -13,7 +13,7 @@ buildGoModule (finalAttrs: {
   src = fetchFromGitHub {
     owner = "MarkusFreitag";
     repo = "changelogger";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     sha256 = "sha256-Glup2Y3sGO2hNKFeZXOrffHct2F4Ebn9+f6yOy3pekY=";
   };
 

--- a/pkgs/by-name/ch/changelogger/package.nix
+++ b/pkgs/by-name/ch/changelogger/package.nix
@@ -47,6 +47,6 @@ buildGoModule (finalAttrs: {
     homepage = "https://github.com/MarkusFreitag/changelogger";
     license = lib.licenses.mit;
     mainProgram = "changelogger";
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ hythera ];
   };
 })


### PR DESCRIPTION
Manual backport of #476373 (one commit) and #476427.

Closes #478708: the adoption should be backported too, so you can use the merge bot on backports. And the housekeeping changes make automatic backports possible more likely to succeed and are non-breaking, so they can be backported too.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
