### PR TITLE
wrapNeovim: symlink treesitter grammars in the wrapper

### DIFF
--- a/pkgs/applications/editors/neovim/utils.nix
+++ b/pkgs/applications/editors/neovim/utils.nix
@@ -343,7 +343,9 @@ let
 
           nativeBuildInputs = [ toNvimTreesitterGrammar ];
 
-          passthru = grammar.passthru or { };
+          passthru = grammar.passthru or { } // {
+            isTreesitterGrammar = true;
+          };
 
           meta = {
             platforms = lib.platforms.all;

--- a/pkgs/applications/editors/neovim/utils.nix
+++ b/pkgs/applications/editors/neovim/utils.nix
@@ -60,7 +60,7 @@ let
     };
 
   /**
-    * Builds a vim package (see ':h packages') with additionnal info:
+    * Builds a vim package (see ':h packages') with additional info:
     - the user lua configuration (specified by user)
     - the advised and advised by nixpkgs in passthru.initLua)
     - runtime dependencies (specified in plugins' "runtimeDeps")
@@ -110,7 +110,7 @@ let
       # viml config set by the user along with the plugin
       inherit userPluginViml;
 
-      # recommanded configuration set in vim plugins ".passthru.initLua"
+      # recommended configuration set in vim plugins ".passthru.initLua"
       inherit pluginAdvisedLua;
 
       # A Vim "package", see ':h packages'
@@ -135,8 +135,8 @@ let
     arguments (["-u" writeText "init.vim" GENERATEDRC)]).
     This makes it possible to write the config anywhere: on a per-project basis
     .nvimrc or in $XDG_CONFIG_HOME/nvim/init.vim to avoid sideeffects.
-    Indeed, note that wrapping with `-u init.vim` has sideeffects like .nvimrc wont be loaded
-    anymore, $MYVIMRC wont be set etc
+    Indeed, note that wrapping with `-u init.vim` has sideeffects like .nvimrc won't be loaded
+    anymore, $MYVIMRC won't be set etc
   */
   makeNeovimConfig =
     {

--- a/pkgs/applications/editors/neovim/wrapper.nix
+++ b/pkgs/applications/editors/neovim/wrapper.nix
@@ -338,8 +338,7 @@ let
           unwrapped = neovim-unwrapped;
           initRc = neovimRcContent';
 
-          tests = callPackage ./tests {
-          };
+          tests = callPackage ./tests { };
         };
 
         meta = {

--- a/pkgs/applications/editors/vim/plugins/nvim-treesitter/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/nvim-treesitter/overrides.nix
@@ -21,7 +21,10 @@ let
     vimUtils.toVimPlugin (
       runCommand "nvim-treesitter-queries-${language}"
         {
-          passthru = { inherit language; };
+          passthru = {
+            inherit language;
+            isTreesitterQuery = true;
+          };
           meta.description = "Queries for ${language} from nvim-treesitter";
         }
         ''
@@ -94,12 +97,7 @@ let
       ];
     in
     self.nvim-treesitter.overrideAttrs {
-      passthru.dependencies = [
-        (symlinkJoin {
-          name = "nvim-treesitter-grammars";
-          paths = grammarPlugins ++ queryPlugins;
-        })
-      ];
+      passthru.dependencies = grammarPlugins ++ queryPlugins;
     };
 
   withAllGrammars = withPlugins (_: allGrammars);


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Tested using:

```nix
# test.nix
# to run:
# - nix-build test.nix -A unstable && ./result/bin/neovim test.nix
# - nix-build test.nix -A stable && ./result/bin/neovim test.nix
# and then do `:lua vim.treesitter.start()`
{ pkgs ? import ./. { } }:
{
  unstable = pkgs.wrapNeovimUnstable pkgs.neovim-unwrapped {
    autoconfigure = true;
    autowrapRuntimeDeps = true;
    plugins = with pkgs.vimPlugins; [
      (nvim-treesitter.withPlugins (p: [
        p.nix
        p.python
      ]))
    ];
  };

  stable = pkgs.neovim.override {
    configure = {
      packages.myVimPackage = with pkgs.vimPlugins; {
        start = [
          (nvim-treesitter.withPlugins (p: [
            p.nix
            p.python
          ]))
        ];
        opt = [ ];
      };
    };
  };
}
```

Surprisingly, derivations from that file didn't change after this PR. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
