### PR TITLE
python3Packages.scspell: enable tests, fix license

### DIFF
--- a/pkgs/development/python-modules/scspell/default.nix
+++ b/pkgs/development/python-modules/scspell/default.nix
@@ -3,6 +3,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   setuptools,
+  pytestCheckHook,
   versionCheckHook,
   writableTmpDirAsHomeHook,
 }:
@@ -22,6 +23,7 @@ buildPythonPackage {
   build-system = [ setuptools ];
 
   nativeCheckInputs = [
+    pytestCheckHook
     versionCheckHook
     writableTmpDirAsHomeHook
   ];

--- a/pkgs/development/python-modules/scspell/default.nix
+++ b/pkgs/development/python-modules/scspell/default.nix
@@ -35,7 +35,7 @@ buildPythonPackage {
   meta = {
     description = "Spell checker for source code";
     homepage = "https://github.com/myint/scspell";
-    license = lib.licenses.gpl2;
+    license = lib.licenses.gpl2Only;
     maintainers = with lib.maintainers; [ guelakais ];
     mainProgram = "scspell";
   };


### PR DESCRIPTION
- Run the included Python tests
- Fix `meta.license` (`lib.licenses.gpl2` is deprecated, one should either specify `gpl2Plus` or `gpl2Only`)

> [!NOTE]
> Originally, this PR was titled `python3Packages.scspell: 2.3 -> 2.3-unstable-2025-04-06; enable tests`. The version update is now already on `master`, so I updated this PR to contain only the relevant remaining changes I made.

<details>
<summary>Original description</summary>

Diff: https://github.com/myint/scspell/compare/v2.3...df550351f255c572c1a74852d233c83bbfbd49fb

- The version bump fixes the build of `python314Packages.scspell`.
  - The old, now removed `setup.py` used `s` of an `ast.Constant` instance. This property was [removed in Python 3.14](https://docs.python.org/3.14/whatsnew/3.14.html#id9).
- Run the included Python tests
- Some cleanup

Hydra: https://hydra.nixos.org/build/317383048/nixlog/2
Tracking: https://github.com/NixOS/nixpkgs/issues/475732

</details>

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux — `python3{12,13,14}Packages.scspell`
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
