### PR TITLE
teams/clevercloud: handle team with external membership

### DIFF
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -182,12 +182,6 @@ with lib.maintainers;
     enableFeatureFreezePing = true;
   };
 
-  clevercloud = {
-    members = [ floriansanderscc ];
-    scope = "Maintain Clever Cloud related packages.";
-    shortName = "CleverCloud";
-  };
-
   cloudposse = {
     members = [ dudymas ];
     scope = "Maintain atmos and applications made by the Cloud Posse team.";

--- a/pkgs/by-name/cl/clever-tools/package.nix
+++ b/pkgs/by-name/cl/clever-tools/package.nix
@@ -58,6 +58,6 @@ buildNpmPackage rec {
     description = "Deploy on Clever Cloud and control your applications, add-ons, services from command line";
     license = lib.licenses.asl20;
     mainProgram = "clever";
-    teams = [ lib.teams.clevercloud ];
+    maintainers = [ lib.maintainers.floriansanderscc ];
   };
 }


### PR DESCRIPTION
The @NixOS/nixpkgs-core team has recently reviewed Nixpkgs teams, and decided that teams should be organized internally around specific topics of maintenance, rather than having membership gated by external criteria. This means having maintainer responsibility and authority decided by consensus of existing maintainers and team members in an area of interest, rather than being granted or revoked based on employment, membership in an external organization, or role in another FOSS project. The reasoning is given in the full statement at https://github.com/NixOS/org/issues/220#issuecomment-3678147410.

We are now triaging teams to make sure they’re in line with this model and working with their members to find the best way forward for each case. This is being tracked at #478780.

@florian-sanders-cc

This team was flagged as apparently having external membership criteria. By default, we’ll merge this to drop the team after a week if we don’t hear back from you, but we’re also happy to implement alternatives, e.g.:

- Redistribute members to maintainer lists of individual packages per their request.
- Reorganize or merge the team into one or more teams relating to specific areas of maintenance interest with open membership criteria.
- Clarify that the team is dedicated to maintenance of software maintained upstream by a certain organization, but is open to all contributors. For example, `lib.teams.jetbrains` and `lib.teams.qt-kde` handle maintenance of JetBrains IDEs and KDE software, but have no expectation that members are affiliated with those organizations, even though some may be.