### PR TITLE
python3Packages.dt8852: init at 1.1.0

### DIFF
--- a/pkgs/development/python-modules/dt8852/default.nix
+++ b/pkgs/development/python-modules/dt8852/default.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  fetchPypi,
+  buildPythonPackage,
+  setuptools,
+  pyserial,
+}:
+
+buildPythonPackage rec {
+  pname = "dt8852";
+  version = "1.1.0";
+  pyproject = true;
+
+  # Not using Codeberg because there's no tagged release there.
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-3WiHJQnlP39CGzxu/sZ1jWcP40tyr2G62H4yYuwS0wA=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    pyserial
+  ];
+
+  # No tests available on PyPi and Codeberg source.
+  doCheck = false;
+
+  pythonImportsCheck = [ "dt8852" ];
+
+  meta = {
+    description = "Dt8852 is a cross-platform Python package and module for reading and controlling CEM DT-8852 and equivalent Sound Level Meter and Data Logger devices";
+    homepage = "https://codeberg.org/randysimons/dt8852";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ drupol ];
+    mainProgram = "dt8852";
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4642,6 +4642,8 @@ self: super: with self; {
 
   dsnap = callPackage ../development/python-modules/dsnap { };
 
+  dt8852 = callPackage ../development/python-modules/dt8852 { };
+
   dtfabric = callPackage ../development/python-modules/dtfabric { };
 
   dtlssocket = callPackage ../development/python-modules/dtlssocket { };


### PR DESCRIPTION
Working super fine!

<img width="1452" height="1091" alt="image" src="https://github.com/user-attachments/assets/d668abd9-1a53-4f26-8a08-0fc35c348367" />

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
