### PR TITLE
teams/redcodelabs: handle team with external membership

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -28532,12 +28532,6 @@
     github = "wrrrzr";
     githubId = 161970349;
   };
-  wr0belj = {
-    name = "Jakub Wróbel";
-    email = "wrobel.jakub@protonmail.com";
-    github = "wr0belj";
-    githubId = 40501814;
-  };
   wr7 = {
     name = "wr7";
     email = "d-wr7@outlook.com";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -28387,12 +28387,6 @@
     githubId = 78392041;
     name = "Winter";
   };
-  wintrmvte = {
-    name = "Jakub Lutczyn";
-    email = "kubalutczyn@gmail.com";
-    github = "wintrmvte";
-    githubId = 41823252;
-  };
   wirew0rm = {
     email = "alex@wirew0rm.de";
     github = "wirew0rm";

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -861,7 +861,6 @@ with lib.maintainers;
   redcodelabs = {
     members = [
       unrooted
-      wr0belj
       wintrmvte
     ];
     scope = "Maintain Red Code Labs related packages and modules.";

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -858,14 +858,6 @@ with lib.maintainers;
     enableFeatureFreezePing = true;
   };
 
-  redcodelabs = {
-    members = [
-      unrooted
-    ];
-    scope = "Maintain Red Code Labs related packages and modules.";
-    shortName = "Red Code Labs";
-  };
-
   rocm = {
     github = "rocm";
   };

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -861,7 +861,6 @@ with lib.maintainers;
   redcodelabs = {
     members = [
       unrooted
-      wintrmvte
     ];
     scope = "Maintain Red Code Labs related packages and modules.";
     shortName = "Red Code Labs";

--- a/pkgs/by-name/go/godspeed/package.nix
+++ b/pkgs/by-name/go/godspeed/package.nix
@@ -31,7 +31,6 @@ buildGoModule rec {
     changelog = "https://github.com/redcode-labs/GodSpeed/releases/tag/${version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
-    teams = [ lib.teams.redcodelabs ];
     mainProgram = "godspeed";
     broken = stdenv.hostPlatform.isDarwin;
   };

--- a/pkgs/by-name/go/gosh/package.nix
+++ b/pkgs/by-name/go/gosh/package.nix
@@ -24,7 +24,6 @@ buildGoModule rec {
     homepage = "https://github.com/redcode-labs/GoSH";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
-    teams = [ lib.teams.redcodelabs ];
     mainProgram = "GoSH";
   };
 }

--- a/pkgs/by-name/sa/sammler/package.nix
+++ b/pkgs/by-name/sa/sammler/package.nix
@@ -26,6 +26,5 @@ buildGoModule rec {
     homepage = "https://github.com/redcode-labs/Sammler";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
-    teams = [ lib.teams.redcodelabs ];
   };
 }

--- a/pkgs/by-name/sn/snowcrash/package.nix
+++ b/pkgs/by-name/sn/snowcrash/package.nix
@@ -29,7 +29,6 @@ buildGoModule rec {
     homepage = "https://github.com/redcode-labs/SNOWCRASH";
     license = with lib.licenses; [ mit ];
     maintainers = with lib.maintainers; [ fab ];
-    teams = [ lib.teams.redcodelabs ];
     mainProgram = "SNOWCRASH";
   };
 }


### PR DESCRIPTION
The @NixOS/nixpkgs-core team has recently reviewed Nixpkgs teams, and decided that teams should be organized internally around specific topics of maintenance, rather than having membership gated by external criteria. This means having maintainer responsibility and authority decided by consensus of existing maintainers and team members in an area of interest, rather than being granted or revoked based on employment, membership in an external organization, or role in another FOSS project. The reasoning is given in the full statement at https://github.com/NixOS/org/issues/220#issuecomment-3678147410.

We are now triaging teams to make sure they’re in line with this model and working with their members to find the best way forward for each case. This is being tracked at #478780.

@unrooted @wr0belj @wintrmvte

This team was flagged as apparently having external membership criteria. By default, we’ll merge this to drop the team after a week if we don’t hear back from you, but we’re also happy to implement alternatives, e.g.:

- Redistribute members to maintainer lists of individual packages per their request.
- Reorganize or merge the team into one or more teams relating to specific areas of maintenance interest with open membership criteria.
- Clarify that the team is dedicated to maintenance of software maintained upstream by a certain organization, but is open to all contributors. For example, `lib.teams.jetbrains` and `lib.teams.qt-kde` handle maintenance of JetBrains IDEs and KDE software, but have no expectation that members are affiliated with those organizations, even though some may be.