### PR TITLE
teams/nix: clarify relation to Nix team

### DIFF
--- a/ci/OWNERS
+++ b/ci/OWNERS
@@ -83,8 +83,9 @@
 # @raitobezarius is not "code owner", but is listed here to be notified of changes
 # pertaining to the Nix package manager.
 # i.e. no authority over those files.
-pkgs/tools/package-management/nix/                    @NixOS/nix-team @raitobezarius
-nixos/modules/installer/tools/nix-fallback-paths.nix  @NixOS/nix-team @raitobezarius
+# Otherwise keep in-sync with lib.teams.nix.
+pkgs/tools/package-management/nix/                    @Artturin @Ericson2314 @lovesegfault @Mic92 @philiptaron @roberth @tomberek @xokdvium @raitobezarius
+nixos/modules/installer/tools/nix-fallback-paths.nix  @Artturin @Ericson2314 @lovesegfault @Mic92 @philiptaron @roberth @tomberek @xokdvium @raitobezarius
 
 # Nixpkgs documentation
 /maintainers/scripts/db-to-md.sh @jtojnar @ryantm

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7533,12 +7533,6 @@
     githubId = 8173116;
     name = "Dean Eckert";
   };
-  eelco = {
-    email = "edolstra+nixpkgs@gmail.com";
-    github = "edolstra";
-    githubId = 1148549;
-    name = "Eelco Dolstra";
-  };
   ehegnes = {
     email = "eric.hegnes@gmail.com";
     github = "ehegnes";

--- a/maintainers/scripts/nix-generate-from-cpan.nix
+++ b/maintainers/scripts/nix-generate-from-cpan.nix
@@ -29,7 +29,6 @@ stdenv.mkDerivation {
   '';
 
   meta = {
-    maintainers = with lib.maintainers; [ eelco ];
     description = "Utility to generate a Nix expression for a Perl package from CPAN";
     mainProgram = "nix-generate-from-cpan";
     platforms = lib.platforms.unix;

--- a/maintainers/scripts/nixpkgs-lint.nix
+++ b/maintainers/scripts/nixpkgs-lint.nix
@@ -29,7 +29,6 @@ stdenv.mkDerivation {
   '';
 
   meta = {
-    maintainers = [ lib.maintainers.eelco ];
     description = "A utility for Nixpkgs contributors to check Nixpkgs for common errors";
     mainProgram = "nixpkgs-lint";
     platforms = lib.platforms.unix;

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -742,16 +742,20 @@ with lib.maintainers;
     enableFeatureFreezePing = true;
   };
 
-  # same as https://github.com/orgs/NixOS/teams/nix-team
+  # keep in-sync with ci/OWNERS
   nix = {
     members = [
-      mic92
-      tomberek
-      roberth
+      artturin
       ericson2314
+      lovesegfault
+      mic92
+      philiptaron
+      roberth
+      tomberek
+      xokdvium
     ];
-    scope = "Maintain the Nix package manager.";
-    shortName = "Nix/nix-cli ecosystem";
+    scope = "Maintain the packaging for the Nix package manager itself.";
+    shortName = "Nix packaging";
     enableFeatureFreezePing = true;
   };
 

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -745,7 +745,6 @@ with lib.maintainers;
   # same as https://github.com/orgs/NixOS/teams/nix-team
   nix = {
     members = [
-      eelco
       mic92
       tomberek
       roberth

--- a/modules/generic/meta-maintainers/test.nix
+++ b/modules/generic/meta-maintainers/test.nix
@@ -6,6 +6,13 @@
 #
 # Debugging:
 #   drop .test from the end of this file, then use nix repl on it
+let
+  ghost = {
+    github = "ghost";
+    githubId = 0;
+    name = "ghost";
+  };
+in
 rec {
   lib = import ../../../lib;
 
@@ -13,8 +20,8 @@ rec {
     modules = [
       ../meta-maintainers.nix
       {
-        _file = "eelco.nix";
-        meta.maintainers = [ lib.maintainers.eelco ];
+        _file = "ghost.nix";
+        meta.maintainers = [ ghost ];
       }
     ];
   };
@@ -26,7 +33,7 @@ rec {
           lib.maintainers.pierron
           lib.maintainers.roberth
         ];
-        "eelco.nix" = [ lib.maintainers.eelco ];
+        "ghost.nix" = [ ghost ];
       };
     { };
 

--- a/nixos/tests/misc.nix
+++ b/nixos/tests/misc.nix
@@ -6,7 +6,6 @@ let
 in
 {
   name = "misc";
-  meta.maintainers = with lib.maintainers; [ eelco ];
 
   nodes.machine =
     { lib, ... }:

--- a/pkgs/by-name/ni/nix-serve/package.nix
+++ b/pkgs/by-name/ni/nix-serve/package.nix
@@ -61,7 +61,6 @@ stdenv.mkDerivation {
   meta = {
     homepage = "https://github.com/edolstra/nix-serve";
     description = "Utility for sharing a Nix store as a binary cache";
-    maintainers = [ lib.maintainers.eelco ];
     license = lib.licenses.lgpl21;
     # See https://github.com/edolstra/nix-serve/issues/57
     broken = stdenv.hostPlatform.isDarwin;

--- a/pkgs/by-name/va/valgrind/package.nix
+++ b/pkgs/by-name/va/valgrind/package.nix
@@ -112,7 +112,6 @@ stdenv.mkDerivation rec {
 
     license = lib.licenses.gpl3Plus;
 
-    maintainers = [ lib.maintainers.eelco ];
     platforms =
       with lib.platforms;
       lib.intersectLists (x86 ++ power ++ s390x ++ armv7 ++ aarch64 ++ mips ++ riscv64) (

--- a/pkgs/tools/package-management/nix/common-meson.nix
+++ b/pkgs/tools/package-management/nix/common-meson.nix
@@ -11,11 +11,6 @@
     inherit hash;
   },
   patches ? [ ],
-  maintainers ? [
-    lib.maintainers.artturin
-    lib.maintainers.philiptaron
-    lib.maintainers.lovesegfault
-  ],
   teams ? [ lib.teams.nix ],
   self_attribute_name,
 }@args:
@@ -272,7 +267,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     homepage = "https://nixos.org/";
     license = lib.licenses.lgpl21Plus;
-    inherit maintainers teams;
+    inherit teams;
     platforms = lib.platforms.unix;
     # Gets stuck in functional-tests in cross-trunk jobset and doesn't timeout
     # https://hydra.nixos.org/build/298175022

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -120,11 +120,6 @@ let
       nixComponentsAttributeName
     ];
 
-  maintainers = [
-    lib.maintainers.artturin
-    lib.maintainers.philiptaron
-    lib.maintainers.lovesegfault
-  ];
   teams = [ lib.teams.nix ];
 
   # FIXME: https://github.com/NixOS/nixpkgs/issues/476794
@@ -150,7 +145,7 @@ lib.makeExtensible (
       nixComponents_2_30 =
         (nixDependencies.callPackage ./modular/packages.nix rec {
           version = "2.30.3";
-          inherit maintainers teams;
+          inherit teams;
           otherSplices = generateSplicesForNixComponents "nixComponents_2_30";
           src = fetchFromGitHub {
             owner = "NixOS";
@@ -175,7 +170,7 @@ lib.makeExtensible (
       nixComponents_2_31 =
         (nixDependencies.callPackage ./modular/packages.nix rec {
           version = "2.31.2";
-          inherit (self.nix_2_30.meta) maintainers teams;
+          inherit (self.nix_2_30.meta) teams;
           otherSplices = generateSplicesForNixComponents "nixComponents_2_31";
           src = fetchFromGitHub {
             owner = "NixOS";
@@ -206,7 +201,7 @@ lib.makeExtensible (
       nixComponents_2_32 =
         (nixDependencies.callPackage ./modular/packages.nix rec {
           version = "2.32.5";
-          inherit (self.nix_2_31.meta) maintainers teams;
+          inherit (self.nix_2_31.meta) teams;
           otherSplices = generateSplicesForNixComponents "nixComponents_2_32";
           src = fetchFromGitHub {
             owner = "NixOS";
@@ -221,7 +216,7 @@ lib.makeExtensible (
 
       nixComponents_git = nixDependencies.callPackage ./modular/packages.nix rec {
         version = "2.34pre20251217_${lib.substring 0 8 src.rev}";
-        inherit maintainers teams;
+        inherit teams;
         otherSplices = generateSplicesForNixComponents "nixComponents_git";
         src = fetchFromGitHub {
           owner = "NixOS";

--- a/pkgs/tools/package-management/nix/modular/packages.nix
+++ b/pkgs/tools/package-management/nix/modular/packages.nix
@@ -3,7 +3,6 @@
   splicePackages,
   nixDependencies,
   pkgs,
-  maintainers,
   teams,
   otherSplices,
   version,
@@ -27,7 +26,6 @@ let
         f = import ./packaging/components.nix {
           inherit
             lib
-            maintainers
             teams
             officialRelease
             pkgs

--- a/pkgs/tools/package-management/nix/modular/packaging/components.nix
+++ b/pkgs/tools/package-management/nix/modular/packaging/components.nix
@@ -3,7 +3,6 @@
   pkgs,
   src,
   officialRelease,
-  maintainers,
   teams,
   version,
 }:
@@ -200,7 +199,6 @@ let
           environments.
         '';
       license = prevAttrs.meta.license or lib.licenses.lgpl21Plus;
-      maintainers = prevAttrs.meta.maintainers or [ ] ++ scope.maintainers;
       teams = prevAttrs.meta.teams or [ ] ++ scope.teams;
       platforms = prevAttrs.meta.platforms or (lib.platforms.unix ++ lib.platforms.windows);
     };
@@ -224,7 +222,6 @@ in
 # This becomes the pkgs.nixComponents attribute set
 {
   inherit version;
-  inherit maintainers;
   inherit teams;
 
   inherit filesetToSource;

--- a/pkgs/tools/package-management/nix/modular/packaging/everything.nix
+++ b/pkgs/tools/package-management/nix/modular/packaging/everything.nix
@@ -4,7 +4,6 @@
   lndir,
   buildEnv,
 
-  maintainers,
   teams,
 
   version,
@@ -228,7 +227,6 @@ stdenv.mkDerivation (finalAttrs: {
     longDescription = nix-cli.meta.longDescription;
     homepage = nix-cli.meta.homepage;
     license = nix-cli.meta.license;
-    maintainers = maintainers;
     teams = teams;
     platforms = nix-cli.meta.platforms;
     outputsToInstall = [


### PR DESCRIPTION
The @NixOS/nixpkgs-core team has recently reviewed Nixpkgs teams, and decided that teams should be organized internally around specific topics of maintenance, rather than having membership gated by external criteria. This means having maintainer responsibility and authority decided by consensus of existing maintainers and team members in an area of interest, rather than being granted or revoked based on employment, membership in an external organization, or role in another FOSS project. The reasoning is given in the full statement at https://github.com/NixOS/org/issues/220#issuecomment-3678147410.

We are now triaging teams to make sure they’re in line with this model and working with their members to find the best way forward for each case. This is being tracked at #478780.

This team was flagged as apparently having external membership criteria. In this case, `lib.teams.nix` has historically been the maintainers of the Nix package in Nixpkgs rather than members of the @NixOS/nix-team, and the comment equating it with @NixOS/nix-team was only added in 2681649b3e74cb835148b280a4ecc3c8b27e1d25 in March 2025.

The maintainers of the Nixpkgs Nix packaging are not identical to the @NixOS/nix-team members even now: @roberth has left the @NixOS/nix-team but is currently listed in `lib.teams.nix`, @Radvendii and @xokdvium are part of the @NixOS/nix-team but not listed in `lib.teams.nix`, and @Artturin, @philiptaron, and @lovesegfault are additional maintainers listed in the Nix packaging itself.

Therefore, this PR moves the additional maintainers for the Nix package into the Nixpkgs team, removes the comment, and clarifies the scope. If the `lib.teams.nix` naming is considered too ambiguous, we could potentially rename it to e.g. `lib.teams.nix-packaging`, although this divergence was already the case historically until earlier this year.