### PR TITLE
python3Packages.mlx: inject absolute path to clang++ instead of $CXX, cleanup

### DIFF
--- a/pkgs/development/python-modules/mlx/default.nix
+++ b/pkgs/development/python-modules/mlx/default.nix
@@ -23,6 +23,9 @@
   pytestCheckHook,
   python,
   runCommand,
+
+  # passthru
+  mlx,
 }:
 
 let
@@ -34,121 +37,120 @@ let
     hash = "sha256-15FvyPOFqTOr5vdWQoPnZz+mYH919++EtghjozDlnSA=";
   };
 
-  mlx = buildPythonPackage rec {
-    pname = "mlx";
-    version = "0.30.1";
-    pyproject = true;
-
-    src = fetchFromGitHub {
-      owner = "ml-explore";
-      repo = "mlx";
-      tag = "v${version}";
-      hash = "sha256-Vt0RH+70VBwUjXSfPTsNdRS3g0ookJHhzf2kvgEtgH8=";
-    };
-
-    patches = [
-      (replaceVars ./darwin-build-fixes.patch {
-        sdkVersion = apple-sdk.version;
-      })
-    ];
-
-    postPatch = ''
-      substituteInPlace pyproject.toml \
-        --replace-fail "nanobind==2.10.2" "nanobind"
-
-      substituteInPlace mlx/backend/cpu/jit_compiler.cpp \
-        --replace-fail "g++" "${lib.getExe' stdenv.cc "c++"}"
-    '';
-
-    dontUseCmakeConfigure = true;
-
-    enableParallelBuilding = true;
-
-    # Allows multiple cores to be used in Python builds.
-    postUnpack = ''
-      export MAKEFLAGS+="''${enableParallelBuilding:+-j$NIX_BUILD_CORES}"
-    '';
-
-    # updates the wrong fetcher rev attribute
-    passthru.skipBulkUpdate = true;
-
-    env = {
-      DEV_RELEASE = 1;
-      CMAKE_ARGS = toString [
-        # NOTE The `metal` command-line utility used to build the Metal kernels is not open-source.
-        # To build mlx with Metal support in Nix, you'd need to use one of the sandbox escape
-        # hatches which let you interact with a native install of Xcode, such as `composeXcodeWrapper`
-        # or by changing the upstream (e.g., https://github.com/zed-industries/zed/discussions/7016).
-        (lib.cmakeBool "MLX_BUILD_METAL" false)
-        (lib.cmakeBool "USE_SYSTEM_FMT" true)
-        (lib.cmakeOptionType "filepath" "FETCHCONTENT_SOURCE_DIR_GGUFLIB" "${gguf-tools}")
-        (lib.cmakeOptionType "filepath" "FETCHCONTENT_SOURCE_DIR_JSON" "${nlohmann_json.src}")
-      ];
-    };
-
-    build-system = [
-      setuptools
-    ];
-
-    nativeBuildInputs = [
-      cmake
-    ];
-
-    buildInputs = [
-      fmt
-      gguf-tools
-      nanobind
-      nlohmann_json
-      pybind11
-    ];
-
-    pythonImportsCheck = [ "mlx" ];
-
-    # Run the mlx Python test suite.
-    nativeCheckInputs = [
-      numpy
-      pytestCheckHook
-    ];
-
-    enabledTestPaths = [
-      "python/tests/"
-    ];
-
-    # Additional testing by executing the example Python scripts supplied with mlx
-    # using the version of the library we've built.
-    passthru.tests = {
-      mlxTest =
-        runCommand "run-mlx-examples"
-          {
-            buildInputs = [ mlx ];
-            nativeBuildInputs = [ python ];
-          }
-          ''
-            cp ${src}/examples/python/logistic_regression.py .
-            ${python.interpreter} logistic_regression.py
-            rm logistic_regression.py
-
-            cp ${src}/examples/python/linear_regression.py .
-            ${python.interpreter} linear_regression.py
-            rm linear_regression.py
-
-            touch $out
-          '';
-    };
-
-    meta = {
-      homepage = "https://github.com/ml-explore/mlx";
-      description = "Array framework for Apple silicon";
-      changelog = "https://github.com/ml-explore/mlx/releases/tag/${src.tag}";
-      license = lib.licenses.mit;
-      platforms = [ "aarch64-darwin" ];
-      maintainers = with lib.maintainers; [
-        Gabriella439
-        booxter
-        cameronyule
-        viraptor
-      ];
-    };
-  };
 in
-mlx
+buildPythonPackage rec {
+  pname = "mlx";
+  version = "0.30.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ml-explore";
+    repo = "mlx";
+    tag = "v${version}";
+    hash = "sha256-Vt0RH+70VBwUjXSfPTsNdRS3g0ookJHhzf2kvgEtgH8=";
+  };
+
+  patches = [
+    (replaceVars ./darwin-build-fixes.patch {
+      sdkVersion = apple-sdk.version;
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "nanobind==2.10.2" "nanobind"
+
+    substituteInPlace mlx/backend/cpu/jit_compiler.cpp \
+      --replace-fail "g++" "${lib.getExe' stdenv.cc "c++"}"
+  '';
+
+  dontUseCmakeConfigure = true;
+
+  enableParallelBuilding = true;
+
+  # Allows multiple cores to be used in Python builds.
+  postUnpack = ''
+    export MAKEFLAGS+="''${enableParallelBuilding:+-j$NIX_BUILD_CORES}"
+  '';
+
+  # updates the wrong fetcher rev attribute
+  passthru.skipBulkUpdate = true;
+
+  env = {
+    DEV_RELEASE = 1;
+    CMAKE_ARGS = toString [
+      # NOTE The `metal` command-line utility used to build the Metal kernels is not open-source.
+      # To build mlx with Metal support in Nix, you'd need to use one of the sandbox escape
+      # hatches which let you interact with a native install of Xcode, such as `composeXcodeWrapper`
+      # or by changing the upstream (e.g., https://github.com/zed-industries/zed/discussions/7016).
+      (lib.cmakeBool "MLX_BUILD_METAL" false)
+      (lib.cmakeBool "USE_SYSTEM_FMT" true)
+      (lib.cmakeOptionType "filepath" "FETCHCONTENT_SOURCE_DIR_GGUFLIB" "${gguf-tools}")
+      (lib.cmakeOptionType "filepath" "FETCHCONTENT_SOURCE_DIR_JSON" "${nlohmann_json.src}")
+    ];
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    fmt
+    gguf-tools
+    nanobind
+    nlohmann_json
+    pybind11
+  ];
+
+  pythonImportsCheck = [ "mlx" ];
+
+  # Run the mlx Python test suite.
+  nativeCheckInputs = [
+    numpy
+    pytestCheckHook
+  ];
+
+  enabledTestPaths = [
+    "python/tests/"
+  ];
+
+  # Additional testing by executing the example Python scripts supplied with mlx
+  # using the version of the library we've built.
+  passthru.tests = {
+    mlxTest =
+      runCommand "run-mlx-examples"
+        {
+          buildInputs = [ mlx ];
+          nativeBuildInputs = [ python ];
+        }
+        ''
+          cp ${src}/examples/python/logistic_regression.py .
+          ${python.interpreter} logistic_regression.py
+          rm logistic_regression.py
+
+          cp ${src}/examples/python/linear_regression.py .
+          ${python.interpreter} linear_regression.py
+          rm linear_regression.py
+
+          touch $out
+        '';
+  };
+
+  meta = {
+    homepage = "https://github.com/ml-explore/mlx";
+    description = "Array framework for Apple silicon";
+    changelog = "https://github.com/ml-explore/mlx/releases/tag/${src.tag}";
+    license = lib.licenses.mit;
+    platforms = [ "aarch64-darwin" ];
+    maintainers = with lib.maintainers; [
+      Gabriella439
+      booxter
+      cameronyule
+      viraptor
+    ];
+  };
+}

--- a/pkgs/development/python-modules/mlx/default.nix
+++ b/pkgs/development/python-modules/mlx/default.nix
@@ -38,7 +38,7 @@ let
   };
 
 in
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "mlx";
   version = "0.30.1";
   pyproject = true;
@@ -46,7 +46,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "ml-explore";
     repo = "mlx";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-Vt0RH+70VBwUjXSfPTsNdRS3g0ookJHhzf2kvgEtgH8=";
   };
 
@@ -128,11 +128,11 @@ buildPythonPackage rec {
           nativeBuildInputs = [ python ];
         }
         ''
-          cp ${src}/examples/python/logistic_regression.py .
+          cp ${finalAttrs.src}/examples/python/logistic_regression.py .
           ${python.interpreter} logistic_regression.py
           rm logistic_regression.py
 
-          cp ${src}/examples/python/linear_regression.py .
+          cp ${finalAttrs.src}/examples/python/linear_regression.py .
           ${python.interpreter} linear_regression.py
           rm linear_regression.py
 
@@ -143,7 +143,7 @@ buildPythonPackage rec {
   meta = {
     homepage = "https://github.com/ml-explore/mlx";
     description = "Array framework for Apple silicon";
-    changelog = "https://github.com/ml-explore/mlx/releases/tag/${src.tag}";
+    changelog = "https://github.com/ml-explore/mlx/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     platforms = [ "aarch64-darwin" ];
     maintainers = with lib.maintainers; [
@@ -153,4 +153,4 @@ buildPythonPackage rec {
       viraptor
     ];
   };
-}
+})

--- a/pkgs/development/python-modules/mlx/default.nix
+++ b/pkgs/development/python-modules/mlx/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
   replaceVars,
@@ -56,7 +57,7 @@ let
         --replace-fail "nanobind==2.10.2" "nanobind"
 
       substituteInPlace mlx/backend/cpu/jit_compiler.cpp \
-        --replace-fail "g++" "$CXX"
+        --replace-fail "g++" "${lib.getExe' stdenv.cc "c++"}"
     '';
 
     dontUseCmakeConfigure = true;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- **python3Packages.mlx: inject absolute path to clang++ instead of $CXX**
- **python3Packages.mlx: simplify self reference in passthru**
- **python3Packages.mlx: switch to finalAttrs pattern**

Otherwise, it may fail at runtime with:

```
xcode-select: error: No developer tools were found and no install could be requested (possibly because there is no active GUI session).
If developer tools are located at a non-default location on disk, use `sudo xcode-select --switch path/to/Xcode.app` to specify the Xcode that you wish to use for command line developer tools.
Use `xcode-select --install` to install the standalone command line developer tools, or visit http://adc.apple.com to download Xcode or the standalone command line tools installation package.
See `man xcode-select` for more details.
```
if `clang++` is not globally available on the mac.

cc @Gabriella439 @booxter @cameronyule @viraptor

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
