### PR TITLE
teams/ngi: handle team with external membership

### DIFF
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -724,19 +724,6 @@ with lib.maintainers;
     enableFeatureFreezePing = true;
   };
 
-  ngi = {
-    members = [
-      eljamm
-      ethancedwards8
-      fricklerhandwerk
-      OPNA2608
-      prince213
-      wegank
-    ];
-    scope = "Maintain NGI-supported software.";
-    shortName = "NGI";
-  };
-
   nim = {
     github = "nim";
     enableFeatureFreezePing = true;

--- a/nixos/modules/services/security/reaction.nix
+++ b/nixos/modules/services/security/reaction.nix
@@ -200,11 +200,8 @@ in
       environment.systemPackages = [ cfg.package ];
     };
 
-  meta.maintainers =
-    with lib.maintainers;
-    [
-      ppom
-      phanirithvij
-    ]
-    ++ lib.teams.ngi.members;
+  meta.maintainers = with lib.maintainers; [
+    ppom
+    phanirithvij
+  ];
 }

--- a/nixos/modules/services/web-apps/peertube-runner.nix
+++ b/nixos/modules/services/web-apps/peertube-runner.nix
@@ -251,6 +251,4 @@ in
       ${cfg.group} = { };
     };
   };
-
-  meta.maintainers = lib.teams.ngi.members;
 }

--- a/nixos/tests/blint.nix
+++ b/nixos/tests/blint.nix
@@ -7,12 +7,9 @@
 {
   name = "owasp blint test";
 
-  meta.maintainers =
-    with lib;
-    [
-      maintainers.ethancedwards8
-    ]
-    ++ teams.ngi.members;
+  meta.maintainers = with lib; [
+    maintainers.ethancedwards8
+  ];
 
   nodes.machine = {
     environment.systemPackages = with pkgs; [

--- a/nixos/tests/corteza.nix
+++ b/nixos/tests/corteza.nix
@@ -4,7 +4,6 @@ let
 in
 {
   name = "corteza";
-  meta.maintainers = lib.teams.ngi.members;
 
   nodes.machine = {
     services.corteza = {

--- a/nixos/tests/dep-scan.nix
+++ b/nixos/tests/dep-scan.nix
@@ -7,12 +7,9 @@
 {
   name = "owasp dep-scan test";
 
-  meta.maintainers =
-    with lib;
-    [
-      maintainers.ethancedwards8
-    ]
-    ++ teams.ngi.members;
+  meta.maintainers = with lib; [
+    maintainers.ethancedwards8
+  ];
 
   nodes.machine = {
     environment.systemPackages = with pkgs; [

--- a/nixos/tests/mitmproxy.nix
+++ b/nixos/tests/mitmproxy.nix
@@ -9,7 +9,6 @@ let
 in
 {
   name = "mitmproxy";
-  meta.maintainers = lib.teams.ngi.members;
 
   nodes.machine =
     { pkgs, ... }:

--- a/nixos/tests/nominatim.nix
+++ b/nixos/tests/nominatim.nix
@@ -10,7 +10,7 @@ in
 {
   name = "nominatim";
   meta = {
-    maintainers = with lib.teams; geospatial.members ++ ngi.members;
+    maintainers = with lib.teams; geospatial.members;
   };
 
   nodes = {

--- a/nixos/tests/reaction-firewall.nix
+++ b/nixos/tests/reaction-firewall.nix
@@ -69,11 +69,8 @@
   # - run_tests()
   interactive.sshBackdoor.enable = true; # ssh -o User=root vsock%3
 
-  meta.maintainers =
-    with lib.maintainers;
-    [
-      ppom
-      phanirithvij
-    ]
-    ++ lib.teams.ngi.members;
+  meta.maintainers = with lib.maintainers; [
+    ppom
+    phanirithvij
+  ];
 }

--- a/nixos/tests/reaction.nix
+++ b/nixos/tests/reaction.nix
@@ -100,11 +100,8 @@
       ];
     };
 
-  meta.maintainers =
-    with lib.maintainers;
-    [
-      ppom
-      phanirithvij
-    ]
-    ++ lib.teams.ngi.members;
+  meta.maintainers = with lib.maintainers; [
+    ppom
+    phanirithvij
+  ];
 }

--- a/nixos/tests/taler/tests/basic.nix
+++ b/nixos/tests/taler/tests/basic.nix
@@ -12,9 +12,6 @@ import ../../make-test-python.nix (
     # - run_tests()
 
     name = "GNU Taler Basic Test";
-    meta = {
-      maintainers = lib.teams.ngi.members;
-    };
 
     # Taler components virtual-machine nodes
     nodes = {

--- a/nixos/tests/web-apps/peertube.nix
+++ b/nixos/tests/web-apps/peertube.nix
@@ -9,7 +9,7 @@ import ../make-test-python.nix (
   in
   {
     name = "peertube";
-    meta.maintainers = with lib.maintainers; [ izorkin ] ++ lib.teams.ngi.members;
+    meta.maintainers = with lib.maintainers; [ izorkin ];
 
     nodes = {
       database = {

--- a/pkgs/applications/editors/vscode/extensions/teamtype.teamtype/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/teamtype.teamtype/default.nix
@@ -17,6 +17,5 @@ vscode-utils.buildVscodeMarketplaceExtension {
     homepage = "https://github.com/teamtype/teamtype/tree/main/vscode-plugin";
     license = lib.licenses.agpl3Plus;
     maintainers = [ lib.maintainers.ethancedwards8 ];
-    teams = [ lib.teams.ngi ];
   };
 }

--- a/pkgs/by-name/ae/aerogramme/package.nix
+++ b/pkgs/by-name/ae/aerogramme/package.nix
@@ -42,7 +42,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://aerogramme.deuxfleurs.fr/";
     license = lib.licenses.eupl12;
     maintainers = with lib.maintainers; [ supinie ];
-    teams = with lib.teams; [ ngi ];
     mainProgram = "aerogramme";
     platforms = lib.platforms.linux;
   };

--- a/pkgs/by-name/ag/agorakit/package.nix
+++ b/pkgs/by-name/ag/agorakit/package.nix
@@ -39,6 +39,5 @@ php82.buildComposerProject2 (finalAttrs: {
     license = lib.licenses.agpl3Only;
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [ shogo ];
-    teams = with lib.teams; [ ngi ];
   };
 })

--- a/pkgs/by-name/al/alive2/package.nix
+++ b/pkgs/by-name/al/alive2/package.nix
@@ -67,7 +67,6 @@ clangStdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.mit;
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [ shogo ];
-    teams = [ lib.teams.ngi ];
     mainProgram = "alive";
   };
 })

--- a/pkgs/by-name/ar/arcan/package.nix
+++ b/pkgs/by-name/ar/arcan/package.nix
@@ -199,7 +199,6 @@ stdenv.mkDerivation (finalAttrs: {
       lgpl2Plus
     ];
     maintainers = [ ];
-    teams = with lib.teams; [ ngi ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/ar/arpa2-leaf/package.nix
+++ b/pkgs/by-name/ar/arpa2-leaf/package.nix
@@ -44,7 +44,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://gitlab.com/arpa2/leaf";
     changelog = "https://gitlab.com/arpa2/leaf/-/blob/v${finalAttrs.version}/CHANGES";
     license = lib.licenses.bsd2;
-    teams = with lib.teams; [ ngi ];
     maintainers = with lib.maintainers; [ ethancedwards8 ];
     platforms = lib.platforms.linux;
   };

--- a/pkgs/by-name/au/autobase/package.nix
+++ b/pkgs/by-name/au/autobase/package.nix
@@ -38,6 +38,5 @@ buildNpmPackage (finalAttrs: {
     homepage = "https://github.com/holepunchto/autobase";
     license = lib.licenses.mit;
     maintainers = [ ];
-    teams = with lib.teams; [ ngi ];
   };
 })

--- a/pkgs/by-name/bl/blink-qt/package.nix
+++ b/pkgs/by-name/bl/blink-qt/package.nix
@@ -78,7 +78,6 @@ python3Packages.buildPythonApplication rec {
     downloadPage = "https://github.com/agprojects/blink-qt";
     changelog = "https://github.com/AGProjects/blink-qt/releases/tag/${version}";
     license = lib.licenses.gpl3Plus;
-    teams = [ lib.teams.ngi ];
     platforms = lib.platforms.unix;
     mainProgram = "blink";
   };

--- a/pkgs/by-name/bl/blint/package.nix
+++ b/pkgs/by-name/bl/blint/package.nix
@@ -68,7 +68,6 @@ python3Packages.buildPythonApplication rec {
     license = lib.licenses.mit;
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ ethancedwards8 ];
-    teams = with lib.teams; [ ngi ];
     mainProgram = "blint";
   };
 }

--- a/pkgs/by-name/br/briar-desktop/package.nix
+++ b/pkgs/by-name/br/briar-desktop/package.nix
@@ -68,7 +68,6 @@ stdenv.mkDerivation (finalAttrs: {
       onny
       supinie
     ];
-    teams = with lib.teams; [ ngi ];
     platforms = [ "x86_64-linux" ];
   };
 })

--- a/pkgs/by-name/cn/cnsprcy/package.nix
+++ b/pkgs/by-name/cn/cnsprcy/package.nix
@@ -33,7 +33,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
       supinie
       oluchitheanalyst
     ];
-    teams = [ lib.teams.ngi ];
     mainProgram = "cnspr";
     platforms = lib.platforms.linux;
   };

--- a/pkgs/by-name/co/corestore/package.nix
+++ b/pkgs/by-name/co/corestore/package.nix
@@ -34,6 +34,5 @@ buildNpmPackage (finalAttrs: {
     homepage = "https://github.com/holepunchto/corestore";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ themadbit ];
-    teams = with lib.teams; [ ngi ];
   };
 })

--- a/pkgs/by-name/co/corteza/package.nix
+++ b/pkgs/by-name/co/corteza/package.nix
@@ -29,7 +29,6 @@ let
     changelog = "https://docs.cortezaproject.org/corteza-docs/${lib.versions.majorMinor version}/changelog/index.html";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ prince213 ];
-    teams = with lib.teams; [ ngi ];
   };
 
   mkWebApp =

--- a/pkgs/by-name/de/dep-scan/package.nix
+++ b/pkgs/by-name/de/dep-scan/package.nix
@@ -78,7 +78,6 @@ python3Packages.buildPythonApplication rec {
     changelog = "https://github.com/owasp-dep-scan/dep-scan/releases/tag/v${version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
-    teams = [ lib.teams.ngi ];
     mainProgram = "dep-scan";
   };
 }

--- a/pkgs/by-name/do/dokieli/package.nix
+++ b/pkgs/by-name/do/dokieli/package.nix
@@ -76,7 +76,6 @@ stdenv.mkDerivation (finalAttrs: {
     ];
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [ shogo ];
-    teams = [ lib.teams.ngi ];
     mainProgram = "dokieli";
   };
 })

--- a/pkgs/by-name/eq/equihash/package.nix
+++ b/pkgs/by-name/eq/equihash/package.nix
@@ -29,7 +29,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Memory-hard PoW with fast verification";
     homepage = "https://github.com/stef/equihash/";
     license = lib.licenses.cc0;
-    teams = [ lib.teams.ngi ];
     # ld -z not available on darwin
     platforms = lib.platforms.linux;
   };

--- a/pkgs/by-name/fr/freediameter/package.nix
+++ b/pkgs/by-name/fr/freediameter/package.nix
@@ -46,7 +46,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/freeDiameter/freeDiameter";
     license = lib.licenses.bsd3;
     platforms = lib.platforms.unix;
-    teams = with lib.teams; [ ngi ];
     maintainers = [ ];
   };
 })

--- a/pkgs/by-name/ga/galene/package.nix
+++ b/pkgs/by-name/ga/galene/package.nix
@@ -48,7 +48,6 @@ buildGoModule (finalAttrs: {
     changelog = "https://github.com/jech/galene/raw/${finalAttrs.src.tag}/CHANGES";
     license = lib.licenses.mit;
     platforms = lib.platforms.linux;
-    teams = [ lib.teams.ngi ];
     maintainers = with lib.maintainers; [
       rgrunbla
       erdnaxe

--- a/pkgs/by-name/gn/gnunet-messenger-cli/package.nix
+++ b/pkgs/by-name/gn/gnunet-messenger-cli/package.nix
@@ -49,7 +49,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://git.gnunet.org/messenger-cli.git";
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.all;
-    teams = with lib.teams; [ ngi ];
     maintainers = [ lib.maintainers.ethancedwards8 ];
     mainProgram = "gnunet-messenger-cli";
   };

--- a/pkgs/by-name/gn/gnunet/package.nix
+++ b/pkgs/by-name/gn/gnunet/package.nix
@@ -125,7 +125,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://gnunet.org/";
     license = lib.licenses.agpl3Plus;
     maintainers = with lib.maintainers; [ pstn ];
-    teams = with lib.teams; [ ngi ];
     platforms = lib.platforms.unix;
     changelog = "https://git.gnunet.org/gnunet.git/tree/ChangeLog?h=v${finalAttrs.version}";
     # meson: "Can not run test applications in this cross environment." (for dane_verify_crt_raw)

--- a/pkgs/by-name/ho/holo-cli/package.nix
+++ b/pkgs/by-name/ho/holo-cli/package.nix
@@ -38,7 +38,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "Holo` Command Line Interface";
     homepage = "https://github.com/holo-routing/holo-cli";
-    teams = with lib.teams; [ ngi ];
     maintainers = with lib.maintainers; [ themadbit ];
     license = lib.licenses.mit;
     mainProgram = "holo-cli";

--- a/pkgs/by-name/ho/holo-daemon/package.nix
+++ b/pkgs/by-name/ho/holo-daemon/package.nix
@@ -39,7 +39,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "`holo` daemon that provides the routing protocols, tools and policies";
     homepage = "https://github.com/holo-routing/holo";
-    teams = with lib.teams; [ ngi ];
     maintainers = with lib.maintainers; [ themadbit ];
     license = lib.licenses.mit;
     mainProgram = "holod";

--- a/pkgs/by-name/hy/hyperbeam/package.nix
+++ b/pkgs/by-name/hy/hyperbeam/package.nix
@@ -32,7 +32,6 @@ buildNpmPackage (finalAttrs: {
     mainProgram = "hyperbeam";
     license = lib.licenses.mit;
     platforms = lib.platforms.all;
-    teams = with lib.teams; [ ngi ];
     maintainers = with lib.maintainers; [ davhau ];
   };
 })

--- a/pkgs/by-name/hy/hyperblobs/package.nix
+++ b/pkgs/by-name/hy/hyperblobs/package.nix
@@ -41,7 +41,6 @@ buildNpmPackage (finalAttrs: {
     homepage = "https://github.com/holepunchto/hyperblobs";
     license = lib.licenses.asl20;
     platforms = lib.platforms.all;
-    teams = with lib.teams; [ ngi ];
     maintainers = [ ];
   };
 })

--- a/pkgs/by-name/hy/hypercore/package.nix
+++ b/pkgs/by-name/hy/hypercore/package.nix
@@ -34,7 +34,6 @@ buildNpmPackage (finalAttrs: {
     description = "Secure, distributed append-only log";
     homepage = "https://github.com/holepunchto/hypercore";
     license = lib.licenses.mit;
-    teams = with lib.teams; [ ngi ];
     maintainers = [ lib.maintainers.goodylove ];
     platforms = lib.platforms.all;
   };

--- a/pkgs/by-name/hy/hyperswarm/package.nix
+++ b/pkgs/by-name/hy/hyperswarm/package.nix
@@ -35,7 +35,6 @@ buildNpmPackage (finalAttrs: {
     homepage = "https://github.com/holepunchto/hyperswarm";
     license = lib.licenses.mit;
     platforms = lib.platforms.unix;
-    teams = with lib.teams; [ ngi ];
     maintainers = [ ];
   };
 })

--- a/pkgs/by-name/ic/icestudio/package.nix
+++ b/pkgs/by-name/ic/icestudio/package.nix
@@ -120,7 +120,6 @@ buildNpmPackage rec {
       rcoeurjoly
       amerino
     ];
-    teams = [ lib.teams.ngi ];
     mainProgram = "icestudio";
     platforms = lib.platforms.linux;
   };

--- a/pkgs/by-name/in/inko/package.nix
+++ b/pkgs/by-name/in/inko/package.nix
@@ -69,7 +69,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://inko-lang.org/";
     license = lib.licenses.mpl20;
     maintainers = [ lib.maintainers.feathecutie ];
-    teams = [ lib.teams.ngi ];
     platforms = lib.platforms.unix;
     mainProgram = "inko";
   };

--- a/pkgs/by-name/iv/ivm/package.nix
+++ b/pkgs/by-name/iv/ivm/package.nix
@@ -60,7 +60,6 @@ rustPlatform.buildRustPackage (finalAttr: {
     homepage = "https://github.com/inko-lang/ivm";
     license = lib.licenses.mpl20;
     maintainers = [ lib.maintainers.feathecutie ];
-    teams = [ lib.teams.ngi ];
     platforms = lib.platforms.unix;
     mainProgram = "ivm";
   };

--- a/pkgs/by-name/ja/jaq/package.nix
+++ b/pkgs/by-name/ja/jaq/package.nix
@@ -69,7 +69,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/01mf02/jaq";
     changelog = "https://github.com/01mf02/jaq/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
-    teams = [ lib.teams.ngi ];
     maintainers = with lib.maintainers; [
       siraben
     ];

--- a/pkgs/by-name/ka/kaidan/package.nix
+++ b/pkgs/by-name/ka/kaidan/package.nix
@@ -97,7 +97,6 @@ stdenv.mkDerivation (finalAttrs: {
       cc-by-sa-40
     ];
     maintainers = with lib.maintainers; [ astro ];
-    teams = with lib.teams; [ ngi ];
     platforms = with lib.platforms; linux;
   };
 })

--- a/pkgs/by-name/ki/kikit/default.nix
+++ b/pkgs/by-name/ki/kikit/default.nix
@@ -106,7 +106,6 @@ buildPythonApplication rec {
       jfly
       matusf
     ];
-    teams = with lib.teams; [ ngi ];
     license = lib.licenses.mit;
   };
 }

--- a/pkgs/by-name/lc/lctime/package.nix
+++ b/pkgs/by-name/lc/lctime/package.nix
@@ -95,7 +95,6 @@ python3Packages.buildPythonApplication rec {
       cc0
     ];
     maintainers = with lib.maintainers; [ eljamm ];
-    teams = with lib.teams; [ ngi ];
     mainProgram = "lctime";
   };
 }

--- a/pkgs/by-name/li/lib25519/package.nix
+++ b/pkgs/by-name/li/lib25519/package.nix
@@ -83,7 +83,6 @@ stdenv.mkDerivation (finalAttrs: {
       imadnyc
       jleightcap
     ];
-    teams = with lib.teams; [ ngi ];
     # This supports whatever platforms libcpucycles supports
     inherit (libcpucycles.meta) platforms;
   };

--- a/pkgs/by-name/li/libeufin/package.nix
+++ b/pkgs/by-name/li/libeufin/package.nix
@@ -116,7 +116,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Integration and sandbox testing for FinTech APIs and data formats";
     license = lib.licenses.agpl3Plus;
     maintainers = with lib.maintainers; [ atemu ];
-    teams = with lib.teams; [ ngi ];
     mainProgram = "libeufin-bank";
     sourceProvenance = with lib.sourceTypes; [
       fromSource

--- a/pkgs/by-name/li/libgdstk/package.nix
+++ b/pkgs/by-name/li/libgdstk/package.nix
@@ -46,6 +46,5 @@ stdenv.mkDerivation (finalAttrs: {
       eljamm
       gonsolo
     ];
-    teams = with lib.teams; [ ngi ];
   };
 })

--- a/pkgs/by-name/li/libgnunetchat/package.nix
+++ b/pkgs/by-name/li/libgnunetchat/package.nix
@@ -54,7 +54,6 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://git.gnunet.org/libgnunetchat.git/plain/ChangeLog?h=v${finalAttrs.version}";
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.all;
-    teams = with lib.teams; [ ngi ];
     maintainers = [ lib.maintainers.ethancedwards8 ];
   };
 })

--- a/pkgs/by-name/li/libks/package.nix
+++ b/pkgs/by-name/li/libks/package.nix
@@ -72,7 +72,6 @@ stdenv.mkDerivation rec {
     description = "Foundational support for signalwire C products";
     homepage = "https://github.com/signalwire/libks";
     maintainers = with lib.maintainers; [ misuzu ];
-    teams = [ lib.teams.ngi ];
     platforms = lib.platforms.unix;
     license = lib.licenses.mit;
   };

--- a/pkgs/by-name/li/libopaque/package.nix
+++ b/pkgs/by-name/li/libopaque/package.nix
@@ -52,7 +52,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/stef/libopaque/";
     changelog = "https://github.com/stef/libopaque/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.lgpl3Plus;
-    teams = [ lib.teams.ngi ];
     platforms = lib.platforms.unix;
     pkgConfigModules = [ "libopaque" ];
   };

--- a/pkgs/by-name/li/liboprf/package.nix
+++ b/pkgs/by-name/li/liboprf/package.nix
@@ -39,7 +39,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/stef/liboprf";
     changelog = "https://github.com/stef/liboprf/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.lgpl3Plus;
-    teams = [ lib.teams.ngi ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/li/librecast/package.nix
+++ b/pkgs/by-name/li/librecast/package.nix
@@ -40,7 +40,6 @@ stdenv.mkDerivation (finalAttrs: {
       jasonodoom
       jleightcap
     ];
-    teams = with lib.teams; [ ngi ];
     platforms = lib.platforms.gnu;
   };
 })

--- a/pkgs/by-name/li/libxeddsa/package.nix
+++ b/pkgs/by-name/li/libxeddsa/package.nix
@@ -32,7 +32,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/Syndace/libxeddsa";
     changelog = "https://github.com/Syndace/libxeddsa/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.mit;
-    teams = with lib.teams; [ ngi ];
     maintainers = [ ];
     platforms = lib.platforms.all;
   };

--- a/pkgs/by-name/li/lillydap/package.nix
+++ b/pkgs/by-name/li/lillydap/package.nix
@@ -39,7 +39,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://gitlab.com/arpa2/lillydap";
     changelog = "https://gitlab.com/arpa2/lillydap/-/blob/v${finalAttrs.version}/CHANGES";
     license = lib.licenses.bsd2;
-    teams = with lib.teams; [ ngi ];
     maintainers = with lib.maintainers; [ ethancedwards8 ];
     platforms = lib.platforms.unix;
   };

--- a/pkgs/by-name/mi/misskey/package.nix
+++ b/pkgs/by-name/mi/misskey/package.nix
@@ -148,7 +148,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://misskey-hub.net/";
     license = lib.licenses.agpl3Only;
     maintainers = [ lib.maintainers.feathecutie ];
-    teams = [ lib.teams.ngi ];
     platforms = lib.platforms.unix;
     mainProgram = "misskey";
   };

--- a/pkgs/by-name/mo/mox/package.nix
+++ b/pkgs/by-name/mo/mox/package.nix
@@ -39,6 +39,5 @@ buildGoModule (finalAttrs: {
       dit7ya
       kotatsuyaki
     ];
-    teams = with lib.teams; [ ngi ];
   };
 })

--- a/pkgs/by-name/na/naja/package.nix
+++ b/pkgs/by-name/na/naja/package.nix
@@ -111,7 +111,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Structural Netlist API (and more) for EDA post synthesis flow development";
     homepage = "https://github.com/najaeda/naja";
     license = lib.licenses.asl20;
-    teams = [ lib.teams.ngi ];
     mainProgram = "naja_edit";
     platforms = lib.platforms.all;
   };

--- a/pkgs/by-name/no/nominatim-ui/package.nix
+++ b/pkgs/by-name/no/nominatim-ui/package.nix
@@ -94,7 +94,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl2;
     teams = with lib.teams; [
       geospatial
-      ngi
     ];
     changelog = "https://github.com/osm-search/nominatim-ui/releases/tag/v${finalAttrs.version}";
   };

--- a/pkgs/by-name/no/nominatim/nominatim-api.nix
+++ b/pkgs/by-name/no/nominatim/nominatim-api.nix
@@ -58,7 +58,6 @@ buildPythonPackage rec {
     maintainers = with lib.maintainers; [ mausch ];
     teams = with lib.teams; [
       geospatial
-      ngi
     ];
   };
 }

--- a/pkgs/by-name/no/nominatim/package.nix
+++ b/pkgs/by-name/no/nominatim/package.nix
@@ -78,7 +78,6 @@ python3Packages.buildPythonApplication rec {
     maintainers = with lib.maintainers; [ mausch ];
     teams = with lib.teams; [
       geospatial
-      ngi
     ];
     mainProgram = "nominatim";
   };

--- a/pkgs/by-name/ok/oku/package.nix
+++ b/pkgs/by-name/ok/oku/package.nix
@@ -67,7 +67,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     changelog = "https://github.com/OkuBrowser/oku/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.agpl3Plus;
     maintainers = with lib.maintainers; [ ethancedwards8 ];
-    teams = with lib.teams; [ ngi ];
     mainProgram = "oku";
     platforms = lib.platforms.linux;
   };

--- a/pkgs/by-name/om/omnom/package.nix
+++ b/pkgs/by-name/om/omnom/package.nix
@@ -87,7 +87,6 @@ buildGoModule (finalAttrs: {
     description = "Webpage bookmarking and snapshotting service";
     homepage = "https://github.com/asciimoo/omnom";
     license = lib.licenses.agpl3Only;
-    teams = [ lib.teams.ngi ];
     mainProgram = "omnom";
   };
 })

--- a/pkgs/by-name/ow/owi/package.nix
+++ b/pkgs/by-name/ow/owi/package.nix
@@ -87,7 +87,6 @@ ocamlPackages.buildDunePackage {
       ethancedwards8
       redianthus
     ];
-    teams = with lib.teams; [ ngi ];
     mainProgram = "owi";
     badPlatforms = lib.platforms.darwin;
   };

--- a/pkgs/by-name/pi/pixelfed/package.nix
+++ b/pkgs/by-name/pi/pixelfed/package.nix
@@ -44,7 +44,6 @@ php.buildComposerProject2 (finalAttrs: {
     description = "Federated image sharing platform";
     license = lib.licenses.agpl3Only;
     homepage = "https://pixelfed.org/";
-    teams = with lib.teams; [ ngi ];
     platforms = php.meta.platforms;
   };
 })

--- a/pkgs/by-name/pw/pwdsphinx/package.nix
+++ b/pkgs/by-name/pw/pwdsphinx/package.nix
@@ -67,7 +67,6 @@ python3Packages.buildPythonApplication rec {
     homepage = "https://www.ctrlc.hu/~stef/blog/posts/sphinx.html";
     downloadPage = "https://github.com/stef/pwdsphinx";
     changelog = "https://github.com/stef/pwdsphinx/releases/tag/v${version}";
-    teams = [ lib.teams.ngi ];
     license = lib.licenses.gpl3Plus;
     mainProgram = "sphinx";
   };

--- a/pkgs/by-name/qu/quick-sasl/package.nix
+++ b/pkgs/by-name/qu/quick-sasl/package.nix
@@ -52,7 +52,6 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://gitlab.com/arpa2/Quick-SASL/-/blob/v${finalAttrs.version}/CHANGES";
     license = lib.licenses.bsd2;
     platforms = lib.platforms.linux;
-    teams = with lib.teams; [ ngi ];
     maintainers = with lib.maintainers; [ ethancedwards8 ];
     mainProgram = "qsasl-server";
   };

--- a/pkgs/by-name/ra/raylib/package.nix
+++ b/pkgs/by-name/ra/raylib/package.nix
@@ -82,7 +82,6 @@ lib.checkListOfEnum "${pname}: platform"
         downloadPage = "https://github.com/raysan5/raylib";
         license = lib.licenses.zlib;
         maintainers = [ lib.maintainers.diniamo ];
-        teams = [ lib.teams.ngi ];
         platforms = lib.platforms.all;
         changelog = "https://github.com/raysan5/raylib/blob/${finalAttrs.version}/CHANGELOG";
       };

--- a/pkgs/by-name/re/re-isearch/package.nix
+++ b/pkgs/by-name/re/re-isearch/package.nix
@@ -85,6 +85,5 @@ stdenv.mkDerivation {
     license = lib.licenses.asl20;
     platforms = lib.platforms.linux;
     maintainers = [ lib.maintainers.astro ];
-    teams = [ lib.teams.ngi ];
   };
 }

--- a/pkgs/by-name/re/reaction/package.nix
+++ b/pkgs/by-name/re/reaction/package.nix
@@ -68,7 +68,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     license = lib.licenses.agpl3Plus;
     mainProgram = "reaction";
     maintainers = with lib.maintainers; [ ppom ];
-    teams = [ lib.teams.ngi ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/ro/rosenpass/package.nix
+++ b/pkgs/by-name/ro/rosenpass/package.nix
@@ -55,7 +55,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
       asl20
     ];
     maintainers = with lib.maintainers; [ wucke13 ];
-    teams = with lib.teams; [ ngi ];
     platforms = [
       "aarch64-darwin"
       "aarch64-linux"

--- a/pkgs/by-name/sc/scion-bootstrapper/package.nix
+++ b/pkgs/by-name/sc/scion-bootstrapper/package.nix
@@ -65,7 +65,6 @@ buildGoModule (finalAttrs: {
       matthewcroughan
       sarcasticadmin
     ];
-    teams = with lib.teams; [ ngi ];
     mainProgram = "scion-bootstrapper";
   };
 })

--- a/pkgs/by-name/sc/scion/package.nix
+++ b/pkgs/by-name/sc/scion/package.nix
@@ -56,6 +56,5 @@ buildGoModule (finalAttrs: {
       sarcasticadmin
       matthewcroughan
     ];
-    teams = with lib.teams; [ ngi ];
   };
 })

--- a/pkgs/by-name/se/servo/package.nix
+++ b/pkgs/by-name/se/servo/package.nix
@@ -174,7 +174,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
       hexa
       supinie
     ];
-    teams = with lib.teams; [ ngi ];
     mainProgram = "servo";
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };

--- a/pkgs/by-name/sl/slipshow/package.nix
+++ b/pkgs/by-name/sl/slipshow/package.nix
@@ -61,7 +61,6 @@ ocamlPackages.buildDunePackage rec {
     license = lib.licenses.gpl3Only;
     downloadPage = "https://github.com/panglesd/slipshow";
     maintainers = [ lib.maintainers.ethancedwards8 ];
-    teams = [ lib.teams.ngi ];
     mainProgram = "slipshow";
   };
 }

--- a/pkgs/by-name/sn/sniffnet/package.nix
+++ b/pkgs/by-name/sn/sniffnet/package.nix
@@ -99,7 +99,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
       asl20
     ];
     maintainers = [ ];
-    teams = [ lib.teams.ngi ];
     mainProgram = "sniffnet";
   };
 })

--- a/pkgs/by-name/so/sofia_sip/package.nix
+++ b/pkgs/by-name/so/sofia_sip/package.nix
@@ -102,7 +102,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/freeswitch/sofia-sip";
     platforms = lib.platforms.unix;
     license = lib.licenses.lgpl2Plus;
-    teams = [ lib.teams.ngi ];
     pkgConfigModules = [
       "sofia-sip-ua"
       "sofia-sip-ua-glib"

--- a/pkgs/by-name/st/steamworks/package.nix
+++ b/pkgs/by-name/st/steamworks/package.nix
@@ -74,7 +74,6 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://gitlab.com/arpa2/steamworks/-/blob/v${finalAttrs.version}/CHANGES";
     license = lib.licenses.bsd2;
     maintainers = [ lib.maintainers.ethancedwards8 ];
-    teams = [ lib.teams.ngi ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/st/stract/package.nix
+++ b/pkgs/by-name/st/stract/package.nix
@@ -71,6 +71,5 @@ rustPlatform.buildRustPackage {
     maintainers = with lib.maintainers; [
       ailsa-sun
     ];
-    teams = [ lib.teams.ngi ];
   };
 }

--- a/pkgs/by-name/sy/sylk/package.nix
+++ b/pkgs/by-name/sy/sylk/package.nix
@@ -38,7 +38,6 @@ appimageTools.wrapType2 rec {
     license = lib.licenses.agpl3Plus;
     mainProgram = "sylk";
     maintainers = with lib.maintainers; [ zimbatm ];
-    teams = with lib.teams; [ ngi ];
     platforms = [
       "i386-linux"
       "x86_64-linux"

--- a/pkgs/by-name/sy/sylkserver/package.nix
+++ b/pkgs/by-name/sy/sylkserver/package.nix
@@ -55,7 +55,6 @@ python3Packages.buildPythonApplication rec {
     downloadPage = "https://github.com/AGProjects/sylkserver";
     changelog = "https://github.com/AGProjects/sylkserver/releases/tag/${version}";
     license = lib.licenses.gpl3Plus;
-    teams = [ lib.teams.ngi ];
     mainProgram = "sylk-server";
   };
 }

--- a/pkgs/by-name/ta/taldir/package.nix
+++ b/pkgs/by-name/ta/taldir/package.nix
@@ -42,7 +42,6 @@ buildGoModule (finalAttrs: {
   meta = {
     homepage = "https://git.taler.net/taldir.git";
     description = "Directory service to resolve wallet mailboxes by messenger addresses";
-    teams = with lib.teams; [ ngi ];
     # themadbit will maintain after being added to maintainers
     maintainers = [ ];
     license = lib.licenses.agpl3Plus;

--- a/pkgs/by-name/ta/taler-challenger/package.nix
+++ b/pkgs/by-name/ta/taler-challenger/package.nix
@@ -76,7 +76,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://git.taler.net/challenger.git";
     license = lib.licenses.agpl3Plus;
     maintainers = with lib.maintainers; [ wegank ];
-    teams = with lib.teams; [ ngi ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/ta/taler-depolymerization/package.nix
+++ b/pkgs/by-name/ta/taler-depolymerization/package.nix
@@ -37,6 +37,5 @@ rustPlatform.buildRustPackage {
     description = "Wire gateway for Bitcoin/Ethereum";
     homepage = "https://git.taler.net/depolymerization.git/";
     license = lib.licenses.agpl3Only;
-    teams = [ lib.teams.ngi ];
   };
 }

--- a/pkgs/by-name/ta/taler-exchange/package.nix
+++ b/pkgs/by-name/ta/taler-exchange/package.nix
@@ -128,7 +128,6 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://git.taler.net/exchange.git/tree/ChangeLog";
     license = lib.licenses.agpl3Plus;
     maintainers = with lib.maintainers; [ astro ];
-    teams = with lib.teams; [ ngi ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/ta/taler-mdb/package.nix
+++ b/pkgs/by-name/ta/taler-mdb/package.nix
@@ -50,7 +50,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://git.taler.net/taler-mdb.git";
     description = "Sales integration with the Multi-Drop-Bus of Snack machines, NFC readers and QR code display";
     license = lib.licenses.agpl3Plus;
-    teams = with lib.teams; [ ngi ];
     maintainers = [ ];
     mainProgram = "taler-mdb";
   };

--- a/pkgs/by-name/ta/taler-merchant/package.nix
+++ b/pkgs/by-name/ta/taler-merchant/package.nix
@@ -115,7 +115,6 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://git.taler.net/merchant.git/tree/ChangeLog";
     license = lib.licenses.agpl3Plus;
     maintainers = with lib.maintainers; [ astro ];
-    teams = with lib.teams; [ ngi ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/ta/taler-sync/package.nix
+++ b/pkgs/by-name/ta/taler-sync/package.nix
@@ -58,7 +58,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://git.taler.net/sync.git";
     license = lib.licenses.agpl3Plus;
     maintainers = with lib.maintainers; [ wegank ];
-    teams = with lib.teams; [ ngi ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/ta/taler-twister/package.nix
+++ b/pkgs/by-name/ta/taler-twister/package.nix
@@ -41,7 +41,6 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     homepage = "https://git.taler.net/twister.git";
     description = "Fault injector for HTTP traffic";
-    teams = with lib.teams; [ ngi ];
     maintainers = [ ];
     license = lib.licenses.agpl3Plus;
     mainProgram = "twister";

--- a/pkgs/by-name/ta/taler-wallet-core/package.nix
+++ b/pkgs/by-name/ta/taler-wallet-core/package.nix
@@ -112,7 +112,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://git.taler.net/wallet-core.git/";
     description = "CLI wallet for GNU Taler written in TypeScript and Anastasis Web UI";
     license = lib.licenses.gpl3Plus;
-    teams = [ lib.teams.ngi ];
     platforms = lib.platforms.linux;
     mainProgram = "taler-wallet-cli";
     # ./configure doesn't understand --build / --host

--- a/pkgs/by-name/te/teamtype/package.nix
+++ b/pkgs/by-name/te/teamtype/package.nix
@@ -48,7 +48,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     changelog = "https://github.com/teamtype/teamtype/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.agpl3Plus;
     mainProgram = "teamtype";
-    teams = [ lib.teams.ngi ];
     maintainers = with lib.maintainers; [
       prince213
       ethancedwards8

--- a/pkgs/by-name/tl/tlspool/package.nix
+++ b/pkgs/by-name/tl/tlspool/package.nix
@@ -64,7 +64,6 @@ stdenv.mkDerivation (finalAttrs: {
       cc-by-sa-40 # docs
       bsd2 # userspace
     ];
-    teams = with lib.teams; [ ngi ];
     maintainers = with lib.maintainers; [ ethancedwards8 ];
     platforms = lib.platforms.linux;
     mainProgram = "tlsserver";

--- a/pkgs/by-name/ts/tslib/package.nix
+++ b/pkgs/by-name/ts/tslib/package.nix
@@ -27,6 +27,5 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.lgpl21;
     platforms = lib.platforms.linux; # requires linux headers <linux/input.h>
     maintainers = with lib.maintainers; [ shogo ];
-    teams = with lib.teams; [ ngi ];
   };
 })

--- a/pkgs/by-name/um/umap/package.nix
+++ b/pkgs/by-name/um/umap/package.nix
@@ -135,7 +135,6 @@ python.pkgs.buildPythonApplication rec {
     ];
     teams = with lib.teams; [
       geospatial
-      ngi
     ];
     mainProgram = "umap";
   };

--- a/pkgs/by-name/yf/yffi/package.nix
+++ b/pkgs/by-name/yf/yffi/package.nix
@@ -44,7 +44,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     downloadPage = "https://github.com/y-crdt/y-crdt/tags";
     changelog = "https://github.com/y-crdt/y-crdt/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
-    teams = with lib.teams; [ ngi ];
     platforms = with lib.platforms; linux;
   };
 })

--- a/pkgs/development/libraries/spandsp/common.nix
+++ b/pkgs/development/libraries/spandsp/common.nix
@@ -212,7 +212,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/freeswitch/spandsp";
     platforms = with lib.platforms; unix;
     maintainers = with lib.maintainers; [ misuzu ];
-    teams = [ lib.teams.ngi ];
     license = lib.licenses.gpl2;
     downloadPage = "http://www.soft-switch.org/downloads/spandsp/";
   };

--- a/pkgs/development/python-modules/cryptodatahub/default.nix
+++ b/pkgs/development/python-modules/cryptodatahub/default.nix
@@ -60,6 +60,5 @@ buildPythonPackage rec {
     homepage = "https://gitlab.com/coroner/cryptodatahub";
     changelog = "https://gitlab.com/coroner/cryptodatahub/-/blob/${src.tag}/CHANGELOG.rst";
     license = lib.licenses.mpl20;
-    teams = with lib.teams; [ ngi ];
   };
 }

--- a/pkgs/development/python-modules/cryptolyzer/default.nix
+++ b/pkgs/development/python-modules/cryptolyzer/default.nix
@@ -76,6 +76,5 @@ buildPythonPackage rec {
     license = lib.licenses.mpl20;
     mainProgram = "cryptolyze";
     maintainers = with lib.maintainers; [ kranzes ];
-    teams = with lib.teams; [ ngi ];
   };
 }

--- a/pkgs/development/python-modules/cryptoparser/default.nix
+++ b/pkgs/development/python-modules/cryptoparser/default.nix
@@ -66,6 +66,5 @@ buildPythonPackage rec {
     changelog = "https://gitlab.com/coroner/cryptoparser/-/blob/${src.tag}/CHANGELOG.md";
     license = lib.licenses.mpl20;
     maintainers = with lib.maintainers; [ kranzes ];
-    teams = with lib.teams; [ ngi ];
   };
 }

--- a/pkgs/development/python-modules/django-cache-memoize/default.nix
+++ b/pkgs/development/python-modules/django-cache-memoize/default.nix
@@ -48,6 +48,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/peterbe/django-cache-memoize";
     changelog = "https://github.com/peterbe/django-cache-memoize/blob/${src.rev}/CHANGELOG.rst";
     license = lib.licenses.mpl20;
-    teams = [ lib.teams.ngi ];
   };
 }

--- a/pkgs/development/python-modules/dmt-core/default.nix
+++ b/pkgs/development/python-modules/dmt-core/default.nix
@@ -80,6 +80,5 @@ buildPythonPackage rec {
       jasonodoom
       jleightcap
     ];
-    teams = with lib.teams; [ ngi ];
   };
 }

--- a/pkgs/development/python-modules/doubleratchet/default.nix
+++ b/pkgs/development/python-modules/doubleratchet/default.nix
@@ -48,7 +48,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/Syndace/python-doubleratchet";
     changelog = "https://github.com/Syndace/python-doubleratchet/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.mit;
-    teams = with lib.teams; [ ngi ];
     maintainers = with lib.maintainers; [ axler1 ];
   };
 }

--- a/pkgs/development/python-modules/ds-analysis-lib/default.nix
+++ b/pkgs/development/python-modules/ds-analysis-lib/default.nix
@@ -52,7 +52,6 @@ buildPythonPackage rec {
       homepage
       license
       maintainers
-      teams
       ;
   };
 }

--- a/pkgs/development/python-modules/ds-reporting-lib/default.nix
+++ b/pkgs/development/python-modules/ds-reporting-lib/default.nix
@@ -29,7 +29,6 @@ buildPythonPackage rec {
       homepage
       license
       maintainers
-      teams
       ;
   };
 }

--- a/pkgs/development/python-modules/ds-server-lib/default.nix
+++ b/pkgs/development/python-modules/ds-server-lib/default.nix
@@ -54,7 +54,6 @@ buildPythonPackage rec {
       homepage
       license
       maintainers
-      teams
       ;
   };
 }

--- a/pkgs/development/python-modules/ds-xbom-lib/default.nix
+++ b/pkgs/development/python-modules/ds-xbom-lib/default.nix
@@ -29,7 +29,6 @@ buildPythonPackage rec {
       homepage
       license
       maintainers
-      teams
       ;
   };
 }

--- a/pkgs/development/python-modules/gdstk/default.nix
+++ b/pkgs/development/python-modules/gdstk/default.nix
@@ -87,7 +87,6 @@ buildPythonPackage {
       changelog
       license
       maintainers
-      teams
       ;
   };
 }

--- a/pkgs/development/python-modules/highctidh/default.nix
+++ b/pkgs/development/python-modules/highctidh/default.nix
@@ -41,7 +41,6 @@ buildPythonPackage rec {
     description = "Fork of high-ctidh as as a portable shared library with Python bindings";
     homepage = "https://codeberg.org/vula/highctidh";
     license = lib.licenses.publicDomain;
-    teams = with lib.teams; [ ngi ];
     maintainers = with lib.maintainers; [
       lorenzleutgeb
       mightyiam

--- a/pkgs/development/python-modules/lb-matching-tools/default.nix
+++ b/pkgs/development/python-modules/lb-matching-tools/default.nix
@@ -36,6 +36,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/metabrainz/listenbrainz-matching-tools";
     changelog = "https://github.com/metabrainz/listenbrainz-matching-tools/releases/tag/${src.tag}";
     license = lib.licenses.gpl2Plus;
-    teams = [ lib.teams.ngi ];
   };
 }

--- a/pkgs/development/python-modules/liberty-parser/default.nix
+++ b/pkgs/development/python-modules/liberty-parser/default.nix
@@ -60,6 +60,5 @@ buildPythonPackage rec {
       gpl3Plus
     ];
     maintainers = with lib.maintainers; [ eljamm ];
-    teams = with lib.teams; [ ngi ];
   };
 }

--- a/pkgs/development/python-modules/liblistenbrainz/default.nix
+++ b/pkgs/development/python-modules/liblistenbrainz/default.nix
@@ -40,6 +40,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/metabrainz/liblistenbrainz";
     changelog = "https://github.com/metabrainz/liblistenbrainz/releases/tag/${src.tag}";
     license = lib.licenses.gpl3Plus;
-    teams = [ lib.teams.ngi ];
   };
 }

--- a/pkgs/development/python-modules/msrplib/default.nix
+++ b/pkgs/development/python-modules/msrplib/default.nix
@@ -34,8 +34,5 @@ buildPythonPackage {
     description = "MSRP (RFC4975) client library";
     homepage = "https://github.com/AGProjects/python3-msrplib";
     license = lib.licenses.lgpl21Plus;
-    teams = [
-      lib.teams.ngi
-    ];
   };
 }

--- a/pkgs/development/python-modules/omemo/default.nix
+++ b/pkgs/development/python-modules/omemo/default.nix
@@ -74,7 +74,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/Syndace/python-omemo";
     changelog = "https://github.com/Syndace/python-omemo/blob/${src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
-    teams = with lib.teams; [ ngi ];
     maintainers = with lib.maintainers; [ themadbit ];
   };
 }

--- a/pkgs/development/python-modules/opaque/default.nix
+++ b/pkgs/development/python-modules/opaque/default.nix
@@ -47,7 +47,6 @@ buildPythonPackage rec {
       description
       homepage
       license
-      teams
       ;
   };
 }

--- a/pkgs/development/python-modules/otr/default.nix
+++ b/pkgs/development/python-modules/otr/default.nix
@@ -42,8 +42,5 @@ buildPythonPackage rec {
     description = "Off-The-Record Messaging protocol implementation for Python";
     homepage = "https://github.com/AGProjects/python3-otr";
     license = lib.licenses.lgpl21Plus;
-    teams = [
-      lib.teams.ngi
-    ];
   };
 }

--- a/pkgs/development/python-modules/pluralizer/default.nix
+++ b/pkgs/development/python-modules/pluralizer/default.nix
@@ -29,6 +29,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/weixu365/pluralizer-py";
     changelog = "https://github.com/weixu365/pluralizer-py/releases/tag/${src.tag}";
     license = lib.licenses.mit;
-    teams = [ lib.teams.ngi ];
   };
 }

--- a/pkgs/development/python-modules/plyer/default.nix
+++ b/pkgs/development/python-modules/plyer/default.nix
@@ -87,8 +87,5 @@ buildPythonPackage rec {
     description = "Plyer is a platform-independent api to use features commonly found on various platforms";
     homepage = "https://github.com/kivy/plyer";
     license = lib.licenses.mit;
-    teams = [
-      lib.teams.ngi
-    ];
   };
 }

--- a/pkgs/development/python-modules/pyequihash/default.nix
+++ b/pkgs/development/python-modules/pyequihash/default.nix
@@ -44,7 +44,6 @@ buildPythonPackage rec {
       description
       homepage
       license
-      teams
       ;
   };
 }

--- a/pkgs/development/python-modules/pyoprf/default.nix
+++ b/pkgs/development/python-modules/pyoprf/default.nix
@@ -59,7 +59,6 @@ buildPythonPackage rec {
       description
       changelog
       license
-      teams
       ;
   };
 }

--- a/pkgs/development/python-modules/python3-application/default.nix
+++ b/pkgs/development/python-modules/python3-application/default.nix
@@ -44,7 +44,6 @@ buildPythonPackage rec {
       chanley
       yureien
     ];
-    teams = [ lib.teams.ngi ];
     longDescription = ''
       This package is a collection of modules that are useful when building python applications. Their purpose is to eliminate the need to divert resources into implementing the small tasks that every application needs to do in order to run successfully and focus instead on the application logic itself.
       The modules that the application package provides are:

--- a/pkgs/development/python-modules/python3-sipsimple/default.nix
+++ b/pkgs/development/python-modules/python3-sipsimple/default.nix
@@ -156,7 +156,6 @@ buildPythonPackage (finalAttrs: {
     homepage = "https://sipsimpleclient.org/";
     downloadPage = "https://github.com/AGProjects/python3-sipsimple";
     license = lib.licenses.gpl3Plus;
-    teams = [ lib.teams.ngi ];
     maintainers = [ lib.maintainers.ethancedwards8 ];
   };
 })

--- a/pkgs/development/python-modules/requests-http-message-signatures/default.nix
+++ b/pkgs/development/python-modules/requests-http-message-signatures/default.nix
@@ -37,6 +37,5 @@ buildPythonPackage rec {
     homepage = "https://dev.funkwhale.audio/funkwhale/requests-http-message-signatures";
     changelog = "https://dev.funkwhale.audio/funkwhale/requests-http-message-signatures/-/blob/${src.tag}/CHANGELOG.md";
     license = lib.licenses.asl20;
-    teams = [ lib.teams.ngi ];
   };
 }

--- a/pkgs/development/python-modules/sat-tmp/default.nix
+++ b/pkgs/development/python-modules/sat-tmp/default.nix
@@ -43,6 +43,5 @@ buildPythonPackage rec {
     homepage = "https://libervia.org";
     license = lib.licenses.agpl3Plus;
     maintainers = [ lib.maintainers.ethancedwards8 ];
-    teams = [ lib.teams.ngi ];
   };
 }

--- a/pkgs/development/python-modules/troi/default.nix
+++ b/pkgs/development/python-modules/troi/default.nix
@@ -84,6 +84,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/metabrainz/troi-recommendation-playground";
     changelog = "https://github.com/metabrainz/troi-recommendation-playground/releases/tag/${src.tag}";
     license = lib.licenses.gpl2Only;
-    teams = [ lib.teams.ngi ];
   };
 }

--- a/pkgs/development/python-modules/twomemo/default.nix
+++ b/pkgs/development/python-modules/twomemo/default.nix
@@ -49,7 +49,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/Syndace/python-twomemo";
     changelog = "https://github.com/Syndace/python-twomemo/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.mit;
-    teams = with lib.teams; [ ngi ];
     maintainers = with lib.maintainers; [ themadbit ];
   };
 }

--- a/pkgs/development/python-modules/typesense/default.nix
+++ b/pkgs/development/python-modules/typesense/default.nix
@@ -73,6 +73,5 @@ buildPythonPackage rec {
     description = "Python client for Typesense, an open source and typo tolerant search engine";
     homepage = "https://github.com/typesense/typesense-python";
     license = lib.licenses.asl20;
-    teams = [ lib.teams.ngi ];
   };
 }

--- a/pkgs/development/python-modules/urwid-satext/default.nix
+++ b/pkgs/development/python-modules/urwid-satext/default.nix
@@ -40,7 +40,6 @@ buildPythonPackage rec {
     homepage = "https://libervia.org";
     changelog = "https://repos.goffi.org/urwid-satext/file/${src.rev}/CHANGELOG";
     license = lib.licenses.lgpl3Plus;
-    teams = with lib.teams; [ ngi ];
     maintainers = [ lib.maintainers.oluchitheanalyst ];
   };
 }

--- a/pkgs/development/python-modules/wokkel/default.nix
+++ b/pkgs/development/python-modules/wokkel/default.nix
@@ -67,6 +67,5 @@ buildPythonPackage rec {
     changelog = "https://github.com/ralphm/wokkel/blob/${version}/NEWS.rst";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.ethancedwards8 ];
-    teams = [ lib.teams.ngi ];
   };
 }

--- a/pkgs/development/python-modules/x3dh/default.nix
+++ b/pkgs/development/python-modules/x3dh/default.nix
@@ -49,7 +49,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/Syndace/python-x3dh";
     changelog = "https://github.com/Syndace/python-x3dh/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.mit;
-    teams = with lib.teams; [ ngi ];
     maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/xcaplib/default.nix
+++ b/pkgs/development/python-modules/xcaplib/default.nix
@@ -43,7 +43,6 @@ buildPythonPackage {
     description = "XCAP (RFC4825) client library";
     homepage = "https://github.com/AGProjects/python3-xcaplib";
     license = lib.licenses.lgpl21Plus;
-    teams = [ lib.teams.ngi ];
     maintainers = [ lib.maintainers.ethancedwards8 ];
     mainProgram = "xcapclient3";
   };

--- a/pkgs/development/python-modules/xeddsa/default.nix
+++ b/pkgs/development/python-modules/xeddsa/default.nix
@@ -46,7 +46,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/Syndace/python-xeddsa";
     changelog = "https://github.com/Syndace/python-xeddsa/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.mit;
-    teams = with lib.teams; [ ngi ];
     maintainers = [ ];
   };
 }


### PR DESCRIPTION
The @NixOS/nixpkgs-core team has recently reviewed Nixpkgs teams, and decided that teams should be organized internally around specific topics of maintenance, rather than having membership gated by external criteria. This means having maintainer responsibility and authority decided by consensus of existing maintainers and team members in an area of interest, rather than being granted or revoked based on employment, membership in an external organization, or role in another FOSS project. The reasoning is given in the full statement at https://github.com/NixOS/org/issues/220#issuecomment-3678147410.

We are now triaging teams to make sure they’re in line with this model and working with their members to find the best way forward for each case. This is being tracked at #478780.

@eljamm @ethancedwards8 @fricklerhandwerk @OPNA2608 @Prince213 @wegank 

This team was flagged as apparently having external membership criteria. By default, we’ll merge this to drop the team after a week if we don’t hear back from you, but we’re also happy to implement alternatives, e.g.:

- Redistribute members to maintainer lists of individual packages per their request.
- Reorganize or merge the team into one or more teams relating to specific areas of maintenance interest with open membership criteria.
- Clarify that the team is dedicated to maintenance of software maintained upstream by a certain organization, but is open to all contributors. For example, `lib.teams.jetbrains` and `lib.teams.qt-kde` handle maintenance of JetBrains IDEs and KDE software, but have no expectation that members are affiliated with those organizations, even though some may be.

---

**Could you clarify the relation of this team to the Nix@NGI effort?** In particular, we’re not clear on whether this team is dedicated to maintaining software that has some relationship with NGI upstream, or whether membership is restricted to participants in Nix@NGI. If the former, then we can just clarify that in the description, although as this team is listed on many diverse packages, it may be worth splitting up into individual topic‐focused teams even in that case.