### PR TITLE
hytale-launcher: init at 2026.03.03-a4f6003

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13725,6 +13725,12 @@
     githubId = 34152449;
     name = "Karl Hallsby";
   };
+  karol-broda = {
+    email = "nix@karolbroda.com";
+    github = "karol-broda";
+    githubId = 122811026;
+    name = "Karol Broda";
+  };
   karpfediem = {
     name = "Karpfen";
     github = "karpfediem";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15455,6 +15455,14 @@
     githubId = 591860;
     name = "Lionello Lunesu";
   };
+  liquidnya = {
+    name = "Alice ✨🌙 Luna";
+    github = "liquidnya";
+    githubId = 7364785;
+    email = "alice@liquidnya.dev";
+    matrix = "@liquidnya:matrix.org";
+    keys = [ { fingerprint = "7C2D E075 FA93 D61C C9A7  876F 7966 C19E 32F9 EF06"; } ];
+  };
   lisanna-dettwyler = {
     email = "lisanna.dettwyler@gmail.com";
     github = "lisanna-dettwyler";

--- a/pkgs/by-name/hy/hytale-launcher/package.nix
+++ b/pkgs/by-name/hy/hytale-launcher/package.nix
@@ -14,7 +14,6 @@
   glib,
   webkitgtk_4_1,
   xdg-utils,
-  temurin-bin-25,
   libGL,
   alsa-lib,
   udev,
@@ -56,6 +55,22 @@ let
     stripRoot = false;
   };
 
+  launcherRunScript = writeScript "hytale-launcher-run" ''
+    #!/bin/bash
+    LAUNCHER_DIR="$HOME/.local/share/Hytale/bin"
+    LAUNCHER_BIN="$LAUNCHER_DIR/hytale-launcher"
+    NIX_BIN="${src}/hytale-launcher"
+    NIX_STORE_PATH_FILE="$LAUNCHER_DIR/.nix-store-path"
+
+    if [[ ! -f "$LAUNCHER_BIN" ]] || [[ "$(cat "$NIX_STORE_PATH_FILE" 2>/dev/null)" != "$NIX_BIN" ]]; then
+      mkdir -p "$LAUNCHER_DIR"
+      cp "$NIX_BIN" "$LAUNCHER_BIN"
+      echo "$NIX_BIN" > "$NIX_STORE_PATH_FILE"
+    fi
+
+    exec "$LAUNCHER_BIN" "$@"
+  '';
+
   fhsEnv = buildFHSEnv {
     pname = "hytale-launcher";
     version = finalVersion;
@@ -87,7 +102,7 @@ let
       stdenv.cc.cc.lib
     ];
 
-    runScript = "${src}/hytale-launcher";
+    runScript = "${launcherRunScript}";
 
     extraBwrapArgs = [
       "--setenv __NV_DISABLE_EXPLICIT_SYNC 1"
@@ -95,7 +110,6 @@ let
       # taken from the flatpak at https://launcher.hytale.com/builds/release/linux/amd64/hytale-launcher-latest.flatpak
       "--setenv WEBKIT_DISABLE_COMPOSITING_MODE 1"
       "--setenv DESKTOP_STARTUP_ID com.hypixel.HytaleLauncher"
-      "--setenv JAVA_HOME ${temurin-bin-25}"
     ];
 
     extraInstallCommands = ''

--- a/pkgs/by-name/hy/hytale-launcher/package.nix
+++ b/pkgs/by-name/hy/hytale-launcher/package.nix
@@ -1,0 +1,156 @@
+{
+  lib,
+  stdenv,
+  fetchzip,
+  buildFHSEnv,
+  makeWrapper,
+  makeDesktopItem,
+  writeScript,
+  gtk3,
+  nss,
+  libsecret,
+  libsoup_3,
+  gdk-pixbuf,
+  glib,
+  webkitgtk_4_1,
+  xdg-utils,
+  temurin-bin-25,
+  libGL,
+  alsa-lib,
+  udev,
+  libx11,
+  libxcursor,
+  libxrandr,
+  libxi,
+  icu,
+  openssl,
+  version ? null,
+  hytaleHashes ? null,
+}:
+
+let
+  sources = lib.importJSON ./pin.json;
+
+  finalVersion = if version != null then version else sources.version;
+  finalHytaleHashes = if hytaleHashes != null then hytaleHashes else sources.hashes;
+
+  # TODO: add icon once a stable versioned source is available
+  desktopItem = makeDesktopItem {
+    name = "hytale-launcher";
+    desktopName = "Hytale Launcher";
+    exec = "hytale-launcher";
+    comment = "Official launcher for Hytale";
+    categories = [ "Game" ];
+    terminal = false;
+    startupWMClass = "com.hypixel.HytaleLauncher";
+  };
+
+  os = if stdenv.hostPlatform.system == "x86_64-linux" then "linux" else "darwin";
+  arch = if stdenv.hostPlatform.system == "x86_64-linux" then "amd64" else "arm64";
+
+  src = fetchzip {
+    url = "https://launcher.hytale.com/builds/release/${os}/${arch}/hytale-launcher-${finalVersion}.zip";
+    hash =
+      finalHytaleHashes.${stdenv.hostPlatform.system}
+        or (throw "unsupported system: ${stdenv.hostPlatform.system}");
+    stripRoot = false;
+  };
+
+  fhsEnv = buildFHSEnv {
+    pname = "hytale-launcher";
+    version = finalVersion;
+
+    targetPkgs = pkgs: [
+      # launcher dependencies (webkit/tauri)
+      gtk3
+      nss
+      libsecret
+      libsoup_3
+      gdk-pixbuf
+      glib
+      webkitgtk_4_1
+      xdg-utils
+      # graphics
+      libGL
+      # audio
+      alsa-lib
+      # input/display
+      udev
+      libx11
+      libxcursor
+      libxrandr
+      libxi
+      # .NET runtime dependencies :(
+      icu
+      openssl
+      # misc
+      stdenv.cc.cc.lib
+    ];
+
+    runScript = "${src}/hytale-launcher";
+
+    extraBwrapArgs = [
+      "--setenv __NV_DISABLE_EXPLICIT_SYNC 1"
+      "--setenv WEBKIT_DISABLE_DMABUF_RENDERER 1"
+      # taken from the flatpak at https://launcher.hytale.com/builds/release/linux/amd64/hytale-launcher-latest.flatpak
+      "--setenv WEBKIT_DISABLE_COMPOSITING_MODE 1"
+      "--setenv DESKTOP_STARTUP_ID com.hypixel.HytaleLauncher"
+      "--setenv JAVA_HOME ${temurin-bin-25}"
+    ];
+
+    extraInstallCommands = ''
+      mkdir -p $out/share/applications
+      cp ${desktopItem}/share/applications/*.desktop $out/share/applications/
+    '';
+
+    passthru = {
+      inherit src;
+      updateScript = ./update.sh;
+    };
+
+    meta = {
+      description = "Official launcher for Hytale";
+      longDescription = ''
+        Official launcher for Hytale, an upcoming block-based game from Hypixel Studios.
+
+        Note: The launcher's built-in auto-update mechanism will not work on NixOS
+        due to the immutable nature of the Nix store. You may see an error message
+        about "failed to remove existing executable: read-only file system", this
+        is expected and the launcher will continue to work. Updates must be applied
+        by updating the nixpkgs package.
+      '';
+      homepage = "https://hytale.com";
+      license = lib.licenses.unfree;
+      maintainers = with lib.maintainers; [
+        gepbird
+        karol-broda
+        liquidnya
+      ];
+      mainProgram = "hytale-launcher";
+      platforms = [
+        "x86_64-linux"
+        "aarch64-darwin"
+      ];
+      sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    };
+  };
+
+  darwinPackage = stdenv.mkDerivation {
+    pname = "hytale-launcher";
+    version = finalVersion;
+    inherit src;
+
+    nativeBuildInputs = [ makeWrapper ];
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p "$out/Applications" "$out/bin"
+      cp -r hytale-launcher.app "$out/Applications/"
+      makeWrapper "$out/Applications/hytale-launcher.app/Contents/MacOS/hytale-launcher" "$out/bin/hytale-launcher"
+      runHook postInstall
+    '';
+
+    inherit (fhsEnv) passthru meta;
+  };
+in
+if stdenv.hostPlatform.isDarwin then darwinPackage else fhsEnv

--- a/pkgs/by-name/hy/hytale-launcher/pin.json
+++ b/pkgs/by-name/hy/hytale-launcher/pin.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026.03.05-dea483c",
+  "version": "2026.03.09-9a5ec66",
   "hashes": {
-    "x86_64-linux": "sha256-LViFlYnelktFUzKhz4qHQeG1zPV/Ud3ZHIeWbCzjQTA=",
-    "aarch64-darwin": "sha256-/YDYZr2PwnkUcYsLK6djNWa2F1D3luph3zxFE/uTGoY="
+    "x86_64-linux": "sha256-84tEF15HFQwOKJW4MtuBTv2D0TEMWqOr9fK5jB/BeNc=",
+    "aarch64-darwin": "sha256-jmHmwwNe3Ur6uX3sONTsGjJU0nOdQIC15X5A139dzs8="
   }
 }

--- a/pkgs/by-name/hy/hytale-launcher/pin.json
+++ b/pkgs/by-name/hy/hytale-launcher/pin.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026.03.03-a4f6003",
+  "version": "2026.03.05-dea483c",
   "hashes": {
-    "x86_64-linux": "sha256-AiNtOekw3LxhIX4WLlmO3lTvC0RWkueQ1+aWhugX3Aw=",
-    "aarch64-darwin": "sha256-nhSraSCxuXyI29+ge9biwoUZiiWn6eHMBnQVIwkXWXU="
+    "x86_64-linux": "sha256-LViFlYnelktFUzKhz4qHQeG1zPV/Ud3ZHIeWbCzjQTA=",
+    "aarch64-darwin": "sha256-/YDYZr2PwnkUcYsLK6djNWa2F1D3luph3zxFE/uTGoY="
   }
 }

--- a/pkgs/by-name/hy/hytale-launcher/pin.json
+++ b/pkgs/by-name/hy/hytale-launcher/pin.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026.03.09-9a5ec66",
+  "version": "2026.03.24-a65f18c",
   "hashes": {
-    "x86_64-linux": "sha256-84tEF15HFQwOKJW4MtuBTv2D0TEMWqOr9fK5jB/BeNc=",
-    "aarch64-darwin": "sha256-jmHmwwNe3Ur6uX3sONTsGjJU0nOdQIC15X5A139dzs8="
+    "x86_64-linux": "sha256-pABTyxhUZe0pvrAnyYw5GCVBfr1xgJYc3uplZb3k8hk=",
+    "aarch64-darwin": "sha256-XacE+msmzwI3k7VLHnSk+2sujw1GKNFjdUx6eLzGJFU="
   }
 }

--- a/pkgs/by-name/hy/hytale-launcher/pin.json
+++ b/pkgs/by-name/hy/hytale-launcher/pin.json
@@ -1,0 +1,7 @@
+{
+  "version": "2026.03.03-a4f6003",
+  "hashes": {
+    "x86_64-linux": "sha256-AiNtOekw3LxhIX4WLlmO3lTvC0RWkueQ1+aWhugX3Aw=",
+    "aarch64-darwin": "sha256-nhSraSCxuXyI29+ge9biwoUZiiWn6eHMBnQVIwkXWXU="
+  }
+}

--- a/pkgs/by-name/hy/hytale-launcher/update.sh
+++ b/pkgs/by-name/hy/hytale-launcher/update.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env nix-shell
+#!nix-shell --pure -I nixpkgs=./. -i bash -p bash curl cacert jq nix nix-prefetch
+
+launcherJson=$(curl -s https://launcher.hytale.com/version/release/launcher.json)
+
+function launcherJq() {
+  echo "$launcherJson" | jq --raw-output "$@"
+}
+
+latestVersion=$(launcherJq '.version')
+if [[ $latestVersion == "$UPDATE_NIX_OLD_VERSION" ]]; then
+  echo "package is up-to-date"
+  exit 0
+fi
+
+function selectUrlAndHash() {
+  local os="$1"
+  local arch="$2"
+  # shellcheck disable=SC2016
+  launcherJq --arg os "$os" --arg arch "$arch" '[.download_url[$os][$arch].url, .download_url[$os][$arch].sha256] | join(" ")'
+}
+
+function prefetch() {
+  nix store prefetch-file --json --hash-type sha256 "$@" | jq --raw-output '[.hash, .storePath] | join(" ")'
+}
+
+function fetchzipFile() {
+  local file="$1"
+  shift
+  # keep a reference to the store path to keep it in the sandbox
+  derivationArgs="{ src = builtins.storePath $(echo -n "$file" | jq -Rsa '.'); }"
+  nix-prefetch -I nixpkgs=./. --quiet fetchzip --url "file://$file" --derivationArgs --expr "$derivationArgs" "$@"
+}
+
+function update() {
+  local system="$1"
+  shift
+  read -r url expectedHash < <(selectUrlAndHash "$@")
+  read -r _zipHash zipPath < <(prefetch --expected-hash "$expectedHash" "$url")
+  hash=$(fetchzipFile "$zipPath" --no-stripRoot)
+
+  currentPin="$(dirname "${BASH_SOURCE[0]}")/pin.json"
+  newPin=$(mktemp)
+  jq --arg ver "$latestVersion" --arg sys "$system" --arg hash "$hash" \
+     '.version = $ver | .hashes[$sys] = $hash' \
+     "$currentPin" > "$newPin"
+  mv "$newPin" "$currentPin"
+}
+
+update "x86_64-linux" "linux" "amd64"
+update "aarch64-darwin" "darwin" "arm64"


### PR DESCRIPTION
adds the official hytale launcher, a game launcher for [hytale](https://hytale.com) - an upcoming block-based game from hypixel studios.

the package fetches the prebuilt linux binary and patches it with autoPatchelfHook for nixos compatibility

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
