### PR TITLE
pkgsMusl.patchutils: fix build

### DIFF
--- a/pkgs/tools/text/patchutils/0.3.3.nix
+++ b/pkgs/tools/text/patchutils/0.3.3.nix
@@ -5,6 +5,10 @@ callPackage ./generic.nix (
   // {
     version = "0.3.3";
     sha256 = "0g5df00cj4nczrmr4k791l7la0sq2wnf8rn981fsrz1f3d2yix4i";
-    patches = [ ./drop-comments.patch ]; # we would get into a cycle when using fetchpatch on this one
+    patches = [
+      # we would get into a cycle when using fetchpatch on this one
+      ./drop-comments.patch
+      ./getenv-signature.patch
+    ];
   }
 )

--- a/pkgs/tools/text/patchutils/0.4.2.nix
+++ b/pkgs/tools/text/patchutils/0.4.2.nix
@@ -7,6 +7,9 @@ callPackage ./generic.nix (
     sha256 = "sha256-iHWwll/jPeYriQ9s15O+f6/kGk5VLtv2QfH+1eu/Re0=";
     # for gitdiff
     extraBuildInputs = [ python3 ];
-    patches = [ ./Make-grepdiff1-test-case-pcre-aware.patch ];
+    patches = [
+      ./Make-grepdiff1-test-case-pcre-aware.patch
+      ./getenv-signature.patch
+    ];
   }
 )

--- a/pkgs/tools/text/patchutils/default.nix
+++ b/pkgs/tools/text/patchutils/default.nix
@@ -5,5 +5,8 @@ callPackage ./generic.nix (
   // {
     version = "0.3.4";
     sha256 = "0xp8mcfyi5nmb5a2zi5ibmyshxkb1zv1dgmnyn413m7ahgdx8mfg";
+    patches = [
+      ./getenv-signature.patch
+    ];
   }
 )

--- a/pkgs/tools/text/patchutils/getenv-signature.patch
+++ b/pkgs/tools/text/patchutils/getenv-signature.patch
@@ -1,0 +1,46 @@
+From 64e5c63ef72ab97ecae6d43845634aa34da0b426 Mon Sep 17 00:00:00 2001
+From: Yureka <yuka@yuka.dev>
+Date: Sun, 11 Jan 2026 16:49:07 +0100
+Subject: [PATCH] getopt.{c,h}: Do not use unspecified signatures
+
+Unspecified signatures no longer work with C23, and the GNU getopt signature matches the one specified by POSIX
+---
+ src/getopt.c | 2 +-
+ src/getopt.h | 7 -------
+ 2 files changed, 1 insertion(+), 8 deletions(-)
+
+diff --git a/src/getopt.c b/src/getopt.c
+index 9bafa45..c268441 100644
+--- a/src/getopt.c
++++ b/src/getopt.c
+@@ -209,7 +209,7 @@ static char *posixly_correct;
+    whose names are inconsistent.  */
+ 
+ #ifndef getenv
+-extern char *getenv ();
++extern char *getenv (const char *);
+ #endif
+ 
+ static char *
+diff --git a/src/getopt.h b/src/getopt.h
+index a1b8dd6..0aea224 100644
+--- a/src/getopt.h
++++ b/src/getopt.h
+@@ -138,14 +138,7 @@ struct option
+    `getopt'.  */
+ 
+ #if (defined __STDC__ && __STDC__) || defined __cplusplus
+-# ifdef __GNU_LIBRARY__
+-/* Many other libraries have conflicting prototypes for getopt, with
+-   differences in the consts, in stdlib.h.  To avoid compilation
+-   errors, only prototype getopt for the GNU C library.  */
+ extern int getopt (int __argc, char *const *__argv, const char *__shortopts);
+-# else /* not __GNU_LIBRARY__ */
+-extern int getopt ();
+-# endif /* __GNU_LIBRARY__ */
+ 
+ # ifndef __need_getopt
+ extern int getopt_long (int __argc, char *const *__argv, const char *__shortopts,
+-- 
+2.52.0
+


### PR DESCRIPTION
Upstream has addressed this in release 0.4.3 and later with commit dc88e96 "Integrate gnulib properly".

Since these versions of patchutils need to stay around for fetchpatch / fetchpatch2 Fixed-Output Derivations, we'll need to carry these patches.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
