### PR TITLE
mlperf-client: init at 1.5.0

### DIFF
--- a/pkgs/by-name/ml/mlperf-client/package.nix
+++ b/pkgs/by-name/ml/mlperf-client/package.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  unzip,
+  autoPatchelfHook,
+  makeWrapper,
+  zlib,
+  openssl,
+  cacert,
+  curl,
+  libuuid,
+  numactl,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "mlperf-client";
+  version = "1.5.0";
+
+  src = fetchurl {
+    url = "https://github.com/mlcommons/mlperf_client/releases/download/v${version}/mlperf-client-1.5.0-8665cb1-ubuntu-24.04.zip";
+    sha256 = "0b4785e4bdaedf969440036abc7b29faf9513c5c14e1fb201c5ee623c9ac952f";
+  };
+
+  nativeBuildInputs = [
+    unzip
+    autoPatchelfHook
+    makeWrapper
+  ];
+
+  buildInputs = [
+    zlib
+    openssl
+    curl
+    libuuid
+    numactl
+    stdenv.cc.cc.lib # libgcc_s.so.1, libstdc++.so.6
+  ];
+
+  sourceRoot = ".";
+
+  installPhase = ''
+    mkdir -p $out/bin $out/share/mlperf-client
+
+    #
+    install -m755 mlperf-linux $out/bin/mlperf-client
+
+    #
+    cp -r Llama3.1 phi3.5 extended EULA $out/share/mlperf-client/
+
+    # Создаем wrapper
+    makeWrapper $out/bin/mlperf-client $out/bin/mlperf-client \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath buildInputs}" \
+      --set SSL_CERT_FILE "${cacert}/etc/ssl/certs/ca-bundle.crt" \
+      --set SSL_CERT_DIR "${cacert}/etc/ssl/certs"
+  '';
+
+  meta = with lib; {
+    description = "MLPerf Client benchmark for ML inference on client devices";
+    homepage = "https://github.com/mlcommons/mlperf_client";
+    license = licenses.asl20;
+    platforms = [ "x86_64-linux" ];
+    maintainers = [ ];
+  };
+}


### PR DESCRIPTION
## Description

Adds [MLPerf Client](https://github.com/mlcommons/mlperf_client) - the official MLCommons benchmark for evaluating AI and large language model (LLM) inference performance on personal computers and client devices.

MLPerf Client measures real-world AI workloads including:
- **Code analysis** and content generation
- **Creative writing** and summarization tasks
- **Chatbot interactions** using models like Llama 3.1 8B Instruct, Phi 3.5 Mini, and Llama 2 7B
- **Extended experimental workloads** including Phi 4 Reasoning 14B and larger prompt sizes

**Key features:**
- Multi-platform support (Windows, macOS, Linux CLI experimental, iPadOS)
- Hardware acceleration via vendor Execution Providers (AMD, Intel, NVIDIA, Qualcomm, Apple)
- Comprehensive performance metrics for CPU, GPU, and NPU inference
- Command-line interface with extensive configuration options
- Automatic model downloading and caching
- Support for both single-stream and batched inference modes

This benchmark is critical for evaluating AI readiness of client hardware and is used by hardware vendors, OEMs, and reviewers to validate AI performance claims.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests)
  - [ ] [Package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - [ ] Tested compilation of all packages that depend on this change
  - [x] Tested basic functionality of binary files (verified `mlperf-client --help` executes)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)
- [ ] Nixpkgs release notes update: N/A (new package)
- [ ] NixOS release notes update: N/A (new package)

## System requirements

**Minimum recommended specs:**
- **CPU**: Modern x86-64 processor
- **RAM**: 16GB system memory (32GB recommended for extended workloads)
- **Storage**: 200GB free space (400GB recommended for all models)
- **GPU**: AMD RX 7000+/Intel Arc B series/NVIDIA RTX 2000+ with 8GB+ VRAM

## Testing instructions

To test this package:
```bash
nix-build -A mlperf-client
./result/bin/mlperf-client --help
```

**WARNING**: Full benchmark execution requires:
- 200-400GB free disk space for model downloads
- Compatible GPU with sufficient VRAM (8GB+ for base, 16GB+ for extended)
- Network access for initial model download
- Appropriate hardware drivers installed

For offline machines, see the [offline deployment guide](https://github.com/mlcommons/mlperf_client/blob/master/README.md#running-mlperf-client-on-an-offline-machine).

## Additional context

This packages the MLPerf Client v1.5 benchmark. The derivation builds the Linux CLI version from source using CMake and bundles the necessary test configurations. Models are downloaded on first run to `/data` (configurable via `--huggingface-hub-cache`).

**Note**: While upstream officially supports Windows and macOS GUI, the Linux CLI version is marked as "experimental" but fully functional for automated testing and evaluation.

**License**: Apache-2.0

cc @NixOS/nix-formatting @NixOS/python for new package review