### PR TITLE
nixos/budgie: Move out from X11

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2305.section.md
+++ b/nixos/doc/manual/release-notes/rl-2305.section.md
@@ -61,7 +61,7 @@ In addition to numerous new and updated packages, this release has the following
 
 - [blesh](https://github.com/akinomyoga/ble.sh), a line editor written in pure bash. Available as [programs.bash.blesh](#opt-programs.bash.blesh.enable).
 
-- [Budgie Desktop](https://github.com/BuddiesOfBudgie/budgie-desktop), a familiar, modern desktop environment. Available as [services.xserver.desktopManager.budgie](options.html#opt-services.xserver.desktopManager.budgie).
+- [Budgie Desktop](https://github.com/BuddiesOfBudgie/budgie-desktop), a familiar, modern desktop environment. Available as `services.xserver.desktopManager.budgie`.
 
 - [clash-verge](https://github.com/zzzgydi/clash-verge), a Clash GUI based on tauri. Available as [programs.clash-verge](#opt-programs.clash-verge.enable).
 

--- a/nixos/modules/services/desktop-managers/budgie.nix
+++ b/nixos/modules/services/desktop-managers/budgie.nix
@@ -17,7 +17,7 @@ let
     types
     ;
 
-  cfg = config.services.xserver.desktopManager.budgie;
+  cfg = config.services.desktopManager.budgie;
 
   nixos-background-light = pkgs.nixos-artwork.wallpapers.nineish;
   nixos-background-dark = pkgs.nixos-artwork.wallpapers.nineish-dark-gray;
@@ -63,8 +63,15 @@ in
 {
   meta.maintainers = lib.teams.budgie.members;
 
+  imports = [
+    (lib.mkRenamedOptionModule
+      [ "services" "xserver" "desktopManager" "budgie" ]
+      [ "services" "desktopManager" "budgie" ]
+    )
+  ];
+
   options = {
-    services.xserver.desktopManager.budgie = {
+    services.desktopManager.budgie = {
       enable = mkEnableOption "the Budgie desktop";
 
       sessionPath = mkOption {
@@ -128,7 +135,7 @@ in
       };
     };
 
-    services.xserver.desktopManager.budgie.sessionPath = [ pkgs.budgie-desktop-view ];
+    services.desktopManager.budgie.sessionPath = [ pkgs.budgie-desktop-view ];
 
     environment.extraInit = ''
       ${concatMapStrings (p: ''

--- a/nixos/modules/services/x11/desktop-managers/default.nix
+++ b/nixos/modules/services/x11/desktop-managers/default.nix
@@ -37,7 +37,7 @@ in
     ./surf-display.nix
     ./cde.nix
     ./cinnamon.nix
-    ./budgie.nix
+    ../../desktop-managers/budgie.nix
     ../../desktop-managers/lomiri.nix
     ../../desktop-managers/cosmic.nix
     ../../desktop-managers/gnome.nix

--- a/nixos/tests/budgie.nix
+++ b/nixos/tests/budgie.nix
@@ -12,20 +12,18 @@
       ];
 
       services.xserver.enable = true;
+      services.xserver.displayManager.lightdm.enable = true;
 
-      services.xserver.displayManager = {
-        lightdm.enable = true;
-        autoLogin = {
-          enable = true;
-          user = "alice";
-        };
+      services.displayManager.autoLogin = {
+        enable = true;
+        user = "alice";
       };
 
       # We don't ship gnome-text-editor in Budgie module, we add this line mainly
       # to catch eval issues related to this option.
       environment.budgie.excludePackages = [ pkgs.gnome-text-editor ];
 
-      services.xserver.desktopManager.budgie = {
+      services.desktopManager.budgie = {
         enable = true;
         extraPlugins = [
           pkgs.budgie-analogue-clock-applet

--- a/pkgs/by-name/ca/calamares-nixos-extensions/src/modules/nixos/main.py
+++ b/pkgs/by-name/ca/calamares-nixos-extensions/src/modules/nixos/main.py
@@ -197,7 +197,7 @@ cfgbudgie = """  # Enable the X11 windowing system.
 
   # Enable the Budgie Desktop environment.
   services.xserver.displayManager.lightdm.enable = true;
-  services.xserver.desktopManager.budgie.enable = true;
+  services.desktopManager.budgie.enable = true;
 
 """
 


### PR DESCRIPTION
Budgie 10.10 is wayland only.


Similar to https://github.com/NixOS/nixpkgs/commit/b9eea406166ab5b16c950a9542b4c4a8e5e51bad

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

