### PR TITLE
enola: init at 0.4.0

### DIFF
--- a/pkgs/by-name/en/enola/package.nix
+++ b/pkgs/by-name/en/enola/package.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildGoModule,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "enola";
+  version = "0.4.0";
+
+  src = fetchFromGitHub {
+    owner = "TheYahya";
+    repo = "enola";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-vXc/Ak4IUIzZwH67jEZrsrWk9DPbJvGuXpqIdauIOZ0=";
+  };
+
+  vendorHash = "sha256-8xwvnwpK/jExB3U7EA3Xa5kpUbqN27qvUrIwCAwWbE4=";
+
+  meta = {
+    description = "CLI to find social media accounts by username, similar to Sherlock";
+    homepage = "https://github.com/TheYahya/enola";
+    changelog = "https://github.com/TheYahya/enola/releases/tag/v${finalAttrs.version}";
+    mainProgram = "enola";
+    maintainers = with lib.maintainers; [
+      nicknb
+    ];
+    license = lib.licenses.mit;
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
Adds [enola](https://github.com/TheYahya/enola), a CLI to find social media accounts by username, similar to [Sherlock](https://github.com/sherlock-project/sherlock)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
