### PR TITLE
odamex: 11.2.0 -> 12.1.0

### DIFF
--- a/pkgs/by-name/od/odamex/package.nix
+++ b/pkgs/by-name/od/odamex/package.nix
@@ -197,8 +197,9 @@ stdenv.mkDerivation (finalAttrs: {
   passthru.updateScript = nix-update-script { };
 
   meta = {
-    homepage = "http://odamex.net/";
+    homepage = "https://odamex.net";
     description = "Client/server port for playing old-school Doom online";
+    changelog = "https://github.com/odamex/odamex/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.gpl2Only;
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ eljamm ];

--- a/pkgs/by-name/od/odamex/package.nix
+++ b/pkgs/by-name/od/odamex/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
 
   cmake,
   copyDesktopItems,
@@ -52,25 +51,15 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "odamex";
-  version = "11.2.0";
+  version = "12.1.0";
 
   src = fetchFromGitHub {
     owner = "odamex";
     repo = "odamex";
     tag = finalAttrs.version;
-    hash = "sha256-f9st852Sqmdmb/qNP1ioBY9MApt9Ruw8dBjkkyGM5Qs=";
+    hash = "sha256-kLI1gdGH5NXJ8YI1tR0N5W6yvGZ+7302z0QLl2j+b0k=";
     fetchSubmodules = true;
   };
-
-  patches = [
-    # fix file-open panel on Darwin
-    # https://github.com/odamex/odamex/pull/1402
-    # TODO: remove on next release
-    (fetchpatch {
-      url = "https://patch-diff.githubusercontent.com/raw/odamex/odamex/pull/1402.patch";
-      hash = "sha256-JrcQ0rYkaFP5aKNWeXbrY2TN4r8nHpue19qajNXJXg4=";
-    })
-  ];
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/by-name/od/odamex/package.nix
+++ b/pkgs/by-name/od/odamex/package.nix
@@ -202,6 +202,7 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/odamex/odamex/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.gpl2Only;
     platforms = lib.platforms.unix;
+    broken = stdenv.hostPlatform.isDarwin;
     maintainers = with lib.maintainers; [ eljamm ];
     mainProgram = "odalaunch";
   };


### PR DESCRIPTION
- Bump to 12.1.0
- Remove now unneeded patch (did not test. compilation fails otherwise.)
- Change meta information

Changelog: https://github.com/odamex/odamex/releases/tag/12.0.0 https://github.com/odamex/odamex/releases/tag/12.1.0
Diff: https://github.com/odamex/odamex/compare/11.2.0...12.1.0

~Known issue: portmidi is not playing any music. It also happens on 11.2.0, so it's not an issue introduced with this change. (Did it ever work on the nix package?)~ User error.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
