### PR TITLE
[staging-next] pkgsMusl.libmpeg2: fix build

### DIFF
--- a/pkgs/by-name/li/libmpeg2/getopt-getenv-signatures.patch
+++ b/pkgs/by-name/li/libmpeg2/getopt-getenv-signatures.patch
@@ -1,0 +1,26 @@
+diff --git a/src/getopt.c b/src/getopt.c
+index 4744e43..19776f3 100644
+--- a/src/getopt.c
++++ b/src/getopt.c
+@@ -208,7 +208,7 @@ static char *posixly_correct;
+    whose names are inconsistent.  */
+ 
+ #ifndef getenv
+-extern char *getenv ();
++extern char *getenv (const char *);
+ #endif
+ 
+ static char *
+diff --git a/src/getopt.h b/src/getopt.h
+index b0147e9..6f1e784 100644
+--- a/src/getopt.h
++++ b/src/getopt.h
+@@ -133,7 +133,7 @@ struct option
+    errors, only prototype getopt for the GNU C library.  */
+ extern int getopt (int __argc, char *const *__argv, const char *__shortopts);
+ # else /* not __GNU_LIBRARY__ */
+-extern int getopt ();
++extern int getopt (int, char *const*, const char *);
+ # endif /* __GNU_LIBRARY__ */
+ 
+ # ifndef __need_getopt

--- a/pkgs/by-name/li/libmpeg2/package.nix
+++ b/pkgs/by-name/li/libmpeg2/package.nix
@@ -13,6 +13,11 @@ stdenv.mkDerivation rec {
     sha256 = "1m3i322n2fwgrvbs1yck7g5md1dbg22bhq5xdqmjpz5m7j4jxqny";
   };
 
+  patches = [
+    # Fixes mismatching definitions with C23 / GCC15 on non-glibc platforms
+    ./getopt-getenv-signatures.patch
+  ];
+
   # Otherwise clang fails with 'duplicate symbol ___sputc'
   buildFlags = lib.optional stdenv.hostPlatform.isDarwin "CFLAGS=-std=gnu89";
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Technically the affected files might be >22 years old copies from gnulib, but we can not expect the abandoned project to update its release tarball with a fresh copy.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
