### PR TITLE
zapret2: init at 0.8.3

### DIFF
--- a/pkgs/by-name/za/zapret2/package.nix
+++ b/pkgs/by-name/za/zapret2/package.nix
@@ -1,0 +1,145 @@
+{
+  stdenv,
+  fetchFromGitHub,
+  lib,
+  makeWrapper,
+  pkg-config,
+  bind,
+  curl,
+  iptables,
+  libcap,
+  libmnl,
+  libnfnetlink,
+  libnetfilter_queue,
+  luajit,
+  nmap,
+  ipset,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "zapret2";
+  version = "0.8.3";
+
+  src = fetchFromGitHub {
+    owner = "bol-van";
+    repo = "zapret2";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-0mVdqKRTWZcDEQUrAjqK1ujtUAeuqOYtM1pyo+yJxN8=";
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+    pkg-config
+  ];
+
+  buildInputs = [
+    bind
+    curl
+    iptables
+    libcap
+    libmnl
+    libnfnetlink
+    libnetfilter_queue
+    luajit
+    nmap
+    ipset
+  ];
+
+  # Fix Lua detection and systemd unit
+  postPatch = ''
+    # Fix deprecated KillMode
+    sed -i 's/KillMode=none/KillMode=mixed/g' init.d/systemd/zapret2.service
+
+    # Prepare user exclude files
+    cp ipset/zapret-hosts-user-exclude.txt.default ipset/zapret-hosts-user-exclude.txt
+
+    # Help Makefile find luajit
+    sed -i 's|lua5.1|luajit-5.1|g' nfq2/Makefile || true
+    sed -i 's|LUA_PC_NAME := lua|LUA_PC_NAME := luajit|g' nfq2/Makefile || true
+  '';
+
+  # Set environment variables for the build
+  preBuild = ''
+    export LUA_INCLUDE_DIR=${luajit}/include/luajit-2.1
+    export LUA_LIB_DIR=${luajit}/lib
+    export PKG_CONFIG_PATH="${luajit}/lib/pkgconfig:$PKG_CONFIG_PATH"
+  '';
+
+  # Pass variables to make
+  makeFlags = [
+    "PREFIX=${placeholder "out"}/opt/zapret2"
+    "LUA_LIB_NAME=luajit-5.1"
+  ];
+
+  installPhase = ''
+    mkdir -p $out/opt/zapret2/{ip2net,mdig,nfq2,ipset,blockcheck2.d/{custom,standard},files/fake,common,lua,init.d/sysv}
+    mkdir -p $out/etc/{systemd/system,sysusers.d}
+    mkdir -p $out/share/{doc/zapret2,licenses/zapret2}
+    mkdir -p $out/bin
+
+    # Install binaries (built from source)
+    install -Dm755 nfq2/nfqws2  -t $out/opt/zapret2/nfq2/
+    install -Dm755 ip2net/ip2net -t $out/opt/zapret2/ip2net/
+    install -Dm755 mdig/mdig    -t $out/opt/zapret2/mdig/
+
+    # Install scripts and configs
+    install -Dm755 blockcheck2.sh -t $out/opt/zapret2/
+    install -Dm644 blockcheck2.d/custom/* -t $out/opt/zapret2/blockcheck2.d/custom/
+    install -Dm644 blockcheck2.d/standard/* -t $out/opt/zapret2/blockcheck2.d/standard/
+    install -Dm644 files/fake/* -t $out/opt/zapret2/files/fake/
+    install -Dm644 common/* -t $out/opt/zapret2/common/
+    install -Dm644 lua/* -t $out/opt/zapret2/lua/
+
+    # Install ipset files
+    for f in ipset/*.sh; do [ -f "$f" ] && install -Dm755 "$f" -t $out/opt/zapret2/ipset/; done
+    for f in ipset/*.txt ipset/*.default; do [ -f "$f" ] && install -Dm644 "$f" -t $out/opt/zapret2/ipset/; done
+
+    # Install init scripts
+    install -Dm755 init.d/sysv/{functions,zapret2} -t $out/opt/zapret2/init.d/sysv/
+    install -Dm644 init.d/systemd/* -t $out/etc/systemd/system/
+
+    # Create sysusers config
+    echo "u zapret2 - \"zapret2 Anti-DPI software\"" > $out/etc/sysusers.d/zapret2.conf
+
+    # Create symlinks
+    ln -s $out/opt/zapret2/init.d/sysv/zapret2 $out/bin/zapret2
+    ln -s $out/opt/zapret2/ip2net/ip2net $out/bin/ip2net
+    ln -s $out/opt/zapret2/mdig/mdig    $out/bin/mdig
+    ln -s $out/opt/zapret2/nfq2/nfqws2  $out/bin/nfqws2
+
+    # Install docs
+    install -Dm644 docs/*.* -t $out/share/doc/zapret2/
+    install -Dm644 docs/LICENSE.txt -T $out/share/licenses/zapret2/LICENSE
+
+    # Install main config
+    install -Dm644 config.default -T $out/opt/zapret2/config
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/ip2net --prefix PATH : ${lib.makeBinPath [ bind ]}
+    wrapProgram $out/bin/mdig    --prefix PATH : ${
+      lib.makeBinPath [
+        bind
+        nmap
+      ]
+    }
+    wrapProgram $out/bin/nfqws2  --prefix PATH : ${
+      lib.makeBinPath [
+        iptables
+        ipset
+        nmap
+        curl
+        luajit
+      ]
+    }
+  '';
+
+  meta = with lib; {
+    description = "Anti-DPI software for bypassing DPI systems";
+    homepage = "https://github.com/bol-van/zapret2";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = [ ];
+    mainProgram = "nfqws2";
+  };
+})


### PR DESCRIPTION
## Description

**NOTE**: This is `zapret2`, the successor to `zapret` (already in nixpkgs). The author created a new repository and completely rewrote the core functionality.

Adds [zapret2](https://github.com/bol-van/zapret2) - an autonomous anti-DPI (Deep Packet Inspection) tool designed to bypass network blocks and throttling without requiring external servers.

**Key differences from zapret (v1):**
- Core DPI circumvention logic moved from C to **Lua scripts** for greater flexibility
- Strategies are now programmable in Lua instead of being hardcoded in C
- More modular architecture for easier community contributions
- Maintains the same focus on embedded devices (OpenWrt routers) while supporting desktop Linux, FreeBSD, OpenBSD, and Windows

**Supported functionality:**
- HTTP(S) traffic obfuscation
- TCP/UDP protocol signature analysis (VPN blocking circumvention)
- Transparent proxy modes (iptables, nfqueue)
- Hostlist and ipset-based filtering
- Reassembly and decryption of protocols (TLS, QUIC)
- IPv4/IPv6 support

This tool is essential for users in regions with aggressive network filtering, providing a local solution without relying on external proxy servers.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests)
  - [ ] [Package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - [ ] Tested compilation of all packages that depend on this change
  - [x] Tested basic functionality of binary files (verified `zapret-lib --help` and `zapret-antidpi --help`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)
- [ ] Nixpkgs release notes update: N/A (new package)
- [ ] NixOS release notes update: N/A (new package)

## Dependencies

The derivation includes these runtime dependencies:
- `bind` (for DNS tools)
- `curl` (for downloads)
- `iptables` (for transparent proxy)
- `libnetfilter_queue` (nfqueue support)
- `luajit` (Lua strategy engine)
- `nmap` (network utilities)
- `ipset` (optional, for iptables mode)

## Testing instructions

To test this package:
```bash
nix-build -A zapret2
./result/bin/zapret-lib --help
./result/bin/zapret-antidpi --help
```

**WARNING**: Testing DPI circumvention requires network access and appropriate permissions. The `blockcheck2.sh` script can be used to test which strategies work for your network environment.

For detailed usage, see the [official documentation](https://github.com/bol-van/zapret2/tree/master/docs).

## Additional context

This is a **new package** (zapret2) and does **not** replace the existing `zapret` package in nixpkgs. The author transitioned to a new repository and redesigned the architecture. The old version remains functional but is no longer actively developed.

The derivation builds from source and installs both the core C components (`zapret-lib`, `zapret-antidpi`) and the Lua strategy libraries. Configuration examples are included in `/share/zapret2`.

**License**: MIT

cc @NixOS/nix-formatting for new package review