### PR TITLE
python3Packages.fickling: 0.1.6 -> 0.1.7

### DIFF
--- a/pkgs/development/python-modules/fickling/default.nix
+++ b/pkgs/development/python-modules/fickling/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  pythonOlder,
   hatchling,
   numpy,
   pytestCheckHook,
@@ -12,14 +13,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "fickling";
-  version = "0.1.6";
+  version = "0.1.7";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "trailofbits";
     repo = "fickling";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-p2XkHKqheVHqLTQKmUApiYH7NIaHc091B/TjiCDYWtA=";
+    hash = "sha256-uirVOJ6CI7gBu9lOoPtpjUZeBmIhBMI0tjSDI/ASy7w=";
   };
 
   build-system = [
@@ -45,11 +46,8 @@ buildPythonPackage (finalAttrs: {
   ]
   ++ lib.concatAttrValues finalAttrs.passthru.optional-dependencies;
 
-  disabledTestPaths = [
-    # https://github.com/trailofbits/fickling/issues/162
-    # AttributeError: module 'numpy.lib.format' has no attribute...
-    "test/test_polyglot.py"
-  ];
+  # Tests fail upstream in pytorch under python 3.14
+  doCheck = pythonOlder "3.14";
 
   pythonImportsCheck = [ "fickling" ];
 

--- a/pkgs/development/python-modules/fickling/default.nix
+++ b/pkgs/development/python-modules/fickling/default.nix
@@ -10,7 +10,7 @@
   torchvision,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "fickling";
   version = "0.1.6";
   pyproject = true;
@@ -18,7 +18,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "trailofbits";
     repo = "fickling";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-p2XkHKqheVHqLTQKmUApiYH7NIaHc091B/TjiCDYWtA=";
   };
 
@@ -40,7 +40,10 @@ buildPythonPackage rec {
     ];
   };
 
-  nativeCheckInputs = [ pytestCheckHook ] ++ lib.concatAttrValues optional-dependencies;
+  nativeCheckInputs = [
+    pytestCheckHook
+  ]
+  ++ lib.concatAttrValues finalAttrs.passthru.optional-dependencies;
 
   disabledTestPaths = [
     # https://github.com/trailofbits/fickling/issues/162
@@ -53,8 +56,8 @@ buildPythonPackage rec {
   meta = {
     description = "Python pickling decompiler and static analyzer";
     homepage = "https://github.com/trailofbits/fickling";
-    changelog = "https://github.com/trailofbits/fickling/releases/tag/${src.tag}";
+    changelog = "https://github.com/trailofbits/fickling/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.lgpl3Plus;
     maintainers = with lib.maintainers; [ sarahec ];
   };
-}
+})


### PR DESCRIPTION
1. Applied `finalAttrs` fix
2. Version bump (tested on python 3.13 and 3.14)

**Note**: package builds fine standalone but can fail in `nixpkgs-review` due to test failures in `python3.14-torch-2.9.1`. See https://github.com/pytorch/pytorch/issues/172254

Supersedes #479237 
Tracking: #475732

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
