### PR TITLE
git-wt: init at 0.13.0

### DIFF
--- a/pkgs/by-name/gi/git-wt/package.nix
+++ b/pkgs/by-name/gi/git-wt/package.nix
@@ -5,14 +5,14 @@
   git,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "git-wt";
   version = "0.12.1";
 
   src = fetchFromGitHub {
     owner = "k1LoW";
     repo = "git-wt";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-poAKWBKvTOCIuBrDMm9S1TaYqsK5HweybTNO+p0FBfk=";
   };
 
@@ -23,15 +23,15 @@ buildGoModule rec {
   ldflags = [
     "-s"
     "-w"
-    "-X github.com/k1LoW/git-wt/version.Version=v${version}"
+    "-X github.com/k1LoW/git-wt/version.Version=v${finalAttrs.version}"
   ];
 
   meta = {
     description = "Git subcommand that makes git worktree simple";
     homepage = "https://github.com/k1LoW/git-wt";
-    changelog = "https://github.com/k1LoW/git-wt/releases/tag/v${version}";
+    changelog = "https://github.com/k1LoW/git-wt/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ ryoppippi ];
     mainProgram = "git-wt";
   };
-}
+})

--- a/pkgs/by-name/gi/git-wt/package.nix
+++ b/pkgs/by-name/gi/git-wt/package.nix
@@ -7,13 +7,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "git-wt";
-  version = "0.12.1";
+  version = "0.13.0";
 
   src = fetchFromGitHub {
     owner = "k1LoW";
     repo = "git-wt";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-poAKWBKvTOCIuBrDMm9S1TaYqsK5HweybTNO+p0FBfk=";
+    hash = "sha256-513y6uB32ln1k3N4f8L2ph6sf2/1tLfLSO+4kEc4nB8=";
   };
 
   vendorHash = "sha256-K5geAvG+mvnKeixOyZt0C1T5ojSBFmx2K/Msol0HsSg=";

--- a/pkgs/by-name/gi/git-wt/package.nix
+++ b/pkgs/by-name/gi/git-wt/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildGoModule,
+  git,
+}:
+
+buildGoModule rec {
+  pname = "git-wt";
+  version = "0.12.1";
+
+  src = fetchFromGitHub {
+    owner = "k1LoW";
+    repo = "git-wt";
+    rev = "v${version}";
+    hash = "sha256-poAKWBKvTOCIuBrDMm9S1TaYqsK5HweybTNO+p0FBfk=";
+  };
+
+  vendorHash = "sha256-K5geAvG+mvnKeixOyZt0C1T5ojSBFmx2K/Msol0HsSg=";
+
+  nativeCheckInputs = [ git ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/k1LoW/git-wt/version.Version=v${version}"
+  ];
+
+  meta = {
+    description = "Git subcommand that makes git worktree simple";
+    homepage = "https://github.com/k1LoW/git-wt";
+    changelog = "https://github.com/k1LoW/git-wt/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ryoppippi ];
+    mainProgram = "git-wt";
+  };
+}


### PR DESCRIPTION
A Git subcommand that makes `git worktree` simple.

https://github.com/k1LoW/git-wt

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc