### PR TITLE
obs-studio-plugins.obs-plugin-countdown: init at 2.1.1

### DIFF
--- a/pkgs/applications/video/obs-studio/plugins/default.nix
+++ b/pkgs/applications/video/obs-studio/plugins/default.nix
@@ -64,6 +64,8 @@
 
   obs-pipewire-audio-capture = callPackage ./obs-pipewire-audio-capture.nix { };
 
+  obs-plugin-countdown = qt6Packages.callPackage ./obs-plugin-countdown.nix { };
+
   obs-recursion-effect = callPackage ./obs-recursion-effect.nix { };
 
   obs-replay-source = qt6Packages.callPackage ./obs-replay-source.nix { };

--- a/pkgs/applications/video/obs-studio/plugins/obs-plugin-countdown.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-plugin-countdown.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  obs-studio,
+  cmake,
+  qt6,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "obs-plugin-countdown";
+  version = "2.1.1";
+
+  src = fetchFromGitHub {
+    owner = "ashmanix";
+    repo = "obs-plugin-countdown";
+    tag = finalAttrs.version;
+    hash = "sha256-rDs+X2eH8aUUH6phEo/pelUY1mHnnJNc6mqcT/lT+6c=";
+  };
+
+  buildInputs = [
+    obs-studio
+    qt6.qtbase
+  ];
+  dontWrapQtApps = true;
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  postInstall = ''
+    rm -rf "$out/obs-plugins" "$out/data"
+  '';
+
+  meta = {
+    description = "OBS plugin that creates countdown timers";
+    homepage = "https://github.com/ashmanix/obs-plugin-countdown";
+    changelog = "https://github.com/ashmanix/obs-plugin-countdown/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Add [obs-plugin-countdown](https://github.com/ashmanix/obs-plugin-countdown), an OBS plugin that creates countdown timers.

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
