### PR TITLE
teams/c3d2: handle team with external membership

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22256,13 +22256,6 @@
     githubId = 255667;
     name = "Linus Karl";
   };
-  revol-xut = {
-    email = "revol-xut@protonmail.com";
-    name = "Tassilo Tanneberger";
-    github = "tanneberger";
-    githubId = 32239737;
-    keys = [ { fingerprint = "91EB E870 1639 1323 642A  6803 B966 009D 57E6 9CC6"; } ];
-  };
   rexies = {
     name = "Rexiel Scarlet";
     github = "Rexcrazy804";

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -147,7 +147,6 @@ with lib.maintainers;
     members = [
       astro
       SuperSandro2000
-      revol-xut
       oxapentane
     ];
     scope = "Maintain packages used in the C3D2 hackspace";

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -143,16 +143,6 @@ with lib.maintainers;
     enableFeatureFreezePing = true;
   };
 
-  c3d2 = {
-    members = [
-      astro
-      SuperSandro2000
-      oxapentane
-    ];
-    scope = "Maintain packages used in the C3D2 hackspace";
-    shortName = "c3d2";
-  };
-
   cachix = {
     # Verify additions to this team with at least one existing member of the team.
     members = [

--- a/nixos/modules/services/misc/portunus.nix
+++ b/nixos/modules/services/misc/portunus.nix
@@ -313,5 +313,5 @@ in
     ];
   };
 
-  meta.maintainers = [ lib.maintainers.majewsky ] ++ lib.teams.c3d2.members;
+  meta.maintainers = [ lib.maintainers.majewsky ];
 }

--- a/nixos/modules/services/web-apps/librespeed.nix
+++ b/nixos/modules/services/web-apps/librespeed.nix
@@ -440,6 +440,4 @@ in
       };
     };
   };
-
-  meta.maintainers = lib.teams.c3d2.members;
 }

--- a/nixos/modules/services/web-apps/pretalx.nix
+++ b/nixos/modules/services/web-apps/pretalx.nix
@@ -31,7 +31,7 @@ in
 
 {
   meta = {
-    maintainers = with lib.maintainers; [ hexa ] ++ lib.teams.c3d2.members;
+    maintainers = with lib.maintainers; [ hexa ];
   };
 
   options.services.pretalx = {

--- a/nixos/tests/web-apps/pretalx.nix
+++ b/nixos/tests/web-apps/pretalx.nix
@@ -2,7 +2,6 @@
 
 {
   name = "pretalx";
-  meta.maintainers = lib.teams.c3d2.members;
 
   nodes = {
     pretalx =

--- a/pkgs/by-name/le/ledfx/package.nix
+++ b/pkgs/by-name/le/ledfx/package.nix
@@ -85,7 +85,6 @@ python3.pkgs.buildPythonApplication rec {
     homepage = "https://github.com/LedFx/LedFx";
     changelog = "https://github.com/LedFx/LedFx/blob/${version}/CHANGELOG.rst";
     license = lib.licenses.gpl3Only;
-    teams = [ lib.teams.c3d2 ];
     mainProgram = "ledfx";
   };
 }

--- a/pkgs/by-name/li/librespeed-rust/package.nix
+++ b/pkgs/by-name/li/librespeed-rust/package.nix
@@ -30,7 +30,6 @@ rustPlatform.buildRustPackage rec {
     description = "Very lightweight speed test implementation in Rust";
     homepage = "https://github.com/librespeed/speedtest-rust";
     license = lib.licenses.lgpl3Plus;
-    teams = with lib.teams; [ c3d2 ];
     mainProgram = "librespeed-rs";
   };
 }

--- a/pkgs/by-name/li/lingua-franca/package.nix
+++ b/pkgs/by-name/li/lingua-franca/package.nix
@@ -40,6 +40,5 @@ stdenv.mkDerivation rec {
     sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     license = lib.licenses.bsd2;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ revol-xut ];
   };
 }

--- a/pkgs/by-name/ma/matrix-synapse-unwrapped/plugins/ldap3.nix
+++ b/pkgs/by-name/ma/matrix-synapse-unwrapped/plugins/ldap3.nix
@@ -41,6 +41,5 @@ buildPythonPackage rec {
     description = "LDAP3 auth provider for Synapse";
     homepage = "https://github.com/matrix-org/matrix-synapse-ldap3";
     license = lib.licenses.asl20;
-    teams = [ lib.teams.c3d2 ];
   };
 }

--- a/pkgs/by-name/me/mediagoblin/package.nix
+++ b/pkgs/by-name/me/mediagoblin/package.nix
@@ -175,6 +175,5 @@ python.pkgs.buildPythonApplication rec {
     description = "Free software media publishing platform that anyone can run";
     homepage = "https://mediagoblin.org/";
     license = lib.licenses.agpl3Plus;
-    teams = [ lib.teams.c3d2 ];
   };
 }

--- a/pkgs/by-name/me/mediawiki/package.nix
+++ b/pkgs/by-name/me/mediawiki/package.nix
@@ -40,6 +40,5 @@ stdenvNoCC.mkDerivation rec {
     license = lib.licenses.gpl2Plus;
     homepage = "https://www.mediawiki.org/";
     platforms = lib.platforms.all;
-    teams = [ lib.teams.c3d2 ];
   };
 }

--- a/pkgs/by-name/nc/ncpamixer/package.nix
+++ b/pkgs/by-name/nc/ncpamixer/package.nix
@@ -61,7 +61,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/fulhax/ncpamixer";
     license = lib.licenses.mit;
     platforms = lib.platforms.linux;
-    teams = [ lib.teams.c3d2 ];
     mainProgram = "ncpamixer";
   };
 }

--- a/pkgs/by-name/op/openwebrx/package.nix
+++ b/pkgs/by-name/op/openwebrx/package.nix
@@ -40,7 +40,6 @@ let
       homepage = "https://github.com/jketterl/js8py";
       description = "Library to decode the output of the js8 binary of JS8Call";
       license = lib.licenses.gpl3Only;
-      teams = with lib.teams; [ c3d2 ];
     };
   };
 
@@ -83,7 +82,6 @@ let
       description = "Set of connectors that are used by OpenWebRX to interface with SDR hardware";
       license = lib.licenses.gpl3Only;
       platforms = lib.platforms.unix;
-      teams = with lib.teams; [ c3d2 ];
     };
   };
 
@@ -136,6 +134,5 @@ python3Packages.buildPythonApplication rec {
     description = "Simple DSP library and command-line tool for Software Defined Radio";
     mainProgram = "openwebrx";
     license = lib.licenses.gpl3Only;
-    teams = with lib.teams; [ c3d2 ];
   };
 }

--- a/pkgs/by-name/po/portunus/package.nix
+++ b/pkgs/by-name/po/portunus/package.nix
@@ -29,6 +29,5 @@ buildGoModule rec {
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ majewsky ];
-    teams = [ lib.teams.c3d2 ];
   };
 }

--- a/pkgs/by-name/pr/pretalx/package.nix
+++ b/pkgs/by-name/pr/pretalx/package.nix
@@ -43,7 +43,6 @@ let
     changelog = "https://docs.pretalx.org/changelog/#${version}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ hexa ];
-    teams = [ lib.teams.c3d2 ];
     platforms = lib.platforms.linux;
   };
 

--- a/pkgs/by-name/we/websocketpp/package.nix
+++ b/pkgs/by-name/we/websocketpp/package.nix
@@ -35,6 +35,5 @@ stdenv.mkDerivation rec {
     description = "C++/Boost Asio based websocket client/server library";
     license = lib.licenses.bsd3;
     platforms = lib.platforms.unix;
-    maintainers = with lib.maintainers; [ revol-xut ];
   };
 }

--- a/pkgs/servers/xmpp/prosody/default.nix
+++ b/pkgs/servers/xmpp/prosody/default.nix
@@ -122,6 +122,5 @@ stdenv.mkDerivation (finalAttrs: {
       toastal
       mirror230469
     ];
-    teams = with lib.teams; [ c3d2 ];
   };
 })


### PR DESCRIPTION
The @NixOS/nixpkgs-core team has recently reviewed Nixpkgs teams, and decided that teams should be organized internally around specific topics of maintenance, rather than having membership gated by external criteria. This means having maintainer responsibility and authority decided by consensus of existing maintainers and team members in an area of interest, rather than being granted or revoked based on employment, membership in an external organization, or role in another FOSS project. The reasoning is given in the full statement at https://github.com/NixOS/org/issues/220#issuecomment-3678147410.

We are now triaging teams to make sure they’re in line with this model and working with their members to find the best way forward for each case. This is being tracked at #478780.

@astro @SuperSandro2000 @tanneberger @gshipunov 

This team was flagged as apparently having external membership criteria. By default, we’ll merge this to drop the team after a week if we don’t hear back from you, but we’re also happy to implement alternatives, e.g.:

- Redistribute members to maintainer lists of individual packages per their request.
- Reorganize or merge the team into one or more teams relating to specific areas of maintenance interest with open membership criteria.
- Clarify that the team is dedicated to maintenance of software maintained upstream by a certain organization, but is open to all contributors. For example, `lib.teams.jetbrains` and `lib.teams.qt-kde` handle maintenance of JetBrains IDEs and KDE software, but have no expectation that members are affiliated with those organizations, even though some may be.