### PR TITLE
auto-claude: init at 2.7.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9990,6 +9990,12 @@
     githubId = 76840985;
     name = "GueLaKais";
   };
+  gui-wf = {
+    email = "dev@gui.wf";
+    github = "gui-wf";
+    githubId = 48162143;
+    name = "Guilherme Fontes";
+  };
   guibert = {
     email = "david.guibert@gmail.com";
     github = "dguibert";
@@ -10025,12 +10031,6 @@
     github = "guitargeek";
     githubId = 6578603;
     name = "Jonas Rembser";
-  };
-  gui-wf = {
-    name = "Guilherme Fontes";
-    email = "dev@gui.wf";
-    github = "gui-wf";
-    githubId = 48162143;
   };
   gurjaka = {
     name = "Gurami Esartia";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10026,6 +10026,12 @@
     githubId = 6578603;
     name = "Jonas Rembser";
   };
+  gui-wf = {
+    name = "Guilherme Fontes";
+    email = "dev@gui.wf";
+    github = "gui-wf";
+    githubId = 48162143;
+  };
   gurjaka = {
     name = "Gurami Esartia";
     email = "esartia.gurika@gmail.com";

--- a/pkgs/by-name/au/auto-claude/package.nix
+++ b/pkgs/by-name/au/auto-claude/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  appimageTools,
+  fetchurl,
+  nix-update-script,
+}:
+let
+  pname = "auto-claude";
+  version = "2.7.2";
+
+  src = fetchurl {
+    url = "https://github.com/AndyMik90/Auto-Claude/releases/download/v${version}/Auto-Claude-${version}-linux-x86_64.AppImage";
+    hash = "sha256-wI6jHRXnc2BcBEHzDDep5JJcpNLOFWzox4rWExBwUoA=";
+  };
+
+  appimageContents = appimageTools.extractType2 { inherit pname version src; };
+in
+appimageTools.wrapType2 {
+  inherit pname version src;
+
+  extraPkgs =
+    pkgs: with pkgs; [
+      libsecret
+      libGL
+      mesa
+    ];
+
+  extraInstallCommands = ''
+    # Install desktop file
+    install -Dm644 ${appimageContents}/auto-claude-ui.desktop \
+      $out/share/applications/${pname}.desktop
+
+    # Install icon (only 4096x4096 available in AppImage)
+    install -Dm644 ${appimageContents}/usr/share/icons/hicolor/4096x4096/apps/auto-claude-ui.png \
+      $out/share/icons/hicolor/4096x4096/apps/${pname}.png
+
+    # Fix desktop file paths
+    substituteInPlace $out/share/applications/${pname}.desktop \
+      --replace-fail 'Exec=AppRun --no-sandbox %U' 'Exec=${pname} %U' \
+      --replace-fail 'Icon=auto-claude-ui' 'Icon=${pname}'
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Autonomous multi-agent coding framework powered by Claude AI";
+    homepage = "https://github.com/AndyMik90/Auto-Claude";
+    downloadPage = "https://github.com/AndyMik90/Auto-Claude/releases";
+    changelog = "https://github.com/AndyMik90/Auto-Claude/releases/tag/v${version}";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ gui-wf ];
+    mainProgram = "auto-claude";
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+}

--- a/pkgs/by-name/au/auto-claude/package.nix
+++ b/pkgs/by-name/au/auto-claude/package.nix
@@ -6,11 +6,11 @@
 }:
 let
   pname = "auto-claude";
-  version = "2.7.2";
+  version = "2.7.4";
 
   src = fetchurl {
     url = "https://github.com/AndyMik90/Auto-Claude/releases/download/v${version}/Auto-Claude-${version}-linux-x86_64.AppImage";
-    hash = "sha256-wI6jHRXnc2BcBEHzDDep5JJcpNLOFWzox4rWExBwUoA=";
+    hash = "sha256-8aq8WEv64ZpeEVkEU3+L6n2doP8AFeKM8BcnA+thups=";
   };
 
   appimageContents = appimageTools.extractType2 { inherit pname version src; };


### PR DESCRIPTION
## Description

Add Auto-Claude, an autonomous multi-agent coding framework powered by Claude AI.

- Homepage: https://github.com/AndyMik90/Auto-Claude
- License: AGPL-3.0

## Package

Uses `appimageTools.wrapType2` to wrap the official AppImage release (standard pattern for Electron apps).

## Testing

- [x] `nix-build -A auto-claude` succeeds
- [x] Application launches and GUI appears
- [x] Desktop file and icons install correctly

## Maintainer

Adding myself (gui-wf) as maintainer.

cc @gui-wf