### PR TITLE
ocamlPackages.labltk: clean & fix

### DIFF
--- a/pkgs/development/ocaml-modules/labltk/default.nix
+++ b/pkgs/development/ocaml-modules/labltk/default.nix
@@ -11,85 +11,66 @@
 }:
 
 let
-  defaultStdenv = stdenv;
-  params =
-    let
-      mkNewParam =
-        {
-          version,
-          sha256,
-          rev ? version,
-          stdenv ? defaultStdenv,
-        }:
-        {
-          inherit stdenv version;
-          src = fetchzip {
-            url = "https://github.com/garrigue/labltk/archive/${rev}.tar.gz";
-            inherit sha256;
-          };
-        };
-    in
-    rec {
-      "4.06" = mkNewParam {
-        version = "8.06.4";
-        rev = "labltk-8.06.4";
-        sha256 = "03xwnnnahb2rf4siymzqyqy8zgrx3h26qxjgbp5dh1wdl7n02c7g";
-        stdenv = gcc13Stdenv;
-      };
-      "4.07" = mkNewParam {
-        version = "8.06.5";
-        rev = "1b71e2c6f3ae6847d3d5e79bf099deb7330fb419";
-        sha256 = "02vchmrm3izrk7daldd22harhgrjhmbw6i1pqw6hmfmrmrypypg2";
-        stdenv = gcc13Stdenv;
-      };
-      _8_06_7 = mkNewParam {
-        version = "8.06.7";
-        sha256 = "1cqnxjv2dvw9csiz4iqqyx6rck04jgylpglk8f69kgybf7k7xk2h";
-        stdenv = gcc13Stdenv;
-      };
-      "4.08" = _8_06_7;
-      "4.09" = _8_06_7;
-      "4.10" = mkNewParam {
-        version = "8.06.8";
-        sha256 = "0lfjc7lscq81ibqb3fcybdzs2r1i2xl7rsgi7linq46a0pcpkinw";
-      };
-      "4.11" = mkNewParam {
-        version = "8.06.9";
-        sha256 = "1k42k3bjkf22gk39lwwzqzfhgjyhxnclslldrzpg5qy1829pbnc0";
-      };
-      "4.12" = mkNewParam {
-        version = "8.06.10";
-        sha256 = "06cck7wijq4zdshzhxm6jyl8k3j0zglj2axsyfk6q1sq754zyf4a";
-      };
-      "4.13" = mkNewParam {
-        version = "8.06.11";
-        sha256 = "1zjpg9jvs6i9jvbgn6zgispwqiv8rxvaszxcx9ha9fax3wzhv9qy";
-      };
-      "4.14" = mkNewParam {
-        version = "8.06.12";
-        sha256 = "sha256:17fmb13l18isgwr38hg9r5a0nayf2hhw6acj5153cy1sygsdg3b5";
-      };
-      "5.0" = mkNewParam {
-        version = "8.06.13";
-        sha256 = "sha256-Vpf13g3DEWlUI5aypiowGp2fkQPK0cOGv2XiRUY/Ip4=";
-      };
-      "5.2" = mkNewParam {
-        version = "8.06.14";
-        sha256 = "sha256-eVSQetk+i3KObjHfsvnD615cIsq3aZ7IxycX42cuPIU=";
-      };
-      "5.3" = mkNewParam {
-        version = "8.06.15";
-        sha256 = "sha256-I/y5qr5sasCtlrwxL/Lex79rg0o4tzDMBmQY7MdpU2w=";
-      };
+  params = {
+    "4.09" = {
+      version = "8.06.7";
+      sha256 = "1cqnxjv2dvw9csiz4iqqyx6rck04jgylpglk8f69kgybf7k7xk2h";
+      stdenv = gcc13Stdenv;
     };
-  param =
-    params.${lib.versions.majorMinor ocaml.version}
-    or (throw "labltk is not available for OCaml ${ocaml.version}");
+    "4.10" = {
+      version = "8.06.8";
+      sha256 = "0lfjc7lscq81ibqb3fcybdzs2r1i2xl7rsgi7linq46a0pcpkinw";
+      stdenv = gcc13Stdenv;
+    };
+    "4.11" = {
+      version = "8.06.9";
+      sha256 = "1k42k3bjkf22gk39lwwzqzfhgjyhxnclslldrzpg5qy1829pbnc0";
+      stdenv = gcc13Stdenv;
+    };
+    "4.12" = {
+      version = "8.06.10";
+      sha256 = "06cck7wijq4zdshzhxm6jyl8k3j0zglj2axsyfk6q1sq754zyf4a";
+    };
+    "4.13" = {
+      version = "8.06.11";
+      sha256 = "1zjpg9jvs6i9jvbgn6zgispwqiv8rxvaszxcx9ha9fax3wzhv9qy";
+    };
+    "4.14" = {
+      version = "8.06.12";
+      sha256 = "sha256:17fmb13l18isgwr38hg9r5a0nayf2hhw6acj5153cy1sygsdg3b5";
+    };
+    "5.0" = {
+      version = "8.06.13";
+      sha256 = "sha256-Vpf13g3DEWlUI5aypiowGp2fkQPK0cOGv2XiRUY/Ip4=";
+    };
+    "5.2" = {
+      version = "8.06.14";
+      sha256 = "sha256-eVSQetk+i3KObjHfsvnD615cIsq3aZ7IxycX42cuPIU=";
+    };
+    "5.3" = {
+      version = "8.06.15";
+      sha256 = "sha256-I/y5qr5sasCtlrwxL/Lex79rg0o4tzDMBmQY7MdpU2w=";
+    };
+  };
+  param = {
+    inherit stdenv;
+    # Dummy version to let the `meta` attribute set evaluate
+    version = "";
+    sha256 = lib.fakeSha256;
+  }
+  // (params."${lib.versions.majorMinor ocaml.version}" or {
+  }
+  );
 in
 
 param.stdenv.mkDerivation {
-  inherit (param) version src;
+  inherit (param) version;
   pname = "ocaml${ocaml.version}-labltk";
+
+  src = fetchzip {
+    url = "https://github.com/garrigue/labltk/archive/${param.version}.tar.gz";
+    inherit (param) sha256;
+  };
 
   strictDeps = true;
 


### PR DESCRIPTION
Current version has build & evaluation issues

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
