### PR TITLE
rmrfrs: init at 0.8.8

### DIFF
--- a/pkgs/by-name/rm/rmrfrs/package.nix
+++ b/pkgs/by-name/rm/rmrfrs/package.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  nix-update-script,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "rmrfrs";
+  version = "0.8.8";
+
+  src = fetchFromGitHub {
+    owner = "trinhminhtriet";
+    repo = "rmrfrs";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-1QF1l6V6YmKDPqlbXpMeWg3Pt5AonBHelD63mJkSWNM=";
+  };
+
+  cargoHash = "sha256-mPQN/JN6b9/1xo1JSj0LpVjb7rGTwrfU0PY7pbENdg4=";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Powerful filesystem cleaning tool designed to optimize storage by identifying and removing unnecessary files within known project structures";
+    homepage = "https://github.com/trinhminhtriet/rmrfrs";
+    downloadPage = "https://github.com/trinhminhtriet/rmrfrs";
+    changelog = "https://github.com/trinhminhtriet/rmrfrs/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      adda
+    ];
+    mainProgram = "rmrfrs";
+    platforms = with lib.platforms; windows ++ darwin ++ linux;
+  };
+})


### PR DESCRIPTION
This PR adds [`rmrfrs`](https://github.com/trinhminhtriet/rmrfrs), "a powerful filesystem cleaning tool designed to optimize storage by identifying and removing unnecessary files within known project structures." (And yes, unless specified otherwise, it asks for confirmation for each folder before the removal; something that is not necessarily specified in the project README :wink:)
 
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
