### PR TITLE
teams/uzinfocom: drop and replace team with induvidual maintainers

### DIFF
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -961,17 +961,6 @@ with lib.maintainers;
     shortName = "coqui-ai TTS";
   };
 
-  uzinfocom = {
-    members = [
-      orzklv
-      bahrom04
-      bemeritus
-      shakhzodkudratov
-    ];
-    scope = "Maintain Uzbek Linux state & community packages and modules.";
-    shortName = "Uzinfocom Open Source";
-  };
-
   wdz = {
     members = [
       n0emis

--- a/nixos/modules/services/security/e-imzo.nix
+++ b/nixos/modules/services/security/e-imzo.nix
@@ -46,5 +46,10 @@ in
     };
   };
 
-  meta.maintainers = lib.teams.uzinfocom.members;
+  meta.maintainers = with lib.maintainers; [
+    orzklv
+    shakhzodkudratov
+    bahrom04
+    bemeritus
+  ];
 }

--- a/pkgs/by-name/e-/e-imzo-manager/package.nix
+++ b/pkgs/by-name/e-/e-imzo-manager/package.nix
@@ -77,6 +77,11 @@ stdenv.mkDerivation (finalAttrs: {
     description = "GTK application for managing E-IMZO keys";
     license = with lib.licenses; [ agpl3Plus ];
     platforms = lib.platforms.linux;
-    teams = [ lib.teams.uzinfocom ];
+    maintainers = with lib.maintainers; [
+      orzklv
+      shakhzodkudratov
+      bahrom04
+      bemeritus
+    ];
   };
 })

--- a/pkgs/by-name/e-/e-imzo/package.nix
+++ b/pkgs/by-name/e-/e-imzo/package.nix
@@ -49,6 +49,11 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     homepage = "https://e-imzo.soliq.uz";
     license = lib.licenses.unfree;
     sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
-    teams = [ lib.teams.uzinfocom ];
+    maintainers = with lib.maintainers; [
+      orzklv
+      shakhzodkudratov
+      bahrom04
+      bemeritus
+    ];
   };
 })

--- a/pkgs/by-name/hu/hunspell/dictionaries.nix
+++ b/pkgs/by-name/hu/hunspell/dictionaries.nix
@@ -844,7 +844,12 @@ rec {
       license = with lib.licenses; [
         gpl3Plus
       ];
-      teams = [ lib.teams.uzinfocom ];
+      maintainers = with lib.maintainers; [
+        orzklv
+        shakhzodkudratov
+        bahrom04
+        bemeritus
+      ];
     };
   };
 


### PR DESCRIPTION
Following the PR https://github.com/NixOS/nixpkgs/pull/478863, we removed the team and decided to appoint individual maintainers to packages we have been maintaining. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
