### PR TITLE
Dissolve c3d2 team

### DIFF
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -143,17 +143,6 @@ with lib.maintainers;
     enableFeatureFreezePing = true;
   };
 
-  c3d2 = {
-    members = [
-      astro
-      SuperSandro2000
-      revol-xut
-      oxapentane
-    ];
-    scope = "Maintain packages used in the C3D2 hackspace";
-    shortName = "c3d2";
-  };
-
   categorization = {
     github = "categorization";
   };

--- a/nixos/modules/services/misc/portunus.nix
+++ b/nixos/modules/services/misc/portunus.nix
@@ -313,5 +313,5 @@ in
     ];
   };
 
-  meta.maintainers = [ lib.maintainers.majewsky ] ++ lib.teams.c3d2.members;
+  meta.maintainers = pkgs.portunus.meta.maintainers;
 }

--- a/nixos/modules/services/web-apps/librespeed.nix
+++ b/nixos/modules/services/web-apps/librespeed.nix
@@ -441,5 +441,5 @@ in
     };
   };
 
-  meta.maintainers = lib.teams.c3d2.members;
+  meta.maintainers = pkgs.librespeed-rust.meta.maintainers;
 }

--- a/nixos/modules/services/web-apps/pretalx.nix
+++ b/nixos/modules/services/web-apps/pretalx.nix
@@ -30,9 +30,7 @@ let
 in
 
 {
-  meta = {
-    maintainers = with lib.maintainers; [ hexa ] ++ lib.teams.c3d2.members;
-  };
+  meta.maintainers = pkgs.pretalx.meta.maintainers;
 
   options.services.pretalx = {
     enable = lib.mkEnableOption "pretalx";

--- a/nixos/tests/web-apps/pretalx.nix
+++ b/nixos/tests/web-apps/pretalx.nix
@@ -1,8 +1,8 @@
-{ lib, ... }:
+{ pkgs, ... }:
 
 {
   name = "pretalx";
-  meta.maintainers = lib.teams.c3d2.members;
+  meta.maintainers = pkgs.pretalx.meta.maintainers;
 
   nodes = {
     pretalx =

--- a/pkgs/by-name/le/ledfx/package.nix
+++ b/pkgs/by-name/le/ledfx/package.nix
@@ -85,7 +85,7 @@ python3.pkgs.buildPythonApplication rec {
     homepage = "https://github.com/LedFx/LedFx";
     changelog = "https://github.com/LedFx/LedFx/blob/${version}/CHANGELOG.rst";
     license = lib.licenses.gpl3Only;
-    teams = [ lib.teams.c3d2 ];
+    maintainers = with lib.maintainers; [ SuperSandro2000 ];
     mainProgram = "ledfx";
   };
 }

--- a/pkgs/by-name/li/librespeed-rust/package.nix
+++ b/pkgs/by-name/li/librespeed-rust/package.nix
@@ -30,7 +30,7 @@ rustPlatform.buildRustPackage rec {
     description = "Very lightweight speed test implementation in Rust";
     homepage = "https://github.com/librespeed/speedtest-rust";
     license = lib.licenses.lgpl3Plus;
-    teams = with lib.teams; [ c3d2 ];
+    maintainers = with lib.maintainers; [ SuperSandro2000 ];
     mainProgram = "librespeed-rs";
   };
 }

--- a/pkgs/by-name/ma/matrix-synapse-unwrapped/plugins/ldap3.nix
+++ b/pkgs/by-name/ma/matrix-synapse-unwrapped/plugins/ldap3.nix
@@ -41,6 +41,6 @@ buildPythonPackage rec {
     description = "LDAP3 auth provider for Synapse";
     homepage = "https://github.com/matrix-org/matrix-synapse-ldap3";
     license = lib.licenses.asl20;
-    teams = [ lib.teams.c3d2 ];
+    maintainers = with lib.maintainers; [ SuperSandro2000 ];
   };
 }

--- a/pkgs/by-name/me/mediagoblin/package.nix
+++ b/pkgs/by-name/me/mediagoblin/package.nix
@@ -175,6 +175,6 @@ python.pkgs.buildPythonApplication rec {
     description = "Free software media publishing platform that anyone can run";
     homepage = "https://mediagoblin.org/";
     license = lib.licenses.agpl3Plus;
-    teams = [ lib.teams.c3d2 ];
+    teams = with lib.maintainers; [ SuperSandro2000 ];
   };
 }

--- a/pkgs/by-name/me/mediawiki/package.nix
+++ b/pkgs/by-name/me/mediawiki/package.nix
@@ -40,6 +40,6 @@ stdenvNoCC.mkDerivation rec {
     license = lib.licenses.gpl2Plus;
     homepage = "https://www.mediawiki.org/";
     platforms = lib.platforms.all;
-    teams = [ lib.teams.c3d2 ];
+    teams = with lib.maintainers; [ SuperSandro2000 ];
   };
 }

--- a/pkgs/by-name/nc/ncpamixer/package.nix
+++ b/pkgs/by-name/nc/ncpamixer/package.nix
@@ -61,7 +61,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/fulhax/ncpamixer";
     license = lib.licenses.mit;
     platforms = lib.platforms.linux;
-    teams = [ lib.teams.c3d2 ];
+    maintainers = with lib.maintainers; [ SuperSandro2000 ];
     mainProgram = "ncpamixer";
   };
 }

--- a/pkgs/by-name/op/openwebrx/package.nix
+++ b/pkgs/by-name/op/openwebrx/package.nix
@@ -40,7 +40,6 @@ let
       homepage = "https://github.com/jketterl/js8py";
       description = "Library to decode the output of the js8 binary of JS8Call";
       license = lib.licenses.gpl3Only;
-      teams = with lib.teams; [ c3d2 ];
     };
   };
 
@@ -83,7 +82,6 @@ let
       description = "Set of connectors that are used by OpenWebRX to interface with SDR hardware";
       license = lib.licenses.gpl3Only;
       platforms = lib.platforms.unix;
-      teams = with lib.teams; [ c3d2 ];
     };
   };
 
@@ -136,6 +134,5 @@ python3Packages.buildPythonApplication rec {
     description = "Simple DSP library and command-line tool for Software Defined Radio";
     mainProgram = "openwebrx";
     license = lib.licenses.gpl3Only;
-    teams = with lib.teams; [ c3d2 ];
   };
 }

--- a/pkgs/by-name/po/portunus/package.nix
+++ b/pkgs/by-name/po/portunus/package.nix
@@ -28,7 +28,9 @@ buildGoModule rec {
     homepage = "https://github.com/majewsky/portunus";
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ majewsky ];
-    teams = [ lib.teams.c3d2 ];
+    maintainers = with lib.maintainers; [
+      majewsky
+      SuperSandro2000
+    ];
   };
 }

--- a/pkgs/by-name/pr/pretalx/package.nix
+++ b/pkgs/by-name/pr/pretalx/package.nix
@@ -42,8 +42,10 @@ let
     homepage = "https://github.com/pretalx/pretalx";
     changelog = "https://docs.pretalx.org/changelog/#${version}";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ hexa ];
-    teams = [ lib.teams.c3d2 ];
+    maintainers = with lib.maintainers; [
+      hexa
+      SuperSandro2000
+    ];
     platforms = lib.platforms.linux;
   };
 

--- a/pkgs/servers/xmpp/prosody/default.nix
+++ b/pkgs/servers/xmpp/prosody/default.nix
@@ -121,7 +121,7 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [
       toastal
       mirror230469
+      SuperSandro2000
     ];
-    teams = with lib.teams; [ c3d2 ];
   };
 })


### PR DESCRIPTION
@astro agreed to take openwebrx and to open a PR with it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
