### PR TITLE
teams/cloudposse: drop inactive team

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7188,12 +7188,6 @@
     name = "Louis Orleans";
     keys = [ { fingerprint = "llSOkL8Tn5+LOmWa4PDci+dQXZIRy11NSumDiFzNkAM"; } ];
   };
-  dudymas = {
-    email = "jeremy.white@cloudposse.com";
-    github = "dudymas";
-    githubId = 928448;
-    name = "Jeremy White";
-  };
   dukc = {
     email = "ajieskola@gmail.com";
     github = "dukc";

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -142,7 +142,6 @@ with lib.maintainers;
   };
 
   cloudposse = {
-    members = [ dudymas ];
     scope = "Maintain atmos and applications made by the Cloud Posse team.";
     shortName = "CloudPosse";
     enableFeatureFreezePing = true;

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -141,12 +141,6 @@ with lib.maintainers;
     enableFeatureFreezePing = true;
   };
 
-  cloudposse = {
-    scope = "Maintain atmos and applications made by the Cloud Posse team.";
-    shortName = "CloudPosse";
-    enableFeatureFreezePing = true;
-  };
-
   coq = {
     members = [
       cohencyril

--- a/pkgs/by-name/at/atmos/package.nix
+++ b/pkgs/by-name/at/atmos/package.nix
@@ -54,6 +54,5 @@ buildGoModule (finalAttrs: {
     description = "Universal Tool for DevOps and Cloud Automation (works with terraform, helm, helmfile, etc)";
     mainProgram = "atmos";
     license = lib.licenses.asl20;
-    teams = [ lib.teams.cloudposse ];
   };
 })


### PR DESCRIPTION
The @NixOS/nixpkgs-core team has recently reviewed Nixpkgs teams, and decided that teams should be organized internally around specific topics of maintenance, rather than having membership gated by external criteria. This means having maintainer responsibility and authority decided by consensus of existing maintainers and team members in an area of interest, rather than being granted or revoked based on employment, membership in an external organization, or role in another FOSS project. The reasoning is given in the full statement at https://github.com/NixOS/org/issues/220#issuecomment-3678147410.

We are now triaging teams to make sure they’re in line with this model and working with their members to find the best way forward for each case. This is being tracked at #478780.

@dudymas 

This team was flagged as apparently having external membership criteria. Since all members are eligible for removal per our [inactive maintainer removal criteria](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status), this PR drops the maintainers entries and the team. By default, we’ll merge this after a week if we don’t hear back from you.