### PR TITLE
occt: init at 15.0.13

### DIFF
--- a/pkgs/by-name/oc/occt/package.nix
+++ b/pkgs/by-name/oc/occt/package.nix
@@ -1,0 +1,93 @@
+{
+  lib,
+  stdenv,
+  autoPatchelfHook,
+  makeWrapper,
+  zlib,
+  openssl,
+  cacert,
+  fetchurl,
+  hicolor-icon-theme,
+  alsa-lib,
+  libpulseaudio,
+  libglvnd,
+  xorg,
+  glibc,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "occt";
+  version = "15.0.13";
+
+  src = fetchurl {
+    url = "https://dl.ocbase.com/per/linux/occt-${version}-linux-x86_64.tar.gz";
+    sha256 = "sha256-523ae1bf5a27e4b6465ddd6b62540680f7336fee21962e04f65cad019bb51e97";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    makeWrapper
+  ];
+
+  buildInputs = [
+    zlib
+    openssl
+    cacert
+    alsa-lib
+    libpulseaudio
+    libglvnd
+    xorg.libXext
+    xorg.libXrender
+    hicolor-icon-theme
+    glibc
+  ]
+  ++ (with xorg; [
+    libXcursor
+    libXinerama
+    libXi
+    libXrandr
+    libXfixes
+    libXdamage
+    libXcomposite
+  ]);
+
+  dontUnpack = true;
+
+  installPhase = ''
+        mkdir -p $out/opt/occt $out/bin $out/share/{applications,licenses/occt}
+
+        install -m755 $src $out/opt/occt/occt
+
+        touch $out/opt/occt/disable_update
+        touch $out/opt/occt/use_home_config
+
+        makeWrapper $out/opt/occt/occt $out/bin/occt \
+          --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath buildInputs}" \
+          --set DOTNET_SYSTEM_GLOBALIZATION_INVARIANT 1 \
+          --set SSL_CERT_FILE "${cacert}/etc/ssl/certs/ca-bundle.crt" \
+          --set SSL_CERT_DIR "${cacert}/etc/ssl/certs" \
+          --set LOCALE_ARCHIVE "${glibc}/lib/locale/locale-archive" \
+          --prefix XDG_DATA_DIRS : "${hicolor-icon-theme}/share"
+
+        cat > $out/share/applications/occt.desktop <<EOF
+    [Desktop Entry]
+    Name=OCCT
+    Comment=OverClock Checking Tool - CPU/GPU stress testing and monitoring
+    Exec=$out/bin/occt
+    Icon=occt
+    Terminal=false
+    Type=Application
+    Categories=System;
+    EOF
+
+        echo "Proprietary OCCT License - Personal Edition" > $out/share/licenses/occt/LICENSE
+  '';
+
+  meta = with lib; {
+    description = "OverClock Checking Tool - CPU/GPU stress testing and monitoring";
+    homepage = "https://www.ocbase.com/";
+    license = licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    maintainers = [ ];
+  };
+}


### PR DESCRIPTION
## Description

Adds [OCCT (OverClock Checking Tool)](https://www.ocbase.com/) - a comprehensive stability testing and benchmarking software for PC hardware.

OCCT is a proprietary but freely usable tool for stress testing CPU, GPU, memory, VRAM, and power supplies. Key features include:
- Multiple test modes (CPU+RAM combined, per-core CPU, Linpack, memory, 3D/VRAM, power supply)
- Innovative memory latency & bandwidth benchmarking
- Portable executable (no installation required)
- WHEA error tracking and monitoring
- Error detection for GPU artifacts and system instability
- Free edition is fully featured for diagnostic use

This is particularly valuable for system builders, overclockers, and stability testing on NixOS systems where traditional Windows tools aren't available.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests)
  - [ ] [Package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - [ ] Tested compilation of all packages that depend on this change
  - [x] Tested basic functionality of binary files (verified `occt --help` executes)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)
- [ ] Nixpkgs release notes update: N/A (new package)
- [ ] NixOS release notes update: N/A (new package)

## Testing instructions

To test this package:
```bash
nix-build -A occt
./result/bin/occt --help
```

Note: Full stress testing requires hardware interaction and appropriate system permissions. The free edition is fully functional for diagnostic purposes.

## Additional context

This packages the proprietary but freely distributable OCCT tool. The derivation downloads the official binary release and wraps it for NixOS compatibility. The package follows the new `pkgs/by-name` structure and includes necessary dependencies (gcc-libs, glibc, zlib, hicolor-icon-theme).

**License**: Proprietary with free edition (LicenseRef-Proprietary)

cc @NixOS/nix-formatting for new package review