### PR TITLE
unocss-language-server: init at 0.1.8

### DIFF
--- a/pkgs/by-name/un/unocss-language-server/package.nix
+++ b/pkgs/by-name/un/unocss-language-server/package.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchPnpmDeps,
+  pnpmConfigHook,
+  pnpm,
+  nodejs,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "unocss-language-server";
+  version = "0.1.8";
+
+  src = fetchFromGitHub {
+    owner = "xna00";
+    repo = "unocss-language-server";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-rRi9JvjljvjBbY6UsH2YzAQcp+Z+MqxK7hhDNkpEANw=";
+  };
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    fetcherVersion = 3;
+    hash = "sha256-vGSr+nLtV189QVoe1cKZoX+sUhTlqOe+EgurnXHCILY=";
+  };
+
+  nativeBuildInputs = [
+    nodejs
+    pnpmConfigHook
+    pnpm
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    pnpm run build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,lib/unocss-language-server}
+    cp -r {out,bin,node_modules} $out/lib/unocss-language-server/
+
+    chmod +x $out/lib/unocss-language-server/bin/index.js
+    patchShebangs $out/lib/unocss-language-server/bin/index.js
+    ln -s $out/lib/unocss-language-server/bin/index.js $out/bin/unocss-language-server
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Language server for UnoCSS";
+    homepage = "https://github.com/xna00/unocss-language-server";
+    changelog = "https://github.com/xna00/unocss-language-server/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ryoppippi ];
+    mainProgram = "unocss-language-server";
+  };
+})

--- a/pkgs/by-name/un/unocss-language-server/package.nix
+++ b/pkgs/by-name/un/unocss-language-server/package.nix
@@ -34,9 +34,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildPhase = ''
     runHook preBuild
-
+  buildPhase = ''
+    runHook preBuild
+    
     pnpm run build
-
+    
     runHook postBuild
   '';
 

--- a/pkgs/by-name/un/unocss-language-server/package.nix
+++ b/pkgs/by-name/un/unocss-language-server/package.nix
@@ -34,11 +34,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildPhase = ''
     runHook preBuild
-  buildPhase = ''
-    runHook preBuild
-    
+
     pnpm run build
-    
+
     runHook postBuild
   '';
 


### PR DESCRIPTION
Language server for UnoCSS, providing autocompletion and other features for UnoCSS utility classes.

Homepage: https://github.com/unocss/unocss

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc