### PR TITLE
teams/iog: handle team with external membership

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16058,13 +16058,6 @@
     githubId = 7802795;
     name = "Manoj Karthick";
   };
-  manveru = {
-    email = "m.fellinger@gmail.com";
-    matrix = "@manveru:matrix.org";
-    github = "manveru";
-    githubId = 3507;
-    name = "Michael Fellinger";
-  };
   maolonglong = {
     email = "shaolong.chen@outlook.it";
     github = "maolonglong";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6737,12 +6737,6 @@
     githubId = 392583;
     name = "Dirk-Willem van Gulik";
   };
-  disassembler = {
-    email = "disasm@gmail.com";
-    github = "disassembler";
-    githubId = 651205;
-    name = "Samuel Leathers";
-  };
   disserman = {
     email = "disserman@gmail.com";
     github = "divi255";

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -503,7 +503,6 @@ with lib.maintainers;
     members = [
       cleverca22
       disassembler
-      manveru
     ];
     scope = "Input-Output Global employees, which maintain critical software";
     shortName = "Input-Output Global employees";

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -502,7 +502,6 @@ with lib.maintainers;
   iog = {
     members = [
       cleverca22
-      disassembler
     ];
     scope = "Input-Output Global employees, which maintain critical software";
     shortName = "Input-Output Global employees";

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -499,14 +499,6 @@ with lib.maintainers;
     shortName = "Infisical";
   };
 
-  iog = {
-    members = [
-      cleverca22
-    ];
-    scope = "Input-Output Global employees, which maintain critical software";
-    shortName = "Input-Output Global employees";
-  };
-
   java = {
     github = "java";
     enableFeatureFreezePing = true;

--- a/pkgs/by-name/ad/adms/package.nix
+++ b/pkgs/by-name/ad/adms/package.nix
@@ -49,7 +49,6 @@ stdenv.mkDerivation rec {
     description = "Automatic device model synthesizer";
     homepage = "https://github.com/Qucs/adms";
     license = lib.licenses.gpl3;
-    maintainers = with lib.maintainers; [ disassembler ];
     platforms = with lib.platforms; unix;
   };
 }

--- a/pkgs/by-name/ai/airsonic/package.nix
+++ b/pkgs/by-name/ai/airsonic/package.nix
@@ -29,6 +29,5 @@ stdenv.mkDerivation rec {
     sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     license = lib.licenses.gpl3;
     platforms = lib.platforms.all;
-    maintainers = with lib.maintainers; [ disassembler ];
   };
 }

--- a/pkgs/by-name/am/amazon-ssm-agent/package.nix
+++ b/pkgs/by-name/am/amazon-ssm-agent/package.nix
@@ -174,7 +174,6 @@ buildGoModule rec {
     license = lib.licenses.asl20;
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [
-      manveru
       anthonyroussel
       arianvp
     ];

--- a/pkgs/by-name/bo/book-summary/package.nix
+++ b/pkgs/by-name/bo/book-summary/package.nix
@@ -20,6 +20,5 @@ rustPlatform.buildRustPackage rec {
     mainProgram = "book-summary";
     homepage = "https://github.com/dvogt23/book-summary";
     license = lib.licenses.mit;
-    teams = with lib.teams; [ iog ];
   };
 }

--- a/pkgs/by-name/bu/bundix/package.nix
+++ b/pkgs/by-name/bu/bundix/package.nix
@@ -48,7 +48,6 @@ buildRubyGem rec {
     homepage = "https://github.com/nix-community/bundix";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
-      manveru
       zimbatm
     ];
     platforms = lib.platforms.all;

--- a/pkgs/by-name/ca/calamares/package.nix
+++ b/pkgs/by-name/ca/calamares/package.nix
@@ -126,7 +126,6 @@ stdenv.mkDerivation (finalAttrs: {
       cc0
     ];
     maintainers = with lib.maintainers; [
-      manveru
       vlinkz
     ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/cb/cbonsai/package.nix
+++ b/pkgs/by-name/cb/cbonsai/package.nix
@@ -35,7 +35,6 @@ stdenv.mkDerivation rec {
     mainProgram = "cbonsai";
     homepage = "https://gitlab.com/jallbrit/cbonsai";
     license = with lib.licenses; [ gpl3Only ];
-    maintainers = with lib.maintainers; [ manveru ];
     platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/by-name/cr/crystal2nix/package.nix
+++ b/pkgs/by-name/cr/crystal2nix/package.nix
@@ -40,7 +40,6 @@ crystal.buildCrystalPackage rec {
     mainProgram = "crystal2nix";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
-      manveru
       peterhoeg
     ];
   };

--- a/pkgs/by-name/cu/cucumber/package.nix
+++ b/pkgs/by-name/cu/cucumber/package.nix
@@ -18,7 +18,6 @@ bundlerApp {
     license = lib.licenses.mit;
     mainProgram = "cucumber";
     maintainers = with lib.maintainers; [
-      manveru
       nicknovitski
       anthonyroussel
     ];

--- a/pkgs/by-name/da/damon/package.nix
+++ b/pkgs/by-name/da/damon/package.nix
@@ -21,7 +21,6 @@ buildGoModule {
     homepage = "https://github.com/hashicorp/damon";
     license = lib.licenses.mpl20;
     description = "Terminal UI (TUI) for HashiCorp Nomad";
-    teams = [ lib.teams.iog ];
     mainProgram = "damon";
   };
 }

--- a/pkgs/by-name/db/dbmate/package.nix
+++ b/pkgs/by-name/db/dbmate/package.nix
@@ -25,6 +25,5 @@ buildGoModule rec {
     homepage = "https://github.com/amacneil/dbmate";
     changelog = "https://github.com/amacneil/dbmate/releases/tag/v${version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ manveru ];
   };
 }

--- a/pkgs/by-name/di/di/package.nix
+++ b/pkgs/by-name/di/di/package.nix
@@ -19,7 +19,6 @@ stdenv.mkDerivation rec {
     description = "Disk information utility; displays everything 'df' does and more";
     homepage = "https://diskinfo-di.sourceforge.io/";
     license = lib.licenses.zlib;
-    maintainers = with lib.maintainers; [ manveru ];
     platforms = lib.platforms.all;
   };
 }

--- a/pkgs/by-name/ej/ejson/package.nix
+++ b/pkgs/by-name/ej/ejson/package.nix
@@ -27,6 +27,5 @@ buildGoModule rec {
     mainProgram = "ejson";
     license = lib.licenses.mit;
     homepage = "https://github.com/Shopify/ejson";
-    maintainers = [ lib.maintainers.manveru ];
   };
 }

--- a/pkgs/by-name/en/enter-tex/package.nix
+++ b/pkgs/by-name/en/enter-tex/package.nix
@@ -76,7 +76,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://gitlab.gnome.org/World/gedit/enter-tex";
     description = "LaTeX editor for the GNOME desktop";
     maintainers = with lib.maintainers; [
-      manveru
       bobby285271
     ];
     license = lib.licenses.gpl3Plus;

--- a/pkgs/by-name/go/google-fonts/package.nix
+++ b/pkgs/by-name/go/google-fonts/package.nix
@@ -78,7 +78,6 @@ stdenvNoCC.mkDerivation {
     ];
     platforms = lib.platforms.all;
     hydraPlatforms = [ ];
-    maintainers = with lib.maintainers; [ manveru ];
     sourceProvenance = [ lib.sourceTypes.binaryBytecode ];
   };
 }

--- a/pkgs/by-name/gr/grafana-reporter/package.nix
+++ b/pkgs/by-name/gr/grafana-reporter/package.nix
@@ -39,6 +39,5 @@ buildGoModule rec {
     mainProgram = "grafana-reporter";
     homepage = "https://github.com/IzakMarais/reporter";
     license = lib.licenses.mit;
-    maintainers = [ lib.maintainers.disassembler ];
   };
 }

--- a/pkgs/by-name/hu/hue-cli/package.nix
+++ b/pkgs/by-name/hu/hue-cli/package.nix
@@ -17,7 +17,6 @@ bundlerApp {
     license = lib.licenses.mit;
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [
-      manveru
       nicknovitski
     ];
     mainProgram = "hue";

--- a/pkgs/by-name/ik/iksemel/package.nix
+++ b/pkgs/by-name/ik/iksemel/package.nix
@@ -37,7 +37,6 @@ stdenv.mkDerivation rec {
 
     homepage = "https://github.com/timothytylee/iksemel-1.4";
     license = lib.licenses.gpl2;
-    maintainers = with lib.maintainers; [ disassembler ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/le/ledger-web/package.nix
+++ b/pkgs/by-name/le/ledger-web/package.nix
@@ -26,7 +26,6 @@ bundlerApp {
     homepage = "https://github.com/peterkeen/ledger-web";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
-      manveru
       nicknovitski
     ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/li/libgedit-amtk/package.nix
+++ b/pkgs/by-name/li/libgedit-amtk/package.nix
@@ -77,7 +77,6 @@ stdenv.mkDerivation rec {
     changelog = "https://gitlab.gnome.org/World/gedit/libgedit-amtk/-/blob/${version}/NEWS?ref_type=tags";
     description = "Actions, Menus and Toolbars Kit for GTK applications";
     maintainers = with lib.maintainers; [
-      manveru
       bobby285271
     ];
     license = lib.licenses.lgpl21Plus;

--- a/pkgs/by-name/li/libgedit-tepl/package.nix
+++ b/pkgs/by-name/li/libgedit-tepl/package.nix
@@ -68,7 +68,6 @@ stdenv.mkDerivation rec {
     homepage = "https://gitlab.gnome.org/World/gedit/libgedit-tepl";
     description = "Text editor product line";
     maintainers = with lib.maintainers; [
-      manveru
       bobby285271
     ];
     license = lib.licenses.lgpl3Plus;

--- a/pkgs/by-name/li/lifelines/package.nix
+++ b/pkgs/by-name/li/lifelines/package.nix
@@ -36,7 +36,6 @@ stdenv.mkDerivation {
     description = "Genealogy tool with ncurses interface";
     homepage = "https://lifelines.github.io/lifelines/";
     license = lib.licenses.mit;
-    maintainers = [ lib.maintainers.disassembler ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/lo/lolcat/package.nix
+++ b/pkgs/by-name/lo/lolcat/package.nix
@@ -18,7 +18,6 @@
     license = lib.licenses.bsd3;
     maintainers = [
       lib.maintainers.StillerHarpo
-      lib.maintainers.manveru
       lib.maintainers.nicknovitski
     ];
     mainProgram = "lolcat";

--- a/pkgs/by-name/ma/mailhog/package.nix
+++ b/pkgs/by-name/ma/mailhog/package.nix
@@ -40,7 +40,6 @@ buildGoModule rec {
     homepage = "https://github.com/mailhog/MailHog";
     changelog = "https://github.com/mailhog/MailHog/releases/tag/v${version}";
     maintainers = with lib.maintainers; [
-      disassembler
       jojosch
     ];
     license = lib.licenses.mit;

--- a/pkgs/by-name/ma/marathonctl/package.nix
+++ b/pkgs/by-name/ma/marathonctl/package.nix
@@ -26,7 +26,6 @@ buildGoModule rec {
     homepage = "https://github.com/shoenig/marathonctl";
     description = "CLI tool for Marathon";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ manveru ];
     mainProgram = "marathonctl";
   };
 }

--- a/pkgs/by-name/ma/matter-compiler/package.nix
+++ b/pkgs/by-name/ma/matter-compiler/package.nix
@@ -20,7 +20,6 @@ bundlerApp {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       rvlander
-      manveru
       nicknovitski
     ];
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/md/mdl/package.nix
+++ b/pkgs/by-name/md/mdl/package.nix
@@ -17,7 +17,6 @@ bundlerApp {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       gerschtli
-      manveru
       nicknovitski
       totoroot
     ];

--- a/pkgs/by-name/mi/mint/package.nix
+++ b/pkgs/by-name/mi/mint/package.nix
@@ -40,6 +40,5 @@ crystal.buildCrystalPackage rec {
     mainProgram = "mint";
     homepage = "https://www.mint-lang.com/";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ manveru ];
   };
 }

--- a/pkgs/by-name/mp/mpdcron/package.nix
+++ b/pkgs/by-name/mp/mpdcron/package.nix
@@ -65,7 +65,6 @@ stdenv.mkDerivation {
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [
       lovek323
-      manveru
     ];
   };
 }

--- a/pkgs/by-name/pd/pdns/package.nix
+++ b/pkgs/by-name/pd/pdns/package.nix
@@ -108,7 +108,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl2Only;
     maintainers = with lib.maintainers; [
       mic92
-      disassembler
       nickcao
     ];
   };

--- a/pkgs/by-name/pr/procodile/package.nix
+++ b/pkgs/by-name/pr/procodile/package.nix
@@ -16,7 +16,6 @@ bundlerApp {
     homepage = "https://github.com/adamcooke/procodile";
     license = with lib.licenses; mit;
     maintainers = with lib.maintainers; [
-      manveru
       nicknovitski
     ];
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/pr/prometheus-surfboard-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-surfboard-exporter/package.nix
@@ -29,7 +29,6 @@ buildGoModule rec {
     mainProgram = "surfboard_exporter";
     homepage = "https://github.com/ipstatic/surfboard_exporter";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ disassembler ];
     platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/by-name/pt/pt/package.nix
+++ b/pkgs/by-name/pt/pt/package.nix
@@ -16,7 +16,6 @@ bundlerApp {
     homepage = "http://www.github.com/raul/pt";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
-      manveru
       nicknovitski
     ];
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/r1/r10k/package.nix
+++ b/pkgs/by-name/r1/r10k/package.nix
@@ -42,7 +42,6 @@ bundlerApp rec {
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       zimbatm
-      manveru
       nicknovitski
       anthonyroussel
     ];

--- a/pkgs/by-name/ra/rake/package.nix
+++ b/pkgs/by-name/ra/rake/package.nix
@@ -16,7 +16,6 @@ bundlerApp {
     homepage = "https://github.com/ruby/rake";
     license = with lib.licenses; mit;
     maintainers = with lib.maintainers; [
-      manveru
       nicknovitski
     ];
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/re/redis-dump/package.nix
+++ b/pkgs/by-name/re/redis-dump/package.nix
@@ -20,7 +20,6 @@ bundlerApp {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       offline
-      manveru
       nicknovitski
     ];
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/ri/riemann-dash/package.nix
+++ b/pkgs/by-name/ri/riemann-dash/package.nix
@@ -16,7 +16,6 @@ bundlerApp {
     homepage = "https://github.com/riemann/riemann-dash";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
-      manveru
       nicknovitski
     ];
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/ri/riemann-tools/package.nix
+++ b/pkgs/by-name/ri/riemann-tools/package.nix
@@ -36,7 +36,6 @@ bundlerApp {
     description = "Tools to submit data to Riemann";
     homepage = "https://riemann.io";
     maintainers = with lib.maintainers; [
-      manveru
       nicknovitski
     ];
     license = lib.licenses.mit;

--- a/pkgs/by-name/sa/sass/package.nix
+++ b/pkgs/by-name/sa/sass/package.nix
@@ -21,7 +21,6 @@ bundlerApp {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       romildo
-      manveru
       nicknovitski
     ];
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/t/t/package.nix
+++ b/pkgs/by-name/t/t/package.nix
@@ -17,7 +17,6 @@ bundlerApp {
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       offline
-      manveru
       nicknovitski
     ];
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/ta/taskjuggler/package.nix
+++ b/pkgs/by-name/ta/taskjuggler/package.nix
@@ -29,7 +29,6 @@ bundlerApp {
     license = lib.licenses.gpl2;
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [
-      manveru
       nicknovitski
     ];
   };

--- a/pkgs/by-name/te/terraform-landscape/package.nix
+++ b/pkgs/by-name/te/terraform-landscape/package.nix
@@ -18,7 +18,6 @@ bundlerApp {
     license = with lib.licenses; asl20;
     maintainers = with lib.maintainers; [
       mbode
-      manveru
       nicknovitski
     ];
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/ti/timetrap/package.nix
+++ b/pkgs/by-name/ti/timetrap/package.nix
@@ -55,7 +55,6 @@ stdenv.mkDerivation {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       jerith666
-      manveru
       nicknovitski
     ];
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/wa/wayback_machine_downloader/package.nix
+++ b/pkgs/by-name/wa/wayback_machine_downloader/package.nix
@@ -14,7 +14,6 @@ bundlerApp {
     description = "Download websites from the Internet Archive Wayback Machine";
     homepage = "https://github.com/hartator/wayback-machine-downloader";
     license = lib.licenses.mit;
-    maintainers = [ lib.maintainers.manveru ];
     platforms = lib.platforms.all;
     mainProgram = "wayback_machine_downloader";
   };

--- a/pkgs/by-name/wp/wpscan/package.nix
+++ b/pkgs/by-name/wp/wpscan/package.nix
@@ -26,7 +26,6 @@ bundlerApp {
     license = lib.licenses.unfreeRedistributable;
     maintainers = with lib.maintainers; [
       nyanloutre
-      manveru
     ];
     platforms = lib.platforms.unix;
   };

--- a/pkgs/development/compilers/crystal/default.nix
+++ b/pkgs/development/compilers/crystal/default.nix
@@ -275,7 +275,6 @@ let
         license = lib.licenses.asl20;
         maintainers = with lib.maintainers; [
           david50407
-          manveru
           peterhoeg
           donovanglover
         ];

--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -350,7 +350,6 @@ let
             description = "Object-oriented language for quick and easy programming";
             homepage = "https://www.ruby-lang.org/";
             license = lib.licenses.ruby;
-            maintainers = with lib.maintainers; [ manveru ];
             platforms = lib.platforms.all;
             mainProgram = "ruby";
             knownVulnerabilities = op (lib.versionOlder ver.majMin "3.0") "This Ruby release has reached its end of life. See https://www.ruby-lang.org/en/downloads/branches/.";

--- a/pkgs/development/libraries/gecode/3.nix
+++ b/pkgs/development/libraries/gecode/3.nix
@@ -35,6 +35,5 @@ stdenv.mkDerivation rec {
     homepage = "https://www.gecode.org";
     description = "Toolkit for developing constraint-based systems";
     platforms = lib.platforms.all;
-    maintainers = [ lib.maintainers.manveru ];
   };
 }

--- a/pkgs/development/python-modules/cccolutils/default.nix
+++ b/pkgs/development/python-modules/cccolutils/default.nix
@@ -39,6 +39,5 @@ buildPythonPackage rec {
     description = "Python Kerberos 5 Credential Cache Collection Utilities";
     homepage = "https://pagure.io/cccolutils";
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [ disassembler ];
   };
 }

--- a/pkgs/development/python-modules/openidc-client/default.nix
+++ b/pkgs/development/python-modules/openidc-client/default.nix
@@ -22,6 +22,5 @@ buildPythonPackage rec {
     description = "CLI python OpenID Connect client with token caching and management";
     homepage = "https://github.com/puiterwijk";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ disassembler ];
   };
 }

--- a/pkgs/development/python-modules/rpmfluff/default.nix
+++ b/pkgs/development/python-modules/rpmfluff/default.nix
@@ -22,6 +22,5 @@ buildPythonPackage rec {
     description = "Lightweight way of building RPMs, and sabotaging them";
     homepage = "https://pagure.io/rpmfluff";
     license = lib.licenses.gpl2;
-    maintainers = with lib.maintainers; [ disassembler ];
   };
 }

--- a/pkgs/development/tools/build-managers/drake/default.nix
+++ b/pkgs/development/tools/build-managers/drake/default.nix
@@ -16,7 +16,6 @@ bundlerApp {
     homepage = "http://quix.github.io/rake/";
     maintainers = with lib.maintainers; [
       romildo
-      manveru
       nicknovitski
     ];
     license = lib.licenses.mit;

--- a/pkgs/development/tools/compass/default.nix
+++ b/pkgs/development/tools/compass/default.nix
@@ -20,7 +20,6 @@ bundlerEnv {
     license = with lib.licenses; mit;
     maintainers = with lib.maintainers; [
       offline
-      manveru
       nicknovitski
     ];
     mainProgram = "compass";

--- a/pkgs/development/tools/haskell/vaultenv/default.nix
+++ b/pkgs/development/tools/haskell/vaultenv/default.nix
@@ -88,6 +88,5 @@ mkDerivation rec {
   license = lib.licenses.bsd3;
   maintainers = with lib.maintainers; [
     lnl7
-    manveru
   ];
 }

--- a/pkgs/tools/package-management/fpm/default.nix
+++ b/pkgs/tools/package-management/fpm/default.nix
@@ -16,7 +16,6 @@ bundlerApp {
     homepage = "https://github.com/jordansissel/fpm";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
-      manveru
       nicknovitski
     ];
     platforms = lib.platforms.unix;


### PR DESCRIPTION
The @NixOS/nixpkgs-core team has recently reviewed Nixpkgs teams, and decided that teams should be organized internally around specific topics of maintenance, rather than having membership gated by external criteria. This means having maintainer responsibility and authority decided by consensus of existing maintainers and team members in an area of interest, rather than being granted or revoked based on employment, membership in an external organization, or role in another FOSS project. The reasoning is given in the full statement at https://github.com/NixOS/org/issues/220#issuecomment-3678147410.

We are now triaging teams to make sure they’re in line with this model and working with their members to find the best way forward for each case. This is being tracked at #478780.

@cleverca22 @disassembler @manveru 

This team was flagged as apparently having external membership criteria. By default, we’ll merge this to drop the team after a week if we don’t hear back from you, but we’re also happy to implement alternatives, e.g.:

- Redistribute members to maintainer lists of individual packages per their request.
- Reorganize or merge the team into one or more teams relating to specific areas of maintenance interest with open membership criteria.
- Clarify that the team is dedicated to maintenance of software maintained upstream by a certain organization, but is open to all contributors. For example, `lib.teams.jetbrains` and `lib.teams.qt-kde` handle maintenance of JetBrains IDEs and KDE software, but have no expectation that members are affiliated with those organizations, even though some may be.