### PR TITLE
teams/mercury: handle team with external membership

### DIFF
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -670,18 +670,6 @@ with lib.maintainers;
     shortName = "Matrix";
   };
 
-  mercury = {
-    members = [
-      _9999years
-      Gabriella439
-      curran
-      lf-
-      jkachmar
-    ];
-    scope = "Group registry for packages maintained by Mercury";
-    shortName = "Mercury Employees";
-  };
-
   minimal-bootstrap = {
     members = [
       alejandrosame

--- a/pkgs/by-name/ho/honeycomb-refinery/package.nix
+++ b/pkgs/by-name/ho/honeycomb-refinery/package.nix
@@ -52,6 +52,9 @@ buildGoModule (finalAttrs: {
     description = "Tail-sampling proxy for OpenTelemetry";
     mainProgram = "refinery";
     license = lib.licenses.asl20;
-    teams = [ lib.teams.mercury ];
+    maintainers = with lib.maintainers; [
+      jkachmar
+      lf-
+    ];
   };
 })

--- a/pkgs/by-name/py/pyroscope/package.nix
+++ b/pkgs/by-name/py/pyroscope/package.nix
@@ -55,7 +55,10 @@ buildGoModule (finalAttrs: {
     homepage = "https://github.com/grafana/pyroscope";
     changelog = "https://github.com/grafana/pyroscope/blob/${finalAttrs.src.rev}/CHANGELOG.md";
     license = lib.licenses.agpl3Only;
-    teams = [ lib.teams.mercury ];
+    maintainers = with lib.maintainers; [
+      jkachmar
+      lf-
+    ];
     mainProgram = "pyroscope";
   };
 })

--- a/pkgs/by-name/tc/tcld/package.nix
+++ b/pkgs/by-name/tc/tcld/package.nix
@@ -69,7 +69,9 @@ buildGoModule (finalAttrs: {
     homepage = "https://www.github.com/temporalio/tcld";
     changelog = "https://github.com/temporalio/tcld/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
-    teams = [ lib.teams.mercury ];
+    maintainers = with lib.maintainers; [
+      jkachmar
+    ];
     mainProgram = "tcld";
   };
 })

--- a/pkgs/test/haskell/incremental/default.nix
+++ b/pkgs/test/haskell/incremental/default.nix
@@ -33,7 +33,11 @@ let
   }) temporary;
 in
 temporary-incremental-build.overrideAttrs (old: {
-  meta = {
-    teams = [ lib.teams.mercury ];
+  meta = old.meta // {
+    maintainers = old.meta.maintainers or [ ] ++ [
+      lib.maintainers._9999years
+      lib.maintainers.Gabriella439
+      lib.maintainers.lf-
+    ];
   };
 })


### PR DESCRIPTION
The @NixOS/nixpkgs-core team has recently reviewed Nixpkgs teams, and decided that teams should be organized internally around specific topics of maintenance, rather than having membership gated by external criteria. This means having maintainer responsibility and authority decided by consensus of existing maintainers and team members in an area of interest, rather than being granted or revoked based on employment, membership in an external organization, or role in another FOSS project. The reasoning is given in the full statement at https://github.com/NixOS/org/issues/220#issuecomment-3678147410.

We are now triaging teams to make sure they’re in line with this model and working with their members to find the best way forward for each case. This is being tracked at #478780.

@9999years @Gabriella439 @curranosaurus @lf- @jkachmar 

This team was flagged as apparently having external membership criteria. By default, we’ll merge this to drop the team after a week if we don’t hear back from you, but we’re also happy to implement alternatives, e.g.:

- Redistribute members to maintainer lists of individual packages per their request.
- Reorganize or merge the team into one or more teams relating to specific areas of maintenance interest with open membership criteria.
- Clarify that the team is dedicated to maintenance of software maintained upstream by a certain organization, but is open to all contributors. For example, `lib.teams.jetbrains` and `lib.teams.qt-kde` handle maintenance of JetBrains IDEs and KDE software, but have no expectation that members are affiliated with those organizations, even though some may be.