### PR TITLE
teams/wdz: handle team with external membership

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -29173,6 +29173,12 @@
     githubId = 17357089;
     name = "Soham Sen";
   };
+  yureka-wdz = {
+    email = "yureka@wdz.de";
+    github = "yureka-wdz";
+    githubId = 255085068;
+    name = "Yureka (WDZ)";
+  };
   yuriaisaka = {
     email = "yuri.aisaka+nix@gmail.com";
     github = "yuriaisaka";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18195,12 +18195,6 @@
     githubId = 61601147;
     name = "basti n00b0ss";
   };
-  n0emis = {
-    email = "nixpkgs@n0emis.network";
-    github = "n0emis";
-    githubId = 22817873;
-    name = "Ember Keske";
-  };
   n3oney = {
     name = "Michał Minarowski";
     email = "nixpkgs@neoney.dev";

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -836,15 +836,6 @@ with lib.maintainers;
     shortName = "coqui-ai TTS";
   };
 
-  wdz = {
-    members = [
-      johannwagner
-      yuka
-    ];
-    scope = "Group registration for WDZ GmbH team members who collectively maintain packages.";
-    shortName = "WDZ GmbH";
-  };
-
   windows = {
     members = [
       RossSmyth

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -838,7 +838,6 @@ with lib.maintainers;
 
   wdz = {
     members = [
-      n0emis
       johannwagner
       yuka
     ];

--- a/nixos/modules/services/monitoring/librenms.nix
+++ b/nixos/modules/services/monitoring/librenms.nix
@@ -824,5 +824,8 @@ in
 
   };
 
-  meta.maintainers = with lib.maintainers; [ netali ] ++ lib.teams.wdz.members;
+  meta.maintainers = with lib.maintainers; [
+    netali
+    johannwagner
+  ];
 }

--- a/nixos/modules/services/networking/fastnetmon-advanced.nix
+++ b/nixos/modules/services/networking/fastnetmon-advanced.nix
@@ -245,5 +245,5 @@ in
     })
   ];
 
-  meta.maintainers = lib.teams.wdz.members;
+  meta.maintainers = with lib.maintainers; [ yureka-wdz ];
 }

--- a/nixos/modules/services/web-apps/peering-manager.nix
+++ b/nixos/modules/services/web-apps/peering-manager.nix
@@ -420,5 +420,5 @@ in
     ];
   };
 
-  meta.maintainers = with lib.maintainers; [ yuka ];
+  meta.maintainers = with lib.maintainers; [ yureka-wdz ];
 }

--- a/nixos/tests/fastnetmon-advanced.nix
+++ b/nixos/tests/fastnetmon-advanced.nix
@@ -2,7 +2,7 @@
 
 {
   name = "fastnetmon-advanced";
-  meta.maintainers = lib.teams.wdz.members;
+  meta.maintainers = with lib.maintainers; [ yureka-wdz ];
 
   nodes = {
     bird =

--- a/nixos/tests/librenms.nix
+++ b/nixos/tests/librenms.nix
@@ -6,7 +6,7 @@ let
 in
 {
   name = "librenms";
-  meta.maintainers = lib.teams.wdz.members;
+  meta.maintainers = with lib.maintainers; [ johannwagner ];
 
   nodes.librenms = {
     time.timeZone = "Europe/Berlin";

--- a/nixos/tests/web-apps/peering-manager.nix
+++ b/nixos/tests/web-apps/peering-manager.nix
@@ -2,8 +2,8 @@
 {
   name = "peering-manager";
 
-  meta = with lib.maintainers; {
-    maintainers = [ yuka ];
+  meta = {
+    maintainers = with lib.maintainers; [ yureka-wdz ];
   };
 
   nodes.machine =

--- a/pkgs/by-name/ar/arouteserver/package.nix
+++ b/pkgs/by-name/ar/arouteserver/package.nix
@@ -61,7 +61,9 @@ python3Packages.buildPythonPackage rec {
     homepage = "https://github.com/pierky/arouteserver";
     changelog = "https://github.com/pierky/arouteserver/blob/v${version}/CHANGES.rst";
     license = with lib.licenses; [ gpl3Only ];
-    maintainers = with lib.maintainers; [ marcel ];
-    teams = [ lib.teams.wdz ];
+    maintainers = with lib.maintainers; [
+      marcel
+      johannwagner
+    ];
   };
 }

--- a/pkgs/by-name/bn/bngblaster/package.nix
+++ b/pkgs/by-name/bn/bngblaster/package.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/rtbrick/bngblaster/";
     changelog = "https://github.com/rtbrick/bngblaster/releases/tag/${finalAttrs.version}";
     license = lib.licenses.bsd3;
-    teams = [ lib.teams.wdz ];
+    maintainers = with lib.maintainers; [ johannwagner ];
     badPlatforms = lib.platforms.darwin;
   };
 })

--- a/pkgs/by-name/ca/camunda-modeler/package.nix
+++ b/pkgs/by-name/ca/camunda-modeler/package.nix
@@ -76,8 +76,10 @@ stdenvNoCC.mkDerivation rec {
   meta = {
     homepage = "https://github.com/camunda/camunda-modeler";
     description = "Integrated modeling solution for BPMN, DMN and Forms based on bpmn.io";
-    teams = [ lib.teams.wdz ];
-    maintainers = with lib.maintainers; [ vringar ];
+    maintainers = with lib.maintainers; [
+      vringar
+      johannwagner
+    ];
     license = lib.licenses.mit;
     inherit (electron.meta) platforms;
     mainProgram = "camunda-modeler";

--- a/pkgs/by-name/fa/fastnetmon-advanced/package.nix
+++ b/pkgs/by-name/fa/fastnetmon-advanced/package.nix
@@ -62,7 +62,7 @@ stdenv.mkDerivation rec {
     homepage = "https://fastnetmon.com";
     changelog = "https://github.com/FastNetMon/fastnetmon-advanced-releases/releases/tag/v${version}";
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
-    teams = [ lib.teams.wdz ];
+    maintainers = with lib.maintainers; [ yureka-wdz ];
     license = lib.licenses.unfree;
     platforms = [ "x86_64-linux" ];
   };

--- a/pkgs/by-name/fe/fernglas/package.nix
+++ b/pkgs/by-name/fe/fernglas/package.nix
@@ -77,7 +77,7 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/wobcom/fernglas/releases/tag/fernglas-${version}";
     license = lib.licenses.eupl12;
     platforms = lib.platforms.linux;
-    teams = [ lib.teams.wdz ];
+    maintainers = with lib.maintainers; [ yureka-wdz ];
     mainProgram = "fernglas";
   };
 }

--- a/pkgs/by-name/ip/iperf3d/package.nix
+++ b/pkgs/by-name/ip/iperf3d/package.nix
@@ -30,7 +30,9 @@ rustPlatform.buildRustPackage rec {
     mainProgram = "iperf3d";
     homepage = "https://github.com/wobcom/iperf3d";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ netali ];
-    teams = [ lib.teams.wdz ];
+    maintainers = with lib.maintainers; [
+      netali
+      johannwagner
+    ];
   };
 }

--- a/pkgs/by-name/ir/irrd/package.nix
+++ b/pkgs/by-name/ir/irrd/package.nix
@@ -157,6 +157,6 @@ py.pkgs.buildPythonPackage rec {
     description = "Internet Routing Registry database server, processing IRR objects in the RPSL format";
     license = lib.licenses.mit;
     homepage = "https://github.com/irrdnet/irrd";
-    teams = [ lib.teams.wdz ];
+    maintainers = with lib.maintainers; [ yureka-wdz ];
   };
 }

--- a/pkgs/by-name/li/libdict/package.nix
+++ b/pkgs/by-name/li/libdict/package.nix
@@ -43,6 +43,5 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/rtbrick/libdict/releases/tag/${finalAttrs.version}";
     description = "C library of key-value data structures";
     license = lib.licenses.bsd2;
-    teams = [ lib.teams.wdz ];
   };
 })

--- a/pkgs/by-name/li/librenms/package.nix
+++ b/pkgs/by-name/li/librenms/package.nix
@@ -128,8 +128,10 @@ phpPackage.buildComposerProject2 rec {
     description = "Auto-discovering PHP/MySQL/SNMP based network monitoring";
     homepage = "https://www.librenms.org/";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ netali ];
-    teams = [ lib.teams.wdz ];
+    maintainers = with lib.maintainers; [
+      netali
+      johannwagner
+    ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/ou/oui/package.nix
+++ b/pkgs/by-name/ou/oui/package.nix
@@ -21,7 +21,7 @@ buildGoModule rec {
     description = "MAC Address CLI Toolkit";
     homepage = "https://github.com/thatmattlove/oui";
     license = with lib.licenses; [ bsd3 ];
-    teams = [ lib.teams.wdz ];
+    maintainers = with lib.maintainers; [ johannwagner ];
     mainProgram = "oui";
   };
 }

--- a/pkgs/by-name/ox/oxidized/package.nix
+++ b/pkgs/by-name/ox/oxidized/package.nix
@@ -32,8 +32,8 @@ bundlerApp {
     maintainers = with lib.maintainers; [
       nicknovitski
       liberodark
+      johannwagner
     ];
-    teams = with lib.teams; [ wdz ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/pe/peering-manager/package.nix
+++ b/pkgs/by-name/pe/peering-manager/package.nix
@@ -91,7 +91,7 @@ python.pkgs.buildPythonApplication rec {
     license = lib.licenses.asl20;
     description = "BGP sessions management tool";
     mainProgram = "peering-manager";
-    teams = [ lib.teams.wdz ];
+    maintainers = with lib.maintainers; [ yureka-wdz ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/development/php-packages/rrd/default.nix
+++ b/pkgs/development/php-packages/rrd/default.nix
@@ -27,6 +27,5 @@ buildPecl {
     description = "PHP bindings to RRD tool system";
     license = lib.licenses.bsd0;
     homepage = "https://github.com/php/pecl-processing-rrd";
-    teams = [ lib.teams.wdz ];
   };
 }

--- a/pkgs/development/python-modules/aggregate6/default.nix
+++ b/pkgs/development/python-modules/aggregate6/default.nix
@@ -45,6 +45,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/job/aggregate6";
     license = with lib.licenses; [ bsd2 ];
     maintainers = with lib.maintainers; [ marcel ];
-    teams = [ lib.teams.wdz ];
   };
 }

--- a/pkgs/development/python-modules/asgi-logger/default.nix
+++ b/pkgs/development/python-modules/asgi-logger/default.nix
@@ -27,6 +27,5 @@ buildPythonPackage rec {
     description = "Access logger for ASGI servers";
     homepage = "https://github.com/Kludex/asgi-logger";
     license = lib.licenses.mit;
-    teams = [ lib.teams.wdz ];
   };
 }

--- a/pkgs/development/python-modules/command-runner/default.nix
+++ b/pkgs/development/python-modules/command-runner/default.nix
@@ -36,6 +36,5 @@ buildPythonPackage rec {
     '';
     changelog = "https://github.com/netinvent/command_runner/releases/tag/${src.tag}";
     license = lib.licenses.bsd3;
-    teams = [ lib.teams.wdz ];
   };
 }

--- a/pkgs/development/python-modules/coredis/default.nix
+++ b/pkgs/development/python-modules/coredis/default.nix
@@ -75,6 +75,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/alisaifee/coredis";
     changelog = "https://github.com/alisaifee/coredis/blob/${src.tag}/HISTORY.rst";
     license = lib.licenses.mit;
-    teams = [ lib.teams.wdz ];
   };
 }

--- a/pkgs/development/python-modules/imia/default.nix
+++ b/pkgs/development/python-modules/imia/default.nix
@@ -33,6 +33,5 @@ buildPythonPackage rec {
     changelog = "https://github.com/alex-oleshkevich/imia/releases/tag/v${version}";
     homepage = "https://github.com/alex-oleshkevich/imia";
     license = lib.licenses.mit;
-    teams = [ lib.teams.wdz ];
   };
 }

--- a/pkgs/development/python-modules/py-radix-sr/default.nix
+++ b/pkgs/development/python-modules/py-radix-sr/default.nix
@@ -43,6 +43,5 @@ buildPythonPackage rec {
       isc
       bsdOriginal
     ];
-    teams = [ lib.teams.wdz ];
   };
 }

--- a/pkgs/development/python-modules/pyixapi/default.nix
+++ b/pkgs/development/python-modules/pyixapi/default.nix
@@ -38,6 +38,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/peering-manager/pyixapi/";
     changelog = "https://github.com/peering-manager/pyixapi/releases/tag/${src.tag}";
     license = lib.licenses.asl20;
-    teams = [ lib.teams.wdz ];
   };
 }

--- a/pkgs/development/python-modules/smtpdfix/default.nix
+++ b/pkgs/development/python-modules/smtpdfix/default.nix
@@ -46,6 +46,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/bebleo/smtpdfix";
     changelog = "https://github.com/bebleo/smtpdfix/releases/tag/v${version}";
     license = lib.licenses.mit;
-    teams = [ lib.teams.wdz ];
   };
 }

--- a/pkgs/development/python-modules/starlette-wtf/default.nix
+++ b/pkgs/development/python-modules/starlette-wtf/default.nix
@@ -43,6 +43,5 @@ buildPythonPackage rec {
     changelog = "https://github.com/muicss/starlette-wtf/blob/v${version}/CHANGELOG.md";
     homepage = "https://github.com/muicss/starlette-wtf";
     license = lib.licenses.mit;
-    teams = [ lib.teams.wdz ];
   };
 }

--- a/pkgs/development/python-modules/wtforms-bootstrap5/default.nix
+++ b/pkgs/development/python-modules/wtforms-bootstrap5/default.nix
@@ -34,6 +34,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/LaunchPlatform/wtforms-bootstrap5";
     changelog = "https://github.com/LaunchPlatform/wtforms-bootstrap5/releases/tag/${version}";
     license = lib.licenses.mit;
-    teams = [ lib.teams.wdz ];
   };
 }

--- a/pkgs/servers/monitoring/prometheus/junos-czerwonk-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/junos-czerwonk-exporter.nix
@@ -22,6 +22,6 @@ buildGoModule rec {
     mainProgram = "junos_exporter";
     homepage = "https://github.com/czerwonk/junos_exporter";
     license = lib.licenses.mit;
-    teams = [ lib.teams.wdz ];
+    maintainers = with lib.maintainers; [ johannwagner ];
   };
 }


### PR DESCRIPTION
The @NixOS/nixpkgs-core team has recently reviewed Nixpkgs teams, and decided that teams should be organized internally around specific topics of maintenance, rather than having membership gated by external criteria. This means having maintainer responsibility and authority decided by consensus of existing maintainers and team members in an area of interest, rather than being granted or revoked based on employment, membership in an external organization, or role in another FOSS project. The reasoning is given in the full statement at https://github.com/NixOS/org/issues/220#issuecomment-3678147410.

We are now triaging teams to make sure they’re in line with this model and working with their members to find the best way forward for each case. This is being tracked at #478780.

@n0emis @johannwagner @yuyuyureka 

This team was flagged as apparently having external membership criteria. By default, we’ll merge this to drop the team after a week if we don’t hear back from you, but we’re also happy to implement alternatives, e.g.:

- Redistribute members to maintainer lists of individual packages per their request.
- Reorganize or merge the team into one or more teams relating to specific areas of maintenance interest with open membership criteria.
- Clarify that the team is dedicated to maintenance of software maintained upstream by a certain organization, but is open to all contributors. For example, `lib.teams.jetbrains` and `lib.teams.qt-kde` handle maintenance of JetBrains IDEs and KDE software, but have no expectation that members are affiliated with those organizations, even though some may be.