### PR TITLE
teams/secshell: handle team with external membership

### DIFF
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -892,15 +892,6 @@ with lib.maintainers;
     enableFeatureFreezePing = true;
   };
 
-  secshell = {
-    members = [
-      felbinger
-      juli0604
-    ];
-    scope = "Maintain packages and modules created by members of Secure Shell Networks.";
-    shortName = "secshell";
-  };
-
   serokell = {
     # Verify additions by approval of an already existing member of the team.
     members = [ balsoft ];

--- a/nixos/modules/services/networking/suricata/default.nix
+++ b/nixos/modules/services/networking/suricata/default.nix
@@ -22,8 +22,6 @@ let
     ;
 in
 {
-  meta.maintainers = lib.teams.secshell.members;
-
   options.services.suricata = {
     enable = mkEnableOption "Suricata";
 

--- a/nixos/modules/services/web-apps/part-db.nix
+++ b/nixos/modules/services/web-apps/part-db.nix
@@ -17,8 +17,6 @@ let
     ;
 in
 {
-  meta.maintainers = lib.teams.secshell.members;
-
   options.services.part-db = {
     enable = mkEnableOption "PartDB";
 

--- a/nixos/tests/suricata.nix
+++ b/nixos/tests/suricata.nix
@@ -1,7 +1,6 @@
 { lib, pkgs, ... }:
 {
   name = "suricata";
-  meta.maintainers = lib.teams.secshell.members;
 
   nodes = {
     ids = {

--- a/pkgs/by-name/od/odhcp6c/package.nix
+++ b/pkgs/by-name/od/odhcp6c/package.nix
@@ -28,7 +28,6 @@ stdenv.mkDerivation {
     description = "Embedded DHCPv6-client for OpenWrt";
     homepage = "https://openwrt.org/packages/pkgdata/odhcp6c";
     license = lib.licenses.gpl2Only;
-    teams = with lib.teams; [ secshell ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/pa/part-db/package.nix
+++ b/pkgs/by-name/pa/part-db/package.nix
@@ -84,7 +84,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://docs.part-db.de/";
     changelog = "https://github.com/Part-DB/Part-DB-server/releases/tag/v${version}";
     license = lib.licenses.agpl3Plus;
-    teams = with lib.teams; [ secshell ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/development/python-modules/napalm/ros.nix
+++ b/pkgs/development/python-modules/napalm/ros.nix
@@ -42,6 +42,5 @@ buildPythonPackage rec {
     changelog = "https://github.com/napalm-automation-community/napalm-ros/releases/tag/${src.tag}";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux;
-    teams = with lib.teams; [ secshell ];
   };
 }

--- a/pkgs/development/python-modules/netbox-attachments/default.nix
+++ b/pkgs/development/python-modules/netbox-attachments/default.nix
@@ -42,6 +42,5 @@ buildPythonPackage rec {
     changelog = "https://github.com/Kani999/netbox-attachments/releases/tag/${src.tag}";
     license = lib.licenses.asl20;
     platforms = lib.platforms.linux;
-    teams = with lib.teams; [ secshell ];
   };
 }

--- a/pkgs/development/python-modules/netbox-bgp/default.nix
+++ b/pkgs/development/python-modules/netbox-bgp/default.nix
@@ -37,6 +37,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/netbox-community/netbox-bgp";
     changelog = "https://github.com/netbox-community/netbox-bgp/releases/tag/${src.tag}";
     license = lib.licenses.asl20;
-    teams = with lib.teams; [ secshell ];
   };
 }

--- a/pkgs/development/python-modules/netbox-contextmenus/default.nix
+++ b/pkgs/development/python-modules/netbox-contextmenus/default.nix
@@ -28,6 +28,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/PieterL75/netbox_contextmenus/";
     changelog = "https://github.com/PieterL75/netbox_contextmenus/releases/tag/${src.tag}";
     license = lib.licenses.mit;
-    teams = with lib.teams; [ secshell ];
   };
 }

--- a/pkgs/development/python-modules/netbox-contract/default.nix
+++ b/pkgs/development/python-modules/netbox-contract/default.nix
@@ -48,6 +48,5 @@ buildPythonPackage rec {
     changelog = "https://github.com/mlebreuil/netbox-contract/releases/tag/${src.tag}";
     license = lib.licenses.mit;
     platforms = lib.platforms.linux;
-    teams = with lib.teams; [ secshell ];
   };
 }

--- a/pkgs/development/python-modules/netbox-dns/default.nix
+++ b/pkgs/development/python-modules/netbox-dns/default.nix
@@ -31,6 +31,5 @@ buildPythonPackage rec {
     changelog = "https://github.com/peteeckel/netbox-plugin-dns/releases/tag/${src.tag}";
     license = lib.licenses.mit;
     platforms = lib.platforms.linux;
-    teams = with lib.teams; [ secshell ];
   };
 }

--- a/pkgs/development/python-modules/netbox-interface-synchronization/default.nix
+++ b/pkgs/development/python-modules/netbox-interface-synchronization/default.nix
@@ -41,6 +41,5 @@ buildPythonPackage rec {
     changelog = "https://github.com/NetTech2001/netbox-interface-synchronization/releases/tag/${src.tag}";
     license = lib.licenses.gpl3Only;
     platforms = lib.platforms.linux;
-    teams = with lib.teams; [ secshell ];
   };
 }

--- a/pkgs/development/python-modules/netbox-napalm-plugin/default.nix
+++ b/pkgs/development/python-modules/netbox-napalm-plugin/default.nix
@@ -48,6 +48,5 @@ buildPythonPackage rec {
     changelog = "https://github.com/netbox-community/netbox-napalm-plugin/releases/tag/${src.tag}";
     license = lib.licenses.asl20;
     platforms = lib.platforms.linux;
-    teams = with lib.teams; [ secshell ];
   };
 }

--- a/pkgs/development/python-modules/netbox-qrcode/default.nix
+++ b/pkgs/development/python-modules/netbox-qrcode/default.nix
@@ -47,6 +47,5 @@ buildPythonPackage rec {
     changelog = "https://github.com/netbox-community/netbox-qrcode/releases/tag/${src.tag}";
     license = lib.licenses.asl20;
     platforms = lib.platforms.linux;
-    teams = with lib.teams; [ secshell ];
   };
 }

--- a/pkgs/development/python-modules/netbox-topology-views/default.nix
+++ b/pkgs/development/python-modules/netbox-topology-views/default.nix
@@ -42,6 +42,5 @@ buildPythonPackage rec {
     changelog = "https://github.com/netbox-community/netbox-topology-views/releases/tag/${src.tag}";
     license = lib.licenses.asl20;
     platforms = lib.platforms.linux;
-    teams = with lib.teams; [ secshell ];
   };
 }


### PR DESCRIPTION
The @NixOS/nixpkgs-core team has recently reviewed Nixpkgs teams, and decided that teams should be organized internally around specific topics of maintenance, rather than having membership gated by external criteria. This means having maintainer responsibility and authority decided by consensus of existing maintainers and team members in an area of interest, rather than being granted or revoked based on employment, membership in an external organization, or role in another FOSS project. The reasoning is given in the full statement at https://github.com/NixOS/org/issues/220#issuecomment-3678147410.

We are now triaging teams to make sure they’re in line with this model and working with their members to find the best way forward for each case. This is being tracked at #478780.

@felbinger @juli0604 

This team was flagged as apparently having external membership criteria. By default, we’ll merge this to drop the team after a week if we don’t hear back from you, but we’re also happy to implement alternatives, e.g.:

- Redistribute members to maintainer lists of individual packages per their request.
- Reorganize or merge the team into one or more teams relating to specific areas of maintenance interest with open membership criteria.
- Clarify that the team is dedicated to maintenance of software maintained upstream by a certain organization, but is open to all contributors. For example, `lib.teams.jetbrains` and `lib.teams.qt-kde` handle maintenance of JetBrains IDEs and KDE software, but have no expectation that members are affiliated with those organizations, even though some may be.