### PR TITLE
better-adb-sync: init at 1.4.0

### DIFF
--- a/pkgs/by-name/be/better-adb-sync/package.nix
+++ b/pkgs/by-name/be/better-adb-sync/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  android-tools,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "better-adb-sync";
+  version = "1.4.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "jb2170";
+    repo = "better-adb-sync";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ghOpcnQEZiAEZOiVWhrHa66WgiyyYQZgTJEokJFKMRs=";
+  };
+
+  build-system = with python3Packages; [ setuptools ];
+
+  # The tool relies on the `adb` binary being available in the system
+  makeWrapperArgs = [
+    "--prefix PATH : ${lib.makeBinPath [ android-tools ]}"
+  ];
+
+  pythonImportsCheck = [
+    "BetterADBSync"
+  ];
+
+  meta = {
+    description = "Synchronize files between a PC and an Android device using ADB (Android Debug Bridge)";
+    homepage = "https://github.com/jb2170/better-adb-sync";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      lucc
+      Misaka13514
+    ];
+    mainProgram = "adbsync";
+  };
+})


### PR DESCRIPTION
Add https://github.com/jb2170/better-adb-sync 1.4.0, an rsync-like program to sync files between a computer and an Android device

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
