### PR TITLE
teams/deshaw: handle team with external membership

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11273,12 +11273,6 @@
     name = "Antoine Labarussias";
     keys = [ { fingerprint = "5CB5 9AA0 D180 1997 2FB3  E0EC 943A 1DE9 372E BE4E"; } ];
   };
-  invokes-su = {
-    email = "nixpkgs-commits@deshaw.com";
-    github = "invokes-su";
-    githubId = 88038050;
-    name = "Souvik Sen";
-  };
   io12 = {
     github = "io12";
     githubId = 7348004;

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -193,7 +193,6 @@ with lib.maintainers;
     members = [
       de11n
       despsyched
-      invokes-su
     ];
     scope = "Group registration for D. E. Shaw employees who collectively maintain packages.";
     shortName = "D. E. Shaw employees";

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -188,16 +188,6 @@ with lib.maintainers;
     enableFeatureFreezePing = true;
   };
 
-  deshaw = {
-    # Verify additions to this team with at least one already existing member of the team.
-    members = [
-      de11n
-      despsyched
-    ];
-    scope = "Group registration for D. E. Shaw employees who collectively maintain packages.";
-    shortName = "D. E. Shaw employees";
-  };
-
   dhall = {
     members = [
       Gabriella439

--- a/nixos/tests/iscsi-multipath-root.nix
+++ b/nixos/tests/iscsi-multipath-root.nix
@@ -5,9 +5,6 @@ let
 in
 {
   name = "iscsi";
-  meta = {
-    maintainers = pkgs.lib.teams.deshaw.members;
-  };
 
   nodes = {
     target =

--- a/nixos/tests/iscsi-root.nix
+++ b/nixos/tests/iscsi-root.nix
@@ -5,13 +5,10 @@ let
 in
 {
   name = "iscsi";
-  meta.maintainers =
-    with lib.maintainers;
-    [
-      das_j
-      helsinki-Jo
-    ]
-    ++ lib.teams.deshaw.members;
+  meta.maintainers = with lib.maintainers; [
+    das_j
+    helsinki-Jo
+  ];
 
   nodes = {
     target =

--- a/pkgs/by-name/dc/dcgm/package.nix
+++ b/pkgs/by-name/dc/dcgm/package.nix
@@ -170,7 +170,10 @@ stdenv.mkDerivation {
     description = "Data Center GPU Manager (DCGM) is a daemon that allows users to monitor NVIDIA data-center GPUs";
     homepage = "https://developer.nvidia.com/dcgm";
     license = lib.licenses.asl20;
-    teams = [ lib.teams.deshaw ];
+    maintainers = with lib.maintainers; [
+      de11n
+      despsyched
+    ];
     mainProgram = "dcgmi";
     platforms = lib.platforms.linux;
   };

--- a/pkgs/by-name/ja/javacc/package.nix
+++ b/pkgs/by-name/ja/javacc/package.nix
@@ -65,6 +65,5 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://javacc.github.io/javacc";
     license = lib.licenses.bsd2;
     mainProgram = "javacc";
-    teams = [ lib.teams.deshaw ];
   };
 })

--- a/pkgs/by-name/me/memcached-exporter/package.nix
+++ b/pkgs/by-name/me/memcached-exporter/package.nix
@@ -26,6 +26,9 @@ buildGoModule (finalAttrs: {
     homepage = "https://github.com/prometheus/memcached_exporter";
     license = lib.licenses.asl20;
     mainProgram = "memcached_exporter";
-    teams = with lib.teams; [ deshaw ];
+    maintainers = with lib.maintainers; [
+      de11n
+      despsyched
+    ];
   };
 })

--- a/pkgs/by-name/ms/mscp/package.nix
+++ b/pkgs/by-name/ms/mscp/package.nix
@@ -39,7 +39,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/upa/mscp";
     mainProgram = "mscp";
     license = lib.licenses.gpl3Only;
-    teams = [ lib.teams.deshaw ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/pa/patroni/package.nix
+++ b/pkgs/by-name/pa/patroni/package.nix
@@ -65,6 +65,9 @@ python3Packages.buildPythonApplication rec {
     changelog = "https://github.com/patroni/patroni/blob/v${version}/docs/releases.rst";
     license = lib.licenses.mit;
     platforms = lib.platforms.unix;
-    teams = [ lib.teams.deshaw ];
+    maintainers = with lib.maintainers; [
+      de11n
+      despsyched
+    ];
   };
 }

--- a/pkgs/by-name/pr/procfd/package.nix
+++ b/pkgs/by-name/pr/procfd/package.nix
@@ -29,6 +29,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
     license = lib.licenses.bsd3;
     mainProgram = "procfd";
     platforms = lib.platforms.linux;
-    teams = with lib.teams; [ deshaw ];
+    maintainers = with lib.maintainers; [
+      de11n
+      despsyched
+    ];
   };
 })

--- a/pkgs/by-name/pr/prometheus-dcgm-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-dcgm-exporter/package.nix
@@ -46,7 +46,10 @@ buildGoModule rec {
     description = "NVIDIA GPU metrics exporter for Prometheus leveraging DCGM";
     homepage = "https://github.com/NVIDIA/dcgm-exporter";
     license = lib.licenses.asl20;
-    teams = [ lib.teams.deshaw ];
+    maintainers = with lib.maintainers; [
+      de11n
+      despsyched
+    ];
     mainProgram = "dcgm-exporter";
     platforms = lib.platforms.linux;
   };

--- a/pkgs/by-name/pr/prometheus-elasticsearch-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-elasticsearch-exporter/package.nix
@@ -21,6 +21,9 @@ buildGoModule rec {
     mainProgram = "elasticsearch_exporter";
     homepage = "https://github.com/prometheus-community/elasticsearch_exporter";
     license = lib.licenses.asl20;
-    teams = [ lib.teams.deshaw ];
+    maintainers = with lib.maintainers; [
+      de11n
+      despsyched
+    ];
   };
 }

--- a/pkgs/by-name/re/remctl/package.nix
+++ b/pkgs/by-name/re/remctl/package.nix
@@ -60,6 +60,9 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://www.eyrie.org/~eagle/software/remctl";
     mainProgram = "remctl";
     license = lib.licenses.mit;
-    teams = [ lib.teams.deshaw ];
+    maintainers = with lib.maintainers; [
+      de11n
+      despsyched
+    ];
   };
 })

--- a/pkgs/development/libraries/tclap/1.4.nix
+++ b/pkgs/development/libraries/tclap/1.4.nix
@@ -43,7 +43,6 @@ stdenv.mkDerivation {
     description = "Templatized C++ Command Line Parser Library (v1.4)";
     homepage = "https://tclap.sourceforge.net/";
     license = lib.licenses.mit;
-    teams = [ lib.teams.deshaw ];
     platforms = lib.platforms.all;
   };
 }

--- a/pkgs/development/python-modules/datefinder/default.nix
+++ b/pkgs/development/python-modules/datefinder/default.nix
@@ -34,6 +34,9 @@ buildPythonPackage rec {
     description = "Extract datetime objects from strings";
     homepage = "https://github.com/akoumjian/datefinder";
     license = lib.licenses.mit;
-    teams = [ lib.teams.deshaw ];
+    maintainers = with lib.maintainers; [
+      de11n
+      despsyched
+    ];
   };
 }

--- a/pkgs/development/python-modules/jenkinsapi/default.nix
+++ b/pkgs/development/python-modules/jenkinsapi/default.nix
@@ -55,8 +55,11 @@ buildPythonPackage rec {
   meta = {
     description = "Python API for accessing resources on a Jenkins continuous-integration server";
     homepage = "https://github.com/salimfadhley/jenkinsapi";
-    maintainers = with lib.maintainers; [ drets ];
-    teams = [ lib.teams.deshaw ];
+    maintainers = with lib.maintainers; [
+      de11n
+      despsyched
+      drets
+    ];
     license = lib.licenses.mit;
   };
 }

--- a/pkgs/development/python-modules/krb5/default.nix
+++ b/pkgs/development/python-modules/krb5/default.nix
@@ -39,7 +39,10 @@ buildPythonPackage rec {
     description = "Kerberos API bindings for Python";
     homepage = "https://github.com/jborean93/pykrb5";
     license = lib.licenses.mit;
-    teams = [ lib.teams.deshaw ];
+    maintainers = with lib.maintainers; [
+      de11n
+      despsyched
+    ];
     broken = stdenv.hostPlatform.isDarwin; # TODO: figure out how to build on Darwin
   };
 }

--- a/pkgs/development/python-modules/opentelemetry-api/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-api/default.nix
@@ -65,7 +65,6 @@ let
       changelog = "https://github.com/open-telemetry/opentelemetry-python/releases/tag/${src.tag}";
       license = lib.licenses.asl20;
       maintainers = [ lib.maintainers.natsukium ];
-      teams = [ lib.teams.deshaw ];
     };
   };
 in

--- a/pkgs/development/python-modules/opentelemetry-instrumentation/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-instrumentation/default.nix
@@ -56,6 +56,5 @@ buildPythonPackage rec {
     changelog = "https://github.com/open-telemetry/opentelemetry-python-contrib/releases/tag/v${version}";
     license = lib.licenses.asl20;
     maintainers = [ lib.maintainers.natsukium ];
-    teams = [ lib.teams.deshaw ];
   };
 }

--- a/pkgs/development/python-modules/pytest-grpc/default.nix
+++ b/pkgs/development/python-modules/pytest-grpc/default.nix
@@ -24,6 +24,5 @@ buildPythonPackage rec {
     description = "Pytest plugin for grpc";
     homepage = "https://github.com/MobileDynasty/pytest-env";
     license = lib.licenses.mit;
-    teams = [ lib.teams.deshaw ];
   };
 }

--- a/pkgs/development/python-modules/ydiff/default.nix
+++ b/pkgs/development/python-modules/ydiff/default.nix
@@ -55,6 +55,9 @@ buildPythonPackage rec {
     '';
     homepage = "https://github.com/ymattw/ydiff";
     license = lib.licenses.bsd3;
-    teams = [ lib.teams.deshaw ];
+    maintainers = with lib.maintainers; [
+      de11n
+      despsyched
+    ];
   };
 }

--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -800,7 +800,10 @@ let
         description = "SPNEGO HTTP Authentication Module";
         homepage = "https://github.com/stnoonan/spnego-http-auth-nginx-module";
         license = with lib.licenses; [ bsd2 ];
-        teams = [ lib.teams.deshaw ];
+        maintainers = with lib.maintainers; [
+          de11n
+          despsyched
+        ];
       };
     };
 

--- a/pkgs/servers/monitoring/prometheus/fastly-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/fastly-exporter.nix
@@ -26,7 +26,6 @@ buildGoModule rec {
     description = "Prometheus exporter for the Fastly Real-time Analytics API";
     homepage = "https://github.com/fastly/fastly-exporter";
     license = lib.licenses.asl20;
-    teams = [ lib.teams.deshaw ];
     mainProgram = "fastly-exporter";
   };
 }

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -2724,7 +2724,10 @@ with self;
     meta = {
       description = "BSD process resource limit and priority functions";
       license = with lib.licenses; [ artistic2 ];
-      teams = [ teams.deshaw ];
+      maintainers = with lib.maintainers; [
+        de11n
+        despsyched
+      ];
     };
   };
 
@@ -4967,7 +4970,6 @@ with self;
         artistic1
         gpl1Plus
       ];
-      teams = [ teams.deshaw ];
     };
   };
 
@@ -5982,7 +5984,10 @@ with self;
         artistic1
         gpl1Plus
       ];
-      teams = [ teams.deshaw ];
+      maintainers = with lib.maintainers; [
+        de11n
+        despsyched
+      ];
     };
   };
 
@@ -13427,7 +13432,10 @@ with self;
         artistic1
         gpl1Plus
       ];
-      teams = [ teams.deshaw ];
+      maintainers = with lib.maintainers; [
+        de11n
+        despsyched
+      ];
     };
   };
 
@@ -13458,7 +13466,10 @@ with self;
         artistic1
         gpl1Plus
       ];
-      teams = [ teams.deshaw ];
+      maintainers = with lib.maintainers; [
+        de11n
+        despsyched
+      ];
     };
   };
 
@@ -13773,7 +13784,10 @@ with self;
         artistic1
         gpl1Plus
       ];
-      teams = [ teams.deshaw ];
+      maintainers = with lib.maintainers; [
+        de11n
+        despsyched
+      ];
     };
   };
 
@@ -14018,7 +14032,10 @@ with self;
         artistic1
         gpl1Plus
       ];
-      teams = [ teams.deshaw ];
+      maintainers = with lib.maintainers; [
+        de11n
+        despsyched
+      ];
     };
   };
 
@@ -14036,7 +14053,10 @@ with self;
         artistic1
         gpl1Plus
       ];
-      teams = [ teams.deshaw ];
+      maintainers = with lib.maintainers; [
+        de11n
+        despsyched
+      ];
     };
   };
 
@@ -14742,7 +14762,10 @@ with self;
     meta = {
       description = "This is the Git.pm, plus the other files in the perl/Git directory, from github's git/git";
       license = with lib.licenses; [ gpl2Plus ];
-      teams = [ teams.deshaw ];
+      maintainers = with lib.maintainers; [
+        de11n
+        despsyched
+      ];
     };
   };
 
@@ -15271,7 +15294,10 @@ with self;
         artistic1
         gpl1Plus
       ];
-      teams = [ teams.deshaw ];
+      maintainers = with lib.maintainers; [
+        de11n
+        despsyched
+      ];
     };
   };
 
@@ -18917,7 +18943,10 @@ with self;
         artistic1
         gpl1Plus
       ];
-      teams = [ teams.deshaw ];
+      maintainers = with lib.maintainers; [
+        de11n
+        despsyched
+      ];
     };
   };
 
@@ -20409,7 +20438,10 @@ with self;
         artistic1
         gpl1Plus
       ];
-      teams = [ teams.deshaw ];
+      maintainers = with lib.maintainers; [
+        de11n
+        despsyched
+      ];
     };
   };
 
@@ -26712,8 +26744,11 @@ with self;
       description = "Perl extension for Apache ZooKeeper";
       homepage = "https://github.com/mark-5/p5-net-zookeeper";
       license = with lib.licenses; [ asl20 ];
-      maintainers = [ maintainers.ztzg ];
-      teams = [ teams.deshaw ];
+      maintainers = with lib.maintainers; [
+        de11n
+        despsyched
+        ztzg
+      ];
     };
   };
 
@@ -27084,7 +27119,6 @@ with self;
         artistic1
         gpl1Plus
       ];
-      teams = [ teams.deshaw ];
     };
   };
 
@@ -27272,7 +27306,10 @@ with self;
         artistic1
         gpl1Plus
       ];
-      teams = [ teams.deshaw ];
+      maintainers = with lib.maintainers; [
+        de11n
+        despsyched
+      ];
     };
   };
 
@@ -27964,7 +28001,6 @@ with self;
         artistic1
         gpl1Plus
       ];
-      teams = [ teams.deshaw ];
     };
   };
 
@@ -28037,7 +28073,6 @@ with self;
         artistic1
         gpl1Plus
       ];
-      teams = [ teams.deshaw ];
       mainProgram = "ppkg-config";
     };
   };
@@ -28457,7 +28492,10 @@ with self;
         artistic1
         gpl1Plus
       ];
-      teams = [ teams.deshaw ];
+      maintainers = with lib.maintainers; [
+        de11n
+        despsyched
+      ];
     };
   };
 
@@ -28475,7 +28513,6 @@ with self;
         artistic1
         gpl1Plus
       ];
-      teams = [ teams.deshaw ];
       mainProgram = "poe-gen-tests";
     };
   };


### PR DESCRIPTION
The @NixOS/nixpkgs-core team has recently reviewed Nixpkgs teams, and decided that teams should be organized internally around specific topics of maintenance, rather than having membership gated by external criteria. This means having maintainer responsibility and authority decided by consensus of existing maintainers and team members in an area of interest, rather than being granted or revoked based on employment, membership in an external organization, or role in another FOSS project. The reasoning is given in the full statement at https://github.com/NixOS/org/issues/220#issuecomment-3678147410.

We are now triaging teams to make sure they’re in line with this model and working with their members to find the best way forward for each case. This is being tracked at #478780.

@de11n @DESPsyched @invokes-su

This team was flagged as apparently having external membership criteria. By default, we’ll merge this to drop the team after a week if we don’t hear back from you, but we’re also happy to implement alternatives, e.g.:

- Redistribute members to maintainer lists of individual packages per their request.
- Reorganize or merge the team into one or more teams relating to specific areas of maintenance interest with open membership criteria.
- Clarify that the team is dedicated to maintenance of software maintained upstream by a certain organization, but is open to all contributors. For example, `lib.teams.jetbrains` and `lib.teams.qt-kde` handle maintenance of JetBrains IDEs and KDE software, but have no expectation that members are affiliated with those organizations, even though some may be.