### PR TITLE
teams/uzinfocom: handle team with external membership

### DIFF
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -961,17 +961,6 @@ with lib.maintainers;
     shortName = "coqui-ai TTS";
   };
 
-  uzinfocom = {
-    members = [
-      orzklv
-      bahrom04
-      bemeritus
-      shakhzodkudratov
-    ];
-    scope = "Maintain Uzbek Linux state & community packages and modules.";
-    shortName = "Uzinfocom Open Source";
-  };
-
   wdz = {
     members = [
       n0emis

--- a/nixos/modules/services/security/e-imzo.nix
+++ b/nixos/modules/services/security/e-imzo.nix
@@ -45,6 +45,4 @@ in
       };
     };
   };
-
-  meta.maintainers = lib.teams.uzinfocom.members;
 }

--- a/pkgs/by-name/e-/e-imzo-manager/package.nix
+++ b/pkgs/by-name/e-/e-imzo-manager/package.nix
@@ -77,6 +77,5 @@ stdenv.mkDerivation (finalAttrs: {
     description = "GTK application for managing E-IMZO keys";
     license = with lib.licenses; [ agpl3Plus ];
     platforms = lib.platforms.linux;
-    teams = [ lib.teams.uzinfocom ];
   };
 })

--- a/pkgs/by-name/e-/e-imzo/package.nix
+++ b/pkgs/by-name/e-/e-imzo/package.nix
@@ -49,6 +49,5 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     homepage = "https://e-imzo.soliq.uz";
     license = lib.licenses.unfree;
     sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
-    teams = [ lib.teams.uzinfocom ];
   };
 })

--- a/pkgs/by-name/hu/hunspell/dictionaries.nix
+++ b/pkgs/by-name/hu/hunspell/dictionaries.nix
@@ -844,7 +844,6 @@ rec {
       license = with lib.licenses; [
         gpl3Plus
       ];
-      teams = [ lib.teams.uzinfocom ];
     };
   };
 


### PR DESCRIPTION
The @NixOS/nixpkgs-core team has recently reviewed Nixpkgs teams, and decided that teams should be organized internally around specific topics of maintenance, rather than having membership gated by external criteria. This means having maintainer responsibility and authority decided by consensus of existing maintainers and team members in an area of interest, rather than being granted or revoked based on employment, membership in an external organization, or role in another FOSS project. The reasoning is given in the full statement at https://github.com/NixOS/org/issues/220#issuecomment-3678147410.

We are now triaging teams to make sure they’re in line with this model and working with their members to find the best way forward for each case. This is being tracked at #478780.

@orzklv @bahrom04 @bemeritus @shakhzodkudratov 

This team was flagged as apparently having external membership criteria. By default, we’ll merge this to drop the team after a week if we don’t hear back from you, but we’re also happy to implement alternatives, e.g.:

- Redistribute members to maintainer lists of individual packages per their request.
- Reorganize or merge the team into one or more teams relating to specific areas of maintenance interest with open membership criteria.
- Clarify that the team is dedicated to maintenance of software maintained upstream by a certain organization, but is open to all contributors. For example, `lib.teams.jetbrains` and `lib.teams.qt-kde` handle maintenance of JetBrains IDEs and KDE software, but have no expectation that members are affiliated with those organizations, even though some may be.