### PR TITLE
man-db: adopt, use new GitLab repo, cleanup

### DIFF
--- a/pkgs/by-name/ma/man-db/package.nix
+++ b/pkgs/by-name/ma/man-db/package.nix
@@ -1,13 +1,19 @@
 {
   buildPackages,
   gdbm,
-  fetchurl,
+  fetchFromGitLab,
+  autoconf,
+  automake,
+  flex,
+  gettext,
+  gnulib,
   groff,
   gzip,
   lib,
   libiconv,
   libiconvReal,
   libpipeline,
+  libtool,
   makeWrapper,
   nixosTests,
   pkg-config,
@@ -24,9 +30,11 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "man-db";
   version = "2.13.1";
 
-  src = fetchurl {
-    url = "mirror://savannah/man-db/man-db-${finalAttrs.version}.tar.xz";
-    hash = "sha256-iv67b362u4VCkpRYhB9cfm8kDjDIY1jB+8776gdsh9k=";
+  src = fetchFromGitLab {
+    owner = "man-db";
+    repo = "man-db";
+    tag = finalAttrs.version;
+    hash = "sha256-o85IJCsP5NA4AUhr6SNLOSnAoIEWoEejVG8w08jfyqQ=";
   };
 
   outputs = [
@@ -37,7 +45,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   strictDeps = true;
   nativeBuildInputs = [
+    autoconf
+    automake
+    flex
+    gettext
     groff
+    libtool
     makeWrapper
     pkg-config
     zstd
@@ -88,6 +101,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   preConfigure = ''
+    ./bootstrap --no-git --gnulib-srcdir=${gnulib} --gen
     configureFlagsArray+=("--with-sections=1 n l 8 3 0 2 5 4 9 6 7")
   '';
 

--- a/pkgs/by-name/ma/man-db/package.nix
+++ b/pkgs/by-name/ma/man-db/package.nix
@@ -15,6 +15,7 @@
   libpipeline,
   libtool,
   makeWrapper,
+  nix-update-script,
   nixosTests,
   pkg-config,
   stdenv,
@@ -131,8 +132,11 @@ stdenv.mkDerivation (finalAttrs: {
     !stdenv.hostPlatform.isMusl # iconv binary
   ;
 
-  passthru.tests = {
-    nixos = nixosTests.man;
+  passthru = {
+    tests = {
+      nixos = nixosTests.man;
+    };
+    updateScript = nix-update-script { };
   };
 
   meta = {

--- a/pkgs/by-name/ma/man-db/package.nix
+++ b/pkgs/by-name/ma/man-db/package.nix
@@ -127,5 +127,6 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.unix;
     mainProgram = "man";
+    maintainers = with lib.maintainers; [ mdaniels5757 ];
   };
 }

--- a/pkgs/by-name/ma/man-db/package.nix
+++ b/pkgs/by-name/ma/man-db/package.nix
@@ -20,12 +20,12 @@ let
   libiconv' =
     if stdenv.hostPlatform.isDarwin || stdenv.hostPlatform.isFreeBSD then libiconvReal else libiconv;
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "man-db";
   version = "2.13.1";
 
   src = fetchurl {
-    url = "mirror://savannah/man-db/man-db-${version}.tar.xz";
+    url = "mirror://savannah/man-db/man-db-${finalAttrs.version}.tar.xz";
     hash = "sha256-iv67b362u4VCkpRYhB9cfm8kDjDIY1jB+8776gdsh9k=";
   };
 
@@ -129,4 +129,4 @@ stdenv.mkDerivation rec {
     mainProgram = "man";
     maintainers = with lib.maintainers; [ mdaniels5757 ];
   };
-}
+})


### PR DESCRIPTION
To verify the GitLab repo, see meta.homepage.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of <s>all binary files, usually in `./result/bin/`</s> `./result/bin/man`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
