### PR TITLE
haskellPackages.dataframe: pin to 0.3.3.6

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2034,6 +2034,10 @@ with haskellLib;
   # https://github.com/obsidiansystems/database-id/issues/1
   database-id-class = doJailbreak super.database-id-class;
 
+  # 2026-01-23: too strict bounds on random >= 1.3
+  # TODO: when (likely in 25.x) Stackage bumps random to 1.3, unpin
+  ihaskell-dataframe = doJailbreak super.ihaskell-dataframe;
+
   # Too strict version bounds on base
   # https://github.com/gibiansky/IHaskell/issues/1217
   ihaskell-display = doJailbreak super.ihaskell-display;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2034,6 +2034,12 @@ with haskellLib;
   # https://github.com/obsidiansystems/database-id/issues/1
   database-id-class = doJailbreak super.database-id-class;
 
+  # TODO: when (likely in 25.x) Stackage bumps random to 1.3, review
+  dataframe-persistent = lib.pipe super.dataframe-persistent [
+    doJailbreak # 2026-01-23: too strict bounds on dataframe >= 0.4
+    dontCheck # 2026-01-23: test uses dataframe function not exported in 0.3.3.6
+  ];
+
   # 2026-01-23: too strict bounds on random >= 1.3
   # TODO: when (likely in 25.x) Stackage bumps random to 1.3, unpin
   ihaskell-dataframe = doJailbreak super.ihaskell-dataframe;

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -1261,7 +1261,6 @@ broken-packages:
   - database-migrate # failure in job https://hydra.nixos.org/build/233201597 at 2023-09-02
   - database-study # failure in job https://hydra.nixos.org/build/233222466 at 2023-09-02
   - datadog # failure in job https://hydra.nixos.org/build/233191124 at 2023-09-02
-  - dataframe # failure in job https://hydra.nixos.org/build/315095739 at 2025-11-29
   - DataIndex # failure in job https://hydra.nixos.org/build/233254506 at 2023-09-02
   - datalog # failure in job https://hydra.nixos.org/build/233242707 at 2023-09-02
   - datapacker # failure in job https://hydra.nixos.org/build/233206524 at 2023-09-02

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -26,6 +26,9 @@
 # keep-sorted start skip_lines=1 case=no numeric=yes
 default-package-overrides:
   - chs-cabal == 0.1.1.2 # matches Cabal 3.12 (GHC 9.10)
+  # 2026-01-23: dataframe >= 0.3.3.7 uses random-1.3, which breaks dependency coherence on 25.11, whose default version is random-1.2
+  # TODO: when (likely in 25.x) Stackage bumps random to 1.3, review
+  - dataframe == 0.3.3.6
   # 2025-12-26: Needs to match egison-pattern-src from Stackage LTS
   - egison-pattern-src-th-mode < 0.2.2
   - extensions == 0.1.0.2 # matches Cabal 3.12 (GHC 9.10)

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
@@ -672,8 +672,6 @@ dont-distribute-packages:
  - datadog-tracing
  - datafix
  - dataflow
- - dataframe-hasktorch
- - dataframe-persistent
  - datasets
  - date-conversions
  - dbjava
@@ -1788,7 +1786,6 @@ dont-distribute-packages:
  - ifscs
  - ige-mac-integration
  - igrf
- - ihaskell-dataframe
  - ihaskell-rlangqq
  - ihaskell-symtegration
  - ihttp
@@ -3399,7 +3396,6 @@ dont-distribute-packages:
  - symantic-http-test
  - symantic-lib
  - symbiote
- - symbolic-regression
  - symmetry-operations-symbols
  - Synapse
  - synapse


### PR DESCRIPTION
`dataframe-0.4.0.5` had its `random` dependency [bumped upstream](https://github.com/mchav/dataframe/commit/4f2b414a5693088667ab49e321661bc1c4797ee2) from `>=1` to `>=1.3` on 2025-12-02, which broke the package. Pinning `dataframe` to the latest version that supports `random-1.2`, `0.3.3.6`, fixes this and avoids a bunch of coherency issues that would result from overriding `dataframe`'s dependency to use `random_1_3_1`. 

Other changes: 

- `ihaskell-dataframe`: jailbroke
- `dataframe-persistent`: jailbroke and ignored checks, which depend on `dataframe >= 0.4`

It is likely that `random` will be bumped to 1.3 in Stackage LTS 25; when that happens I believe this pinning can go away. 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux (wsl)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable: (not applicable)
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage]. 
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking. (rollback a major version of `dataframe`)
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
