### PR TITLE
nixos/sssd: remove unnecessary capabilities

### DIFF
--- a/nixos/modules/services/misc/sssd.nix
+++ b/nixos/modules/services/misc/sssd.nix
@@ -158,18 +158,9 @@ in
           NotifyAccess = "main";
           PIDFile = "/run/sssd.pid";
           CapabilityBoundingSet = [
-            "CAP_IPC_LOCK"
-            "CAP_CHOWN"
             "CAP_DAC_READ_SEARCH"
-            "CAP_KILL"
-            "CAP_NET_ADMIN"
-            "CAP_SYS_NICE"
-            "CAP_FOWNER"
             "CAP_SETGID"
             "CAP_SETUID"
-            "CAP_SYS_ADMIN"
-            "CAP_SYS_RESOURCE"
-            "CAP_BLOCK_SUSPEND"
           ];
           Restart = "on-abnormal";
           StateDirectory = baseNameOf dataDir;


### PR DESCRIPTION
New version of sssd not need capabilities :

```
CAP_BLOCK_SUSPEND
CAP_CHOWN
CAP_FOWNER
CAP_IPC_LOCK
CAP_KILL
CAP_NET_ADMIN
CAP_SYS_ADMIN
CAP_SYS_NICE
CAP_SYS_RESOURCE
```

Tested in my side with AD.
nixosTests.sssd-ldap OK

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
