### PR TITLE
stirling-pdf: disable automatic updates

### DIFF
--- a/pkgs/by-name/st/stirling-pdf/package.nix
+++ b/pkgs/by-name/st/stirling-pdf/package.nix
@@ -59,7 +59,8 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  passthru.updateScript = ./update.sh;
+  # See https://github.com/NixOS/nixpkgs/pull/465183#pullrequestreview-3647028893
+  # passthru.updateScript = ./update.sh;
 
   meta = {
     changelog = "https://github.com/Stirling-Tools/Stirling-PDF/releases/tag/v${finalAttrs.version}";


### PR DESCRIPTION
Since 2.0 the frontend is built using an NPM build that's wrapped into
the Gradle build. This requires additional work to make everything work
inside Nix' build sandbox.

Context: https://github.com/NixOS/nixpkgs/pull/465183#pullrequestreview-3647028893
