### PR TITLE
teams/ctrl-os: handle team with external membership

### DIFF
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -177,18 +177,6 @@ with lib.maintainers;
     shortName = "Cosmopolitan";
   };
 
-  ctrl-os = {
-    # Existing members may approve additions.
-    members = [
-      blitz
-      messemar
-      flyfloh
-    ];
-
-    scope = "Team of Cyberus Technology employees that maintain packages relevant to CTRL-OS";
-    shortName = "CTRL-OS";
-  };
-
   cuda = {
     github = "cuda-maintainers";
   };

--- a/pkgs/by-name/cy/cyclonedx-cli/package.nix
+++ b/pkgs/by-name/cy/cyclonedx-cli/package.nix
@@ -33,8 +33,10 @@ buildDotnetModule rec {
     description = "CycloneDX CLI tool for SBOM analysis, merging, diffs and format conversions";
     homepage = "https://github.com/CycloneDX/cyclonedx-cli";
     changelog = "https://github.com/CycloneDX/cyclonedx-cli/releases/tag/v${version}";
-    maintainers = with lib.maintainers; [ thillux ];
-    teams = [ lib.teams.ctrl-os ];
+    maintainers = with lib.maintainers; [
+      blitz
+      thillux
+    ];
     license = lib.licenses.asl20;
     platforms = with lib.platforms; (linux ++ darwin);
     mainProgram = "cyclonedx";

--- a/pkgs/by-name/cy/cyclonedx-python/package.nix
+++ b/pkgs/by-name/cy/cyclonedx-python/package.nix
@@ -37,7 +37,9 @@ python3Packages.buildPythonApplication rec {
     homepage = "https://github.com/CycloneDX/cyclonedx-python";
     changelog = "https://github.com/CycloneDX/cyclonedx-python/releases/tag/${src.tag}";
     license = lib.licenses.asl20;
-    teams = [ lib.teams.ctrl-os ];
+    maintainers = with lib.maintainers; [
+      blitz
+    ];
     mainProgram = "cyclonedx-py";
   };
 }

--- a/pkgs/by-name/ov/OVMF-cloud-hypervisor/package.nix
+++ b/pkgs/by-name/ov/OVMF-cloud-hypervisor/package.nix
@@ -140,8 +140,8 @@ edk2.mkDerivation projectDscPath (finalAttrs: {
     description = "Sample UEFI firmware for Cloud Hypervisor and KVM";
     homepage = "https://github.com/tianocore/tianocore.github.io/wiki/OVMF";
     license = lib.licenses.bsd2;
-    teams = with lib.teams; [
-      ctrl-os
+    maintainers = with lib.maintainers; [
+      messemar
     ];
     broken = stdenv.hostPlatform.isDarwin;
   };

--- a/pkgs/development/python-modules/localzone/default.nix
+++ b/pkgs/development/python-modules/localzone/default.nix
@@ -39,6 +39,5 @@ buildPythonPackage rec {
     homepage = "https://localzone.iomaestro.com";
     changelog = "https://github.com/ags-slc/localzone/blob/v${version}/CHANGELOG.rst";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ flyfloh ];
   };
 }

--- a/pkgs/development/python-modules/pymetno/default.nix
+++ b/pkgs/development/python-modules/pymetno/default.nix
@@ -35,6 +35,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/Danielhiversen/pyMetno/";
     changelog = "https://github.com/Danielhiversen/pyMetno/releases/tag/${version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ flyfloh ];
   };
 }

--- a/pkgs/development/python-modules/python-miio/default.nix
+++ b/pkgs/development/python-modules/python-miio/default.nix
@@ -82,6 +82,5 @@ buildPythonPackage rec {
     description = "Python library for interfacing with Xiaomi smart appliances";
     homepage = "https://github.com/rytilahti/python-miio";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ flyfloh ];
   };
 }

--- a/pkgs/development/python-modules/rxv/default.nix
+++ b/pkgs/development/python-modules/rxv/default.nix
@@ -47,6 +47,5 @@ buildPythonPackage rec {
     description = "Python library for communicate with Yamaha RX-Vxxx receivers";
     homepage = "https://github.com/wuub/rxv";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ flyfloh ];
   };
 }


### PR DESCRIPTION
The @NixOS/nixpkgs-core team has recently reviewed Nixpkgs teams, and decided that teams should be organized internally around specific topics of maintenance, rather than having membership gated by external criteria. This means having maintainer responsibility and authority decided by consensus of existing maintainers and team members in an area of interest, rather than being granted or revoked based on employment, membership in an external organization, or role in another FOSS project. The reasoning is given in the full statement at https://github.com/NixOS/org/issues/220#issuecomment-3678147410.

We are now triaging teams to make sure they’re in line with this model and working with their members to find the best way forward for each case. This is being tracked at #478780.

@blitz @messemar @flyfloh

This team was flagged as apparently having external membership criteria. By default, we’ll merge this to drop the team after a week if we don’t hear back from you, but we’re also happy to implement alternatives, e.g.:

- Redistribute members to maintainer lists of individual packages per their request.
- Reorganize or merge the team into one or more teams relating to specific areas of maintenance interest with open membership criteria.
- Clarify that the team is dedicated to maintenance of software maintained upstream by a certain organization, but is open to all contributors. For example, `lib.teams.jetbrains` and `lib.teams.qt-kde` handle maintenance of JetBrains IDEs and KDE software, but have no expectation that members are affiliated with those organizations, even though some may be.

We noticed that the two packages this team is currently listed on are for CycloneDX – we are working on formalizing SBOM initiatives in Nixpkgs and will likely reach out in relation to this soon.