### PR TITLE
openssh-askpass: init at 10.2.p1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18208,6 +18208,12 @@
     matrix = "@neoney:matrix.org";
     keys = [ { fingerprint = "9E6A 25F2 C1F2 9D76 ED00  1932 1261 173A 01E1 0298"; } ];
   };
+  n3tshift = {
+    email = "n3tshift@tilde.pink";
+    github = "n3tshift";
+    githubId = 254145391;
+    name = "n3tshift";
+  };
   n8henrie = {
     name = "Nathan Henrie";
     email = "nate@n8henrie.com";

--- a/pkgs/by-name/op/openssh-askpass/package.nix
+++ b/pkgs/by-name/op/openssh-askpass/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  stdenv,
+  openssh,
+  gtk3,
+  pkg-config,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "openssh-askpass";
+  inherit (openssh) src version;
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ gtk3 ];
+
+  sourceRoot = "${openssh.pname}-${finalAttrs.version}/contrib";
+  makeFlags = "gnome-ssh-askpass3";
+  dontConfigure = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/libexec
+    cp -a gnome-ssh-askpass3 $out/libexec/gtk-ssh-askpass
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "A passphrase dialog for OpenSSH and GTK";
+    homepage = "https://www.openssh.org";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ n3tshift ];
+  };
+})


### PR DESCRIPTION
first time contrib, followed the official docs but reckon there's bound to be some mistakes even though it does build locally with `nix-build`. not sure if it will work but i have also enabled `nix-update-script` for automatic package updates as per the guide

main reasoning for trying to get this in nixpkgs is:

1) it uses the official openssh (contrib) sources;
2) doesn't rely on 3rd-party github projects;
3) looks more modern than the likes of x11_ssh_askpass;
4) other distros such as alpine provide it as well

set myself as the maintainer in the process. let me know if any of this needs adjustments