### PR TITLE
nauty: 2.9.1 -> 2.9.3

### DIFF
--- a/pkgs/by-name/na/nauty/package.nix
+++ b/pkgs/by-name/na/nauty/package.nix
@@ -5,13 +5,13 @@
 }:
 stdenv.mkDerivation rec {
   pname = "nauty";
-  version = "2.9.1";
+  version = "2.9.3";
 
   src = fetchurl {
     url = "https://pallini.di.uniroma1.it/nauty${
       builtins.replaceStrings [ "." ] [ "_" ] version
     }.tar.gz";
-    sha256 = "sha256-SI+pBtEKNyxy0jZMXe5I4PcwcAT75SwrzlDFLejNhz4=";
+    sha256 = "sha256-n8TtrgT4ig9Yg5hb47Oc9/iY/WzJbpa57iVFJ0PMG1s=";
   };
 
   outputs = [
@@ -19,10 +19,8 @@ stdenv.mkDerivation rec {
     "dev"
   ];
 
-  # HACK: starting from 2.8.9, the makefile tries to copy .libs/*.a files unconditionally
-  dontDisableStatic = true;
-
   configureFlags = [
+    "--libdir=${placeholder "dev"}/lib"
     # Prevent nauty from sniffing some cpu features. While those are very
     # widely available, it can lead to nasty bugs when they are not available:
     # https://groups.google.com/forum/#!topic/sage-packaging/Pe4SRDNYlhA
@@ -31,19 +29,11 @@ stdenv.mkDerivation rec {
     "--${if stdenv.hostPlatform.sse4_aSupport then "enable" else "disable"}-clz"
   ];
 
-  installPhase = ''
-    mkdir -p "$out"/{bin,share/doc/nauty} "$dev"/{lib,include/nauty}
-
-    find . -type f -perm -111 \! -name '*.*' \! -name configure -exec cp '{}' "$out/bin" \;
+  postInstall = ''
+    mkdir -p "$out/share/doc/nauty" "$dev/include/nauty"
     cp [Rr][Ee][Aa][Dd]* COPYRIGHT This* [Cc]hange* "$out/share/doc/nauty"
-
     cp *.h "$dev/include/nauty"
-    for i in *.a; do
-      cp "$i" "$dev/lib/lib$i";
-    done
   '';
-
-  checkTarget = "checks";
 
   meta = {
     description = "Programs for computing automorphism groups of graphs and digraphs";


### PR DESCRIPTION
Remove our ad-hoc install phase, since nauty now has an install target.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
