### PR TITLE
to-html: add runtime dependencies

### DIFF
--- a/pkgs/by-name/to/to-html/package.nix
+++ b/pkgs/by-name/to/to-html/package.nix
@@ -2,17 +2,20 @@
   lib,
   fetchFromGitHub,
   installShellFiles,
+  makeWrapper,
   rustPlatform,
+  unixtools,
+  which,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.1.6";
   pname = "to-html";
 
   src = fetchFromGitHub {
     owner = "Aloso";
     repo = "to-html";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-eNFt9/yK4oHOspNM8PMTewhx8APaHzmgNdrWqrUuQSU=";
   };
 
@@ -21,21 +24,32 @@ rustPlatform.buildRustPackage rec {
   # Requires external resources
   doCheck = false;
 
-  nativeBuildInputs = [ installShellFiles ];
+  nativeBuildInputs = [
+    installShellFiles
+    makeWrapper
+  ];
 
   postInstall = ''
     installShellCompletion \
       $releaseDir/build/to-html-*/out/to-html.{bash,fish} \
       --zsh $releaseDir/build/to-html-*/out/_to-html
+
+    wrapProgram $out/bin/to-html \
+      --suffix PATH : ${
+        lib.makeBinPath [
+          unixtools.script
+          which
+        ]
+      }
   '';
 
   meta = {
     description = "Terminal wrapper for rendering a terminal on a website by converting ANSI escape sequences to HTML";
     mainProgram = "to-html";
     homepage = "https://github.com/Aloso/to-html";
-    changelog = "https://github.com/Aloso/to-html/blob/${src.rev}/CHANGELOG.md";
+    changelog = "https://github.com/Aloso/to-html/blob/${finalAttrs.src.rev}/CHANGELOG.md";
     license = lib.licenses.mit;
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [ icewind1991 ];
   };
-}
+})


### PR DESCRIPTION
Use `wrapProgram` to add `script` and `which` to `PATH`

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
