### PR TITLE
home-assistant: 2026.1.0 -> 2026.1.1

### DIFF
--- a/pkgs/development/python-modules/zha-quirks/default.nix
+++ b/pkgs/development/python-modules/zha-quirks/default.nix
@@ -13,7 +13,7 @@
 
 buildPythonPackage rec {
   pname = "zha-quirks";
-  version = "0.0.151";
+  version = "0.0.152";
   pyproject = true;
 
   disabled = pythonOlder "3.12";
@@ -22,7 +22,7 @@ buildPythonPackage rec {
     owner = "zigpy";
     repo = "zha-device-handlers";
     tag = version;
-    hash = "sha256-eB4Xmkbueig9UgGs0d9WLGFLQ20XiCdFtI4KKa8frJw=";
+    hash = "sha256-b0px65f/M1Lm7FUh6NLnF90tK5FKytMEPHdMenrpsso=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/zha/default.nix
+++ b/pkgs/development/python-modules/zha/default.nix
@@ -23,7 +23,7 @@
 
 buildPythonPackage rec {
   pname = "zha";
-  version = "0.0.83";
+  version = "0.0.84";
   pyproject = true;
 
   disabled = pythonOlder "3.12";
@@ -32,7 +32,7 @@ buildPythonPackage rec {
     owner = "zigpy";
     repo = "zha";
     tag = version;
-    hash = "sha256-/poB5dkD5bta/GWOah6+bz+w++C1NWf649TUzqvDfU0=";
+    hash = "sha256-CoV2EOlbLVmcr7dfHi63oFLMzCMf2P3vc+CoaOAu1FQ=";
   };
 
   postPatch = ''

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "2026.1.0";
+  version = "2026.1.1";
   components = {
     "3_day_blinds" =
       ps: with ps; [

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -293,13 +293,13 @@ let
   extraBuildInputs = extraPackages python.pkgs;
 
   # Don't forget to run update-component-packages.py after updating
-  hassVersion = "2026.1.0";
+  hassVersion = "2026.1.1";
 
 in
 python.pkgs.buildPythonApplication rec {
   pname = "homeassistant";
   version =
-    #assert (componentPackages.version == hassVersion);
+    assert (componentPackages.version == hassVersion);
     hassVersion;
   pyproject = true;
 
@@ -314,13 +314,13 @@ python.pkgs.buildPythonApplication rec {
     owner = "home-assistant";
     repo = "core";
     tag = version;
-    hash = "sha256-LoB8hm5ruC6kvulHmtYxbJ6JkkTmgzCbiyBjVdaHFGI=";
+    hash = "sha256-l2/mi/WfZ3PbuB7LEhpWkubsY1xMyUjeolxPDHYEXWU=";
   };
 
   # Secondary source is pypi sdist for translations
   sdist = fetchPypi {
     inherit pname version;
-    hash = "sha256-D6p/pMN7jM8e7ckXlMaQQvj4VZ8ufCBfHCeQaCYr3sY=";
+    hash = "sha256-Ll1wwcdkH/A2N8M1ZuE1RvjNFRu6ipEyuy4Th34s/Uo=";
   };
 
   build-system = with python.pkgs; [

--- a/pkgs/servers/home-assistant/frontend.nix
+++ b/pkgs/servers/home-assistant/frontend.nix
@@ -8,7 +8,7 @@ buildPythonPackage rec {
   # the frontend version corresponding to a specific home-assistant version can be found here
   # https://github.com/home-assistant/home-assistant/blob/master/homeassistant/components/frontend/manifest.json
   pname = "home-assistant-frontend";
-  version = "20260107.0";
+  version = "20260107.1";
   format = "wheel";
 
   src = fetchPypi {
@@ -17,7 +17,7 @@ buildPythonPackage rec {
     pname = "home_assistant_frontend";
     dist = "py3";
     python = "py3";
-    hash = "sha256-bRkcIoy12gaHNZdRypFdaArsZiM/5Sm4YNMUD1AMYUI=";
+    hash = "sha256-P/7ZKtNwZZN7klPNISxOjfsdbk2KzFzGbTM5H44we7I=";
   };
 
   # there is nothing to strip in this package

--- a/pkgs/servers/home-assistant/pytest-homeassistant-custom-component.nix
+++ b/pkgs/servers/home-assistant/pytest-homeassistant-custom-component.nix
@@ -18,7 +18,7 @@
 
 buildPythonPackage rec {
   pname = "pytest-homeassistant-custom-component";
-  version = "0.13.305";
+  version = "0.13.306";
   pyproject = true;
 
   disabled = pythonOlder "3.13";
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     owner = "MatthewFlamm";
     repo = "pytest-homeassistant-custom-component";
     tag = version;
-    hash = "sha256-wxoG5xnlvViWgu0cYIG84coOGJrFVuaX5jHoHXm9s9s=";
+    hash = "sha256-RcUI15/+0nu453mcrRzMo2VvJAn3Up336LiuJygJaM0=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/servers/home-assistant/stubs.nix
+++ b/pkgs/servers/home-assistant/stubs.nix
@@ -10,7 +10,7 @@
 
 buildPythonPackage rec {
   pname = "homeassistant-stubs";
-  version = "2026.1.0";
+  version = "2026.1.1";
   pyproject = true;
 
   disabled = python.version != home-assistant.python.version;
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     owner = "KapJI";
     repo = "homeassistant-stubs";
     tag = version;
-    hash = "sha256-1gJtsQo3OOki1hjRnD8Bb+800k8fCd0TJS3BZW76Osg=";
+    hash = "sha256-owl8Twq1FtRtWm9QZlhx/ZgsaOVaPX3W+oxiP0ZCPQg=";
   };
 
   build-system = [


### PR DESCRIPTION
Diff: https://github.com/home-assistant/core/compare/2026.1.0...2026.1.1

Changelog: https://github.com/home-assistant/core/releases/tag/2026.1.1

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
