### PR TITLE
nixos/borgbackup: Add option `randomizedOffset`

### DIFF
--- a/nixos/modules/services/backup/borgbackup.nix
+++ b/nixos/modules/services/backup/borgbackup.nix
@@ -971,7 +971,7 @@ in
       environment.systemPackages = [
         config.services.borgbackup.package
       ]
-      ++ (lib.flatten (lib.mapAttrsToList mkBorgWrapper jobs));
+      ++ lib.flatten (lib.mapAttrsToList mkBorgWrapper jobs);
     }
   );
 }

--- a/nixos/modules/services/backup/borgbackup.nix
+++ b/nixos/modules/services/backup/borgbackup.nix
@@ -194,6 +194,7 @@ let
       timerConfig = {
         Persistent = cfg.persistentTimer;
         OnCalendar = cfg.startAt;
+        RandomizedOffsetSec = cfg.randomizedOffset;
       };
       # if remote-backup wait for network
       after = lib.optional (cfg.persistentTimer && !isLocalPath cfg.repo) "network-online.target";
@@ -497,6 +498,20 @@ in
                 {manpage}`systemd.timer(5)`
                 which triggers the backup immediately if the last trigger
                 was missed (e.g. if the system was powered down).
+              '';
+            };
+
+            randomizedOffset = lib.mkOption {
+              default = "0";
+              type = lib.types.str;
+              example = "2h";
+              description = ''
+                Set the `RandomizedOffsetSec` option for the
+                {manpage}`systemd.timer(5)`
+                which adds a random but static offset to the starting time of
+                the different jobs. This prevents locking issues with borg and resource
+                exhaustion. Must be in the format described in
+                {manpage}`systemd.time(7)`.
               '';
             };
 


### PR DESCRIPTION
Running multiple borgbackup jobs at the same time is not possible: Borg locks the state directory and concurrent jobs will be killed and not run.

With the new option `randomizedOffset`, jobs can be staggered over a timeframe. This has also the added benefit of stretching the load.

This change has been sitting for a while but the option `RandomizedOffsetSec` requires systemd-258 and I needed to wait for it to hit the tree.

Borg with this added option has been running since end of November on my server and has not have locking issues since then (but often before).

@dotlambda: It also includes the removal of unnecessary parentheses you have asked for in https://github.com/NixOS/nixpkgs/pull/447400#discussion_r2401276653 :)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
