### PR TITLE
teams/serokell: handle team with external membership

### DIFF
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -901,13 +901,6 @@ with lib.maintainers;
     shortName = "secshell";
   };
 
-  serokell = {
-    # Verify additions by approval of an already existing member of the team.
-    members = [ balsoft ];
-    scope = "Group registration for Serokell employees who collectively maintain packages.";
-    shortName = "Serokell employees";
-  };
-
   stdenv = {
     enableFeatureFreezePing = true;
     github = "stdenv";

--- a/nixos/tests/oci-containers.nix
+++ b/nixos/tests/oci-containers.nix
@@ -16,7 +16,7 @@ let
     makeTest {
       name = "oci-containers-${backend}";
 
-      meta.maintainers = lib.teams.serokell.members ++ (with lib.maintainers; [ benley ]);
+      meta.maintainers = with lib.maintainers; [ benley ];
 
       nodes = {
         ${backend} =

--- a/pkgs/by-name/ac/acme-sh/package.nix
+++ b/pkgs/by-name/ac/acme-sh/package.nix
@@ -74,7 +74,6 @@ stdenv.mkDerivation rec {
       - Cron job notifications for renewal or error etc.
     '';
     license = lib.licenses.gpl3Only;
-    teams = [ lib.teams.serokell ];
     inherit (coreutils.meta) platforms;
     mainProgram = "acme.sh";
   };

--- a/pkgs/by-name/da/danger-gitlab/package.nix
+++ b/pkgs/by-name/da/danger-gitlab/package.nix
@@ -15,7 +15,6 @@ bundlerApp {
     description = "Gem that exists to ensure all dependencies are set up for Danger with GitLab";
     homepage = "https://github.com/danger/danger-gitlab-gem";
     license = lib.licenses.mit;
-    teams = with lib.teams; [ serokell ];
     mainProgram = "danger";
   };
 }

--- a/pkgs/by-name/de/deploy-rs/package.nix
+++ b/pkgs/by-name/de/deploy-rs/package.nix
@@ -25,7 +25,6 @@ rustPlatform.buildRustPackage {
       teutat3s
       jk
     ];
-    teams = [ lib.teams.serokell ];
     mainProgram = "deploy";
   };
 }

--- a/pkgs/by-name/oa/oauth2-proxy/package.nix
+++ b/pkgs/by-name/oa/oauth2-proxy/package.nix
@@ -28,7 +28,6 @@ buildGoModule rec {
     description = "Reverse proxy that provides authentication with Google, Github, or other providers";
     homepage = "https://github.com/oauth2-proxy/oauth2-proxy/";
     license = lib.licenses.mit;
-    teams = [ lib.teams.serokell ];
     mainProgram = "oauth2-proxy";
   };
 }

--- a/pkgs/by-name/va/vault-bin/package.nix
+++ b/pkgs/by-name/va/vault-bin/package.nix
@@ -67,7 +67,6 @@ stdenv.mkDerivation rec {
       Chili-Man
       techknowlogick
     ];
-    teams = [ lib.teams.serokell ];
     mainProgram = "vault";
     platforms = [
       "x86_64-linux"

--- a/pkgs/by-name/yo/youtrack/package.nix
+++ b/pkgs/by-name/yo/youtrack/package.nix
@@ -44,7 +44,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   meta = {
     description = "Issue tracking and project management tool for developers";
     maintainers = [ lib.maintainers.leona ];
-    teams = [ lib.teams.serokell ];
     sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     # https://www.jetbrains.com/youtrack/buy/license.html
     license = lib.licenses.unfree;


### PR DESCRIPTION
The @NixOS/nixpkgs-core team has recently reviewed Nixpkgs teams, and decided that teams should be organized internally around specific topics of maintenance, rather than having membership gated by external criteria. This means having maintainer responsibility and authority decided by consensus of existing maintainers and team members in an area of interest, rather than being granted or revoked based on employment, membership in an external organization, or role in another FOSS project. The reasoning is given in the full statement at https://github.com/NixOS/org/issues/220#issuecomment-3678147410.

We are now triaging teams to make sure they’re in line with this model and working with their members to find the best way forward for each case. This is being tracked at #478780.

@balsoft

This team was flagged as apparently having external membership criteria. By default, we’ll merge this to drop the team after a week if we don’t hear back from you, but we’re also happy to implement alternatives, e.g.:

- Redistribute members to maintainer lists of individual packages per their request.
- Reorganize or merge the team into one or more teams relating to specific areas of maintenance interest with open membership criteria.
- Clarify that the team is dedicated to maintenance of software maintained upstream by a certain organization, but is open to all contributors. For example, `lib.teams.jetbrains` and `lib.teams.qt-kde` handle maintenance of JetBrains IDEs and KDE software, but have no expectation that members are affiliated with those organizations, even though some may be.