### PR TITLE
python3Packages.langchain-mongodb: 0.9.0 -> 0.10.0

### DIFF
--- a/pkgs/development/python-modules/langchain-mongodb/default.nix
+++ b/pkgs/development/python-modules/langchain-mongodb/default.nix
@@ -33,7 +33,7 @@
   gitUpdater,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "langchain-mongodb";
   version = "0.9.0";
   pyproject = true;
@@ -41,11 +41,11 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain-mongodb";
-    tag = "libs/langchain-mongodb/v${version}";
+    tag = "libs/langchain-mongodb/v${finalAttrs.version}";
     hash = "sha256-g2FEowzGvP7a/zx/qn8EUxj5s6j/miMlzkRJEE64G0k=";
   };
 
-  sourceRoot = "${src.name}/libs/langchain-mongodb";
+  sourceRoot = "${finalAttrs.src.name}/libs/langchain-mongodb";
 
   build-system = [ hatchling ];
 
@@ -104,7 +104,7 @@ buildPythonPackage rec {
   };
 
   meta = {
-    changelog = "https://github.com/langchain-ai/langchain-mongodb/releases/tag/${src.tag}";
+    changelog = "https://github.com/langchain-ai/langchain-mongodb/releases/tag/${finalAttrs.src.tag}";
     description = "Integration package connecting MongoDB and LangChain";
     homepage = "https://github.com/langchain-ai/langchain-mongodb";
     license = lib.licenses.mit;
@@ -113,4 +113,4 @@ buildPythonPackage rec {
       sarahec
     ];
   };
-}
+})

--- a/pkgs/development/python-modules/langchain-mongodb/default.nix
+++ b/pkgs/development/python-modules/langchain-mongodb/default.nix
@@ -35,14 +35,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "langchain-mongodb";
-  version = "0.9.0";
+  version = "0.10.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain-mongodb";
     tag = "libs/langchain-mongodb/v${finalAttrs.version}";
-    hash = "sha256-g2FEowzGvP7a/zx/qn8EUxj5s6j/miMlzkRJEE64G0k=";
+    hash = "sha256-MRvj6RJ6N+u1wA+zkyWhe4tnGaC4FduPl+k7AhBIwLI=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/libs/langchain-mongodb";


### PR DESCRIPTION
1. Applied `finalAttrs` fix.
2. Version update (fixes build issues under Python 3.14)

[CHANGELOG](https://github.com/langchain-ai/langchain-mongodb/releases/tag/libs%2Flangchain-mongodb%2Fv0.10.0)
[DIFF] (https://github.com/langchain-ai/langchain-mongodb/compare/libs/langchain-mongodb/v0.9.0...libs/langchain-mongodb/v0.10.0)

Tracking: #475732

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
