### PR TITLE
llvmPackages.libllvm: disable `getMacOSHostVersion` on LLVM < 21

### DIFF
--- a/pkgs/development/compilers/llvm/common/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/common/llvm/default.nix
@@ -297,49 +297,30 @@ stdenv.mkDerivation (
             substituteInPlace unittests/Support/VirtualFileSystemTest.cpp \
               --replace-fail "PhysicalFileSystemWorkingDirFailure" "DISABLED_PhysicalFileSystemWorkingDirFailure"
           ''
+        +
+          # Fails on macOS ≥ 26 due to the changed OS version scheme.
+          #
+          # This was fixed upstream in LLVM 21 with
+          # 88f041f3e05e26617856cc096d2e2864dfaa1c7b, but it’s too
+          # painful to backport all the way.
+          lib.optionalString
+            (
+              lib.versionOlder release_version "21"
+              ||
+                # Rebuild avoidance; TODO: clean up on `staging`.
+                stdenv.hostPlatform.isx86
+            )
+            ''
+              substituteInPlace unittests/TargetParser/Host.cpp \
+                --replace-fail "getMacOSHostVersion" "DISABLED_getMacOSHostVersion"
+            ''
+        +
+          # This test fails with a `dysmutil` crash; have not yet dug into what's
+          # going on here (TODO(@rrbutani)).
+          lib.optionalString (stdenv.hostPlatform.isx86 && lib.versionOlder release_version "19") ''
+            rm test/tools/dsymutil/ARM/obfuscated.test
+          ''
       )
-      +
-        optionalString (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86)
-          (
-              # This test fails on darwin x86_64 because `sw_vers` reports a different
-              # macOS version than what LLVM finds by reading
-              # `/System/Library/CoreServices/SystemVersion.plist` (which is passed into
-              # the sandbox on macOS).
-              #
-              # The `sw_vers` provided by nixpkgs reports the macOS version associated
-              # with the `CoreFoundation` framework with which it was built. Because
-              # nixpkgs pins the SDK for `aarch64-darwin` and `x86_64-darwin` what
-              # `sw_vers` reports is not guaranteed to match the macOS version of the host
-              # that's building this derivation.
-              #
-              # Astute readers will note that we only _patch_ this test on aarch64-darwin
-              # (to use the nixpkgs provided `sw_vers`) instead of disabling it outright.
-              # So why does this test pass on aarch64?
-              #
-              # Well, it seems that `sw_vers` on aarch64 actually links against the _host_
-              # CoreFoundation framework instead of the nixpkgs provided one.
-              #
-              # Not entirely sure what the right fix is here. I'm assuming aarch64
-              # `sw_vers` doesn't intentionally link against the host `CoreFoundation`
-              # (still digging into how this ends up happening, will follow up) but that
-              # aside I think the more pertinent question is: should we be patching LLVM's
-              # macOS version detection logic to use `sw_vers` instead of reading host
-              # paths? This *is* a way in which details about builder machines can creep
-              # into the artifacts that are produced, affecting reproducibility, but it's
-              # not clear to me when/where/for what this even gets used in LLVM.
-              #
-              # TODO(@rrbutani): fix/follow-up
-              ''
-                substituteInPlace unittests/TargetParser/Host.cpp \
-                  --replace-fail "getMacOSHostVersion" "DISABLED_getMacOSHostVersion"
-              ''
-            +
-              # This test fails with a `dysmutil` crash; have not yet dug into what's
-              # going on here (TODO(@rrbutani)).
-              lib.optionalString (lib.versionOlder release_version "19") ''
-                rm test/tools/dsymutil/ARM/obfuscated.test
-              ''
-          )
 
       +
         # FileSystem permissions tests fail with various special bits

--- a/pkgs/development/compilers/llvm/common/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/common/llvm/default.nix
@@ -293,21 +293,14 @@ stdenv.mkDerivation (
           ''
         +
           # fails when run in sandbox
-          optionalString (!stdenv.hostPlatform.isx86) ''
+          ''
             substituteInPlace unittests/Support/VirtualFileSystemTest.cpp \
               --replace-fail "PhysicalFileSystemWorkingDirFailure" "DISABLED_PhysicalFileSystemWorkingDirFailure"
           ''
       )
       +
-        # dup of above patch with different conditions
         optionalString (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86)
-          # fails when run in sandbox
           (
-            ''
-              substituteInPlace unittests/Support/VirtualFileSystemTest.cpp \
-                --replace-fail "PhysicalFileSystemWorkingDirFailure" "DISABLED_PhysicalFileSystemWorkingDirFailure"
-            ''
-            +
               # This test fails on darwin x86_64 because `sw_vers` reports a different
               # macOS version than what LLVM finds by reading
               # `/System/Library/CoreServices/SystemVersion.plist` (which is passed into


### PR DESCRIPTION
Currently untested. See commit messages.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
