### PR TITLE
sqruff: 0.29.3 -> 0.32.0; add self to maintainers

### DIFF
--- a/pkgs/by-name/sq/sqruff/package.nix
+++ b/pkgs/by-name/sq/sqruff/package.nix
@@ -8,16 +8,16 @@
 }:
 rustPlatform.buildRustPackage rec {
   pname = "sqruff";
-  version = "0.29.3";
+  version = "0.32.0";
 
   src = fetchFromGitHub {
     owner = "quarylabs";
     repo = "sqruff";
     tag = "v${version}";
-    hash = "sha256-bJmkHOACjdSXHE56okrIFERs1wK00XeyipdIFbRjIFI=";
+    hash = "sha256-/hMeYhiz2W1zu68LfZmmTK41nV5nJSLMZFQ4HKp0BSw=";
   };
 
-  cargoHash = "sha256-TxADMtapo6Pc4Z0MUkzkzUIrLnGa1DdZFzfTq4buF4g=";
+  cargoHash = "sha256-ytPLhC9qOcdA09xcQGwtUXUaD9QXn0bjyzgT4I/4xjw=";
 
   # Disable the `python` feature which doesn't work on Nix yet
   buildNoDefaultFeatures = true;
@@ -28,14 +28,17 @@ rustPlatform.buildRustPackage rec {
     substituteInPlace \
       crates/cli/tests/config_not_found.rs \
       crates/cli/tests/configure_rule.rs \
+      crates/cli/tests/dialect_override.rs \
       crates/cli/tests/fix_parse_errors.rs \
       crates/cli/tests/fix_return_code.rs \
+      crates/cli/tests/ignore_data_directory.rs \
+      crates/cli/tests/verbose_logging_ignore.rs \
       crates/cli/tests/ui_github.rs \
       crates/cli/tests/ui_json.rs \
       crates/cli/tests/ui.rs \
       --replace-fail \
-      'sqruff_path.push(format!("../../target/{}/sqruff", profile));' \
-      'sqruff_path.push(format!("../../target/${stdenv.hostPlatform.rust.cargoShortTarget}/{}/sqruff", profile));'
+      '"../../target/{}/sqruff"' \
+      '"../../target/${stdenv.hostPlatform.rust.cargoShortTarget}/{}/sqruff"'
   '';
 
   nativeCheckInputs = [ versionCheckHook ];

--- a/pkgs/by-name/sq/sqruff/package.nix
+++ b/pkgs/by-name/sq/sqruff/package.nix
@@ -54,6 +54,9 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/quarylabs/sqruff/releases/tag/${version}";
     license = lib.licenses.asl20;
     mainProgram = "sqruff";
-    maintainers = with lib.maintainers; [ hasnep ];
+    maintainers = with lib.maintainers; [
+      hasnep
+      pyrox0
+    ];
   };
 }


### PR DESCRIPTION
https://github.com/quarylabs/sqruff/releases/tag/v0.32.0
https://github.com/quarylabs/sqruff/releases/tag/v0.31.0
https://github.com/quarylabs/sqruff/releases/tag/v0.30.1

Had to fix the tests

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
