### PR TITLE
teams/flyingcircus: handle team with external membership

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6997,13 +6997,6 @@
     githubId = 974130;
     name = "David Pätzel";
   };
-  dpausp = {
-    email = "dpausp@posteo.de";
-    github = "dpausp";
-    githubId = 1965950;
-    name = "Tobias Stenzel";
-    keys = [ { fingerprint = "4749 0887 CF3B 85A1 6355  C671 78C7 DD40 DF23 FB16"; } ];
-  };
   dpc = {
     email = "dpc@dpc.pw";
     github = "dpc";

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -359,18 +359,6 @@ with lib.maintainers;
     github = "flutter";
   };
 
-  flyingcircus = {
-    # Verify additions by approval of an already existing member of the team.
-    members = [
-      theuni
-      frlan
-      leona
-      osnyx
-    ];
-    scope = "Team for Flying Circus employees who collectively maintain packages.";
-    shortName = "Flying Circus employees";
-  };
-
   forgejo = {
     members = [
       adamcstephens

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -363,7 +363,6 @@ with lib.maintainers;
     # Verify additions by approval of an already existing member of the team.
     members = [
       theuni
-      dpausp
       frlan
       leona
       osnyx

--- a/nixos/modules/services/mail/mailpit.nix
+++ b/nixos/modules/services/mail/mailpit.nix
@@ -101,4 +101,9 @@ in
       }
     ) instances;
   };
+
+  meta.maintainers = [
+    lib.maintainers.leona
+    lib.maintainers.osnyx
+  ];
 }

--- a/nixos/modules/services/mail/mailpit.nix
+++ b/nixos/modules/services/mail/mailpit.nix
@@ -101,6 +101,4 @@ in
       }
     ) instances;
   };
-
-  meta.maintainers = lib.teams.flyingcircus.members;
 }

--- a/nixos/modules/services/networking/knot-resolver.nix
+++ b/nixos/modules/services/networking/knot-resolver.nix
@@ -33,6 +33,8 @@ in
 {
   meta.maintainers = [
     lib.maintainers.vcunat # upstream developer
+    lib.maintainers.leona
+    lib.maintainers.osnyx
   ];
 
   ###### interface

--- a/nixos/modules/services/networking/knot-resolver.nix
+++ b/nixos/modules/services/networking/knot-resolver.nix
@@ -33,8 +33,7 @@ in
 {
   meta.maintainers = [
     lib.maintainers.vcunat # upstream developer
-  ]
-  ++ lib.teams.flyingcircus.members;
+  ];
 
   ###### interface
   options.services.knot-resolver = {

--- a/nixos/tests/mailpit.nix
+++ b/nixos/tests/mailpit.nix
@@ -1,6 +1,10 @@
 { lib, ... }:
 {
   name = "mailpit";
+  meta.maintainers = [
+    lib.maintainers.leona
+    lib.maintainers.osnyx
+  ];
 
   nodes.machine =
     { pkgs, ... }:

--- a/nixos/tests/mailpit.nix
+++ b/nixos/tests/mailpit.nix
@@ -1,7 +1,6 @@
 { lib, ... }:
 {
   name = "mailpit";
-  meta.maintainers = lib.teams.flyingcircus.members;
 
   nodes.machine =
     { pkgs, ... }:

--- a/nixos/tests/matomo.nix
+++ b/nixos/tests/matomo.nix
@@ -51,5 +51,7 @@
     mmilata
     twey
     boozedog
+    leona
+    osnyx
   ];
 }

--- a/nixos/tests/matomo.nix
+++ b/nixos/tests/matomo.nix
@@ -46,13 +46,10 @@
       machine.wait_for_unit("phpfpm-matomo.service")
   '';
 
-  meta.maintainers =
-    with lib.maintainers;
-    [
-      florianjacob
-      mmilata
-      twey
-      boozedog
-    ]
-    ++ lib.teams.flyingcircus.members;
+  meta.maintainers = with lib.maintainers; [
+    florianjacob
+    mmilata
+    twey
+    boozedog
+  ];
 }

--- a/nixos/tests/oci-containers.nix
+++ b/nixos/tests/oci-containers.nix
@@ -73,7 +73,7 @@ let
     type:
     makeTest {
       name = "oci-containers-podman-rootless-${type}";
-      meta.maintainers = lib.teams.flyingcircus.members ++ [ lib.maintainers.ma27 ];
+      meta.maintainers = [ lib.maintainers.ma27 ];
       nodes = {
         podman =
           { pkgs, ... }:

--- a/nixos/tests/oci-containers.nix
+++ b/nixos/tests/oci-containers.nix
@@ -73,7 +73,11 @@ let
     type:
     makeTest {
       name = "oci-containers-podman-rootless-${type}";
-      meta.maintainers = [ lib.maintainers.ma27 ];
+      meta.maintainers = [
+        lib.maintainers.leona
+        lib.maintainers.ma27
+        lib.maintainers.osnyx
+      ];
       nodes = {
         podman =
           { pkgs, ... }:

--- a/nixos/tests/postgresql/anonymizer.nix
+++ b/nixos/tests/postgresql/anonymizer.nix
@@ -11,6 +11,10 @@ let
     package:
     makeTest {
       name = "postgresql_anonymizer-${package.name}";
+      meta.maintainers = [
+        lib.maintainers.leona
+        lib.maintainers.osnyx
+      ];
 
       nodes.machine =
         { pkgs, ... }:

--- a/nixos/tests/postgresql/anonymizer.nix
+++ b/nixos/tests/postgresql/anonymizer.nix
@@ -11,7 +11,6 @@ let
     package:
     makeTest {
       name = "postgresql_anonymizer-${package.name}";
-      meta.maintainers = lib.teams.flyingcircus.members;
 
       nodes.machine =
         { pkgs, ... }:

--- a/pkgs/by-name/el/eliot-tree/package.nix
+++ b/pkgs/by-name/el/eliot-tree/package.nix
@@ -46,6 +46,5 @@ python3Packages.buildPythonApplication rec {
     description = "Render Eliot logs as an ASCII tree";
     mainProgram = "eliot-tree";
     license = lib.licenses.mit;
-    maintainers = [ lib.maintainers.dpausp ];
   };
 }

--- a/pkgs/by-name/kn/knot-resolver_6/package.nix
+++ b/pkgs/by-name/kn/knot-resolver_6/package.nix
@@ -143,7 +143,6 @@ let
       maintainers = [
         lib.maintainers.vcunat # upstream developer
       ];
-      teams = [ lib.teams.flyingcircus ];
       mainProgram = "kresd";
     };
   });

--- a/pkgs/by-name/kn/knot-resolver_6/package.nix
+++ b/pkgs/by-name/kn/knot-resolver_6/package.nix
@@ -142,6 +142,8 @@ let
       platforms = lib.platforms.unix;
       maintainers = [
         lib.maintainers.vcunat # upstream developer
+        lib.maintainers.leona
+        lib.maintainers.osnyx
       ];
       mainProgram = "kresd";
     };

--- a/pkgs/by-name/ma/matomo/package.nix
+++ b/pkgs/by-name/ma/matomo/package.nix
@@ -118,6 +118,5 @@ stdenv.mkDerivation (finalAttrs: {
       boozedog
       niklaskorz
     ];
-    teams = [ lib.teams.flyingcircus ];
   };
 })

--- a/pkgs/by-name/ma/matomo/package.nix
+++ b/pkgs/by-name/ma/matomo/package.nix
@@ -117,6 +117,8 @@ stdenv.mkDerivation (finalAttrs: {
       twey
       boozedog
       niklaskorz
+      leona
+      osnyx
     ];
   };
 })

--- a/pkgs/by-name/pg/pg-dump-anon/package.nix
+++ b/pkgs/by-name/pg/pg-dump-anon/package.nix
@@ -33,6 +33,10 @@ buildGoModule rec {
   meta = {
     description = "Export databases with data being anonymized with the anonymizer extension";
     homepage = "https://postgresql-anonymizer.readthedocs.io/en/stable/";
+    maintainers = [
+      lib.maintainers.leona
+      lib.maintainers.osnyx
+    ];
     license = lib.licenses.postgresql;
     mainProgram = "pg_dump_anon";
   };

--- a/pkgs/by-name/pg/pg-dump-anon/package.nix
+++ b/pkgs/by-name/pg/pg-dump-anon/package.nix
@@ -33,7 +33,6 @@ buildGoModule rec {
   meta = {
     description = "Export databases with data being anonymized with the anonymizer extension";
     homepage = "https://postgresql-anonymizer.readthedocs.io/en/stable/";
-    teams = [ lib.teams.flyingcircus ];
     license = lib.licenses.postgresql;
     mainProgram = "pg_dump_anon";
   };

--- a/pkgs/by-name/pr/proftpd/package.nix
+++ b/pkgs/by-name/pr/proftpd/package.nix
@@ -80,7 +80,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     homepage = "http://www.proftpd.org/";
-    teams = [ lib.teams.flyingcircus ];
     license = lib.licenses.gpl2Plus;
     mainProgram = "proftpd";
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/pr/proftpd/package.nix
+++ b/pkgs/by-name/pr/proftpd/package.nix
@@ -80,6 +80,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     homepage = "http://www.proftpd.org/";
+    maintainers = [
+      lib.maintainers.leona
+      lib.maintainers.osnyx
+    ];
     license = lib.licenses.gpl2Plus;
     mainProgram = "proftpd";
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/ra/rabbitmqadmin-ng/package.nix
+++ b/pkgs/by-name/ra/rabbitmqadmin-ng/package.nix
@@ -31,7 +31,6 @@ rustPlatform.buildRustPackage rec {
 
   meta = {
     description = "Command line tool for RabbitMQ that uses the HTTP API";
-    teams = [ lib.teams.flyingcircus ];
     homepage = "https://www.rabbitmq.com/docs/management-cli";
     license = with lib.licenses; [
       mit

--- a/pkgs/by-name/ra/rabbitmqadmin-ng/package.nix
+++ b/pkgs/by-name/ra/rabbitmqadmin-ng/package.nix
@@ -32,6 +32,10 @@ rustPlatform.buildRustPackage rec {
   meta = {
     description = "Command line tool for RabbitMQ that uses the HTTP API";
     homepage = "https://www.rabbitmq.com/docs/management-cli";
+    maintainers = [
+      lib.maintainers.leona
+      lib.maintainers.osnyx
+    ];
     license = with lib.licenses; [
       mit
       asl20

--- a/pkgs/development/python-modules/eliot/default.nix
+++ b/pkgs/development/python-modules/eliot/default.nix
@@ -68,6 +68,5 @@ buildPythonPackage rec {
     changelog = "https://github.com/itamarst/eliot/blob/${version}/docs/source/news.rst";
     mainProgram = "eliot-prettyprint";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ dpausp ];
   };
 }

--- a/pkgs/development/python-modules/myst-docutils/default.nix
+++ b/pkgs/development/python-modules/myst-docutils/default.nix
@@ -74,6 +74,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/executablebooks/MyST-Parser";
     changelog = "https://github.com/executablebooks/MyST-Parser/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ dpausp ];
   };
 }

--- a/pkgs/servers/sql/percona-server/8_0.nix
+++ b/pkgs/servers/sql/percona-server/8_0.nix
@@ -207,7 +207,6 @@ stdenv.mkDerivation (finalAttrs: {
       Long-term support release.
     '';
     license = lib.licenses.gpl2Only;
-    teams = [ lib.teams.flyingcircus ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/servers/sql/percona-server/8_0.nix
+++ b/pkgs/servers/sql/percona-server/8_0.nix
@@ -207,6 +207,10 @@ stdenv.mkDerivation (finalAttrs: {
       Long-term support release.
     '';
     license = lib.licenses.gpl2Only;
+    maintainers = [
+      lib.maintainers.leona
+      lib.maintainers.osnyx
+    ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/servers/sql/percona-server/8_4.nix
+++ b/pkgs/servers/sql/percona-server/8_4.nix
@@ -219,6 +219,10 @@ stdenv.mkDerivation (finalAttrs: {
       Long-term support release.
     '';
     license = lib.licenses.gpl2Only;
+    maintainers = [
+      lib.maintainers.leona
+      lib.maintainers.osnyx
+    ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/servers/sql/percona-server/8_4.nix
+++ b/pkgs/servers/sql/percona-server/8_4.nix
@@ -219,7 +219,6 @@ stdenv.mkDerivation (finalAttrs: {
       Long-term support release.
     '';
     license = lib.licenses.gpl2Only;
-    teams = [ lib.teams.flyingcircus ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/servers/sql/postgresql/ext/anonymizer.nix
+++ b/pkgs/servers/sql/postgresql/ext/anonymizer.nix
@@ -24,7 +24,7 @@ buildPgrxExtension {
   passthru.tests = nixosTests.postgresql.anonymizer.passthru.override postgresql;
 
   meta = {
-    inherit (pg-dump-anon.meta) homepage license;
+    inherit (pg-dump-anon.meta) homepage maintainers license;
     description = "Extension to mask or replace personally identifiable information (PII) or commercially sensitive data from a PostgreSQL database";
   };
 }

--- a/pkgs/servers/sql/postgresql/ext/anonymizer.nix
+++ b/pkgs/servers/sql/postgresql/ext/anonymizer.nix
@@ -24,7 +24,7 @@ buildPgrxExtension {
   passthru.tests = nixosTests.postgresql.anonymizer.passthru.override postgresql;
 
   meta = {
-    inherit (pg-dump-anon.meta) homepage teams license;
+    inherit (pg-dump-anon.meta) homepage license;
     description = "Extension to mask or replace personally identifiable information (PII) or commercially sensitive data from a PostgreSQL database";
   };
 }

--- a/pkgs/servers/sql/postgresql/ext/pgvectorscale/package.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgvectorscale/package.nix
@@ -68,6 +68,10 @@ buildPgrxExtension (finalAttrs: {
     # Upstream removed support for PostgreSQL 13 on 0.9.0: https://github.com/timescale/pgvectorscale/releases/tag/0.9.0
     broken = lib.versionOlder postgresql.version "14";
     homepage = "https://github.com/timescale/pgvectorscale";
+    maintainers = [
+      lib.maintainers.leona
+      lib.maintainers.osnyx
+    ];
     description = "Complement to pgvector for high performance, cost efficient vector search on large workloads";
     license = lib.licenses.postgresql;
     platforms = postgresql.meta.platforms;

--- a/pkgs/servers/sql/postgresql/ext/pgvectorscale/package.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgvectorscale/package.nix
@@ -68,7 +68,6 @@ buildPgrxExtension (finalAttrs: {
     # Upstream removed support for PostgreSQL 13 on 0.9.0: https://github.com/timescale/pgvectorscale/releases/tag/0.9.0
     broken = lib.versionOlder postgresql.version "14";
     homepage = "https://github.com/timescale/pgvectorscale";
-    teams = [ lib.teams.flyingcircus ];
     description = "Complement to pgvector for high performance, cost efficient vector search on large workloads";
     license = lib.licenses.postgresql;
     platforms = postgresql.meta.platforms;

--- a/pkgs/servers/varnish/default.nix
+++ b/pkgs/servers/varnish/default.nix
@@ -136,6 +136,10 @@ let
         description = "Web application accelerator also known as a caching HTTP reverse proxy";
         homepage = "https://www.varnish-cache.org";
         license = lib.licenses.bsd2;
+        maintainers = [
+          lib.maintainers.leona
+          lib.maintainers.osnyx
+        ];
         platforms = lib.platforms.unix;
       };
     };

--- a/pkgs/servers/varnish/default.nix
+++ b/pkgs/servers/varnish/default.nix
@@ -136,7 +136,6 @@ let
         description = "Web application accelerator also known as a caching HTTP reverse proxy";
         homepage = "https://www.varnish-cache.org";
         license = lib.licenses.bsd2;
-        teams = [ lib.teams.flyingcircus ];
         platforms = lib.platforms.unix;
       };
     };

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-docs/default.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-docs/default.nix
@@ -14,7 +14,6 @@ mkDiscoursePlugin {
   };
   meta = {
     homepage = "https://github.com/discourse/discourse-docs";
-    maintainers = with lib.maintainers; [ dpausp ];
     license = lib.licenses.mit;
     description = "Find and filter knowledge base topics";
   };

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-prometheus/default.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-prometheus/default.nix
@@ -23,7 +23,6 @@ mkDiscoursePlugin {
 
   meta = {
     homepage = "https://github.com/discourse/discourse-prometheus";
-    maintainers = with lib.maintainers; [ dpausp ];
     license = lib.licenses.mit;
     description = "Official Discourse Plugin for Prometheus Monitoring";
   };

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-saved-searches/default.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-saved-searches/default.nix
@@ -14,7 +14,6 @@ mkDiscoursePlugin {
   };
   meta = {
     homepage = "https://github.com/discourse/discourse-saved-searches";
-    maintainers = with lib.maintainers; [ dpausp ];
     license = lib.licenses.mit;
     description = "Allow users to save searches and be notified of new results";
   };

--- a/pkgs/tools/backup/percona-xtrabackup/generic.nix
+++ b/pkgs/tools/backup/percona-xtrabackup/generic.nix
@@ -110,6 +110,5 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl2Only;
     platforms = lib.platforms.linux;
     maintainers = [ lib.maintainers.izorkin ];
-    teams = [ lib.teams.flyingcircus ];
   };
 })

--- a/pkgs/tools/backup/percona-xtrabackup/generic.nix
+++ b/pkgs/tools/backup/percona-xtrabackup/generic.nix
@@ -109,6 +109,10 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "http://www.percona.com/software/percona-xtrabackup";
     license = lib.licenses.gpl2Only;
     platforms = lib.platforms.linux;
-    maintainers = [ lib.maintainers.izorkin ];
+    maintainers = [
+      lib.maintainers.izorkin
+      lib.maintainers.leona
+      lib.maintainers.osnyx
+    ];
   };
 })


### PR DESCRIPTION
The @NixOS/nixpkgs-core team has recently reviewed Nixpkgs teams, and decided that teams should be organized internally around specific topics of maintenance, rather than having membership gated by external criteria. This means having maintainer responsibility and authority decided by consensus of existing maintainers and team members in an area of interest, rather than being granted or revoked based on employment, membership in an external organization, or role in another FOSS project. The reasoning is given in the full statement at https://github.com/NixOS/org/issues/220#issuecomment-3678147410.

We are now triaging teams to make sure they’re in line with this model and working with their members to find the best way forward for each case. This is being tracked at #478780.

@ctheune @dpausp @frlan @leona-ya @osnyx

This team was flagged as apparently having external membership criteria. By default, we’ll merge this to drop the team after a week if we don’t hear back from you, but we’re also happy to implement alternatives, e.g.:

- Redistribute members to maintainer lists of individual packages per their request.
- Reorganize or merge the team into one or more teams relating to specific areas of maintenance interest with open membership criteria.
- Clarify that the team is dedicated to maintenance of software maintained upstream by a certain organization, but is open to all contributors. For example, `lib.teams.jetbrains` and `lib.teams.qt-kde` handle maintenance of JetBrains IDEs and KDE software, but have no expectation that members are affiliated with those organizations, even though some may be.