### PR TITLE
termcap: fix build

### DIFF
--- a/pkgs/by-name/te/termcap/function-declarations.patch
+++ b/pkgs/by-name/te/termcap/function-declarations.patch
@@ -1,0 +1,47 @@
+--- a/termcap.c
++++ b/termcap.c
+@@ -126,7 +126,7 @@
+    for tgetnum, tgetflag and tgetstr to find.  */
+ static char *term_entry;
+ 
+-static char *tgetst1 ();
++static char *tgetst1 (char *ptr, char **area);
+ 
+ /* Search entry BP for capability CAP.
+    Return a pointer to the capability (in BP) if found,
+@@ -317,7 +317,7 @@
+ tputs (str, nlines, outfun)
+      register char *str;
+      int nlines;
+-     register int (*outfun) ();
++     register int (*outfun) (...);
+ {
+   register int padcount = 0;
+   register int speed;
+@@ -389,10 +389,10 @@
+ 
+ /* Forward declarations of static functions.  */
+ 
+-static int scan_file ();
+-static char *gobble_line ();
+-static int compare_contin ();
+-static int name_match ();
++static int scan_file (char *str, int fd, register struct termcap_buffer *bufp);
++static char *gobble_line (int fd, register struct termcap_buffer *bufp, char *append_end);
++static int compare_contin (register char *str1, register char *str2);
++static int name_match (char *line, char *name);
+ 
+ #ifdef VMS
+ 
+--- a/tparam.c
++++ b/tparam.c
+@@ -88,7 +88,8 @@
+ 
+    The fourth and following args to tparam serve as the parameter values.  */
+ 
+-static char *tparam1 ();
++static char *tparam1 (char *string, char *outstring, int len, char *up, char *left, register int *argp);
++
+ 
+ /* VARARGS 2 */
+ char *

--- a/pkgs/by-name/te/termcap/package.nix
+++ b/pkgs/by-name/te/termcap/package.nix
@@ -1,23 +1,25 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchzip,
   fetchpatch,
   autoreconfHook,
   enableStatic ? stdenv.hostPlatform.isStatic,
   enableShared ? !stdenv.hostPlatform.isStatic,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "termcap";
   version = "1.3.1";
 
-  src = fetchurl {
-    url = "mirror://gnu/termcap/termcap-${version}.tar.gz";
-    hash = "sha256-kaDiLlOHykRntbyxjt8cUbkwJi/UZtX9o5bdnSZxkQA=";
+  src = fetchzip {
+    url = "mirror://gnu/termcap/termcap-${finalAttrs.version}.tar.gz";
+    hash = "sha256-IO0rqQuhd+U3haNOY6w7tDRGNbNEwTgKyj2s+509RUo=";
   };
 
   patches = [
+    ./function-declarations.patch
+
     (fetchpatch {
       name = "0001-tparam-replace-write-with-fprintf.patch";
       url = "https://github.com/msys2/MINGW-packages/raw/c6691ad1bd9d4c6823a18068ca0683c3e32ea005/mingw-w64-termcap/0001-tparam-replace-write-with-fprintf.patch";
@@ -40,7 +42,7 @@ stdenv.mkDerivation rec {
     "AR=${stdenv.cc.targetPrefix}ar"
   ];
 
-  env.NIX_CFLAGS_COMPILE = toString (
+  env.NIX_CFLAGS_COMPILE = lib.concatStringsSep " " (
     [
       "-DSTDC_HEADERS"
     ]
@@ -73,7 +75,10 @@ stdenv.mkDerivation rec {
     description = "Terminal feature database";
     homepage = "https://www.gnu.org/software/termutils/";
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [ wegank ];
+    maintainers = with lib.maintainers; [
+      prince213
+      wegank
+    ];
     platforms = lib.platforms.all;
   };
-}
+})


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/479253.

In align with the steps in https://github.com/NixOS/nixpkgs/issues/475479.
Supersedes and closes https://github.com/NixOS/nixpkgs/pull/478354.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
