### PR TITLE
nixos/amazon: move nvme_core.io_timeout to runtime module

### DIFF
--- a/nixos/maintainers/scripts/ec2/amazon-image.nix
+++ b/nixos/maintainers/scripts/ec2/amazon-image.nix
@@ -11,7 +11,6 @@ let
     mkOption
     optionalString
     types
-    versionAtLeast
     ;
   inherit (lib.options) literalExpression;
   cfg = config.amazonImage;
@@ -45,16 +44,6 @@ in
       ];
     })
   ];
-
-  # Amazon recommends setting this to the highest possible value for a good EBS
-  # experience, which prior to 4.15 was 255.
-  # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/nvme-ebs-volumes.html#timeout-nvme-ebs-volumes
-  config.boot.kernelParams =
-    let
-      timeout =
-        if versionAtLeast config.boot.kernelPackages.kernel.version "4.15" then "4294967295" else "255";
-    in
-    [ "nvme_core.io_timeout=${timeout}" ];
 
   options.amazonImage = {
     contents = mkOption {

--- a/nixos/modules/virtualisation/amazon-image.nix
+++ b/nixos/modules/virtualisation/amazon-image.nix
@@ -59,10 +59,19 @@ in
     ];
     boot.initrd.kernelModules = [ "xen-blkfront" ];
     boot.initrd.availableKernelModules = [ "nvme" ];
-    boot.kernelParams = [
-      "console=ttyS0,115200n8"
-      "random.trust_cpu=on"
-    ];
+    boot.kernelParams =
+      let
+        # Amazon recommends setting this to the highest possible value for a good EBS
+        # experience, which prior to 4.15 was 255.
+        # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/nvme-ebs-volumes.html#timeout-nvme-ebs-volumes
+        nvmeTimeout =
+          if lib.versionAtLeast config.boot.kernelPackages.kernel.version "4.15" then "4294967295" else "255";
+      in
+      [
+        "console=ttyS0,115200n8"
+        "random.trust_cpu=on"
+        "nvme_core.io_timeout=${nvmeTimeout}"
+      ];
 
     # Prevent the nouveau kernel module from being loaded, as it
     # interferes with the nvidia/nvidia-uvm modules needed for CUDA.


### PR DESCRIPTION
This kernel parameter was accidentally added to the image builder module in 2018 (e4777ae2d84c) when it should have been in the runtime config. This causes a mismatch between AMIs built with the builder and systems configured with just the runtime module.

Move it to modules/virtualisation/amazon-image.nix so that all EC2 instances get the recommended NVMe timeout, regardless of how they were provisioned.

Unsure if this is release notes worthy, cc @arianvp.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
