### PR TITLE
teams/stridtech: handle team with external membership

### DIFF
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -923,15 +923,6 @@ with lib.maintainers;
     shortName = "Steam";
   };
 
-  stridtech = {
-    # Verify additions by approval of an already existing member of the team
-    members = [
-      ulrikstrid
-    ];
-    scope = "Group registration for Strid Tech AB team members who collectively maintain packages";
-    shortName = "StridTech";
-  };
-
   swift = {
     members = [
       dduan

--- a/pkgs/applications/editors/vscode/extensions/ms-azuretools.vscode-bicep/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/ms-azuretools.vscode-bicep/default.nix
@@ -25,7 +25,6 @@ vscode-utils.buildVscodeMarketplaceExtension {
     downloadPage = "https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-bicep";
     homepage = "https://github.com/Azure/bicep/tree/main/src/vscode-bicep";
     license = lib.licenses.mit;
-    teams = [ lib.teams.stridtech ];
   };
 }
 

--- a/pkgs/by-name/az/azure-cli/package.nix
+++ b/pkgs/by-name/az/azure-cli/package.nix
@@ -480,7 +480,6 @@ py.pkgs.toPythonApplication (
       license = lib.licenses.mit;
       mainProgram = "az";
       maintainers = with lib.maintainers; [ katexochen ];
-      teams = [ lib.teams.stridtech ];
       platforms = lib.platforms.all;
     };
   }

--- a/pkgs/by-name/bi/bicep-lsp/package.nix
+++ b/pkgs/by-name/bi/bicep-lsp/package.nix
@@ -50,7 +50,6 @@ buildDotnetModule rec {
     homepage = "https://github.com/Azure/bicep/";
     changelog = "https://github.com/Azure/bicep/releases/tag/v${version}";
     license = lib.licenses.mit;
-    teams = [ lib.teams.stridtech ];
     platforms = lib.platforms.all;
     badPlatforms = [ "aarch64-linux" ];
   };

--- a/pkgs/by-name/bi/bicep/package.nix
+++ b/pkgs/by-name/bi/bicep/package.nix
@@ -57,7 +57,6 @@ buildDotnetModule rec {
     changelog = "https://github.com/Azure/bicep/releases/tag/v${version}";
     license = lib.licenses.mit;
     maintainers = [ ];
-    teams = [ lib.teams.stridtech ];
     mainProgram = "bicep";
   };
 }

--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -385,7 +385,6 @@ let
         license = lib.licenses.openssl;
         mainProgram = "openssl";
         maintainers = with lib.maintainers; [ thillux ];
-        teams = [ lib.teams.stridtech ];
         pkgConfigModules = [
           "libcrypto"
           "libssl"

--- a/pkgs/servers/http/nginx/generic.nix
+++ b/pkgs/servers/http/nginx/generic.nix
@@ -319,7 +319,6 @@ stdenv.mkDerivation {
         ];
         teams = with lib.teams; [
           helsinki-systems
-          stridtech
         ];
       };
 }


### PR DESCRIPTION
The @NixOS/nixpkgs-core team has recently reviewed Nixpkgs teams, and decided that teams should be organized internally around specific topics of maintenance, rather than having membership gated by external criteria. This means having maintainer responsibility and authority decided by consensus of existing maintainers and team members in an area of interest, rather than being granted or revoked based on employment, membership in an external organization, or role in another FOSS project. The reasoning is given in the full statement at https://github.com/NixOS/org/issues/220#issuecomment-3678147410.

We are now triaging teams to make sure they’re in line with this model and working with their members to find the best way forward for each case. This is being tracked at #478780.

@ulrikstrid 

This team was flagged as apparently having external membership criteria. By default, we’ll merge this to drop the team after a week if we don’t hear back from you, but we’re also happy to implement alternatives, e.g.:

- Redistribute members to maintainer lists of individual packages per their request.
- Reorganize or merge the team into one or more teams relating to specific areas of maintenance interest with open membership criteria.
- Clarify that the team is dedicated to maintenance of software maintained upstream by a certain organization, but is open to all contributors. For example, `lib.teams.jetbrains` and `lib.teams.qt-kde` handle maintenance of JetBrains IDEs and KDE software, but have no expectation that members are affiliated with those organizations, even though some may be.