### PR TITLE
D 2.112.1

### DIFF
--- a/pkgs/by-name/dm/dmd/generic.nix
+++ b/pkgs/by-name/dm/dmd/generic.nix
@@ -74,25 +74,16 @@ stdenv.mkDerivation (finalAttrs: {
   # https://issues.dlang.org/show_bug.cgi?id=19553
   hardeningDisable = [ "fortify" ];
 
-  patches =
-    lib.optionals (lib.versionOlder version "2.088.0") [
-      # Migrates D1-style operator overloads in DMD source, to allow building with
-      # a newer DMD
-      (fetchpatch {
-        url = "https://github.com/dlang/dmd/commit/c4d33e5eb46c123761ac501e8c52f33850483a8a.patch";
-        stripLen = 1;
-        extraPrefix = "dmd/";
-        hash = "sha256-N21mAPfaTo+zGCip4njejasraV5IsWVqlGR5eOdFZZE=";
-      })
-    ]
-    ++ [
-      (fetchpatch {
-        url = "https://github.com/dlang/dmd/commit/fdd25893e0ac04893d6eba8652903d499b7b0dfc.patch";
-        stripLen = 1;
-        extraPrefix = "dmd/";
-        hash = "sha256-Uccb8rBPBLAEPWbOYWgdR5xN3wJoIkKKhLGu58IK1sM=";
-      })
-    ];
+  patches = lib.optionals (lib.versionOlder version "2.088.0") [
+    # Migrates D1-style operator overloads in DMD source, to allow building with
+    # a newer DMD
+    (fetchpatch {
+      url = "https://github.com/dlang/dmd/commit/c4d33e5eb46c123761ac501e8c52f33850483a8a.patch";
+      stripLen = 1;
+      extraPrefix = "dmd/";
+      hash = "sha256-N21mAPfaTo+zGCip4njejasraV5IsWVqlGR5eOdFZZE=";
+    })
+  ];
 
   postPatch = ''
     patchShebangs dmd/compiler/test/{runnable,fail_compilation,compilable,tools}{,/extra-files}/*.sh
@@ -189,6 +180,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     NIX_ENFORCE_PURITY= \
       make -C phobos unittest -j$checkJobs $checkFlags \
+        DISABLED_TESTS=std/datetime/timezone \
         DFLAGS="-version=TZDatabaseDir -version=LibcurlPath -J$PWD"
 
     runHook postCheck

--- a/pkgs/by-name/dm/dmd/package.nix
+++ b/pkgs/by-name/dm/dmd/package.nix
@@ -1,5 +1,5 @@
 import ./generic.nix {
-  version = "2.110.0";
-  dmdHash = "sha256-icXp9xWF2AI2gp7z/lQFAChmXfQePe9b5pbpQ9Mn19Y=";
-  phobosHash = "sha256-CmJpcHM+sIsaYBlpALCFoQFG+93s8gUyWmM0tYqjXkk=";
+  version = "2.112.1";
+  dmdHash = "sha256-UqNNUGoGmOV0lGNCGaFk8HbOE01qD55WuJ8NyQzqLJs=";
+  phobosHash = "sha256-CNvDSlerOXh6Qn060MNaSF1IIcbrcZzljyIxkm+TQQ0=";
 }

--- a/pkgs/by-name/dt/dtools/package.nix
+++ b/pkgs/by-name/dt/dtools/package.nix
@@ -8,13 +8,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "dtools";
-  version = "2.110.0";
+  version = "2.112.1";
 
   src = fetchFromGitHub {
     owner = "dlang";
     repo = "tools";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-xMEHnrstL5hAkhp8+/z1I2KZWZ7eztWZnUGLTKCfbBI=";
+    hash = "sha256-WHgV33fu1YhRQCERVatqXKEqmfHlUvZ4IXhga/yOQ3w=";
     name = "dtools";
   };
 

--- a/pkgs/by-name/du/dub/package.nix
+++ b/pkgs/by-name/du/dub/package.nix
@@ -10,7 +10,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "dub";
-  version = "1.39.0";
+  version = "1.41.0";
 
   enableParallelBuilding = true;
 
@@ -18,7 +18,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "dlang";
     repo = "dub";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-73b15A9+hClD6IbuxTy9QZKpTKjUFYBuqGOclUyhrnM=";
+    hash = "sha256-86TzaRdu+CFM0Ld2fXxjaUUT9dl37MYPdmsvxE4ZUkE=";
   };
 
   postPatch = ''
@@ -139,6 +139,7 @@ stdenv.mkDerivation (finalAttrs: {
     rm -r test/pr2642-cache-db
     rm -r test/pr2644-describe-artifact-path
     rm -r test/pr2647-build-deep
+    rm -r test/issue2698-cimportpaths-broken-with-dmd-ldc
 
     ./test/run-unittest.sh
 

--- a/pkgs/by-name/ld/ldc/package.nix
+++ b/pkgs/by-name/ld/ldc/package.nix
@@ -32,13 +32,13 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "ldc";
-  version = "1.41.0";
+  version = "1.42.0";
 
   src = fetchFromGitHub {
     owner = "ldc-developers";
     repo = "ldc";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-6LcpY3LSFK4KgEiGrFp/LONu5Vr+/+vI04wEEpF3s+s=";
+    hash = "sha256-adA14tx/bruGvHVoODz13f8h/U2ol1lK0ytxnypsLv8=";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
Bump dmd and dtools to 2.112.1
Bump dub to its latest release as of D 2.112.1, which is 1.41.0
Bump ldc to 1.42.0, based on dmd 2.112.1

https://dlang.org/changelog/2.112.0.html
https://dlang.org/changelog/2.112.1.html

Fixes #479037

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
