### PR TITLE
teams/bitnomial: handle team with external membership

### DIFF
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -96,16 +96,6 @@ with lib.maintainers;
     enableFeatureFreezePing = true;
   };
 
-  bitnomial = {
-    # Verify additions to this team with at least one already existing member of the team.
-    members = [
-      cdepillabout
-      wraithm
-    ];
-    scope = "Group registration for packages maintained by Bitnomial.";
-    shortName = "Bitnomial employees";
-  };
-
   blockchains = {
     members = [
       mmahut

--- a/pkgs/by-name/ap/aptly/package.nix
+++ b/pkgs/by-name/ap/aptly/package.nix
@@ -65,8 +65,11 @@ buildGoModule (finalAttrs: {
     description = "Debian repository management tool";
     license = lib.licenses.mit;
     changelog = "https://github.com/aptly-dev/aptly/releases/tag/v${finalAttrs.version}";
-    maintainers = [ lib.maintainers.montag451 ];
-    teams = [ lib.teams.bitnomial ];
+    maintainers = with lib.maintainers; [
+      cdepillabout
+      montag451
+      wraithm
+    ];
     mainProgram = "aptly";
   };
 })

--- a/pkgs/by-name/gr/grafana-dash-n-grab/package.nix
+++ b/pkgs/by-name/gr/grafana-dash-n-grab/package.nix
@@ -32,7 +32,10 @@ buildGoModule rec {
     description = "Grafana Dash-n-Grab (gdg) -- backup and restore Grafana dashboards, datasources, and other entities";
     license = lib.licenses.bsd3;
     homepage = "https://github.com/esnet/gdg";
-    teams = [ lib.teams.bitnomial ];
+    maintainers = with lib.maintainers; [
+      cdepillabout
+      wraithm
+    ];
     mainProgram = "gdg";
     changelog = "https://github.com/esnet/gdg/releases/tag/v${version}";
   };

--- a/pkgs/by-name/tf/tftui/package.nix
+++ b/pkgs/by-name/tf/tftui/package.nix
@@ -51,7 +51,10 @@ python3Packages.buildPythonApplication rec {
     homepage = "https://github.com/idoavrah/terraform-tui";
     changelog = "https://github.com/idoavrah/terraform-tui/releases/tag/v${version}";
     license = lib.licenses.asl20;
-    teams = [ lib.teams.bitnomial ];
+    maintainers = with lib.maintainers; [
+      cdepillabout
+      wraithm
+    ];
     mainProgram = "tftui";
   };
 }


### PR DESCRIPTION
The @NixOS/nixpkgs-core team has recently reviewed Nixpkgs teams, and decided that teams should be organized internally around specific topics of maintenance, rather than having membership gated by external criteria. This means having maintainer responsibility and authority decided by consensus of existing maintainers and team members in an area of interest, rather than being granted or revoked based on employment, membership in an external organization, or role in another FOSS project. The reasoning is given in the full statement at https://github.com/NixOS/org/issues/220#issuecomment-3678147410.

We are now triaging teams to make sure they’re in line with this model and working with their members to find the best way forward for each case. This is being tracked at #478780.

@cdepillabout @wraithm

This team was flagged as apparently having external membership criteria. By default, we’ll merge this to drop the team after a week if we don’t hear back from you, but we’re also happy to implement alternatives, e.g.:

- Redistribute members to maintainer lists of individual packages per their request.
- Reorganize or merge the team into one or more teams relating to specific areas of maintenance interest with open membership criteria.
- Clarify that the team is dedicated to maintenance of software maintained upstream by a certain organization, but is open to all contributors. For example, `lib.teams.jetbrains` and `lib.teams.qt-kde` handle maintenance of JetBrains IDEs and KDE software, but have no expectation that members are affiliated with those organizations, even though some may be.