### PR TITLE
config: add replaceStdenv, cudaCapabilities, cudaForwardCompat options

### DIFF
--- a/pkgs/stdenv/default.nix
+++ b/pkgs/stdenv/default.nix
@@ -43,7 +43,7 @@ in
 # Select the appropriate stages for the platform `system'.
 if crossSystem != localSystem || crossOverlays != [ ] then
   stagesCross
-else if config ? replaceStdenv then
+else if (config.replaceStdenv or null) != null then
   stagesCustom
 else if localSystem.isLinux then
   stagesLinux

--- a/pkgs/stdenv/default.nix
+++ b/pkgs/stdenv/default.nix
@@ -43,7 +43,7 @@ in
 # Select the appropriate stages for the platform `system'.
 if crossSystem != localSystem || crossOverlays != [ ] then
   stagesCross
-else if config.replaceStdenv != null then
+else if (config.replaceStdenv or null) != null then
   stagesCustom
 else if localSystem.isLinux then
   stagesLinux

--- a/pkgs/stdenv/default.nix
+++ b/pkgs/stdenv/default.nix
@@ -43,7 +43,7 @@ in
 # Select the appropriate stages for the platform `system'.
 if crossSystem != localSystem || crossOverlays != [ ] then
   stagesCross
-else if (config.replaceStdenv or null) != null then
+else if config.replaceStdenv != null then
   stagesCustom
 else if localSystem.isLinux then
   stagesLinux

--- a/pkgs/stdenv/default.nix
+++ b/pkgs/stdenv/default.nix
@@ -43,6 +43,7 @@ in
 # Select the appropriate stages for the platform `system'.
 if crossSystem != localSystem || crossOverlays != [ ] then
   stagesCross
+# The `or null` fallback is needed for contexts that don't use the module system (e.g. tarball builds).
 else if (config.replaceStdenv or null) != null then
   stagesCustom
 else if localSystem.isLinux then


### PR DESCRIPTION
Fixes #479220

Users with config.warnUndeclaredOptions = true were getting warnings for replaceStdenv, cudaCapabilities, and cudaForwardCompat because these options were used but not declared in pkgs/top-level/config.nix.

This PR adds proper option declarations for:
- `cudaCapabilities`: A list of CUDA capabilities to build for (default: `[]`)
- `cudaForwardCompat`: Whether to enable PTX support for future hardware (default: `true`)
- `replaceStdenv`: A function to replace the standard environment globally (default: `null`)

Also updates pkgs/stdenv/default.nix to check (config.replaceStdenv or null) != null instead of config ? replaceStdenv, since the option now always exists but may be null.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at passthru.tests.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran nixpkgs-review on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in ./result/bin/.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a 👍 [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

---

Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=4217675