### PR TITLE
icloudpd: 1.31.0 -> 1.32.2

### DIFF
--- a/pkgs/by-name/ic/icloudpd/package.nix
+++ b/pkgs/by-name/ic/icloudpd/package.nix
@@ -9,14 +9,14 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "icloudpd";
-  version = "1.31.0";
+  version = "1.32.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "icloud-photos-downloader";
     repo = "icloud_photos_downloader";
     tag = "v${version}";
-    hash = "sha256-GZhc5AeOxfSPxloN630lQguh63ha63Wnuh0H6pMkPyE=";
+    hash = "sha256-XwMY3OBGYDA/DKTXYgxuMV9pbamy8NbitMrEbsEmlMk=";
   };
 
   pythonRelaxDeps = true;
@@ -62,7 +62,21 @@ python3Packages.buildPythonApplication rec {
     "test_autodelete_photos_dry_run"
     "test_retry_fail_delete_after_download_internal_error"
     "test_autodelete_invalid_creation_date"
+    "test_all_http_methods_covered"
+    "test_builtin_timeout_error_handling"
+    "test_connection_error_handling"
+    "test_new_connection_error_handling"
+    "test_normal_request"
+    "test_other_exceptions_pass_through"
+    "test_timeout_error_handling"
+    "test_response_to_har_entry_with_large_streaming_response"
+    "test_response_to_har_entry_with_real_json_response"
+    "test_response_to_har_entry_with_real_streaming_response"
+    "test_response_to_har_entry_with_real_text_response"
+    "test_streaming_vs_non_streaming_behavior"
+    # touches non-existing folders
     "test_folder_structure_de_posix"
+    "test_missing_directory"
   ];
 
   passthru = {


### PR DESCRIPTION
Diff: https://github.com/icloud-photos-downloader/icloud_photos_downloader/compare/v1.31.0...v1.32.2
Resolves: #478381

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
