### PR TITLE
text-embeddings-inference: init at 1.8.3

### DIFF
--- a/pkgs/by-name/te/text-embeddings-inference/package.nix
+++ b/pkgs/by-name/te/text-embeddings-inference/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  openssl,
+  protobuf,
+  cmake,
+  onnxruntime,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "text-embeddings-inference";
+  version = "1.8.3";
+
+  src = fetchFromGitHub {
+    owner = "huggingface";
+    repo = "text-embeddings-inference";
+    rev = "v${version}";
+    hash = "sha256-Z6dNThzIHCKbiuyGTbvhZ9Wc2cbsxEp4nRTAOUqbuow=";
+  };
+
+  cargoHash = "sha256-9DOPHt6SoCTJpKRujDBr8vBvFT+YHA3hHFsLW2EOcxc=";
+
+  nativeBuildInputs = [
+    pkg-config
+    cmake
+    protobuf
+  ];
+
+  buildInputs = [
+    openssl
+    onnxruntime
+  ];
+
+  PROTOC = "${protobuf}/bin/protoc";
+  ORT_LIB_LOCATION = "${onnxruntime}/lib";
+  ORT_SKIP_DOWNLOAD = "1";
+
+  cargoBuildFlags = [
+    "--features"
+    "candle"
+  ];
+
+  #
+  doCheck = false;
+
+  meta = with lib; {
+    description = "A blazing fast inference solution for text embeddings models";
+    homepage = "https://github.com/huggingface/text-embeddings-inference";
+    license = licenses.asl20;
+    platforms = platforms.linux;
+    maintainers = [ ];
+  };
+}


### PR DESCRIPTION
## Description

Adds [Text Embeddings Inference (TEI)](https://github.com/huggingface/text-embeddings-inference) - a high-performance inference solution for text embeddings and sequence classification models from Hugging Face.

TEI provides optimized serving of popular embedding models (BERT, RoBERTa, XLM-RoBERTa, JinaBERT, etc.) with features like:
- Dynamic batching and optimized transformers code using Flash Attention
- Multiple backends (CUDA, ONNX, Metal for Apple Silicon)
- gRPC and REST APIs
- Support for re-rankers and sequence classification models
- Production-ready features (OpenTelemetry tracing, Prometheus metrics)

This is particularly useful for RAG pipelines, semantic search, and other ML applications requiring efficient embedding generation.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests)
  - [ ] [Package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - [ ] Tested compilation of all packages that depend on this change
  - [x] Tested basic functionality of binary files (verified `text-embeddings-router --help` executes)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)
- [ ] Nixpkgs release notes update: N/A (new package)
- [ ] NixOS release notes update: N/A (new package)

## Testing instructions

To test this package:
```bash
nix-build -A text-embeddings-inference
./result/bin/text-embeddings-router --help
```

For runtime testing, you can run the server (requires model download):
```bash
export MODEL=Qwen/Qwen3-Embedding-0.6B
./result/bin/text-embeddings-router --model-id $MODEL --port 8080
```

## Additional context

This is a new package addition. The derivation builds the Rust-based binary from source using the GitHub release tag v1.8.3. The package is placed in `pkgs/by-name/te/text-embeddings-inference/` following the new Nixpkgs structure.

cc @NixOS/nix-formatting for new package review