### PR TITLE
teams/cyberus: handle team with external membership

### DIFF
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -240,17 +240,6 @@ with lib.maintainers;
     github = "cuda-maintainers";
   };
 
-  cyberus = {
-    # Verify additions by approval of an already existing member of the team.
-    members = [
-      xanderio
-      snu
-      e1mo
-    ];
-    scope = "Team for Cyberus Technology employees who collectively maintain packages.";
-    shortName = "Cyberus Technology employees";
-  };
-
   danklinux = {
     members = [
       luckshiba

--- a/nixos/modules/services/web-apps/dependency-track.nix
+++ b/nixos/modules/services/web-apps/dependency-track.nix
@@ -629,6 +629,9 @@ in
   };
 
   meta = {
-    maintainers = lib.teams.cyberus.members;
+    maintainers = with lib.maintainers; [
+      e1mo
+      xanderio
+    ];
   };
 }

--- a/nixos/modules/services/web-apps/plausible.nix
+++ b/nixos/modules/services/web-apps/plausible.nix
@@ -330,6 +330,9 @@ in
     ];
   };
 
-  meta.maintainers = teams.cyberus.members;
+  meta.maintainers = with lib.maintainers; [
+    e1mo
+    xanderio
+  ];
   meta.doc = ./plausible.md;
 }

--- a/nixos/tests/dependency-track.nix
+++ b/nixos/tests/dependency-track.nix
@@ -5,7 +5,10 @@ in
 {
   name = "dependency-track";
   meta = {
-    maintainers = pkgs.lib.teams.cyberus.members;
+    maintainers = with pkgs.lib.maintainers; [
+      e1mo
+      xanderio
+    ];
   };
 
   nodes = {

--- a/nixos/tests/outline.nix
+++ b/nixos/tests/outline.nix
@@ -2,7 +2,10 @@
 {
   name = "outline";
 
-  meta.maintainers = lib.teams.cyberus.members;
+  meta.maintainers = with lib.maintainers; [
+    e1mo
+    xanderio
+  ];
 
   node.pkgsReadOnly = false;
 

--- a/nixos/tests/plausible.nix
+++ b/nixos/tests/plausible.nix
@@ -2,7 +2,10 @@
 {
   name = "plausible";
   meta = {
-    maintainers = lib.teams.cyberus.members;
+    maintainers = with lib.maintainers; [
+      e1mo
+      xanderio
+    ];
   };
 
   nodes.machine =

--- a/pkgs/by-name/de/dependency-track/package.nix
+++ b/pkgs/by-name/de/dependency-track/package.nix
@@ -120,7 +120,10 @@ maven.buildMavenPackage rec {
     description = "Intelligent Component Analysis platform that allows organizations to identify and reduce risk in the software supply chain";
     homepage = "https://github.com/DependencyTrack/dependency-track";
     license = lib.licenses.asl20;
-    teams = [ lib.teams.cyberus ];
+    maintainers = with lib.maintainers; [
+      e1mo
+      xanderio
+    ];
     mainProgram = "dependency-track";
     inherit (jre_headless.meta) platforms;
   };

--- a/pkgs/by-name/gi/gitlab-container-registry/package.nix
+++ b/pkgs/by-name/gi/gitlab-container-registry/package.nix
@@ -37,10 +37,8 @@ buildGo124Module rec {
   meta = {
     description = "GitLab Docker toolset to pack, ship, store, and deliver content";
     license = lib.licenses.asl20;
-    teams = with lib.teams; [
-      gitlab
-      cyberus
-    ];
+    maintainers = with lib.maintainers; [ e1mo ];
+    teams = with lib.teams; [ gitlab ];
     platforms = lib.platforms.unix;
     mainProgram = "registry";
   };

--- a/pkgs/by-name/gi/gitlab-elasticsearch-indexer/package.nix
+++ b/pkgs/by-name/gi/gitlab-elasticsearch-indexer/package.nix
@@ -54,7 +54,10 @@ buildGoModule rec {
     description = "Indexes Git repositories into Elasticsearch for GitLab";
     mainProgram = "gitlab-elasticsearch-indexer";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ yayayayaka ];
-    teams = [ lib.teams.cyberus ];
+    maintainers = with lib.maintainers; [
+      e1mo
+      xanderio
+      yayayayaka
+    ];
   };
 }

--- a/pkgs/by-name/la/lavacli/package.nix
+++ b/pkgs/by-name/la/lavacli/package.nix
@@ -38,7 +38,7 @@ python3.pkgs.buildPythonApplication rec {
     homepage = "https://lava.gitlab.io/lavacli/";
     changelog = "https://gitlab.com/lava/lavacli/-/commits/v${version}?ref_type=tags";
     license = lib.licenses.agpl3Only;
-    teams = [ lib.teams.cyberus ];
+    maintainers = with lib.maintainers; [ snu ];
     mainProgram = "lavacli";
   };
 }

--- a/pkgs/by-name/pl/plausible/package.nix
+++ b/pkgs/by-name/pl/plausible/package.nix
@@ -182,7 +182,10 @@ beamPackages.mixRelease rec {
     changelog = "https://github.com/plausible/analytics/blob/${src.rev}/CHANGELOG.md";
     description = "Simple, open-source, lightweight (< 1 KB) and privacy-friendly web analytics alternative to Google Analytics";
     mainProgram = "plausible";
-    teams = with lib.teams; [ cyberus ];
+    maintainers = with lib.maintainers; [
+      e1mo
+      xanderio
+    ];
     platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/by-name/ta/tailscale-gitops-pusher/package.nix
+++ b/pkgs/by-name/ta/tailscale-gitops-pusher/package.nix
@@ -31,6 +31,9 @@ buildGoModule {
     description = "Allows users to use a GitOps flow for managing Tailscale ACLs";
     license = lib.licenses.bsd3;
     mainProgram = "gitops-pusher";
-    teams = [ lib.teams.cyberus ];
+    maintainers = with lib.maintainers; [
+      e1mo
+      xanderio
+    ];
   };
 }

--- a/pkgs/development/python-modules/mkdocs-include-markdown-plugin/default.nix
+++ b/pkgs/development/python-modules/mkdocs-include-markdown-plugin/default.nix
@@ -42,6 +42,9 @@ buildPythonPackage rec {
     description = "Mkdocs Markdown includer plugin";
     homepage = "https://pypi.org/project/mkdocs-include-markdown-plugin/";
     license = lib.licenses.asl20;
-    teams = [ lib.teams.cyberus ];
+    maintainers = with lib.maintainers; [
+      e1mo
+      xanderio
+    ];
   };
 }

--- a/pkgs/servers/web-apps/outline/default.nix
+++ b/pkgs/servers/web-apps/outline/default.nix
@@ -95,9 +95,10 @@ stdenv.mkDerivation rec {
     license = lib.licenses.bsl11;
     maintainers = with lib.maintainers; [
       cab404
+      e1mo
+      xanderio
       yrd
     ];
-    teams = [ lib.teams.cyberus ];
     platforms = lib.platforms.linux;
   };
 }


### PR DESCRIPTION
The @NixOS/nixpkgs-core team has recently reviewed Nixpkgs teams, and decided that teams should be organized internally around specific topics of maintenance, rather than having membership gated by external criteria. This means having maintainer responsibility and authority decided by consensus of existing maintainers and team members in an area of interest, rather than being granted or revoked based on employment, membership in an external organization, or role in another FOSS project. The reasoning is given in the full statement at https://github.com/NixOS/org/issues/220#issuecomment-3678147410.

We are now triaging teams to make sure they’re in line with this model and working with their members to find the best way forward for each case. This is being tracked at #478780.

@xanderio @snue @e1mo 

This team was flagged as apparently having external membership criteria. By default, we’ll merge this to drop the team after a week if we don’t hear back from you, but we’re also happy to implement alternatives, e.g.:

- Redistribute members to maintainer lists of individual packages per their request.
- Reorganize or merge the team into one or more teams relating to specific areas of maintenance interest with open membership criteria.
- Clarify that the team is dedicated to maintenance of software maintained upstream by a certain organization, but is open to all contributors. For example, `lib.teams.jetbrains` and `lib.teams.qt-kde` handle maintenance of JetBrains IDEs and KDE software, but have no expectation that members are affiliated with those organizations, even though some may be.