### PR TITLE
cdp8: init at 8.0.1

### DIFF
--- a/pkgs/by-name/cd/cdp8/clear-stdlib-for-use-with-gcc.patch
+++ b/pkgs/by-name/cd/cdp8/clear-stdlib-for-use-with-gcc.patch
@@ -1,0 +1,62 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2d9de2f..5c185da 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -12,7 +12,7 @@ endif()
+ message(STATUS "${CMAKE_HOME_DIRECTORY}")
+ message(STATUS "installing to ${CMAKE_INSTALL_PREFIX}")
+ 
+-set(CMAKE_CXX_FLAGS_RELEASE "-O2 -std=c++11 -stdlib=libc++")
++set(CMAKE_CXX_FLAGS_RELEASE "-O2 -std=c++11 ")
+ set(CMAKE_C_FLAGS_RELEASE "-O2 ")
+ set(CMAKE_VERBOSE_MAKEFILE OFF)
+ 
+diff --git a/dev/externals/fastconv/CMakeLists.txt b/dev/externals/fastconv/CMakeLists.txt
+index 73d768d..ddcf279 100644
+--- a/dev/externals/fastconv/CMakeLists.txt
++++ b/dev/externals/fastconv/CMakeLists.txt
+@@ -1,6 +1,6 @@
+ if(APPLE)
+   set(CMAKE_C_FLAGS "-O2 -Wall  -Dunix -fomit-frame-pointer -funroll-loops")
+-  set(CMAKE_CXX_FLAGS "-O2 -Wall  -Dunix -fomit-frame-pointer -funroll-loops  -std=c++11 -stdlib=libc++")
++  set(CMAKE_CXX_FLAGS "-O2 -Wall  -Dunix -fomit-frame-pointer -funroll-loops  -std=c++11 ")
+ else()
+   if(MINGW OR MSVC)
+     if(MINGW) 
+diff --git a/dev/externals/mctools/CMakeLists.txt b/dev/externals/mctools/CMakeLists.txt
+index 84c0923..054a5df 100644
+--- a/dev/externals/mctools/CMakeLists.txt
++++ b/dev/externals/mctools/CMakeLists.txt
+@@ -1,6 +1,6 @@
+ if(APPLE)
+   set(CMAKE_C_FLAGS "-O2 -Wall  -Dunix -fomit-frame-pointer -funroll-loops")
+-  set(CMAKE_CXX_FLAGS "-O2 -Wall  -Dunix -fomit-frame-pointer -funroll-loops -std=c++11 -stdlib=libc++")
++  set(CMAKE_CXX_FLAGS "-O2 -Wall  -Dunix -fomit-frame-pointer -funroll-loops -std=c++11 ")
+ #  SET(CMAKE_EXE_LINKER_FLAGS "-static")
+ else()
+   if(MINGW OR MSVC)
+diff --git a/dev/externals/paprogs/pvplay/CMakeLists.txt b/dev/externals/paprogs/pvplay/CMakeLists.txt
+index 8a42595..b7275ea 100644
+--- a/dev/externals/paprogs/pvplay/CMakeLists.txt
++++ b/dev/externals/paprogs/pvplay/CMakeLists.txt
+@@ -1,7 +1,7 @@
+ if(APPLE)
+ # -mmacosx-version-min=10.9
+   set(CMAKE_C_FLAGS "-O2 -Wall  -Dunix  -DMAC -DPA_USE_COREAUDIO  -fomit-frame-pointer -funroll-loops")
+-  set(CMAKE_CXX_FLAGS "-O2 -Wall  -Dunix -DMAC -DPA_USE_COREAUDIO -fomit-frame-pointer -mmacosx-version-min=10.9 -funroll-loops -std=c++11 -stdlib=libc++")
++  set(CMAKE_CXX_FLAGS "-O2 -Wall  -Dunix -DMAC -DPA_USE_COREAUDIO -fomit-frame-pointer -mmacosx-version-min=10.9 -funroll-loops -std=c++11 ")
+   include_directories ( /Developer/Headers/FlatCarbon )
+   find_library(COREAUDIOLIB CoreAudio)
+   find_library(AUDIOTOOLBOX AudioToolbox)
+diff --git a/dev/externals/reverb/CMakeLists.txt b/dev/externals/reverb/CMakeLists.txt
+index 30da6d6..9ab8cee 100644
+--- a/dev/externals/reverb/CMakeLists.txt
++++ b/dev/externals/reverb/CMakeLists.txt
+@@ -1,6 +1,6 @@
+ if(APPLE)
+   set(CMAKE_C_FLAGS "-O2 -Wall  -Dunix -fomit-frame-pointer -funroll-loops")
+-  set(CMAKE_CXX_FLAGS "-O2 -Wall   -Dunix -fomit-frame-pointer -funroll-loops -std=c++11 -stdlib=libc++")
++  set(CMAKE_CXX_FLAGS "-O2 -Wall   -Dunix -fomit-frame-pointer -funroll-loops -std=c++11 ")
+ else()
+   if(MINGW OR MSVC)
+     if(MINGW)

--- a/pkgs/by-name/cd/cdp8/package.nix
+++ b/pkgs/by-name/cd/cdp8/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+}:
+
+stdenv.mkDerivation (final: {
+  pname = "CDP8";
+  version = "8.0.1-unstable-2026-01-07";
+
+  src = fetchFromGitHub {
+    owner = "ComposersDesktop";
+    repo = "CDP8";
+    rev = "57067a05b0f925cceb3a6c3368afb4d85a7b2842";
+    hash = "sha256-7BIx9CjNXnlHk5Ffg013L9dG0GJ0pvYCXu0cf/Gv01E=";
+  };
+
+  patches = [
+    # Remove mentions of incompatible -stdlib
+    ./clear-stdlib-for-use-with-gcc.patch
+  ];
+
+  # Build errors in many files when format hardening is enabled:
+  #   cc1: error: '-Wformat-security' ignored without '-Wformat' [-Werror=format-security]
+  hardeningDisable = [ "format" ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  cmakeFlags = [
+    # file RPATH_CHANGE could not write new RPATH.
+    (lib.cmakeBool "CMAKE_SKIP_BUILD_RPATH" true)
+  ];
+
+  meta = {
+    description = "Large suite of command line programs for sound processing";
+    homepage = "http://www.composersdesktop.com/";
+    license = lib.licenses.lgpl2;
+    maintainers = with lib.maintainers; [ jpotier ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
This is in fact a few commit after the 8.0.1 tag, as the software project simply does not build at the tag set upstream. The version in CMakeLists.txt is still 8.0.1, but many patches to the build process and some bugs were fixed.

CDP8 or Composers Desktop Project major version 8 (http://www.composersdesktop.com/) is a large suite of command line programs for sound processing, in the musique concrete tradition.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
