### PR TITLE
[25.11] libgda5: Fix build with gettext 0.25

### DIFF
--- a/pkgs/development/libraries/libgda/5.x.nix
+++ b/pkgs/development/libraries/libgda/5.x.nix
@@ -8,6 +8,7 @@
   libxml2,
   gtk3,
   openssl,
+  gettext,
   gnome,
   gobject-introspection,
   vala,
@@ -46,12 +47,24 @@ stdenv.mkDerivation rec {
 
     # Fix configure detection of features with c99.
     ./0001-gcc14-fix.patch
+
+    # Fix build with gettext 0.25
+    (fetchpatch {
+      url = "https://src.fedoraproject.org/rpms/libgda5/raw/945495e5c6cdd98a5360eff77245421876a97a57/f/gettext.patch";
+      hash = "sha256-DOCsCbx+HLZvlpMgSQrW5YoWl/EhDuQEln18YDqgCVk=";
+    })
+    # Fix conflicting types
+    (fetchpatch {
+      url = "https://src.fedoraproject.org/rpms/libgda5/raw/76be2c07cb747ce30cc63da21662abb589814404/f/types.patch";
+      hash = "sha256-LdvDQm7p0uWznBCD8qhJ5h44zNWLmI0BoqYPCeTBN9M=";
+    })
   ];
 
   nativeBuildInputs = [
     pkg-config
     intltool
     itstool
+    gettext
     gobject-introspection
     vala
     autoreconfHook


### PR DESCRIPTION
Manual backport of #478754.

https://hydra.nixos.org/build/318667697






## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

