### PR TITLE
teams/fslabs: handle team with external membership

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17617,12 +17617,6 @@
       }
     ];
   };
-  mockersf = {
-    email = "francois.mockers@vleue.com";
-    github = "mockersf";
-    githubId = 8672791;
-    name = "François Mockers";
-  };
   modderme123 = {
     email = "modderme123@gmail.com";
     github = "milomg";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19295,12 +19295,6 @@
     githubId = 1839979;
     name = "Niklas Thörne";
   };
-  NthTensor = {
-    email = "miles.silberlingcook@gmail.com";
-    github = "NthTensor";
-    githubId = 16138381;
-    name = "Miles Silberling-Cook";
-  };
   nudelsalat = {
     email = "nudelsalat@clouz.de";
     name = "Fabian Dreßler";

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -398,7 +398,6 @@ with lib.maintainers;
     # Verify additions to this team with at least one already existing member of the team.
     members = [
       lpostula
-      NthTensor
     ];
     scope = "Group registration for packages maintained by Foresight Spatial Labs.";
     shortName = "Foresight Spatial Labs employees";

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -398,7 +398,6 @@ with lib.maintainers;
     # Verify additions to this team with at least one already existing member of the team.
     members = [
       lpostula
-      mockersf
       NthTensor
     ];
     scope = "Group registration for packages maintained by Foresight Spatial Labs.";

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -394,15 +394,6 @@ with lib.maintainers;
     github = "freedesktop";
   };
 
-  fslabs = {
-    # Verify additions to this team with at least one already existing member of the team.
-    members = [
-      lpostula
-    ];
-    scope = "Group registration for packages maintained by Foresight Spatial Labs.";
-    shortName = "Foresight Spatial Labs employees";
-  };
-
   gcc = {
     members = [
       synthetica

--- a/pkgs/servers/monitoring/grafana/plugins/grafana-exploretraces-app/default.nix
+++ b/pkgs/servers/monitoring/grafana/plugins/grafana-exploretraces-app/default.nix
@@ -7,7 +7,7 @@ grafanaPlugin {
   meta = {
     description = "Opinionated traces app";
     license = lib.licenses.agpl3Only;
-    teams = [ lib.teams.fslabs ];
+    maintainers = with lib.maintainers; [ lpostula ];
     platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/servers/monitoring/grafana/plugins/grafana-lokiexplore-app/default.nix
+++ b/pkgs/servers/monitoring/grafana/plugins/grafana-lokiexplore-app/default.nix
@@ -7,7 +7,7 @@ grafanaPlugin {
   meta = {
     description = "Browse Loki logs without the need for writing complex queries";
     license = lib.licenses.agpl3Only;
-    teams = [ lib.teams.fslabs ];
+    maintainers = with lib.maintainers; [ lpostula ];
     platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/servers/monitoring/grafana/plugins/grafana-oncall-app/default.nix
+++ b/pkgs/servers/monitoring/grafana/plugins/grafana-oncall-app/default.nix
@@ -7,7 +7,7 @@ grafanaPlugin {
   meta = {
     description = "Developer-friendly incident response for Grafana";
     license = lib.licenses.agpl3Only;
-    teams = [ lib.teams.fslabs ];
+    maintainers = with lib.maintainers; [ lpostula ];
     platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/servers/monitoring/grafana/plugins/grafana-pyroscope-app/default.nix
+++ b/pkgs/servers/monitoring/grafana/plugins/grafana-pyroscope-app/default.nix
@@ -7,7 +7,7 @@ grafanaPlugin {
   meta = {
     description = "Integrate seamlessly with Pyroscope, the open-source continuous profiling platform, providing a smooth, query-less experience for browsing and analyzing profiling data";
     license = lib.licenses.agpl3Only;
-    teams = [ lib.teams.fslabs ];
+    maintainers = with lib.maintainers; [ lpostula ];
     platforms = lib.platforms.unix;
   };
 }


### PR DESCRIPTION
The @NixOS/nixpkgs-core team has recently reviewed Nixpkgs teams, and decided that teams should be organized internally around specific topics of maintenance, rather than having membership gated by external criteria. This means having maintainer responsibility and authority decided by consensus of existing maintainers and team members in an area of interest, rather than being granted or revoked based on employment, membership in an external organization, or role in another FOSS project. The reasoning is given in the full statement at https://github.com/NixOS/org/issues/220#issuecomment-3678147410.

We are now triaging teams to make sure they’re in line with this model and working with their members to find the best way forward for each case. This is being tracked at #478780.

@loispostula @mockersf @NthTensor

This team was flagged as apparently having external membership criteria. By default, we’ll merge this to drop the team after a week if we don’t hear back from you, but we’re also happy to implement alternatives, e.g.:

- Redistribute members to maintainer lists of individual packages per their request.
- Reorganize or merge the team into one or more teams relating to specific areas of maintenance interest with open membership criteria.
- Clarify that the team is dedicated to maintenance of software maintained upstream by a certain organization, but is open to all contributors. For example, `lib.teams.jetbrains` and `lib.teams.qt-kde` handle maintenance of JetBrains IDEs and KDE software, but have no expectation that members are affiliated with those organizations, even though some may be.