### PR TITLE
nixos/cage: add option to restart service if changed

### DIFF
--- a/nixos/modules/services/wayland/cage.nix
+++ b/nixos/modules/services/wayland/cage.nix
@@ -14,6 +14,13 @@ in
   options.services.cage = {
     enable = mkEnableOption "cage kiosk service";
 
+    restartIfChanged = mkOption {
+      type = types.bool;
+      default = false;
+      example = true;
+      description = "Whether to restart the 'cage-tty1' service when its configuration changes.";
+    };
+
     user = mkOption {
       type = types.str;
       default = "demo";
@@ -74,7 +81,7 @@ in
       wantedBy = [ "graphical.target" ];
       conflicts = [ "getty@tty1.service" ];
 
-      restartIfChanged = false;
+      restartIfChanged = cfg.restartIfChanged;
       unitConfig.ConditionPathExists = "/dev/tty1";
       serviceConfig = {
         ExecStart = ''

--- a/nixos/modules/services/wayland/cage.nix
+++ b/nixos/modules/services/wayland/cage.nix
@@ -11,43 +11,45 @@ let
   cfg = config.services.cage;
 in
 {
-  options.services.cage.enable = mkEnableOption "cage kiosk service";
+  options.services.cage = {
+    enable = mkEnableOption "cage kiosk service";
 
-  options.services.cage.user = mkOption {
-    type = types.str;
-    default = "demo";
-    description = ''
-      User to log-in as.
-    '';
-  };
-
-  options.services.cage.extraArguments = mkOption {
-    type = types.listOf types.str;
-    default = [ ];
-    defaultText = literalExpression "[]";
-    description = "Additional command line arguments to pass to Cage.";
-    example = [ "-d" ];
-  };
-
-  options.services.cage.environment = mkOption {
-    type = types.attrsOf types.str;
-    default = { };
-    example = {
-      WLR_LIBINPUT_NO_DEVICES = "1";
+    user = mkOption {
+      type = types.str;
+      default = "demo";
+      description = ''
+        User to log-in as.
+      '';
     };
-    description = "Additional environment variables to pass to Cage.";
-  };
 
-  options.services.cage.program = mkOption {
-    type = types.path;
-    default = "${pkgs.xterm}/bin/xterm";
-    defaultText = literalExpression ''"''${pkgs.xterm}/bin/xterm"'';
-    description = ''
-      Program to run in cage.
-    '';
-  };
+    extraArguments = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      defaultText = literalExpression "[]";
+      description = "Additional command line arguments to pass to Cage.";
+      example = [ "-d" ];
+    };
 
-  options.services.cage.package = mkPackageOption pkgs "cage" { };
+    environment = mkOption {
+      type = types.attrsOf types.str;
+      default = { };
+      example = {
+        WLR_LIBINPUT_NO_DEVICES = "1";
+      };
+      description = "Additional environment variables to pass to Cage.";
+    };
+
+    program = mkOption {
+      type = types.path;
+      default = "${pkgs.xterm}/bin/xterm";
+      defaultText = literalExpression ''"''${pkgs.xterm}/bin/xterm"'';
+      description = ''
+        Program to run in cage.
+      '';
+    };
+
+    package = mkPackageOption pkgs "cage" { };
+  };
 
   config = mkIf cfg.enable {
 


### PR DESCRIPTION
Added an option to restart the Cage service if the configuration changes. Since Cage is primarily a kiosk compositor made for running one app at a time, it is often necessary to restart Cage if the app changes, contrary to other general-purpose compositors where keeping them alive is often desired.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
