### PR TITLE
nextcloud31.packages.apps.recognize: 9.0.7 -> 9.0.9, 10.0.4 -> 10.0.7

### DIFF
--- a/pkgs/servers/nextcloud/packages/apps/recognize.nix
+++ b/pkgs/servers/nextcloud/packages/apps/recognize.nix
@@ -2,7 +2,7 @@
   stdenv,
   fetchurl,
   lib,
-  nodejs,
+  nodejs_22,
   node-pre-gyp,
   node-gyp,
   python3,
@@ -15,16 +15,17 @@
   ncVersion,
 }:
 let
+  nodejs = nodejs_22;
   latestVersionForNc = {
     "31" = {
-      version = "9.0.7";
-      appHash = "sha256-7EK4QIM9/Qbku2cTOmMcz6ywqKT9l2Ot1DYsdAXOo2E=";
-      modelHash = "sha256-h3tYtnQUcuFbWAuiKsN2wiFSbbRy/7eNO992MtGrzkc=";
+      version = "9.0.9";
+      appHash = "sha256-JyxECdAjg+f62hccPUuQ7dFknzETs/JvTB6y5hkbH1M=";
+      modelHash = "sha256-xqCYMJYCk1fZ9ZnIW+hmB0AWrn9APNdu1hk6id6MQQY=";
     };
     "32" = {
-      version = "10.0.4";
-      appHash = "sha256-/RHnnvGJMcxe4EuceYc20xh3qkYy1ZzGsyvp0h03eLk=";
-      modelHash = "sha256-AJzVVdZrQs1US1JokW5VokL/uTsK7WiKmuZhw7WeRnU=";
+      version = "10.0.7";
+      appHash = "sha256-quuH9ZNQhvlJ6SsFeboVIrMtF9K6ckpQkXb9OXDvFm8=";
+      modelHash = "sha256-Q862f4mNWE6V4ZUpfNFZrs4kwRF/29uETCroyie0+zA=";
     };
   };
   currentVersionInfo =


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Bumped versions and updated hashes


had to go to nodejs 22 to fix the following
```
Classifier process output: TypeError: (0 , util_1.isNullOrUndefined) is not a function
    at createTensorsTypeOpAttr (/nix/store/drralynyfj061f3rxkfk5vchvs5255mr-nextcloud-app-recognize-9.0.9/node_modules/@tensorflow/tfjs-node/dist/nodejs_kernel_backend.js:675:38)
    at Object.kernelFunc (/nix/store/drralynyfj061f3rxkfk5vchvs5255mr-nextcloud-app-recognize-9.0.9/node_modules/@tensorflow/tfjs-node/dist/kernels/Cast.js:30:65)
    at kernelFunc (/nix/store/drralynyfj061f3rxkfk5vchvs5255mr-nextcloud-app-recognize-9.0.9/node_modules/@tensorflow/tfjs/node_modules/@tensorflow/tfjs-core/dist/tf-core.node.js:4707:32)
    at /nix/store/drralynyfj061f3rxkfk5vchvs5255mr-nextcloud-app-recognize-9.0.9/node_modules/@tensorflow/tfjs/node_modules/@tensorflow/tfjs-core/dist/tf-core.node.js:4767:27
    at Engine.scopedRun (/nix/store/drralynyfj061f3rxkfk5vchvs5255mr-nextcloud-app-recognize-9.0.9/node_modules/@tensorflow/tfjs/node_modules/@tensorflow/tfjs-core/dist/tf-core.node.js:4572:23)
    at Engine.runKernelFunc (/nix/store/drralynyfj061f3rxkfk5vchvs5255mr-nextcloud-app-recognize-9.0.9/node_modules/@tensorflow/tfjs/node_modules/@tensorflow/tfjs-core/dist/tf-core.node.js:4763:14)
    at Engine.runKernel (/nix/store/drralynyfj061f3rxkfk5vchvs5255mr-nextcloud-app-recognize-9.0.9/node_modules/@tensorflow/tfjs/node_modules/@tensorflow/tfjs-core/dist/tf-core.node.js:4636:21)
    at cast_ (/nix/store/drralynyfj061f3rxkfk5vchvs5255mr-nextcloud-app-recognize-9.0.9/node_modules/@tensorflow/tfjs/dist/tf.node.js:4084:19)
    at cast__op (/nix/store/drralynyfj061f3rxkfk5vchvs5255mr-nextcloud-app-recognize-9.0.9/node_modules/@tensorflow/tfjs/dist/tf.node.js:4027:28)
    at getGlobalTensorClass.toInt (/nix/store/drralynyfj061f3rxkfk5vchvs5255mr-nextcloud-app-recognize-9.0.9/node_modules/@tensorflow/tfjs/dist/tf.node.js:33989:12)
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
