### PR TITLE
beamPackages.elixir_1_20: init at 1.20.0-rc.1

### DIFF
--- a/pkgs/development/beam-modules/default.nix
+++ b/pkgs/development/beam-modules/default.nix
@@ -48,6 +48,11 @@ let
       # BEAM-based languages.
       elixir = elixir_1_18;
 
+      elixir_1_20 = callPackage ../interpreters/elixir/1.20.nix {
+        inherit erlang;
+        debugInfo = true;
+      };
+
       elixir_1_19 = callPackage ../interpreters/elixir/1.19.nix {
         inherit erlang;
         debugInfo = true;

--- a/pkgs/development/interpreters/elixir/1.19.nix
+++ b/pkgs/development/interpreters/elixir/1.19.nix
@@ -1,7 +1,7 @@
 import ./generic-builder.nix {
   version = "1.19.5";
   hash = "sha256-ph7zu0F5q+/QZcsVIwpdU1icN84Rn3nIVpnRelpRIMQ=";
-  # https://hexdocs.pm/elixir/1.19.0-rc.1/compatibility-and-deprecations.html#between-elixir-and-erlang-otp
+  # https://hexdocs.pm/elixir/1.19.5/compatibility-and-deprecations.html#between-elixir-and-erlang-otp
   minimumOTPVersion = "26";
   maximumOTPVersion = "28";
 }

--- a/pkgs/development/interpreters/elixir/1.20.nix
+++ b/pkgs/development/interpreters/elixir/1.20.nix
@@ -1,0 +1,7 @@
+import ./generic-builder.nix {
+  version = "1.20.0-rc.1";
+  hash = "sha256-FuTZHDI8ZNe6SHjiaPDZh21Ah7ek4kHqlYVvx0ybqI4=";
+  # https://hexdocs.pm/elixir/1.20.0-rc.1/compatibility-and-deprecations.html#between-elixir-and-erlang-otp
+  minimumOTPVersion = "26";
+  maximumOTPVersion = "28";
+}

--- a/pkgs/top-level/beam-packages.nix
+++ b/pkgs/top-level/beam-packages.nix
@@ -51,6 +51,7 @@ in
     # `beam.packages.erlang_27.elixir`.
     inherit (self.packages.erlang)
       elixir
+      elixir_1_20
       elixir_1_19
       elixir_1_18
       elixir_1_17


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
