### PR TITLE
nixos/virtualisation: nixos-container improve imperative container options

### DIFF
--- a/nixos/doc/manual/administration/imperative-containers.section.md
+++ b/nixos/doc/manual/administration/imperative-containers.section.md
@@ -34,6 +34,30 @@ chosen as container IP. This behavior can be altered by setting
     --local-address 10.235.1.2 --host-address 10.235.1.1
 ```
 
+You can bind mount directories from the host into the container, either read-write or read-only:
+
+```ShellSession
+# nixos-container create foo --bind /host/directory:/container/directory --bind-ro /host/ro-dir:/container/ro-dir
+```
+
+You can restrict system calls using seccomp filters:
+
+```ShellSession
+# nixos-container create foo --system-call-filter="@clock"
+```
+
+Add or drop Linux capabilities for security hardening:
+
+```ShellSession
+# nixos-container create foo --capability="CAP_NET_RAW" --drop-capability="CAP_SYS_ADMIN"
+```
+
+Pass additional flags to systemd-nspawn using `--extra-flags`:
+
+```ShellSession
+# nixos-container create foo --extra-flags="--private-network"
+```
+
 Creating a container does not start it. To start the container, run:
 
 ```ShellSession


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Improve imperative containers by allowing users the ability to specify extra flags to enable customization of nspawn behavior beyond the predefined options.

Should attenuate the issues felt in #18355 

```
nixos-container create foo --extra-flags="--private-network"
```

Also, added some prettier options for common options such as:

RW/RO binds
```
nixos-container --bind <host_path>:<container_path> --bind-ro <host_path>:<container_path>
```

Cap add/drop:
```
nixos-container --capability=CAP_NET_RAW --drop-capability="CAP_SYS_ADMIN"
```

System call filter:
```
nixos-container create foo --system-call-filter="@clock"
```

## Things done

Added options to `nixos-container.pl` script.
Added tests.
Added new options to documentation.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ X ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [  ] [NixOS tests] in [nixos/tests].
  - [ X ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ X ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ X ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
