### PR TITLE
luciole: init at 2026-01-19

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -695,6 +695,12 @@
     githubId = 25004152;
     name = "Adrian Gunnar Lauterer";
   };
+  AdrienCos = {
+    email = "adrien@cosson.io";
+    github = "AdrienCos";
+    githubId = 25573947;
+    name = "Adrien Cosson";
+  };
   AdrienLemaire = {
     email = "lemaire.adrien@gmail.com";
     github = "AdrienLemaire";

--- a/pkgs/by-name/lu/luciole/package.nix
+++ b/pkgs/by-name/lu/luciole/package.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchzip,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "luciole";
+  version = "2026-01-19";
+
+  src = fetchzip {
+    url = "https://luciole-vision.com/fonts/Luciole_webfonts.zip";
+    hash = "sha256-67yd5U8RmTX+zf9qnmrnZ4WITV674DJcYWovXaS402Y=";
+  };
+
+  # The .zip contains multiple formats, only install the .ttf ones
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 -t $out/share/fonts/truetype $src/Luciole_webfonts/Luciole-*/*.ttf
+
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://luciole-vision.com";
+    description = "Sans-serif typeface optimized for visual impairment";
+    longDescription = ''
+      Luciole is a new typeface developed explicitly for visually impaired people.
+    '';
+    license = lib.licenses.cc-by-40;
+    maintainers = with lib.maintainers; [ AdrienCos ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
An open-source typeface specially developed for people with vision impairments.

Note: the homepage of the typeface does not mention any versioning information, I used `1.0` as a placeholder for now. If it needs to be changed/removed, let me know.

https://luciole-vision.com

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
