### PR TITLE
rye-lang: init at 0.0.96

### DIFF
--- a/pkgs/by-name/ry/rye-lang/package.nix
+++ b/pkgs/by-name/ry/rye-lang/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  bash,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "rye-lang";
+  version = "0.0.96";
+
+  src = fetchFromGitHub {
+    owner = "refaktor";
+    repo = "rye";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Ef9tGx3u8lhy2k0VVBKGmmKPBBoW1mCi1lecj0Jyak8=";
+  };
+
+  vendorHash = "sha256-cmZ+3hQUHDkpex8H7pSdyFtMHyhwyur69CBS3CV/5rU=";
+
+  buildInputs = [
+    bash
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+    go build -o $GOPATH/bin/rye
+    runHook postBuild
+  '';
+
+  checkPhase = ''
+    runHook preCheck
+    cd tests/
+    patchShebangs *
+    $GOPATH/bin/rye . test
+    runHook postCheck
+  '';
+
+  meta = {
+    description = "High-level, dynamic programming language inspired by Rebol, Factor, Linux shells, and Go.";
+    homepage = "https://github.com/refaktor/rye";
+    license = lib.licenses.bsd3;
+    mainProgram = "rye";
+    maintainers = [ ];
+  };
+})


### PR DESCRIPTION
Introduce the [Rye programming language](https://ryelang.org/) to nixpkgs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
