### PR TITLE
python3Packages.nuitka: 2.8.10 -> 4.1.2

### DIFF
--- a/pkgs/development/python-modules/nuitka/default.nix
+++ b/pkgs/development/python-modules/nuitka/default.nix
@@ -1,35 +1,51 @@
 {
   lib,
-  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
   isPyPy,
-  ordered-set,
-  python,
+  pythonAtLeast,
+
+  # build-system
   setuptools,
+
+  # dependencies
+  appdirs,
+  jinja2,
+  pyyaml,
+  tqdm,
   zstandard,
-  wheel,
+
+  # tests
+  python,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "nuitka";
-  version = "2.8.10";
+  version = "4.0.8";
   pyproject = true;
+
+  disabled =
+    # Requires CPython
+    isPyPy
+    # Test failures
+    || (pythonAtLeast "3.14");
 
   src = fetchFromGitHub {
     owner = "Nuitka";
     repo = "Nuitka";
-    tag = version;
-    hash = "sha256-+CevWpYvqY3SX3/QE7SPlbsFtXkdlNTg9m91VtZCHvM=";
+    tag = finalAttrs.version;
+    hash = "sha256-f12FAItua3VASk2ipesQEalWYREpXidl7Jo3URczf9g=";
   };
 
   build-system = [
     setuptools
-    wheel
   ];
 
   dependencies = [
-    ordered-set
+    appdirs
+    jinja2
+    pyyaml
+    tqdm
     zstandard
   ];
 
@@ -43,14 +59,15 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "nuitka" ];
 
-  # Requires CPython
-  disabled = isPyPy;
-
   meta = {
     description = "Python compiler with full language support and CPython compatibility";
     license = lib.licenses.asl20;
     homepage = "https://nuitka.net/";
-    # never built on darwin since first introduction in nixpkgs
-    broken = stdenv.hostPlatform.isDarwin;
+    downloadPage = "https://github.com/Nuitka/Nuitka";
+    changelog = "https://nuitka.net/changelog/Changelog.html";
+    badPlatforms = [
+      # never built on darwin since first introduction in nixpkgs
+      lib.systems.inspect.patterns.isDarwin
+    ];
   };
-}
+})

--- a/pkgs/development/python-modules/nuitka/default.nix
+++ b/pkgs/development/python-modules/nuitka/default.nix
@@ -1,35 +1,52 @@
 {
   lib,
-  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
   isPyPy,
-  ordered-set,
-  python,
+  pythonAtLeast,
+
+  # build-system
   setuptools,
+
+  # dependencies
+  appdirs,
+  jinja2,
+  pyyaml,
+  tqdm,
   zstandard,
-  wheel,
+
+  # tests
+  python,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "nuitka";
-  version = "2.8.10";
+  version = "4.1.2";
   pyproject = true;
+  __structuredAttrs = true;
+
+  disabled =
+    # Requires CPython
+    isPyPy
+    # Test failures
+    || (pythonAtLeast "3.14");
 
   src = fetchFromGitHub {
     owner = "Nuitka";
     repo = "Nuitka";
-    tag = version;
-    hash = "sha256-+CevWpYvqY3SX3/QE7SPlbsFtXkdlNTg9m91VtZCHvM=";
+    tag = finalAttrs.version;
+    hash = "sha256-vrXunbaSmiQDCG+9+xZuyod03pJAD3kJ2cdV/ac7CyQ=";
   };
 
   build-system = [
     setuptools
-    wheel
   ];
 
   dependencies = [
-    ordered-set
+    appdirs
+    jinja2
+    pyyaml
+    tqdm
     zstandard
   ];
 
@@ -43,14 +60,15 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "nuitka" ];
 
-  # Requires CPython
-  disabled = isPyPy;
-
   meta = {
     description = "Python compiler with full language support and CPython compatibility";
     license = lib.licenses.asl20;
     homepage = "https://nuitka.net/";
-    # never built on darwin since first introduction in nixpkgs
-    broken = stdenv.hostPlatform.isDarwin;
+    downloadPage = "https://github.com/Nuitka/Nuitka";
+    changelog = "https://nuitka.net/changelog/Changelog.html";
+    badPlatforms = [
+      # never built on darwin since first introduction in nixpkgs
+      lib.systems.inspect.patterns.isDarwin
+    ];
   };
-}
+})


### PR DESCRIPTION


## Things done

Diff: https://github.com/Nuitka/Nuitka/compare/2.8.10...4.1.2
- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc