### PR TITLE
gnuradio: lndir to $man properly

### DIFF
--- a/pkgs/applications/radio/gnuradio/wrapper.nix
+++ b/pkgs/applications/radio/gnuradio/wrapper.nix
@@ -225,10 +225,13 @@ let
           lndir
         ];
         buildCommand = ''
-          mkdir $out
+          ${builtins.concatStringsSep "\n" (
+            map (output: ''
+              mkdir ''$${output}
+              lndir -silent ${unwrapped.${output}} ''$${output}
+            '') outputs
+          )}
           cd $out
-          lndir -silent ${unwrapped.out}
-          lndir -silent ${unwrapped.man}
           ${lib.optionalString (extraPackages != [ ]) (
             builtins.concatStringsSep "\n" (
               map (pkg: ''

--- a/pkgs/applications/radio/gnuradio/wrapper.nix
+++ b/pkgs/applications/radio/gnuradio/wrapper.nix
@@ -246,7 +246,7 @@ let
             mv -f "$i".tmp "$i"
             if head -1 "$i" | grep -q ${unwrapped.python}; then
               substituteInPlace "$i" \
-                --replace ${unwrapped.python} ${pythonEnv}
+                --replace-fail ${unwrapped.python} ${pythonEnv}
             fi
             wrapProgram "$i" ${makeWrapperArgs}
           done

--- a/pkgs/applications/radio/gnuradio/wrapper.nix
+++ b/pkgs/applications/radio/gnuradio/wrapper.nix
@@ -9,7 +9,7 @@
   # For the wrapper
   makeWrapper,
   # For lndir
-  xorg,
+  lndir,
   # To define a the gnuradio.pkgs scope
   newScope,
   # For Emulating wrapGAppsHook3
@@ -222,7 +222,7 @@ let
           ;
         nativeBuildInputs = [
           makeWrapper
-          xorg.lndir
+          lndir
         ];
         buildCommand = ''
           mkdir $out


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc