### PR TITLE
linuxPackages.ddcci-driver: 0.4.5-unstable-{2024-09-26 -> 2025-09-27}

### DIFF
--- a/pkgs/os-specific/linux/ddcci/default.nix
+++ b/pkgs/os-specific/linux/ddcci/default.nix
@@ -4,28 +4,19 @@
   fetchFromGitLab,
   kernel,
   kernelModuleMakeFlags,
-  fetchpatch,
 }:
 
 stdenv.mkDerivation rec {
   pname = "ddcci-driver";
-  version = "0.4.5-unstable-2024-09-26";
+  version = "0.4.5-unstable-2025-09-27";
   name = "${pname}-${kernel.version}-${version}";
 
   src = fetchFromGitLab {
     owner = "${pname}-linux";
     repo = "${pname}-linux";
-    rev = "0233e1ee5eddb4b8a706464f3097bad5620b65f4";
-    hash = "sha256-Osvojt8UE+cenOuMoSY+T+sODTAAKkvY/XmBa5bQX88=";
+    rev = "bbb7553373f815d78e93a4a9f071ce968563694a";
+    hash = "sha256-fQjsDjbtFKhs0bUCFfKRgCg516TXdwIkhKEbIISjgs0=";
   };
-
-  patches = [
-    # See https://gitlab.com/ddcci-driver-linux/ddcci-driver-linux/-/merge_requests/17
-    (fetchpatch {
-      url = "https://gitlab.com/ddcci-driver-linux/ddcci-driver-linux/-/commit/e0605c9cdff7bf3fe9587434614473ba8b7e5f63.patch";
-      hash = "sha256-sTq03HtWQBd7Wy4o1XbdmMjXQE2dG+1jajx4HtwBHjM=";
-    })
-  ];
 
   hardeningDisable = [ "pic" ];
 


### PR DESCRIPTION
removed the patch since it was merged (see https://gitlab.com/ddcci-driver-linux/ddcci-driver-linux/-/merge_requests/17)

I changed the commit message to this because `0.4.5-unstable-2024-09-26 -> 0.4.5-unstable-2025-09-27` was too long to fit in one line, let me know if I should still change it back to that

I successfully built every package available at https://search.nixos.org/packages?channel=unstable&query=ddcci-driver on both `x86_64-linux` and `aarch64-linux` with the following exceptions:
- all `-zen`, `-xanmod` and `-lqx` packages on `aarch64-linux` since they're marked as broken
- all `-xanmod` packages on `x86_64-linux` since they started building from source (I haven't found any build failure issue - I'll investigate later and open one if it does fail to build) 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
