### PR TITLE
nixos/sonarr: conditionally provision required directories with StateDirectory

### DIFF
--- a/nixos/modules/services/misc/servarr/sonarr.nix
+++ b/nixos/modules/services/misc/servarr/sonarr.nix
@@ -17,7 +17,12 @@ in
       dataDir = lib.mkOption {
         type = lib.types.str;
         default = "/var/lib/sonarr/.config/NzbDrone";
-        description = "The directory where Sonarr stores its data files.";
+        description = ''
+          The Sonarr home directory used to store all data. If left as the default value
+          this directory will automatically be created before the Sonarr server starts, otherwise
+          you are responsible for ensuring the directory exists with appropriate ownership
+          and permissions.
+        '';
       };
 
       openFirewall = lib.mkOption {
@@ -35,13 +40,29 @@ in
       user = lib.mkOption {
         type = lib.types.str;
         default = "sonarr";
-        description = "User account under which Sonaar runs.";
+        description = ''
+          User account under which Sonarr runs.";
+
+          ::: {.note}
+          If left as the default value this user will automatically be created
+          on system activation, otherwise you are responsible for
+          ensuring the user exists before the Sonarr service starts.
+          :::
+        '';
       };
 
       group = lib.mkOption {
         type = lib.types.str;
         default = "sonarr";
-        description = "Group under which Sonaar runs.";
+        description = ''
+          Group account under which Sonarr runs.
+
+          ::: {.note}
+          If left as the default value this group will automatically be created
+          on system activation, otherwise you are responsible for
+          ensuring the group exists before the Sonarr service starts.
+          :::
+        '';
       };
 
       package = lib.mkPackageOption pkgs "sonarr" { };
@@ -49,10 +70,6 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    systemd.tmpfiles.rules = [
-      "d '${cfg.dataDir}' 0700 ${cfg.user} ${cfg.group} - -"
-    ];
-
     systemd.services.sonarr = {
       description = "Sonarr";
       after = [ "network.target" ];
@@ -69,6 +86,9 @@ in
           "-data=${cfg.dataDir}"
         ];
         Restart = "on-failure";
+      }
+      // lib.optionalAttrs (cfg.dataDir == "/var/lib/sonarr/.config/NzbDrone") {
+        StateDirectory = "sonarr";
       };
     };
 


### PR DESCRIPTION
Currently only the `sonarr` user can access anything in `services.sonarr.dataDir`. So even if you give an other user the `sonarr` group they still can't access anything. The reason i want to be able to traverse the directory is so that i can scrape the logs with Grafana Alloy.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
