### PR TITLE
teams/determinatesystems: handle team with external membership

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9853,12 +9853,6 @@
     githubId = 10908649;
     name = "Graham Bennett";
   };
-  grahamc = {
-    email = "graham@grahamc.com";
-    github = "grahamc";
-    githubId = 76716;
-    name = "Graham Christensen";
-  };
   grahamnorris = {
     email = "oss@grahamjnorris.com";
     github = "grahamnorris";

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -280,7 +280,6 @@ with lib.maintainers;
     # Verify additions to this team with at least one already existing member of the team.
     members = [
       cole-h
-      grahamc
     ];
     scope = "Group registration for packages maintained by Determinate Systems.";
     shortName = "Determinate Systems employees";

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -276,15 +276,6 @@ with lib.maintainers;
     shortName = "D. E. Shaw employees";
   };
 
-  determinatesystems = {
-    # Verify additions to this team with at least one already existing member of the team.
-    members = [
-      cole-h
-    ];
-    scope = "Group registration for packages maintained by Determinate Systems.";
-    shortName = "Determinate Systems employees";
-  };
-
   dhall = {
     members = [
       Gabriella439

--- a/nixos/modules/hardware/mcelog.nix
+++ b/nixos/modules/hardware/mcelog.nix
@@ -5,7 +5,6 @@
   ...
 }:
 {
-  meta.maintainers = with lib.maintainers; [ grahamc ];
   options = {
 
     hardware.mcelog = {

--- a/nixos/modules/services/misc/lifecycled.nix
+++ b/nixos/modules/services/misc/lifecycled.nix
@@ -30,7 +30,6 @@ in
 {
   meta.maintainers = with lib.maintainers; [
     cole-h
-    grahamc
   ];
 
   options = {

--- a/nixos/modules/system/boot/loader/external/external.nix
+++ b/nixos/modules/system/boot/loader/external/external.nix
@@ -14,7 +14,6 @@ in
   meta = {
     maintainers = with maintainers; [
       cole-h
-      grahamc
       raitobezarius
     ];
     doc = ./external.md;

--- a/nixos/tests/gocd-agent.nix
+++ b/nixos/tests/gocd-agent.nix
@@ -14,7 +14,6 @@ in
   name = "gocd-agent";
   meta = with pkgs.lib.maintainers; {
     maintainers = [
-      grahamc
       swarren83
     ];
 

--- a/nixos/tests/hound.nix
+++ b/nixos/tests/hound.nix
@@ -2,9 +2,6 @@
 { pkgs, ... }:
 {
   name = "hound";
-  meta = with pkgs.lib.maintainers; {
-    maintainers = [ grahamc ];
-  };
   nodes.machine =
     { pkgs, ... }:
     {

--- a/nixos/tests/wireguard/generated.nix
+++ b/nixos/tests/wireguard/generated.nix
@@ -7,7 +7,6 @@
   name = "wireguard-generated";
   meta.maintainers = with lib.maintainers; [
     ma27
-    grahamc
   ];
 
   nodes = {

--- a/nixos/tests/wordpress.nix
+++ b/nixos/tests/wordpress.nix
@@ -5,7 +5,6 @@ rec {
   meta = with lib.maintainers; {
     maintainers = [
       flokli
-      grahamc # under duress!
       mmilata
     ];
   };

--- a/pkgs/applications/video/obs-studio/plugins/wlrobs.nix
+++ b/pkgs/applications/video/obs-studio/plugins/wlrobs.nix
@@ -36,7 +36,6 @@ stdenv.mkDerivation {
   meta = {
     description = "Obs-studio plugin that allows you to screen capture on wlroots based wayland compositors";
     homepage = "https://hg.sr.ht/~scoopta/wlrobs";
-    maintainers = with lib.maintainers; [ grahamc ];
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.linux;
   };

--- a/pkgs/by-name/aw/aws-nuke/package.nix
+++ b/pkgs/by-name/aw/aws-nuke/package.nix
@@ -57,7 +57,6 @@ buildGoModule rec {
     homepage = "https://github.com/ekristen/aws-nuke";
     changelog = "https://github.com/ekristen/aws-nuke/releases/tag/${src.tag}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ grahamc ];
     mainProgram = "aws-nuke";
     # fork/exec exe/mockgen: exec format error
     # resources/autoscaling_mock_test.go:1: running "../mocks/generate_mocks.sh": exit status 1

--- a/pkgs/by-name/bo/bootspec/package.nix
+++ b/pkgs/by-name/bo/bootspec/package.nix
@@ -23,7 +23,7 @@ rustPlatform.buildRustPackage rec {
     description = "Implementation of RFC-0125's datatype and synthesis tooling";
     homepage = "https://github.com/DeterminateSystems/bootspec";
     license = lib.licenses.mit;
-    teams = [ lib.teams.determinatesystems ];
+    maintainers = [ lib.maintainers.cole-h ];
     platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/by-name/bu/buildkite-agent-metrics/package.nix
+++ b/pkgs/by-name/bu/buildkite-agent-metrics/package.nix
@@ -32,6 +32,5 @@ buildGoModule rec {
     description = "Command-line tool (and Lambda) for collecting Buildkite agent metrics";
     homepage = "https://github.com/buildkite/buildkite-agent-metrics";
     license = lib.licenses.mit;
-    teams = [ lib.teams.determinatesystems ];
   };
 }

--- a/pkgs/by-name/co/coldsnap/package.nix
+++ b/pkgs/by-name/co/coldsnap/package.nix
@@ -27,7 +27,6 @@ rustPlatform.buildRustPackage rec {
     description = "Command line interface for Amazon EBS snapshots";
     changelog = "https://github.com/awslabs/coldsnap/blob/${src.rev}/CHANGELOG.md";
     license = lib.licenses.asl20;
-    teams = [ lib.teams.determinatesystems ];
     mainProgram = "coldsnap";
   };
 }

--- a/pkgs/by-name/ef/efitools/package.nix
+++ b/pkgs/by-name/ef/efitools/package.nix
@@ -51,7 +51,6 @@ stdenv.mkDerivation rec {
     description = "Tools for manipulating UEFI secure boot platforms";
     homepage = "https://git.kernel.org/pub/scm/linux/kernel/git/jejb/efitools.git";
     license = lib.licenses.gpl2Only;
-    maintainers = [ lib.maintainers.grahamc ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/fa/facetimehd-calibration/package.nix
+++ b/pkgs/by-name/fa/facetimehd-calibration/package.nix
@@ -28,7 +28,6 @@ stdenvNoCC.mkDerivation {
     maintainers = with lib.maintainers; [
       alexshpilkin
       womfoo
-      grahamc
     ];
     platforms = lib.platforms.all;
     sourceProvenance = with lib.sourceTypes; [ binaryFirmware ];

--- a/pkgs/by-name/fa/facetimehd-firmware/package.nix
+++ b/pkgs/by-name/fa/facetimehd-firmware/package.nix
@@ -69,7 +69,6 @@ stdenvNoCC.mkDerivation {
     license = lib.licenses.unfree;
     maintainers = with lib.maintainers; [
       womfoo
-      grahamc
     ];
     platforms = [
       "i686-linux"

--- a/pkgs/by-name/go/gocd-agent/package.nix
+++ b/pkgs/by-name/go/gocd-agent/package.nix
@@ -28,7 +28,6 @@ stdenv.mkDerivation rec {
       binaryNativeCode
     ];
     maintainers = with lib.maintainers; [
-      grahamc
       swarren83
     ];
   };

--- a/pkgs/by-name/go/gocd-server/package.nix
+++ b/pkgs/by-name/go/gocd-server/package.nix
@@ -26,7 +26,6 @@ stdenv.mkDerivation rec {
       binaryNativeCode
     ];
     maintainers = with lib.maintainers; [
-      grahamc
       swarren83
     ];
   };

--- a/pkgs/by-name/ho/hound/package.nix
+++ b/pkgs/by-name/ho/hound/package.nix
@@ -58,7 +58,6 @@ buildGoModule rec {
     homepage = "https://github.com/hound-search/hound";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
-      grahamc
       SuperSandro2000
     ];
   };

--- a/pkgs/by-name/li/libfprint-2-tod1-goodix/package.nix
+++ b/pkgs/by-name/li/libfprint-2-tod1-goodix/package.nix
@@ -37,6 +37,5 @@ stdenv.mkDerivation {
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.unfree;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ grahamc ];
   };
 }

--- a/pkgs/by-name/li/libfprint-tod/package.nix
+++ b/pkgs/by-name/li/libfprint-tod/package.nix
@@ -47,7 +47,6 @@ libfprint.overrideAttrs (
       description = "Library designed to make it easy to add support for consumer fingerprint readers, with support for loaded drivers";
       license = lib.licenses.lgpl21;
       platforms = lib.platforms.linux;
-      maintainers = with lib.maintainers; [ grahamc ];
     };
   }
 )

--- a/pkgs/by-name/li/lifecycled/package.nix
+++ b/pkgs/by-name/li/lifecycled/package.nix
@@ -28,7 +28,6 @@ buildGoModule rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       cole-h
-      grahamc
     ];
   };
 }

--- a/pkgs/by-name/lo/lorri/package.nix
+++ b/pkgs/by-name/lo/lorri/package.nix
@@ -69,7 +69,6 @@ in
     homepage = "https://github.com/nix-community/lorri";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
-      grahamc
       Profpatsch
       nyarly
     ];

--- a/pkgs/by-name/xm/xmloscopy/package.nix
+++ b/pkgs/by-name/xm/xmloscopy/package.nix
@@ -60,6 +60,5 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/grahamc/xmloscopy";
     license = lib.licenses.mit;
     platforms = lib.platforms.all;
-    maintainers = with lib.maintainers; [ grahamc ];
   };
 }

--- a/pkgs/by-name/zp/zpool-auto-expand-partitions/package.nix
+++ b/pkgs/by-name/zp/zpool-auto-expand-partitions/package.nix
@@ -41,7 +41,7 @@ rustPlatform.buildRustPackage rec {
     description = "Tool that aims to expand all partitions in a specified zpool to fill the available space";
     homepage = "https://github.com/DeterminateSystems/zpool-auto-expand-partitions";
     license = lib.licenses.asl20;
-    teams = [ lib.teams.determinatesystems ];
+    maintainers = [ lib.maintainers.cole-h ];
     mainProgram = "zpool_part_disks";
   };
 }

--- a/pkgs/development/python-modules/brother-ql/default.nix
+++ b/pkgs/development/python-modules/brother-ql/default.nix
@@ -42,7 +42,6 @@ buildPythonPackage rec {
     '';
     homepage = "https://github.com/LunarEclipse363/brother_ql_next";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ grahamc ];
     mainProgram = "brother_ql";
   };
 }

--- a/pkgs/development/python-modules/packbits/default.nix
+++ b/pkgs/development/python-modules/packbits/default.nix
@@ -18,6 +18,5 @@ buildPythonPackage rec {
     description = "PackBits encoder/decoder for Python";
     homepage = "https://github.com/psd-tools/packbits";
     license = [ lib.licenses.mit ];
-    maintainers = with lib.maintainers; [ grahamc ];
   };
 }

--- a/pkgs/development/python-modules/pylibdmtx/default.nix
+++ b/pkgs/development/python-modules/pylibdmtx/default.nix
@@ -47,6 +47,5 @@ buildPythonPackage rec {
     description = "Read and write Data Matrix barcodes from Python 2 and 3 using the libdmtx library";
     homepage = "https://github.com/NaturalHistoryMuseum/pylibdmtx/";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ grahamc ];
   };
 }

--- a/pkgs/misc/documentation-highlighter/default.nix
+++ b/pkgs/misc/documentation-highlighter/default.nix
@@ -6,7 +6,6 @@ runCommand "documentation-highlighter"
       homepage = "https://highlightjs.org";
       license = lib.licenses.bsd3;
       platforms = lib.platforms.all;
-      maintainers = [ lib.maintainers.grahamc ];
     };
     src = lib.sources.cleanSourceWith {
       src = ./.;

--- a/pkgs/os-specific/linux/facetimehd/default.nix
+++ b/pkgs/os-specific/linux/facetimehd/default.nix
@@ -45,7 +45,6 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl2Only;
     maintainers = with lib.maintainers; [
       womfoo
-      grahamc
       kraem
     ];
     platforms = [

--- a/pkgs/tools/misc/pgbadger/default.nix
+++ b/pkgs/tools/misc/pgbadger/default.nix
@@ -56,7 +56,6 @@ buildPerlPackage rec {
     description = "Fast PostgreSQL Log Analyzer";
     changelog = "https://github.com/darold/pgbadger/raw/v${version}/ChangeLog";
     license = lib.licenses.postgresql;
-    teams = [ lib.teams.determinatesystems ];
     mainProgram = "pgbadger";
   };
 }


### PR DESCRIPTION
The @NixOS/nixpkgs-core team has recently reviewed Nixpkgs teams, and decided that teams should be organized internally around specific topics of maintenance, rather than having membership gated by external criteria. This means having maintainer responsibility and authority decided by consensus of existing maintainers and team members in an area of interest, rather than being granted or revoked based on employment, membership in an external organization, or role in another FOSS project. The reasoning is given in the full statement at https://github.com/NixOS/org/issues/220#issuecomment-3678147410.

We are now triaging teams to make sure they’re in line with this model and working with their members to find the best way forward for each case. This is being tracked at #478780.

@cole-h @grahamc

This team was flagged as apparently having external membership criteria. By default, we’ll merge this to drop the team after a week if we don’t hear back from you, but we’re also happy to implement alternatives, e.g.:

- Redistribute members to maintainer lists of individual packages per their request.
- Reorganize or merge the team into one or more teams relating to specific areas of maintenance interest with open membership criteria.
- Clarify that the team is dedicated to maintenance of software maintained upstream by a certain organization, but is open to all contributors. For example, `lib.teams.jetbrains` and `lib.teams.qt-kde` handle maintenance of JetBrains IDEs and KDE software, but have no expectation that members are affiliated with those organizations, even though some may be.