### PR TITLE
soundthread: init at 0.4.0-beta

### DIFF
--- a/pkgs/by-name/so/soundthread/package.nix
+++ b/pkgs/by-name/so/soundthread/package.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  godot,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "soundthread";
+  version = "0.4.0-beta";
+
+  src = fetchFromGitHub {
+    owner = "j-p-higgins";
+    repo = "SoundThread";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-JOmi+qJpoE+lZFlaedvQFHaMvlbSQWRQAVFQO/Bi+Ys=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    godot
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    export HOME=$(mktemp -d)
+    mkdir -p $HOME/.local/share/godot/
+    ln -s "${godot.export-template}"/share/godot/export_templates "$HOME"/.local/share/godot/
+    mkdir -p build
+    godot4 --headless --export-release "Linux" ./build/soundthread
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D -m 755 -t $out/libexec ./build/soundthread
+    install -D -m 644 -T ./theme/images/icon.png $out/share/icons/hicolor/256x256/apps/soundthread.png
+    install -d -m 755 $out/bin
+    ln -s $out/libexec/soundthread $out/bin/soundthread
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    homepage = "https://github.com/j-p-higgins/SoundThread";
+    description = "Node based GUI for The Composers Desktop Project";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ jpotier ];
+    mainProgram = "soundthread";
+  };
+})


### PR DESCRIPTION
SoundThread is a GODOT Node based GUI for The Composers Desktop Project.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
