### PR TITLE
everforest-gtk-theme: 0-unstable-2025-10-15 -> 0-unstable-2025-10-23

### DIFF
--- a/pkgs/by-name/ev/everforest-gtk-theme/fix-install-script.patch
+++ b/pkgs/by-name/ev/everforest-gtk-theme/fix-install-script.patch
@@ -1,0 +1,34 @@
+From f9be45b024e29efa6082cdfe6f47ca6b1110f20a Mon Sep 17 00:00:00 2001
+From: poz <poz@poz.pet>
+Date: Fri, 9 Jan 2026 03:25:01 +0100
+Subject: [PATCH] fix install script
+
+---
+ themes/install.sh | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/themes/install.sh b/themes/install.sh
+index 1dc573f1..b1657b62 100755
+--- a/themes/install.sh
++++ b/themes/install.sh
+@@ -130,6 +130,7 @@ install() {
+ 	ln -s assets/no-events.svg no-events.svg
+ 	ln -s assets/process-working.svg process-working.svg
+ 	ln -s assets/no-notifications.svg no-notifications.svg
++	cd - > /dev/null
+ 
+ 	# GTK2 Themes
+ 	mkdir -p                                                                      		 "${THEME_DIR}/gtk-2.0"
+@@ -166,7 +167,11 @@ install() {
+ 	cp -r "${SRC_DIR}/main/metacity-1/metacity-theme-3${window}${color}.xml"             "${THEME_DIR}/metacity-1/metacity-theme-3.xml"
+ 	cp -r "${SRC_DIR}/assets/metacity-1/assets${window}"                                 "${THEME_DIR}/metacity-1/assets"
+ 	cp -r "${SRC_DIR}/assets/metacity-1/thumbnail${ELSE_DARK:-}.png"                     "${THEME_DIR}/metacity-1/thumbnail.png"
+-	cd "${THEME_DIR}/metacity-1" && ln -s metacity-theme-3.xml metacity-theme-1.xml && ln -s metacity-theme-3.xml metacity-theme-2.xml
++
++	cd "${THEME_DIR}/metacity-1"
++	ln -s metacity-theme-3.xml metacity-theme-1.xml
++	ln -s metacity-theme-3.xml metacity-theme-2.xml
++	cd - > /dev/null
+ 
+ 	# XFWM4 Themes
+ 	mkdir -p                                                                             "${THEME_DIR}/xfwm4"

--- a/pkgs/by-name/ev/everforest-gtk-theme/package.nix
+++ b/pkgs/by-name/ev/everforest-gtk-theme/package.nix
@@ -4,18 +4,26 @@
   fetchFromGitHub,
   gnome-themes-extra,
   gtk-engine-murrine,
+  gtk3,
+  sassc,
 }:
 
 stdenvNoCC.mkDerivation {
   pname = "everforest-gtk-theme";
-  version = "0-unstable-2025-10-15";
+  version = "0-unstable-2025-10-23";
 
   src = fetchFromGitHub {
     owner = "Fausto-Korpsvart";
     repo = "Everforest-GTK-Theme";
-    rev = "930a5dc57f7a06e8c6538d531544e41c56dbb27a";
-    hash = "sha256-mlJE7gVElWUjJIZnAL5ztchphmaU82llol+YdKqnSxg=";
+    rev = "9b8be4d6648ae9eaae3dd550105081f8c9054825";
+    hash = "sha256-XHO6NoXJwwZ8gBzZV/hJnVq5BvkEKYWvqLBQT00dGdE=";
   };
+
+  patches = [
+    # remove when merged
+    # https://github.com/Fausto-Korpsvart/Everforest-GTK-Theme/pull/34
+    ./fix-install-script.patch
+  ];
 
   propagatedUserEnvPkgs = [
     gtk-engine-murrine
@@ -25,13 +33,34 @@ stdenvNoCC.mkDerivation {
     gnome-themes-extra
   ];
 
+  nativeBuildInputs = [
+    gtk3
+    sassc
+  ];
+
   dontBuild = true;
+  dontFixup = true;
+  dontDropIconThemeCache = true;
+
+  postPatch = ''
+    patchShebangs themes/install.sh
+  '';
 
   installPhase = ''
     runHook preInstall
+
     mkdir -p "$out/share/"{themes,icons}
+
     cp -a icons/* "$out/share/icons/"
-    cp -a themes/* "$out/share/themes/"
+
+    for theme in "$out/share/icons/"*; do
+      gtk-update-icon-cache "$theme"
+    done
+
+    cd themes
+    ./install.sh --name Everforest --theme all --dest "$out/share/themes"
+    cd ..
+
     runHook postInstall
   '';
 


### PR DESCRIPTION
this updates everforest-gtk-theme to the latest commit alongside including my patch from https://github.com/Fausto-Korpsvart/Everforest-GTK-Theme/pull/34 that fixes the install script

the install script is now used to actually build the theme properly instead of copying the sources to `$out`

I'm running a patched version of this theme with the same changes as this PR and it's working on both `x86_64-linux` and `aarch64-linux`
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
