### PR TITLE
yaziPlugins: update on 2026-01-10

### DIFF
--- a/pkgs/by-name/ya/yazi/plugins/compress/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/compress/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "compress.yazi";
-  version = "0-unstable-2026-01-05";
+  version = "0-unstable-2026-01-10";
 
   src = fetchFromGitHub {
     owner = "KKV9";
     repo = "compress.yazi";
-    rev = "c9c16d8eb3d8f15bea5d58419229529921c58c94";
-    hash = "sha256-tllxA9rlyQGuFHMMhoTjjAAJImsCTAgawBd3c9ZGzMU=";
+    rev = "e6007f7c3f364cdb7146f5b6b282790948fb0bd6";
+    hash = "sha256-m5FfN2gnTHsbwP2aYaE+K6kNGfAC7HBVtCyy6HzNRrE=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/mediainfo/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/mediainfo/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "mediainfo.yazi";
-  version = "25.5.31-unstable-2026-01-01";
+  version = "25.5.31-unstable-2026-01-07";
 
   src = fetchFromGitHub {
     owner = "boydaihungst";
     repo = "mediainfo.yazi";
-    rev = "90a165237447778109a281f5bfc8e7b73d371cd5";
-    hash = "sha256-PJyZ9Rs5WjHHfHPd9ROmWvos1YzBc83ppj4Y/obx4BE=";
+    rev = "7cd6b042aba45367701e00819705bd0bac2c963c";
+    hash = "sha256-Ehg8PFiOLy4iKgsOjj8KiNGTdj3VwkdmNP3lvdBi9aY=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/mime-ext/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/mime-ext/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "mime-ext.yazi";
-  version = "25.12.29-unstable-2025-12-30";
+  version = "25.12.29-unstable-2026-01-07";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "da5b69563c67717c4bb422c9c72cc0cb9baa0632";
-    hash = "sha256-LjlcAKlAZ/r4BDdcUGFX+e4LLZRHEH/jCsciKMs4QWg=";
+    rev = "68f7d4898c19dcf50beda251f8143992c3e8371f";
+    hash = "sha256-6iA/C0dzbLPkEDbdEs8oAnVfG6W+L8/dYyjTuO5euOw=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/ouch/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/ouch/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "ouch.yazi";
-  version = "0-unstable-2025-11-25";
+  version = "0-unstable-2026-01-09";
 
   src = fetchFromGitHub {
     owner = "ndtoan96";
     repo = "ouch.yazi";
-    rev = "cfb91404d3d83bcf7bbf90d689d226699b0e4147";
-    hash = "sha256-6TyKPsapXJMiSRFrKRfP/hamOiG6LfgbPp7flh5tKoo=";
+    rev = "594b8a2b246633d46b03a3261c9aebd1c4b5abf3";
+    hash = "sha256-+M0ZFh2jKts5GP9KgKsbpeNe0ldXQGyUZlYjDbp4yhw=";
   };
 
   meta = {


### PR DESCRIPTION
- compress: 0-unstable-2026-01-05 → 0-unstable-2026-01-10
- mediainfo: 25.5.31-unstable-2026-01-01 → 25.5.31-unstable-2026-01-07
- mime-ext: 25.12.29-unstable-2025-12-30 → 25.12.29-unstable-2026-01-07
- ouch: 0-unstable-2025-11-25 → 0-unstable-2026-01-09


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
