### PR TITLE
openarc: init at 1.3.0

### DIFF
--- a/pkgs/by-name/op/openarc/package.nix
+++ b/pkgs/by-name/op/openarc/package.nix
@@ -1,0 +1,83 @@
+{
+  lib,
+  autoreconfHook,
+  fetchFromGitHub,
+  makeWrapper,
+  stdenv,
+
+  jansson,
+  libidn2,
+  libmilter,
+  openssl,
+  pkg-config,
+  python3,
+  python3Packages,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "openarc";
+  version = "1.3.0";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "flowerysong";
+    repo = "OpenARC";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-eEQ0iiAt/RCxHJPpEiZY1TNgjGJjg+kMsVWI7vNaWlc=";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+    makeWrapper
+  ];
+
+  buildInputs = [
+    jansson
+    libidn2
+    libmilter
+    openssl
+  ];
+
+  enableParallelBuilding = true;
+
+  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isDarwin "-DBIND_8_COMPAT";
+
+  postInstall = ''
+    wrapProgram $out/bin/openarc-keygen \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          openssl
+          python3
+        ]
+      }
+  '';
+
+  doCheck = true;
+
+  nativeCheckInputs = [
+    openssl
+    python3Packages.miltertest
+    python3Packages.pytest
+  ];
+
+  # The build sandbox breaks these file permission tests
+  preCheck = ''
+    substituteInPlace test/test_config.py \
+      --replace-fail "def test_config_requiresafekeys" "def disabled_test_config_requiresafekeys"
+  '';
+
+  meta = {
+    homepage = "https://github.com/flowerysong/OpenARC";
+    description = "Open source library and filter for adding Authenticated Received Chain (ARC) support (RFC 8617) to email messages";
+    sourceProvenance = [ lib.sourceTypes.fromSource ];
+    license = with lib.licenses; [
+      bsd2
+      sendmail
+    ];
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ lucasbergman ];
+    mainProgram = "openarc";
+  };
+})

--- a/pkgs/development/python-modules/miltertest/default.nix
+++ b/pkgs/development/python-modules/miltertest/default.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "miltertest";
+  version = "1.0.0";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "flowerysong";
+    repo = "miltertest";
+    tag = "v${version}";
+    hash = "sha256-8KpuIR+UxRcJbb2pwKDOkSmyXovlyOa4DpeUDn1oK0Y=";
+  };
+
+  build-system = [ hatchling ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "miltertest" ];
+
+  meta = {
+    description = "Pure python implementation of the milter protocol";
+    homepage = "https://github.com/flowerysong/miltertest";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ lucasbergman ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10465,6 +10465,8 @@ self: super: with self; {
 
   millheater = callPackage ../development/python-modules/millheater { };
 
+  miltertest = callPackage ../development/python-modules/miltertest { };
+
   mim-solvers = callPackage ../development/python-modules/mim-solvers { inherit (pkgs) mim-solvers; };
 
   minari = callPackage ../development/python-modules/minari { };


### PR DESCRIPTION
OpenARC is an implementation of RFC 8617, a protocol for attaching a digitally signed chain of custody to mail messages. This is especially useful when a host wants to forward mail for that host's users to another provider. For example, Gmail recommends[1] that forwarding hosts attach an ARC seal to messages.

The original implementation[2] from the Trusted Domain Project has not been touched in about eight years, so this packages the @flowerysong repo. That is the same version packaged by Arch Linux[3].

1. https://support.google.com/a/answer/81126
2. https://github.com/trusteddomainproject/OpenARC
3. https://wiki.archlinux.org/title/OpenARC

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `fcf82a6f1cc2a95fbbc4abe755770256d43959d4`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>openarc</li>
  </ul>
</details>

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
