### PR TITLE
teams/lumiguide: handle team with external membership

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22688,12 +22688,6 @@
     githubId = 53882428;
     name = "Erik Rodriguez";
   };
-  roelvandijk = {
-    email = "roel@lambdacube.nl";
-    github = "roelvandijk";
-    githubId = 710906;
-    name = "Roel van Dijk";
-  };
   rogarb = {
     email = "rogarb@rgarbage.fr";
     github = "rogarb";

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -615,7 +615,6 @@ with lib.maintainers;
   lumiguide = {
     # Verify additions by approval of an already existing member of the team.
     members = [
-      roelvandijk
       lucus16
     ];
     scope = "Group registration for LumiGuide employees who collectively maintain packages.";

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -612,15 +612,6 @@ with lib.maintainers;
     enableFeatureFreezePing = true;
   };
 
-  lumiguide = {
-    # Verify additions by approval of an already existing member of the team.
-    members = [
-      lucus16
-    ];
-    scope = "Group registration for LumiGuide employees who collectively maintain packages.";
-    shortName = "Lumiguide employees";
-  };
-
   lumina = {
     github = "lumina";
     enableFeatureFreezePing = true;

--- a/nixos/modules/hardware/openrazer.nix
+++ b/nixos/modules/hardware/openrazer.nix
@@ -177,8 +177,4 @@ in
       };
     };
   };
-
-  meta = {
-    maintainers = with lib.maintainers; [ roelvandijk ];
-  };
 }

--- a/pkgs/by-name/es/esptool/package.nix
+++ b/pkgs/by-name/es/esptool/package.nix
@@ -119,7 +119,6 @@ python3Packages.buildPythonApplication rec {
       dezgeg
       dotlambda
     ];
-    teams = [ lib.teams.lumiguide ];
     platforms = with lib.platforms; linux ++ darwin;
     mainProgram = "esptool";
   };

--- a/pkgs/by-name/pi/picoscope/package.nix
+++ b/pkgs/by-name/pi/picoscope/package.nix
@@ -108,7 +108,7 @@ stdenv.mkDerivation {
 
   meta = {
     homepage = "https://www.picotech.com/downloads/linux";
-    maintainers = with lib.maintainers; [ wirew0rm ] ++ lib.teams.lumiguide.members;
+    maintainers = with lib.maintainers; [ wirew0rm ];
     platforms = [ "x86_64-linux" ];
     license = lib.licenses.unfree;
     sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];

--- a/pkgs/development/python-modules/openrazer/common.nix
+++ b/pkgs/development/python-modules/openrazer/common.nix
@@ -14,7 +14,6 @@ rec {
     homepage = "https://openrazer.github.io/";
     license = lib.licenses.gpl2Only;
     maintainers = with lib.maintainers; [ evanjs ];
-    teams = [ lib.teams.lumiguide ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/os-specific/linux/it87/default.nix
+++ b/pkgs/os-specific/linux/it87/default.nix
@@ -41,6 +41,5 @@ stdenv.mkDerivation rec {
       "x86_64-linux"
       "i686-linux"
     ];
-    teams = [ lib.teams.lumiguide ];
   };
 }


### PR DESCRIPTION
The @NixOS/nixpkgs-core team has recently reviewed Nixpkgs teams, and decided that teams should be organized internally around specific topics of maintenance, rather than having membership gated by external criteria. This means having maintainer responsibility and authority decided by consensus of existing maintainers and team members in an area of interest, rather than being granted or revoked based on employment, membership in an external organization, or role in another FOSS project. The reasoning is given in the full statement at https://github.com/NixOS/org/issues/220#issuecomment-3678147410.

We are now triaging teams to make sure they’re in line with this model and working with their members to find the best way forward for each case. This is being tracked at #478780.

@roelvandijk @Lucus16 

This team was flagged as apparently having external membership criteria. By default, we’ll merge this to drop the team after a week if we don’t hear back from you, but we’re also happy to implement alternatives, e.g.:

- Redistribute members to maintainer lists of individual packages per their request.
- Reorganize or merge the team into one or more teams relating to specific areas of maintenance interest with open membership criteria.
- Clarify that the team is dedicated to maintenance of software maintained upstream by a certain organization, but is open to all contributors. For example, `lib.teams.jetbrains` and `lib.teams.qt-kde` handle maintenance of JetBrains IDEs and KDE software, but have no expectation that members are affiliated with those organizations, even though some may be.