### PR TITLE
gh-actions-language-server: init at 0.0.3

### DIFF
--- a/pkgs/by-name/gh/gh-actions-language-server/package-lock.json
+++ b/pkgs/by-name/gh/gh-actions-language-server/package-lock.json
@@ -1,0 +1,895 @@
+{
+	"name": "gh-actions-language-server",
+	"version": "0.0.3",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "gh-actions-language-server",
+			"version": "0.0.3",
+			"license": "MIT",
+			"dependencies": {
+				"@actions/languageserver": "^0.3.13",
+				"@actions/workflow-parser": "^0.3.13",
+				"@octokit/rest": "^19.0.7",
+				"@octokit/types": "^9.0.0",
+				"vscode-languageserver": "^8.0.2",
+				"vscode-languageserver-textdocument": "^1.0.7",
+				"yaml": "^2.1.3"
+			},
+			"bin": {
+				"gh-actions-language-server": "bin/gh-actions-language-server"
+			},
+			"devDependencies": {
+				"@biomejs/biome": "^1.9.4",
+				"@types/bun": "latest"
+			},
+			"engines": {
+				"node": ">=13.2.0"
+			},
+			"peerDependencies": {
+				"typescript": "^5.0.0"
+			}
+		},
+		"node_modules/@actions/expressions": {
+			"version": "0.3.34",
+			"resolved": "https://registry.npmjs.org/@actions/expressions/-/expressions-0.3.34.tgz",
+			"integrity": "sha512-bJ5n/4b3aXRJ9ZtNR5jkbsoMjvnmFKf6zhuLAkjZm3mdTIOCSWf+2en6ZAz+HfuXzmdz2TK6bwTxhZjqx6pg7Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@actions/languageserver": {
+			"version": "0.3.34",
+			"resolved": "https://registry.npmjs.org/@actions/languageserver/-/languageserver-0.3.34.tgz",
+			"integrity": "sha512-JLqFWUdyKrvmdLu28H61dnM9hm+nW8NlDmuAg1tygfdHBQFhe8+IxMY/nFJbhaZq0lTE5xiuzkNKmHhipA8jLg==",
+			"license": "MIT",
+			"dependencies": {
+				"@actions/languageservice": "^0.3.34",
+				"@actions/workflow-parser": "^0.3.34",
+				"@octokit/rest": "^21.1.1",
+				"@octokit/types": "^9.0.0",
+				"vscode-languageserver": "^8.0.2",
+				"vscode-languageserver-textdocument": "^1.0.7",
+				"yaml": "^2.1.3"
+			},
+			"bin": {
+				"actions-languageserver": "bin/actions-languageserver"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@actions/languageserver/node_modules/@octokit/auth-token": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-5.1.2.tgz",
+			"integrity": "sha512-JcQDsBdg49Yky2w2ld20IHAlwr8d/d8N6NiOXbtuoPCqzbsiJgF633mVUw3x4mo0H5ypataQIX7SFu3yy44Mpw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@actions/languageserver/node_modules/@octokit/core": {
+			"version": "6.1.6",
+			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.1.6.tgz",
+			"integrity": "sha512-kIU8SLQkYWGp3pVKiYzA5OSaNF5EE03P/R8zEmmrG6XwOg5oBjXyQVVIauQ0dgau4zYhpZEhJrvIYt6oM+zZZA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@octokit/auth-token": "^5.0.0",
+				"@octokit/graphql": "^8.2.2",
+				"@octokit/request": "^9.2.3",
+				"@octokit/request-error": "^6.1.8",
+				"@octokit/types": "^14.0.0",
+				"before-after-hook": "^3.0.2",
+				"universal-user-agent": "^7.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@actions/languageserver/node_modules/@octokit/core/node_modules/@octokit/types": {
+			"version": "14.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-14.1.0.tgz",
+			"integrity": "sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^25.1.0"
+			}
+		},
+		"node_modules/@actions/languageserver/node_modules/@octokit/endpoint": {
+			"version": "10.1.4",
+			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-10.1.4.tgz",
+			"integrity": "sha512-OlYOlZIsfEVZm5HCSR8aSg02T2lbUWOsCQoPKfTXJwDzcHQBrVBGdGXb89dv2Kw2ToZaRtudp8O3ZIYoaOjKlA==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/types": "^14.0.0",
+				"universal-user-agent": "^7.0.2"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@actions/languageserver/node_modules/@octokit/endpoint/node_modules/@octokit/types": {
+			"version": "14.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-14.1.0.tgz",
+			"integrity": "sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^25.1.0"
+			}
+		},
+		"node_modules/@actions/languageserver/node_modules/@octokit/graphql": {
+			"version": "8.2.2",
+			"resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-8.2.2.tgz",
+			"integrity": "sha512-Yi8hcoqsrXGdt0yObxbebHXFOiUA+2v3n53epuOg1QUgOB6c4XzvisBNVXJSl8RYA5KrDuSL2yq9Qmqe5N0ryA==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/request": "^9.2.3",
+				"@octokit/types": "^14.0.0",
+				"universal-user-agent": "^7.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@actions/languageserver/node_modules/@octokit/graphql/node_modules/@octokit/types": {
+			"version": "14.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-14.1.0.tgz",
+			"integrity": "sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^25.1.0"
+			}
+		},
+		"node_modules/@actions/languageserver/node_modules/@octokit/openapi-types": {
+			"version": "25.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-25.1.0.tgz",
+			"integrity": "sha512-idsIggNXUKkk0+BExUn1dQ92sfysJrje03Q0bv0e+KPLrvyqZF8MnBpFz8UNfYDwB3Ie7Z0TByjWfzxt7vseaA==",
+			"license": "MIT"
+		},
+		"node_modules/@actions/languageserver/node_modules/@octokit/plugin-paginate-rest": {
+			"version": "11.6.0",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.6.0.tgz",
+			"integrity": "sha512-n5KPteiF7pWKgBIBJSk8qzoZWcUkza2O6A0za97pMGVrGfPdltxrfmfF5GucHYvHGZD8BdaZmmHGz5cX/3gdpw==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/types": "^13.10.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"peerDependencies": {
+				"@octokit/core": ">=6"
+			}
+		},
+		"node_modules/@actions/languageserver/node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/openapi-types": {
+			"version": "24.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+			"license": "MIT"
+		},
+		"node_modules/@actions/languageserver/node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/types": {
+			"version": "13.10.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^24.2.0"
+			}
+		},
+		"node_modules/@actions/languageserver/node_modules/@octokit/plugin-request-log": {
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-5.3.1.tgz",
+			"integrity": "sha512-n/lNeCtq+9ofhC15xzmJCNKP2BWTv8Ih2TTy+jatNCCq/gQP/V7rK3fjIfuz0pDWDALO/o/4QY4hyOF6TQQFUw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 18"
+			},
+			"peerDependencies": {
+				"@octokit/core": ">=6"
+			}
+		},
+		"node_modules/@actions/languageserver/node_modules/@octokit/plugin-rest-endpoint-methods": {
+			"version": "13.5.0",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-13.5.0.tgz",
+			"integrity": "sha512-9Pas60Iv9ejO3WlAX3maE1+38c5nqbJXV5GrncEfkndIpZrJ/WPMRd2xYDcPPEt5yzpxcjw9fWNoPhsSGzqKqw==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/types": "^13.10.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"peerDependencies": {
+				"@octokit/core": ">=6"
+			}
+		},
+		"node_modules/@actions/languageserver/node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/openapi-types": {
+			"version": "24.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+			"license": "MIT"
+		},
+		"node_modules/@actions/languageserver/node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
+			"version": "13.10.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^24.2.0"
+			}
+		},
+		"node_modules/@actions/languageserver/node_modules/@octokit/request": {
+			"version": "9.2.4",
+			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.2.4.tgz",
+			"integrity": "sha512-q8ybdytBmxa6KogWlNa818r0k1wlqzNC+yNkcQDECHvQo8Vmstrg18JwqJHdJdUiHD2sjlwBgSm9kHkOKe2iyA==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/endpoint": "^10.1.4",
+				"@octokit/request-error": "^6.1.8",
+				"@octokit/types": "^14.0.0",
+				"fast-content-type-parse": "^2.0.0",
+				"universal-user-agent": "^7.0.2"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@actions/languageserver/node_modules/@octokit/request-error": {
+			"version": "6.1.8",
+			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.8.tgz",
+			"integrity": "sha512-WEi/R0Jmq+IJKydWlKDmryPcmdYSVjL3ekaiEL1L9eo1sUnqMJ+grqmC9cjk7CA7+b2/T397tO5d8YLOH3qYpQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/types": "^14.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@actions/languageserver/node_modules/@octokit/request-error/node_modules/@octokit/types": {
+			"version": "14.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-14.1.0.tgz",
+			"integrity": "sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^25.1.0"
+			}
+		},
+		"node_modules/@actions/languageserver/node_modules/@octokit/request/node_modules/@octokit/types": {
+			"version": "14.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-14.1.0.tgz",
+			"integrity": "sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^25.1.0"
+			}
+		},
+		"node_modules/@actions/languageserver/node_modules/@octokit/rest": {
+			"version": "21.1.1",
+			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-21.1.1.tgz",
+			"integrity": "sha512-sTQV7va0IUVZcntzy1q3QqPm/r8rWtDCqpRAmb8eXXnKkjoQEtFe3Nt5GTVsHft+R6jJoHeSiVLcgcvhtue/rg==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/core": "^6.1.4",
+				"@octokit/plugin-paginate-rest": "^11.4.2",
+				"@octokit/plugin-request-log": "^5.3.1",
+				"@octokit/plugin-rest-endpoint-methods": "^13.3.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@actions/languageserver/node_modules/before-after-hook": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-3.0.2.tgz",
+			"integrity": "sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A==",
+			"license": "Apache-2.0"
+		},
+		"node_modules/@actions/languageserver/node_modules/universal-user-agent": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+			"integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
+			"license": "ISC"
+		},
+		"node_modules/@actions/languageservice": {
+			"version": "0.3.34",
+			"resolved": "https://registry.npmjs.org/@actions/languageservice/-/languageservice-0.3.34.tgz",
+			"integrity": "sha512-BFtt0p33F40o57LyCV08AQOIKw8jE0R+4J4wnZ0TC1cqgJbsBsR2RmDC+hGFEubmKblcDV1/9li/PiswuwbBKg==",
+			"license": "MIT",
+			"dependencies": {
+				"@actions/expressions": "^0.3.34",
+				"@actions/workflow-parser": "^0.3.34",
+				"vscode-languageserver-textdocument": "^1.0.7",
+				"vscode-languageserver-types": "^3.17.2",
+				"vscode-uri": "^3.0.8",
+				"yaml": "^2.1.1"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@actions/workflow-parser": {
+			"version": "0.3.34",
+			"resolved": "https://registry.npmjs.org/@actions/workflow-parser/-/workflow-parser-0.3.34.tgz",
+			"integrity": "sha512-Yx6bPVfHYpDs3VF27pcQne31zBVLHgLe/ksOYFjpOjk4rr7BW2pG3Bawh6ojSCItgGbF38j9ibxOvPQPeFG4ew==",
+			"license": "MIT",
+			"dependencies": {
+				"@actions/expressions": "^0.3.34",
+				"cronstrue": "^2.21.0",
+				"yaml": "^2.0.0-8"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@biomejs/biome": {
+			"version": "1.9.4",
+			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-1.9.4.tgz",
+			"integrity": "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT OR Apache-2.0",
+			"bin": {
+				"biome": "bin/biome"
+			},
+			"engines": {
+				"node": ">=14.21.3"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/biome"
+			},
+			"optionalDependencies": {
+				"@biomejs/cli-darwin-arm64": "1.9.4",
+				"@biomejs/cli-darwin-x64": "1.9.4",
+				"@biomejs/cli-linux-arm64": "1.9.4",
+				"@biomejs/cli-linux-arm64-musl": "1.9.4",
+				"@biomejs/cli-linux-x64": "1.9.4",
+				"@biomejs/cli-linux-x64-musl": "1.9.4",
+				"@biomejs/cli-win32-arm64": "1.9.4",
+				"@biomejs/cli-win32-x64": "1.9.4"
+			}
+		},
+		"node_modules/@biomejs/cli-darwin-arm64": {
+			"version": "1.9.4",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-1.9.4.tgz",
+			"integrity": "sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/cli-darwin-x64": {
+			"version": "1.9.4",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.9.4.tgz",
+			"integrity": "sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/cli-linux-arm64": {
+			"version": "1.9.4",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.9.4.tgz",
+			"integrity": "sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/cli-linux-arm64-musl": {
+			"version": "1.9.4",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.9.4.tgz",
+			"integrity": "sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/cli-linux-x64": {
+			"version": "1.9.4",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-1.9.4.tgz",
+			"integrity": "sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/cli-linux-x64-musl": {
+			"version": "1.9.4",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-1.9.4.tgz",
+			"integrity": "sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/cli-win32-arm64": {
+			"version": "1.9.4",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.9.4.tgz",
+			"integrity": "sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/cli-win32-x64": {
+			"version": "1.9.4",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-1.9.4.tgz",
+			"integrity": "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@octokit/auth-token": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-3.0.4.tgz",
+			"integrity": "sha512-TWFX7cZF2LXoCvdmJWY7XVPi74aSY0+FfBZNSXEXFkMpjcqsQwDSYVv5FhRFaI0V1ECnwbz4j59T/G+rXNWaIQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/@octokit/core": {
+			"version": "4.2.4",
+			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-4.2.4.tgz",
+			"integrity": "sha512-rYKilwgzQ7/imScn3M9/pFfUf4I1AZEH3KhyJmtPdE2zfaXAn2mFfUy4FbKewzc2We5y/LlKLj36fWJLKC2SIQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@octokit/auth-token": "^3.0.0",
+				"@octokit/graphql": "^5.0.0",
+				"@octokit/request": "^6.0.0",
+				"@octokit/request-error": "^3.0.0",
+				"@octokit/types": "^9.0.0",
+				"before-after-hook": "^2.2.0",
+				"universal-user-agent": "^6.0.0"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/@octokit/endpoint": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.6.tgz",
+			"integrity": "sha512-5L4fseVRUsDFGR00tMWD/Trdeeihn999rTMGRMC1G/Ldi1uWlWJzI98H4Iak5DB/RVvQuyMYKqSK/R6mbSOQyg==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/types": "^9.0.0",
+				"is-plain-object": "^5.0.0",
+				"universal-user-agent": "^6.0.0"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/@octokit/graphql": {
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-5.0.6.tgz",
+			"integrity": "sha512-Fxyxdy/JH0MnIB5h+UQ3yCoh1FG4kWXfFKkpWqjZHw/p+Kc8Y44Hu/kCgNBT6nU1shNumEchmW/sUO1JuQnPcw==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/request": "^6.0.0",
+				"@octokit/types": "^9.0.0",
+				"universal-user-agent": "^6.0.0"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/@octokit/openapi-types": {
+			"version": "18.1.1",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-18.1.1.tgz",
+			"integrity": "sha512-VRaeH8nCDtF5aXWnjPuEMIYf1itK/s3JYyJcWFJT8X9pSNnBtriDf7wlEWsGuhPLl4QIH4xM8fqTXDwJ3Mu6sw==",
+			"license": "MIT"
+		},
+		"node_modules/@octokit/plugin-paginate-rest": {
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-6.1.2.tgz",
+			"integrity": "sha512-qhrmtQeHU/IivxucOV1bbI/xZyC/iOBhclokv7Sut5vnejAIAEXVcGQeRpQlU39E0WwK9lNvJHphHri/DB6lbQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/tsconfig": "^1.0.2",
+				"@octokit/types": "^9.2.3"
+			},
+			"engines": {
+				"node": ">= 14"
+			},
+			"peerDependencies": {
+				"@octokit/core": ">=4"
+			}
+		},
+		"node_modules/@octokit/plugin-request-log": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
+			"integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@octokit/core": ">=3"
+			}
+		},
+		"node_modules/@octokit/plugin-rest-endpoint-methods": {
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-7.2.3.tgz",
+			"integrity": "sha512-I5Gml6kTAkzVlN7KCtjOM+Ruwe/rQppp0QU372K1GP7kNOYEKe8Xn5BW4sE62JAHdwpq95OQK/qGNyKQMUzVgA==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/types": "^10.0.0"
+			},
+			"engines": {
+				"node": ">= 14"
+			},
+			"peerDependencies": {
+				"@octokit/core": ">=3"
+			}
+		},
+		"node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-10.0.0.tgz",
+			"integrity": "sha512-Vm8IddVmhCgU1fxC1eyinpwqzXPEYu0NrYzD3YZjlGjyftdLBTeqNblRC0jmJmgxbJIsQlyogVeGnrNaaMVzIg==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^18.0.0"
+			}
+		},
+		"node_modules/@octokit/request": {
+			"version": "6.2.8",
+			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-6.2.8.tgz",
+			"integrity": "sha512-ow4+pkVQ+6XVVsekSYBzJC0VTVvh/FCTUUgTsboGq+DTeWdyIFV8WSCdo0RIxk6wSkBTHqIK1mYuY7nOBXOchw==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/endpoint": "^7.0.0",
+				"@octokit/request-error": "^3.0.0",
+				"@octokit/types": "^9.0.0",
+				"is-plain-object": "^5.0.0",
+				"node-fetch": "^2.6.7",
+				"universal-user-agent": "^6.0.0"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/@octokit/request-error": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-3.0.3.tgz",
+			"integrity": "sha512-crqw3V5Iy2uOU5Np+8M/YexTlT8zxCfI+qu+LxUB7SZpje4Qmx3mub5DfEKSO8Ylyk0aogi6TYdf6kxzh2BguQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/types": "^9.0.0",
+				"deprecation": "^2.0.0",
+				"once": "^1.4.0"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/@octokit/rest": {
+			"version": "19.0.13",
+			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-19.0.13.tgz",
+			"integrity": "sha512-/EzVox5V9gYGdbAI+ovYj3nXQT1TtTHRT+0eZPcuC05UFSWO3mdO9UY1C0i2eLF9Un1ONJkAk+IEtYGAC+TahA==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/core": "^4.2.1",
+				"@octokit/plugin-paginate-rest": "^6.1.2",
+				"@octokit/plugin-request-log": "^1.0.4",
+				"@octokit/plugin-rest-endpoint-methods": "^7.1.2"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/@octokit/tsconfig": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@octokit/tsconfig/-/tsconfig-1.0.2.tgz",
+			"integrity": "sha512-I0vDR0rdtP8p2lGMzvsJzbhdOWy405HcGovrspJ8RRibHnyRgggUSNO5AIox5LmqiwmatHKYsvj6VGFHkqS7lA==",
+			"license": "MIT"
+		},
+		"node_modules/@octokit/types": {
+			"version": "9.3.2",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
+			"integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^18.0.0"
+			}
+		},
+		"node_modules/@types/bun": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/@types/bun/-/bun-1.3.5.tgz",
+			"integrity": "sha512-RnygCqNrd3srIPEWBd5LFeUYG7plCoH2Yw9WaZGyNmdTEei+gWaHqydbaIRkIkcbXwhBT94q78QljxN0Sk838w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"bun-types": "1.3.5"
+			}
+		},
+		"node_modules/@types/node": {
+			"version": "25.0.6",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.6.tgz",
+			"integrity": "sha512-NNu0sjyNxpoiW3YuVFfNz7mxSQ+S4X2G28uqg2s+CzoqoQjLPsWSbsFFyztIAqt2vb8kfEAsJNepMGPTxFDx3Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~7.16.0"
+			}
+		},
+		"node_modules/before-after-hook": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
+			"integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
+			"license": "Apache-2.0"
+		},
+		"node_modules/bun-types": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/bun-types/-/bun-types-1.3.5.tgz",
+			"integrity": "sha512-inmAYe2PFLs0SUbFOWSVD24sg1jFlMPxOjOSSCYqUgn4Hsc3rDc7dFvfVYjFPNHtov6kgUeulV4SxbuIV/stPw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
+		"node_modules/cronstrue": {
+			"version": "2.59.0",
+			"resolved": "https://registry.npmjs.org/cronstrue/-/cronstrue-2.59.0.tgz",
+			"integrity": "sha512-YKGmAy84hKH+hHIIER07VCAHf9u0Ldelx1uU6EBxsRPDXIA1m5fsKmJfyC3xBhw6cVC/1i83VdbL4PvepTrt8A==",
+			"license": "MIT",
+			"bin": {
+				"cronstrue": "bin/cli.js"
+			}
+		},
+		"node_modules/deprecation": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+			"integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
+			"license": "ISC"
+		},
+		"node_modules/fast-content-type-parse": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-2.0.1.tgz",
+			"integrity": "sha512-nGqtvLrj5w0naR6tDPfB4cUmYCqouzyQiz6C5y/LtcDllJdrcc6WaWW6iXyIIOErTa/XRybj28aasdn4LkVk6Q==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/is-plain-object": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/node-fetch": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+			"integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+			"license": "MIT",
+			"dependencies": {
+				"whatwg-url": "^5.0.0"
+			},
+			"engines": {
+				"node": "4.x || >=6.0.0"
+			},
+			"peerDependencies": {
+				"encoding": "^0.1.0"
+			},
+			"peerDependenciesMeta": {
+				"encoding": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+			"license": "ISC",
+			"dependencies": {
+				"wrappy": "1"
+			}
+		},
+		"node_modules/tr46": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+			"license": "MIT"
+		},
+		"node_modules/typescript": {
+			"version": "5.9.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
+			}
+		},
+		"node_modules/undici-types": {
+			"version": "7.16.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+			"integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/universal-user-agent": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
+			"integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
+			"license": "ISC"
+		},
+		"node_modules/vscode-jsonrpc": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.1.0.tgz",
+			"integrity": "sha512-6TDy/abTQk+zDGYazgbIPc+4JoXdwC8NHU9Pbn4UJP1fehUyZmM4RHp5IthX7A6L5KS30PRui+j+tbbMMMafdw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/vscode-languageserver": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-8.1.0.tgz",
+			"integrity": "sha512-eUt8f1z2N2IEUDBsKaNapkz7jl5QpskN2Y0G01T/ItMxBxw1fJwvtySGB9QMecatne8jFIWJGWI61dWjyTLQsw==",
+			"license": "MIT",
+			"dependencies": {
+				"vscode-languageserver-protocol": "3.17.3"
+			},
+			"bin": {
+				"installServerIntoExtension": "bin/installServerIntoExtension"
+			}
+		},
+		"node_modules/vscode-languageserver-protocol": {
+			"version": "3.17.3",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.3.tgz",
+			"integrity": "sha512-924/h0AqsMtA5yK22GgMtCYiMdCOtWTSGgUOkgEDX+wk2b0x4sAfLiO4NxBxqbiVtz7K7/1/RgVrVI0NClZwqA==",
+			"license": "MIT",
+			"dependencies": {
+				"vscode-jsonrpc": "8.1.0",
+				"vscode-languageserver-types": "3.17.3"
+			}
+		},
+		"node_modules/vscode-languageserver-protocol/node_modules/vscode-languageserver-types": {
+			"version": "3.17.3",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.3.tgz",
+			"integrity": "sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA==",
+			"license": "MIT"
+		},
+		"node_modules/vscode-languageserver-textdocument": {
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+			"integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+			"license": "MIT"
+		},
+		"node_modules/vscode-languageserver-types": {
+			"version": "3.17.5",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+			"integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+			"license": "MIT"
+		},
+		"node_modules/vscode-uri": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+			"integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+			"license": "MIT"
+		},
+		"node_modules/webidl-conversions": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+			"license": "BSD-2-Clause"
+		},
+		"node_modules/whatwg-url": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+			"integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+			"license": "MIT",
+			"dependencies": {
+				"tr46": "~0.0.3",
+				"webidl-conversions": "^3.0.0"
+			}
+		},
+		"node_modules/wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+			"license": "ISC"
+		},
+		"node_modules/yaml": {
+			"version": "2.8.2",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+			"integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+			"license": "ISC",
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/eemeli"
+			}
+		}
+	}
+}

--- a/pkgs/by-name/gh/gh-actions-language-server/package.nix
+++ b/pkgs/by-name/gh/gh-actions-language-server/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchurl,
+  nix-update-script,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "gh-actions-language-server";
+  version = "0.0.3";
+
+  src = fetchurl {
+    url = "https://registry.npmjs.org/gh-actions-language-server/-/gh-actions-language-server-${finalAttrs.version}.tgz";
+    hash = "sha256-lgisfGIWGT/WCGqOfm/rqSXVeDWqSge2YJ+ZiBMmS48=";
+  };
+
+  # The npm registry tarball doesn't include a package-lock.json.
+  # We generate and maintain one locally to ensure reproducible builds.
+  postPatch = ''
+    cp ${./package-lock.json} package-lock.json
+  '';
+
+  npmDepsHash = "sha256-mu4ZmokeQzQMRzDobMzXkdAlOTNm/ahHYERi1n+By3c=";
+
+  dontNpmBuild = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Language server for GitHub Actions workflows";
+    homepage = "https://github.com/actions/languageservices";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ryoppippi ];
+    mainProgram = "gh-actions-language-server";
+  };
+})


### PR DESCRIPTION
Language server for GitHub Actions workflows, providing completion, validation, and diagnostics for GitHub Actions workflow files.

Homepage: https://github.com/actions/languageservices

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc