### PR TITLE
wg-access-server: 0.12.1 -> 0.13.1

### DIFF
--- a/pkgs/by-name/wg/wg-access-server/package.nix
+++ b/pkgs/by-name/wg/wg-access-server/package.nix
@@ -8,14 +8,14 @@
   nixosTests,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "wg-access-server";
   version = "0.12.1";
 
   src = fetchFromGitHub {
     owner = "freifunkMUC";
     repo = "wg-access-server";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-AhFqEmHrx9MCdjnB/YA3qU7KsaMyLO+vo53VWUrcL8I=";
   };
 
@@ -34,12 +34,12 @@ buildGoModule rec {
   checkFlags = [ "-skip=TestDNSProxy_ServeDNS" ];
 
   ui = buildNpmPackage {
-    inherit version src;
+    inherit (finalAttrs) version src;
     pname = "wg-access-server-ui";
 
     npmDepsHash = "sha256-04AkSDSKsr20Jbx5BJy36f8kWNlzzplu/xnoDTkU8OQ=";
 
-    sourceRoot = "${src.name}/website";
+    sourceRoot = "${finalAttrs.src.name}/website";
 
     installPhase = ''
       mv build $out
@@ -48,11 +48,11 @@ buildGoModule rec {
 
   postPatch = ''
     substituteInPlace internal/services/website_router.go \
-        --replace-fail 'website/build' "${ui}"
+        --replace-fail 'website/build' "${finalAttrs.ui}"
   '';
 
   preBuild = ''
-    VERSION=v${version} go generate buildinfo/buildinfo.go
+    VERSION=v${finalAttrs.version} go generate buildinfo/buildinfo.go
   '';
 
   postInstall = ''
@@ -72,4 +72,4 @@ buildGoModule rec {
     maintainers = with lib.maintainers; [ xanderio ];
     mainProgram = "wg-access-server";
   };
-}
+})

--- a/pkgs/by-name/wg/wg-access-server/package.nix
+++ b/pkgs/by-name/wg/wg-access-server/package.nix
@@ -6,6 +6,7 @@
   makeWrapper,
   iptables,
   nixosTests,
+  nodejs_22,
 }:
 
 buildGoModule (finalAttrs: {
@@ -36,6 +37,8 @@ buildGoModule (finalAttrs: {
   ui = buildNpmPackage {
     inherit (finalAttrs) version src;
     pname = "wg-access-server-ui";
+
+    nodejs = nodejs_22;
 
     npmDepsHash = "sha256-04AkSDSKsr20Jbx5BJy36f8kWNlzzplu/xnoDTkU8OQ=";
 

--- a/pkgs/by-name/wg/wg-access-server/package.nix
+++ b/pkgs/by-name/wg/wg-access-server/package.nix
@@ -11,17 +11,17 @@
 
 buildGoModule (finalAttrs: {
   pname = "wg-access-server";
-  version = "0.12.1";
+  version = "0.13.1";
 
   src = fetchFromGitHub {
     owner = "freifunkMUC";
     repo = "wg-access-server";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-AhFqEmHrx9MCdjnB/YA3qU7KsaMyLO+vo53VWUrcL8I=";
+    hash = "sha256-x4QNEn5SR6D1YIiv+mKnQlZ94jZ7BrdIxiLxBqhtBjg=";
   };
 
   proxyVendor = true; # darwin/linux hash mismatch
-  vendorHash = "sha256-YwFq0KxUctU3ElZBo/b68pyp4lJnFGL9ClKIwUzdngM=";
+  vendorHash = "sha256-pjQeF1+1gr/0pF76KNdK7GDX3pYBTqqY3xbJeMLsJIM=";
 
   env.CGO_ENABLED = 1;
 
@@ -40,7 +40,7 @@ buildGoModule (finalAttrs: {
 
     nodejs = nodejs_22;
 
-    npmDepsHash = "sha256-04AkSDSKsr20Jbx5BJy36f8kWNlzzplu/xnoDTkU8OQ=";
+    npmDepsHash = "sha256-UntV5+9E2lyp8IQGKbbnBNdd0JLvM5NsfkLvCSOgyGo=";
 
     sourceRoot = "${finalAttrs.src.name}/website";
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Refactor to use `finalAttrs`
pin nodejs to `nodejs_22` to workaround a recent build failure due to the update of the default nodejs version.
update to 1.13.1 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
