### PR TITLE
python3Packages.python-cstruct: 6.1 -> 6.2

### DIFF
--- a/pkgs/development/python-modules/cstruct/default.nix
+++ b/pkgs/development/python-modules/cstruct/default.nix
@@ -3,18 +3,21 @@
   buildPythonPackage,
   fetchFromGitHub,
   pytestCheckHook,
+  setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "cstruct";
-  version = "6.1";
-  format = "setuptools";
+  version = "6.2";
+  pyproject = true;
+
+  build-system = [ setuptools ];
 
   src = fetchFromGitHub {
     owner = "andreax79";
     repo = "python-cstruct";
-    tag = "v${version}";
-    hash = "sha256-9MC6f8U++vJkglBmGMTmiamE8XqUNKTzKOz7TA148Ys=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-jLpuvApEP8Acva/OV3ulwl4+dOy8t/cD/LFJWWnD3BM=";
   };
 
   pythonImportsCheck = [ "cstruct" ];
@@ -24,8 +27,8 @@ buildPythonPackage rec {
   meta = {
     description = "C-style structs for Python";
     homepage = "https://github.com/andreax79/python-cstruct";
-    changelog = "https://github.com/andreax79/python-cstruct/blob/${src.tag}/changelog.txt";
+    changelog = "https://github.com/andreax79/python-cstruct/blob/${finalAttrs.src.tag}/changelog.txt";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ tnias ];
   };
-}
+})


### PR DESCRIPTION
Upstream released version 6.2.

Now with Python 3.14 support. (See the python314 failures tracking issue https://github.com/NixOS/nixpkgs/issues/475732)

Because it now uses the modern pyproject+setuptools structure, I manually created the bump PR instead of waiting on r-ryantm (the package update bot).

Changelog: https://github.com/andreax79/python-cstruct/blob/v6.2/changelog.txt#L202

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
