### PR TITLE
xray-exporter: init at 0.1.9

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -134,6 +134,7 @@ let
         "v2ray"
         "varnish"
         "wireguard"
+        "xray"
         "zfs"
       ]
       (

--- a/nixos/modules/services/monitoring/prometheus/exporters/xray.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/xray.nix
@@ -1,0 +1,52 @@
+{
+  config,
+  lib,
+  pkgs,
+  options,
+  ...
+}:
+
+let
+  cfg = config.services.prometheus.exporters.xray;
+  inherit (lib) mkOption types concatStringsSep;
+in
+{
+  port = 9550;
+  extraOpts = {
+    xrayEndpoint = mkOption {
+      type = types.str;
+      default = "127.0.0.1:8080";
+      description = ''
+        Xray API endpoint.
+      '';
+    };
+    logPath = mkOption {
+      type = types.str;
+      default = "/var/log/xray/access.log";
+      description = ''
+        Path to Xray access log file.
+      '';
+    };
+    logTimeWindow = mkOption {
+      type = types.nullOr types.int;
+      default = null;
+      description = ''
+        Time window in minutes for user metrics.
+      '';
+    };
+  };
+  serviceOpts = {
+    serviceConfig = {
+      ExecStart = ''
+        ${pkgs.prometheus-xray-exporter}/bin/xray-exporter \
+          --xray-endpoint ${cfg.xrayEndpoint} \
+          --listen ${cfg.listenAddress}:${toString cfg.port} \
+          --log-path "${cfg.logPath}" \
+          ${
+            lib.optionalString (cfg.logTimeWindow != null) "--log-time-window ${toString cfg.logTimeWindow}"
+          } \
+          ${concatStringsSep " \\\n  " cfg.extraFlags}
+      '';
+    };
+  };
+}

--- a/nixos/tests/prometheus-exporters.nix
+++ b/nixos/tests/prometheus-exporters.nix
@@ -2098,6 +2098,19 @@ let
           wait_until_succeeds("curl -f localhost:9134/metrics | grep 'zfs_scrape_collector_success{.*} 1'")
         '';
       };
+
+    xray =
+      { ... }:
+      {
+        exporterConfig = {
+          enable = true;
+        };
+        exporterTest = ''
+          wait_for_unit("prometheus-xray-exporter.service")
+          wait_for_open_port(9550)
+          succeed("curl -sSf http://localhost:9550/metrics | grep 'go_info'")
+        '';
+      };
   };
 in
 lib.mapAttrs (

--- a/pkgs/by-name/pr/prometheus-xray-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-xray-exporter/package.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule rec {
+  pname = "xray-exporter";
+  version = "0.1.9";
+
+  src = fetchFromGitHub {
+    owner = "compassvpn";
+    repo = "xray-exporter";
+    rev = "v${version}";
+    hash = "sha256-Gk+8ie18FR05b8ynZezPjo9/U6L0vcdOgqcq1ze2v48=";
+  };
+
+  vendorHash = "sha256-W+iPYQBs+rAry0yKRoF4Htc8GCfh1iXhbD//KLl8Hlk=";
+
+  meta = with lib; {
+    description = "Prometheus exporter for Xray daemon";
+    homepage = "https://github.com/compassvpn/xray-exporter";
+    license = licenses.mit;
+    maintainers = [ ];
+    mainProgram = "xray-exporter";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

xray exporter is a prometheus exporter for xray, a proxy app for uncensorship. Previously I have ported [v2ray-exporter](https://github.com/NixOS/nixpkgs/pull/130149), but it has not been updated for years, and it causes bug in latest version of xray. I'm not planning to add myself to maintainers since this package may not be updated at all like v2ray-exporter after I port it in, but I still need to port it because adding it outside nixpkgs takes a lot of effort as prometheus exporters have complex configurations in nixpkgs that is hard to monkeypatch. If there is another version update, I'll consider making myself maintainer of it. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
