### PR TITLE
nixos/homebox: set TMPDIR to fix uploading attachments/images

### DIFF
--- a/nixos/modules/services/web-apps/homebox.nix
+++ b/nixos/modules/services/web-apps/homebox.nix
@@ -43,6 +43,7 @@ in
           HBOX_OPTIONS_ALLOW_REGISTRATION = "false";
           HBOX_OPTIONS_CHECK_GITHUB_RELEASE = "false";
           HBOX_MODE = "production";
+          HOME = "/var/lib/homebox";
         }
       '';
       description = ''
@@ -92,6 +93,9 @@ in
         HBOX_OPTIONS_ALLOW_REGISTRATION = "false";
         HBOX_OPTIONS_CHECK_GITHUB_RELEASE = "false";
         HBOX_MODE = "production";
+        # Fix this startup issue:
+        #   failed to create modcache index dir: mkdir /var/empty/.cache: read-only file system
+        HOME = "/var/lib/homebox";
       })
 
       (mkIf cfg.database.createLocally {

--- a/nixos/modules/services/web-apps/homebox.nix
+++ b/nixos/modules/services/web-apps/homebox.nix
@@ -44,6 +44,7 @@ in
           HBOX_OPTIONS_CHECK_GITHUB_RELEASE = "false";
           HBOX_MODE = "production";
           HOME = "/var/lib/homebox";
+          TMPDIR = "/var/lib/homebox/tmp";
         }
       '';
       description = ''
@@ -96,6 +97,9 @@ in
         # Fix this startup issue:
         #   failed to create modcache index dir: mkdir /var/empty/.cache: read-only file system
         HOME = "/var/lib/homebox";
+        # Fix uploading/saving attachments/images:
+        # [...] rename /tmp/ced4804c80b1ed1f6e88060f6d829db421e6dbf3a189715265900b5d6b0243ed.1889b3d16ab36e22.tmp /var/lib/homebox/data/5f42f81b-e9ad-4495-b6a6-9e9f704db30e/documents/ced4804c80b1ed1f6e88060f6d829db421e6dbf3a189715265900b5d6b0243ed: invalid cross-device link" [...]
+        TMPDIR = "/var/lib/homebox/tmp";
       })
 
       (mkIf cfg.database.createLocally {
@@ -121,6 +125,10 @@ in
       requires = lib.optional cfg.database.createLocally "postgresql.target";
       after = lib.optional cfg.database.createLocally "postgresql.target";
       environment = lib.filterAttrs (_: v: v != null) cfg.settings;
+      preStart = ''
+        "${pkgs.coreutils}/bin/rm" -rf /var/lib/homebox/tmp
+        "${pkgs.coreutils}/bin/mkdir" -p /var/lib/homebox/tmp
+      '';
       serviceConfig = {
         User = cfg.user;
         Group = cfg.group;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Allow uploading attachments again.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
