### PR TITLE
dokuwiki: add `extraConfigs` to combine

### DIFF
--- a/nixos/modules/services/web-apps/dokuwiki.nix
+++ b/nixos/modules/services/web-apps/dokuwiki.nix
@@ -115,7 +115,7 @@ let
   pkg =
     hostName: cfg:
     cfg.package.combine {
-      inherit (cfg) plugins templates;
+      inherit (cfg) plugins templates extraConfigs;
 
       pname = p: "${p.pname}-${hostName}";
 
@@ -342,6 +342,22 @@ let
             };
             # And then pass this theme to the template list like this:
             in [ template-bootstrap3 ]
+          '';
+        };
+
+        extraConfigs = mkOption {
+          type = types.attrsOf types.path;
+          default = { };
+          description = ''
+            Path(s) to additional configuration files that are then linked to the 'conf' directory.
+          '';
+          example = literalExpression ''
+            {
+              "acronyms.local.conf" = pkgs.writeText "acronyms.local.conf" '''
+                r13y  reproducibility
+              ''';
+              "entities.local.conf" = ./dokuwiki-entities;
+            }
           '';
         };
 

--- a/nixos/tests/dokuwiki.nix
+++ b/nixos/tests/dokuwiki.nix
@@ -30,11 +30,11 @@ let
     r13y  reproducibility
   '';
 
-  dwWithAcronyms = pkgs.dokuwiki.overrideAttrs (prev: {
-    installPhase = prev.installPhase or "" + ''
-      ln -sf ${acronymsFile} $out/share/dokuwiki/conf/acronyms.local.conf
-    '';
-  });
+  dwWithAcronyms = pkgs.dokuwiki.combine {
+    extraConfigs = {
+      "acronyms.local.conf" = acronymsFile;
+    };
+  };
 
   mkNode =
     webserver:

--- a/nixos/tests/dokuwiki.nix
+++ b/nixos/tests/dokuwiki.nix
@@ -30,12 +30,6 @@ let
     r13y  reproducibility
   '';
 
-  dwWithAcronyms = pkgs.dokuwiki.combine {
-    extraConfigs = {
-      "acronyms.local.conf" = acronymsFile;
-    };
-  };
-
   mkNode =
     webserver:
     { ... }:
@@ -53,9 +47,11 @@ let
             };
           };
           "site2.local" = {
-            package = dwWithAcronyms;
             usersFile = "/var/lib/dokuwiki/site2.local/users.auth.php";
             plugins = [ plugin-icalevents ];
+            extraConfigs = {
+              "acronyms.local.conf" = acronymsFile;
+            };
             settings = {
               useacl = true;
               superuser = "admin";


### PR DESCRIPTION
Dokuwiki has a plethora of small extra config files. Currently those are not handled by the combine functionality and have to be added using `overrideAttrs`.

This adds the `extraConfigs` parameter that takes name-path-pairs that are then linked into the config folder. The module also gains another option of the same name that is then passed on to the package.

The existing parameters `localConfig` and `pluginsConfig` are also mapped to this mechanism inside the implementation.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
