### PR TITLE
treewide: fix `rec-set-dynamic-attrs`

### DIFF
--- a/pkgs/applications/editors/sublime/4/common.nix
+++ b/pkgs/applications/editors/sublime/4/common.nix
@@ -142,15 +142,13 @@ stdenv.mkDerivation rec {
 
   dontUnpack = true;
 
-  ${primaryBinary} = binaryPackage;
-
   nativeBuildInputs = [
     makeWrapper
   ];
 
   installPhase = ''
     mkdir -p "$out/bin"
-    makeWrapper "''$${primaryBinary}/${primaryBinary}" "$out/bin/${primaryBinary}"
+    makeWrapper "${binaryPackage}/${primaryBinary}" "$out/bin/${primaryBinary}"
   ''
   + builtins.concatStringsSep "" (
     map (binaryAlias: "ln -s $out/bin/${primaryBinary} $out/bin/${binaryAlias}\n") primaryBinaryAliases
@@ -159,18 +157,20 @@ stdenv.mkDerivation rec {
     mkdir -p "$out/share/applications"
 
     substitute \
-      "''$${primaryBinary}/${primaryBinary}.desktop" \
+      "${binaryPackage}/${primaryBinary}.desktop" \
       "$out/share/applications/${primaryBinary}.desktop" \
       --replace-fail "/opt/${primaryBinary}/${primaryBinary}" "${primaryBinary}"
 
-    for directory in ''$${primaryBinary}/Icon/*; do
+    for directory in ${binaryPackage}/Icon/*; do
       size=$(basename $directory)
       mkdir -p "$out/share/icons/hicolor/$size/apps"
-      ln -s ''$${primaryBinary}/Icon/$size/* $out/share/icons/hicolor/$size/apps
+      ln -s ${binaryPackage}/Icon/$size/* $out/share/icons/hicolor/$size/apps
     done
   '';
 
   passthru = {
+    unwrapped = binaryPackage;
+
     updateScript =
       let
         script = writeShellScript "${packageAttribute}-update-script" ''
@@ -191,7 +191,7 @@ stdenv.mkDerivation rec {
           fi
 
           for platform in ${lib.escapeShellArgs meta.platforms}; do
-              update-source-version "${packageAttribute}.${primaryBinary}" "$latestVersion" --ignore-same-version --file="$versionFile" --version-key=buildVersion --source-key="sources.$platform"
+              update-source-version "${packageAttribute}".unwrapped "$latestVersion" --ignore-same-version --file="$versionFile" --version-key=buildVersion --source-key="sources.$platform"
           done
         '';
       in

--- a/pkgs/applications/version-management/sublime-merge/common.nix
+++ b/pkgs/applications/version-management/sublime-merge/common.nix
@@ -144,8 +144,6 @@ stdenv.mkDerivation rec {
 
   dontUnpack = true;
 
-  ${primaryBinary} = binaryPackage;
-
   nativeBuildInputs = [
     makeWrapper
   ];
@@ -153,7 +151,7 @@ stdenv.mkDerivation rec {
   installPhase = ''
     runHook preInstall
     mkdir -p "$out/bin"
-    makeWrapper "''$${primaryBinary}/${primaryBinary}" "$out/bin/${primaryBinary}"
+    makeWrapper "${binaryPackage}/${primaryBinary}" "$out/bin/${primaryBinary}"
   ''
   + builtins.concatStringsSep "" (
     map (binaryAlias: "ln -s $out/bin/${primaryBinary} $out/bin/${binaryAlias}\n") primaryBinaryAliases
@@ -162,19 +160,21 @@ stdenv.mkDerivation rec {
     mkdir -p "$out/share/applications"
 
     substitute \
-      "''$${primaryBinary}/${primaryBinary}.desktop" \
+      "${binaryPackage}/${primaryBinary}.desktop" \
       "$out/share/applications/${primaryBinary}.desktop" \
       --replace-fail "/opt/${primaryBinary}/${primaryBinary}" "${primaryBinary}"
 
-    for directory in ''$${primaryBinary}/Icon/*; do
+    for directory in ${binaryPackage}/Icon/*; do
       size=$(basename $directory)
       mkdir -p "$out/share/icons/hicolor/$size/apps"
-      ln -s ''$${primaryBinary}/Icon/$size/* $out/share/icons/hicolor/$size/apps
+      ln -s ${binaryPackage}/Icon/$size/* $out/share/icons/hicolor/$size/apps
     done
     runHook postInstall
   '';
 
   passthru = {
+    unwrapped = binaryPackage;
+
     updateScript =
       let
         script = writeShellScript "${packageAttribute}-update-script" ''
@@ -196,7 +196,7 @@ stdenv.mkDerivation rec {
           fi
 
           for platform in ${lib.escapeShellArgs meta.platforms}; do
-              update-source-version "${packageAttribute}.${primaryBinary}" "$latestVersion" --ignore-same-version --file="$versionFile" --version-key=buildVersion --source-key="sources.$platform"
+              update-source-version "${packageAttribute}".unwrapped "$latestVersion" --ignore-same-version --file="$versionFile" --version-key=buildVersion --source-key="sources.$platform"
           done
         '';
       in

--- a/pkgs/by-name/fs/fstar/z3/default.nix
+++ b/pkgs/by-name/fs/fstar/z3/default.nix
@@ -98,11 +98,9 @@ stdenvNoCC.mkDerivation {
     ln -s ${lib.getExe fstarOldZ3} $out/bin/z3-${lib.escapeShellArg fstarOldZ3.version}
   '';
 
-  passthru = rec {
-    new = fstarNewZ3;
-    "z3_${lib.replaceStrings [ "." ] [ "_" ] fstarNewZ3.version}" = new;
+  passthru = {
+    "z3_${lib.replaceStrings [ "." ] [ "_" ] fstarNewZ3.version}" = fstarNewZ3;
 
-    old = fstarOldZ3;
-    "z3_${lib.replaceStrings [ "." ] [ "_" ] fstarOldZ3.version}" = old;
+    "z3_${lib.replaceStrings [ "." ] [ "_" ] fstarOldZ3.version}" = fstarOldZ3;
   };
 }

--- a/pkgs/development/ada-modules/gnatcoll/db.nix
+++ b/pkgs/development/ada-modules/gnatcoll/db.nix
@@ -49,19 +49,19 @@ let
   ];
 in
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
+  version = "25.0.0";
   # executables don't adhere to the string gnatcoll-* scheme
   pname =
     if onlyExecutable then
       builtins.replaceStrings [ "_" ] [ "-" ] component
     else
       "gnatcoll-${component}";
-  version = "25.0.0";
 
   src = fetchFromGitHub {
     owner = "AdaCore";
     repo = "gnatcoll-db";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     sha256 = "0q35ii0aa4hh59v768l5cilg1b30a4ckcvlbfy0lkcbp3rcfnbz3";
   };
 
@@ -108,4 +108,4 @@ stdenv.mkDerivation rec {
     maintainers = [ lib.maintainers.sternenseemann ];
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/development/compilers/dotnet/packages.nix
+++ b/pkgs/development/compilers/dotnet/packages.nix
@@ -32,6 +32,9 @@ let
       )
     );
   inherit (vmr) targetRid releaseManifest;
+  sdkVersion = releaseManifest.sdkVersion;
+  runtimeVersion = releaseManifest.runtimeVersion;
+  aspnetcoreVersion = releaseManifest.aspNetCoreVersion or releaseManifest.runtimeVersion;
 
   # TODO: do this properly
   hostRid = targetRid;
@@ -114,9 +117,9 @@ let
     ];
   };
 
-  sdk = mkCommon "sdk" rec {
+  sdk = mkCommon "sdk" {
     pname = "${baseName}-sdk";
-    version = releaseManifest.sdkVersion;
+    version = sdkVersion;
 
     src = vmr;
     dontUnpack = true;
@@ -136,7 +139,7 @@ let
       runHook preInstall
 
       mkdir -p "$out"/share
-      cp -r "$src"/lib/dotnet-sdk-${version}-${targetRid} "$out"/share/dotnet
+      cp -r "$src"/lib/dotnet-sdk-${sdkVersion}-${targetRid} "$out"/share/dotnet
       chmod +w "$out"/share/dotnet
       mkdir "$out"/bin
       ln -s "$out"/share/dotnet/dotnet "$out"/bin/dotnet
@@ -159,7 +162,10 @@ let
     '';
 
     ${
-      if stdenvNoCC.hostPlatform.isDarwin && lib.versionAtLeast version "10" then "postInstall" else null
+      if stdenvNoCC.hostPlatform.isDarwin && lib.versionAtLeast sdkVersion "10" then
+        "postInstall"
+      else
+        null
     } =
       ''
         mkdir -p "$out"/nix-support
@@ -182,9 +188,9 @@ let
     };
   };
 
-  runtime = mkCommon "runtime" rec {
+  runtime = mkCommon "runtime" {
     pname = "${baseName}-runtime";
-    version = releaseManifest.runtimeVersion;
+    version = runtimeVersion;
 
     src = vmr;
     dontUnpack = true;
@@ -193,7 +199,7 @@ let
       runHook preInstall
 
       mkdir -p "$out"/share
-      cp -r "$src/lib/dotnet-runtime-${version}-${targetRid}" "$out"/share/dotnet
+      cp -r "$src/lib/dotnet-runtime-${runtimeVersion}-${targetRid}" "$out"/share/dotnet
       chmod +w "$out"/share/dotnet
       mkdir "$out"/bin
       ln -s "$out"/share/dotnet/dotnet "$out"/bin/dotnet
@@ -210,9 +216,9 @@ let
     };
   };
 
-  aspnetcore = mkCommon "aspnetcore" rec {
+  aspnetcore = mkCommon "aspnetcore" {
     pname = "${baseName}-aspnetcore-runtime";
-    version = releaseManifest.aspNetCoreVersion or releaseManifest.runtimeVersion;
+    version = aspnetcoreVersion;
 
     src = vmr;
     dontUnpack = true;
@@ -226,7 +232,7 @@ let
       mkdir "$out"/bin
       ln -s "$out"/share/dotnet/dotnet "$out"/bin/dotnet
 
-      cp -Tr "$src/lib/aspnetcore-runtime-${version}-${targetRid}"/shared/Microsoft.AspNetCore.App "$out"/share/dotnet/shared/Microsoft.AspNetCore.App
+      cp -Tr "$src/lib/aspnetcore-runtime-${aspnetcoreVersion}-${targetRid}"/shared/Microsoft.AspNetCore.App "$out"/share/dotnet/shared/Microsoft.AspNetCore.App
       chmod +w "$out"/share/dotnet/shared
 
       runHook postInstall

--- a/pkgs/development/compilers/dotnet/vmr.nix
+++ b/pkgs/development/compilers/dotnet/vmr.nix
@@ -59,10 +59,11 @@ let
 
   _icu = if isDarwin then darwin.ICU else icu;
 
-in
-stdenv.mkDerivation rec {
-  pname = "${baseName}-vmr";
   version = release;
+in
+stdenv.mkDerivation {
+  pname = "${baseName}-vmr";
+  inherit version;
 
   # TODO: fix this in the binary sdk packages
   preHook = lib.optionalString stdenv.hostPlatform.isDarwin ''


### PR DESCRIPTION
Lix will soon warn, and in the future, error on `rec-set-dynamic-attrs`. This commit fix where attrs are dynamically set in a recursive function currently present in nixpkgs.


@piegamesde 

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
