### PR TITLE
qt6Packages.drumstick: 2.10.0 -> 2.11.0

### DIFF
--- a/pkgs/by-name/so/sonivox/package.nix
+++ b/pkgs/by-name/so/sonivox/package.nix
@@ -7,22 +7,22 @@
 
 stdenv.mkDerivation rec {
   pname = "sonivox";
-  version = "3.6.16";
+  version = "4.0.0";
 
   src = fetchFromGitHub {
-    owner = "pedrolcl";
+    owner = "EmbeddedSynth";
     repo = "sonivox";
-    rev = "v${version}";
-    hash = "sha256-2OWlm1GZI08OeiG3AswRyvguv9MUYo1dLo6QUPr3r3s=";
+    tag = "v${version}";
+    hash = "sha256-eOC/7R45X93Q9KKnP+/fyPMESOVyTnzpqnLHnDQwLnQ=";
   };
 
   nativeBuildInputs = [ cmake ];
 
   meta = {
-    homepage = "https://github.com/pedrolcl/sonivox";
+    homepage = "https://github.com/EmbeddedSynth/sonivox";
     description = "MIDI synthesizer library";
     license = lib.licenses.asl20;
     maintainers = [ lib.maintainers.wegank ];
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.all;
   };
 }

--- a/pkgs/by-name/so/sonivox/package.nix
+++ b/pkgs/by-name/so/sonivox/package.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/pedrolcl/sonivox";
     description = "MIDI synthesizer library";
     license = lib.licenses.asl20;
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.wegank ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/development/libraries/drumstick/default.nix
+++ b/pkgs/development/libraries/drumstick/default.nix
@@ -25,11 +25,11 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "drumstick";
-  version = "2.10.0";
+  version = "2.11.0";
 
   src = fetchurl {
     url = "mirror://sourceforge/drumstick/${version}/drumstick-${version}.tar.bz2";
-    hash = "sha256-rFoH1daXHiT3LZWQRP+buzMRQSWLJfGMgRtJ9XFy/L0=";
+    hash = "sha256-vPlhQ+i8gifI/UIXii7KhZQ+RYBdnE09FVCXQiJcQdU=";
   };
 
   patches = [ ./drumstick-plugins.patch ];


### PR DESCRIPTION
https://sourceforge.net/p/drumstick/news/2025/12/drumstick-libraries-v2110-released/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
