### PR TITLE
jqfmt: 0-unstable-2025-07-28 -> 0.1.0

### DIFF
--- a/pkgs/by-name/jq/jqfmt/package.nix
+++ b/pkgs/by-name/jq/jqfmt/package.nix
@@ -2,28 +2,25 @@
   buildGoModule,
   fetchFromGitHub,
   lib,
-  nix-update-script,
 }:
-buildGoModule {
+buildGoModule (finalAttrs: {
   pname = "jqfmt";
-  version = "0-unstable-2025-07-28";
+  version = "0.1.0";
 
   src = fetchFromGitHub {
     owner = "noperator";
     repo = "jqfmt";
-    rev = "74b59e03caff3ac5a8c061088d2c228a5c27b171";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-3PYIyjZm265atBAfuj5aHmWoAv4H29I7gN4/rjl1d0o=";
   };
 
   vendorHash = "sha256-avpZSgQKFZxLmYGj+2Gi+wSDHnAgF0/hyp4HtoQ0ZCo=";
 
-  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch=main" ]; };
-
   meta = {
     description = "Like gofmt, but for jq";
     homepage = "https://github.com/noperator/jqfmt";
-    license = lib.licenses.mit; # Doesn't have Licence file, but Readme points to MIT
+    license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ heisfer ];
     mainProgram = "jqfmt";
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Nothing changed, just unstable to tag release.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
