### PR TITLE
livekit-libwebrtc: 125-unstable-2025-07-25 -> 137-unstable-2026-03-12, enable x11 and pipewire, zed-editor: 0.226.5 -> 0.228.0

### DIFF
--- a/pkgs/by-name/li/livekit-libwebrtc/0001-shared-libraries.patch
+++ b/pkgs/by-name/li/livekit-libwebrtc/0001-shared-libraries.patch
@@ -1,15 +1,17 @@
-diff --git a/BUILD.gn b/BUILD.gn
-index d5289b8..598bbbc 100644
 --- a/BUILD.gn
 +++ b/BUILD.gn
-@@ -138,8 +138,8 @@ config("library_impl_config") {
+@@ -143,8 +143,12 @@
  # target_defaults and direct_dependent_settings.
  config("common_inherited_config") {
-   defines = []
+   defines = [ "PROTOBUF_ENABLE_DEBUG_LOGGING_MAY_LEAK_PII=0" ]
 -  cflags = []
 -  ldflags = []
 +  cflags = [ "-fvisibility=default" ]
 +  ldflags = [ "-lavutil", "-lavformat", "-lavcodec" ]
- 
-   if (rtc_dlog_always_on) {
-     defines += [ "DLOG_ALWAYS_ON" ]
++
++  if (is_linux) {
++    ldflags += [ "-Wl,--version-script=" + rebase_path("//libwebrtc.version", root_build_dir) ]
++  }
+
+   if (rtc_objc_prefix != "") {
+     defines += [ "RTC_OBJC_TYPE_PREFIX=${rtc_objc_prefix}" ]

--- a/pkgs/by-name/li/livekit-libwebrtc/chromium-129-rust.patch
+++ b/pkgs/by-name/li/livekit-libwebrtc/chromium-129-rust.patch
@@ -1,0 +1,21 @@
+diff --git a/build/config/compiler/BUILD.gn b/build/config/compiler/BUILD.gn
+index 45086d6838cac..81132ad8ecb31 100644
+--- a/build/config/compiler/BUILD.gn
++++ b/build/config/compiler/BUILD.gn
+@@ -1727,16 +1727,6 @@ config("runtime_library") {
+     configs += [ "//build/config/c++:runtime_library" ]
+   }
+ 
+-  # Rust and C++ both provide intrinsics for LLVM to call for math operations. We
+-  # want to use the C++ intrinsics, not the ones in the Rust compiler_builtins
+-  # library. The Rust symbols are marked as weak, so that they can be replaced by
+-  # the C++ symbols. This config ensures the C++ symbols exist and are strong in
+-  # order to cause that replacement to occur by explicitly linking in clang's
+-  # compiler-rt library.
+-  if (is_clang && !is_nacl && !is_cronet_build) {
+-    configs += [ "//build/config/clang:compiler_builtins" ]
+-  }
+-
+   # TODO(crbug.com/40570904): Come up with a better name for is POSIX + Fuchsia
+   # configuration.
+   if (is_posix || is_fuchsia) {

--- a/pkgs/by-name/li/livekit-libwebrtc/libwebrtc.version
+++ b/pkgs/by-name/li/livekit-libwebrtc/libwebrtc.version
@@ -1,0 +1,22 @@
+/* Linker version script for libwebrtc.so (Linux only).
+ *
+ * When libwebrtc.so is built with rtc_use_pipewire=true and
+ * -fvisibility=default, PipeWire lazy-load trampoline stubs (pw_*, spa_*)
+ * are exported as weak symbols. If the PipeWire ALSA plugin
+ * (libasound_module_pcm_pipewire.so) is later dlopen'd by libasound,
+ * the dynamic linker may resolve the plugin's pw_* references through
+ * libwebrtc.so's broken trampolines instead of the real libpipewire.so,
+ * causing a SIGSEGV (NULL function pointer dereference).
+ *
+ * This script hides only those third-party symbol namespaces while
+ * keeping every WebRTC / BoringSSL / internal symbol exported (which
+ * the Rust webrtc-sys bindings require).
+ */
+{
+  global:
+    *;
+
+  local:
+    pw_*;
+    spa_*;
+};

--- a/pkgs/by-name/li/livekit-libwebrtc/mkSystemLibraries.nix
+++ b/pkgs/by-name/li/livekit-libwebrtc/mkSystemLibraries.nix
@@ -10,7 +10,7 @@
   libxml2,
   libxslt,
   minizip,
-  ffmpeg_6,
+  ffmpeg_8,
 }:
 {
   "brotli" = {
@@ -58,7 +58,7 @@
     path = "third_party/zlib/BUILD.gn";
   };
   "ffmpeg" = {
-    package = ffmpeg_6;
+    package = ffmpeg_8;
     path = "third_party/ffmpeg/BUILD.gn";
   };
 }

--- a/pkgs/by-name/li/livekit-libwebrtc/package.nix
+++ b/pkgs/by-name/li/livekit-libwebrtc/package.nix
@@ -9,7 +9,6 @@
   xcbuild,
   python3,
   ninja,
-  darwinMinVersionHook,
   git,
   cpio,
   pkg-config,
@@ -28,7 +27,19 @@
   libxml2,
   libxslt,
   minizip,
-  ffmpeg_6,
+  ffmpeg_8,
+  libepoxy,
+  libgbm,
+  libGL,
+  libxcomposite,
+  libxdamage,
+  libxext,
+  libxfixes,
+  libxrandr,
+  libxtst,
+  pipewire,
+  libx11,
+  libxi,
 }:
 let
   platformMap = {
@@ -63,13 +74,13 @@ let
       libxml2
       libxslt
       minizip
-      ffmpeg_6
+      ffmpeg_8
       ;
   };
 in
 stdenv.mkDerivation {
   pname = "livekit-libwebrtc";
-  version = "125-unstable-2025-07-25";
+  version = "137-unstable-2026-03-12";
 
   gclientDeps = gclient2nix.importGclientDeps ./sources.json;
   sourceRoot = "src";
@@ -77,30 +88,45 @@ stdenv.mkDerivation {
   patches = [
     # Adds missing dependencies to generated LICENSE
     (fetchpatch {
-      url = "https://raw.githubusercontent.com/livekit/rust-sdks/b41861c7b71762d5d85b3de07ae67ffcae7c3fa2/webrtc-sys/libwebrtc/patches/add_licenses.patch";
+      url = "https://raw.githubusercontent.com/livekit/rust-sdks/a4343fe9d88fcc96f8e88959c90d509abbd0307b/webrtc-sys/libwebrtc/patches/add_licenses.patch";
       hash = "sha256-9A4KyRW1K3eoQxsTbPX0vOnj66TCs2Fxjpsu5wO8mGI=";
     })
     # Fixes the certificate chain, required for Let's Encrypt certs
     (fetchpatch {
-      url = "https://raw.githubusercontent.com/livekit/rust-sdks/b41861c7b71762d5d85b3de07ae67ffcae7c3fa2/webrtc-sys/libwebrtc/patches/ssl_verify_callback_with_native_handle.patch";
-      hash = "sha256-/gneuCac4VGJCWCjJZlgLKFOTV+x7Lc5KVFnNIKenwM=";
+      url = "https://raw.githubusercontent.com/livekit/rust-sdks/a4343fe9d88fcc96f8e88959c90d509abbd0307b/webrtc-sys/libwebrtc/patches/ssl_verify_callback_with_native_handle.patch";
+      hash = "sha256-RBvRcJzoKItpEbqpe07YZe1D1ZVGS12EnDSISldGy+0=";
     })
     # Adds dependencies and features required by livekit
     (fetchpatch {
-      url = "https://raw.githubusercontent.com/livekit/rust-sdks/b41861c7b71762d5d85b3de07ae67ffcae7c3fa2/webrtc-sys/libwebrtc/patches/add_deps.patch";
-      hash = "sha256-EMNYcTcBYh51Tt96+HP43ND11qGKClfx3xIPQmIBSo0=";
+      url = "https://raw.githubusercontent.com/livekit/rust-sdks/a4343fe9d88fcc96f8e88959c90d509abbd0307b/webrtc-sys/libwebrtc/patches/add_deps.patch";
+      hash = "sha256-DwRtGdU5sppmiFsVuyhJoVCQrRl5JFmZJfxgUPhYXBg=";
     })
-    # Fixes "error: no matching member function for call to 'emplace'"
+    # Fix gcc-related errors
     (fetchpatch {
-      url = "https://raw.githubusercontent.com/zed-industries/livekit-rust-sdks/5f04705ac3f356350ae31534ffbc476abc9ea83d/webrtc-sys/libwebrtc/patches/abseil_use_optional.patch";
-      hash = "sha256-FOwlwOqgv5IEBCMogPACbXXxdNhGzpYcVfsolcwA7qU=";
-
-      extraPrefix = "third_party/";
+      url = "https://raw.githubusercontent.com/livekit/rust-sdks/a4343fe9d88fcc96f8e88959c90d509abbd0307b/webrtc-sys/libwebrtc/patches/force_gcc.patch";
+      hash = "sha256-1d73Pi1HkbunjYvp1NskUNE4xXbCmnh++rC6NrCJHbY=";
       stripLen = 1;
+      extraPrefix = "build/";
     })
-    # Required for dynamically linking to ffmpeg libraries and exposing symbols
+    # fix a gcc-related dav1d compile option
+    (fetchpatch {
+      url = "https://raw.githubusercontent.com/livekit/rust-sdks/a4343fe9d88fcc96f8e88959c90d509abbd0307b/webrtc-sys/libwebrtc/patches/david_disable_gun_source_macro.patch";
+      hash = "sha256-RCZpeeSQHaxkL3dY2oFFXDjYeU0KHw7idQFONGge8+0=";
+      stripLen = 1;
+      extraPrefix = "third_party/";
+    })
+    # Required for dynamically linking to ffmpeg libraries, exposing symbols,
+    # and hiding PipeWire symbols via version script (Linux only) to prevent
+    # SIGSEGV when ALSA's PipeWire plugin is loaded.
     ./0001-shared-libraries.patch
-  ];
+    # Borrow a patch from chromium to prevent a build failure due to missing libclang libraries
+    ./chromium-129-rust.patch
+  ]
+  ++ (lib.optionals stdenv.hostPlatform.isLinux [
+    # Fix a broken build with pipewire 1.5+
+    # From https://github.com/Thaodan/tg_owt/commit/960b6b30a9c7e9e4451031c30f362fd01d2ce7c1
+    ./pipewire-1.5.patch
+  ]);
 
   postPatch = ''
     substituteInPlace .gn \
@@ -131,13 +157,24 @@ stdenv.mkDerivation {
           -delete
       fi
     done
+
+    # Trick the update_rust.py script into thinking we have *this specific* rust available.
+    # It isn't actually needed for the libwebrtc build, but GN will fail if it isn't there.
+    mkdir -p third_party/rust-toolchain
+    (python3 tools/rust/update_rust.py --print-package-version || true) \
+      | head -n 1 \
+      | sed 's/.* expected Rust version is \([^ ]*\) .*/rustc 1.0 1234 (\1 chromium)/' \
+      > third_party/rust-toolchain/VERSION
   ''
   + lib.optionalString stdenv.hostPlatform.isLinux ''
+    mkdir -p buildtools/linux64
     ln -sf ${lib.getExe gn} buildtools/linux64/gn
+    cp ${./libwebrtc.version} libwebrtc.version
     substituteInPlace build/toolchain/linux/BUILD.gn \
       --replace 'toolprefix = "aarch64-linux-gnu-"' 'toolprefix = ""'
   ''
   + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    mkdir -p buildtools/mac
     ln -sf ${lib.getExe gn} buildtools/mac/gn
     chmod +x build/toolchain/apple/linker_driver.py
     patchShebangs build/toolchain/apple/linker_driver.py
@@ -174,6 +211,18 @@ stdenv.mkDerivation {
     glib
     alsa-lib
     pulseaudio
+    libepoxy
+    libgbm
+    libGL
+    libxcomposite
+    libxdamage
+    libxext
+    libxfixes
+    libxrandr
+    libxtst
+    pipewire
+    libx11
+    libxi
   ]);
 
   preConfigure = ''
@@ -200,16 +249,19 @@ stdenv.mkDerivation {
     "is_component_build=true"
     "enable_stripping=true"
     "rtc_use_h264=true"
+    "rtc_use_h265=true"
     "use_custom_libcxx=false"
     "use_rtti=true"
   ]
   ++ (lib.optionals stdenv.hostPlatform.isLinux [
-    "use_goma=false"
-    "rtc_use_pipewire=false"
+    "rtc_use_pipewire=true"
     "symbol_level=0"
     "enable_iterator_debugging=false"
-    "rtc_use_x11=false"
+    "rtc_use_x11=true"
     "use_sysroot=false"
+    "use_custom_libcxx_for_host=false"
+    "use_libcxx_modules=false"
+    "use_llvm_libatomic=false"
     "is_clang=false"
   ])
   ++ (lib.optionals stdenv.hostPlatform.isDarwin [
@@ -233,6 +285,7 @@ stdenv.mkDerivation {
     "pc:peer_connection"
     "sdk:videocapture_objc"
     "sdk:mac_framework_objc"
+    "desktop_capture_objc"
   ];
 
   postBuild =
@@ -251,10 +304,11 @@ stdenv.mkDerivation {
     mkdir -p $out/lib
     mkdir -p $dev/include
 
-    install -m0644 obj/webrtc.ninja args.gn LICENSE.md $dev
+    install -m0644 obj/webrtc.ninja obj/modules/desktop_capture/desktop_capture.ninja args.gn LICENSE.md $dev
 
     pushd ../..
     find . -name "*.h" -print | cpio -pd $dev/include
+    find . -name "*.inc" -print | cpio -pd $dev/include
     popd
   ''
   + lib.optionalString stdenv.hostPlatform.isLinux ''

--- a/pkgs/by-name/li/livekit-libwebrtc/pipewire-1.5.patch
+++ b/pkgs/by-name/li/livekit-libwebrtc/pipewire-1.5.patch
@@ -1,0 +1,35 @@
+From 960b6b30a9c7e9e4451031c30f362fd01d2ce7c1 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Bj=C3=B6rn=20Kettunen?= <bjorn.kettunen@thaodan.de>
+Date: Fri, 28 Nov 2025 19:41:02 +0200
+Subject: [PATCH] Fix building with Pipewire 1.5.81 and later. Resolves #167
+
+---
+ .../desktop_capture/linux/wayland/shared_screencast_stream.cc   | 2 ++
+ modules/video_capture/linux/pipewire_session.cc             | 1 +
+ 2 files changed, 3 insertions(+)
+
+diff --git a/modules/desktop_capture/linux/wayland/shared_screencast_stream.cc b/modules/desktop_capture/linux/wayland/shared_screencast_stream.cc
+index 71ea4d9f5..7ef1a030e 100644
+--- a/modules/desktop_capture/linux/wayland/shared_screencast_stream.cc
++++ b/modules/desktop_capture/linux/wayland/shared_screencast_stream.cc
+@@ -13,6 +13,8 @@
+ #include <fcntl.h>
+ #include <libdrm/drm_fourcc.h>
+ #include <pipewire/pipewire.h>
++#include <spa/pod/parser.h>
++#include <spa/pod/iter.h>
+ #include <spa/param/video/format-utils.h>
+ #include <sys/mman.h>
+ 
+diff --git a/modules/video_capture/linux/pipewire_session.cc b/modules/video_capture/linux/pipewire_session.cc
+index d2d8eeaf8..c16d511ba 100644
+--- a/modules/video_capture/linux/pipewire_session.cc
++++ b/modules/video_capture/linux/pipewire_session.cc
+@@ -15,6 +15,7 @@
+ #include <spa/param/format.h>
+ #include <spa/param/video/raw.h>
+ #include <spa/pod/parser.h>
++#include <spa/pod/iter.h>
+ 
+ #include "common_video/libyuv/include/webrtc_libyuv.h"
+ #include "modules/video_capture/device_info_impl.h"

--- a/pkgs/by-name/li/livekit-libwebrtc/sources.json
+++ b/pkgs/by-name/li/livekit-libwebrtc/sources.json
@@ -1,74 +1,74 @@
 {
     "src": {
         "args": {
-            "hash": "sha256-zSWjPxcrvLpi+zaJ+GReG3YsjPKqxBdkKfe8Gj/O0dA=",
+            "hash": "sha256-KVbw0ikSo1fkLT63zo5/GIBwUDB8QRcxubhP7pYD5vA=",
             "owner": "webrtc-sdk",
             "repo": "webrtc",
-            "rev": "db3ba7af86dd6d48174ed35387d11c0794f1a21b"
+            "rev": "a4bd28d99eb9ed3bc8e41ce7b9ce7254ee7308bd"
         },
         "fetcher": "fetchFromGitHub"
     },
     "src/base": {
         "args": {
-            "hash": "sha256-Hw0cXws+0M2UcvcnJZGkUtH28ZEDfxNl0e8ngWlAZnA=",
-            "rev": "738cf0c976fd3d07c5f1853f050594c5295300d8",
+            "hash": "sha256-MTG+pjMPY6/dqeEUy+xJVxPuICETtV98S+h/lFwGItg=",
+            "rev": "86c814633cf284bc8057a539bc722e2a672afe2f",
             "url": "https://chromium.googlesource.com/chromium/src/base"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/build": {
         "args": {
-            "hash": "sha256-mPjb7/TTJ7/oatBdIRGhSsacjbyu5ZilUgyplAtji1s=",
+            "hash": "sha256-qFZ12YFX4qxFEHU+VWOG+HDYYPXodgGz+iJ7WEc7cD8=",
             "owner": "webrtc-sdk",
             "repo": "build",
-            "rev": "6978bac6466311e4bee4c7a9fd395faa939e0fcd"
+            "rev": "01021e6c12636951a6b4e5342e16b2101b352367"
         },
         "fetcher": "fetchFromGitHub"
     },
     "src/buildtools": {
         "args": {
-            "hash": "sha256-OS9k7sDzAVH+NU9P4ilKJavkiov/1qq1fG5AWq9kH/Y=",
-            "rev": "5eb927f0a922dfacf10cfa84ee76f39dcf2a7311",
+            "hash": "sha256-YWtmMKL1ydueNJ4XM/Pq+8OpqIFe5A6/vYyfZTv7/EI=",
+            "rev": "0f32cb9025766951122d4ed19aba87a94ded3f43",
             "url": "https://chromium.googlesource.com/chromium/src/buildtools"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/testing": {
         "args": {
-            "hash": "sha256-VisK7NDR/xDC3OM7LD9Gyo58rs1GE37i7QRYC/Kk12k=",
-            "rev": "d6e731571c33f30e5dc46f54c69e6d432566e55c",
+            "hash": "sha256-s65cABkyMo+FkAmilS67qM3VnrT7iYZg9scycrXzxyE=",
+            "rev": "a89c37d36bf80c05963727e28b9916835ae88d3a",
             "url": "https://chromium.googlesource.com/chromium/src/testing"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/third_party": {
         "args": {
-            "hash": "sha256-TdB8qMcmXO3xgYyJkHHwn/8tVg1pFMlrNABpQQ80bOY=",
-            "rev": "f36c4b6e56aaa94606c87fa0c3f7cbdbb5c70546",
+            "hash": "sha256-q+xVOFlpC0vnLMSF9Z6ZRL7mb/cu8jBpsWjDNFFgiKM=",
+            "rev": "8062e0e102496ff14a8c58b586f014527424953d",
             "url": "https://chromium.googlesource.com/chromium/src/third_party"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/third_party/boringssl/src": {
         "args": {
-            "hash": "sha256-Ln6rnbn2hwszst24E/6EpP2C3Scoppe7wvVKFtxuPjQ=",
-            "rev": "12391e648d3c6f04a718721568cc89208b780654",
+            "hash": "sha256-5Efqc8pLs4ZskXQGpFdTb5cw//v3+DR285m/DsrWSWA=",
+            "rev": "34492c89a8e381e0e856a686cc71b1eb5bd728db",
             "url": "https://boringssl.googlesource.com/boringssl.git"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/third_party/breakpad/breakpad": {
         "args": {
-            "hash": "sha256-qAIXZ1jZous0Un0jVkOQ66nA2525NziV3Lbso2/+Z1Y=",
-            "rev": "76788faa4ef163081f82273bfca7fae8a734b971",
+            "hash": "sha256-0ynZuxIqBIpNkfD3Y9XdPFQr7HeQcsUO3lhnqvH+k8c=",
+            "rev": "232a723f5096ab02d53d87931efa485fa77d3b03",
             "url": "https://chromium.googlesource.com/breakpad/breakpad.git"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/third_party/catapult": {
         "args": {
-            "hash": "sha256-uqtyxO7Ge3egBsYmwcRGiV1lqm4iYVHrqYfDz7r6Byo=",
-            "rev": "88367fd8c736a2601fc183920c9ffe9ac2ec32ac",
+            "hash": "sha256-FIJZE1Qu1MLZA4qxB68k1NjhgSbFTjf57YF85JicVZw=",
+            "rev": "000f47cfa393d7f9557025a252862e2a61a60d44",
             "url": "https://chromium.googlesource.com/catapult.git"
         },
         "fetcher": "fetchFromGitiles"
@@ -83,8 +83,8 @@
     },
     "src/third_party/clang-format/script": {
         "args": {
-            "hash": "sha256-whD8isX2ZhLrFzdxHhFP1S/sZDRgyrzLFaVd7OEFqYo=",
-            "rev": "3c0acd2d4e73dd911309d9e970ba09d58bf23a62",
+            "hash": "sha256-d9uweklBffiuCWEb03ti1eFLnMac2qRtvggzXY1n/RU=",
+            "rev": "37f6e68a107df43b7d7e044fd36a13cbae3413f2",
             "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/clang/tools/clang-format.git"
         },
         "fetcher": "fetchFromGitiles"
@@ -97,42 +97,50 @@
         },
         "fetcher": "fetchFromGitiles"
     },
+    "src/third_party/compiler-rt/src": {
+        "args": {
+            "hash": "sha256-yo7BFGgwJNScsXwnCAu8gFBdZVS8/HJplzUk2e73mVg=",
+            "rev": "57213f125d03209892fed26189feb3b736e96735",
+            "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/compiler-rt.git"
+        },
+        "fetcher": "fetchFromGitiles"
+    },
     "src/third_party/crc32c/src": {
         "args": {
-            "hash": "sha256-urg0bmnfMfHagLPELp4WrNCz1gBZ6DFOWpDue1KsMtc=",
-            "rev": "fa5ade41ee480003d9c5af6f43567ba22e4e17e6",
+            "hash": "sha256-KBraGaO5LmmPP+p8RuDogGldbTWdNDK+WzF4Q09keuE=",
+            "rev": "d3d60ac6e0f16780bcfcc825385e1d338801a558",
             "url": "https://chromium.googlesource.com/external/github.com/google/crc32c.git"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/third_party/dav1d/libdav1d": {
         "args": {
-            "hash": "sha256-AA2bcrsW1xFspyl5TqYUJeAwKM06rWTNtXr/uMVIJmw=",
-            "rev": "006ca01d387ac6652825d6cce1a57b2de67dbf8d",
+            "hash": "sha256-+DY4p41VuAlx7NvOfXjWzgEhvtpebjkjbFwSYOzSjv4=",
+            "rev": "8d956180934f16244bdb58b39175824775125e55",
             "url": "https://chromium.googlesource.com/external/github.com/videolan/dav1d.git"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/third_party/depot_tools": {
         "args": {
-            "hash": "sha256-RguGUaIpxtxrY+LksFmeNbZuitZpB6O9HJc1c4TMXeQ=",
-            "rev": "495b23b39aaba2ca3b55dd27cadc523f1cb17ee6",
+            "hash": "sha256-DWQyYtpAAGiryeGJzIWlUwY5yn4cNwXY957vlPDUNak=",
+            "rev": "fa8fc854e1766b86f10c9a15902cf3cc23adaac2",
             "url": "https://chromium.googlesource.com/chromium/tools/depot_tools.git"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/third_party/ffmpeg": {
         "args": {
-            "hash": "sha256-6+Sc5DsPaKW68PSUS4jlpzRXjPhEN7LFQATVVL9Xhfo=",
-            "rev": "901248a373cbbe7af68fb92faf3be7d4f679150d",
+            "hash": "sha256-hNzQZQxaa2Wtl7GWWF852cFmmXy4pc15Pp0d59TTfnI=",
+            "rev": "01f23648c6b84de6c0f717fa4e1816f53b9ee72e",
             "url": "https://chromium.googlesource.com/chromium/third_party/ffmpeg.git"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/third_party/flatbuffers/src": {
         "args": {
-            "hash": "sha256-LecJwLDG6szZZ/UOCFD+MDqH3NKawn0sdEwgnMt8wMM=",
-            "rev": "bcb9ef187628fe07514e57756d05e6a6296f7dc5",
+            "hash": "sha256-tbc45o0MbMvK5XqRUJt5Eg8BU6+TJqlmwFgQhHq6wRM=",
+            "rev": "8db59321d9f02cdffa30126654059c7d02f70c32",
             "url": "https://chromium.googlesource.com/external/github.com/google/flatbuffers.git"
         },
         "fetcher": "fetchFromGitiles"
@@ -147,40 +155,40 @@
     },
     "src/third_party/freetype/src": {
         "args": {
-            "hash": "sha256-XBHWUw28bsCpwUXb+faE36DRdujuKiWoJ+dEmUk07s4=",
-            "rev": "b3a6a20a805366e0bc7044d1402d04c53f9c1660",
+            "hash": "sha256-Vlin6Z+QisUyj6R+TclVOm8x6673YhUIWob9Ih6gzC8=",
+            "rev": "1da283b8ae6d6b94f34a5c4b8c1227adc9dbb1d8",
             "url": "https://chromium.googlesource.com/chromium/src/third_party/freetype2.git"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/third_party/fuzztest/src": {
         "args": {
-            "hash": "sha256-8w4yIW15VamdjevMO27NYuf+GFu5AvHSooDZH0PbS6s=",
-            "rev": "65354bf09a2479945b4683c42948695d4f2f7c07",
+            "hash": "sha256-L2QG0pUmGjGdtdlivxYfxSqO9YaVHpIT6lvJwBMTxMw=",
+            "rev": "b10387fdbbca18192f85eaa5323a59f44bf9c468",
             "url": "https://chromium.googlesource.com/external/github.com/google/fuzztest.git"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/third_party/google_benchmark/src": {
         "args": {
-            "hash": "sha256-gztnxui9Fe/FTieMjdvfJjWHjkImtlsHn6fM1FruyME=",
-            "rev": "344117638c8ff7e239044fd0fa7085839fc03021",
+            "hash": "sha256-cH8s1gP6kCcojAAfTt5iQCVqiAaSooNk4BdaILujM3w=",
+            "rev": "761305ec3b33abf30e08d50eb829e19a802581cc",
             "url": "https://chromium.googlesource.com/external/github.com/google/benchmark.git"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/third_party/googletest/src": {
         "args": {
-            "hash": "sha256-JCIJrjN/hH6oAgvJRuv3aJA+z6Qe7yefyRbAhP5bZDc=",
-            "rev": "5197b1a8e6a1ef9f214f4aa537b0be17cbf91946",
+            "hash": "sha256-QT9PQ9bF+eCPfRLkcHpH4jc0UZfGPc98fHf8QDV5bZg=",
+            "rev": "cd430b47a54841ec45d64d2377d7cabaf0eba610",
             "url": "https://chromium.googlesource.com/external/github.com/google/googletest.git"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/third_party/grpc/src": {
         "args": {
-            "hash": "sha256-64JEVCx/PCM0dvv7kAQvSjLc0QbRAZVBDzwD/FAV6T8=",
-            "rev": "822dab21d9995c5cf942476b35ca12a1aa9d2737",
+            "hash": "sha256-xivmP36VCSbiMAV3PDUjzCrF+AJzFXJdMe5e2q9yW/k=",
+            "rev": "957c9f95224b1e1318c0ecb98d0e7584ea5ccff2",
             "url": "https://chromium.googlesource.com/external/github.com/grpc/grpc.git"
         },
         "fetcher": "fetchFromGitiles"
@@ -195,24 +203,24 @@
     },
     "src/third_party/harfbuzz-ng/src": {
         "args": {
-            "hash": "sha256-VAan6P8PHSq8RsGE4YbI/wCfFAhzl3nJMt0cQBYi5Ls=",
-            "rev": "155015f4bec434ecc2f94621665844218f05ce51",
+            "hash": "sha256-lNnCtgIegUy4DLhYaGZXcEaFw83KWAHoKpz69AEsWp4=",
+            "rev": "9f83bbbe64654b45ba5bb06927ff36c2e7588495",
             "url": "https://chromium.googlesource.com/external/github.com/harfbuzz/harfbuzz.git"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/third_party/icu": {
         "args": {
-            "hash": "sha256-frsmwYMiFixEULsE91x5+p98DvkyC0s0fNupqjoRnvg=",
-            "rev": "364118a1d9da24bb5b770ac3d762ac144d6da5a4",
+            "hash": "sha256-eGI/6wk6IOUPvX7pRTm4VJk1CqkkxalTu84L36i/D6k=",
+            "rev": "4c8cc4b365a505ce35be1e0bd488476c5f79805d",
             "url": "https://chromium.googlesource.com/chromium/deps/icu.git"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/third_party/instrumented_libs": {
         "args": {
-            "hash": "sha256-SGEB74fK9e0WWT77ZNISE9fVlXGGPvZMBUsQ3XD+DsA=",
-            "rev": "0172d67d98df2d30bd2241959d0e9569ada25abe",
+            "hash": "sha256-8kokdsnn5jD9KgM/6g0NuITBbKkGXWEM4BMr1nCrfdU=",
+            "rev": "69015643b3f68dbd438c010439c59adc52cac808",
             "url": "https://chromium.googlesource.com/chromium/third_party/instrumented_libraries.git"
         },
         "fetcher": "fetchFromGitiles"
@@ -227,128 +235,136 @@
     },
     "src/third_party/libFuzzer/src": {
         "args": {
-            "hash": "sha256-T0dO+1A0r6kLFoleMkY8heu80biPntCpvA6YfqA7b+E=",
-            "rev": "758bd21f103a501b362b1ca46fa8fcb692eaa303",
+            "hash": "sha256-Lb+HczYax0T7qvC0/Nwhc5l2szQTUYDouWRMD/Qz7sA=",
+            "rev": "e31b99917861f891308269c36a32363b120126bb",
             "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/compiler-rt/lib/fuzzer.git"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/third_party/libaom/source/libaom": {
         "args": {
-            "hash": "sha256-0tLfbfYyCnG89DHNIoYoiitN9pFFcuX/Nymp3Q5xhBg=",
-            "rev": "eefd5585a0c4c204fcf7d30065f8c2ca35c38a82",
+            "hash": "sha256-ngVZ+xK0b+jKUmawteQ7VFAQzoebX4jqZ3hP9pW+Q0Q=",
+            "rev": "a23a4799ec2d7dd6e436c7b64a34553773014ed7",
             "url": "https://aomedia.googlesource.com/aom.git"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/third_party/libc++/src": {
         "args": {
-            "hash": "sha256-ocJqlENHw19VpkFxKwHneGw3aNh56nt+/JeopxLj2M8=",
-            "rev": "e3b94d0e5b86883fd77696bf10dc33ba250ba99b",
+            "hash": "sha256-lqeuVUgeAKm1pxo+w1vyUbBkBXBzLCQ+Lfu44neKLPo=",
+            "rev": "917609c669e43edc850eeb192a342434a54e1dfd",
             "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libcxx.git"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/third_party/libc++abi/src": {
         "args": {
-            "hash": "sha256-qBupfCAnSNpvqcwFycQEi5v6TBAH5LdQI5YcLeQD2y8=",
-            "rev": "932d253fedb390a08b17ec3a92469a4553934a6a",
+            "hash": "sha256-X9cAbyd8ZPSwqOGhPYwIZ6b9E3tVwAuAYZKMgbZQxgk=",
+            "rev": "f2a7f2987f9dcdf8b04c2d8cd4dcb186641a7c3e",
             "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libcxxabi.git"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/third_party/libjpeg_turbo": {
         "args": {
-            "hash": "sha256-+t75ZAdOXc7Nd1/8zEQLX+enZb8upqIQuR6qzb9z7Cg=",
-            "rev": "9b894306ec3b28cea46e84c32b56773a98c483da",
+            "hash": "sha256-Ig+tmprZDvlf/M72/DTar2pbxat9ZElgSqdXdoM0lPs=",
+            "rev": "e14cbfaa85529d47f9f55b0f104a579c1061f9ad",
             "url": "https://chromium.googlesource.com/chromium/deps/libjpeg_turbo.git"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/third_party/libsrtp": {
         "args": {
-            "hash": "sha256-XOPiDAOHpWyCiXI+fi1CAie0Zaj4v14m9Kc8+jbzpUY=",
-            "rev": "7a7e64c8b5a632f55929cb3bb7d3e6fb48c3205a",
+            "hash": "sha256-bkG1+ss+1a2rCHGwZjhvf5UaNVbPPZJt9HZSIPBKGwM=",
+            "rev": "a52756acb1c5e133089c798736dd171567df11f5",
             "url": "https://chromium.googlesource.com/chromium/deps/libsrtp.git"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/third_party/libunwind/src": {
         "args": {
-            "hash": "sha256-/4/Trextb4F9UMDVrg4uG9QZl6S0H9FiwnL+2S5+ZpE=",
-            "rev": "419b03c0b8f20d6da9ddcb0d661a94a97cdd7dad",
+            "hash": "sha256-XdFKn+cGOxA0fHkVMG9UAhCmpML44ocoyHB7XnumX7o=",
+            "rev": "81e2cb40a70de2b6978e6d8658891ded9a77f7e3",
             "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libunwind.git"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/third_party/libvpx/source/libvpx": {
         "args": {
-            "hash": "sha256-JbeUgX8Dx8GkQ79ElZHK8gYI3/4o6NrTV+HpblwLvIE=",
-            "rev": "8762f5efb2917765316a198e6713f0bc93b07c9b",
+            "hash": "sha256-NIGpzP6elcPScHJlZmnPHJdmXsuHcbuELT0C4Ha5PcA=",
+            "rev": "ff1d193f4b9dfa9b2ced51efbb6ec7a69e58e88c",
             "url": "https://chromium.googlesource.com/webm/libvpx.git"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/third_party/libyuv": {
         "args": {
-            "hash": "sha256-hD5B9fPNwf8M98iS/PYeUJgJxtBvvf2BrrlnBNYXSg0=",
-            "rev": "a6a2ec654b1be1166b376476a7555c89eca0c275",
+            "hash": "sha256-b/EYCWBQvsNoGhea31DPBKpG8eouf0OBi5TgdHDHs9A=",
+            "rev": "1e40e34573c3861480d107cd4a4ce290df79951f",
             "url": "https://chromium.googlesource.com/libyuv/libyuv.git"
+        },
+        "fetcher": "fetchFromGitiles"
+    },
+    "src/third_party/llvm-libc/src": {
+        "args": {
+            "hash": "sha256-yNNx3gOGafMNvZ+aebDKHVj6QM8g0zt0d69PWlWLkyk=",
+            "rev": "912274164f0877ca917c06e8484ad3be1784833a",
+            "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libc.git"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/third_party/lss": {
         "args": {
-            "hash": "sha256-hE8uZf9Fst66qJkoVYChiB8G41ie+k9M4X0W+5JUSdw=",
-            "rev": "ce877209e11aa69dcfffbd53ef90ea1d07136521",
+            "hash": "sha256-rhp4EcZYdgSfu9cqn+zxxGx6v2IW8uX8V+iA0UfZhFY=",
+            "rev": "ed31caa60f20a4f6569883b2d752ef7522de51e0",
             "url": "https://chromium.googlesource.com/linux-syscall-support.git"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/third_party/nasm": {
         "args": {
-            "hash": "sha256-SiRXHsUlWXtH6dbDjDjqNAm105ibEB3jOfNtQAM4CaY=",
-            "rev": "f477acb1049f5e043904b87b825c5915084a9a29",
+            "hash": "sha256-neYrS4kQ76ihUh22Q3uPR67Ld8+yerA922YSZU1KxJs=",
+            "rev": "9f916e90e6fc34ec302573f6ce147e43e33d68ca",
             "url": "https://chromium.googlesource.com/chromium/deps/nasm.git"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/third_party/openh264/src": {
         "args": {
-            "hash": "sha256-J7Eqe2QevZh1xfap19W8AVCcwfRu7ztknnbKFJUAH1c=",
-            "rev": "09a4f3ec842a8932341b195c5b01e141c8a16eb7",
+            "hash": "sha256-tf0lnxATCkoq+xRti6gK6J47HwioAYWnpEsLGSA5Xdg=",
+            "rev": "652bdb7719f30b52b08e506645a7322ff1b2cc6f",
             "url": "https://chromium.googlesource.com/external/github.com/cisco/openh264"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/third_party/perfetto": {
         "args": {
-            "hash": "sha256-fS0P/0Bqn9EreCPRC65Lw7/zcpMquo7RDf6dmbMDa74=",
-            "rev": "0e424063dbfd4e7400aa3b77b5c00b84893aee7b",
-            "url": "https://android.googlesource.com/platform/external/perfetto.git"
+            "hash": "sha256-I0qiAh3VliVop+3S2/tP6VwCAJOk0Vu7xy8vHJZ1w2A=",
+            "rev": "a54dd38d60593129ae56d400f1a72860670abea4",
+            "url": "https://chromium.googlesource.com/external/github.com/google/perfetto.git"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/third_party/protobuf-javascript/src": {
         "args": {
-            "hash": "sha256-TmP6xftUVTD7yML7UEM/DB8bcsL5RFlKPyCpcboD86U=",
-            "rev": "e34549db516f8712f678fcd4bc411613b5cc5295",
+            "hash": "sha256-zq86SrDASl6aYPFPijRZp03hJqXUFz2Al/KkiNq7i0M=",
+            "rev": "eb785a9363664a402b6336dfe96aad27fb33ffa8",
             "url": "https://chromium.googlesource.com/external/github.com/protocolbuffers/protobuf-javascript"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/third_party/re2/src": {
         "args": {
-            "hash": "sha256-FA9wAZwqLx7oCPf+qeqZ7hhpJ9J2DSMXZAWllHIX/qY=",
-            "rev": "b84e3ff189980a33d4a0c6fa1201aa0b3b8bab4a",
+            "hash": "sha256-f/k2rloV2Nwb0KuJGUX4SijFxAx69EXcsXOG4vo+Kis=",
+            "rev": "c84a140c93352cdabbfb547c531be34515b12228",
             "url": "https://chromium.googlesource.com/external/github.com/google/re2.git"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/tools": {
         "args": {
-            "hash": "sha256-19oGSveaPv8X+/hsevUe4fFtLASC3HfPtbnw3TWpYQk=",
-            "rev": "0d6482e40fe26f738a0acf6ebb0f797358538b48",
+            "hash": "sha256-kZFZl8SC9nZIIOVtNl/5H4huw6BCBsBkJVJ4gaUmly4=",
+            "rev": "ffcbc837bbb14d80d09147c2af5302ff6bd4bd69",
             "url": "https://chromium.googlesource.com/chromium/src/tools"
         },
         "fetcher": "fetchFromGitiles"

--- a/pkgs/by-name/ze/zed-editor/package.nix
+++ b/pkgs/by-name/ze/zed-editor/package.nix
@@ -15,6 +15,7 @@
   sqlite,
   zlib,
   zstd,
+  glib,
   alsa-lib,
   libxkbcommon,
   wayland,
@@ -107,7 +108,7 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "zed-editor";
-  version = "0.226.5";
+  version = "0.228.0";
 
   outputs = [
     "out"
@@ -120,7 +121,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     owner = "zed-industries";
     repo = "zed";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-ZfYwlHTWirUb2RjEIQyonIHMneCi7ZGD2kPYOfe5HiI=";
+    hash = "sha256-oQ3cW4cFBkyrO4elTXB3Etek6ilL0XkB45z/tuPwTJs=";
   };
 
   postPatch = ''
@@ -132,6 +133,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
     # newer versions work just as well.
     substituteInPlace script/generate-licenses \
       --replace-fail '$CARGO_ABOUT_VERSION' '${cargo-about.version}'
+  ''
+  + lib.optionalString stdenv.hostPlatform.isLinux ''
+    # webrtc-sys expects glib headers to be in the sysroot, so we have to point it in the right direction
+    substituteInPlace $cargoDepsCopy/*/webrtc-sys-*/build.rs \
+      --replace-fail 'builder.include(&glib_path);' 'builder.include("${lib.getInclude glib}/include/glib-2.0");' \
+      --replace-fail 'builder.include(&glib_path_config);' 'builder.include("${lib.getLib glib}/lib/glib-2.0/include");'
   '';
 
   # remove package that has a broken Cargo.toml
@@ -140,7 +147,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     rm -r $out/git/*/candle-book/
   '';
 
-  cargoHash = "sha256-kdGHSNfvB/GUQ/7iqzXcCF4sbyaMiLYq+/zogg9N/aU=";
+  cargoHash = "sha256-K4lxI11fEuLYBWy6Z+o0MmtJFJYawwS4UUq0Jgue2hE=";
 
   nativeBuildInputs = [
     cmake
@@ -168,6 +175,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     zstd
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
+    glib
     alsa-lib
     libxkbcommon
     wayland


### PR DESCRIPTION
Update livekit-libwebrtc to version 137. Also enable x11 and pipewire.

This is needed for use of libwebrtc's DesktopCapturer in Zed (https://github.com/zed-industries/zed/pull/42670).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
