### PR TITLE
bats: add usage example to longDescription

### DIFF
--- a/pkgs/by-name/ba/bats/package.nix
+++ b/pkgs/by-name/ba/bats/package.nix
@@ -255,6 +255,21 @@ resholve.mkDerivation rec {
   meta = {
     homepage = "https://github.com/bats-core/bats-core";
     description = "Bash Automated Testing System";
+    longDescription = ''
+      Bats can be extended with libraries. The available libraries are:
+
+        bats-assert
+        bats-file
+        bats-detik
+        bats-support
+
+      An example of building this package with a few libraries:
+
+        bats.withLibraries (p: [
+          p.bats-assert
+          p.bats-support
+        ])
+    '';
     mainProgram = "bats";
     maintainers = with lib.maintainers; [ abathur ];
     license = lib.licenses.mit;

--- a/pkgs/by-name/ba/bats/package.nix
+++ b/pkgs/by-name/ba/bats/package.nix
@@ -258,17 +258,18 @@ resholve.mkDerivation rec {
     longDescription = ''
       Bats can be extended with libraries. The available libraries are:
 
-        bats-assert
-        bats-file
-        bats-detik
-        bats-support
+      - `bats-assert`
+      - `bats-file`
+      - `bats-detik`
+      - `bats-support`
 
       An example of building this package with a few libraries:
-
-        bats.withLibraries (p: [
-          p.bats-assert
-          p.bats-support
-        ])
+      ```nix
+      bats.withLibraries (p: [
+        p.bats-assert
+        p.bats-support
+      ])
+      ```
     '';
     mainProgram = "bats";
     maintainers = with lib.maintainers; [ abathur ];


### PR DESCRIPTION
The `bats` package provides a `withLibraries` function to easily include helper library such as `bats-assert` and `bats-support`. However, this capability is not immediately visible to users browsing packages via `Nixpkgs Package Search`.

This commit adds a `longDescription` to document this feature, providing a code example on how to compose `bats` with its libraries.


## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
