### PR TITLE
maintainers: rename adamperkowski to koi, update upstream references

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -606,17 +606,6 @@
     githubId = 50264672;
     name = "Adam Freeth";
   };
-  adamperkowski = {
-    name = "Adam Perkowski";
-    email = "me@adamperkowski.dev";
-    matrix = "@adam:matrix.system72.dev";
-    github = "koibtw";
-    githubId = 75480869;
-    keys = [
-      { fingerprint = "00F6 1623 FB56 BC5B B709  4E63 4CE6 C117 2DF6 BE79"; }
-      { fingerprint = "5A53 0832 DA91 20B0 CA57  DDB6 7CBD B58E CF1D 3478"; }
-    ];
-  };
   adamt = {
     email = "mail@adamtulinius.dk";
     github = "adamtulinius";
@@ -14031,6 +14020,17 @@
     github = "koffydrop";
     githubId = 67888720;
     name = "Kira";
+  };
+  koi = {
+    name = "koi";
+    email = "me@koi.rip";
+    matrix = "@koi:system72.dev";
+    github = "koibtw";
+    githubId = 75480869;
+    keys = [
+      { fingerprint = "00F6 1623 FB56 BC5B B709  4E63 4CE6 C117 2DF6 BE79"; }
+      { fingerprint = "5A53 0832 DA91 20B0 CA57  DDB6 7CBD B58E CF1D 3478"; }
+    ];
   };
   kolaente = {
     email = "k@knt.li";

--- a/nixos/modules/programs/nvrs.nix
+++ b/nixos/modules/programs/nvrs.nix
@@ -10,7 +10,7 @@ let
   settingsFormat = pkgs.formats.toml { };
 in
 {
-  meta.maintainers = with lib.maintainers; [ adamperkowski ];
+  meta.maintainers = with lib.maintainers; [ koi ];
 
   options.programs.nvrs = {
     enable = lib.mkEnableOption "nvrs";

--- a/pkgs/by-name/gh/gh-webhook/package.nix
+++ b/pkgs/by-name/gh/gh-webhook/package.nix
@@ -26,7 +26,7 @@ buildGoModule (finalAttrs: {
     description = "GitHub CLI extension to chatter with Webhooks";
     homepage = "https://github.com/cli/gh-webhook";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ adamperkowski ];
+    maintainers = with lib.maintainers; [ koi ];
     mainProgram = "gh-webhook";
   };
 })

--- a/pkgs/by-name/go/gocheat/package.nix
+++ b/pkgs/by-name/go/gocheat/package.nix
@@ -27,7 +27,7 @@ buildGoModule (finalAttrs: {
     homepage = "https://github.com/Achno/gocheat";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
-      adamperkowski
+      koi
       sebaguardian
     ];
     mainProgram = "gocheat";

--- a/pkgs/by-name/ju/julec/package.nix
+++ b/pkgs/by-name/ju/julec/package.nix
@@ -122,7 +122,7 @@ clangStdenv.mkDerivation (finalAttrs: {
     ];
     mainProgram = "julec";
     maintainers = with lib.maintainers; [
-      adamperkowski
+      koi
       sebaguardian
     ];
   };

--- a/pkgs/by-name/ki/kitget/package.nix
+++ b/pkgs/by-name/ki/kitget/package.nix
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   src = fetchFromGitea {
     domain = "codeberg.org";
-    owner = "adamperkowski";
+    owner = "koibtw";
     repo = "kitget";
     tag = "v${finalAttrs.version}";
     hash = "sha256-i26nu5SkcPhqwh+/bw1rz7h8K2u+hhSsOGiLj3sF1RQ=";
@@ -28,9 +28,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Display and customize cat images in your terminal";
-    homepage = "https://codeberg.org/adamperkowski/kitget";
+    homepage = "https://codeberg.org/koibtw/kitget";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ adamperkowski ];
+    maintainers = with lib.maintainers; [ koi ];
     mainProgram = "kitget";
     platforms = lib.platforms.linux;
   };

--- a/pkgs/by-name/nv/nvrs/package.nix
+++ b/pkgs/by-name/nv/nvrs/package.nix
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.1.9";
 
   src = fetchFromGitHub {
-    owner = "adamperkowski";
+    owner = "koibtw";
     repo = "nvrs";
     tag = "v${finalAttrs.version}";
     hash = "sha256-6ATkebFYuOOvhzSO+gClPbtaz9/Zph4m8/cqkufRYFw=";
@@ -47,9 +47,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "Fast new version checker for software releases";
     homepage = "https://nvrs.adamperkowski.dev";
-    changelog = "https://github.com/adamperkowski/nvrs/blob/v${finalAttrs.version}/CHANGELOG.md";
+    changelog = "https://github.com/koibtw/nvrs/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ adamperkowski ];
+    maintainers = with lib.maintainers; [ koi ];
     mainProgram = "nvrs";
     platforms = lib.platforms.linux;
   };

--- a/pkgs/by-name/pr/prettier-plugin-jinja-template/package.nix
+++ b/pkgs/by-name/pr/prettier-plugin-jinja-template/package.nix
@@ -24,7 +24,7 @@ buildNpmPackage (finalAttrs: {
     description = "Formatter plugin for Jinja2 template files";
     homepage = "https://github.com/davidodenwald/prettier-plugin-jinja-template";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ adamperkowski ];
+    maintainers = with lib.maintainers; [ koi ];
     mainProgram = "prettier-plugin-jinja-template";
   };
 })

--- a/pkgs/by-name/zs/zsnow/package.nix
+++ b/pkgs/by-name/zs/zsnow/package.nix
@@ -65,7 +65,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "XSnow for Wayland";
     homepage = "https://github.com/DarkVanityOfLight/ZSnoW";
     license = lib.licenses.cc-by-nc-sa-40;
-    maintainers = [ lib.maintainers.adamperkowski ];
+    maintainers = [ lib.maintainers.koi ];
     platforms = lib.platforms.linux;
     mainProgram = "zsnow";
   };


### PR DESCRIPTION
new username. all verifiable, package sources all redirect from `adamperkowski` to `koibtw`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
