### PR TITLE
hyprdynamicmonitors: init at 1.4.0

### DIFF
--- a/pkgs/by-name/hy/hyprdynamicmonitors/package.nix
+++ b/pkgs/by-name/hy/hyprdynamicmonitors/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildGoModule,
+  installShellFiles,
+  stdenv,
+}:
+buildGoModule (finalAttrs: {
+  pname = "hyprdynamicmonitors";
+  version = "1.4.0";
+
+  src = fetchFromGitHub {
+    owner = "fiffeek";
+    repo = "hyprdynamicmonitors";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-msAgix63TsGgETwJajdr//F19+UUhGCbrjinNbgMPHo=";
+  };
+
+  vendorHash = "sha256-WBK1PhhxaRa0FUAfSxtKOiesw71wy0753FYIgSlo0bE=";
+
+  subPackages = [ "." ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/fiffeek/hyprdynamicmonitors/cmd.Version=${finalAttrs.version}"
+    "-X github.com/fiffeek/hyprdynamicmonitors/cmd.Commit=unknown"
+    "-X github.com/fiffeek/hyprdynamicmonitors/cmd.BuildDate=1970-01-01T00:00:00Z"
+  ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd hyprdynamicmonitors \
+      --bash <($out/bin/hyprdynamicmonitors completion bash) \
+      --fish <($out/bin/hyprdynamicmonitors completion fish) \
+      --zsh <($out/bin/hyprdynamicmonitors completion zsh)
+  '';
+
+  meta = {
+    description = "Dynamic monitor configuration for Hyprland";
+    homepage = "https://github.com/fiffeek/hyprdynamicmonitors";
+    changelog = "https://github.com/fiffeek/hyprdynamicmonitors/releases/tag/v${finalAttrs.version}";
+    mainProgram = "hyprdynamicmonitors";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ nukdokplex ];
+  };
+})


### PR DESCRIPTION
derivation was taken from project's repo flake

@fiffeek you can help upstream you project to nixpkgs

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
