### PR TITLE
magicq: init at 1.9.7.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -20118,6 +20118,13 @@
     githubId = 686076;
     name = "Vitalii Voloshyn";
   };
+  panakotta00 = {
+    name = "Panakotta00";
+    github = "Panakotta00";
+    githubId = 16022267;
+    email = "panakotta00@gmail.com";
+    keys = [ { fingerprint = "ABF8 D539 0F8C F623 8F49  7338 BA6C E8AC 4B73 53B9"; } ];
+  };
   pancaek = {
     github = "pancaek";
     githubId = 20342389;

--- a/pkgs/by-name/ma/magicq/package.nix
+++ b/pkgs/by-name/ma/magicq/package.nix
@@ -1,0 +1,100 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  copyDesktopItems,
+  makeDesktopItem,
+  dpkg,
+  alsa-lib-with-plugins,
+  ffmpeg_4,
+  libGL,
+  libGLU,
+  libarchive,
+  libgcc,
+  libsForQt5,
+  qt5,
+  libusb-compat-0_1,
+  libusb1,
+  libz,
+  portaudio,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "magicq";
+  version = "1.9.7.3";
+  src_version = builtins.replaceStrings [ "." ] [ "_" ] finalAttrs.version;
+
+  src = fetchurl {
+    url = "https://secure.chamsys.co.uk/downloads/v${finalAttrs.src_version}/magicq_ubuntu_v${finalAttrs.src_version}.deb";
+    hash = "sha256-FsVSt9iIhwL/wI2XYmKJrA7800wFQ2qJ/uF3bbMLw0Q=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    copyDesktopItems
+    dpkg
+    qt5.wrapQtAppsHook
+  ];
+  buildInputs = [
+    alsa-lib-with-plugins
+    ffmpeg_4
+    libGL
+    libGLU
+    libarchive
+    libgcc
+    libsForQt5.qt5.qtbase
+    libsForQt5.qt5.qtmultimedia
+    qt5.qtbase
+    libusb-compat-0_1
+    libusb1
+    libz
+    portaudio
+  ];
+
+  installPhase = ''
+    mkdir $out
+    cp -r . $out
+    rm -r $out/opt/magicq/lib
+    rm $out/opt/magicq/plugins/imageformats/libqtiff.so
+    rm $out/opt/magicq/plugins/printsupport/libcupsprintersupport.so
+    rm $out/opt/magicq/plugins/mediaservice/libgstcamerabin.so
+    mv $out/usr/share $out/share
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    mkdir $out/bin
+    makeWrapper $out/opt/magicq/bin/mqqt $out/bin/magicq \
+    --chdir $out/opt/magicq
+    wrapQtApp $out/bin/magicq
+    sed "s|@out@|$out|g" -i $out/share/applications/magicq.desktop
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "magicq";
+      desktopName = "MagicQ by ChamSys Ltd.";
+      genericName = "MagicQ";
+      exec = "@out@/bin/magicq";
+      path = "@out@/opt/magicq/";
+      icon = "magicq";
+      categories = [
+        "AudioVideo"
+        "Qt"
+      ];
+    })
+  ];
+
+  meta = {
+    description = "MagicQ Lighting Console Software";
+    homepage = "https://chamsyslighting.com/product/magicq-software/";
+    license = lib.licenses.unfree;
+    platforms = lib.platforms.linux;
+    mainProgram = "magicq";
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    maintainers = with lib.maintainers; [ panakotta00 ];
+  };
+})


### PR DESCRIPTION
# Description
Adds MagicQ by ChamSys Ltd. to nixpkgs.

Repackages the from the developer provided .deb file.

MagicQ Homepage: https://chamsyslighting.com/product/magicq-software/

The licensing scheme is unclear but probably full copyright by ChamSys Ltd. and all rights reserved for ChamSys Ltd.

I'm unsure about the Qt5 setup. I don't know how to fix the Qt Platform Plugin issue. I only got it working using a wrapper that configures the necessary environment variables.

The wrapper also specifies a certain working directory. This is required by MagicQ to function properly.
I have also manually overwritten a .desktop file as the in the .deb file provided ones appear to not work properly (tested with ulauncher).

I'm also unsure about any ChamSys specific drivers, I've used and tested it as pure PC application (on laptop using touchscreen) and with Art-Net output.

# Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).