### PR TITLE
lenspect: 1.0.3 -> 1.0.4

### DIFF
--- a/pkgs/by-name/le/lenspect/package.nix
+++ b/pkgs/by-name/le/lenspect/package.nix
@@ -2,10 +2,12 @@
   blueprint-compiler,
   desktop-file-utils,
   fetchFromGitHub,
+  glib-networking,
   gobject-introspection,
   lib,
   libadwaita,
   libsecret,
+  libsoup_3,
   meson,
   ninja,
   nix-update-script,
@@ -16,14 +18,14 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "lenspect";
-  version = "1.0.3";
+  version = "1.0.4";
   pyproject = false;
 
   src = fetchFromGitHub {
     owner = "vmkspv";
     repo = "lenspect";
     tag = "v${version}";
-    hash = "sha256-6CC7kTM+Ph/J+aKHCyBIGfKYQIU53t9J5+X4/sCwqJY=";
+    hash = "sha256-zYIDTFjT9izc4WFjs9fYDPDrQ8z16i2Bko5JW0tgCBk=";
   };
 
   nativeBuildInputs = [
@@ -37,8 +39,10 @@ python3Packages.buildPythonApplication rec {
   ];
 
   buildInputs = [
+    glib-networking
     libadwaita
     libsecret
+    libsoup_3
   ];
 
   dependencies = with python3Packages; [


### PR DESCRIPTION
Changes: https://github.com/vmkspv/lenspect/releases/tag/v1.0.4

Fixes build error without [`libsoup`](https://github.com/vmkspv/lenspect/blob/fe57447e1b92f4b37575a56362cc135ce42453eb/src/vt_provider.py#L25) and TLS issue fix with `glib-networking`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
