### PR TITLE
gst_all_1.gst-plugins-good: Request assembly optimisations, exclude nasm on non-x86_64

### DIFF
--- a/pkgs/development/libraries/gstreamer/good/default.nix
+++ b/pkgs/development/libraries/gstreamer/good/default.nix
@@ -103,10 +103,13 @@ stdenv.mkDerivation (finalAttrs: {
     meson
     ninja
     gettext
-    nasm
     orc
     libshout
     glib
+  ]
+  # https://gitlab.freedesktop.org/gstreamer/gstreamer/-/blob/bb7069bd6fff80e8599d6e79f3f000b83dbce4d6/subprojects/gst-plugins-good/meson.build#L435-443
+  ++ lib.optionals stdenv.hostPlatform.isx86_64 [
+    nasm
   ]
   ++ lib.optionals enableDocumentation [
     hotdoc
@@ -208,6 +211,7 @@ stdenv.mkDerivation (finalAttrs: {
     "-Dexamples=disabled" # requires many dependencies and probably not useful for our users
     "-Dglib_debug=disabled" # cast checks should be disabled on stable releases
     (lib.mesonEnable "doc" enableDocumentation)
+    (lib.mesonEnable "asm" true)
   ]
   ++ lib.optionals (!qt5Support) [
     "-Dqt5=disabled"


### PR DESCRIPTION
I was looking over at my ppc64 machine and wondering why it was building NASM. It's not a *huge* dependency, but it's still abit curious.

https://gitlab.freedesktop.org/gstreamer/gstreamer/-/blob/bb7069bd6fff80e8599d6e79f3f000b83dbce4d6/subprojects/gst-plugins-good/meson.build#L435-443

NASM is an x86-specific assembler. gst-plugins-good only looks for & uses it when targeting x86_64. So let's exclude it when targeting anything else.

Let's also explicitly request asm via a Meson option, so if this ever needs anything else (on x86_64 or another arch), or if it finds but fails to run NASM, it'll fail loudly instead of quietly.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux (cross)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
