### PR TITLE
nixos/shadow: apply `UMASK` setting using `pam_umask` by default

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -83,6 +83,10 @@ of pulling the upstream container image from Docker Hub. If you want the old beh
 
 - `rocmPackages_6` has been removed. `rocmPackages` has been updated to ROCm 7.x. Out of tree packages may rely on obsolete hipblas APIs or compile time constant warp size and need to be updated.
 
+- The default mode for new files (configured in `security.loginDefs.settings.UMASK`) is now properly applied using `pam_umask`. The default `UMASK` value has been corrected to match the previous effective behavior, which was a mask of `022`. If you previously configured `enableUMask` or added a `pam_umask` rule expecting the previous default mask of `077` to apply, then you need to explicitly configure `UMASK`. If you have not explicitly configured `enableUMask` or added a `pam_umask` rule, no changes are required.
+
+- The mode for new home directories is now configured using `security.loginDefs.settings.HOME_MODE`, and that setting has a default value of `077` matching the previous effective behavior. If you previously configured `UMASK` expecting that setting to also apply to home directories, then you need to explicitly configure `HOME_MODE`. If you have not explicitly configured `UMASK`, no changes are required.
+
 - The Bash implementation of the `nixos-rebuild` program is removed. All switchable systems now use the Python rewrite. Any prior usage of `system.rebuild.enableNg` must now be removed. If you have any outstanding issues with the new implementation, please open an issue on GitHub.
 
 - `services.desktopManager.gnome` no longer installs the Geary e-mail client since it is not part of the GNOME [core applications](https://apps.gnome.org/) list. Geary's position in the default favorite apps section has been replaced by GNOME Text Editor. To keep it installed, add `programs.geary.enable = true;` to your configuration.

--- a/nixos/modules/programs/shadow.nix
+++ b/nixos/modules/programs/shadow.nix
@@ -74,6 +74,12 @@ in
               ];
             };
 
+            HOME_MODE = lib.mkOption {
+              description = "The mode for new home directories.";
+              default = "077";
+              type = lib.types.str;
+            };
+
             SYS_UID_MIN = lib.mkOption {
               description = "Range of user IDs used for the creation of system users by useradd or newusers.";
               default = 400;
@@ -138,10 +144,9 @@ in
               type = lib.types.str;
             };
 
-            # Ensure privacy for newly created home directories.
             UMASK = lib.mkOption {
               description = "The file mode creation mask is initialized to this value.";
-              default = "077";
+              default = "022";
               type = lib.types.str;
             };
           };

--- a/nixos/modules/programs/shadow.nix
+++ b/nixos/modules/programs/shadow.nix
@@ -250,6 +250,7 @@ in
         groupdel.rootOK = true;
         login = {
           startSession = true;
+          enableUMask = true;
           allowNullPassword = true;
           showMotd = true;
           updateWtmp = true;

--- a/nixos/modules/services/display-managers/greetd.nix
+++ b/nixos/modules/services/display-managers/greetd.nix
@@ -78,6 +78,7 @@ in
     security.pam.services.greetd = {
       allowNullPassword = true;
       startSession = true;
+      enableUMask = true;
       enableGnomeKeyring = lib.mkDefault config.services.gnome.gnome-keyring.enable;
     };
 

--- a/nixos/modules/services/display-managers/lemurs.nix
+++ b/nixos/modules/services/display-managers/lemurs.nix
@@ -59,6 +59,7 @@ in
     security.pam.services.lemurs = {
       unixAuth = true;
       startSession = true;
+      enableUMask = true;
       # See https://github.com/coastalwhite/lemurs/issues/166
       setLoginUid = false;
       enableGnomeKeyring = lib.mkDefault config.services.gnome.gnome-keyring.enable;

--- a/nixos/modules/services/display-managers/ly.nix
+++ b/nixos/modules/services/display-managers/ly.nix
@@ -100,6 +100,7 @@ in
     security.pam.services = {
       ly = {
         startSession = true;
+        enableUMask = true;
         unixAuth = true;
         enableGnomeKeyring = lib.mkDefault config.services.gnome.gnome-keyring.enable;
       };

--- a/nixos/modules/services/monitoring/cockpit.nix
+++ b/nixos/modules/services/monitoring/cockpit.nix
@@ -120,6 +120,7 @@ in
 
     security.pam.services.cockpit = {
       startSession = true;
+      enableUMask = true;
     };
 
     networking.firewall.allowedTCPPorts = mkIf cfg.openFirewall [ cfg.port ];

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -805,6 +805,7 @@ in
 
       security.pam.services.sshd = lib.mkIf (cfg.settings.UsePAM == true) {
         startSession = true;
+        enableUMask = true;
         showMotd = true;
         unixAuth = if cfg.settings.PasswordAuthentication == true then true else false;
       };

--- a/nixos/modules/services/networking/xrdp.nix
+++ b/nixos/modules/services/networking/xrdp.nix
@@ -218,6 +218,7 @@ in
       security.pam.services.xrdp-sesman = {
         allowNullPassword = true;
         startSession = true;
+        enableUMask = true;
       };
 
     })

--- a/nixos/modules/system/boot/systemd/user.nix
+++ b/nixos/modules/system/boot/systemd/user.nix
@@ -234,6 +234,7 @@ in
       # Ensure that pam_systemd gets included. This is special-cased
       # in systemd to provide XDG_RUNTIME_DIR.
       startSession = true;
+      enableUMask = true;
       # Disable pam_mount in systemd-user to prevent it from being called
       # multiple times during login, because it will prevent pam_mount from
       # unmounting the previously mounted volumes.

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1653,6 +1653,7 @@ in
   udp-over-tcp = runTest ./udp-over-tcp.nix;
   ulogd = runTest ./ulogd/ulogd.nix;
   umami = runTest ./web-apps/umami.nix;
+  umask = runTest ./umask.nix;
   umurmur = runTest ./umurmur.nix;
   unbound = runTest ./unbound.nix;
   unifi = runTest ./unifi.nix;

--- a/nixos/tests/umask.nix
+++ b/nixos/tests/umask.nix
@@ -1,0 +1,26 @@
+{ pkgs, ... }:
+{
+  name = "umask";
+  meta.maintainers = with pkgs.lib.maintainers; [ majiir ];
+
+  nodes.machine = {
+    users.users.test = {
+      isNormalUser = true;
+    };
+  };
+
+  testScript = ''
+    machine.wait_for_unit("multi-user.target")
+
+    home_mode = machine.succeed("stat -c '%a' /home/test").strip()
+    assert home_mode == "700", f"Home directory has incorrect permissions: {home_mode}"
+
+    machine.succeed("su test -l -c 'mkdir /home/test/foo'")
+    dir_mode = machine.succeed("stat -c '%a' /home/test/foo").strip()
+    assert dir_mode == "755", f"New directory has incorrect permissions: {dir_mode}"
+
+    machine.succeed("su test -l -c 'touch /home/test/foo/bar'")
+    file_mode = machine.succeed("stat -c '%a' /home/test/foo/bar").strip()
+    assert file_mode == "644", f"New file has incorrect permissions: {file_mode}"
+  '';
+}


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/346922. See https://github.com/NixOS/nixpkgs/issues/346922#issuecomment-3707761083 for the background on this change.

Although some option defaults are changing, this does not change any default behavior. The new test asserts the default behavior, and it passes both before and after the change. This is technically a breaking change for users who have explicitly configured `UMASK` to control home directory creation mode or enabled the (very new) `enableUMask` option expecting the `077` default to apply.

The test should fail if you configure the test machine with a different mask, e.g. `security.loginDefs.settings.UMASK = "027"`. But it currently doesn't, because the `su` PAM service doesn't have `enableUMask` set. That's why this pull request is a draft.

I had thought that enabling `pam_umask` for any service that sets `startSession` would be enough, but it apparently isn't. I would like input from reviewers on how to find the right set of services to enable the rule.

While it would be possible to enable the rule by default, I'm reluctant to do this because there are many rules enabled by default. In general, being explicit would make the PAM module simpler to manage. I think we should have a compelling justification for enabling `pam_umask` (or any other rule) for every possible service.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
    - [ ] `umask` (but the test still passes when it should fail)
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
