### PR TITLE
teams/apm: handle team with external membership

### DIFF
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -56,16 +56,6 @@ with lib.maintainers;
     enableFeatureFreezePing = true;
   };
 
-  apm = {
-    scope = "Team for packages maintained by employees of Akademie für Pflegeberufe und Management GmbH.";
-    shortName = "apm employees";
-    # Edits to this list should only be done by an already existing member.
-    members = [
-      DutchGerman
-      friedow
-    ];
-  };
-
   apparmor = {
     scope = "AppArmor-related modules, userspace tool packages and profiles";
     shortName = "apparmor";

--- a/pkgs/development/python-modules/jsonschema-rs/default.nix
+++ b/pkgs/development/python-modules/jsonschema-rs/default.nix
@@ -48,6 +48,9 @@ buildPythonPackage rec {
     homepage = "https://github.com/Stranger6667/jsonschema/tree/master/crates/jsonschema-py";
     changelog = "https://github.com/Stranger6667/jsonschema/blob/python-v${version}/crates/jsonschema-py/CHANGELOG.md";
     license = lib.licenses.mit;
-    teams = [ lib.teams.apm ];
+    maintainers = with lib.maintainers; [
+      DutchGerman
+      friedow
+    ];
   };
 }

--- a/pkgs/development/python-modules/minify-html/default.nix
+++ b/pkgs/development/python-modules/minify-html/default.nix
@@ -35,6 +35,9 @@ buildPythonPackage rec {
     homepage = "https://github.com/wilsonzlin/minify-html/tree/master/minify-html-python";
     changelog = "https://github.com/wilsonzlin/minify-html/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.mit;
-    teams = [ lib.teams.apm ];
+    maintainers = with lib.maintainers; [
+      DutchGerman
+      friedow
+    ];
   };
 }

--- a/pkgs/development/python-modules/tiptapy/default.nix
+++ b/pkgs/development/python-modules/tiptapy/default.nix
@@ -37,6 +37,9 @@ buildPythonPackage {
     homepage = "https://github.com/stckme/tiptapy";
     changelog = "https://github.com/stckme/tiptapy/blob/master/CHANGELOG.rst";
     license = lib.licenses.mit;
-    teams = [ lib.teams.apm ];
+    maintainers = with lib.maintainers; [
+      DutchGerman
+      friedow
+    ];
   };
 }

--- a/pkgs/development/python-modules/weasyprint/default.nix
+++ b/pkgs/development/python-modules/weasyprint/default.nix
@@ -114,6 +114,9 @@ buildPythonPackage (finalAttrs: {
     homepage = "https://weasyprint.org/";
     license = lib.licenses.bsd3;
     mainProgram = "weasyprint";
-    teams = [ lib.teams.apm ];
+    maintainers = with lib.maintainers; [
+      DutchGerman
+      friedow
+    ];
   };
 })

--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -1065,7 +1065,10 @@ let
         homepage = "https://github.com/evanmiller/mod_zip";
         license = with lib.licenses; [ bsd3 ];
         broken = stdenv.hostPlatform.isDarwin;
-        teams = [ lib.teams.apm ];
+        maintainers = with lib.maintainers; [
+          DutchGerman
+          friedow
+        ];
       };
     };
 

--- a/pkgs/servers/sql/postgresql/ext/pg_byteamagic.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_byteamagic.nix
@@ -44,7 +44,10 @@ postgresqlBuildExtension (finalAttrs: {
     homepage = "https://github.com/nmandery/pg_byteamagic";
     changelog = "https://raw.githubusercontent.com/nmandery/pg_byteamagic/refs/tags/v${finalAttrs.version}/Changes";
     license = lib.licenses.bsd2WithViews;
-    teams = [ lib.teams.apm ];
+    maintainers = with lib.maintainers; [
+      DutchGerman
+      friedow
+    ];
     platforms = postgresql.meta.platforms;
   };
 })


### PR DESCRIPTION
The @NixOS/nixpkgs-core team has recently reviewed Nixpkgs teams, and decided that teams should be organized internally around specific topics of maintenance, rather than having membership gated by external criteria. This means having maintainer responsibility and authority decided by consensus of existing maintainers and team members in an area of interest, rather than being granted or revoked based on employment, membership in an external organization, or role in another FOSS project. The reasoning is given in the full statement at https://github.com/NixOS/org/issues/220#issuecomment-3678147410.

We are now triaging teams to make sure they’re in line with this model and working with their members to find the best way forward for each case. This is being tracked at #478780.

@DutchGerman @friedow

This team was flagged as apparently having external membership criteria. By default, we’ll merge this to drop the team after a week if we don’t hear back from you, but we’re also happy to implement alternatives, e.g.:

- Redistribute members to maintainer lists of individual packages per their request.
- Reorganize or merge the team into one or more teams relating to specific areas of maintenance interest with open membership criteria.
- Clarify that the team is dedicated to maintenance of software maintained upstream by a certain organization, but is open to all contributors. For example, `lib.teams.jetbrains` and `lib.teams.qt-kde` handle maintenance of JetBrains IDEs and KDE software, but have no expectation that members are affiliated with those organizations, even though some may be.
