### PR TITLE
hongdown: init at 0.3.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -28157,6 +28157,12 @@
     github = "weitzj";
     githubId = 829277;
   };
+  wellmannmathis = {
+    email = "wellmannmathis@gmail.com";
+    github = "MathisWellmann";
+    githubId = 26856233;
+    name = "Mathis Wellmann";
+  };
   welteki = {
     email = "welteki@pm.me";
     github = "welteki";

--- a/pkgs/by-name/ho/hongdown/package.nix
+++ b/pkgs/by-name/ho/hongdown/package.nix
@@ -1,0 +1,25 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "hongdown";
+  version = "0.3.2";
+
+  src = fetchFromGitHub {
+    owner = "dahlia";
+    repo = "hongdown";
+    tag = finalAttrs.version;
+    hash = "sha256-zk5pwiBonI24ZocnpzAbrZ1gfehm+hwjFUeUKcrCnMc=";
+  };
+  cargoHash = "sha256-62cj+gqXgrIqnH82mLFryKgoUJzY3Zw7P/MusYVZiIw=";
+  meta = {
+    description = "Markdown formatter that enforces Hong Minhee's Markdown style conventions";
+    mainProgram = "hongdown";
+    homepage = "https://github.com/dahlia/hongdown";
+    changelog = "https://github.com/dahlia/hongdown/blob/main/CHANGES.md";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ wellmannmathis ];
+  };
+})


### PR DESCRIPTION
My first package contribution adds `hongdown`, an opinionated markdown formatter written in rust.
The repo can be found here https://github.com/dahlia/hongdown
I've created a PR in that repo to add the package there as well: https://github.com/dahlia/hongdown/pull/1
Would appreciate any feedback as its my first official `nixpkgs` contribution. I've packaged a handful of rust projects myself over the last 3 years full-time on NixOS.
Should I add myself in `meta.maintainers` or is this reserved for dedicated people?

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
