### PR TITLE
libxfce4windowing: Build VAPI

### DIFF
--- a/pkgs/by-name/li/libxfce4windowing/pkg-config-requires.patch
+++ b/pkgs/by-name/li/libxfce4windowing/pkg-config-requires.patch
@@ -1,0 +1,24 @@
+diff --git a/libxfce4windowing/meson.build b/libxfce4windowing/meson.build
+index b1a020b..fcb1b12 100644
+--- a/libxfce4windowing/meson.build
++++ b/libxfce4windowing/meson.build
+@@ -144,6 +144,7 @@ pkgconfig.generate(
+   name: libxfce4windowing_pkgname,
+   filebase: libxfce4windowing_pkgname,
+   description: 'X11/Wayland windowing utility library for Xfce',
++  requires: ['gtk+-3.0'],
+   subdirs: ['xfce4' / libxfce4windowing_pkgname],
+   install_dir: get_option('prefix') / get_option('libdir') / 'pkgconfig',
+ )
+diff --git a/libxfce4windowingui/meson.build b/libxfce4windowingui/meson.build
+index 68aa909..f56c3c1 100644
+--- a/libxfce4windowingui/meson.build
++++ b/libxfce4windowingui/meson.build
+@@ -76,6 +76,7 @@ pkgconfig.generate(
+   name: libxfce4windowingui_pkgname,
+   filebase: libxfce4windowingui_pkgname,
+   description: 'X11/Wayland windowing utility library for Xfce - extra widgets',
++  requires: ['gtk+-3.0'],
+   subdirs: ['xfce4' / libxfce4windowing_pkgname],
+   install_dir: get_option('prefix') / get_option('libdir') / 'pkgconfig',
+ )


### PR DESCRIPTION
budgie-desktop no longer ship this in-tree in 10.10. VAPI support is only available in meson build.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

