### PR TITLE
zig: move ZIG_GLOBAL_CACHE_DIR setup to configurePhase

### DIFF
--- a/doc/hooks/zig.section.md
+++ b/doc/hooks/zig.section.md
@@ -32,6 +32,10 @@ stdenv.mkDerivation {
 
 The variables below are exclusive to `zig`.
 
+#### `dontUseZigConfigure` {#dont-use-zig-configure}
+
+Disables using `zigConfigurePhase`.
+
 #### `dontUseZigBuild` {#dont-use-zig-build}
 
 Disables using `zigBuildPhase`.

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -2762,6 +2762,9 @@
     "index.html#zig-exclusive-variables",
     "index.html#zig-hook-exclusive-variables"
   ],
+  "dont-use-zig-configure": [
+    "index.html#dont-use-zig-configure"
+  ],
   "dont-use-zig-build": [
     "index.html#dont-use-zig-build"
   ],

--- a/pkgs/development/compilers/zig/setup-hook.sh
+++ b/pkgs/development/compilers/zig/setup-hook.sh
@@ -4,9 +4,13 @@
 readonly zigDefaultCpuFlag=@zig_default_cpu_flag@
 readonly zigDefaultOptimizeFlag=@zig_default_optimize_flag@
 
-function zigSetGlobalCacheDir {
+function zigConfigurePhase {
+  runHook preConfigure
+
   ZIG_GLOBAL_CACHE_DIR=$(mktemp -d)
   export ZIG_GLOBAL_CACHE_DIR
+
+  runHook postConfigure
 }
 
 function zigBuildPhase {
@@ -97,8 +101,9 @@ function zigInstallPhase {
   runHook postInstall
 }
 
-# shellcheck disable=SC2154
-addEnvHooks "$hostOffset" zigSetGlobalCacheDir
+if [ -z "${dontUseZigConfigure-}" ] && [ -z "${configurePhase-}" ]; then
+  configurePhase=zigConfigurePhase
+fi
 
 if [ -z "${dontUseZigBuild-}" ] && [ -z "${buildPhase-}" ]; then
   buildPhase=zigBuildPhase


### PR DESCRIPTION
This allows users to put zig in their `mkShell` without ending up with a ZIG_GLOBAL_CACHE_DIR value set that points back to a location that only would exist in the sandbox.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
