### PR TITLE
teams/helsinki-systems: handle team with external membership

### DIFF
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -386,17 +386,6 @@ with lib.maintainers;
     enableFeatureFreezePing = true;
   };
 
-  helsinki-systems = {
-    # Verify additions to this team with at least one already existing member of the team.
-    members = [
-      das_j
-      conni2461
-      helsinki-Jo
-    ];
-    scope = "Group registration for packages maintained by Helsinki Systems";
-    shortName = "Helsinki Systems employees";
-  };
-
   home-assistant = {
     members = [
       dotlambda

--- a/nixos/modules/services/web-apps/icingaweb2/icingaweb2.nix
+++ b/nixos/modules/services/web-apps/icingaweb2/icingaweb2.nix
@@ -17,7 +17,10 @@ let
   };
 in
 {
-  meta.maintainers = teams.helsinki-systems.members;
+  meta.maintainers = with lib.maintainers; [
+    das_j
+    helsinki-Jo
+  ];
 
   options.services.icingaweb2 = with types; {
     enable = mkEnableOption "the icingaweb2 web interface";

--- a/nixos/tests/icingaweb2.nix
+++ b/nixos/tests/icingaweb2.nix
@@ -1,9 +1,10 @@
 { pkgs, ... }:
 {
   name = "icingaweb2";
-  meta = {
-    maintainers = pkgs.lib.teams.helsinki-systems.members;
-  };
+  meta.maintainers = with pkgs.lib.maintainers; [
+    das_j
+    helsinki-Jo
+  ];
 
   nodes = {
     icingaweb2 =

--- a/nixos/tests/iscsi-root.nix
+++ b/nixos/tests/iscsi-root.nix
@@ -5,9 +5,13 @@ let
 in
 {
   name = "iscsi";
-  meta = {
-    maintainers = lib.teams.deshaw.members ++ lib.teams.helsinki-systems.members;
-  };
+  meta.maintainers =
+    with lib.maintainers;
+    [
+      das_j
+      helsinki-Jo
+    ]
+    ++ lib.teams.deshaw.members;
 
   nodes = {
     target =

--- a/nixos/tests/lvm2/systemd-stage-1.nix
+++ b/nixos/tests/lvm2/systemd-stage-1.nix
@@ -70,7 +70,10 @@ import ../make-test-python.nix (
   { pkgs, lib, ... }:
   {
     name = "lvm2-${flavour}-systemd-stage-1";
-    meta.maintainers = lib.teams.helsinki-systems.members;
+    meta.maintainers = with lib.maintainers; [
+      das_j
+      helsinki-Jo
+    ];
 
     nodes.machine =
       { pkgs, lib, ... }:

--- a/nixos/tests/lvm2/thinpool.nix
+++ b/nixos/tests/lvm2/thinpool.nix
@@ -6,7 +6,10 @@ import ../make-test-python.nix (
   { pkgs, lib, ... }:
   {
     name = "lvm2-thinpool";
-    meta.maintainers = lib.teams.helsinki-systems.members;
+    meta.maintainers = with lib.maintainers; [
+      das_j
+      helsinki-Jo
+    ];
 
     nodes.machine =
       { pkgs, lib, ... }:

--- a/nixos/tests/mysql/mariadb-galera.nix
+++ b/nixos/tests/mysql/mariadb-galera.nix
@@ -19,9 +19,12 @@ let
     }:
     makeTest {
       name = "${name}-galera-mariabackup";
-      meta = {
-        maintainers = with lib.maintainers; [ izorkin ] ++ lib.teams.helsinki-systems.members;
-      };
+      meta.maintainers = with lib.maintainers; [
+        conni2461
+        das_j
+        helsinki-Jo
+        izorkin
+      ];
 
       # The test creates a Galera cluster with 3 nodes and is checking if mariabackup-based SST works. The cluster is tested by creating a DB and an empty table on one node,
       # and checking the table's presence on the other node.

--- a/nixos/tests/mysql/mysql-replication.nix
+++ b/nixos/tests/mysql/mysql-replication.nix
@@ -20,9 +20,11 @@ let
     }:
     makeTest {
       name = "${name}-replication";
-      meta = {
-        maintainers = lib.teams.helsinki-systems.members;
-      };
+      meta.maintainers = with lib.maintainers; [
+        conni2461
+        das_j
+        helsinki-Jo
+      ];
 
       nodes = {
         primary = {

--- a/nixos/tests/mysql/mysql.nix
+++ b/nixos/tests/mysql/mysql.nix
@@ -25,9 +25,11 @@ let
     }:
     makeTest {
       inherit name;
-      meta = {
-        maintainers = lib.teams.helsinki-systems.members;
-      };
+      meta.maintainers = with lib.maintainers; [
+        conni2461
+        das_j
+        helsinki-Jo
+      ];
 
       nodes = {
         ${name} =

--- a/nixos/tests/redis.nix
+++ b/nixos/tests/redis.nix
@@ -20,9 +20,10 @@ let
     makeTest {
       inherit name;
       meta.maintainers = [
+        lib.maintainers.das_j
         lib.maintainers.flokli
-      ]
-      ++ lib.teams.helsinki-systems.members;
+        lib.maintainers.helsinki-Jo
+      ];
 
       nodes = {
         machine =

--- a/pkgs/by-name/do/dovecot/package.nix
+++ b/pkgs/by-name/do/dovecot/package.nix
@@ -192,9 +192,10 @@ stdenv.mkDerivation rec {
     ];
     mainProgram = "dovecot";
     maintainers = with lib.maintainers; [
+      das_j
       fpletz
+      helsinki-Jo
     ];
-    teams = [ lib.teams.helsinki-systems ];
     platforms = lib.platforms.unix;
   };
   passthru.tests = {

--- a/pkgs/by-name/do/dovecot_pigeonhole/package.nix
+++ b/pkgs/by-name/do/dovecot_pigeonhole/package.nix
@@ -43,8 +43,10 @@ stdenv.mkDerivation rec {
     homepage = "https://pigeonhole.dovecot.org/";
     description = "Sieve plugin for the Dovecot IMAP server";
     license = lib.licenses.lgpl21Only;
-    maintainers = [ ];
-    teams = [ lib.teams.helsinki-systems ];
+    maintainers = with lib.maintainers; [
+      das_j
+      helsinki-Jo
+    ];
     platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/by-name/ex/exim/package.nix
+++ b/pkgs/by-name/ex/exim/package.nix
@@ -200,8 +200,11 @@ stdenv.mkDerivation rec {
     ];
     mainProgram = "exim";
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ tv ];
-    teams = [ lib.teams.helsinki-systems ];
+    maintainers = with lib.maintainers; [
+      das_j
+      helsinki-Jo
+      tv
+    ];
     changelog = "https://github.com/Exim/exim/blob/exim-${version}/doc/doc-txt/ChangeLog";
   };
 }

--- a/pkgs/by-name/fl/flexoptix-app/package.nix
+++ b/pkgs/by-name/fl/flexoptix-app/package.nix
@@ -70,7 +70,10 @@ appimageTools.wrapAppImage {
     homepage = "https://www.flexoptix.net";
     changelog = "https://www.flexoptix.net/en/flexoptix-app/?os=linux#flexapp__modal__changelog";
     license = lib.licenses.unfree;
-    teams = [ lib.teams.helsinki-systems ];
+    maintainers = with lib.maintainers; [
+      das_j
+      helsinki-Jo
+    ];
     platforms = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/by-name/ge/geoipupdate/package.nix
+++ b/pkgs/by-name/ge/geoipupdate/package.nix
@@ -25,7 +25,10 @@ buildGoModule rec {
     description = "Automatic GeoIP database updater";
     homepage = "https://github.com/maxmind/geoipupdate";
     license = with lib.licenses; [ asl20 ];
-    teams = [ lib.teams.helsinki-systems ];
+    maintainers = with lib.maintainers; [
+      das_j
+      helsinki-Jo
+    ];
     mainProgram = "geoipupdate";
   };
 }

--- a/pkgs/by-name/hy/hydra/package.nix
+++ b/pkgs/by-name/hy/hydra/package.nix
@@ -264,7 +264,11 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://nixos.org/hydra";
     license = lib.licenses.gpl3;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ mindavi ];
-    teams = [ lib.teams.helsinki-systems ];
+    maintainers = with lib.maintainers; [
+      conni2461
+      das_j
+      helsinki-Jo
+      mindavi
+    ];
   };
 })

--- a/pkgs/by-name/li/libmaxminddb/package.nix
+++ b/pkgs/by-name/li/libmaxminddb/package.nix
@@ -17,8 +17,11 @@ stdenv.mkDerivation rec {
     description = "C library for working with MaxMind geolocation DB files";
     homepage = "https://github.com/maxmind/libmaxminddb";
     license = lib.licenses.asl20;
-    teams = [ lib.teams.helsinki-systems ];
     mainProgram = "mmdblookup";
+    maintainers = with lib.maintainers; [
+      das_j
+      helsinki-Jo
+    ];
     platforms = lib.platforms.all;
   };
 }

--- a/pkgs/by-name/li/libspf2/package.nix
+++ b/pkgs/by-name/li/libspf2/package.nix
@@ -40,8 +40,11 @@ stdenv.mkDerivation rec {
       lgpl21Plus
       bsd2
     ];
-    maintainers = with lib.maintainers; [ euxane ];
-    teams = [ lib.teams.helsinki-systems ];
+    maintainers = with lib.maintainers; [
+      das_j
+      euxane
+      helsinki-Jo
+    ];
     platforms = lib.platforms.all;
   };
 }

--- a/pkgs/by-name/ma/mariadb-galera/package.nix
+++ b/pkgs/by-name/ma/mariadb-galera/package.nix
@@ -52,8 +52,12 @@ stdenv.mkDerivation rec {
     mainProgram = "garbd";
     homepage = "https://galeracluster.com/";
     license = lib.licenses.lgpl2Only;
-    maintainers = with lib.maintainers; [ izorkin ];
-    teams = [ lib.teams.helsinki-systems ];
+    maintainers = with lib.maintainers; [
+      conni2461
+      das_j
+      helsinki-Jo
+      izorkin
+    ];
     platforms = lib.platforms.all;
     broken = stdenv.hostPlatform.isDarwin;
   };

--- a/pkgs/by-name/op/opendmarc/package.nix
+++ b/pkgs/by-name/op/opendmarc/package.nix
@@ -70,6 +70,9 @@ stdenv.mkDerivation rec {
       bsd3
       sendmail
     ];
-    teams = [ lib.teams.helsinki-systems ];
+    maintainers = with lib.maintainers; [
+      das_j
+      helsinki-Jo
+    ];
   };
 }

--- a/pkgs/by-name/op/openldap/package.nix
+++ b/pkgs/by-name/op/openldap/package.nix
@@ -159,7 +159,11 @@ stdenv.mkDerivation rec {
     homepage = "https://www.openldap.org/";
     description = "Open source implementation of the Lightweight Directory Access Protocol";
     license = lib.licenses.openldap;
-    teams = [ lib.teams.helsinki-systems ];
+    maintainers = with lib.maintainers; [
+      conni2461
+      das_j
+      helsinki-Jo
+    ];
     platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/by-name/ru/rustdesk-flutter/package.nix
+++ b/pkgs/by-name/ru/rustdesk-flutter/package.nix
@@ -248,7 +248,10 @@ flutter329.buildFlutterApplication rec {
     homepage = "https://rustdesk.com";
     changelog = "https://github.com/rustdesk/rustdesk/releases/${version}";
     license = lib.licenses.agpl3Only;
-    teams = [ lib.teams.helsinki-systems ];
+    maintainers = with lib.maintainers; [
+      das_j
+      helsinki-Jo
+    ];
     mainProgram = "rustdesk";
     platforms = lib.platforms.linux; # should work on darwin as well but I have no machine to test with
   };

--- a/pkgs/by-name/un/unifi-protect-backup/package.nix
+++ b/pkgs/by-name/un/unifi-protect-backup/package.nix
@@ -55,7 +55,10 @@ python3.pkgs.buildPythonApplication rec {
     homepage = "https://github.com/ep1cman/unifi-protect-backup";
     changelog = "https://github.com/ep1cman/unifi-protect-backup/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.mit;
-    teams = [ lib.teams.helsinki-systems ];
+    maintainers = with lib.maintainers; [
+      das_j
+      helsinki-Jo
+    ];
     mainProgram = "unifi-protect-backup";
   };
 }

--- a/pkgs/by-name/wi/wimboot/package.nix
+++ b/pkgs/by-name/wi/wimboot/package.nix
@@ -41,7 +41,10 @@ stdenv.mkDerivation rec {
     homepage = "https://ipxe.org/wimboot";
     description = "Windows Imaging Format bootloader";
     license = lib.licenses.gpl2Plus;
-    teams = [ lib.teams.helsinki-systems ];
+    maintainers = with lib.maintainers; [
+      das_j
+      helsinki-Jo
+    ];
     platforms = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/development/php-packages/maxminddb/default.nix
+++ b/pkgs/development/php-packages/maxminddb/default.nix
@@ -28,8 +28,11 @@ buildPecl {
     description = "C extension that is a drop-in replacement for MaxMind\\Db\\Reader";
     license = with lib.licenses; [ asl20 ];
     homepage = "https://github.com/maxmind/MaxMind-DB-Reader-php";
+    maintainers = with lib.maintainers; [
+      das_j
+      helsinki-Jo
+    ];
     teams = [
-      lib.teams.helsinki-systems
       lib.teams.php
     ];
   };

--- a/pkgs/development/python-modules/bitvector-for-humans/default.nix
+++ b/pkgs/development/python-modules/bitvector-for-humans/default.nix
@@ -36,6 +36,9 @@ buildPythonPackage rec {
     homepage = "https://github.com/JnyJny/bitvector";
     description = "This simple bit vector implementation aims to make addressing single bits a little less fiddly";
     license = lib.licenses.asl20;
-    teams = [ lib.teams.helsinki-systems ];
+    maintainers = with lib.maintainers; [
+      das_j
+      helsinki-Jo
+    ];
   };
 }

--- a/pkgs/development/python-modules/busylight-for-humans/default.nix
+++ b/pkgs/development/python-modules/busylight-for-humans/default.nix
@@ -71,7 +71,10 @@ buildPythonPackage rec {
     homepage = "https://github.com/JnyJny/busylight";
     changelog = "https://github.com/JnyJny/busylight/releases/tag/${src.tag}";
     license = lib.licenses.asl20;
-    teams = [ lib.teams.helsinki-systems ];
+    maintainers = with lib.maintainers; [
+      das_j
+      helsinki-Jo
+    ];
     mainProgram = "busylight";
   };
 }

--- a/pkgs/development/python-modules/paramiko/default.nix
+++ b/pkgs/development/python-modules/paramiko/default.nix
@@ -65,6 +65,5 @@ buildPythonPackage rec {
       between python scripts. All major ciphers and hash methods are
       supported. SFTP client and server mode are both supported too.
     '';
-    teams = [ lib.teams.helsinki-systems ];
   };
 }

--- a/pkgs/servers/http/nginx/generic.nix
+++ b/pkgs/servers/http/nginx/generic.nix
@@ -314,11 +314,10 @@ stdenv.mkDerivation {
         broken = lib.any (m: m.meta.broken or false) modules;
         platforms = lib.platforms.all;
         maintainers = with lib.maintainers; [
+          das_j
           fpletz
+          helsinki-Jo
           raitobezarius
-        ];
-        teams = with lib.teams; [
-          helsinki-systems
         ];
       };
 }

--- a/pkgs/servers/icingaweb2/default.nix
+++ b/pkgs/servers/icingaweb2/default.nix
@@ -38,7 +38,10 @@ stdenvNoCC.mkDerivation rec {
     '';
     homepage = "https://www.icinga.com/products/icinga-web-2/";
     license = lib.licenses.gpl2Plus;
-    teams = [ lib.teams.helsinki-systems ];
+    maintainers = with lib.maintainers; [
+      das_j
+      helsinki-Jo
+    ];
     mainProgram = "icingacli";
     platforms = lib.platforms.all;
   };

--- a/pkgs/servers/icingaweb2/ipl.nix
+++ b/pkgs/servers/icingaweb2/ipl.nix
@@ -28,6 +28,9 @@ stdenvNoCC.mkDerivation rec {
     homepage = "https://github.com/Icinga/icinga-php-library";
     license = lib.licenses.mit;
     platforms = lib.platforms.all;
-    teams = [ lib.teams.helsinki-systems ];
+    maintainers = with lib.maintainers; [
+      das_j
+      helsinki-Jo
+    ];
   };
 }

--- a/pkgs/servers/icingaweb2/thirdparty.nix
+++ b/pkgs/servers/icingaweb2/thirdparty.nix
@@ -28,6 +28,9 @@ stdenvNoCC.mkDerivation rec {
     homepage = "https://github.com/Icinga/icinga-php-thirdparty";
     license = lib.licenses.mit;
     platforms = lib.platforms.all;
-    teams = [ lib.teams.helsinki-systems ];
+    maintainers = with lib.maintainers; [
+      das_j
+      helsinki-Jo
+    ];
   };
 }

--- a/pkgs/servers/monitoring/icinga2/default.nix
+++ b/pkgs/servers/monitoring/icinga2/default.nix
@@ -128,6 +128,9 @@ stdenv.mkDerivation rec {
     homepage = "https://www.icinga.com";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux;
-    teams = [ lib.teams.helsinki-systems ];
+    maintainers = with lib.maintainers; [
+      das_j
+      helsinki-Jo
+    ];
   };
 }

--- a/pkgs/servers/nextcloud/notify_push.nix
+++ b/pkgs/servers/nextcloud/notify_push.nix
@@ -63,6 +63,9 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/nextcloud/notify_push";
     license = lib.licenses.agpl3Plus;
     platforms = lib.platforms.linux;
-    teams = [ lib.teams.helsinki-systems ];
+    maintainers = with lib.maintainers; [
+      das_j
+      helsinki-Jo
+    ];
   };
 }

--- a/pkgs/servers/sql/mariadb/default.nix
+++ b/pkgs/servers/sql/mariadb/default.nix
@@ -220,8 +220,12 @@ let
           description = "Enhanced, drop-in replacement for MySQL";
           homepage = "https://mariadb.org/";
           license = lib.licenses.gpl2Plus;
-          maintainers = with lib.maintainers; [ thoughtpolice ];
-          teams = [ lib.teams.helsinki-systems ];
+          maintainers = with lib.maintainers; [
+            conni2461
+            das_j
+            helsinki-Jo
+            thoughtpolice
+          ];
           platforms = lib.platforms.all;
         };
       };

--- a/pkgs/tools/networking/openssh/default.nix
+++ b/pkgs/tools/networking/openssh/default.nix
@@ -30,10 +30,11 @@ in
     ];
     extraMeta = {
       maintainers = with lib.maintainers; [
-        philiptaron
+        das_j
+        helsinki-Jo
         numinit
+        philiptaron
       ];
-      teams = [ lib.teams.helsinki-systems ];
     };
   };
 

--- a/pkgs/tools/text/diffutils/default.nix
+++ b/pkgs/tools/text/diffutils/default.nix
@@ -83,6 +83,9 @@ stdenv.mkDerivation rec {
     description = "Commands for showing the differences between files (diff, cmp, etc.)";
     license = lib.licenses.gpl3;
     platforms = lib.platforms.unix;
-    maintainers = lib.teams.helsinki-systems.members;
+    maintainers = with lib.maintainers; [
+      das_j
+      helsinki-Jo
+    ];
   };
 }

--- a/pkgs/tools/text/gawk/default.nix
+++ b/pkgs/tools/text/gawk/default.nix
@@ -112,7 +112,10 @@ stdenv.mkDerivation rec {
     '';
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.unix ++ lib.platforms.windows;
-    teams = [ lib.teams.helsinki-systems ];
+    maintainers = with lib.maintainers; [
+      das_j
+      helsinki-Jo
+    ];
     mainProgram = "gawk";
   };
 }


### PR DESCRIPTION
The @NixOS/nixpkgs-core team has recently reviewed Nixpkgs teams, and decided that teams should be organized internally around specific topics of maintenance, rather than having membership gated by external criteria. This means having maintainer responsibility and authority decided by consensus of existing maintainers and team members in an area of interest, rather than being granted or revoked based on employment, membership in an external organization, or role in another FOSS project. The reasoning is given in the full statement at https://github.com/NixOS/org/issues/220#issuecomment-3678147410.

We are now triaging teams to make sure they’re in line with this model and working with their members to find the best way forward for each case. This is being tracked at #478780.

@dasJ @Conni2461 @helsinki-Jo 

This team was flagged as apparently having external membership criteria. By default, we’ll merge this to drop the team after a week if we don’t hear back from you, but we’re also happy to implement alternatives, e.g.:

- Redistribute members to maintainer lists of individual packages per their request.
- Reorganize or merge the team into one or more teams relating to specific areas of maintenance interest with open membership criteria.
- Clarify that the team is dedicated to maintenance of software maintained upstream by a certain organization, but is open to all contributors. For example, `lib.teams.jetbrains` and `lib.teams.qt-kde` handle maintenance of JetBrains IDEs and KDE software, but have no expectation that members are affiliated with those organizations, even though some may be.