### PR TITLE
python3Packages.bugwarrior: 2.0.0 -> 2.1.0

### DIFF
--- a/pkgs/development/python-modules/bugwarrior/default.nix
+++ b/pkgs/development/python-modules/bugwarrior/default.nix
@@ -8,12 +8,10 @@
   setuptools,
   click,
   dogpile-cache,
-  importlib-metadata,
   jinja2,
   lockfile,
   pydantic,
   python-dateutil,
-  pytz,
   requests,
   taskw,
   debianbts,
@@ -27,6 +25,7 @@
   docutils,
   pytest-subtests,
   responses,
+  ruff,
   sphinx,
   sphinx-click,
   sphinx-inline-tabs,
@@ -34,14 +33,14 @@
 
 buildPythonPackage rec {
   pname = "bugwarrior";
-  version = "2.0.0";
+  version = "2.1.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "GothenburgBitFactory";
     repo = "bugwarrior";
     tag = version;
-    hash = "sha256-VuHTrkxLZmQOxyig2krVU9UZDDbLY08MfB9si08lh3E=";
+    hash = "sha256-Px0yOIdXalIJdXMmjMnpl74aaUzaptS8Esy21NMZH98=";
   };
 
   build-system = [ setuptools ];
@@ -49,17 +48,14 @@ buildPythonPackage rec {
   dependencies = [
     click
     dogpile-cache
-    importlib-metadata
     jinja2
     lockfile
     pydantic
     python-dateutil
-    pytz
     requests
     taskw
   ]
   ++ pydantic.optional-dependencies.email;
-  pythonRemoveDeps = [ "tomli" ];
 
   optional-dependencies = {
     bts = [ debianbts ];
@@ -81,6 +77,7 @@ buildPythonPackage rec {
     docutils
     pytest-subtests
     responses
+    ruff
     sphinx
     sphinx-click
     sphinx-inline-tabs


### PR DESCRIPTION
https://github.com/GothenburgBitFactory/bugwarrior/releases/tag/2.1.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
