### PR TITLE
vimPlugins.jupyter-api-nvim: init at 2026-01-10

### DIFF
--- a/pkgs/applications/editors/vim/plugins/non-generated/jupyter-api-nvim/default.nix
+++ b/pkgs/applications/editors/vim/plugins/non-generated/jupyter-api-nvim/default.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  stdenv,
+  vimUtils,
+  nix-update-script,
+  gitMinimal,
+}:
+let
+  version = "0-unstable-2026-01-10";
+  src = fetchFromGitHub {
+    owner = "bitbloxhub";
+    repo = "jupyter-api.nvim";
+    rev = "5dd157fd8cd9ef6d20075c0809f54c9f7af23e43";
+    hash = "sha256-N9Z7SaWeT8b2N3EtwwRLW7DCiQk0+tCd9e573DSq7SQ=";
+  };
+  jupyter-api-nvim-lib = rustPlatform.buildRustPackage {
+    inherit version src;
+    pname = "jupyter-api-nvim-lib";
+
+    cargoHash = "sha256-Oe6NnnNBY2nzYkNYucPpR6iV/8a6/9ZUytKpdHWY+So=";
+
+    env = {
+      # Allow undefined symbols on Darwin - they will be provided by Neovim's LuaJIT runtime
+      RUSTFLAGS = lib.optionalString stdenv.hostPlatform.isDarwin "-C link-arg=-undefined -C link-arg=dynamic_lookup";
+    };
+  };
+in
+vimUtils.buildVimPlugin {
+  pname = "jupyter-api.nvim";
+  inherit version src;
+  preInstall =
+    let
+      ext = stdenv.hostPlatform.extensions.sharedLibrary;
+    in
+    ''
+      mkdir -p target/release
+      ln -s ${jupyter-api-nvim-lib}/lib/libjupyter_api_nvim${ext} target/release/libjupyter_api_nvim${ext}
+    '';
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = "vimPlugins.jupyter-api-nvim.jupyter-api-nvim-lib";
+    };
+
+    # needed for the update script
+    inherit jupyter-api-nvim-lib;
+  };
+
+  meta = {
+    description = "Library for interacting with Jupyter kernels from Neovim Lua";
+    homepage = "https://github.com/bitbloxhub/jupyter-api.nvim/";
+    license = lib.licenses.isc;
+    maintainers = with lib.maintainers; [
+      bitbloxhub
+    ];
+  };
+}


### PR DESCRIPTION
## Things done

Add [`jupyter-api.nvim`](https://github.com/bitbloxhub/jupyter-api.nvim/), a library for interacting with Jupyter kernels from Neovim Lua.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
