### PR TITLE
ucspi-tcp: fix build with GCC 14

### DIFF
--- a/pkgs/by-name/uc/ucspi-tcp/package.nix
+++ b/pkgs/by-name/uc/ucspi-tcp/package.nix
@@ -10,6 +10,9 @@ stdenv.mkDerivation rec {
   pname = "ucspi-tcp";
   version = "0.88";
 
+  # Uses K&R C style function declarations which GCC 14+ rejects
+  env.NIX_CFLAGS_COMPILE = "-std=gnu89";
+
   src = fetchurl {
     url = "https://cr.yp.to/ucspi-tcp/ucspi-tcp-${version}.tar.gz";
     sha256 = "171yl9kfm8w7l17dfxild99mbf877a9k5zg8yysgb1j8nz51a1ja";


### PR DESCRIPTION
Fixes the build with GCC 14+.

The package uses K&R C style function declarations (e.g., `extern int wait_nohang();`) which GCC 14+ treats as `(void)` under C23 semantics, causing "too many arguments" errors.

Adding `-std=gnu89` restores the pre-C23 behavior.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test