### PR TITLE
vanilla-wiiu: init at 0-unstable-2026-08-02

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10975,6 +10975,17 @@
     githubId = 386666;
     keys = [ { fingerprint = "A25F 6321 AAB4 4151 4085  9924 952E ACB7 6703 BA63"; } ];
   };
+  headblockhead = {
+    email = "nixpkgs@edwardh.dev";
+    github = "headblockhead";
+    githubId = 26520767;
+    name = "Edward Hesketh";
+    keys = [
+      { fingerprint = "B02A E7D7 F9C1 5C02 0643 C349 8E97 2E26 D6D4 8C46"; }
+      { fingerprint = "8D13 B80A A22C C7B2 3FCA 1D49 672F FB8B 28B1 7E09"; }
+      { fingerprint = "76C6 E96B 6A56 1DBE 8F92 B2E1 AE25 B4F5 B634 6CCF"; }
+    ];
+  };
   hectorj = {
     email = "hector.jusforgues+nixos@gmail.com";
     github = "hectorj";

--- a/pkgs/by-name/va/vanilla-wiiu/fix-sdl2-include.patch
+++ b/pkgs/by-name/va/vanilla-wiiu/fix-sdl2-include.patch
@@ -1,0 +1,17 @@
+diff --git a/gui/ui/ui_sdl.c b/gui/ui/ui_sdl.c
+index 023165d..09bf82e 100644
+--- a/gui/ui/ui_sdl.c
++++ b/gui/ui/ui_sdl.c
+@@ -5,9 +5,9 @@
+ #include <SDL2/SDL.h>
+ #include <SDL2/SDL_hints.h>
+ #include <SDL2/SDL_syswm.h>
+-#include <SDL_image.h>
+-#include <SDL_power.h>
+-#include <SDL_ttf.h>
++#include <SDL2/SDL_image.h>
++#include <SDL2/SDL_power.h>
++#include <SDL2/SDL_ttf.h>
+ #include <pthread.h>
+ #include <vanilla.h>
+ #include <libavutil/hwcontext.h>

--- a/pkgs/by-name/va/vanilla-wiiu/package.nix
+++ b/pkgs/by-name/va/vanilla-wiiu/package.nix
@@ -1,0 +1,88 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  networkmanager,
+  libnl,
+  openssl,
+  git,
+  SDL2,
+  SDL2_ttf,
+  SDL2_image,
+  libwebp,
+  libtiff,
+  ffmpeg,
+  polkit,
+  libxml2,
+  libx11,
+  libGL,
+  libdrm,
+  gitUpdater,
+}:
+let
+  hostap = fetchFromGitHub {
+    owner = "rolandoislas";
+    repo = "drc-hostap";
+    rev = "418e5e206786de2482864a0ec3a59742a33b6623";
+    hash = "sha256-kAv/PetD6Ia5NzmYMWWyWQll1P+N2bL/zaV9ATiGVV0=";
+    leaveDotGit = true;
+  };
+in
+stdenv.mkDerivation {
+  pname = "vanilla-wiiu";
+  version = "0-unstable-2026-08-02";
+
+  src = fetchFromGitHub {
+    owner = "vanilla-wiiu";
+    repo = "vanilla";
+    rev = "c008b9baf35074a7e340b79f4a51d0aad76ef243";
+    hash = "sha256-wjRhR/hZXOIajMFAjBr5PqFy8zwBa/paMBuV+vhhh90=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    git
+  ];
+
+  buildInputs = [
+    networkmanager
+    libnl
+    openssl
+    SDL2
+    SDL2_ttf
+    SDL2_image
+    libwebp
+    libtiff
+    ffmpeg
+    polkit
+    libxml2
+    libx11
+    libGL
+    libdrm
+  ];
+
+  patches = [ ./fix-sdl2-include.patch ];
+
+  postPatch = ''
+    substituteInPlace pipe/linux/CMakeLists.txt \
+      --replace-fail "https://github.com/rolandoislas/drc-hostap.git" "${hostap}" \
+      --replace-fail "--branch master" "--branch fetchgit"
+  '';
+
+  passthru.updateScript = gitUpdater { };
+
+  meta = {
+    description = "Software clone of the Wii U gamepad";
+    homepage = "https://github.com/vanilla-wiiu/vanilla";
+    license = lib.licenses.gpl2;
+    maintainers = with lib.maintainers; [ headblockhead ];
+    mainProgram = "vanilla";
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
I have added the WiiU gamepad emulation tool [Vanilla](https://github.com/vanilla-wiiu/vanilla) to the pkgs directory, and added myself as a maintainer. 
I have added it under the name "vanilla-wiiu" because the name "vanilla" is used as a boolean argument in pkg-config, causing errors.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
