### PR TITLE
victoriatraces: 0.5.1 -> 0.6.0

### DIFF
--- a/nixos/modules/services/databases/victoriatraces.nix
+++ b/nixos/modules/services/databases/victoriatraces.nix
@@ -156,6 +156,7 @@ in
         SystemCallFilter = [
           "@system-service"
           "~@privileged"
+          "mincore"
         ];
       };
 

--- a/pkgs/by-name/vi/victoriatraces/package.nix
+++ b/pkgs/by-name/vi/victoriatraces/package.nix
@@ -13,21 +13,14 @@
 
 buildGoModule (finalAttrs: {
   pname = "VictoriaTraces";
-  version = "0.5.1";
+  version = "0.6.0";
 
   src = fetchFromGitHub {
     owner = "VictoriaMetrics";
     repo = "VictoriaTraces";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-RvP3hLM8SoDN91PATTI5RTKwnJsomBtWIakRlBprEPA=";
+    hash = "sha256-gXdOPRC3oxMAimMc4v0CjTb224qiocFY9/1PFH4hbRw=";
   };
-
-  postPatch = ''
-    substituteInPlace go.mod \
-      --replace-fail "go 1.25.4" "go 1.25.3"
-    substituteInPlace vendor/modules.txt \
-      --replace-fail "go 1.25.4" "go 1.25.3"
-  '';
 
   vendorHash = null;
 


### PR DESCRIPTION
ChangeLog: https://docs.victoriametrics.com/victoriatraces/changelog/#v060

Just like victoriametrics[1], we now need to allow `mincore`:

    SECCOMP auid=4294967295 uid=61888 gid=61888 ses=4294967295 pid=859923 comm="victoria-traces" exe="/nix/store/kxqhlmqdc6ml4l9asb69w39yny88hmvf-VictoriaTraces-0.6.0/bin/victoria-traces" sig=31 arch=c000003e syscall=27 compat=0 ip=0x40578e code=0x80000000

[1] efca7ca9dc82b268c6773189a1fee25b6b6ed670


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
