### PR TITLE
python3Packages.sanic: disable failing test on darwin

### DIFF
--- a/pkgs/development/python-modules/sanic/default.nix
+++ b/pkgs/development/python-modules/sanic/default.nix
@@ -107,6 +107,10 @@ buildPythonPackage rec {
     # Our mailcap database has a different mime type name for xml documentations
     # AssertionError: assert 'text/xml; charset=utf-8' == 'application/xml'
     "test_guess_content_type"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # KeyError: "getgrnam(): name not found: 'root'"
+    "test_validate_group_sets_gid"
   ];
 
   disabledTestPaths = [


### PR DESCRIPTION
Hydra: https://hydra.nixos.org/build/321996249/nixlog/2

Originally, this PR updated sanic 25.12.0 and also handled the required version bumps to tracerite for that to happen and to sanic-ext to ensure compatibility.

Most of these changes have now landed on `master` via `python-updates`. I'm handling the remaining changes as follows:

- I've put the remaining tracerite changes in https://github.com/NixOS/nixpkgs/pull/493785, should make them easier to review
- I've updated this PR to contain only the remaining changes to `sanic`, i.e., disabling the `test_validate_group_sets_gid` test to fix the build on darwin.


<details>
<summary>Original description</summary>

This fixes the build of `python314Packages.sanic`. The tracerite bump is required for sanic 25.12.0.

Hydra: https://hydra.nixos.org/build/317516718/nixlog/2
Tracking: https://github.com/NixOS/nixpkgs/issues/475732

### python3Packages.tracerite: 1.1.3 -> 2.3.1

Changelog: https://github.com/sanic-org/tracerite/releases/tag/v2.3.1
Diff: https://github.com/sanic-org/tracerite/compare/v1.1.3...v2.3.1

### python3Packages.sanic: 25.3.0 -> 25.12.0

Changelog: https://github.com/sanic-org/sanic/releases/tag/v25.12.0
Diff: https://github.com/sanic-org/sanic/compare/v25.3.0...v25.12.0

### python3Packages.sanic-ext: 24.12.0 -> 25.12.0

Changelog: https://github.com/sanic-org/sanic-ext/releases/tag/v25.12.0
Diff: https://github.com/sanic-org/sanic-ext/compare/v24.12.0...v25.12.0

</details>

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
