### PR TITLE
cagent: init at 1.19.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17024,6 +17024,13 @@
     githubId = 68288772;
     name = "Markus Heinrich";
   };
+  MH0386 = {
+    name = "Mohamed Hisham Abdelzaher";
+    email = "mohamed.hisham.abdelzaher@gmail.com";
+    github = "MH0386";
+    githubId = 77013511;
+    matrix = "@mh0386:matrix.org";
+  };
   mh182 = {
     email = "mh182@chello.at";
     github = "mh182";

--- a/pkgs/by-name/ca/cagent/package.nix
+++ b/pkgs/by-name/ca/cagent/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  stdenv,
+  buildGoModule,
+  fetchFromGitHub,
+  versionCheckHook,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "cagent";
+  version = "1.19.0";
+
+  src = fetchFromGitHub {
+    owner = "docker";
+    repo = "cagent";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-J7IRlSsjXRDvbUKwnV2rrWnEmvqciJw3mN8NerQBtl4=";
+  };
+
+  vendorHash = "sha256-q7mP9JWJEdDbUO/3MHsJwiySNvN2SbhnhEbJArnCW3M=";
+
+  # Disable tests: Networked model providers and writable cache directories are required.
+  doCheck = false;
+
+  # Skip install checks on macOS: The build sandbox is missing the `/etc/protocols` file, which is required for validation.
+  doInstallCheck = !stdenv.hostPlatform.isDarwin;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "version";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X"
+    "github.com/docker/cagent/pkg/version.Version=${finalAttrs.version}"
+    "-X"
+    "github.com/docker/cagent/pkg/version.Commit=${finalAttrs.src.tag}"
+  ];
+
+  meta = {
+    description = "Agent Builder and Runtime by Docker Engineering";
+    longDescription = ''
+      A powerful, easy-to-use, customizable multi-agent runtime that
+      orchestrates AI agents with specialized capabilities and tools,
+      and the interactions between agents.
+    '';
+    homepage = "https://github.com/docker/cagent";
+    changelog = "https://github.com/docker/cagent/releases/tag/v${finalAttrs.version}";
+    downloadPage = "https://github.com/docker/cagent/releases";
+    license = lib.licenses.asl20;
+    mainProgram = "cagent";
+    maintainers = with lib.maintainers; [ MH0386 ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
