### PR TITLE
librecad: fix hash

### DIFF
--- a/pkgs/by-name/li/librecad/package.nix
+++ b/pkgs/by-name/li/librecad/package.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "LibreCAD";
     repo = "LibreCAD";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-s9QA0YC91aziFxgnSeH4+XtQu18cSiRc0B15tyyF8b0=";
+    hash = "sha256-pun0mMCIsL8XfFlP14EkpBitNHL4OKezPfAF17D9pLg=";
   };
 
   buildInputs = [


### PR DESCRIPTION
https://github.com/LibreCAD/LibreCAD/compare/9969a210248a895623930126b4f84e4e19de49a2...1598766fbd8d9ffe9ace21f17d049faa6d6288f9
https://github.com/LibreCAD/LibreCAD/issues/2439

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 479433`
Commit: `9dd85203b733e9e85d6c8a313491b4ca80c9d3a6`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 7 packages built:</summary>
  <ul>
    <li>librecad</li>
    <li>meerk40t</li>
    <li>meerk40t.dist</li>
    <li>python313Packages.ezdxf</li>
    <li>python313Packages.ezdxf.dist</li>
    <li>python314Packages.ezdxf</li>
    <li>python314Packages.ezdxf.dist</li>
  </ul>
</details>

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc