### PR TITLE
rime-latex: init at 0-unstable-2025-04-04

### DIFF
--- a/pkgs/by-name/ri/rime-latex/package.nix
+++ b/pkgs/by-name/ri/rime-latex/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  fetchFromGitHub,
+  stdenvNoCC,
+  nix-update-script,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "rime-latex";
+  version = "0-unstable-2025-04-04";
+
+  src = fetchFromGitHub {
+    owner = "shenlebantongying";
+    repo = "rime_latex";
+    rev = "858f2abc645f0e459e468e98122470ce20b16b30";
+    hash = "sha256-i8Rgze+tQhbE+nl+JSj09ILXeUvf6MOS9Eqsuqis1n0=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    rm -rf README.md .git* LICENSE .script
+
+    mkdir -p $out/share
+    cp -r . $out/share/rime-data
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Typing LaTeX math symbols in RIME";
+    longDescription = ''
+      Typing LaTeX math symbols in RIME.
+
+      Add those lines to `default.custom.yaml`:
+
+      ```yaml
+      patch:
+        schema_list:
+          - schema: latex
+      ```
+
+      Press `\` key then input latex symbol's name: `\lambda` will automatically become `λ`.
+    '';
+    homepage = "https://github.com/shenlebantongying/rime_latex";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ rc-zb ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
Add [rime_latex](https://github.com/shenlebantongying/rime_latex), a handy input method for entering symbols in LaTeX encoding without dedicated editor plugins.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
