### PR TITLE
[25.11] wayvr: init at 26.1.2

### DIFF
--- a/pkgs/by-name/wa/wayvr/package.nix
+++ b/pkgs/by-name/wa/wayvr/package.nix
@@ -1,0 +1,96 @@
+{
+  alsa-lib,
+  dbus,
+  fetchFromGitHub,
+  lib,
+  libX11,
+  libXext,
+  libXrandr,
+  libxcb,
+  libxkbcommon,
+  nix-update-script,
+  openssl,
+  openvr,
+  openxr-loader,
+  pipewire,
+  pkg-config,
+  procps,
+  pulseaudio,
+  rustPlatform,
+  shaderc,
+  stdenv,
+  testers,
+  wayvr,
+  withOpenVR ? !stdenv.hostPlatform.isAarch64,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "wayvr";
+  version = "26.1.2";
+
+  src = fetchFromGitHub {
+    owner = "wlx-team";
+    repo = "wayvr";
+    tag = "v${version}";
+    hash = "sha256-UZ5zcalez6B+212OqCaEXSoRfhaExuy0W8HX8b4flSU=";
+  };
+
+  cargoHash = "sha256-zqB2ybdpQEGdlkNin6mlUfaVRkpOtFl2CVCLAdKDMoQ=";
+
+  nativeBuildInputs = [
+    pkg-config
+    rustPlatform.bindgenHook
+  ];
+
+  buildInputs = [
+    alsa-lib
+    dbus
+    libX11
+    libXext
+    libXrandr
+    libxcb
+    libxkbcommon
+    openssl
+    openxr-loader
+    pipewire
+  ]
+  ++ lib.optionals withOpenVR [ openvr ];
+
+  env.SHADERC_LIB_DIR = "${lib.getLib shaderc}/lib";
+
+  postPatch = ''
+    substituteAllInPlace dash-frontend/src/util/pactl_wrapper.rs \
+      --replace-fail '"pactl"' '"${lib.getExe' pulseaudio "pactl"}"'
+
+    # steam_utils also calls xdg-open as well as steam. Those should probably be pulled from the environment
+    substituteInPlace dash-frontend/src/util/steam_utils.rs \
+      --replace-fail '"pkill"' '"${lib.getExe' procps "pkill"}"'
+  '';
+
+  buildNoDefaultFeatures = true;
+  buildFeatures = [
+    "openxr"
+    "osc"
+    "x11"
+    "wayland"
+  ]
+  ++ lib.optionals withOpenVR [ "openvr" ];
+
+  passthru = {
+    tests.testVersion = testers.testVersion { package = wayvr; };
+
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Your way to enjoy VR on Linux! Access your Wayland/X11 desktop from SteamVR/Monado (OpenVR+OpenXR support)";
+    homepage = "https://github.com/wlx-team/wayvr";
+    license = with lib.licenses; [
+      gpl3Only
+      mit # wayvr-ipc
+    ];
+    maintainers = with lib.maintainers; [ Scrumplex ];
+    platforms = lib.platforms.linux;
+    broken = stdenv.hostPlatform.isAarch64 && withOpenVR;
+    mainProgram = "wayvr";
+  };
+}


### PR DESCRIPTION
Partial backport of #478553

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
