### PR TITLE
glslang: Enable tests

### DIFF
--- a/pkgs/by-name/gl/glslang/external-gtest.patch
+++ b/pkgs/by-name/gl/glslang/external-gtest.patch
@@ -1,0 +1,69 @@
+From ab20ba112e6fa5117bfeadde199fdc6c18cbdfb5 Mon Sep 17 00:00:00 2001
+From: OPNA2608 <opna2608@protonmail.com>
+Date: Mon, 12 Jan 2026 16:41:53 +0100
+Subject: [PATCH] Look for external gtest build, if not building in-tree
+
+---
+ CMakeLists.txt        | 12 ++++++++++++
+ gtests/CMakeLists.txt |  8 +++-----
+ 2 files changed, 15 insertions(+), 5 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 1e7d3ec9..ecda9c53 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -321,6 +321,18 @@ if(ENABLE_GLSLANG_BINARIES)
+     add_subdirectory(StandAlone)
+ endif()
+ 
++option(ALLOW_EXTERNAL_GTEST "Allows to build against installed googletest. This is unsupported if the commit isn't the one in known_good.json")
++set(GMOCK_TARGET gmock)
++if(NOT TARGET ${GMOCK_TARGET})
++    if(ALLOW_EXTERNAL_GTEST)
++        message(STATUS "Trying to find local googletest")
++        find_package(GTest)
++        if(TARGET GTest::gmock)
++            set(GMOCK_TARGET GTest::gmock)
++        endif()
++    endif()
++endif()
++
+ if(GLSLANG_TESTS)
+     enable_testing()
+     add_subdirectory(gtests)
+diff --git a/gtests/CMakeLists.txt b/gtests/CMakeLists.txt
+index 27a5500c..21125775 100644
+--- a/gtests/CMakeLists.txt
++++ b/gtests/CMakeLists.txt
+@@ -32,7 +32,7 @@
+ # POSSIBILITY OF SUCH DAMAGE.
+ 
+ if(GLSLANG_TESTS)
+-    if(TARGET gmock)
++    if(TARGET ${GMOCK_TARGET})
+         message(STATUS "Google Mock found - building tests")
+ 
+         set(TEST_SOURCES
+@@ -76,9 +76,7 @@ if(GLSLANG_TESTS)
+                                    PRIVATE GLSLANG_TEST_BUILD=1)
+         target_include_directories(glslangtests PRIVATE
+                                    ${CMAKE_CURRENT_SOURCE_DIR}
+-                                   ${PROJECT_SOURCE_DIR}
+-                                   ${gmock_SOURCE_DIR}/include
+-                                   ${gtest_SOURCE_DIR}/include)
++                                   ${PROJECT_SOURCE_DIR})
+ 
+         if(ENABLE_OPT)
+             target_link_libraries(glslangtests
+@@ -90,7 +88,7 @@ if(GLSLANG_TESTS)
+             glslang glslang-default-resource-limits
+             $<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,9.0>>:stdc++fs>)
+ 
+-        target_link_libraries(glslangtests PRIVATE ${LIBRARIES} gmock)
++        target_link_libraries(glslangtests PRIVATE ${LIBRARIES} ${GMOCK_TARGET})
+ 
+         # The TARGET_RUNTIME_DLL_DIRS feature requires CMake 3.27 or greater.
+         if(WIN32 AND BUILD_SHARED_LIBS AND CMAKE_VERSION VERSION_LESS "3.27")
+-- 
+2.51.2
+


### PR DESCRIPTION
https://github.com/KhronosGroup/glslang/pull/4140

~~https://github.com/KhronosGroup/glslang/issues/3799 says that this fails on non-LE platforms, but the problematic tool in question was moved to SPIRV-tools in https://github.com/KhronosGroup/glslang/commit/3a7f78758f8faa9a6e059b09e25fc64ede7fbfb0, so that *might* no longer be an issue…
Making a note to check this out the next time my ppc64 machine is free, and send a follow-up PR to disable them on `!stdenv.hostPlatform.isLittleEndian` if they still fail.~~

Fails on non-LE due to different issues, skipping affected part of the tests.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] powerpc64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
