### PR TITLE
teams/ororatech: handle team with external membership

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27706,12 +27706,6 @@
     githubId = 116078858;
     keys = [ { fingerprint = "CDEA 7E04 69E3 0885 A754  4B05 0104 BC05 F41B 77B8"; } ];
   };
-  victormeriqui = {
-    name = "Victor Meriqui";
-    email = "victor.meriqui@ororatech.com";
-    github = "victormeriqui";
-    githubId = 1396008;
-  };
   videl = {
     email = "thibaut.smith@mailbox.org";
     github = "videl";

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -798,7 +798,6 @@ with lib.maintainers;
     # Edits to this list should only be done by an already existing member.
     members = [
       kip93
-      victormeriqui
     ];
   };
 

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -791,16 +791,6 @@ with lib.maintainers;
     shortName = "OpenStack";
   };
 
-  ororatech = {
-    # email: nixdevs@ororatech.com
-    shortName = "OroraTech GmbH. employees";
-    scope = "Team for packages maintained by employees of OroraTech GmbH.";
-    # Edits to this list should only be done by an already existing member.
-    members = [
-      kip93
-    ];
-  };
-
   pantheon = {
     github = "pantheon";
     enableFeatureFreezePing = true;

--- a/pkgs/development/python-modules/cobs/default.nix
+++ b/pkgs/development/python-modules/cobs/default.nix
@@ -39,6 +39,5 @@ buildPythonPackage rec {
     '';
     homepage = "https://github.com/cmcqueen/cobs-python/";
     license = lib.licenses.mit;
-    teams = [ lib.teams.ororatech ];
   };
 }

--- a/pkgs/development/python-modules/dronecan/default.nix
+++ b/pkgs/development/python-modules/dronecan/default.nix
@@ -27,6 +27,5 @@ buildPythonPackage rec {
     '';
     homepage = "https://dronecan.github.io/";
     license = lib.licenses.mit;
-    teams = [ lib.teams.ororatech ];
   };
 }

--- a/pkgs/development/python-modules/libpcap/default.nix
+++ b/pkgs/development/python-modules/libpcap/default.nix
@@ -65,6 +65,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/karpierz/libpcap/";
     changelog = "https://github.com/karpierz/libpcap/blob/${version}/CHANGES.rst";
     license = lib.licenses.bsd3;
-    teams = [ lib.teams.ororatech ];
   };
 }

--- a/pkgs/development/python-modules/pkg-about/default.nix
+++ b/pkgs/development/python-modules/pkg-about/default.nix
@@ -52,6 +52,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/karpierz/pkg_about/";
     changelog = "https://github.com/karpierz/pkg_about/blob/${version}/CHANGES.rst";
     license = lib.licenses.zlib;
-    teams = [ lib.teams.ororatech ];
   };
 }

--- a/pkgs/development/python-modules/pycyphal/default.nix
+++ b/pkgs/development/python-modules/pycyphal/default.nix
@@ -101,6 +101,5 @@ buildPythonPackage rec {
     homepage = "https://opencyphal.org/";
     changelog = "https://github.com/OpenCyphal/pycyphal/blob/${version}/CHANGELOG.rst";
     license = lib.licenses.mit;
-    teams = [ lib.teams.ororatech ];
   };
 }

--- a/pkgs/development/tools/misc/yakut/default.nix
+++ b/pkgs/development/tools/misc/yakut/default.nix
@@ -55,6 +55,5 @@ buildPythonApplication rec {
     '';
     homepage = "https://github.com/OpenCyphal/yakut/";
     license = lib.licenses.mit;
-    teams = [ lib.teams.ororatech ];
   };
 }


### PR DESCRIPTION
The @NixOS/nixpkgs-core team has recently reviewed Nixpkgs teams, and decided that teams should be organized internally around specific topics of maintenance, rather than having membership gated by external criteria. This means having maintainer responsibility and authority decided by consensus of existing maintainers and team members in an area of interest, rather than being granted or revoked based on employment, membership in an external organization, or role in another FOSS project. The reasoning is given in the full statement at https://github.com/NixOS/org/issues/220#issuecomment-3678147410.

We are now triaging teams to make sure they’re in line with this model and working with their members to find the best way forward for each case. This is being tracked at #478780.

@kip93 @victormeriqui

This team was flagged as apparently having external membership criteria. By default, we’ll merge this to drop the team after a week if we don’t hear back from you, but we’re also happy to implement alternatives, e.g.:

- Redistribute members to maintainer lists of individual packages per their request.
- Reorganize or merge the team into one or more teams relating to specific areas of maintenance interest with open membership criteria.
- Clarify that the team is dedicated to maintenance of software maintained upstream by a certain organization, but is open to all contributors. For example, `lib.teams.jetbrains` and `lib.teams.qt-kde` handle maintenance of JetBrains IDEs and KDE software, but have no expectation that members are affiliated with those organizations, even though some may be.