### PR TITLE
twinejs: init at 2.11.1

### DIFF
--- a/pkgs/by-name/tw/twinejs/package.nix
+++ b/pkgs/by-name/tw/twinejs/package.nix
@@ -1,0 +1,101 @@
+{
+  stdenv,
+  fetchzip,
+  fetchurl,
+  lib,
+  makeWrapper,
+  electron,
+  makeDesktopItem,
+  copyDesktopItems,
+  autoPatchelfHook,
+  glib,
+}:
+let
+  inherit (stdenv.hostPlatform) system;
+  pname = "twinejs";
+  version = "2.11.1";
+  comment = "Tool for telling interactive, nonlinear stories";
+  downloadsByArch =
+    {
+      "x86_64-linux" = {
+        filename = "Linux-x64";
+        hash = "sha256-HcpVOcQ/lWTLeAgTF+1xPj41HO+wC4au8SEJGC0Nm1Q=";
+      };
+      "aarch64-linux" = {
+        filename = "Linux-arm64";
+        hash = "sha256-B6pIAnjznOvkyS7fNSZ+VbvOj77+pn3YPkxDcgfrw5Y=";
+      };
+    }
+    .${system};
+  src = fetchzip {
+    url = "https://github.com/klembot/twinejs/releases/download/${version}/Twine-${version}-${downloadsByArch.filename}.zip";
+    hash = downloadsByArch.hash;
+    stripRoot = false;
+  };
+  icon = fetchurl {
+    url = "https://github.com/klembot/twinejs/raw/refs/heads/develop/icons/logo.svg";
+    hash = "sha256-TwxXOX/ZbrH02ZzTpy0FB4nGhjLmjtkFrE7WEX7xHbw=";
+  };
+  desktopItems = [
+    (makeDesktopItem {
+      inherit comment;
+      name = "twinejs";
+      desktopName = "Twine";
+      icon = "twinejs";
+      exec = "twinejs %u";
+      terminal = false;
+    })
+  ];
+
+  mkChangelog =
+    version:
+    let
+      xs = lib.splitVersion version;
+    in
+    "https://twinery.org/reference/en/release-notes/${lib.concatStringsSep "-" (lib.take 2 xs)}.html#${lib.concatStrings xs}";
+in
+stdenv.mkDerivation (finalAttrs: {
+  inherit
+    pname
+    version
+    src
+    desktopItems
+    icon
+    ;
+
+  nativeBuildInputs = [
+    makeWrapper
+    autoPatchelfHook
+    copyDesktopItems
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    makeWrapper ${electron}/bin/electron $out/bin/twinejs \
+      --add-flags $out/share/twinejs/app.asar \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform=wayland --enable-wayland-ime=true --wayland-text-input-version=3}}" \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          glib # `gio` is required to move items to trash (e.g. when deleting a story)
+        ]
+      }
+    install -m 444 -D resources/app.asar $out/share/twinejs/app.asar
+    install -m 444 -D ${icon} $out/share/icons/hicolor/scalable/apps/twinejs.svg
+    runHook postInstall
+  '';
+
+  meta = {
+    description = comment;
+    homepage = "https://twinery.org";
+    downloadPage = "https://github.com/klembot/twinejs/releases/tag/${finalAttrs.version}";
+    changelog = mkChangelog finalAttrs.version;
+    mainProgram = "twinejs";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [ mcparland ];
+  };
+})


### PR DESCRIPTION
Adds Twine package. https://twinery.org/

Because `twine` was already taken ([source](https://github.com/NixOS/nixpkgs/blob/nixos-25.11/pkgs/development/python-modules/twine/default.nix)), used `twinejs` as that is the name of the original repository at https://github.com/klembot/twinejs

Tested on X with i3, untested on Wayland.

Derivation mostly copied from how [Obsidian](https://github.com/NixOS/nixpkgs/blob/nixos-25.11/pkgs/by-name/ob/obsidian/package.nix) is packaged, as both are Electron apps.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
