### PR TITLE
qt5.qtwebengine: Pin to GCC 14

### DIFF
--- a/pkgs/development/libraries/qt-5/5.15/default.nix
+++ b/pkgs/development/libraries/qt-5/5.15/default.nix
@@ -10,6 +10,7 @@
   generateSplicesForMkScope,
   lib,
   stdenv,
+  gcc14Stdenv,
   fetchurl,
   fetchgit,
   fetchpatch,
@@ -246,12 +247,15 @@ let
   addPackages =
     self:
     let
-      qtModule = callPackage ../qtModule.nix {
-        inherit patches;
-        # Use a variant of mkDerivation that does not include wrapQtApplications
-        # to avoid cyclic dependencies between Qt modules.
-        mkDerivation = (callPackage ../mkDerivation.nix { wrapQtAppsHook = null; }) stdenv.mkDerivation;
-      };
+      qtModuleWithStdenv =
+        stdenv:
+        callPackage ../qtModule.nix {
+          inherit patches;
+          # Use a variant of mkDerivation that does not include wrapQtApplications
+          # to avoid cyclic dependencies between Qt modules.
+          mkDerivation = (callPackage ../mkDerivation.nix { wrapQtAppsHook = null; }) stdenv.mkDerivation;
+        };
+      qtModule = qtModuleWithStdenv stdenv;
 
       callPackage = self.newScope {
         inherit
@@ -326,14 +330,22 @@ let
       qtvirtualkeyboard = callPackage ../modules/qtvirtualkeyboard.nix { };
       qtwayland = callPackage ../modules/qtwayland.nix { };
       qtwebchannel = callPackage ../modules/qtwebchannel.nix { };
-      qtwebengine = callPackage ../modules/qtwebengine.nix {
-        # Won’t build with Clang 20, as `-Wenum-constexpr-conversion`
-        # was made a hard error.
-        stdenv = if stdenv.cc.isClang then llvmPackages_19.stdenv else stdenv;
-        inherit (srcs.qtwebengine) version;
-        inherit (darwin) bootstrap_cmds;
-        python = python3;
-      };
+      qtwebengine =
+        # Actually propagating stdenv change
+        let
+          # Won’t build with Clang 20, as `-Wenum-constexpr-conversion`
+          # was made a hard error.
+          # qt5webengine no longer maintained, FTBFS with GCC 15
+          stdenv' = if stdenv.cc.isClang then llvmPackages_19.stdenv else gcc14Stdenv;
+          qtModule' = qtModuleWithStdenv stdenv';
+        in
+        callPackage ../modules/qtwebengine.nix {
+          inherit (srcs.qtwebengine) version;
+          inherit (darwin) bootstrap_cmds;
+          stdenv = stdenv';
+          qtModule = qtModule';
+          python = python3;
+        };
       qtwebglplugin = callPackage ../modules/qtwebglplugin.nix { };
       qtwebkit = callPackage ../modules/qtwebkit.nix { };
       qtwebsockets = callPackage ../modules/qtwebsockets.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8032,6 +8032,7 @@ with pkgs;
         generateSplicesForMkScope
         lib
         stdenv
+        gcc14Stdenv
         fetchurl
         fetchpatch
         fetchgit


### PR DESCRIPTION
No longer receiving fixes, and known-insecure.

---

Closes #475938

I noticed that changes to `stdenv` weren't actually reaching into the build cus of the whole `qtModule` thing, so I'm not sure if the existing `llvmPackages_19.stdenv` change actually ever did anything… Should do something now, I guess?

AFAIU, there is a desire to not keep `qt5` around for *too* much longer, so this temporary-permanent pin should hopefully not be an issue…

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
