### PR TITLE
jetbrains: 2025.3.1 -> 2025.3.1.1

### DIFF
--- a/pkgs/applications/editors/jetbrains/ides/clion.nix
+++ b/pkgs/applications/editors/jetbrains/ides/clion.nix
@@ -21,20 +21,20 @@ let
   # update-script-start: urls
   urls = {
     x86_64-linux = {
-      url = "https://download.jetbrains.com/cpp/CLion-2025.3.1.tar.gz";
-      hash = "sha256-RK49pTWLoBCmLVWrQSty82TF3NLC3NIASuNLdGOAe70=";
+      url = "https://download.jetbrains.com/cpp/CLion-2025.3.1.1.tar.gz";
+      hash = "sha256-vtTTqvG932G0LBOESaUvTOhF1vQiyvZKPuAu/QcQdzY=";
     };
     aarch64-linux = {
-      url = "https://download.jetbrains.com/cpp/CLion-2025.3.1-aarch64.tar.gz";
-      hash = "sha256-uWw4w9L3/3uYjXXJcP0OkDY+CbgnMQbe/Jrj3vqGjtc=";
+      url = "https://download.jetbrains.com/cpp/CLion-2025.3.1.1-aarch64.tar.gz";
+      hash = "sha256-Yh04N3okMfeqUUL3GZukSUJzMAHdBlE+quDMu/phFc4=";
     };
     x86_64-darwin = {
-      url = "https://download.jetbrains.com/cpp/CLion-2025.3.1.dmg";
-      hash = "sha256-moF0ySKfnIb4baGo4r2rUv+zaeoHgbV+skVwPryDB+I=";
+      url = "https://download.jetbrains.com/cpp/CLion-2025.3.1.1.dmg";
+      hash = "sha256-H6qUuONV/iYZwDJfylpDr/AvF+Wl4gnVkegZhr8hbmQ=";
     };
     aarch64-darwin = {
-      url = "https://download.jetbrains.com/cpp/CLion-2025.3.1-aarch64.dmg";
-      hash = "sha256-EcrorrQ9GHDZaYDx2Sf/VF+r7ZifO/TnMnkRtEHhSfE=";
+      url = "https://download.jetbrains.com/cpp/CLion-2025.3.1.1-aarch64.dmg";
+      hash = "sha256-I7FDOc8OM0P+FGMCdjKKcnHUbUTPRzFz7l56oTcGiXE=";
     };
   };
   # update-script-end: urls
@@ -48,8 +48,8 @@ in
   product = "CLion";
 
   # update-script-start: version
-  version = "2025.3.1";
-  buildNumber = "253.29346.141";
+  version = "2025.3.1.1";
+  buildNumber = "253.29346.307";
   # update-script-end: version
 
   src = fetchurl (urls.${system} or (throw "Unsupported system: ${system}"));

--- a/pkgs/applications/editors/jetbrains/ides/datagrip.nix
+++ b/pkgs/applications/editors/jetbrains/ides/datagrip.nix
@@ -12,20 +12,20 @@ let
   # update-script-start: urls
   urls = {
     x86_64-linux = {
-      url = "https://download.jetbrains.com/datagrip/datagrip-2025.3.2.tar.gz";
-      hash = "sha256-y27WR10h640wdUExvSQAPBFAlr+oT/zPM03BHPisYMw=";
+      url = "https://download.jetbrains.com/datagrip/datagrip-2025.3.3.tar.gz";
+      hash = "sha256-cV0shZxezpvllsM4aUJPLw+PzvSxqy44F5WE10VA764=";
     };
     aarch64-linux = {
-      url = "https://download.jetbrains.com/datagrip/datagrip-2025.3.2-aarch64.tar.gz";
-      hash = "sha256-Gm/rOqJV2s4zLMGLhoWTGBtupiw9nw02+QAyygUX0Gg=";
+      url = "https://download.jetbrains.com/datagrip/datagrip-2025.3.3-aarch64.tar.gz";
+      hash = "sha256-MWqkJiZ7ElSPLv0BT1dcszFbbZOr2Ub7gRrN2bUG1BY=";
     };
     x86_64-darwin = {
-      url = "https://download.jetbrains.com/datagrip/datagrip-2025.3.2.dmg";
-      hash = "sha256-A4OgpPL95YO2LqfTQuVxiw+jBvyDSVQcdb7FroQftPw=";
+      url = "https://download.jetbrains.com/datagrip/datagrip-2025.3.3.dmg";
+      hash = "sha256-JQfAVG4N2UFlQtyWF2GjHzozwOPGi6elInOSQyBf7js=";
     };
     aarch64-darwin = {
-      url = "https://download.jetbrains.com/datagrip/datagrip-2025.3.2-aarch64.dmg";
-      hash = "sha256-pyJFSNydo4Y3J7DBHO+dYT/ZUdFrqgFsoUB8VqnsaWQ=";
+      url = "https://download.jetbrains.com/datagrip/datagrip-2025.3.3-aarch64.dmg";
+      hash = "sha256-QwPJLy4Hv0FJErVTUDirG1iDn8noMlnyk4Zmk0uqZnQ=";
     };
   };
   # update-script-end: urls
@@ -39,8 +39,8 @@ mkJetBrainsProduct {
   product = "DataGrip";
 
   # update-script-start: version
-  version = "2025.3.2";
-  buildNumber = "253.29346.170";
+  version = "2025.3.3";
+  buildNumber = "253.29346.270";
   # update-script-end: version
 
   src = fetchurl (urls.${system} or (throw "Unsupported system: ${system}"));

--- a/pkgs/applications/editors/jetbrains/ides/idea.nix
+++ b/pkgs/applications/editors/jetbrains/ides/idea.nix
@@ -15,20 +15,20 @@ let
   # update-script-start: urls
   urls = {
     x86_64-linux = {
-      url = "https://download.jetbrains.com/idea/ideaIU-2025.3.1.tar.gz";
-      hash = "sha256-IeG5C17GhHZ6A0mLpCTvP5rMXb91nM7v1e3UdPBDrWw=";
+      url = "https://download.jetbrains.com/idea/ideaIU-2025.3.1.1.tar.gz";
+      hash = "sha256-OgZLIpYfPzm4ZrZLYoVY4ND3CNQjo/lWXUPw6BGWmXs=";
     };
     aarch64-linux = {
-      url = "https://download.jetbrains.com/idea/ideaIU-2025.3.1-aarch64.tar.gz";
-      hash = "sha256-CVcRMp0enBRkG6Qm5lLU29OIWyfJoEbkRyWuZ3SR6MM=";
+      url = "https://download.jetbrains.com/idea/ideaIU-2025.3.1.1-aarch64.tar.gz";
+      hash = "sha256-h1FtLwe47B/2z+nRTWj8P3b11XuGYRMlueq6wbYEPMs=";
     };
     x86_64-darwin = {
-      url = "https://download.jetbrains.com/idea/ideaIU-2025.3.1.dmg";
-      hash = "sha256-rfWvODnge6Y4e/DsqU3y9EyCkCOhiYFw6svFy6/OA5M=";
+      url = "https://download.jetbrains.com/idea/ideaIU-2025.3.1.1.dmg";
+      hash = "sha256-XMaynB2VjtB3xUSobmNGT7//HWkIcinZbwvIEn9Kdqo=";
     };
     aarch64-darwin = {
-      url = "https://download.jetbrains.com/idea/ideaIU-2025.3.1-aarch64.dmg";
-      hash = "sha256-ITeGPMOl9KzSW6OKguAE6TXTqU+lZvjjhR1riorBJ3c=";
+      url = "https://download.jetbrains.com/idea/ideaIU-2025.3.1.1-aarch64.dmg";
+      hash = "sha256-e9pi80XBGJL/lAaCu1nmDu5AZ0uy8s3GIEsuGyrTjfg=";
     };
   };
   # update-script-end: urls
@@ -43,8 +43,8 @@ mkJetBrainsProduct {
   productShort = "IDEA";
 
   # update-script-start: version
-  version = "2025.3.1";
-  buildNumber = "253.29346.138";
+  version = "2025.3.1.1";
+  buildNumber = "253.29346.240";
   # update-script-end: version
 
   src = fetchurl (urls.${system} or (throw "Unsupported system: ${system}"));

--- a/pkgs/applications/editors/jetbrains/ides/pycharm-oss.nix
+++ b/pkgs/applications/editors/jetbrains/ides/pycharm-oss.nix
@@ -7,10 +7,10 @@
 let
   src = mkJetBrainsSource {
     # update-script-start: source-args
-    version = "2025.3.1";
-    buildNumber = "253.29346.142";
+    version = "2025.3.1.1";
+    buildNumber = "253.29346.308";
     buildType = "pycharm";
-    ideaHash = "sha256-eAq/lgv6ZcN9SR2E1KYnnhDHe/rBQ3GqqbbF6GstDoU=";
+    ideaHash = "sha256-sx/yLkMsjOQWAMJztoI0T6xQ66pnjnQejgc85PGod2s=";
     androidHash = "sha256-quMCzrjCKIo1pkzw4PWewAs5tz7A2aq7TI5zd+QaaUY=";
     jpsHash = "sha256-iHpt926BDLNUwHRXvkqVgwlWiLo1qSZEaGeJcS0Fjmk=";
     restarterHash = "sha256-acCmC58URd6p9uKZrm0qWgdZkqu9yqCs23v8qgxV2Ag=";

--- a/pkgs/applications/editors/jetbrains/ides/pycharm.nix
+++ b/pkgs/applications/editors/jetbrains/ides/pycharm.nix
@@ -13,20 +13,20 @@ let
   # update-script-start: urls
   urls = {
     x86_64-linux = {
-      url = "https://download.jetbrains.com/python/pycharm-2025.3.1.tar.gz";
-      hash = "sha256-kz/ULXzCp2rUuiP5ESKU5N8BP6TDNiQ1oeM2gFHAc5E=";
+      url = "https://download.jetbrains.com/python/pycharm-2025.3.1.1.tar.gz";
+      hash = "sha256-3lQSHpqNf/yaOyIWeuhYitI//mBuJG/sfvrWMdJvtEs=";
     };
     aarch64-linux = {
-      url = "https://download.jetbrains.com/python/pycharm-2025.3.1-aarch64.tar.gz";
-      hash = "sha256-K29aQwEydz6nyvMEb3dj6noDHb+rbhvnK9yG88x6dYs=";
+      url = "https://download.jetbrains.com/python/pycharm-2025.3.1.1-aarch64.tar.gz";
+      hash = "sha256-tm2+8klFjyMhqPs4uH14fTY0doWDUAsrW9gehU5bGKg=";
     };
     x86_64-darwin = {
-      url = "https://download.jetbrains.com/python/pycharm-2025.3.1.dmg";
-      hash = "sha256-WGye7WfaYJ/B5WWov8NusVWyPlSD1dxunc+LVUD0f6U=";
+      url = "https://download.jetbrains.com/python/pycharm-2025.3.1.1.dmg";
+      hash = "sha256-keHuiyw/lhhOwP3uP8g8puiyRUTtHhXqk4kdSrIOeJQ=";
     };
     aarch64-darwin = {
-      url = "https://download.jetbrains.com/python/pycharm-2025.3.1-aarch64.dmg";
-      hash = "sha256-7I6XhW8A2pAgIMcrDwecwQmD3mu0Q4KS6l+qHlsMuTU=";
+      url = "https://download.jetbrains.com/python/pycharm-2025.3.1.1-aarch64.dmg";
+      hash = "sha256-scG0YiqE3q2BCh3VRhHZ0ep6PDY8zRtBDRBJQGLDOSI=";
     };
   };
   # update-script-end: urls
@@ -40,8 +40,8 @@ in
   product = "PyCharm";
 
   # update-script-start: version
-  version = "2025.3.1";
-  buildNumber = "253.29346.142";
+  version = "2025.3.1.1";
+  buildNumber = "253.29346.308";
   # update-script-end: version
 
   src = fetchurl (urls.${system} or (throw "Unsupported system: ${system}"));

--- a/pkgs/applications/editors/jetbrains/ides/ruby-mine.nix
+++ b/pkgs/applications/editors/jetbrains/ides/ruby-mine.nix
@@ -12,20 +12,20 @@ let
   # update-script-start: urls
   urls = {
     x86_64-linux = {
-      url = "https://download.jetbrains.com/ruby/RubyMine-2025.3.1.tar.gz";
-      hash = "sha256-6esgEcotVpTFjAEWkL9UTQJuOnwcDI3puzehj6DPgRg=";
+      url = "https://download.jetbrains.com/ruby/RubyMine-2025.3.1.1.tar.gz";
+      hash = "sha256-dVd/4LBssEsuzEB+RX44RCrlXfNOyYkRPe3SvOD+N20=";
     };
     aarch64-linux = {
-      url = "https://download.jetbrains.com/ruby/RubyMine-2025.3.1-aarch64.tar.gz";
-      hash = "sha256-v2A8ahuh5hiv23BYlkhEfPzlO02qegzGgHPBt35yfVU=";
+      url = "https://download.jetbrains.com/ruby/RubyMine-2025.3.1.1-aarch64.tar.gz";
+      hash = "sha256-FNco8STJ+HEmcfZFpFiDzM0QYQPxchmPizAPqYHiYWo=";
     };
     x86_64-darwin = {
-      url = "https://download.jetbrains.com/ruby/RubyMine-2025.3.1.dmg";
-      hash = "sha256-T86EmDpqzhbYR5FQt2UoAlCiYLPST7NyWNEUAAxsERU=";
+      url = "https://download.jetbrains.com/ruby/RubyMine-2025.3.1.1.dmg";
+      hash = "sha256-FWHsKzpmvr3CHCcB5nhHKq9NRWVP+IyPGuk2lunLDKU=";
     };
     aarch64-darwin = {
-      url = "https://download.jetbrains.com/ruby/RubyMine-2025.3.1-aarch64.dmg";
-      hash = "sha256-Z/GqZ0uQ7FS6IfNSOtlAIY+Xm+/XQp44rYIryBRtFqQ=";
+      url = "https://download.jetbrains.com/ruby/RubyMine-2025.3.1.1-aarch64.dmg";
+      hash = "sha256-K66IoMXqfs1frfo+gUCKQrp9pIm2iFyLNdFFNkHPYPc=";
     };
   };
   # update-script-end: urls
@@ -39,8 +39,8 @@ mkJetBrainsProduct {
   product = "RubyMine";
 
   # update-script-start: version
-  version = "2025.3.1";
-  buildNumber = "253.29346.140";
+  version = "2025.3.1.1";
+  buildNumber = "253.29346.331";
   # update-script-end: version
 
   src = fetchurl (urls.${system} or (throw "Unsupported system: ${system}"));

--- a/pkgs/applications/editors/jetbrains/source/pycharm_maven_artefacts.json
+++ b/pkgs/applications/editors/jetbrains/source/pycharm_maven_artefacts.json
@@ -1,38 +1,283 @@
 [
     {
+        "url": "org/apache/lucene/lucene-core/10.3.0/lucene-core-10.3.0.jar",
+        "hash": "9d70afe194568ca0328b7f762e64eb8094a5e5a76ea3a30b7182f0e7d5f0dd35",
+        "path": "org/apache/lucene/lucene-core/10.3.0/lucene-core-10.3.0.jar"
+    },
+    {
+        "url": "com/google/guava/guava/33.4.8-jre/guava-33.4.8-jre.jar",
+        "hash": "f3d7f57f67fd622f4d468dfdd692b3a5e3909246c28017ac3263405f0fe617ed",
+        "path": "com/google/guava/guava/33.4.8-jre/guava-33.4.8-jre.jar"
+    },
+    {
+        "url": "com/google/guava/failureaccess/1.0.3/failureaccess-1.0.3.jar",
+        "hash": "cbfc3906b19b8f55dd7cfd6dfe0aa4532e834250d7f080bd8d211a3e246b59cb",
+        "path": "com/google/guava/failureaccess/1.0.3/failureaccess-1.0.3.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/ift/git-learning-project/212.0.2/git-learning-project-212.0.2.jar",
+        "hash": "648eaffe833416e2accea4bf82b980f0e91ae51ef065f5bc74fa3481c373e9fd",
+        "path": "org/jetbrains/intellij/deps/ift/git-learning-project/212.0.2/git-learning-project-212.0.2.jar"
+    },
+    {
+        "url": "org/junit/vintage/junit-vintage-engine/5.13.4/junit-vintage-engine-5.13.4.jar",
+        "hash": "066b702d850ebcde36f2a8181b46a2f0f1416129d1dc63c3a1e1531006e74739",
+        "path": "org/junit/vintage/junit-vintage-engine/5.13.4/junit-vintage-engine-5.13.4.jar"
+    },
+    {
+        "url": "org/openjdk/jmh/jmh-core/1.37/jmh-core-1.37.jar",
+        "hash": "dc0eaf2bbf0036a70b60798c785d6e03a9daf06b68b8edb0f1ba9eb3421baeb3",
+        "path": "org/openjdk/jmh/jmh-core/1.37/jmh-core-1.37.jar"
+    },
+    {
+        "url": "net/sf/jopt-simple/jopt-simple/5.0.4/jopt-simple-5.0.4.jar",
+        "hash": "df26cc58f235f477db07f753ba5a3ab243ebe5789d9f89ecf68dd62ea9a66c28",
+        "path": "net/sf/jopt-simple/jopt-simple/5.0.4/jopt-simple-5.0.4.jar"
+    },
+    {
+        "url": "org/apache/commons/commons-math3/3.6.1/commons-math3-3.6.1.jar",
+        "hash": "1e56d7b058d28b65abd256b8458e3885b674c1d588fa43cd7d1cbb9c7ef2b308",
+        "path": "org/apache/commons/commons-math3/3.6.1/commons-math3-3.6.1.jar"
+    },
+    {
+        "url": "com/jetbrains/fus/reporting/ap-validation/171/ap-validation-171.jar",
+        "hash": "3c8c66663148ac5d2a953cb048a1939b96be543d4612c23e030a7c6fd20390cd",
+        "path": "com/jetbrains/fus/reporting/ap-validation/171/ap-validation-171.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-compiler-ir-for-ide/2.3.20-ij253-45/kotlin-compiler-ir-for-ide-2.3.20-ij253-45.jar",
+        "hash": "230f801ec0de74e6363bf7553c71dbf085d1aaaadcf553afd1248ab51fbcfef1",
+        "path": "org/jetbrains/kotlin/kotlin-compiler-ir-for-ide/2.3.20-ij253-45/kotlin-compiler-ir-for-ide-2.3.20-ij253-45.jar"
+    },
+    {
+        "url": "net/bytebuddy/byte-buddy/1.17.7/byte-buddy-1.17.7.jar",
+        "hash": "3575dcb8a98faf943d3c1595c47a16047c4fce8a83ebbb26262f1a2f67546357",
+        "path": "net/bytebuddy/byte-buddy/1.17.7/byte-buddy-1.17.7.jar"
+    },
+    {
+        "url": "io/grpc/grpc-core/1.73.0/grpc-core-1.73.0.jar",
+        "hash": "cffb55f1e7268e160647e88da142c09c6175ff72970c64f7cb411d78eb661663",
+        "path": "io/grpc/grpc-core/1.73.0/grpc-core-1.73.0.jar"
+    },
+    {
+        "url": "io/grpc/grpc-api/1.73.0/grpc-api-1.73.0.jar",
+        "hash": "bae13d4e4716a0955d316b5fcb75582504325e5b11ac946b13b64b4fce19bc6e",
+        "path": "io/grpc/grpc-api/1.73.0/grpc-api-1.73.0.jar"
+    },
+    {
+        "url": "com/google/android/annotations/4.1.1.4/annotations-4.1.1.4.jar",
+        "hash": "ba734e1e84c09d615af6a09d33034b4f0442f8772dec120efb376d86a565ae15",
+        "path": "com/google/android/annotations/4.1.1.4/annotations-4.1.1.4.jar"
+    },
+    {
+        "url": "org/codehaus/mojo/animal-sniffer-annotations/1.24/animal-sniffer-annotations-1.24.jar",
+        "hash": "c720e6e5bcbe6b2f48ded75a47bccdb763eede79d14330102e0d352e3d89ed92",
+        "path": "org/codehaus/mojo/animal-sniffer-annotations/1.24/animal-sniffer-annotations-1.24.jar"
+    },
+    {
+        "url": "io/perfmark/perfmark-api/0.27.0/perfmark-api-0.27.0.jar",
+        "hash": "c7b478503ec524e55df19b424d46d27c8a68aeb801664fadd4f069b71f52d0f6",
+        "path": "io/perfmark/perfmark-api/0.27.0/perfmark-api-0.27.0.jar"
+    },
+    {
+        "url": "io/grpc/grpc-context/1.73.0/grpc-context-1.73.0.jar",
+        "hash": "d8d6911e225b55501692651272ce961ba5be1f76662ceb7f0aa79ecce8f63f25",
+        "path": "io/grpc/grpc-context/1.73.0/grpc-context-1.73.0.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/plugins/structure-intellij/3.316/structure-intellij-3.316.jar",
+        "hash": "0efe45aca820a2f722f29a49e5ffe5cd14f06c51ad60842247fcb15f8048e28a",
+        "path": "org/jetbrains/intellij/plugins/structure-intellij/3.316/structure-intellij-3.316.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/plugins/structure-base/3.316/structure-base-3.316.jar",
+        "hash": "83789c1710426adb1637f773ec79e46ad0acf845e77e7964d7f2030cc2fd25c9",
+        "path": "org/jetbrains/intellij/plugins/structure-base/3.316/structure-base-3.316.jar"
+    },
+    {
+        "url": "org/atteo/evo-inflector/1.3/evo-inflector-1.3.jar",
+        "hash": "ac0192fd110a0363732b17ea94fd1ce8cfd85790c8e1551e14f866908b5d80e1",
+        "path": "org/atteo/evo-inflector/1.3/evo-inflector-1.3.jar"
+    },
+    {
+        "url": "org/jdom/jdom2/2.0.6.1/jdom2-2.0.6.1.jar",
+        "hash": "0b20f45e3a0fd8f0d12cdc5316b06776e902b1365db00118876f9175c60f302c",
+        "path": "org/jdom/jdom2/2.0.6.1/jdom2-2.0.6.1.jar"
+    },
+    {
+        "url": "com/android/tools/build/aapt2-proto/8.1.0-10154469/aapt2-proto-8.1.0-10154469.jar",
+        "hash": "6d8d14b91285cc7c1b73460f413bb3f80672dc34dc506ed578fba1f6dde8661e",
+        "path": "com/android/tools/build/aapt2-proto/8.1.0-10154469/aapt2-proto-8.1.0-10154469.jar"
+    },
+    {
+        "url": "org/junit/platform/junit-platform-launcher/1.13.4/junit-platform-launcher-1.13.4.jar",
+        "hash": "0b0beaeb6880a31149641d2d848b863712885469670c12099586d7f798522564",
+        "path": "org/junit/platform/junit-platform-launcher/1.13.4/junit-platform-launcher-1.13.4.jar"
+    },
+    {
+        "url": "org/junit/platform/junit-platform-engine/1.13.4/junit-platform-engine-1.13.4.jar",
+        "hash": "390c5f77b84283a64b644f88251b397e0b0debb80bdcc50f899881aecff43a5a",
+        "path": "org/junit/platform/junit-platform-engine/1.13.4/junit-platform-engine-1.13.4.jar"
+    },
+    {
+        "url": "com/jetbrains/fleet/rpc-compiler-plugin/2.2.20-0.1/rpc-compiler-plugin-2.2.20-0.1.jar",
+        "hash": "71e74b74676099dd9ebbb97780401f9b53f205a69d0d515a5e03c5a42fe20c18",
+        "path": "com/jetbrains/fleet/rpc-compiler-plugin/2.2.20-0.1/rpc-compiler-plugin-2.2.20-0.1.jar"
+    },
+    {
+        "url": "org/openjdk/jmh/jmh-generator-annprocess/1.36/jmh-generator-annprocess-1.36.jar",
+        "hash": "c2a88cf8be1eb0870732a7b2e669972efc7f33a145998f568096137f16b20d79",
+        "path": "org/openjdk/jmh/jmh-generator-annprocess/1.36/jmh-generator-annprocess-1.36.jar"
+    },
+    {
+        "url": "jetbrains/fleet/noria-compiler-plugin/2.2.20-0.1/noria-compiler-plugin-2.2.20-0.1.jar",
+        "hash": "dda6a96d529f473c952ba7e8205509de29725ad40eff80af7d371df95ccb14c1",
+        "path": "jetbrains/fleet/noria-compiler-plugin/2.2.20-0.1/noria-compiler-plugin-2.2.20-0.1.jar"
+    },
+    {
+        "url": "org/codehaus/groovy/groovy-ant/3.0.25/groovy-ant-3.0.25.jar",
+        "hash": "fd65c1a0cd1c60272b6ed0f45025d7afae8de20b5c11e2a131a7ccb4b0f1f1b2",
+        "path": "org/codehaus/groovy/groovy-ant/3.0.25/groovy-ant-3.0.25.jar"
+    },
+    {
+        "url": "org/apache/lucene/lucene-memory/10.3.0/lucene-memory-10.3.0.jar",
+        "hash": "ea77d0b2eb0b3e1f7fa04f2fbe671f5af3ae836cc40320411e195bdc9421f17b",
+        "path": "org/apache/lucene/lucene-memory/10.3.0/lucene-memory-10.3.0.jar"
+    },
+    {
         "url": "commons-io/commons-io/2.18.0/commons-io-2.18.0.jar",
         "hash": "f3ca0f8d63c40e23a56d54101c60d5edee136b42d84bfb85bc7963093109cf8b",
         "path": "commons-io/commons-io/2.18.0/commons-io-2.18.0.jar"
     },
     {
-        "url": "org/jetbrains/intellij/deps/rwmutex-idea/0.0.10/rwmutex-idea-0.0.10.jar",
-        "hash": "61cd5eee5367d10e0cca664afdc4bbde2ff7aab9c175c5b520aac8b5315d874d",
-        "path": "org/jetbrains/intellij/deps/rwmutex-idea/0.0.10/rwmutex-idea-0.0.10.jar"
+        "url": "org/jetbrains/kotlinx/kotlinx-serialization-cbor-jvm/1.8.1/kotlinx-serialization-cbor-jvm-1.8.1.jar",
+        "hash": "604c4130ca7a0e979a449cf550087a5c2c586485e8af01dcf24b03b7b287306d",
+        "path": "org/jetbrains/kotlinx/kotlinx-serialization-cbor-jvm/1.8.1/kotlinx-serialization-cbor-jvm-1.8.1.jar"
     },
     {
-        "url": "io/modelcontextprotocol/kotlin-sdk-jvm/0.8.1/kotlin-sdk-jvm-0.8.1.jar",
-        "hash": "095e5d11868ae359bd640c922c2d1ed7a20ba519496599ee697e81c468761339",
-        "path": "io/modelcontextprotocol/kotlin-sdk-jvm/0.8.1/kotlin-sdk-jvm-0.8.1.jar"
+        "url": "org/jetbrains/jps/jps-javac-extension/10/jps-javac-extension-10.jar",
+        "hash": "86b9d2a2378cff951f3bd0750d56ff4cef64f78dbb33e9f7abd9c7e6e14d99de",
+        "path": "org/jetbrains/jps/jps-javac-extension/10/jps-javac-extension-10.jar"
     },
     {
-        "url": "io/modelcontextprotocol/kotlin-sdk-client-jvm/0.8.1/kotlin-sdk-client-jvm-0.8.1.jar",
-        "hash": "e88a667c25b8ebb7c81f76dd96cb34ea804754752b5533a842b99d0daea2be99",
-        "path": "io/modelcontextprotocol/kotlin-sdk-client-jvm/0.8.1/kotlin-sdk-client-jvm-0.8.1.jar"
+        "url": "org/jetbrains/kotlinx/kotlinx-datetime-jvm/0.6.2/kotlinx-datetime-jvm-0.6.2.jar",
+        "hash": "102764921129e1e44a74f408b7a0b8dac6d1892c6042e0e48f8bdbbbf78c6d2e",
+        "path": "org/jetbrains/kotlinx/kotlinx-datetime-jvm/0.6.2/kotlinx-datetime-jvm-0.6.2.jar"
     },
     {
-        "url": "io/modelcontextprotocol/kotlin-sdk-server-jvm/0.8.1/kotlin-sdk-server-jvm-0.8.1.jar",
-        "hash": "6086acf1d65bca24de344b493e3fc241f0db2b25fa0606057eee39e3a2264737",
-        "path": "io/modelcontextprotocol/kotlin-sdk-server-jvm/0.8.1/kotlin-sdk-server-jvm-0.8.1.jar"
+        "url": "org/jetbrains/kotlin/incremental-compilation-impl-tests-for-ide/2.3.20-ij253-45/incremental-compilation-impl-tests-for-ide-2.3.20-ij253-45.jar",
+        "hash": "9d2369a7e71ff367dbed384ee50976c25743b09e4be68a58f9412ad165d8e0d7",
+        "path": "org/jetbrains/kotlin/incremental-compilation-impl-tests-for-ide/2.3.20-ij253-45/incremental-compilation-impl-tests-for-ide-2.3.20-ij253-45.jar"
     },
     {
-        "url": "io/modelcontextprotocol/kotlin-sdk-core-jvm/0.8.1/kotlin-sdk-core-jvm-0.8.1.jar",
-        "hash": "dd9a13ba6b0803040b6fea56b6db66bc9c4f31dacf678dac642aaaff8d88a543",
-        "path": "io/modelcontextprotocol/kotlin-sdk-core-jvm/0.8.1/kotlin-sdk-core-jvm-0.8.1.jar"
+        "url": "io/ktor/ktor-network-tls-jvm/3.1.3/ktor-network-tls-jvm-3.1.3.jar",
+        "hash": "f67507a3e8bf52aa08d753682e6cdda0194e3abe750118b99c9336953e598be9",
+        "path": "io/ktor/ktor-network-tls-jvm/3.1.3/ktor-network-tls-jvm-3.1.3.jar"
     },
     {
-        "url": "com/github/ben-manes/caffeine/caffeine/3.2.2/caffeine-3.2.2.jar",
-        "hash": "c74a6c72221dfb76eb92f2bb40108ea561a7da2f315dc3b1e64afa8f077f210c",
-        "path": "com/github/ben-manes/caffeine/caffeine/3.2.2/caffeine-3.2.2.jar"
+        "url": "org/jsoup/jsoup/1.21.2/jsoup-1.21.2.jar",
+        "hash": "f05496e255734759f0d4b5632da7b24f81313147c78c69e90ad045d096191344",
+        "path": "org/jsoup/jsoup/1.21.2/jsoup-1.21.2.jar"
+    },
+    {
+        "url": "com/intellij/platform/kotlinx-coroutines-guava/1.10.1-intellij-5/kotlinx-coroutines-guava-1.10.1-intellij-5.jar",
+        "hash": "61ff422fe859c2439d94727eb6dcd7ccadb5ba0d9cce4e181db1946209ef9bf6",
+        "path": "com/intellij/platform/kotlinx-coroutines-guava/1.10.1-intellij-5/kotlinx-coroutines-guava-1.10.1-intellij-5.jar"
+    },
+    {
+        "url": "io/ktor/ktor-utils-jvm/3.1.3/ktor-utils-jvm-3.1.3.jar",
+        "hash": "33333937b98fc0c8e943ee4b10b3ea66b49782dfb569c44c142da4f32d85dffc",
+        "path": "io/ktor/ktor-utils-jvm/3.1.3/ktor-utils-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-client-okhttp-jvm/3.1.3/ktor-client-okhttp-jvm-3.1.3.jar",
+        "hash": "a3c111c85eabb8149c485c275768d57cd96a05b595ca1946781c0d4c5fb1654a",
+        "path": "io/ktor/ktor-client-okhttp-jvm/3.1.3/ktor-client-okhttp-jvm-3.1.3.jar"
+    },
+    {
+        "url": "org/java-websocket/Java-WebSocket/1.6.0/Java-WebSocket-1.6.0.jar",
+        "hash": "eae29213e4f16515639c28957200f011b3967fffcada1962cf0255d24919c22f",
+        "path": "org/java-websocket/Java-WebSocket/1.6.0/Java-WebSocket-1.6.0.jar"
+    },
+    {
+        "url": "org/bidib/com/github/markusbernhardt/proxy-vole/1.1.6/proxy-vole-1.1.6.jar",
+        "hash": "4b9fb2e5a13b37cf8bd62eebada8d3485c3dc17df752783b68d89d657bcc01fd",
+        "path": "org/bidib/com/github/markusbernhardt/proxy-vole/1.1.6/proxy-vole-1.1.6.jar"
+    },
+    {
+        "url": "org/javadelight/delight-rhino-sandbox/0.0.17/delight-rhino-sandbox-0.0.17.jar",
+        "hash": "e22941d77d0d01dfc6ee5612ad421860baae8a3a0dea2eeb67658061f34527b4",
+        "path": "org/javadelight/delight-rhino-sandbox/0.0.17/delight-rhino-sandbox-0.0.17.jar"
+    },
+    {
+        "url": "com/jayway/jsonpath/json-path/2.9.0/json-path-2.9.0.jar",
+        "hash": "11a9ee6f88bb31f1450108d1cf6441377dec84aca075eb6bb2343be157575bea",
+        "path": "com/jayway/jsonpath/json-path/2.9.0/json-path-2.9.0.jar"
+    },
+    {
+        "url": "net/minidev/json-smart/2.5.0/json-smart-2.5.0.jar",
+        "hash": "432b9e545848c4141b80717b26e367f83bf33f19250a228ce75da6e967da2bc7",
+        "path": "net/minidev/json-smart/2.5.0/json-smart-2.5.0.jar"
+    },
+    {
+        "url": "net/minidev/accessors-smart/2.5.0/accessors-smart-2.5.0.jar",
+        "hash": "12314fc6881d66a413fd66370787adba16e504fbf7e138690b0f3952e3fbd321",
+        "path": "net/minidev/accessors-smart/2.5.0/accessors-smart-2.5.0.jar"
+    },
+    {
+        "url": "io/ktor/ktor-http-jvm/3.1.3/ktor-http-jvm-3.1.3.jar",
+        "hash": "8a50d94b46f91bd56580b9169272d6cd636f442032ba078a141da70413465946",
+        "path": "io/ktor/ktor-http-jvm/3.1.3/ktor-http-jvm-3.1.3.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/compose-compiler-plugin-for-ide/2.3.20-ij253-45/compose-compiler-plugin-for-ide-2.3.20-ij253-45.jar",
+        "hash": "84612c6b067f7018325c00975bb49a35e1947d8de1c03009e999b746219105f4",
+        "path": "org/jetbrains/kotlin/compose-compiler-plugin-for-ide/2.3.20-ij253-45/compose-compiler-plugin-for-ide-2.3.20-ij253-45.jar"
+    },
+    {
+        "url": "javax/xml/bind/jaxb-api/2.3.1/jaxb-api-2.3.1.jar",
+        "hash": "88b955a0df57880a26a74708bc34f74dcaf8ebf4e78843a28b50eae945732b06",
+        "path": "javax/xml/bind/jaxb-api/2.3.1/jaxb-api-2.3.1.jar"
+    },
+    {
+        "url": "com/google/zxing/core/3.5.1/core-3.5.1.jar",
+        "hash": "1ba7c0fbb6c267e2fb74e1497d855adae633ccc98edc8c75163aa64bc08e3059",
+        "path": "com/google/zxing/core/3.5.1/core-3.5.1.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-dataframe-compiler-plugin-for-ide/2.3.20-ij253-45/kotlin-dataframe-compiler-plugin-for-ide-2.3.20-ij253-45.jar",
+        "hash": "076c66a0899ca0dfaeb18efdf73ca70c0dfbe935a70e7f790e009885b61e56ee",
+        "path": "org/jetbrains/kotlin/kotlin-dataframe-compiler-plugin-for-ide/2.3.20-ij253-45/kotlin-dataframe-compiler-plugin-for-ide-2.3.20-ij253-45.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlinx/kotlinx-collections-immutable-jvm/0.4.0/kotlinx-collections-immutable-jvm-0.4.0.jar",
+        "hash": "d767014ad0c9a27d27d26fd38e7afa030aee0d141338f108781ff02ecf2fdab5",
+        "path": "org/jetbrains/kotlinx/kotlinx-collections-immutable-jvm/0.4.0/kotlinx-collections-immutable-jvm-0.4.0.jar"
+    },
+    {
+        "url": "io/github/oshai/kotlin-logging-jvm/7.0.3/kotlin-logging-jvm-7.0.3.jar",
+        "hash": "241daa21665dd0ca55576a4bc4d8e9ace8891ae3c698cc77f13bb4bdac372e94",
+        "path": "io/github/oshai/kotlin-logging-jvm/7.0.3/kotlin-logging-jvm-7.0.3.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-scripting-compiler-impl/2.3.20-ij253-45/kotlin-scripting-compiler-impl-2.3.20-ij253-45.jar",
+        "hash": "c2b19162264b2aa78371cd834f8703e1c49c032ec9862cdb9b744a4a2a8e7ded",
+        "path": "org/jetbrains/kotlin/kotlin-scripting-compiler-impl/2.3.20-ij253-45/kotlin-scripting-compiler-impl-2.3.20-ij253-45.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/analysis-api-fe10-for-ide/2.3.20-ij253-45/analysis-api-fe10-for-ide-2.3.20-ij253-45.jar",
+        "hash": "cbf24708e46c2e064a37887d5b53d1234ba2b3c1d285ecc9ba82cb6152076297",
+        "path": "org/jetbrains/kotlin/analysis-api-fe10-for-ide/2.3.20-ij253-45/analysis-api-fe10-for-ide-2.3.20-ij253-45.jar"
+    },
+    {
+        "url": "junit/junit/4.13.2/junit-4.13.2.jar",
+        "hash": "8e495b634469d64fb8acfa3495a065cbacc8a0fff55ce1e31007be4c16dc57d3",
+        "path": "junit/junit/4.13.2/junit-4.13.2.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-jps-plugin-tests-for-ide/2.2.20/kotlin-jps-plugin-tests-for-ide-2.2.20.jar",
+        "hash": "2074392bf202ae0cea075828e8739a17642eb3093db5f40e46b955937fbd8cdf",
+        "path": "org/jetbrains/kotlin/kotlin-jps-plugin-tests-for-ide/2.2.20/kotlin-jps-plugin-tests-for-ide-2.2.20.jar"
     },
     {
         "url": "org/jetbrains/intellij/deps/studio-test-platform/2025.1.2-287/studio-test-platform-2025.1.2-287.jar",
@@ -40,14 +285,404 @@
         "path": "org/jetbrains/intellij/deps/studio-test-platform/2025.1.2-287/studio-test-platform-2025.1.2-287.jar"
     },
     {
-        "url": "com/github/marschall/memoryfilesystem/2.8.2/memoryfilesystem-2.8.2.jar",
-        "hash": "8b94840d71ad0caa36b3309425b2d23084bc8788ce84d71f2d805b0fc84d1f5a",
-        "path": "com/github/marschall/memoryfilesystem/2.8.2/memoryfilesystem-2.8.2.jar"
+        "url": "io/ktor/ktor-events-jvm/3.1.3/ktor-events-jvm-3.1.3.jar",
+        "hash": "da7069c6e78809d7c37d104e415613cbd4cd5cec1ed54a332cb64ef6a864a060",
+        "path": "io/ktor/ktor-events-jvm/3.1.3/ktor-events-jvm-3.1.3.jar"
     },
     {
-        "url": "com/googlecode/plist/dd-plist/1.28/dd-plist-1.28.jar",
-        "hash": "88ed8e730f7386297485176c4387146c6914a38c0e58fc296e8a01cdc3b621e1",
-        "path": "com/googlecode/plist/dd-plist/1.28/dd-plist-1.28.jar"
+        "url": "io/ktor/ktor-client-mock-jvm/3.1.3/ktor-client-mock-jvm-3.1.3.jar",
+        "hash": "2ae0d57bb9fceb8ee2aeda6536acc6f3e1de355984b4c9da720566b85f1525e8",
+        "path": "io/ktor/ktor-client-mock-jvm/3.1.3/ktor-client-mock-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-http-jvm/3.1.3/ktor-http-jvm-3.1.3.jar",
+        "hash": "8a50d94b46f91bd56580b9169272d6cd636f442032ba078a141da70413465946",
+        "path": "io/ktor/ktor-http-jvm/3.1.3/ktor-http-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-utils-jvm/3.1.3/ktor-utils-jvm-3.1.3.jar",
+        "hash": "33333937b98fc0c8e943ee4b10b3ea66b49782dfb569c44c142da4f32d85dffc",
+        "path": "io/ktor/ktor-utils-jvm/3.1.3/ktor-utils-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-io-jvm/3.1.3/ktor-io-jvm-3.1.3.jar",
+        "hash": "bb2fb6c00afaa34b539cb30e7584d37bfcba171c266bbdb9990e003579dc24c1",
+        "path": "io/ktor/ktor-io-jvm/3.1.3/ktor-io-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-client-core-jvm/3.1.3/ktor-client-core-jvm-3.1.3.jar",
+        "hash": "746e2a3dece87379d64c40999401969001d373de1458fe851c0d2e0f880b42ef",
+        "path": "io/ktor/ktor-client-core-jvm/3.1.3/ktor-client-core-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-http-cio-jvm/3.1.3/ktor-http-cio-jvm-3.1.3.jar",
+        "hash": "b04aede18e9c008168096dc53a3fc016177b61a5ec3024afbf8caca0cd5dbf42",
+        "path": "io/ktor/ktor-http-cio-jvm/3.1.3/ktor-http-cio-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-network-jvm/3.1.3/ktor-network-jvm-3.1.3.jar",
+        "hash": "fa4e6165b5ad4bf5db337ebd5f16f9b596dc5e401fbea343b9deacb6138240af",
+        "path": "io/ktor/ktor-network-jvm/3.1.3/ktor-network-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-events-jvm/3.1.3/ktor-events-jvm-3.1.3.jar",
+        "hash": "da7069c6e78809d7c37d104e415613cbd4cd5cec1ed54a332cb64ef6a864a060",
+        "path": "io/ktor/ktor-events-jvm/3.1.3/ktor-events-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-websocket-serialization-jvm/3.1.3/ktor-websocket-serialization-jvm-3.1.3.jar",
+        "hash": "67f0f566e2ed51717f6ed55f6d2b4dee1c84be4ea2cd96fc636d0bdf0fd43067",
+        "path": "io/ktor/ktor-websocket-serialization-jvm/3.1.3/ktor-websocket-serialization-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-serialization-jvm/3.1.3/ktor-serialization-jvm-3.1.3.jar",
+        "hash": "0d704bc1148a8fd9a1f2005e0b5189cdaed3030efe24b8236459c41c356f5620",
+        "path": "io/ktor/ktor-serialization-jvm/3.1.3/ktor-serialization-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-websockets-jvm/3.1.3/ktor-websockets-jvm-3.1.3.jar",
+        "hash": "ef28b4f12054ee125765b72fe3230e215a60b73b2ff2072a5c280fcf09329077",
+        "path": "io/ktor/ktor-websockets-jvm/3.1.3/ktor-websockets-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-sse-jvm/3.1.3/ktor-sse-jvm-3.1.3.jar",
+        "hash": "a2ae8a338bb1d446d16dcfea2189ef5a5be31a88123b3879562b7955667a5639",
+        "path": "io/ktor/ktor-sse-jvm/3.1.3/ktor-sse-jvm-3.1.3.jar"
+    },
+    {
+        "url": "com/github/oshi/oshi-core/6.8.2/oshi-core-6.8.2.jar",
+        "hash": "9403c2537ac0dd425e556dfc3434e5d9f9a9547312472f4c27b7ab2673e9e862",
+        "path": "com/github/oshi/oshi-core/6.8.2/oshi-core-6.8.2.jar"
+    },
+    {
+        "url": "io/ktor/ktor-server-core-jvm/3.1.3/ktor-server-core-jvm-3.1.3.jar",
+        "hash": "bf582ba004634d0d343bb2dfa1edd0e8de18cdc2c607a4089db8b79d3085d10a",
+        "path": "io/ktor/ktor-server-core-jvm/3.1.3/ktor-server-core-jvm-3.1.3.jar"
+    },
+    {
+        "url": "com/charleskorn/kaml/kaml-jvm/0.80.1/kaml-jvm-0.80.1.jar",
+        "hash": "7e346b94d47fb4e4495ebd6161fd5c6d01659687e93c460bbfd320ba47bea852",
+        "path": "com/charleskorn/kaml/kaml-jvm/0.80.1/kaml-jvm-0.80.1.jar"
+    },
+    {
+        "url": "it/krzeminski/snakeyaml-engine-kmp-jvm/3.1.1/snakeyaml-engine-kmp-jvm-3.1.1.jar",
+        "hash": "733e1347e3ec909e8a7ee199e48a64d0180569461b3bc08c8a6bb1335f5ce1bd",
+        "path": "it/krzeminski/snakeyaml-engine-kmp-jvm/3.1.1/snakeyaml-engine-kmp-jvm-3.1.1.jar"
+    },
+    {
+        "url": "net/thauvin/erik/urlencoder/urlencoder-lib-jvm/1.6.0/urlencoder-lib-jvm-1.6.0.jar",
+        "hash": "8d0fd2aeb48d19dc49c563ebc00f274947e45f716c107535c12ead63decd688d",
+        "path": "net/thauvin/erik/urlencoder/urlencoder-lib-jvm/1.6.0/urlencoder-lib-jvm-1.6.0.jar"
+    },
+    {
+        "url": "commons-codec/commons-codec/1.18.0/commons-codec-1.18.0.jar",
+        "hash": "ba005f304cef92a3dede24a38ad5ac9b8afccf0d8f75839d6c1338634cf7f6e4",
+        "path": "commons-codec/commons-codec/1.18.0/commons-codec-1.18.0.jar"
+    },
+    {
+        "url": "net/jcip/jcip-annotations/1.0/jcip-annotations-1.0.jar",
+        "hash": "be5805392060c71474bf6c9a67a099471274d30b83eef84bfc4e0889a4f1dcc0",
+        "path": "net/jcip/jcip-annotations/1.0/jcip-annotations-1.0.jar"
+    },
+    {
+        "url": "io/ktor/ktor-network-jvm/3.1.3/ktor-network-jvm-3.1.3.jar",
+        "hash": "fa4e6165b5ad4bf5db337ebd5f16f9b596dc5e401fbea343b9deacb6138240af",
+        "path": "io/ktor/ktor-network-jvm/3.1.3/ktor-network-jvm-3.1.3.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/commons-imaging/1.0-RC-1/commons-imaging-1.0-RC-1.jar",
+        "hash": "ba1cb46e5494286940b016da372ae94a60d2dbc411b6dac5db1e40128725d501",
+        "path": "org/jetbrains/intellij/deps/commons-imaging/1.0-RC-1/commons-imaging-1.0-RC-1.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/analysis-api-impl-base-for-ide/2.3.20-ij253-45/analysis-api-impl-base-for-ide-2.3.20-ij253-45.jar",
+        "hash": "1ae230b0e5847a47838b871060b7271c9b2329febb85e1470d1490ffe2e28fd4",
+        "path": "org/jetbrains/kotlin/analysis-api-impl-base-for-ide/2.3.20-ij253-45/analysis-api-impl-base-for-ide-2.3.20-ij253-45.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-compiler-cli-for-ide/2.3.20-ij253-45/kotlin-compiler-cli-for-ide-2.3.20-ij253-45.jar",
+        "hash": "fd9db5d6b301967133bc977935d22295e247ed2ccefc2583942ef7376fd598c1",
+        "path": "org/jetbrains/kotlin/kotlin-compiler-cli-for-ide/2.3.20-ij253-45/kotlin-compiler-cli-for-ide-2.3.20-ij253-45.jar"
+    },
+    {
+        "url": "org/apache/lucene/lucene-sandbox/10.3.0/lucene-sandbox-10.3.0.jar",
+        "hash": "00aa7be5c214bff31d62b489fbb5f0c389545e9f455324b2b92681956d37c94f",
+        "path": "org/apache/lucene/lucene-sandbox/10.3.0/lucene-sandbox-10.3.0.jar"
+    },
+    {
+        "url": "io/netty/netty-all/4.1.117.Final/netty-all-4.1.117.Final.jar",
+        "hash": "c78613ac0db94650c03a37b2a35b3238b2d018fcac9f10e5fe268c3887cf5e0b",
+        "path": "io/netty/netty-all/4.1.117.Final/netty-all-4.1.117.Final.jar"
+    },
+    {
+        "url": "io/netty/netty-buffer/4.1.117.Final/netty-buffer-4.1.117.Final.jar",
+        "hash": "7d01bf0334ffa3ab55f3828bb50188bf9969774a23791a3df1905e53bfeea8f5",
+        "path": "io/netty/netty-buffer/4.1.117.Final/netty-buffer-4.1.117.Final.jar"
+    },
+    {
+        "url": "io/netty/netty-codec/4.1.117.Final/netty-codec-4.1.117.Final.jar",
+        "hash": "0b93f01cff5bc2a64af829ca01c826e8e861a03b96a871fa2a240fa25681df78",
+        "path": "io/netty/netty-codec/4.1.117.Final/netty-codec-4.1.117.Final.jar"
+    },
+    {
+        "url": "io/netty/netty-codec-http/4.1.117.Final/netty-codec-http-4.1.117.Final.jar",
+        "hash": "a7e19945a6baa86ab285383a0bda632eae7703a889da1d20ea4eaad4c996cc21",
+        "path": "io/netty/netty-codec-http/4.1.117.Final/netty-codec-http-4.1.117.Final.jar"
+    },
+    {
+        "url": "io/netty/netty-common/4.1.117.Final/netty-common-4.1.117.Final.jar",
+        "hash": "5b4e125a341566b24d5030479da475b20ea1f6145bf7b3c3d69fe537088bb4c1",
+        "path": "io/netty/netty-common/4.1.117.Final/netty-common-4.1.117.Final.jar"
+    },
+    {
+        "url": "io/netty/netty-handler/4.1.117.Final/netty-handler-4.1.117.Final.jar",
+        "hash": "f3272149099883cf98ad8a2a82a08111a78d17e604aebc094c80592a730fcac5",
+        "path": "io/netty/netty-handler/4.1.117.Final/netty-handler-4.1.117.Final.jar"
+    },
+    {
+        "url": "io/netty/netty-resolver/4.1.117.Final/netty-resolver-4.1.117.Final.jar",
+        "hash": "0f5f7220d34d32751cc624bc9c47afdde7392f0d9551569c90a568309015d796",
+        "path": "io/netty/netty-resolver/4.1.117.Final/netty-resolver-4.1.117.Final.jar"
+    },
+    {
+        "url": "io/netty/netty-transport/4.1.117.Final/netty-transport-4.1.117.Final.jar",
+        "hash": "c07aac2ea55aa42c34fc6b53fbee661e0de077f45483133b6ca297c70a67a44a",
+        "path": "io/netty/netty-transport/4.1.117.Final/netty-transport-4.1.117.Final.jar"
+    },
+    {
+        "url": "io/opentelemetry/opentelemetry-exporter-otlp-common/1.48.0/opentelemetry-exporter-otlp-common-1.48.0.jar",
+        "hash": "9b3211ad7f1508f6453d16922aad6c7dce5b2f9a88b7e272171f63875ee78efd",
+        "path": "io/opentelemetry/opentelemetry-exporter-otlp-common/1.48.0/opentelemetry-exporter-otlp-common-1.48.0.jar"
+    },
+    {
+        "url": "io/opentelemetry/opentelemetry-exporter-common/1.48.0/opentelemetry-exporter-common-1.48.0.jar",
+        "hash": "bc7af4f3c4ba1a23c20a6e1945f3e17fd3f5719f6f17d62961b3167d939a18e2",
+        "path": "io/opentelemetry/opentelemetry-exporter-common/1.48.0/opentelemetry-exporter-common-1.48.0.jar"
+    },
+    {
+        "url": "io/opentelemetry/semconv/opentelemetry-semconv/1.30.0/opentelemetry-semconv-1.30.0.jar",
+        "hash": "99c2478a9b803b7d385d1624d5c1ab6f9a64cac5a2dc00f44a350744a1d858ac",
+        "path": "io/opentelemetry/semconv/opentelemetry-semconv/1.30.0/opentelemetry-semconv-1.30.0.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-project-model/1.6.0/kotlin-project-model-1.6.0.jar",
+        "hash": "38135d3f995fc505d604aed2e82ac5ba858b2a6a3e476899c3b8be47fd222b68",
+        "path": "org/jetbrains/kotlin/kotlin-project-model/1.6.0/kotlin-project-model-1.6.0.jar"
+    },
+    {
+        "url": "com/squareup/okhttp3/okhttp/5.0.0-alpha.14/okhttp-5.0.0-alpha.14.jar",
+        "hash": "f0e3ffcbba6744ab4918a55aa32ff4f408fcd21e45ab8bd5f7883a1793b2a253",
+        "path": "com/squareup/okhttp3/okhttp/5.0.0-alpha.14/okhttp-5.0.0-alpha.14.jar"
+    },
+    {
+        "url": "com/squareup/okio/okio-jvm/3.9.0/okio-jvm-3.9.0.jar",
+        "hash": "ddc386ff14bd25d5c934167196eaf45b18de4f28e1c55a4db37ae594cbfd37e4",
+        "path": "com/squareup/okio/okio-jvm/3.9.0/okio-jvm-3.9.0.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/jb-jdi/2.45/jb-jdi-2.45.jar",
+        "hash": "f31793446f372ee33659fc7a4ce93a079fa520ae89ddf6f6280ea50425c408d4",
+        "path": "org/jetbrains/intellij/deps/jb-jdi/2.45/jb-jdi-2.45.jar"
+    },
+    {
+        "url": "com/intellij/platform/kotlinx-coroutines-core-jvm/1.10.1-intellij-5/kotlinx-coroutines-core-jvm-1.10.1-intellij-5.jar",
+        "hash": "e9b7e2b1262fd02fe63b08f636903ff36f453f08ae52190c78e3cbf19d777e42",
+        "path": "com/intellij/platform/kotlinx-coroutines-core-jvm/1.10.1-intellij-5/kotlinx-coroutines-core-jvm-1.10.1-intellij-5.jar"
+    },
+    {
+        "url": "com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar",
+        "hash": "766ad2a0783f2687962c8ad74ceecc38a28b9f72a2d085ee438b7813e928d0c7",
+        "path": "com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar"
+    },
+    {
+        "url": "org/codehaus/groovy/groovy-jsr223/3.0.25/groovy-jsr223-3.0.25.jar",
+        "hash": "7d703a1d484ac1135b78b24a4880f5653161cda83454c0f484fa09e29311d3bd",
+        "path": "org/codehaus/groovy/groovy-jsr223/3.0.25/groovy-jsr223-3.0.25.jar"
+    },
+    {
+        "url": "dk/brics/automaton/1.12-4/automaton-1.12-4.jar",
+        "hash": "3941b48f2e9281aab7234395c549cbb399b3dc80fed2e13999a80db47f94b041",
+        "path": "dk/brics/automaton/1.12-4/automaton-1.12-4.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-jps-plugin-classpath/2.3.20-ij253-45/kotlin-jps-plugin-classpath-2.3.20-ij253-45.jar",
+        "hash": "290744db458f813618c460312a1f35bb2ed082485385d558de368c893509d11c",
+        "path": "org/jetbrains/kotlin/kotlin-jps-plugin-classpath/2.3.20-ij253-45/kotlin-jps-plugin-classpath-2.3.20-ij253-45.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/analysis-api-impl-base-tests-for-ide/2.3.20-ij253-45/analysis-api-impl-base-tests-for-ide-2.3.20-ij253-45.jar",
+        "hash": "c6deada2fac53b8ea6523dbda77597b128006674616f140f04df23264c6d1aa3",
+        "path": "org/jetbrains/kotlin/analysis-api-impl-base-tests-for-ide/2.3.20-ij253-45/analysis-api-impl-base-tests-for-ide-2.3.20-ij253-45.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/parcelize-compiler-plugin-for-ide/2.3.20-ij253-45/parcelize-compiler-plugin-for-ide-2.3.20-ij253-45.jar",
+        "hash": "c4e51a757d46f19bdc2264c7be0cba0cc52eb52c9047c0be9b1df91eb8195f4e",
+        "path": "org/jetbrains/kotlin/parcelize-compiler-plugin-for-ide/2.3.20-ij253-45/parcelize-compiler-plugin-for-ide-2.3.20-ij253-45.jar"
+    },
+    {
+        "url": "net/sf/kxml/kxml2/2.3.0/kxml2-2.3.0.jar",
+        "hash": "f264dd9f79a1fde10ce5ecc53221eff24be4c9331c830b7d52f2f08a7b633de2",
+        "path": "net/sf/kxml/kxml2/2.3.0/kxml2-2.3.0.jar"
+    },
+    {
+        "url": "org/jetbrains/teamcity/serviceMessages/2024.07/serviceMessages-2024.07.jar",
+        "hash": "5280d3e4bae23c4f1cc59bab77dab9f7a9626aeceeaa0bb07a9868bcedae2da9",
+        "path": "org/jetbrains/teamcity/serviceMessages/2024.07/serviceMessages-2024.07.jar"
+    },
+    {
+        "url": "com/jetbrains/rd/rd-gen/2025.3.1/rd-gen-2025.3.1.jar",
+        "hash": "03b276130c0c1417c9bd07cfd8d2eea1fa465fc930dd132ac11fc383cf11deec",
+        "path": "com/jetbrains/rd/rd-gen/2025.3.1/rd-gen-2025.3.1.jar"
+    },
+    {
+        "url": "org/junit/jupiter/junit-jupiter-engine/5.13.4/junit-jupiter-engine-5.13.4.jar",
+        "hash": "027404a92fe618b72465792a257951495c503a7d5751e2791e0f51c87f67f5bc",
+        "path": "org/junit/jupiter/junit-jupiter-engine/5.13.4/junit-jupiter-engine-5.13.4.jar"
+    },
+    {
+        "url": "org/jline/jline-terminal-jansi/3.27.0/jline-terminal-jansi-3.27.0.jar",
+        "hash": "a7b369a2e697215fed314a58b736f10ae8bdedf218096916a6bdb7bc886fe470",
+        "path": "org/jline/jline-terminal-jansi/3.27.0/jline-terminal-jansi-3.27.0.jar"
+    },
+    {
+        "url": "org/fusesource/jansi/jansi/2.4.1/jansi-2.4.1.jar",
+        "hash": "2e5e775a9dc58ffa6bbd6aa6f099d62f8b62dcdeb4c3c3bbbe5cf2301bc2dcc1",
+        "path": "org/fusesource/jansi/jansi/2.4.1/jansi-2.4.1.jar"
+    },
+    {
+        "url": "org/jline/jline-terminal/3.27.0/jline-terminal-3.27.0.jar",
+        "hash": "2f461c75091ec3810a42184afc80c96910f54e9dd2110e9ecb9902a5ee6c244b",
+        "path": "org/jline/jline-terminal/3.27.0/jline-terminal-3.27.0.jar"
+    },
+    {
+        "url": "org/jline/jline-native/3.27.0/jline-native-3.27.0.jar",
+        "hash": "d8bc77bc80edc7d9a02a06a069b2d7085629421db0843aba7c153a869ffe525d",
+        "path": "org/jline/jline-native/3.27.0/jline-native-3.27.0.jar"
+    },
+    {
+        "url": "com/fasterxml/jackson/dataformat/jackson-dataformat-yaml/2.19.0/jackson-dataformat-yaml-2.19.0.jar",
+        "hash": "46e54dcbd39d4d12cda18ec9276e7b888e08fc765ea0c77e71662306f0d4abc4",
+        "path": "com/fasterxml/jackson/dataformat/jackson-dataformat-yaml/2.19.0/jackson-dataformat-yaml-2.19.0.jar"
+    },
+    {
+        "url": "commons-logging/commons-logging/1.2/commons-logging-1.2.jar",
+        "hash": "daddea1ea0be0f56978ab3006b8ac92834afeefbd9b7e4e6316fca57df0fa636",
+        "path": "commons-logging/commons-logging/1.2/commons-logging-1.2.jar"
+    },
+    {
+        "url": "org/swinglabs/swingx-core/1.6.2-2/swingx-core-1.6.2-2.jar",
+        "hash": "0df80935d9bc3b3841bc621c6fef6615c93aaf80393ccaa196db11bf97784f18",
+        "path": "org/swinglabs/swingx-core/1.6.2-2/swingx-core-1.6.2-2.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-build-common-tests-for-ide/2.3.20-ij253-45/kotlin-build-common-tests-for-ide-2.3.20-ij253-45.jar",
+        "hash": "c5d0331fb960fbb5e392118d1322e905f37be1b0b0abd6121d06caade7cc9b16",
+        "path": "org/jetbrains/kotlin/kotlin-build-common-tests-for-ide/2.3.20-ij253-45/kotlin-build-common-tests-for-ide-2.3.20-ij253-45.jar"
+    },
+    {
+        "url": "org/junit/platform/junit-platform-launcher/6.0.0/junit-platform-launcher-6.0.0.jar",
+        "hash": "5f097b00c6714bb71ecfb5dec62b59bb4c2f789763fafd1ece96c4ef0e6c280f",
+        "path": "org/junit/platform/junit-platform-launcher/6.0.0/junit-platform-launcher-6.0.0.jar"
+    },
+    {
+        "url": "org/junit/platform/junit-platform-engine/6.0.0/junit-platform-engine-6.0.0.jar",
+        "hash": "6f81842e9c13e997cac66b44614522f3639419e2388ae2d000c4bc0a6b92d93f",
+        "path": "org/junit/platform/junit-platform-engine/6.0.0/junit-platform-engine-6.0.0.jar"
+    },
+    {
+        "url": "org/jspecify/jspecify/1.0.0/jspecify-1.0.0.jar",
+        "hash": "1fad6e6be7557781e4d33729d49ae1cdc8fdda6fe477bb0cc68ce351eafdfbab",
+        "path": "org/jspecify/jspecify/1.0.0/jspecify-1.0.0.jar"
+    },
+    {
+        "url": "com/fasterxml/jackson/core/jackson-databind/2.19.0/jackson-databind-2.19.0.jar",
+        "hash": "ceda311f476c3b18e1d2b240c94e2dcb9c8d44e70f8afa9facab88bac4ddc03a",
+        "path": "com/fasterxml/jackson/core/jackson-databind/2.19.0/jackson-databind-2.19.0.jar"
+    },
+    {
+        "url": "com/fasterxml/jackson/core/jackson-annotations/2.19.0/jackson-annotations-2.19.0.jar",
+        "hash": "ead60e9cac0e42b57092b9e2d087ff43536e9477d4486ba393037a8cc156cda7",
+        "path": "com/fasterxml/jackson/core/jackson-annotations/2.19.0/jackson-annotations-2.19.0.jar"
+    },
+    {
+        "url": "org/jetbrains/markdown-jvm/0.7.2/markdown-jvm-0.7.2.jar",
+        "hash": "02e0f9bf95e4b9f81e34593691a5c0ff14604db39fb8446fe9a4efa66553f3ac",
+        "path": "org/jetbrains/markdown-jvm/0.7.2/markdown-jvm-0.7.2.jar"
+    },
+    {
+        "url": "com/fasterxml/jackson/dataformat/jackson-dataformat-toml/2.19.0/jackson-dataformat-toml-2.19.0.jar",
+        "hash": "e6312d390c6bef67681f8e258f29ced2f3d0fa1d83a72e0bec1513b8c1c4f430",
+        "path": "com/fasterxml/jackson/dataformat/jackson-dataformat-toml/2.19.0/jackson-dataformat-toml-2.19.0.jar"
+    },
+    {
+        "url": "de/cketti/unicode/kotlin-codepoints-jvm/0.9.0/kotlin-codepoints-jvm-0.9.0.jar",
+        "hash": "d642f145f6123739e779d4156145cc5fe7c2173bb58d437b813961a31c337ff9",
+        "path": "de/cketti/unicode/kotlin-codepoints-jvm/0.9.0/kotlin-codepoints-jvm-0.9.0.jar"
+    },
+    {
+        "url": "org/sqlite/native/3.42.0-jb.1/native-3.42.0-jb.1.jar",
+        "hash": "491c4ae84a1bad34c85624682a80def4f3a3a0fb9d517121d05c2dfeb94966f8",
+        "path": "org/sqlite/native/3.42.0-jb.1/native-3.42.0-jb.1.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/allopen-compiler-plugin-for-ide/2.3.20-ij253-45/allopen-compiler-plugin-for-ide-2.3.20-ij253-45.jar",
+        "hash": "f7374912dbbcfc18686114a78804a7f4ba91aa54b6f3bf4be10a54bb643f8a61",
+        "path": "org/jetbrains/kotlin/allopen-compiler-plugin-for-ide/2.3.20-ij253-45/allopen-compiler-plugin-for-ide-2.3.20-ij253-45.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/analysis-api-for-ide/2.3.20-ij253-45/analysis-api-for-ide-2.3.20-ij253-45.jar",
+        "hash": "47db94b0240122449cb95aa00dd8b9d0722948b81f8390b9d27d38797c0fc784",
+        "path": "org/jetbrains/kotlin/analysis-api-for-ide/2.3.20-ij253-45/analysis-api-for-ide-2.3.20-ij253-45.jar"
+    },
+    {
+        "url": "org/apache/lucene/lucene-codecs/10.3.0/lucene-codecs-10.3.0.jar",
+        "hash": "0628a26040706fea7a222a91c8ca339aef9ea8ceda6d24527a817dc7e0ad5c92",
+        "path": "org/apache/lucene/lucene-codecs/10.3.0/lucene-codecs-10.3.0.jar"
+    },
+    {
+        "url": "io/ktor/ktor-websocket-serialization-jvm/3.1.3/ktor-websocket-serialization-jvm-3.1.3.jar",
+        "hash": "67f0f566e2ed51717f6ed55f6d2b4dee1c84be4ea2cd96fc636d0bdf0fd43067",
+        "path": "io/ktor/ktor-websocket-serialization-jvm/3.1.3/ktor-websocket-serialization-jvm-3.1.3.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-stdlib/2.2.20/kotlin-stdlib-2.2.20.jar",
+        "hash": "8836ccffd3585fadda9901244b20d42901d2f3cd581058d8434e2ffabcf3a3e7",
+        "path": "org/jetbrains/kotlin/kotlin-stdlib/2.2.20/kotlin-stdlib-2.2.20.jar"
+    },
+    {
+        "url": "org/jmock/jmock-junit4/2.5.1/jmock-junit4-2.5.1.jar",
+        "hash": "c53b16b999d3b2f1aa273bf5c560273d23e1fa21ce493ba7cbf5243118386b88",
+        "path": "org/jmock/jmock-junit4/2.5.1/jmock-junit4-2.5.1.jar"
+    },
+    {
+        "url": "com/jetbrains/fus/reporting/serialization-kotlin/171/serialization-kotlin-171.jar",
+        "hash": "83380929b70dc8e25db327be8680438f3d80087962a88f4dcf061c919ba2fc32",
+        "path": "com/jetbrains/fus/reporting/serialization-kotlin/171/serialization-kotlin-171.jar"
+    },
+    {
+        "url": "com/jetbrains/intellij/platform/workspace-model-codegen/0.0.9/workspace-model-codegen-0.0.9.jar",
+        "hash": "78e527dfea8d79c16ea9ca875bd943d443b63bf9d0df1f253c233dc54366df35",
+        "path": "com/jetbrains/intellij/platform/workspace-model-codegen/0.0.9/workspace-model-codegen-0.0.9.jar"
+    },
+    {
+        "url": "io/ktor/ktor-client-cio-jvm/3.1.3/ktor-client-cio-jvm-3.1.3.jar",
+        "hash": "9a86341588057a23d3ba4562fdc8afcef6facd071678a0c20b3b28a19ec35c88",
+        "path": "io/ktor/ktor-client-cio-jvm/3.1.3/ktor-client-cio-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/github/smiley4/schema-kenerator-serialization/2.2.0/schema-kenerator-serialization-2.2.0.jar",
+        "hash": "9c4a9713b2722b3b124210e89c3702c3e18c19156a3a06fa6bcef43a850299ca",
+        "path": "io/github/smiley4/schema-kenerator-serialization/2.2.0/schema-kenerator-serialization-2.2.0.jar"
+    },
+    {
+        "url": "org/jetbrains/annotations/26.0.2/annotations-26.0.2.jar",
+        "hash": "2037be378980d3ba9333e97955f3b2cde392aa124d04ca73ce2eee6657199297",
+        "path": "org/jetbrains/annotations/26.0.2/annotations-26.0.2.jar"
+    },
+    {
+        "url": "com/jetbrains/infra/download-pgp-verifier/1.1.4/download-pgp-verifier-1.1.4.jar",
+        "hash": "2bbfa931b2864c4f5e1fd22046d001df8d9a8592a20255baab0d396ed71c854c",
+        "path": "com/jetbrains/infra/download-pgp-verifier/1.1.4/download-pgp-verifier-1.1.4.jar"
     },
     {
         "url": "org/jline/jline-terminal-jna/3.27.0/jline-terminal-jna-3.27.0.jar",
@@ -68,121 +703,6 @@
         "url": "org/jline/jline-native/3.27.0/jline-native-3.27.0.jar",
         "hash": "d8bc77bc80edc7d9a02a06a069b2d7085629421db0843aba7c153a869ffe525d",
         "path": "org/jline/jline-native/3.27.0/jline-native-3.27.0.jar"
-    },
-    {
-        "url": "io/kotest/kotest-assertions-core-jvm/5.5.4/kotest-assertions-core-jvm-5.5.4.jar",
-        "hash": "3acf3de882ec2c714dfc173cc382c38a5aee70c3f2bdda732583916845226d0c",
-        "path": "io/kotest/kotest-assertions-core-jvm/5.5.4/kotest-assertions-core-jvm-5.5.4.jar"
-    },
-    {
-        "url": "io/kotest/kotest-assertions-shared-jvm/5.5.4/kotest-assertions-shared-jvm-5.5.4.jar",
-        "hash": "9977d913ef1fccf2e2663b5906d955fdf8215d0ec48265d669b01e05179e2043",
-        "path": "io/kotest/kotest-assertions-shared-jvm/5.5.4/kotest-assertions-shared-jvm-5.5.4.jar"
-    },
-    {
-        "url": "org/opentest4j/opentest4j/1.2.0/opentest4j-1.2.0.jar",
-        "hash": "58812de60898d976fb81ef3b62da05c6604c18fd4a249f5044282479fc286af2",
-        "path": "org/opentest4j/opentest4j/1.2.0/opentest4j-1.2.0.jar"
-    },
-    {
-        "url": "io/kotest/kotest-common-jvm/5.5.4/kotest-common-jvm-5.5.4.jar",
-        "hash": "a2a4d02b86b2e849e514d18dbdf4b29e2e9d091e3c6f4d9d028db9cdc55dd28b",
-        "path": "io/kotest/kotest-common-jvm/5.5.4/kotest-common-jvm-5.5.4.jar"
-    },
-    {
-        "url": "io/kotest/kotest-assertions-api-jvm/5.5.4/kotest-assertions-api-jvm-5.5.4.jar",
-        "hash": "8b1c3e582e2f6f662261f3f45a6d723f3dd8d8b2b0b86a3f7d8e6c966eca0568",
-        "path": "io/kotest/kotest-assertions-api-jvm/5.5.4/kotest-assertions-api-jvm-5.5.4.jar"
-    },
-    {
-        "url": "com/squareup/javapoet/1.13.0/javapoet-1.13.0.jar",
-        "hash": "4c7517e848a71b36d069d12bb3bf46a70fd4cda3105d822b0ed2e19c00b69291",
-        "path": "com/squareup/javapoet/1.13.0/javapoet-1.13.0.jar"
-    },
-    {
-        "url": "org/jetbrains/markdown-jvm/0.7.2/markdown-jvm-0.7.2.jar",
-        "hash": "02e0f9bf95e4b9f81e34593691a5c0ff14604db39fb8446fe9a4efa66553f3ac",
-        "path": "org/jetbrains/markdown-jvm/0.7.2/markdown-jvm-0.7.2.jar"
-    },
-    {
-        "url": "org/assertj/assertj-swing/3.17.1/assertj-swing-3.17.1.jar",
-        "hash": "e36445438d72d83cc48015dcb3f14d9a97eaa42c4663a9826db2bb50e4c7713b",
-        "path": "org/assertj/assertj-swing/3.17.1/assertj-swing-3.17.1.jar"
-    },
-    {
-        "url": "io/grpc/grpc-netty-shaded/1.73.0/grpc-netty-shaded-1.73.0.jar",
-        "hash": "8328289ba6b73445e982a1cadf8e651ea65354e288c825a43e7c77f16da8a056",
-        "path": "io/grpc/grpc-netty-shaded/1.73.0/grpc-netty-shaded-1.73.0.jar"
-    },
-    {
-        "url": "io/grpc/grpc-util/1.73.0/grpc-util-1.73.0.jar",
-        "hash": "b7df6cbcc30b7a3219f06483a9a9d320a431beda8a1ace5b16d879f84112373f",
-        "path": "io/grpc/grpc-util/1.73.0/grpc-util-1.73.0.jar"
-    },
-    {
-        "url": "io/netty/netty-codec-protobuf/4.2.0.RC2/netty-codec-protobuf-4.2.0.RC2.jar",
-        "hash": "c5fb188895ffdfd529473c5e7ba1c58da2f514a44134b15ad0d51efe3f28bb38",
-        "path": "io/netty/netty-codec-protobuf/4.2.0.RC2/netty-codec-protobuf-4.2.0.RC2.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-build-common-tests-for-ide/2.3.20-ij253-45/kotlin-build-common-tests-for-ide-2.3.20-ij253-45.jar",
-        "hash": "c5d0331fb960fbb5e392118d1322e905f37be1b0b0abd6121d06caade7cc9b16",
-        "path": "org/jetbrains/kotlin/kotlin-build-common-tests-for-ide/2.3.20-ij253-45/kotlin-build-common-tests-for-ide-2.3.20-ij253-45.jar"
-    },
-    {
-        "url": "com/android/tools/smali/smali-dexlib2/3.0.3/smali-dexlib2-3.0.3.jar",
-        "hash": "11cc5e7b75b23feb65e41e28e5c225b4a77dbf7210d6cedd4bdb3f04c1f6ea24",
-        "path": "com/android/tools/smali/smali-dexlib2/3.0.3/smali-dexlib2-3.0.3.jar"
-    },
-    {
-        "url": "com/jetbrains/rd/rd-framework/2025.3.1/rd-framework-2025.3.1.jar",
-        "hash": "85f2a329245e4a6a1e4552ac62db4c1f23b6f02bf3c96e4df8240668187c848a",
-        "path": "com/jetbrains/rd/rd-framework/2025.3.1/rd-framework-2025.3.1.jar"
-    },
-    {
-        "url": "org/jetbrains/intellij/deps/completion/ngram-slp/0.0.3/ngram-slp-0.0.3.jar",
-        "hash": "4ac10d8fb7e6326e09179fd83e664610a3362dc1d661fb32e5b2a19bcb9fc867",
-        "path": "org/jetbrains/intellij/deps/completion/ngram-slp/0.0.3/ngram-slp-0.0.3.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/analysis-api-fe10-for-ide/2.3.20-ij253-45/analysis-api-fe10-for-ide-2.3.20-ij253-45.jar",
-        "hash": "cbf24708e46c2e064a37887d5b53d1234ba2b3c1d285ecc9ba82cb6152076297",
-        "path": "org/jetbrains/kotlin/analysis-api-fe10-for-ide/2.3.20-ij253-45/analysis-api-fe10-for-ide-2.3.20-ij253-45.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/symbol-light-classes-for-ide/2.3.20-ij253-45/symbol-light-classes-for-ide-2.3.20-ij253-45.jar",
-        "hash": "298e61756dab332adc36712f14803e47f65f114f736c41cace04eaef2cce380e",
-        "path": "org/jetbrains/kotlin/symbol-light-classes-for-ide/2.3.20-ij253-45/symbol-light-classes-for-ide-2.3.20-ij253-45.jar"
-    },
-    {
-        "url": "io/mockk/mockk-jvm/1.14.5/mockk-jvm-1.14.5.jar",
-        "hash": "74deb86cbab6871a3e4d0f97ba8eacbdae7aacd7537f142bcb083590465a6219",
-        "path": "io/mockk/mockk-jvm/1.14.5/mockk-jvm-1.14.5.jar"
-    },
-    {
-        "url": "io/mockk/mockk-dsl-jvm/1.14.5/mockk-dsl-jvm-1.14.5.jar",
-        "hash": "d01d6ce85f9824d8ddb22ea7f1bccd581b831ffad504f48a4f18abf9bc6f2eac",
-        "path": "io/mockk/mockk-dsl-jvm/1.14.5/mockk-dsl-jvm-1.14.5.jar"
-    },
-    {
-        "url": "io/mockk/mockk-agent-jvm/1.14.5/mockk-agent-jvm-1.14.5.jar",
-        "hash": "9f78e9988e84c98569edcf9a6225d5b7354939529642e54c2c58da3ef3913106",
-        "path": "io/mockk/mockk-agent-jvm/1.14.5/mockk-agent-jvm-1.14.5.jar"
-    },
-    {
-        "url": "io/mockk/mockk-agent-api-jvm/1.14.5/mockk-agent-api-jvm-1.14.5.jar",
-        "hash": "a919a8fec03dfb0c084cb43dafcebe2dd9351431c7a08c2fc8147037de1d06b7",
-        "path": "io/mockk/mockk-agent-api-jvm/1.14.5/mockk-agent-api-jvm-1.14.5.jar"
-    },
-    {
-        "url": "io/mockk/mockk-core-jvm/1.14.5/mockk-core-jvm-1.14.5.jar",
-        "hash": "060fffe7452e74f6e18bb9dfe1221e92c4ec0de29a84b022fb562ec6cd954691",
-        "path": "io/mockk/mockk-core-jvm/1.14.5/mockk-core-jvm-1.14.5.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-jps-plugin-classpath/2.2.20/kotlin-jps-plugin-classpath-2.2.20.jar",
-        "hash": "fa31a084adbecaaf98166e734fba1bf964e04e22671d70230ed9598cecd22124",
-        "path": "org/jetbrains/kotlin/kotlin-jps-plugin-classpath/2.2.20/kotlin-jps-plugin-classpath-2.2.20.jar"
     },
     {
         "url": "io/ktor/ktor-server-cio-jvm/3.1.3/ktor-server-cio-jvm-3.1.3.jar",
@@ -240,119 +760,39 @@
         "path": "io/ktor/ktor-network-jvm/3.1.3/ktor-network-jvm-3.1.3.jar"
     },
     {
-        "url": "com/fasterxml/jackson/core/jackson-databind/2.19.0/jackson-databind-2.19.0.jar",
-        "hash": "ceda311f476c3b18e1d2b240c94e2dcb9c8d44e70f8afa9facab88bac4ddc03a",
-        "path": "com/fasterxml/jackson/core/jackson-databind/2.19.0/jackson-databind-2.19.0.jar"
+        "url": "com/android/tools/smali/smali-baksmali/3.0.3/smali-baksmali-3.0.3.jar",
+        "hash": "ffd6f3fbba2453440e4c04add42b9f903d84151b5b71f7e6bbb181d8096397a4",
+        "path": "com/android/tools/smali/smali-baksmali/3.0.3/smali-baksmali-3.0.3.jar"
     },
     {
-        "url": "com/fasterxml/jackson/core/jackson-annotations/2.19.0/jackson-annotations-2.19.0.jar",
-        "hash": "ead60e9cac0e42b57092b9e2d087ff43536e9477d4486ba393037a8cc156cda7",
-        "path": "com/fasterxml/jackson/core/jackson-annotations/2.19.0/jackson-annotations-2.19.0.jar"
+        "url": "com/android/tools/smali/smali-util/3.0.3/smali-util-3.0.3.jar",
+        "hash": "8078a04709f42072a240a6fe7666b71755324745c505b39f86ededfd9c2b90c4",
+        "path": "com/android/tools/smali/smali-util/3.0.3/smali-util-3.0.3.jar"
     },
     {
-        "url": "com/jetbrains/rd/rd-text/2025.3.1/rd-text-2025.3.1.jar",
-        "hash": "e465ab42d9c79cdec7147c8210f8e65d5f816704d47b959ac9f2cfc3f68dedb5",
-        "path": "com/jetbrains/rd/rd-text/2025.3.1/rd-text-2025.3.1.jar"
+        "url": "com/github/luben/zstd-jni/1.5.7-4/zstd-jni-1.5.7-4.jar",
+        "hash": "e7f064bf1eab83fa785cf587f657f09649e3b0af6f27caa5382416953b5a35f8",
+        "path": "com/github/luben/zstd-jni/1.5.7-4/zstd-jni-1.5.7-4.jar"
     },
     {
-        "url": "org/slf4j/log4j-over-slf4j/1.7.36/log4j-over-slf4j-1.7.36.jar",
-        "hash": "0a7e032bf5bcdd5b2bf8bf2e5cf02c5646f2aa6fee66933b8150dbe84e651e8a",
-        "path": "org/slf4j/log4j-over-slf4j/1.7.36/log4j-over-slf4j-1.7.36.jar"
+        "url": "com/jetbrains/intellij/documentation/tips-pycharm-community/241.74/tips-pycharm-community-241.74.jar",
+        "hash": "7f9fd8e37ec4dfdef7bfc3bc6a687fa5a322976fc588432fa46d2feb1fefc966",
+        "path": "com/jetbrains/intellij/documentation/tips-pycharm-community/241.74/tips-pycharm-community-241.74.jar"
     },
     {
-        "url": "com/jcraft/jzlib/1.1.3/jzlib-1.1.3.jar",
-        "hash": "89b1360f407381bf61fde411019d8cbd009ebb10cff715f3669017a031027560",
-        "path": "com/jcraft/jzlib/1.1.3/jzlib-1.1.3.jar"
+        "url": "org/jetbrains/jetCheck/0.2.2/jetCheck-0.2.2.jar",
+        "hash": "c5f95c97171311066a13eb750a6bb999fa7eeb43c1394705034926336c0b7b0f",
+        "path": "org/jetbrains/jetCheck/0.2.2/jetCheck-0.2.2.jar"
     },
     {
-        "url": "com/intellij/platform/kotlinx-coroutines-slf4j/1.10.1-intellij-5/kotlinx-coroutines-slf4j-1.10.1-intellij-5.jar",
-        "hash": "1d68dfc6ba67ec96ecb5a373dbd9fb557ce2210ffc2d74d6b528e4f1f73e7003",
-        "path": "com/intellij/platform/kotlinx-coroutines-slf4j/1.10.1-intellij-5/kotlinx-coroutines-slf4j-1.10.1-intellij-5.jar"
+        "url": "io/ktor/ktor-client-cio-jvm/3.1.3/ktor-client-cio-jvm-3.1.3.jar",
+        "hash": "9a86341588057a23d3ba4562fdc8afcef6facd071678a0c20b3b28a19ec35c88",
+        "path": "io/ktor/ktor-client-cio-jvm/3.1.3/ktor-client-cio-jvm-3.1.3.jar"
     },
     {
-        "url": "org/apache/httpcomponents/httpmime/4.5.14/httpmime-4.5.14.jar",
-        "hash": "d401243d5c6eae928a37121b6e819158c8c32ea0584793e7285bb489ab2a3d17",
-        "path": "org/apache/httpcomponents/httpmime/4.5.14/httpmime-4.5.14.jar"
-    },
-    {
-        "url": "org/apache/httpcomponents/httpclient/4.5.14/httpclient-4.5.14.jar",
-        "hash": "c8bc7e1c51a6d4ce72f40d2ebbabf1c4b68bfe76e732104b04381b493478e9d6",
-        "path": "org/apache/httpcomponents/httpclient/4.5.14/httpclient-4.5.14.jar"
-    },
-    {
-        "url": "org/apache/httpcomponents/httpcore/4.4.16/httpcore-4.4.16.jar",
-        "hash": "6c9b3dd142a09dc468e23ad39aad6f75a0f2b85125104469f026e52a474e464f",
-        "path": "org/apache/httpcomponents/httpcore/4.4.16/httpcore-4.4.16.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-gradle-plugin-idea-proto/1.9.20-dev-8162/kotlin-gradle-plugin-idea-proto-1.9.20-dev-8162.jar",
-        "hash": "3841d6ad1fdd4bf90143ac6012146d291409b431e837f143c023135bd24b79a6",
-        "path": "org/jetbrains/kotlin/kotlin-gradle-plugin-idea-proto/1.9.20-dev-8162/kotlin-gradle-plugin-idea-proto-1.9.20-dev-8162.jar"
-    },
-    {
-        "url": "org/apache/lucene/lucene-queries/10.3.0/lucene-queries-10.3.0.jar",
-        "hash": "c0c5891b390759a0cf503c7864e6eb4d8447cc8df20806a4254bfdf3d2f43a91",
-        "path": "org/apache/lucene/lucene-queries/10.3.0/lucene-queries-10.3.0.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlinx/kotlinx-datetime-jvm/0.6.2/kotlinx-datetime-jvm-0.6.2.jar",
-        "hash": "102764921129e1e44a74f408b7a0b8dac6d1892c6042e0e48f8bdbbbf78c6d2e",
-        "path": "org/jetbrains/kotlinx/kotlinx-datetime-jvm/0.6.2/kotlinx-datetime-jvm-0.6.2.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/compose-compiler-plugin-for-ide/2.3.20-ij253-45/compose-compiler-plugin-for-ide-2.3.20-ij253-45.jar",
-        "hash": "84612c6b067f7018325c00975bb49a35e1947d8de1c03009e999b746219105f4",
-        "path": "org/jetbrains/kotlin/compose-compiler-plugin-for-ide/2.3.20-ij253-45/compose-compiler-plugin-for-ide-2.3.20-ij253-45.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/incremental-compilation-impl-tests-for-ide/2.3.20-ij253-45/incremental-compilation-impl-tests-for-ide-2.3.20-ij253-45.jar",
-        "hash": "9d2369a7e71ff367dbed384ee50976c25743b09e4be68a58f9412ad165d8e0d7",
-        "path": "org/jetbrains/kotlin/incremental-compilation-impl-tests-for-ide/2.3.20-ij253-45/incremental-compilation-impl-tests-for-ide-2.3.20-ij253-45.jar"
-    },
-    {
-        "url": "org/junit/jupiter/junit-jupiter-api/6.0.0/junit-jupiter-api-6.0.0.jar",
-        "hash": "88d690d2d373cd66170770c317977196ce9e465f2388930f4bc9665e887385f6",
-        "path": "org/junit/jupiter/junit-jupiter-api/6.0.0/junit-jupiter-api-6.0.0.jar"
-    },
-    {
-        "url": "org/opentest4j/opentest4j/1.3.0/opentest4j-1.3.0.jar",
-        "hash": "48e2df636cab6563ced64dcdff8abb2355627cb236ef0bf37598682ddf742f1b",
-        "path": "org/opentest4j/opentest4j/1.3.0/opentest4j-1.3.0.jar"
-    },
-    {
-        "url": "org/junit/platform/junit-platform-commons/6.0.0/junit-platform-commons-6.0.0.jar",
-        "hash": "86e8faf87f3151a3d545850852a0f2cc55ea8a2434eee9e08f83881c52d55992",
-        "path": "org/junit/platform/junit-platform-commons/6.0.0/junit-platform-commons-6.0.0.jar"
-    },
-    {
-        "url": "org/apiguardian/apiguardian-api/1.1.2/apiguardian-api-1.1.2.jar",
-        "hash": "b509448ac506d607319f182537f0b35d71007582ec741832a1f111e5b5b70b38",
-        "path": "org/apiguardian/apiguardian-api/1.1.2/apiguardian-api-1.1.2.jar"
-    },
-    {
-        "url": "org/jspecify/jspecify/1.0.0/jspecify-1.0.0.jar",
-        "hash": "1fad6e6be7557781e4d33729d49ae1cdc8fdda6fe477bb0cc68ce351eafdfbab",
-        "path": "org/jspecify/jspecify/1.0.0/jspecify-1.0.0.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-scripting-compiler-impl/2.3.20-ij253-45/kotlin-scripting-compiler-impl-2.3.20-ij253-45.jar",
-        "hash": "c2b19162264b2aa78371cd834f8703e1c49c032ec9862cdb9b744a4a2a8e7ded",
-        "path": "org/jetbrains/kotlin/kotlin-scripting-compiler-impl/2.3.20-ij253-45/kotlin-scripting-compiler-impl-2.3.20-ij253-45.jar"
-    },
-    {
-        "url": "org/junit/jupiter/junit-jupiter-engine/5.13.4/junit-jupiter-engine-5.13.4.jar",
-        "hash": "027404a92fe618b72465792a257951495c503a7d5751e2791e0f51c87f67f5bc",
-        "path": "org/junit/jupiter/junit-jupiter-engine/5.13.4/junit-jupiter-engine-5.13.4.jar"
-    },
-    {
-        "url": "org/codehaus/groovy/groovy/3.0.25/groovy-3.0.25.jar",
-        "hash": "ad009e985dd84e4f524f4ed1751866da5bef816b691851bfbcefa48a01180a07",
-        "path": "org/codehaus/groovy/groovy/3.0.25/groovy-3.0.25.jar"
-    },
-    {
-        "url": "org/apache/commons/commons-compress/1.27.1/commons-compress-1.27.1.jar",
-        "hash": "293d80f54b536b74095dcd7ea3cf0a29bbfc3402519281332495f4420d370d16",
-        "path": "org/apache/commons/commons-compress/1.27.1/commons-compress-1.27.1.jar"
+        "url": "io/ktor/ktor-client-core-jvm/3.1.3/ktor-client-core-jvm-3.1.3.jar",
+        "hash": "746e2a3dece87379d64c40999401969001d373de1458fe851c0d2e0f880b42ef",
+        "path": "io/ktor/ktor-client-core-jvm/3.1.3/ktor-client-core-jvm-3.1.3.jar"
     },
     {
         "url": "io/ktor/ktor-http-jvm/3.1.3/ktor-http-jvm-3.1.3.jar",
@@ -360,14 +800,29 @@
         "path": "io/ktor/ktor-http-jvm/3.1.3/ktor-http-jvm-3.1.3.jar"
     },
     {
-        "url": "org/jetbrains/intellij/deps/jb-jdi/2.45/jb-jdi-2.45.jar",
-        "hash": "f31793446f372ee33659fc7a4ce93a079fa520ae89ddf6f6280ea50425c408d4",
-        "path": "org/jetbrains/intellij/deps/jb-jdi/2.45/jb-jdi-2.45.jar"
+        "url": "io/ktor/ktor-events-jvm/3.1.3/ktor-events-jvm-3.1.3.jar",
+        "hash": "da7069c6e78809d7c37d104e415613cbd4cd5cec1ed54a332cb64ef6a864a060",
+        "path": "io/ktor/ktor-events-jvm/3.1.3/ktor-events-jvm-3.1.3.jar"
     },
     {
-        "url": "io/ktor/ktor-network-tls-jvm/3.1.3/ktor-network-tls-jvm-3.1.3.jar",
-        "hash": "f67507a3e8bf52aa08d753682e6cdda0194e3abe750118b99c9336953e598be9",
-        "path": "io/ktor/ktor-network-tls-jvm/3.1.3/ktor-network-tls-jvm-3.1.3.jar"
+        "url": "io/ktor/ktor-websocket-serialization-jvm/3.1.3/ktor-websocket-serialization-jvm-3.1.3.jar",
+        "hash": "67f0f566e2ed51717f6ed55f6d2b4dee1c84be4ea2cd96fc636d0bdf0fd43067",
+        "path": "io/ktor/ktor-websocket-serialization-jvm/3.1.3/ktor-websocket-serialization-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-serialization-jvm/3.1.3/ktor-serialization-jvm-3.1.3.jar",
+        "hash": "0d704bc1148a8fd9a1f2005e0b5189cdaed3030efe24b8236459c41c356f5620",
+        "path": "io/ktor/ktor-serialization-jvm/3.1.3/ktor-serialization-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-sse-jvm/3.1.3/ktor-sse-jvm-3.1.3.jar",
+        "hash": "a2ae8a338bb1d446d16dcfea2189ef5a5be31a88123b3879562b7955667a5639",
+        "path": "io/ktor/ktor-sse-jvm/3.1.3/ktor-sse-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-http-cio-jvm/3.1.3/ktor-http-cio-jvm-3.1.3.jar",
+        "hash": "b04aede18e9c008168096dc53a3fc016177b61a5ec3024afbf8caca0cd5dbf42",
+        "path": "io/ktor/ktor-http-cio-jvm/3.1.3/ktor-http-cio-jvm-3.1.3.jar"
     },
     {
         "url": "io/ktor/ktor-network-jvm/3.1.3/ktor-network-jvm-3.1.3.jar",
@@ -375,24 +830,144 @@
         "path": "io/ktor/ktor-network-jvm/3.1.3/ktor-network-jvm-3.1.3.jar"
     },
     {
-        "url": "org/apache/lucene/lucene-queryparser/10.3.0/lucene-queryparser-10.3.0.jar",
-        "hash": "b4b57bc3d56c5a1ccc674f55a16086c37700eb151fa749b45887e391ec0f26f9",
-        "path": "org/apache/lucene/lucene-queryparser/10.3.0/lucene-queryparser-10.3.0.jar"
+        "url": "io/ktor/ktor-io-jvm/3.1.3/ktor-io-jvm-3.1.3.jar",
+        "hash": "bb2fb6c00afaa34b539cb30e7584d37bfcba171c266bbdb9990e003579dc24c1",
+        "path": "io/ktor/ktor-io-jvm/3.1.3/ktor-io-jvm-3.1.3.jar"
     },
     {
-        "url": "com/google/jimfs/jimfs/1.1/jimfs-1.1.jar",
-        "hash": "c4828e28d7c0a930af9387510b3bada7daa5c04d7c25a75c7b8b081f1c257ddd",
-        "path": "com/google/jimfs/jimfs/1.1/jimfs-1.1.jar"
+        "url": "io/ktor/ktor-websockets-jvm/3.1.3/ktor-websockets-jvm-3.1.3.jar",
+        "hash": "ef28b4f12054ee125765b72fe3230e215a60b73b2ff2072a5c280fcf09329077",
+        "path": "io/ktor/ktor-websockets-jvm/3.1.3/ktor-websockets-jvm-3.1.3.jar"
     },
     {
-        "url": "org/apache/lucene/lucene-memory/10.3.0/lucene-memory-10.3.0.jar",
-        "hash": "ea77d0b2eb0b3e1f7fa04f2fbe671f5af3ae836cc40320411e195bdc9421f17b",
-        "path": "org/apache/lucene/lucene-memory/10.3.0/lucene-memory-10.3.0.jar"
+        "url": "io/ktor/ktor-utils-jvm/3.1.3/ktor-utils-jvm-3.1.3.jar",
+        "hash": "33333937b98fc0c8e943ee4b10b3ea66b49782dfb569c44c142da4f32d85dffc",
+        "path": "io/ktor/ktor-utils-jvm/3.1.3/ktor-utils-jvm-3.1.3.jar"
     },
     {
-        "url": "org/jetbrains/kotlin/noarg-compiler-plugin-for-ide/2.3.20-ij253-45/noarg-compiler-plugin-for-ide-2.3.20-ij253-45.jar",
-        "hash": "261a90d908355e185f0a291aa71b3ce1f4e3c67aa31411244ef8c124958b0c77",
-        "path": "org/jetbrains/kotlin/noarg-compiler-plugin-for-ide/2.3.20-ij253-45/noarg-compiler-plugin-for-ide-2.3.20-ij253-45.jar"
+        "url": "io/ktor/ktor-network-tls-jvm/3.1.3/ktor-network-tls-jvm-3.1.3.jar",
+        "hash": "f67507a3e8bf52aa08d753682e6cdda0194e3abe750118b99c9336953e598be9",
+        "path": "io/ktor/ktor-network-tls-jvm/3.1.3/ktor-network-tls-jvm-3.1.3.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-metadata-jvm/2.2.20/kotlin-metadata-jvm-2.2.20.jar",
+        "hash": "8524eac90f7e8e0f1366883f2c6c820c93bfa61df3d76857c8d3e803cf67315d",
+        "path": "org/jetbrains/kotlin/kotlin-metadata-jvm/2.2.20/kotlin-metadata-jvm-2.2.20.jar"
+    },
+    {
+        "url": "com/google/guava/guava-testlib/33.0.0-jre/guava-testlib-33.0.0-jre.jar",
+        "hash": "79626019fed282b70eef91f645a9febd5f6b9f7be46484b6b328313a481f05f0",
+        "path": "com/google/guava/guava-testlib/33.0.0-jre/guava-testlib-33.0.0-jre.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/intellij-test-discovery-agent/1.0.763/intellij-test-discovery-agent-1.0.763.jar",
+        "hash": "de175ebed73336e126ecba42c8b93a6566f65b169c6b4a4deb8099fe28e944de",
+        "path": "org/jetbrains/intellij/deps/intellij-test-discovery-agent/1.0.763/intellij-test-discovery-agent-1.0.763.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/analysis-api-k2-for-ide/2.3.20-ij253-45/analysis-api-k2-for-ide-2.3.20-ij253-45.jar",
+        "hash": "7fdbe230eae422cec677a358823315996f53853d4b4469e45e1531fb4f4e5245",
+        "path": "org/jetbrains/kotlin/analysis-api-k2-for-ide/2.3.20-ij253-45/analysis-api-k2-for-ide-2.3.20-ij253-45.jar"
+    },
+    {
+        "url": "org/eclipse/xtext/org.eclipse.xtext.xbase.lib/2.40.0/org.eclipse.xtext.xbase.lib-2.40.0.jar",
+        "hash": "5a810154295fc20a0268cae4cbbc6e5a35a8b32480d8727dc8301910524e4b79",
+        "path": "org/eclipse/xtext/org.eclipse.xtext.xbase.lib/2.40.0/org.eclipse.xtext.xbase.lib-2.40.0.jar"
+    },
+    {
+        "url": "oro/oro/2.0.8/oro-2.0.8.jar",
+        "hash": "e00ccdad5df7eb43fdee44232ef64602bf63807c2d133a7be83ba09fd49af26e",
+        "path": "oro/oro/2.0.8/oro-2.0.8.jar"
+    },
+    {
+        "url": "com/google/protobuf/protobuf-java-util/3.24.4-jb.2/protobuf-java-util-3.24.4-jb.2.jar",
+        "hash": "bd30f6cf55c4f9f0891f8b6ea6601c1502b643543d2535c8b477ea0481809e99",
+        "path": "com/google/protobuf/protobuf-java-util/3.24.4-jb.2/protobuf-java-util-3.24.4-jb.2.jar"
+    },
+    {
+        "url": "org/easymock/easymock/5.6.0/easymock-5.6.0.jar",
+        "hash": "63efc00da99774fb0253330ef9b5788b261022ba73f36bf76889ce7edf3d2b31",
+        "path": "org/easymock/easymock/5.6.0/easymock-5.6.0.jar"
+    },
+    {
+        "url": "io/cucumber/cucumber-core/2.4.0/cucumber-core-2.4.0.jar",
+        "hash": "ac0f343d6fc0dca4c93f8b6a6266b3bf4cb4d61913b8a4cd2b3abf50025268cf",
+        "path": "io/cucumber/cucumber-core/2.4.0/cucumber-core-2.4.0.jar"
+    },
+    {
+        "url": "info/cukes/cucumber-html/0.2.6/cucumber-html-0.2.6.jar",
+        "hash": "e2167e99bdb018576cce9cc0aad154ad995fe67a4b0c36c63344f743865f96e7",
+        "path": "info/cukes/cucumber-html/0.2.6/cucumber-html-0.2.6.jar"
+    },
+    {
+        "url": "io/cucumber/cucumber-jvm-deps/1.0.6/cucumber-jvm-deps-1.0.6.jar",
+        "hash": "d1c2cc901dd702eb77a2258c0d1446e4a302d28da0d4b49cd11ff3d5929281fa",
+        "path": "io/cucumber/cucumber-jvm-deps/1.0.6/cucumber-jvm-deps-1.0.6.jar"
+    },
+    {
+        "url": "io/cucumber/gherkin/5.0.0/gherkin-5.0.0.jar",
+        "hash": "e35cfa4a16204bf59fa167bb6d45be0717d6b7cfba1c30f156d8f21cde2f4065",
+        "path": "io/cucumber/gherkin/5.0.0/gherkin-5.0.0.jar"
+    },
+    {
+        "url": "io/cucumber/tag-expressions/1.1.1/tag-expressions-1.1.1.jar",
+        "hash": "e5a0a71fb846752900c0e5a99aa13e5a1bbc3ec97e7faf26803648fa45215584",
+        "path": "io/cucumber/tag-expressions/1.1.1/tag-expressions-1.1.1.jar"
+    },
+    {
+        "url": "org/junit/jupiter/junit-jupiter-api/5.13.4/junit-jupiter-api-5.13.4.jar",
+        "hash": "d1bb81abfd9e03418306b4e6a3390c8db52c58372e749c2980ac29f0c08278f1",
+        "path": "org/junit/jupiter/junit-jupiter-api/5.13.4/junit-jupiter-api-5.13.4.jar"
+    },
+    {
+        "url": "org/opentest4j/opentest4j/1.3.0/opentest4j-1.3.0.jar",
+        "hash": "48e2df636cab6563ced64dcdff8abb2355627cb236ef0bf37598682ddf742f1b",
+        "path": "org/opentest4j/opentest4j/1.3.0/opentest4j-1.3.0.jar"
+    },
+    {
+        "url": "org/junit/platform/junit-platform-commons/1.13.4/junit-platform-commons-1.13.4.jar",
+        "hash": "1c25ca641ebaae44ff3ad21ca1b2ef68d0dd84bfeb07c4805ba7840899b77408",
+        "path": "org/junit/platform/junit-platform-commons/1.13.4/junit-platform-commons-1.13.4.jar"
+    },
+    {
+        "url": "org/apiguardian/apiguardian-api/1.1.2/apiguardian-api-1.1.2.jar",
+        "hash": "b509448ac506d607319f182537f0b35d71007582ec741832a1f111e5b5b70b38",
+        "path": "org/apiguardian/apiguardian-api/1.1.2/apiguardian-api-1.1.2.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-reflect/2.2.20/kotlin-reflect-2.2.20.jar",
+        "hash": "8209083a4a7c4e476d9842b078308fa96a96f07a6bd99f05f3586ee13289ab26",
+        "path": "org/jetbrains/kotlin/kotlin-reflect/2.2.20/kotlin-reflect-2.2.20.jar"
+    },
+    {
+        "url": "org/mockito/mockito-junit-jupiter/5.19.0/mockito-junit-jupiter-5.19.0.jar",
+        "hash": "7cfbb7a9c1198053c699c663479fd4836acc22c2650003c8dee20e7fbc55a65a",
+        "path": "org/mockito/mockito-junit-jupiter/5.19.0/mockito-junit-jupiter-5.19.0.jar"
+    },
+    {
+        "url": "io/github/z4kn4fein/semver-jvm/2.0.0/semver-jvm-2.0.0.jar",
+        "hash": "fbbf174a4e78aa5be1f1b7db73edc5c0a6a2e59e1562263e2c3a2e510fa1ba45",
+        "path": "io/github/z4kn4fein/semver-jvm/2.0.0/semver-jvm-2.0.0.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlinx/kotlinx-serialization-json-jvm/1.8.1/kotlinx-serialization-json-jvm-1.8.1.jar",
+        "hash": "8769e5647557e3700919c32d508f5c5dad53c5d8234cd10846354fbcff14aa24",
+        "path": "org/jetbrains/kotlinx/kotlinx-serialization-json-jvm/1.8.1/kotlinx-serialization-json-jvm-1.8.1.jar"
+    },
+    {
+        "url": "com/intellij/platform/kotlinx-coroutines-test-jvm/1.10.1-intellij-5/kotlinx-coroutines-test-jvm-1.10.1-intellij-5.jar",
+        "hash": "98b5c1291d9e473ce6df9823781a8a2170f1dfb4c30d985c56ff5242df2ff8f5",
+        "path": "com/intellij/platform/kotlinx-coroutines-test-jvm/1.10.1-intellij-5/kotlinx-coroutines-test-jvm-1.10.1-intellij-5.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-compiler-fe10-for-ide/2.3.20-ij253-45/kotlin-compiler-fe10-for-ide-2.3.20-ij253-45.jar",
+        "hash": "d1f296fae451d3e16f70a6812fe88024132422189a6cb8a74e4f62b1fa5f18fd",
+        "path": "org/jetbrains/kotlin/kotlin-compiler-fe10-for-ide/2.3.20-ij253-45/kotlin-compiler-fe10-for-ide-2.3.20-ij253-45.jar"
+    },
+    {
+        "url": "com/jetbrains/mlapi/catboost-shadow-need-slf4j/1.2.5/catboost-shadow-need-slf4j-1.2.5.jar",
+        "hash": "94a06c3fdd4aa638df59c8c783a379ca43a5b933187760e219e09e84f1633d76",
+        "path": "com/jetbrains/mlapi/catboost-shadow-need-slf4j/1.2.5/catboost-shadow-need-slf4j-1.2.5.jar"
     },
     {
         "url": "io/ktor/ktor-serialization-kotlinx-json-jvm/3.1.3/ktor-serialization-kotlinx-json-jvm-3.1.3.jar",
@@ -405,59 +980,104 @@
         "path": "io/ktor/ktor-serialization-kotlinx-jvm/3.1.3/ktor-serialization-kotlinx-jvm-3.1.3.jar"
     },
     {
-        "url": "junit/junit/4.13.2/junit-4.13.2.jar",
-        "hash": "8e495b634469d64fb8acfa3495a065cbacc8a0fff55ce1e31007be4c16dc57d3",
-        "path": "junit/junit/4.13.2/junit-4.13.2.jar"
+        "url": "com/amazon/ion/ion-java/1.11.10/ion-java-1.11.10.jar",
+        "hash": "ede1a1a3bf3e4c182105695728b8b2808f6edd03587dc0e258f9a8920593f903",
+        "path": "com/amazon/ion/ion-java/1.11.10/ion-java-1.11.10.jar"
     },
     {
-        "url": "org/jetbrains/packagesearch/packagesearch-api-client-jvm/3.4.0/packagesearch-api-client-jvm-3.4.0.jar",
-        "hash": "9d0f4c74e96787499fcc2462c32afeb7f4db97db30042e2578f205f61e5898fb",
-        "path": "org/jetbrains/packagesearch/packagesearch-api-client-jvm/3.4.0/packagesearch-api-client-jvm-3.4.0.jar"
+        "url": "org/jetbrains/kotlin/kotlin-test-junit/2.2.20/kotlin-test-junit-2.2.20.jar",
+        "hash": "6842753b11a1544198f4a14b0f8820728327939b859c23c50b5fd4179c693900",
+        "path": "org/jetbrains/kotlin/kotlin-test-junit/2.2.20/kotlin-test-junit-2.2.20.jar"
     },
     {
-        "url": "org/jetbrains/packagesearch/packagesearch-http-models-jvm/3.4.0/packagesearch-http-models-jvm-3.4.0.jar",
-        "hash": "0318b967115de0c7c8fbd93bc6e3d279c82de2954f90794146962921de45972d",
-        "path": "org/jetbrains/packagesearch/packagesearch-http-models-jvm/3.4.0/packagesearch-http-models-jvm-3.4.0.jar"
+        "url": "org/junit/jupiter/junit-jupiter-params/5.13.4/junit-jupiter-params-5.13.4.jar",
+        "hash": "3a8c6365716dbb698c0d49a05456c1e1ad05c406613c550f9dd50037872efc41",
+        "path": "org/junit/jupiter/junit-jupiter-params/5.13.4/junit-jupiter-params-5.13.4.jar"
     },
     {
-        "url": "org/jetbrains/packagesearch/packagesearch-api-models-jvm/3.4.0/packagesearch-api-models-jvm-3.4.0.jar",
-        "hash": "22022fe954980d8e183b252889719fc6ca71a13e91b8e869d92532da308e3da1",
-        "path": "org/jetbrains/packagesearch/packagesearch-api-models-jvm/3.4.0/packagesearch-api-models-jvm-3.4.0.jar"
+        "url": "io/ktor/ktor-websockets-jvm/3.1.3/ktor-websockets-jvm-3.1.3.jar",
+        "hash": "ef28b4f12054ee125765b72fe3230e215a60b73b2ff2072a5c280fcf09329077",
+        "path": "io/ktor/ktor-websockets-jvm/3.1.3/ktor-websockets-jvm-3.1.3.jar"
     },
     {
-        "url": "org/jetbrains/packagesearch/packagesearch-version-utils-jvm/3.4.0/packagesearch-version-utils-jvm-3.4.0.jar",
-        "hash": "4c86546693efaeb889e02d043521cda15da5f10853b0471095b7db80dc0540e7",
-        "path": "org/jetbrains/packagesearch/packagesearch-version-utils-jvm/3.4.0/packagesearch-version-utils-jvm-3.4.0.jar"
+        "url": "org/jetbrains/kotlin/kotlin-script-runtime/2.3.20-ij253-45/kotlin-script-runtime-2.3.20-ij253-45.jar",
+        "hash": "c35fd880ce45b252c0daee0bc644ea91a326a69c9dceda54151f4b2e13f3bdc3",
+        "path": "org/jetbrains/kotlin/kotlin-script-runtime/2.3.20-ij253-45/kotlin-script-runtime-2.3.20-ij253-45.jar"
     },
     {
-        "url": "com/soywiz/korlibs/krypto/krypto-jvm/4.0.10/krypto-jvm-4.0.10.jar",
-        "hash": "0fe8dcdf54b13b5ec56fdb5f63c057364264bb2f51b7f7bc3c271d5b1ba68dcb",
-        "path": "com/soywiz/korlibs/krypto/krypto-jvm/4.0.10/krypto-jvm-4.0.10.jar"
+        "url": "org/jetbrains/kotlin/kotlin-compiler-tests-for-ide/2.3.20-ij253-45/kotlin-compiler-tests-for-ide-2.3.20-ij253-45.jar",
+        "hash": "4b182e6689c0b5ff330195dc89d249df941a11a7027ce08e6e84163fa89d37d2",
+        "path": "org/jetbrains/kotlin/kotlin-compiler-tests-for-ide/2.3.20-ij253-45/kotlin-compiler-tests-for-ide-2.3.20-ij253-45.jar"
     },
     {
-        "url": "com/jgoodies/forms/1.1-preview/forms-1.1-preview.jar",
-        "hash": "26b0fc745ea051b57462be22a150c7600dbac6716b24cc60a5ecc0e8085c41a0",
-        "path": "com/jgoodies/forms/1.1-preview/forms-1.1-preview.jar"
+        "url": "io/cucumber/cucumber-core/1.2.6/cucumber-core-1.2.6.jar",
+        "hash": "ace77c533236213a1aa9f68b8de10e564da809605371ef2f8c73cd8f4c71293a",
+        "path": "io/cucumber/cucumber-core/1.2.6/cucumber-core-1.2.6.jar"
     },
     {
-        "url": "org/jetbrains/testDiscovery/test-discovery-plugin-base/0.1.191/test-discovery-plugin-base-0.1.191.jar",
-        "hash": "5ed74de192bd48546a6bc6e1c9f8f508663d8506ad9ef257aebbd6e829fdea36",
-        "path": "org/jetbrains/testDiscovery/test-discovery-plugin-base/0.1.191/test-discovery-plugin-base-0.1.191.jar"
+        "url": "info/cukes/gherkin/2.12.2/gherkin-2.12.2.jar",
+        "hash": "0a5ebc0506ab1e4a08af1ca150f797304ff53b953c5b1f6fcf1f81551d964aad",
+        "path": "info/cukes/gherkin/2.12.2/gherkin-2.12.2.jar"
     },
     {
-        "url": "com/jetbrains/fleet/rpc-compiler-plugin/2.2.20-0.1/rpc-compiler-plugin-2.2.20-0.1.jar",
-        "hash": "71e74b74676099dd9ebbb97780401f9b53f205a69d0d515a5e03c5a42fe20c18",
-        "path": "com/jetbrains/fleet/rpc-compiler-plugin/2.2.20-0.1/rpc-compiler-plugin-2.2.20-0.1.jar"
+        "url": "org/jmock/jmock-legacy/2.5.1/jmock-legacy-2.5.1.jar",
+        "hash": "0c8d23755cd08d23c3ea194773a08b2c322d2b70cc8c86ac02b424d8a50c9118",
+        "path": "org/jmock/jmock-legacy/2.5.1/jmock-legacy-2.5.1.jar"
     },
     {
-        "url": "org/jetbrains/kotlin/kotlin-jps-plugin-classpath/2.3.20-ij253-45/kotlin-jps-plugin-classpath-2.3.20-ij253-45.jar",
-        "hash": "290744db458f813618c460312a1f35bb2ed082485385d558de368c893509d11c",
-        "path": "org/jetbrains/kotlin/kotlin-jps-plugin-classpath/2.3.20-ij253-45/kotlin-jps-plugin-classpath-2.3.20-ij253-45.jar"
+        "url": "org/jetbrains/nativecerts/jvm-native-trusted-roots/1.1.7/jvm-native-trusted-roots-1.1.7.jar",
+        "hash": "8d715c487c8908a8b3b1d982f013f5ec39fb9033eb4272fdb251d648b5ede48c",
+        "path": "org/jetbrains/nativecerts/jvm-native-trusted-roots/1.1.7/jvm-native-trusted-roots-1.1.7.jar"
     },
     {
-        "url": "com/jetbrains/fus/reporting/configuration/171/configuration-171.jar",
-        "hash": "f138ed43c55cb90192518293a5b46a135221c898b2b05d6c0648645b3d0fac64",
-        "path": "com/jetbrains/fus/reporting/configuration/171/configuration-171.jar"
+        "url": "com/google/code/gson/gson/2.13.1/gson-2.13.1.jar",
+        "hash": "94855942d4992f112946d3de1c334e709237b8126d8130bf07807c018a4a2120",
+        "path": "com/google/code/gson/gson/2.13.1/gson-2.13.1.jar"
+    },
+    {
+        "url": "jaxen/jaxen/1.2.0/jaxen-1.2.0.jar",
+        "hash": "70feef9dd75ad064def05a3ce8975aeba515ee7d1be146d12199c8828a64174c",
+        "path": "jaxen/jaxen/1.2.0/jaxen-1.2.0.jar"
+    },
+    {
+        "url": "com/android/tools/layoutlib/layoutlib/15.2.3/layoutlib-15.2.3.jar",
+        "hash": "e826a88e448a0c1d42abc30c9d047131badbac6fc3922b8e93ac3ea27bb0eb2c",
+        "path": "com/android/tools/layoutlib/layoutlib/15.2.3/layoutlib-15.2.3.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/fastutil/intellij-deps-fastutil/8.5.16-jb1/intellij-deps-fastutil-8.5.16-jb1.jar",
+        "hash": "63aca730b99bb849f4efb87e61765a050b4a46c7d3f2969054e49439cb0132f8",
+        "path": "org/jetbrains/intellij/deps/fastutil/intellij-deps-fastutil/8.5.16-jb1/intellij-deps-fastutil-8.5.16-jb1.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/org.eclipse.jgit/6.6.1.202309021850-r-jb-202407181518/org.eclipse.jgit-6.6.1.202309021850-r-jb-202407181518.jar",
+        "hash": "84f1d58dbf19cd7d42a5301bd256d589af1f520b4c90b8836cee7747f8726992",
+        "path": "org/jetbrains/intellij/deps/org.eclipse.jgit/6.6.1.202309021850-r-jb-202407181518/org.eclipse.jgit-6.6.1.202309021850-r-jb-202407181518.jar"
+    },
+    {
+        "url": "com/googlecode/javaewah/JavaEWAH/1.2.3/JavaEWAH-1.2.3.jar",
+        "hash": "d65226949713c4c61a784f41c51167e7b0316f93764398ebba9e4336b3d954c2",
+        "path": "com/googlecode/javaewah/JavaEWAH/1.2.3/JavaEWAH-1.2.3.jar"
+    },
+    {
+        "url": "one/util/streamex/0.8.4/streamex-0.8.4.jar",
+        "hash": "c8bcde95bb6c659bd611a5bc464380f38118a10a0443f3fc15304d91e5c9dd81",
+        "path": "one/util/streamex/0.8.4/streamex-0.8.4.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/assignment-compiler-plugin-for-ide/2.3.20-ij253-45/assignment-compiler-plugin-for-ide-2.3.20-ij253-45.jar",
+        "hash": "a1c99ebaca3f02a43d27c295ff6481a860c8e1e9f3b5a67dca2d6a01d5d977e5",
+        "path": "org/jetbrains/kotlin/assignment-compiler-plugin-for-ide/2.3.20-ij253-45/assignment-compiler-plugin-for-ide-2.3.20-ij253-45.jar"
+    },
+    {
+        "url": "org/ec4j/core/ec4j-core/0.3.0/ec4j-core-0.3.0.jar",
+        "hash": "cadef0207077074b11a12be442f89ab6cf93fbc2f848702d9371a9611414d558",
+        "path": "org/ec4j/core/ec4j-core/0.3.0/ec4j-core-0.3.0.jar"
+    },
+    {
+        "url": "io/ktor/ktor-network-tls-jvm/3.1.3/ktor-network-tls-jvm-3.1.3.jar",
+        "hash": "f67507a3e8bf52aa08d753682e6cdda0194e3abe750118b99c9336953e598be9",
+        "path": "io/ktor/ktor-network-tls-jvm/3.1.3/ktor-network-tls-jvm-3.1.3.jar"
     },
     {
         "url": "io/ktor/ktor-network-jvm/3.1.3/ktor-network-jvm-3.1.3.jar",
@@ -465,129 +1085,44 @@
         "path": "io/ktor/ktor-network-jvm/3.1.3/ktor-network-jvm-3.1.3.jar"
     },
     {
-        "url": "com/intellij/platform/kotlinx-coroutines-guava/1.10.1-intellij-5/kotlinx-coroutines-guava-1.10.1-intellij-5.jar",
-        "hash": "61ff422fe859c2439d94727eb6dcd7ccadb5ba0d9cce4e181db1946209ef9bf6",
-        "path": "com/intellij/platform/kotlinx-coroutines-guava/1.10.1-intellij-5/kotlinx-coroutines-guava-1.10.1-intellij-5.jar"
+        "url": "org/imgscalr/imgscalr-lib/4.2/imgscalr-lib-4.2.jar",
+        "hash": "6f128a71c5e87a16f810513a73ad3c77d0ee0bb622ee0ce1ead115bccbc76d0a",
+        "path": "org/imgscalr/imgscalr-lib/4.2/imgscalr-lib-4.2.jar"
     },
     {
-        "url": "org/eclipse/xtext/org.eclipse.xtext.xbase.lib/2.40.0/org.eclipse.xtext.xbase.lib-2.40.0.jar",
-        "hash": "5a810154295fc20a0268cae4cbbc6e5a35a8b32480d8727dc8301910524e4b79",
-        "path": "org/eclipse/xtext/org.eclipse.xtext.xbase.lib/2.40.0/org.eclipse.xtext.xbase.lib-2.40.0.jar"
+        "url": "org/jetbrains/jediterm/jediterm-core/3.57/jediterm-core-3.57.jar",
+        "hash": "e3d7c60adfdebe47732889d1ff21bc936ddf9990609ac54501c7cf749b0fe640",
+        "path": "org/jetbrains/jediterm/jediterm-core/3.57/jediterm-core-3.57.jar"
     },
     {
-        "url": "org/jetbrains/kotlin/kotlin-script-runtime/2.2.20/kotlin-script-runtime-2.2.20.jar",
-        "hash": "5c8bd5dd7ae1ea2eeb2778fdbeaa19a562184975f6cab8a0bb6779e4190731ae",
-        "path": "org/jetbrains/kotlin/kotlin-script-runtime/2.2.20/kotlin-script-runtime-2.2.20.jar"
+        "url": "org/jetbrains/kotlin/sam-with-receiver-compiler-plugin-for-ide/2.3.20-ij253-45/sam-with-receiver-compiler-plugin-for-ide-2.3.20-ij253-45.jar",
+        "hash": "98457d26126f1095049a8769d78168ff7d0907f0b472ee28967073709b4b4607",
+        "path": "org/jetbrains/kotlin/sam-with-receiver-compiler-plugin-for-ide/2.3.20-ij253-45/sam-with-receiver-compiler-plugin-for-ide-2.3.20-ij253-45.jar"
     },
     {
-        "url": "org/mockito/mockito-junit-jupiter/5.19.0/mockito-junit-jupiter-5.19.0.jar",
-        "hash": "7cfbb7a9c1198053c699c663479fd4836acc22c2650003c8dee20e7fbc55a65a",
-        "path": "org/mockito/mockito-junit-jupiter/5.19.0/mockito-junit-jupiter-5.19.0.jar"
+        "url": "com/github/marschall/memoryfilesystem/2.8.2/memoryfilesystem-2.8.2.jar",
+        "hash": "8b94840d71ad0caa36b3309425b2d23084bc8788ce84d71f2d805b0fc84d1f5a",
+        "path": "com/github/marschall/memoryfilesystem/2.8.2/memoryfilesystem-2.8.2.jar"
     },
     {
-        "url": "org/jetbrains/intellij/plugins/structure-intellij/3.316/structure-intellij-3.316.jar",
-        "hash": "0efe45aca820a2f722f29a49e5ffe5cd14f06c51ad60842247fcb15f8048e28a",
-        "path": "org/jetbrains/intellij/plugins/structure-intellij/3.316/structure-intellij-3.316.jar"
+        "url": "org/jetbrains/kotlin/kotlin-dist-for-ide/2.2.20/kotlin-dist-for-ide-2.2.20.jar",
+        "hash": "0070e80f9fed930c7209b15a5590f178acfc56028f2b6dd447c2c7cae1fc058d",
+        "path": "org/jetbrains/kotlin/kotlin-dist-for-ide/2.2.20/kotlin-dist-for-ide-2.2.20.jar"
     },
     {
-        "url": "org/jetbrains/intellij/plugins/structure-base/3.316/structure-base-3.316.jar",
-        "hash": "83789c1710426adb1637f773ec79e46ad0acf845e77e7964d7f2030cc2fd25c9",
-        "path": "org/jetbrains/intellij/plugins/structure-base/3.316/structure-base-3.316.jar"
+        "url": "com/squareup/javapoet/1.13.0/javapoet-1.13.0.jar",
+        "hash": "4c7517e848a71b36d069d12bb3bf46a70fd4cda3105d822b0ed2e19c00b69291",
+        "path": "com/squareup/javapoet/1.13.0/javapoet-1.13.0.jar"
     },
     {
-        "url": "org/atteo/evo-inflector/1.3/evo-inflector-1.3.jar",
-        "hash": "ac0192fd110a0363732b17ea94fd1ce8cfd85790c8e1551e14f866908b5d80e1",
-        "path": "org/atteo/evo-inflector/1.3/evo-inflector-1.3.jar"
+        "url": "org/jetbrains/kotlin/kotlin-jps-plugin-classpath/2.2.20/kotlin-jps-plugin-classpath-2.2.20.jar",
+        "hash": "fa31a084adbecaaf98166e734fba1bf964e04e22671d70230ed9598cecd22124",
+        "path": "org/jetbrains/kotlin/kotlin-jps-plugin-classpath/2.2.20/kotlin-jps-plugin-classpath-2.2.20.jar"
     },
     {
-        "url": "org/jdom/jdom2/2.0.6.1/jdom2-2.0.6.1.jar",
-        "hash": "0b20f45e3a0fd8f0d12cdc5316b06776e902b1365db00118876f9175c60f302c",
-        "path": "org/jdom/jdom2/2.0.6.1/jdom2-2.0.6.1.jar"
-    },
-    {
-        "url": "de/cketti/unicode/kotlin-codepoints-jvm/0.9.0/kotlin-codepoints-jvm-0.9.0.jar",
-        "hash": "d642f145f6123739e779d4156145cc5fe7c2173bb58d437b813961a31c337ff9",
-        "path": "de/cketti/unicode/kotlin-codepoints-jvm/0.9.0/kotlin-codepoints-jvm-0.9.0.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/analysis-api-k2-for-ide/2.3.20-ij253-45/analysis-api-k2-for-ide-2.3.20-ij253-45.jar",
-        "hash": "7fdbe230eae422cec677a358823315996f53853d4b4469e45e1531fb4f4e5245",
-        "path": "org/jetbrains/kotlin/analysis-api-k2-for-ide/2.3.20-ij253-45/analysis-api-k2-for-ide-2.3.20-ij253-45.jar"
-    },
-    {
-        "url": "io/netty/netty-tcnative-boringssl-static/2.0.73.Final/netty-tcnative-boringssl-static-2.0.73.Final.jar",
-        "hash": "cfd4332afd70ebb3041e244317dc790d8cb7bf6ddd05591cc1188b8052979946",
-        "path": "io/netty/netty-tcnative-boringssl-static/2.0.73.Final/netty-tcnative-boringssl-static-2.0.73.Final.jar"
-    },
-    {
-        "url": "io/netty/netty-tcnative-classes/2.0.73.Final/netty-tcnative-classes-2.0.73.Final.jar",
-        "hash": "6396a4e67269f3f35851c17613257964f46fd4e937cb3ffe73ddcd963c2a83a7",
-        "path": "io/netty/netty-tcnative-classes/2.0.73.Final/netty-tcnative-classes-2.0.73.Final.jar"
-    },
-    {
-        "url": "io/netty/netty-tcnative-boringssl-static/2.0.73.Final/netty-tcnative-boringssl-static-2.0.73.Final-linux-x86_64.jar",
-        "hash": "a700168761f778704d456e4b0cc9183a42a832ac4b970886663c6c855bf5461c",
-        "path": "io/netty/netty-tcnative-boringssl-static/2.0.73.Final/netty-tcnative-boringssl-static-2.0.73.Final-linux-x86_64.jar"
-    },
-    {
-        "url": "io/netty/netty-tcnative-boringssl-static/2.0.73.Final/netty-tcnative-boringssl-static-2.0.73.Final-linux-aarch_64.jar",
-        "hash": "6d9ebbb6db1567ebc7e3561a555b2e80cded56002f16be4c152bb911f6952cee",
-        "path": "io/netty/netty-tcnative-boringssl-static/2.0.73.Final/netty-tcnative-boringssl-static-2.0.73.Final-linux-aarch_64.jar"
-    },
-    {
-        "url": "io/netty/netty-tcnative-boringssl-static/2.0.73.Final/netty-tcnative-boringssl-static-2.0.73.Final-osx-x86_64.jar",
-        "hash": "f2cbc864db43bc57d13a79444b2f8d784a01345bbe259c9721be00935f8ba748",
-        "path": "io/netty/netty-tcnative-boringssl-static/2.0.73.Final/netty-tcnative-boringssl-static-2.0.73.Final-osx-x86_64.jar"
-    },
-    {
-        "url": "io/netty/netty-tcnative-boringssl-static/2.0.73.Final/netty-tcnative-boringssl-static-2.0.73.Final-osx-aarch_64.jar",
-        "hash": "a1158e70bb79d591c7d7fcc2ab0bcf6682500f7de4961fda4a9cc1b015cad65e",
-        "path": "io/netty/netty-tcnative-boringssl-static/2.0.73.Final/netty-tcnative-boringssl-static-2.0.73.Final-osx-aarch_64.jar"
-    },
-    {
-        "url": "io/netty/netty-tcnative-boringssl-static/2.0.73.Final/netty-tcnative-boringssl-static-2.0.73.Final-windows-x86_64.jar",
-        "hash": "6a8cb27bdd255a718ca100d52cfdac20cce70ab3a92c248efaee50f63eefd11e",
-        "path": "io/netty/netty-tcnative-boringssl-static/2.0.73.Final/netty-tcnative-boringssl-static-2.0.73.Final-windows-x86_64.jar"
-    },
-    {
-        "url": "xml-resolver/xml-resolver/1.2/xml-resolver-1.2.jar",
-        "hash": "47dcde8986019314ef78ae7280a94973a21d2ed95075a40a000b42da956429e1",
-        "path": "xml-resolver/xml-resolver/1.2/xml-resolver-1.2.jar"
-    },
-    {
-        "url": "org/openjdk/jmh/jmh-core/1.37/jmh-core-1.37.jar",
-        "hash": "dc0eaf2bbf0036a70b60798c785d6e03a9daf06b68b8edb0f1ba9eb3421baeb3",
-        "path": "org/openjdk/jmh/jmh-core/1.37/jmh-core-1.37.jar"
-    },
-    {
-        "url": "net/sf/jopt-simple/jopt-simple/5.0.4/jopt-simple-5.0.4.jar",
-        "hash": "df26cc58f235f477db07f753ba5a3ab243ebe5789d9f89ecf68dd62ea9a66c28",
-        "path": "net/sf/jopt-simple/jopt-simple/5.0.4/jopt-simple-5.0.4.jar"
-    },
-    {
-        "url": "org/apache/commons/commons-math3/3.6.1/commons-math3-3.6.1.jar",
-        "hash": "1e56d7b058d28b65abd256b8458e3885b674c1d588fa43cd7d1cbb9c7ef2b308",
-        "path": "org/apache/commons/commons-math3/3.6.1/commons-math3-3.6.1.jar"
-    },
-    {
-        "url": "org/hamcrest/hamcrest/2.2/hamcrest-2.2.jar",
-        "hash": "5e62846a89f05cd78cd9c1a553f340d002458380c320455dd1f8fc5497a8a1c1",
-        "path": "org/hamcrest/hamcrest/2.2/hamcrest-2.2.jar"
-    },
-    {
-        "url": "jetbrains/fleet/rhizomedb-compiler-plugin/2.2.20-0.1/rhizomedb-compiler-plugin-2.2.20-0.1.jar",
-        "hash": "eaaae0ef5b03c8cf3d3978699c517f3e2199f50191568efaff4d525be963f544",
-        "path": "jetbrains/fleet/rhizomedb-compiler-plugin/2.2.20-0.1/rhizomedb-compiler-plugin-2.2.20-0.1.jar"
-    },
-    {
-        "url": "org/codehaus/groovy/groovy-ant/3.0.25/groovy-ant-3.0.25.jar",
-        "hash": "fd65c1a0cd1c60272b6ed0f45025d7afae8de20b5c11e2a131a7ccb4b0f1f1b2",
-        "path": "org/codehaus/groovy/groovy-ant/3.0.25/groovy-ant-3.0.25.jar"
-    },
-    {
-        "url": "org/bouncycastle/bcpg-jdk18on/1.81/bcpg-jdk18on-1.81.jar",
-        "hash": "ac2ddae3a844c1e2378604616dbe7cc17c64caaf9115d8c9c3b29db8b2982411",
-        "path": "org/bouncycastle/bcpg-jdk18on/1.81/bcpg-jdk18on-1.81.jar"
+        "url": "org/jetbrains/compose/components/components-ui-tooling-preview-desktop/1.9.0/components-ui-tooling-preview-desktop-1.9.0.jar",
+        "hash": "ca0857dcde7cffff8eea3cce2940a285f219f673829f7f9a3381f767d224f411",
+        "path": "org/jetbrains/compose/components/components-ui-tooling-preview-desktop/1.9.0/components-ui-tooling-preview-desktop-1.9.0.jar"
     },
     {
         "url": "io/opentelemetry/opentelemetry-sdk/1.48.0/opentelemetry-sdk-1.48.0.jar",
@@ -625,109 +1160,94 @@
         "path": "io/opentelemetry/opentelemetry-sdk-logs/1.48.0/opentelemetry-sdk-logs-1.48.0.jar"
     },
     {
-        "url": "com/jetbrains/rd/rd-gen/2025.3.1/rd-gen-2025.3.1.jar",
-        "hash": "03b276130c0c1417c9bd07cfd8d2eea1fa465fc930dd132ac11fc383cf11deec",
-        "path": "com/jetbrains/rd/rd-gen/2025.3.1/rd-gen-2025.3.1.jar"
+        "url": "com/jcraft/jzlib/1.1.3/jzlib-1.1.3.jar",
+        "hash": "89b1360f407381bf61fde411019d8cbd009ebb10cff715f3669017a031027560",
+        "path": "com/jcraft/jzlib/1.1.3/jzlib-1.1.3.jar"
     },
     {
-        "url": "com/squareup/okhttp3/okhttp/5.0.0-alpha.14/okhttp-5.0.0-alpha.14.jar",
-        "hash": "f0e3ffcbba6744ab4918a55aa32ff4f408fcd21e45ab8bd5f7883a1793b2a253",
-        "path": "com/squareup/okhttp3/okhttp/5.0.0-alpha.14/okhttp-5.0.0-alpha.14.jar"
+        "url": "io/ktor/ktor-client-core-jvm/3.1.3/ktor-client-core-jvm-3.1.3.jar",
+        "hash": "746e2a3dece87379d64c40999401969001d373de1458fe851c0d2e0f880b42ef",
+        "path": "io/ktor/ktor-client-core-jvm/3.1.3/ktor-client-core-jvm-3.1.3.jar"
     },
     {
-        "url": "com/squareup/okio/okio-jvm/3.9.0/okio-jvm-3.9.0.jar",
-        "hash": "ddc386ff14bd25d5c934167196eaf45b18de4f28e1c55a4db37ae594cbfd37e4",
-        "path": "com/squareup/okio/okio-jvm/3.9.0/okio-jvm-3.9.0.jar"
+        "url": "io/ktor/ktor-http-jvm/3.1.3/ktor-http-jvm-3.1.3.jar",
+        "hash": "8a50d94b46f91bd56580b9169272d6cd636f442032ba078a141da70413465946",
+        "path": "io/ktor/ktor-http-jvm/3.1.3/ktor-http-jvm-3.1.3.jar"
     },
     {
-        "url": "org/jetbrains/intellij/deps/java-compatibility/1.0.1/java-compatibility-1.0.1.jar",
-        "hash": "1f799c9e7691a4dcddb1cb3e28e8517d5e6b27c2ac75093f39714afdc9216950",
-        "path": "org/jetbrains/intellij/deps/java-compatibility/1.0.1/java-compatibility-1.0.1.jar"
+        "url": "io/ktor/ktor-http-cio-jvm/3.1.3/ktor-http-cio-jvm-3.1.3.jar",
+        "hash": "b04aede18e9c008168096dc53a3fc016177b61a5ec3024afbf8caca0cd5dbf42",
+        "path": "io/ktor/ktor-http-cio-jvm/3.1.3/ktor-http-cio-jvm-3.1.3.jar"
     },
     {
-        "url": "com/fasterxml/jackson/module/jackson-module-kotlin/2.19.0/jackson-module-kotlin-2.19.0.jar",
-        "hash": "df967eebc2c87eaa3f55338607104ffc8fa62fb2e813d67f95ed4f7f9c6f8cee",
-        "path": "com/fasterxml/jackson/module/jackson-module-kotlin/2.19.0/jackson-module-kotlin-2.19.0.jar"
+        "url": "io/ktor/ktor-events-jvm/3.1.3/ktor-events-jvm-3.1.3.jar",
+        "hash": "da7069c6e78809d7c37d104e415613cbd4cd5cec1ed54a332cb64ef6a864a060",
+        "path": "io/ktor/ktor-events-jvm/3.1.3/ktor-events-jvm-3.1.3.jar"
     },
     {
-        "url": "org/jetbrains/intellij/deps/fastutil/intellij-deps-fastutil/8.5.16-jb1/intellij-deps-fastutil-8.5.16-jb1.jar",
-        "hash": "63aca730b99bb849f4efb87e61765a050b4a46c7d3f2969054e49439cb0132f8",
-        "path": "org/jetbrains/intellij/deps/fastutil/intellij-deps-fastutil/8.5.16-jb1/intellij-deps-fastutil-8.5.16-jb1.jar"
+        "url": "io/ktor/ktor-websocket-serialization-jvm/3.1.3/ktor-websocket-serialization-jvm-3.1.3.jar",
+        "hash": "67f0f566e2ed51717f6ed55f6d2b4dee1c84be4ea2cd96fc636d0bdf0fd43067",
+        "path": "io/ktor/ktor-websocket-serialization-jvm/3.1.3/ktor-websocket-serialization-jvm-3.1.3.jar"
     },
     {
-        "url": "org/apache/thrift/libthrift/0.19.0/libthrift-0.19.0.jar",
-        "hash": "2b6e6550b40467ede7b3034a1a9eb9148fbf920cfdae5bf0b1d2bb3d4e780625",
-        "path": "org/apache/thrift/libthrift/0.19.0/libthrift-0.19.0.jar"
+        "url": "io/ktor/ktor-serialization-jvm/3.1.3/ktor-serialization-jvm-3.1.3.jar",
+        "hash": "0d704bc1148a8fd9a1f2005e0b5189cdaed3030efe24b8236459c41c356f5620",
+        "path": "io/ktor/ktor-serialization-jvm/3.1.3/ktor-serialization-jvm-3.1.3.jar"
     },
     {
-        "url": "org/codehaus/groovy/groovy-xml/3.0.25/groovy-xml-3.0.25.jar",
-        "hash": "d94e6ba5de99225d3d3fc8759d4480721402c7121d130d73d99d838e913500dd",
-        "path": "org/codehaus/groovy/groovy-xml/3.0.25/groovy-xml-3.0.25.jar"
+        "url": "io/ktor/ktor-websockets-jvm/3.1.3/ktor-websockets-jvm-3.1.3.jar",
+        "hash": "ef28b4f12054ee125765b72fe3230e215a60b73b2ff2072a5c280fcf09329077",
+        "path": "io/ktor/ktor-websockets-jvm/3.1.3/ktor-websockets-jvm-3.1.3.jar"
     },
     {
-        "url": "io/ktor/ktor-server-core-jvm/3.1.3/ktor-server-core-jvm-3.1.3.jar",
-        "hash": "bf582ba004634d0d343bb2dfa1edd0e8de18cdc2c607a4089db8b79d3085d10a",
-        "path": "io/ktor/ktor-server-core-jvm/3.1.3/ktor-server-core-jvm-3.1.3.jar"
+        "url": "io/ktor/ktor-sse-jvm/3.1.3/ktor-sse-jvm-3.1.3.jar",
+        "hash": "a2ae8a338bb1d446d16dcfea2189ef5a5be31a88123b3879562b7955667a5639",
+        "path": "io/ktor/ktor-sse-jvm/3.1.3/ktor-sse-jvm-3.1.3.jar"
     },
     {
-        "url": "org/jetbrains/kotlinx/lincheck-jvm/2.33/lincheck-jvm-2.33.jar",
-        "hash": "2dd9c390e2de0acbdd2fce1aabadd378fa75a9cf73ee723dd8cecbe5c8480457",
-        "path": "org/jetbrains/kotlinx/lincheck-jvm/2.33/lincheck-jvm-2.33.jar"
+        "url": "io/mockk/mockk/1.14.5/mockk-1.14.5.jar",
+        "hash": "089e24417bf9f6c34eec5720eebb2cbcc82ea2855ecef90133eb17e1079d5868",
+        "path": "io/mockk/mockk/1.14.5/mockk-1.14.5.jar"
     },
     {
-        "url": "org/jetbrains/kotlin/kotlin-reflect/1.9.21/kotlin-reflect-1.9.21.jar",
-        "hash": "a133e049f0a4e249651582428e166de4dfac9546adf436b6172119255ede510f",
-        "path": "org/jetbrains/kotlin/kotlin-reflect/1.9.21/kotlin-reflect-1.9.21.jar"
+        "url": "io/mockk/mockk-dsl/1.14.5/mockk-dsl-1.14.5.jar",
+        "hash": "089e24417bf9f6c34eec5720eebb2cbcc82ea2855ecef90133eb17e1079d5868",
+        "path": "io/mockk/mockk-dsl/1.14.5/mockk-dsl-1.14.5.jar"
     },
     {
-        "url": "org/ow2/asm/asm-commons/9.6/asm-commons-9.6.jar",
-        "hash": "7aefd0d5c0901701c69f7513feda765fb6be33af2ce7aa17c5781fc87657c511",
-        "path": "org/ow2/asm/asm-commons/9.6/asm-commons-9.6.jar"
+        "url": "io/mockk/mockk-agent/1.14.5/mockk-agent-1.14.5.jar",
+        "hash": "089e24417bf9f6c34eec5720eebb2cbcc82ea2855ecef90133eb17e1079d5868",
+        "path": "io/mockk/mockk-agent/1.14.5/mockk-agent-1.14.5.jar"
     },
     {
-        "url": "org/ow2/asm/asm/9.6/asm-9.6.jar",
-        "hash": "3c6fac2424db3d4a853b669f4e3d1d9c3c552235e19a319673f887083c2303a1",
-        "path": "org/ow2/asm/asm/9.6/asm-9.6.jar"
+        "url": "io/mockk/mockk-agent-api/1.14.5/mockk-agent-api-1.14.5.jar",
+        "hash": "089e24417bf9f6c34eec5720eebb2cbcc82ea2855ecef90133eb17e1079d5868",
+        "path": "io/mockk/mockk-agent-api/1.14.5/mockk-agent-api-1.14.5.jar"
     },
     {
-        "url": "org/ow2/asm/asm-tree/9.6/asm-tree-9.6.jar",
-        "hash": "c43ecf17b539c777e15da7b5b86553b377e2d39a683de6285567d5283888e7ef",
-        "path": "org/ow2/asm/asm-tree/9.6/asm-tree-9.6.jar"
+        "url": "io/mockk/mockk-core/1.14.5/mockk-core-1.14.5.jar",
+        "hash": "089e24417bf9f6c34eec5720eebb2cbcc82ea2855ecef90133eb17e1079d5868",
+        "path": "io/mockk/mockk-core/1.14.5/mockk-core-1.14.5.jar"
     },
     {
-        "url": "org/ow2/asm/asm-util/9.6/asm-util-9.6.jar",
-        "hash": "c635a7402f4aa9bf66b2f4230cea62025a0fe1cd63e8729adefc9b1994fac4c3",
-        "path": "org/ow2/asm/asm-util/9.6/asm-util-9.6.jar"
+        "url": "org/jetbrains/kotlin/kotlinx-serialization-compiler-plugin-for-ide/2.3.20-ij253-45/kotlinx-serialization-compiler-plugin-for-ide-2.3.20-ij253-45.jar",
+        "hash": "7566ed7641a9eb3852d51a58f15f0815827c903b493ed0b7386a9ee4f83769ba",
+        "path": "org/jetbrains/kotlin/kotlinx-serialization-compiler-plugin-for-ide/2.3.20-ij253-45/kotlinx-serialization-compiler-plugin-for-ide-2.3.20-ij253-45.jar"
     },
     {
-        "url": "org/ow2/asm/asm-analysis/9.6/asm-analysis-9.6.jar",
-        "hash": "d92832d7c37edc07c60e2559ac6118b31d642e337a6671edcb7ba9fae68edbbb",
-        "path": "org/ow2/asm/asm-analysis/9.6/asm-analysis-9.6.jar"
+        "url": "org/apache/lucene/lucene-queries/10.3.0/lucene-queries-10.3.0.jar",
+        "hash": "c0c5891b390759a0cf503c7864e6eb4d8447cc8df20806a4254bfdf3d2f43a91",
+        "path": "org/apache/lucene/lucene-queries/10.3.0/lucene-queries-10.3.0.jar"
     },
     {
-        "url": "net/bytebuddy/byte-buddy/1.14.12/byte-buddy-1.14.12.jar",
-        "hash": "970636134d61c183b19f8f58fa631e30d2f2abca344b37848a393cac7863dd70",
-        "path": "net/bytebuddy/byte-buddy/1.14.12/byte-buddy-1.14.12.jar"
+        "url": "ai/grazie/grazie-rule-engine/0.3.11/grazie-rule-engine-0.3.11.jar",
+        "hash": "54b321650a50f78ceee6bd06653ee3cea0b19db5fe95e3c3a109e6af4a20126c",
+        "path": "ai/grazie/grazie-rule-engine/0.3.11/grazie-rule-engine-0.3.11.jar"
     },
     {
-        "url": "net/bytebuddy/byte-buddy-agent/1.14.12/byte-buddy-agent-1.14.12.jar",
-        "hash": "2b309a9300092e0b696f7c471fd51d9969001df784c8ab9f07997437d757ad6d",
-        "path": "net/bytebuddy/byte-buddy-agent/1.14.12/byte-buddy-agent-1.14.12.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlinx/atomicfu-jvm/0.20.2/atomicfu-jvm-0.20.2.jar",
-        "hash": "b3d9ec0298e84ed09e0448c52a643bfdad7f3d8096f1303592a3046e711551af",
-        "path": "org/jetbrains/kotlinx/atomicfu-jvm/0.20.2/atomicfu-jvm-0.20.2.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/assignment-compiler-plugin-for-ide/2.3.20-ij253-45/assignment-compiler-plugin-for-ide-2.3.20-ij253-45.jar",
-        "hash": "a1c99ebaca3f02a43d27c295ff6481a860c8e1e9f3b5a67dca2d6a01d5d977e5",
-        "path": "org/jetbrains/kotlin/assignment-compiler-plugin-for-ide/2.3.20-ij253-45/assignment-compiler-plugin-for-ide-2.3.20-ij253-45.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-scripting-common/2.3.20-ij253-45/kotlin-scripting-common-2.3.20-ij253-45.jar",
-        "hash": "a06d90da5af5a992f93223d26976b81141edf5764dc798431352dbcd6606bce6",
-        "path": "org/jetbrains/kotlin/kotlin-scripting-common/2.3.20-ij253-45/kotlin-scripting-common-2.3.20-ij253-45.jar"
+        "url": "net/fellbaum/jemoji/1.3.1/jemoji-1.3.1.jar",
+        "hash": "80a2f8918240a07d3a6fc7cdcc543d278013f6943c080835e43a22fc90462a9f",
+        "path": "net/fellbaum/jemoji/1.3.1/jemoji-1.3.1.jar"
     },
     {
         "url": "org/mozilla/rhino-runtime/1.7.15/rhino-runtime-1.7.15.jar",
@@ -735,49 +1255,74 @@
         "path": "org/mozilla/rhino-runtime/1.7.15/rhino-runtime-1.7.15.jar"
     },
     {
-        "url": "net/jcip/jcip-annotations/1.0/jcip-annotations-1.0.jar",
-        "hash": "be5805392060c71474bf6c9a67a099471274d30b83eef84bfc4e0889a4f1dcc0",
-        "path": "net/jcip/jcip-annotations/1.0/jcip-annotations-1.0.jar"
+        "url": "org/glassfish/jaxb/jaxb-runtime/2.3.9/jaxb-runtime-2.3.9.jar",
+        "hash": "ba88e5bde7c0d878c3e1f2ec2fcabaf51d201eaf93b3bb9cfecfc1f11b2304d4",
+        "path": "org/glassfish/jaxb/jaxb-runtime/2.3.9/jaxb-runtime-2.3.9.jar"
     },
     {
-        "url": "com/intellij/platform/kotlinx-coroutines-test-jvm/1.10.1-intellij-5/kotlinx-coroutines-test-jvm-1.10.1-intellij-5.jar",
-        "hash": "98b5c1291d9e473ce6df9823781a8a2170f1dfb4c30d985c56ff5242df2ff8f5",
-        "path": "com/intellij/platform/kotlinx-coroutines-test-jvm/1.10.1-intellij-5/kotlinx-coroutines-test-jvm-1.10.1-intellij-5.jar"
+        "url": "org/glassfish/jaxb/txw2/2.3.9/txw2-2.3.9.jar",
+        "hash": "973018b87af911ecf6e6d861dd0d6a477e4d8ae6a883ec5d073d3df1330b87f0",
+        "path": "org/glassfish/jaxb/txw2/2.3.9/txw2-2.3.9.jar"
     },
     {
-        "url": "net/bytebuddy/byte-buddy/1.17.7/byte-buddy-1.17.7.jar",
-        "hash": "3575dcb8a98faf943d3c1595c47a16047c4fce8a83ebbb26262f1a2f67546357",
-        "path": "net/bytebuddy/byte-buddy/1.17.7/byte-buddy-1.17.7.jar"
+        "url": "com/sun/istack/istack-commons-runtime/3.0.12/istack-commons-runtime-3.0.12.jar",
+        "hash": "27d85fc134c9271d5c79d3300fc4669668f017e72409727c428f54f2417f04cd",
+        "path": "com/sun/istack/istack-commons-runtime/3.0.12/istack-commons-runtime-3.0.12.jar"
     },
     {
-        "url": "org/slf4j/slf4j-jdk14/2.0.13/slf4j-jdk14-2.0.13.jar",
-        "hash": "83f17205a6470c3cd4214306d3ed011651c173297f705acef544c01795f253cd",
-        "path": "org/slf4j/slf4j-jdk14/2.0.13/slf4j-jdk14-2.0.13.jar"
+        "url": "com/sun/activation/jakarta.activation/1.2.2/jakarta.activation-1.2.2.jar",
+        "hash": "02156773e4ae9d048d14a56ad35d644bee9f1052a791d072df3ded3c656e6e1a",
+        "path": "com/sun/activation/jakarta.activation/1.2.2/jakarta.activation-1.2.2.jar"
     },
     {
-        "url": "org/junit/jupiter/junit-jupiter-api/5.13.4/junit-jupiter-api-5.13.4.jar",
-        "hash": "d1bb81abfd9e03418306b4e6a3390c8db52c58372e749c2980ac29f0c08278f1",
-        "path": "org/junit/jupiter/junit-jupiter-api/5.13.4/junit-jupiter-api-5.13.4.jar"
+        "url": "org/jetbrains/kotlin/kotlin-compiler-fir-for-ide/2.3.20-ij253-45/kotlin-compiler-fir-for-ide-2.3.20-ij253-45.jar",
+        "hash": "51241b1d60e87ef52b69ad58dc530230dd832def0cec16ca3a57e705f7ecd9bc",
+        "path": "org/jetbrains/kotlin/kotlin-compiler-fir-for-ide/2.3.20-ij253-45/kotlin-compiler-fir-for-ide-2.3.20-ij253-45.jar"
     },
     {
-        "url": "org/opentest4j/opentest4j/1.3.0/opentest4j-1.3.0.jar",
-        "hash": "48e2df636cab6563ced64dcdff8abb2355627cb236ef0bf37598682ddf742f1b",
-        "path": "org/opentest4j/opentest4j/1.3.0/opentest4j-1.3.0.jar"
+        "url": "io/grpc/grpc-kotlin-stub/1.4.3/grpc-kotlin-stub-1.4.3.jar",
+        "hash": "4b5705f8cabd07e82c81dbce36f1554aa9d1740f03e369fd049a71f375dac2f0",
+        "path": "io/grpc/grpc-kotlin-stub/1.4.3/grpc-kotlin-stub-1.4.3.jar"
     },
     {
-        "url": "org/junit/platform/junit-platform-commons/1.13.4/junit-platform-commons-1.13.4.jar",
-        "hash": "1c25ca641ebaae44ff3ad21ca1b2ef68d0dd84bfeb07c4805ba7840899b77408",
-        "path": "org/junit/platform/junit-platform-commons/1.13.4/junit-platform-commons-1.13.4.jar"
+        "url": "com/googlecode/plist/dd-plist/1.28/dd-plist-1.28.jar",
+        "hash": "88ed8e730f7386297485176c4387146c6914a38c0e58fc296e8a01cdc3b621e1",
+        "path": "com/googlecode/plist/dd-plist/1.28/dd-plist-1.28.jar"
     },
     {
-        "url": "org/apiguardian/apiguardian-api/1.1.2/apiguardian-api-1.1.2.jar",
-        "hash": "b509448ac506d607319f182537f0b35d71007582ec741832a1f111e5b5b70b38",
-        "path": "org/apiguardian/apiguardian-api/1.1.2/apiguardian-api-1.1.2.jar"
+        "url": "org/apache/commons/commons-compress/1.27.1/commons-compress-1.27.1.jar",
+        "hash": "293d80f54b536b74095dcd7ea3cf0a29bbfc3402519281332495f4420d370d16",
+        "path": "org/apache/commons/commons-compress/1.27.1/commons-compress-1.27.1.jar"
     },
     {
-        "url": "org/jetbrains/kotlin/kotlin-dataframe-compiler-plugin-for-ide/2.3.20-ij253-45/kotlin-dataframe-compiler-plugin-for-ide-2.3.20-ij253-45.jar",
-        "hash": "076c66a0899ca0dfaeb18efdf73ca70c0dfbe935a70e7f790e009885b61e56ee",
-        "path": "org/jetbrains/kotlin/kotlin-dataframe-compiler-plugin-for-ide/2.3.20-ij253-45/kotlin-dataframe-compiler-plugin-for-ide-2.3.20-ij253-45.jar"
+        "url": "com/intellij/platform/kotlinx-coroutines-debug/1.10.1-intellij-5/kotlinx-coroutines-debug-1.10.1-intellij-5.jar",
+        "hash": "f8f56f19d2b29da511809c3345d2f0bf283bfb94a0a0d83f5b630e1424625723",
+        "path": "com/intellij/platform/kotlinx-coroutines-debug/1.10.1-intellij-5/kotlinx-coroutines-debug-1.10.1-intellij-5.jar"
+    },
+    {
+        "url": "jetbrains/fleet/expects-compiler-plugin/2.2.20-0.1/expects-compiler-plugin-2.2.20-0.1.jar",
+        "hash": "ce4dc5b9232e9467373ef2e79cab9e3404db898ab45020ce14ef893944745331",
+        "path": "jetbrains/fleet/expects-compiler-plugin/2.2.20-0.1/expects-compiler-plugin-2.2.20-0.1.jar"
+    },
+    {
+        "url": "org/bouncycastle/bcpkix-jdk18on/1.81/bcpkix-jdk18on-1.81.jar",
+        "hash": "b38c604871f3690109a3c00982d9145634125de3365a817ba16eb90d88e242c9",
+        "path": "org/bouncycastle/bcpkix-jdk18on/1.81/bcpkix-jdk18on-1.81.jar"
+    },
+    {
+        "url": "org/bouncycastle/bcutil-jdk18on/1.81/bcutil-jdk18on-1.81.jar",
+        "hash": "31a5fe3a7ba42e3457b83930f0ff8d679fb5b76eaadf2b51f5740c92a394bf52",
+        "path": "org/bouncycastle/bcutil-jdk18on/1.81/bcutil-jdk18on-1.81.jar"
+    },
+    {
+        "url": "org/bouncycastle/bcprov-jdk18on/1.81/bcprov-jdk18on-1.81.jar",
+        "hash": "249f396412b0c0ce67f25c8197da757b241b8be3ec4199386c00704a2457459b",
+        "path": "org/bouncycastle/bcprov-jdk18on/1.81/bcprov-jdk18on-1.81.jar"
+    },
+    {
+        "url": "com/android/tools/analytics-library/testing/31.5.0-alpha08/testing-31.5.0-alpha08.jar",
+        "hash": "a000df0643439bfc1a41cc35098491dcb5733766e629ecbed2d68adb473f8420",
+        "path": "com/android/tools/analytics-library/testing/31.5.0-alpha08/testing-31.5.0-alpha08.jar"
     },
     {
         "url": "org/snakeyaml/snakeyaml-engine/2.9/snakeyaml-engine-2.9.jar",
@@ -790,89 +1335,74 @@
         "path": "io/opentelemetry/opentelemetry-sdk-extension-autoconfigure-spi/1.45.0/opentelemetry-sdk-extension-autoconfigure-spi-1.45.0.jar"
     },
     {
-        "url": "com/github/lamba92/kotlinx-document-store-mvstore/0.0.4/kotlinx-document-store-mvstore-0.0.4.jar",
-        "hash": "956a4c7faad66e3471861adaa278d9486f3a050ac25fb6a99ca90809d379adfe",
-        "path": "com/github/lamba92/kotlinx-document-store-mvstore/0.0.4/kotlinx-document-store-mvstore-0.0.4.jar"
+        "url": "org/jetbrains/kotlin/symbol-light-classes-for-ide/2.3.20-ij253-45/symbol-light-classes-for-ide-2.3.20-ij253-45.jar",
+        "hash": "298e61756dab332adc36712f14803e47f65f114f736c41cace04eaef2cce380e",
+        "path": "org/jetbrains/kotlin/symbol-light-classes-for-ide/2.3.20-ij253-45/symbol-light-classes-for-ide-2.3.20-ij253-45.jar"
     },
     {
-        "url": "com/github/lamba92/kotlinx-document-store-core-jvm/0.0.4/kotlinx-document-store-core-jvm-0.0.4.jar",
-        "hash": "7e638082b4a14e3a96ca90f3f5db70ac65591e0b6c6670629e849d22ec34455f",
-        "path": "com/github/lamba92/kotlinx-document-store-core-jvm/0.0.4/kotlinx-document-store-core-jvm-0.0.4.jar"
+        "url": "com/google/truth/truth/0.42/truth-0.42.jar",
+        "hash": "dd652bdf0c4427c59848ac0340fd6b6d20c2cbfaa3c569a8366604dbcda5214c",
+        "path": "com/google/truth/truth/0.42/truth-0.42.jar"
     },
     {
-        "url": "org/apache/lucene/lucene-sandbox/10.3.0/lucene-sandbox-10.3.0.jar",
-        "hash": "00aa7be5c214bff31d62b489fbb5f0c389545e9f455324b2b92681956d37c94f",
-        "path": "org/apache/lucene/lucene-sandbox/10.3.0/lucene-sandbox-10.3.0.jar"
+        "url": "com/googlecode/java-diff-utils/diffutils/1.3.0/diffutils-1.3.0.jar",
+        "hash": "61ba4dc49adca95243beaa0569adc2a23aedb5292ae78aa01186fa782ebdc5c2",
+        "path": "com/googlecode/java-diff-utils/diffutils/1.3.0/diffutils-1.3.0.jar"
     },
     {
-        "url": "org/jline/jline-terminal-jansi/3.27.0/jline-terminal-jansi-3.27.0.jar",
-        "hash": "a7b369a2e697215fed314a58b736f10ae8bdedf218096916a6bdb7bc886fe470",
-        "path": "org/jline/jline-terminal-jansi/3.27.0/jline-terminal-jansi-3.27.0.jar"
+        "url": "com/jetbrains/fus/reporting/connection-client/171/connection-client-171.jar",
+        "hash": "ca8ebd17e33f333647b905d43fc8cce2ad16abd22bfa99b75cb8a499894648b8",
+        "path": "com/jetbrains/fus/reporting/connection-client/171/connection-client-171.jar"
     },
     {
-        "url": "org/fusesource/jansi/jansi/2.4.1/jansi-2.4.1.jar",
-        "hash": "2e5e775a9dc58ffa6bbd6aa6f099d62f8b62dcdeb4c3c3bbbe5cf2301bc2dcc1",
-        "path": "org/fusesource/jansi/jansi/2.4.1/jansi-2.4.1.jar"
+        "url": "io/ktor/ktor-io-jvm/3.1.3/ktor-io-jvm-3.1.3.jar",
+        "hash": "bb2fb6c00afaa34b539cb30e7584d37bfcba171c266bbdb9990e003579dc24c1",
+        "path": "io/ktor/ktor-io-jvm/3.1.3/ktor-io-jvm-3.1.3.jar"
     },
     {
-        "url": "org/jline/jline-terminal/3.27.0/jline-terminal-3.27.0.jar",
-        "hash": "2f461c75091ec3810a42184afc80c96910f54e9dd2110e9ecb9902a5ee6c244b",
-        "path": "org/jline/jline-terminal/3.27.0/jline-terminal-3.27.0.jar"
+        "url": "org/jetbrains/kotlin/scripting-compiler-plugin-for-ide/2.3.20-ij253-45/scripting-compiler-plugin-for-ide-2.3.20-ij253-45.jar",
+        "hash": "75048ae78a873e992533ba3c376a65701cff28fbcafd79d587efc999a638e0bd",
+        "path": "org/jetbrains/kotlin/scripting-compiler-plugin-for-ide/2.3.20-ij253-45/scripting-compiler-plugin-for-ide-2.3.20-ij253-45.jar"
     },
     {
-        "url": "org/jline/jline-native/3.27.0/jline-native-3.27.0.jar",
-        "hash": "d8bc77bc80edc7d9a02a06a069b2d7085629421db0843aba7c153a869ffe525d",
-        "path": "org/jline/jline-native/3.27.0/jline-native-3.27.0.jar"
+        "url": "org/jetbrains/kotlin/kotlin-script-runtime/2.2.20/kotlin-script-runtime-2.2.20.jar",
+        "hash": "5c8bd5dd7ae1ea2eeb2778fdbeaa19a562184975f6cab8a0bb6779e4190731ae",
+        "path": "org/jetbrains/kotlin/kotlin-script-runtime/2.2.20/kotlin-script-runtime-2.2.20.jar"
     },
     {
-        "url": "org/jetbrains/jediterm/jediterm-core/3.57/jediterm-core-3.57.jar",
-        "hash": "e3d7c60adfdebe47732889d1ff21bc936ddf9990609ac54501c7cf749b0fe640",
-        "path": "org/jetbrains/jediterm/jediterm-core/3.57/jediterm-core-3.57.jar"
+        "url": "commons-cli/commons-cli/1.10.0/commons-cli-1.10.0.jar",
+        "hash": "1b273d92160b9fa69c3e65389a5c4decd2f38a697e458e6f75080ae09e886404",
+        "path": "commons-cli/commons-cli/1.10.0/commons-cli-1.10.0.jar"
     },
     {
-        "url": "org/jetbrains/kotlin/kotlin-jps-plugin-tests-for-ide/2.2.20/kotlin-jps-plugin-tests-for-ide-2.2.20.jar",
-        "hash": "2074392bf202ae0cea075828e8739a17642eb3093db5f40e46b955937fbd8cdf",
-        "path": "org/jetbrains/kotlin/kotlin-jps-plugin-tests-for-ide/2.2.20/kotlin-jps-plugin-tests-for-ide-2.2.20.jar"
+        "url": "io/ktor/ktor-client-java-jvm/3.1.3/ktor-client-java-jvm-3.1.3.jar",
+        "hash": "4449fa59e5f4f9a18e18b5ed10db95dba3f65a825cfc32d053097d8bffccfbf1",
+        "path": "io/ktor/ktor-client-java-jvm/3.1.3/ktor-client-java-jvm-3.1.3.jar"
     },
     {
-        "url": "com/jayway/jsonpath/json-path/2.9.0/json-path-2.9.0.jar",
-        "hash": "11a9ee6f88bb31f1450108d1cf6441377dec84aca075eb6bb2343be157575bea",
-        "path": "com/jayway/jsonpath/json-path/2.9.0/json-path-2.9.0.jar"
+        "url": "com/typesafe/config/1.4.4/config-1.4.4.jar",
+        "hash": "ab16decc45cc678b0cf17fb9668f380a73bfdf11b75af1fa1ddec5da82805aea",
+        "path": "com/typesafe/config/1.4.4/config-1.4.4.jar"
     },
     {
-        "url": "net/minidev/json-smart/2.5.0/json-smart-2.5.0.jar",
-        "hash": "432b9e545848c4141b80717b26e367f83bf33f19250a228ce75da6e967da2bc7",
-        "path": "net/minidev/json-smart/2.5.0/json-smart-2.5.0.jar"
+        "url": "org/bouncycastle/bcpg-jdk18on/1.81/bcpg-jdk18on-1.81.jar",
+        "hash": "ac2ddae3a844c1e2378604616dbe7cc17c64caaf9115d8c9c3b29db8b2982411",
+        "path": "org/bouncycastle/bcpg-jdk18on/1.81/bcpg-jdk18on-1.81.jar"
     },
     {
-        "url": "net/minidev/accessors-smart/2.5.0/accessors-smart-2.5.0.jar",
-        "hash": "12314fc6881d66a413fd66370787adba16e504fbf7e138690b0f3952e3fbd321",
-        "path": "net/minidev/accessors-smart/2.5.0/accessors-smart-2.5.0.jar"
+        "url": "com/jetbrains/rd/rd-swing/2025.3.1/rd-swing-2025.3.1.jar",
+        "hash": "8103c08a017068f9ba79aa260471780b38e3a68bce8995ec1d5279b523ac87ca",
+        "path": "com/jetbrains/rd/rd-swing/2025.3.1/rd-swing-2025.3.1.jar"
     },
     {
-        "url": "com/fasterxml/jackson/datatype/jackson-datatype-joda/2.19.0/jackson-datatype-joda-2.19.0.jar",
-        "hash": "585fbc8bb26dffa4a3174d74352dd3e29cba990a9c1b06c1a547906aff2869ec",
-        "path": "com/fasterxml/jackson/datatype/jackson-datatype-joda/2.19.0/jackson-datatype-joda-2.19.0.jar"
+        "url": "org/hdrhistogram/HdrHistogram/2.2.2/HdrHistogram-2.2.2.jar",
+        "hash": "22d1d4316c4ec13a68b559e98c8256d69071593731da96136640f864fa14fad8",
+        "path": "org/hdrhistogram/HdrHistogram/2.2.2/HdrHistogram-2.2.2.jar"
     },
     {
-        "url": "joda-time/joda-time/2.12.7/joda-time-2.12.7.jar",
-        "hash": "385282b005818cfaccdbe8bd2429811e7e641782f2b88932a6b8ff51d668f616",
-        "path": "joda-time/joda-time/2.12.7/joda-time-2.12.7.jar"
-    },
-    {
-        "url": "org/jetbrains/jetCheck/0.2.2/jetCheck-0.2.2.jar",
-        "hash": "c5f95c97171311066a13eb750a6bb999fa7eeb43c1394705034926336c0b7b0f",
-        "path": "org/jetbrains/jetCheck/0.2.2/jetCheck-0.2.2.jar"
-    },
-    {
-        "url": "io/ktor/ktor-events-jvm/3.1.3/ktor-events-jvm-3.1.3.jar",
-        "hash": "da7069c6e78809d7c37d104e415613cbd4cd5cec1ed54a332cb64ef6a864a060",
-        "path": "io/ktor/ktor-events-jvm/3.1.3/ktor-events-jvm-3.1.3.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/analysis-api-for-ide/2.3.20-ij253-45/analysis-api-for-ide-2.3.20-ij253-45.jar",
-        "hash": "47db94b0240122449cb95aa00dd8b9d0722948b81f8390b9d27d38797c0fc784",
-        "path": "org/jetbrains/kotlin/analysis-api-for-ide/2.3.20-ij253-45/analysis-api-for-ide-2.3.20-ij253-45.jar"
+        "url": "com/jetbrains/fus/reporting/configuration/171/configuration-171.jar",
+        "hash": "f138ed43c55cb90192518293a5b46a135221c898b2b05d6c0648645b3d0fac64",
+        "path": "com/jetbrains/fus/reporting/configuration/171/configuration-171.jar"
     },
     {
         "url": "org/jetbrains/kotlin/js-plain-objects-compiler-plugin-for-ide/2.3.20-ij253-45/js-plain-objects-compiler-plugin-for-ide-2.3.20-ij253-45.jar",
@@ -880,14 +1410,244 @@
         "path": "org/jetbrains/kotlin/js-plain-objects-compiler-plugin-for-ide/2.3.20-ij253-45/js-plain-objects-compiler-plugin-for-ide-2.3.20-ij253-45.jar"
     },
     {
-        "url": "org/apache/lucene/lucene-core/10.3.0/lucene-core-10.3.0.jar",
-        "hash": "9d70afe194568ca0328b7f762e64eb8094a5e5a76ea3a30b7182f0e7d5f0dd35",
-        "path": "org/apache/lucene/lucene-core/10.3.0/lucene-core-10.3.0.jar"
+        "url": "io/ktor/ktor-sse-jvm/3.1.3/ktor-sse-jvm-3.1.3.jar",
+        "hash": "a2ae8a338bb1d446d16dcfea2189ef5a5be31a88123b3879562b7955667a5639",
+        "path": "io/ktor/ktor-sse-jvm/3.1.3/ktor-sse-jvm-3.1.3.jar"
     },
     {
-        "url": "org/jetbrains/intellij/deps/gradle-api/9.0.0/gradle-api-9.0.0.jar",
-        "hash": "b21806c4075aa42d4534ba7257097aea091ab99c40466b0f850872cfc07e7507",
-        "path": "org/jetbrains/intellij/deps/gradle-api/9.0.0/gradle-api-9.0.0.jar"
+        "url": "org/codehaus/groovy/groovy-xml/3.0.25/groovy-xml-3.0.25.jar",
+        "hash": "d94e6ba5de99225d3d3fc8759d4480721402c7121d130d73d99d838e913500dd",
+        "path": "org/codehaus/groovy/groovy-xml/3.0.25/groovy-xml-3.0.25.jar"
+    },
+    {
+        "url": "org/junit/platform/junit-platform-suite/1.13.4/junit-platform-suite-1.13.4.jar",
+        "hash": "8088a80b47f5a7e73fa107f466dfa6a86776ca496fc2e7724aba65202d467913",
+        "path": "org/junit/platform/junit-platform-suite/1.13.4/junit-platform-suite-1.13.4.jar"
+    },
+    {
+        "url": "org/junit/platform/junit-platform-suite-api/1.13.4/junit-platform-suite-api-1.13.4.jar",
+        "hash": "9a05bf77e128371f5b3e25ffc89f7af467a9f68dd365fdfced469ebcf533abc9",
+        "path": "org/junit/platform/junit-platform-suite-api/1.13.4/junit-platform-suite-api-1.13.4.jar"
+    },
+    {
+        "url": "org/junit/platform/junit-platform-suite-engine/1.13.4/junit-platform-suite-engine-1.13.4.jar",
+        "hash": "3b34fd8172d70d0d7c59155e487bd8e77d43bdbfdcfe1d78c2b4eea55e9acb92",
+        "path": "org/junit/platform/junit-platform-suite-engine/1.13.4/junit-platform-suite-engine-1.13.4.jar"
+    },
+    {
+        "url": "org/junit/platform/junit-platform-suite-commons/1.13.4/junit-platform-suite-commons-1.13.4.jar",
+        "hash": "e7dacfcfa3bc692c0a7a413cefd5f51ae420415a14d39091bdf88aebfdba70b6",
+        "path": "org/junit/platform/junit-platform-suite-commons/1.13.4/junit-platform-suite-commons-1.13.4.jar"
+    },
+    {
+        "url": "io/vavr/vavr/0.10.4/vavr-0.10.4.jar",
+        "hash": "12622deeea2618b59b284051a9484f1def8ccbebc847c350358f12d325ba9dd5",
+        "path": "io/vavr/vavr/0.10.4/vavr-0.10.4.jar"
+    },
+    {
+        "url": "io/vavr/vavr-match/0.10.4/vavr-match-0.10.4.jar",
+        "hash": "d46f96bf59ccd5800261eec5869a6877ee0a37ea781312e6735be55539f50354",
+        "path": "io/vavr/vavr-match/0.10.4/vavr-match-0.10.4.jar"
+    },
+    {
+        "url": "org/fusesource/jansi/jansi/2.4.1/jansi-2.4.1.jar",
+        "hash": "2e5e775a9dc58ffa6bbd6aa6f099d62f8b62dcdeb4c3c3bbbe5cf2301bc2dcc1",
+        "path": "org/fusesource/jansi/jansi/2.4.1/jansi-2.4.1.jar"
+    },
+    {
+        "url": "org/ow2/asm/asm-analysis/9.8/asm-analysis-9.8.jar",
+        "hash": "e640732fbcd3c6271925a504f125e38384688f4dfbbf92c8622dfcee0d09edb9",
+        "path": "org/ow2/asm/asm-analysis/9.8/asm-analysis-9.8.jar"
+    },
+    {
+        "url": "org/ow2/asm/asm-tree/9.8/asm-tree-9.8.jar",
+        "hash": "14b7880cb7c85eed101e2710432fc3ffb83275532a6a894dc4c4095d49ad59f1",
+        "path": "org/ow2/asm/asm-tree/9.8/asm-tree-9.8.jar"
+    },
+    {
+        "url": "org/ow2/asm/asm/9.8/asm-9.8.jar",
+        "hash": "876eab6a83daecad5ca67eb9fcabb063c97b5aeb8cf1fca7a989ecde17522051",
+        "path": "org/ow2/asm/asm/9.8/asm-9.8.jar"
+    },
+    {
+        "url": "io/ktor/ktor-serialization-jvm/3.1.3/ktor-serialization-jvm-3.1.3.jar",
+        "hash": "0d704bc1148a8fd9a1f2005e0b5189cdaed3030efe24b8236459c41c356f5620",
+        "path": "io/ktor/ktor-serialization-jvm/3.1.3/ktor-serialization-jvm-3.1.3.jar"
+    },
+    {
+        "url": "org/mockito/mockito-core/5.19.0/mockito-core-5.19.0.jar",
+        "hash": "d875ff234a4b72e0eedfe170dd804797a4b87ba4c76207c9659d6f46b527877b",
+        "path": "org/mockito/mockito-core/5.19.0/mockito-core-5.19.0.jar"
+    },
+    {
+        "url": "net/bytebuddy/byte-buddy-agent/1.17.6/byte-buddy-agent-1.17.6.jar",
+        "hash": "8a80959465bb09848cd41a89301490c55b9d940dc6ec30d8abac0f63b39fd5d0",
+        "path": "net/bytebuddy/byte-buddy-agent/1.17.6/byte-buddy-agent-1.17.6.jar"
+    },
+    {
+        "url": "org/objenesis/objenesis/3.3/objenesis-3.3.jar",
+        "hash": "02dfd0b0439a5591e35b708ed2f5474eb0948f53abf74637e959b8e4ef69bfeb",
+        "path": "org/objenesis/objenesis/3.3/objenesis-3.3.jar"
+    },
+    {
+        "url": "net/java/dev/jna/jna-platform/5.17.0/jna-platform-5.17.0.jar",
+        "hash": "b7e3d46c87bad2eb409b0e704916bcd81206168e357312dfddd0e253679cd9e0",
+        "path": "net/java/dev/jna/jna-platform/5.17.0/jna-platform-5.17.0.jar"
+    },
+    {
+        "url": "net/java/dev/jna/jna/5.17.0/jna-5.17.0.jar",
+        "hash": "b3a9408e7c51e08ef0e3bfcc08f443f6ec0f6191ba8cd7c18d53d2b22e5bdbc0",
+        "path": "net/java/dev/jna/jna/5.17.0/jna-5.17.0.jar"
+    },
+    {
+        "url": "com/networknt/json-schema-validator/1.3.1/json-schema-validator-1.3.1.jar",
+        "hash": "81ad7bfe7e59de4cd047eacf24f979ec47db40eac6afc76e6f10288b456b14b1",
+        "path": "com/networknt/json-schema-validator/1.3.1/json-schema-validator-1.3.1.jar"
+    },
+    {
+        "url": "org/apache/commons/commons-lang3/3.18.0/commons-lang3-3.18.0.jar",
+        "hash": "4eeeae8d20c078abb64b015ec158add383ac581571cddc45c68f0c9ae0230720",
+        "path": "org/apache/commons/commons-lang3/3.18.0/commons-lang3-3.18.0.jar"
+    },
+    {
+        "url": "xml-resolver/xml-resolver/1.2/xml-resolver-1.2.jar",
+        "hash": "47dcde8986019314ef78ae7280a94973a21d2ed95075a40a000b42da956429e1",
+        "path": "xml-resolver/xml-resolver/1.2/xml-resolver-1.2.jar"
+    },
+    {
+        "url": "org/slf4j/slf4j-jdk14/2.0.13/slf4j-jdk14-2.0.13.jar",
+        "hash": "83f17205a6470c3cd4214306d3ed011651c173297f705acef544c01795f253cd",
+        "path": "org/slf4j/slf4j-jdk14/2.0.13/slf4j-jdk14-2.0.13.jar"
+    },
+    {
+        "url": "com/jetbrains/mlapi/mlapi-core/0.2.1/mlapi-core-0.2.1.jar",
+        "hash": "02da615dd0adac62f2d87db878f587529e8d2cb82b3a65ed8b5466a518324180",
+        "path": "com/jetbrains/mlapi/mlapi-core/0.2.1/mlapi-core-0.2.1.jar"
+    },
+    {
+        "url": "org/lz4/lz4-java/1.8.0/lz4-java-1.8.0.jar",
+        "hash": "d74a3334fb35195009b338a951f918203d6bbca3d1d359033dc33edd1cadc9ef",
+        "path": "org/lz4/lz4-java/1.8.0/lz4-java-1.8.0.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-gradle-plugin-idea-proto/1.9.20-dev-8162/kotlin-gradle-plugin-idea-proto-1.9.20-dev-8162.jar",
+        "hash": "3841d6ad1fdd4bf90143ac6012146d291409b431e837f143c023135bd24b79a6",
+        "path": "org/jetbrains/kotlin/kotlin-gradle-plugin-idea-proto/1.9.20-dev-8162/kotlin-gradle-plugin-idea-proto-1.9.20-dev-8162.jar"
+    },
+    {
+        "url": "com/jetbrains/fus/reporting/model/171/model-171.jar",
+        "hash": "8aa0be7e7c1a46ef0827d98c026d328a6f9be27aed79b36692a7f38bacd41a6a",
+        "path": "com/jetbrains/fus/reporting/model/171/model-171.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/analysis-api-platform-interface-for-ide/2.3.20-ij253-45/analysis-api-platform-interface-for-ide-2.3.20-ij253-45.jar",
+        "hash": "33db5c2be1f298109a32c67efc9ff9f2351812cd18b1d3e3b6142b8c1f6562a0",
+        "path": "org/jetbrains/kotlin/analysis-api-platform-interface-for-ide/2.3.20-ij253-45/analysis-api-platform-interface-for-ide-2.3.20-ij253-45.jar"
+    },
+    {
+        "url": "javax/annotation/javax.annotation-api/1.3.2/javax.annotation-api-1.3.2.jar",
+        "hash": "e04ba5195bcd555dc95650f7cc614d151e4bcd52d29a10b8aa2197f3ab89ab9b",
+        "path": "javax/annotation/javax.annotation-api/1.3.2/javax.annotation-api-1.3.2.jar"
+    },
+    {
+        "url": "com/jgoodies/jgoodies-common/1.4.0/jgoodies-common-1.4.0.jar",
+        "hash": "efd986ec851c3a5cd57907e72f27d1af9c1e5b1874b07a8b778588646d71d9fc",
+        "path": "com/jgoodies/jgoodies-common/1.4.0/jgoodies-common-1.4.0.jar"
+    },
+    {
+        "url": "io/netty/netty-tcnative-boringssl-static/2.0.73.Final/netty-tcnative-boringssl-static-2.0.73.Final.jar",
+        "hash": "cfd4332afd70ebb3041e244317dc790d8cb7bf6ddd05591cc1188b8052979946",
+        "path": "io/netty/netty-tcnative-boringssl-static/2.0.73.Final/netty-tcnative-boringssl-static-2.0.73.Final.jar"
+    },
+    {
+        "url": "io/netty/netty-tcnative-classes/2.0.73.Final/netty-tcnative-classes-2.0.73.Final.jar",
+        "hash": "6396a4e67269f3f35851c17613257964f46fd4e937cb3ffe73ddcd963c2a83a7",
+        "path": "io/netty/netty-tcnative-classes/2.0.73.Final/netty-tcnative-classes-2.0.73.Final.jar"
+    },
+    {
+        "url": "io/netty/netty-tcnative-boringssl-static/2.0.73.Final/netty-tcnative-boringssl-static-2.0.73.Final-linux-x86_64.jar",
+        "hash": "a700168761f778704d456e4b0cc9183a42a832ac4b970886663c6c855bf5461c",
+        "path": "io/netty/netty-tcnative-boringssl-static/2.0.73.Final/netty-tcnative-boringssl-static-2.0.73.Final-linux-x86_64.jar"
+    },
+    {
+        "url": "io/netty/netty-tcnative-boringssl-static/2.0.73.Final/netty-tcnative-boringssl-static-2.0.73.Final-linux-aarch_64.jar",
+        "hash": "6d9ebbb6db1567ebc7e3561a555b2e80cded56002f16be4c152bb911f6952cee",
+        "path": "io/netty/netty-tcnative-boringssl-static/2.0.73.Final/netty-tcnative-boringssl-static-2.0.73.Final-linux-aarch_64.jar"
+    },
+    {
+        "url": "io/netty/netty-tcnative-boringssl-static/2.0.73.Final/netty-tcnative-boringssl-static-2.0.73.Final-osx-x86_64.jar",
+        "hash": "f2cbc864db43bc57d13a79444b2f8d784a01345bbe259c9721be00935f8ba748",
+        "path": "io/netty/netty-tcnative-boringssl-static/2.0.73.Final/netty-tcnative-boringssl-static-2.0.73.Final-osx-x86_64.jar"
+    },
+    {
+        "url": "io/netty/netty-tcnative-boringssl-static/2.0.73.Final/netty-tcnative-boringssl-static-2.0.73.Final-osx-aarch_64.jar",
+        "hash": "a1158e70bb79d591c7d7fcc2ab0bcf6682500f7de4961fda4a9cc1b015cad65e",
+        "path": "io/netty/netty-tcnative-boringssl-static/2.0.73.Final/netty-tcnative-boringssl-static-2.0.73.Final-osx-aarch_64.jar"
+    },
+    {
+        "url": "io/netty/netty-tcnative-boringssl-static/2.0.73.Final/netty-tcnative-boringssl-static-2.0.73.Final-windows-x86_64.jar",
+        "hash": "6a8cb27bdd255a718ca100d52cfdac20cce70ab3a92c248efaee50f63eefd11e",
+        "path": "io/netty/netty-tcnative-boringssl-static/2.0.73.Final/netty-tcnative-boringssl-static-2.0.73.Final-windows-x86_64.jar"
+    },
+    {
+        "url": "com/jetbrains/intellij/devkit/devkit-runtime-module-repository-jps/252.21158/devkit-runtime-module-repository-jps-252.21158.jar",
+        "hash": "677e12f96a6c48b1b4c4234417cda17bbcb3c25f5c7178ec752ef2a831c65313",
+        "path": "com/jetbrains/intellij/devkit/devkit-runtime-module-repository-jps/252.21158/devkit-runtime-module-repository-jps-252.21158.jar"
+    },
+    {
+        "url": "com/jetbrains/intellij/platform/runtime-repository/252.21158/runtime-repository-252.21158.jar",
+        "hash": "3ad94d6402b94932f4341c908827016787cdc6ee3201ee64970822a610c55d34",
+        "path": "com/jetbrains/intellij/platform/runtime-repository/252.21158/runtime-repository-252.21158.jar"
+    },
+    {
+        "url": "io/netty/netty-codec-compression/4.2.0.RC2/netty-codec-compression-4.2.0.RC2.jar",
+        "hash": "7251646a8ea8d56a2415311de6040159479ac0e35de36dab70b667ed899ac931",
+        "path": "io/netty/netty-codec-compression/4.2.0.RC2/netty-codec-compression-4.2.0.RC2.jar"
+    },
+    {
+        "url": "org/jetbrains/marketplace-zip-signer/0.1.43/marketplace-zip-signer-0.1.43.jar",
+        "hash": "7db707d839949384760b0f3e58eff49bfedea05f822e4f3361c4b540aa5dcc16",
+        "path": "org/jetbrains/marketplace-zip-signer/0.1.43/marketplace-zip-signer-0.1.43.jar"
+    },
+    {
+        "url": "com/sun/activation/javax.activation/1.2.0/javax.activation-1.2.0.jar",
+        "hash": "993302b16cd7056f21e779cc577d175a810bb4900ef73cd8fbf2b50f928ba9ce",
+        "path": "com/sun/activation/javax.activation/1.2.0/javax.activation-1.2.0.jar"
+    },
+    {
+        "url": "org/codehaus/groovy/groovy/3.0.25/groovy-3.0.25.jar",
+        "hash": "ad009e985dd84e4f524f4ed1751866da5bef816b691851bfbcefa48a01180a07",
+        "path": "org/codehaus/groovy/groovy/3.0.25/groovy-3.0.25.jar"
+    },
+    {
+        "url": "io/ktor/ktor-server-sse-jvm/3.1.3/ktor-server-sse-jvm-3.1.3.jar",
+        "hash": "4c172eb930db7d7cfef36cf3ba7d5094ce08dea6fde2b4be7746680a2ebd7c05",
+        "path": "io/ktor/ktor-server-sse-jvm/3.1.3/ktor-server-sse-jvm-3.1.3.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-gradle-statistics-for-ide/2.3.20-ij253-45/kotlin-gradle-statistics-for-ide-2.3.20-ij253-45.jar",
+        "hash": "94ffb26541561992a8eb23937f28437782830f896b90a6eed6f97e479fffdfa0",
+        "path": "org/jetbrains/kotlin/kotlin-gradle-statistics-for-ide/2.3.20-ij253-45/kotlin-gradle-statistics-for-ide-2.3.20-ij253-45.jar"
+    },
+    {
+        "url": "org/jmock/jmock/2.5.1/jmock-2.5.1.jar",
+        "hash": "d96425f4bab28798162e59fffbe7e16ea6c2aab303ee8dfb0a2ec38a5a4e2f36",
+        "path": "org/jmock/jmock/2.5.1/jmock-2.5.1.jar"
+    },
+    {
+        "url": "com/google/jimfs/jimfs/1.1/jimfs-1.1.jar",
+        "hash": "c4828e28d7c0a930af9387510b3bada7daa5c04d7c25a75c7b8b081f1c257ddd",
+        "path": "com/google/jimfs/jimfs/1.1/jimfs-1.1.jar"
+    },
+    {
+        "url": "io/grpc/grpc-stub/1.73.0/grpc-stub-1.73.0.jar",
+        "hash": "050fe139de47d8937e6b0080e8dff3d0f42df6782f147c10bb298c0e9cd94b2f",
+        "path": "io/grpc/grpc-stub/1.73.0/grpc-stub-1.73.0.jar"
+    },
+    {
+        "url": "com/jetbrains/rd/rd-core/2025.3.1/rd-core-2025.3.1.jar",
+        "hash": "05492a77e70f6a35f1ce19b60841ba39f2fcbe03b1b26eee7aea0c8745cc5e7e",
+        "path": "com/jetbrains/rd/rd-core/2025.3.1/rd-core-2025.3.1.jar"
     },
     {
         "url": "org/jetbrains/kotlin/kotlin-jps-common-for-ide/2.3.20-ij253-45/kotlin-jps-common-for-ide-2.3.20-ij253-45.jar",
@@ -895,14 +1655,104 @@
         "path": "org/jetbrains/kotlin/kotlin-jps-common-for-ide/2.3.20-ij253-45/kotlin-jps-common-for-ide-2.3.20-ij253-45.jar"
     },
     {
-        "url": "org/jetbrains/annotations/26.0.2/annotations-26.0.2.jar",
-        "hash": "2037be378980d3ba9333e97955f3b2cde392aa124d04ca73ce2eee6657199297",
-        "path": "org/jetbrains/annotations/26.0.2/annotations-26.0.2.jar"
+        "url": "org/slf4j/log4j-over-slf4j/1.7.36/log4j-over-slf4j-1.7.36.jar",
+        "hash": "0a7e032bf5bcdd5b2bf8bf2e5cf02c5646f2aa6fee66933b8150dbe84e651e8a",
+        "path": "org/slf4j/log4j-over-slf4j/1.7.36/log4j-over-slf4j-1.7.36.jar"
     },
     {
-        "url": "com/amazon/ion/ion-java/1.11.10/ion-java-1.11.10.jar",
-        "hash": "ede1a1a3bf3e4c182105695728b8b2808f6edd03587dc0e258f9a8920593f903",
-        "path": "com/amazon/ion/ion-java/1.11.10/ion-java-1.11.10.jar"
+        "url": "io/kotest/kotest-assertions-core-jvm/5.5.4/kotest-assertions-core-jvm-5.5.4.jar",
+        "hash": "3acf3de882ec2c714dfc173cc382c38a5aee70c3f2bdda732583916845226d0c",
+        "path": "io/kotest/kotest-assertions-core-jvm/5.5.4/kotest-assertions-core-jvm-5.5.4.jar"
+    },
+    {
+        "url": "io/kotest/kotest-assertions-shared-jvm/5.5.4/kotest-assertions-shared-jvm-5.5.4.jar",
+        "hash": "9977d913ef1fccf2e2663b5906d955fdf8215d0ec48265d669b01e05179e2043",
+        "path": "io/kotest/kotest-assertions-shared-jvm/5.5.4/kotest-assertions-shared-jvm-5.5.4.jar"
+    },
+    {
+        "url": "org/opentest4j/opentest4j/1.2.0/opentest4j-1.2.0.jar",
+        "hash": "58812de60898d976fb81ef3b62da05c6604c18fd4a249f5044282479fc286af2",
+        "path": "org/opentest4j/opentest4j/1.2.0/opentest4j-1.2.0.jar"
+    },
+    {
+        "url": "io/kotest/kotest-common-jvm/5.5.4/kotest-common-jvm-5.5.4.jar",
+        "hash": "a2a4d02b86b2e849e514d18dbdf4b29e2e9d091e3c6f4d9d028db9cdc55dd28b",
+        "path": "io/kotest/kotest-common-jvm/5.5.4/kotest-common-jvm-5.5.4.jar"
+    },
+    {
+        "url": "io/kotest/kotest-assertions-api-jvm/5.5.4/kotest-assertions-api-jvm-5.5.4.jar",
+        "hash": "8b1c3e582e2f6f662261f3f45a6d723f3dd8d8b2b0b86a3f7d8e6c966eca0568",
+        "path": "io/kotest/kotest-assertions-api-jvm/5.5.4/kotest-assertions-api-jvm-5.5.4.jar"
+    },
+    {
+        "url": "com/fasterxml/jackson/core/jackson-core/2.19.0/jackson-core-2.19.0.jar",
+        "hash": "da8e859bac94874528116a25f20c68560e4287acbf27628711b8a4f96b028430",
+        "path": "com/fasterxml/jackson/core/jackson-core/2.19.0/jackson-core-2.19.0.jar"
+    },
+    {
+        "url": "org/slf4j/slf4j-api/2.0.13/slf4j-api-2.0.13.jar",
+        "hash": "e7c2a48e8515ba1f49fa637d57b4e2f590b3f5bd97407ac699c3aa5efb1204a9",
+        "path": "org/slf4j/slf4j-api/2.0.13/slf4j-api-2.0.13.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/noarg-compiler-plugin-for-ide/2.3.20-ij253-45/noarg-compiler-plugin-for-ide-2.3.20-ij253-45.jar",
+        "hash": "261a90d908355e185f0a291aa71b3ce1f4e3c67aa31411244ef8c124958b0c77",
+        "path": "org/jetbrains/kotlin/noarg-compiler-plugin-for-ide/2.3.20-ij253-45/noarg-compiler-plugin-for-ide-2.3.20-ij253-45.jar"
+    },
+    {
+        "url": "com/intellij/platform/kotlinx-coroutines-slf4j/1.10.1-intellij-5/kotlinx-coroutines-slf4j-1.10.1-intellij-5.jar",
+        "hash": "1d68dfc6ba67ec96ecb5a373dbd9fb557ce2210ffc2d74d6b528e4f1f73e7003",
+        "path": "com/intellij/platform/kotlinx-coroutines-slf4j/1.10.1-intellij-5/kotlinx-coroutines-slf4j-1.10.1-intellij-5.jar"
+    },
+    {
+        "url": "com/ibm/icu/icu4j/77.1/icu4j-77.1.jar",
+        "hash": "b3640b9f416a4411fd33c59abbeea8fd57d024c23e1819bf9673220a97499fe3",
+        "path": "com/ibm/icu/icu4j/77.1/icu4j-77.1.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/low-level-api-fir-for-ide/2.3.20-ij253-45/low-level-api-fir-for-ide-2.3.20-ij253-45.jar",
+        "hash": "635cd736b002e250cbb2165f5cb05b2a9750f403ec8eaf6e1be9fad67f3ec1aa",
+        "path": "org/jetbrains/kotlin/low-level-api-fir-for-ide/2.3.20-ij253-45/low-level-api-fir-for-ide-2.3.20-ij253-45.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlinx/kotlinx-serialization-protobuf-jvm/1.8.1/kotlinx-serialization-protobuf-jvm-1.8.1.jar",
+        "hash": "fbd174f72ea82364baa112069f2d7b361758f6b68bd81d2ac51b02c66a48e924",
+        "path": "org/jetbrains/kotlinx/kotlinx-serialization-protobuf-jvm/1.8.1/kotlinx-serialization-protobuf-jvm-1.8.1.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/rwmutex-idea/0.0.10/rwmutex-idea-0.0.10.jar",
+        "hash": "61cd5eee5367d10e0cca664afdc4bbde2ff7aab9c175c5b520aac8b5315d874d",
+        "path": "org/jetbrains/intellij/deps/rwmutex-idea/0.0.10/rwmutex-idea-0.0.10.jar"
+    },
+    {
+        "url": "io/grpc/grpc-protobuf/1.73.0/grpc-protobuf-1.73.0.jar",
+        "hash": "5c0ca9e321c02845c47dc6edcef9f22e49015cef7753c54012f5398425163c08",
+        "path": "io/grpc/grpc-protobuf/1.73.0/grpc-protobuf-1.73.0.jar"
+    },
+    {
+        "url": "com/google/api/grpc/proto-google-common-protos/2.51.0/proto-google-common-protos-2.51.0.jar",
+        "hash": "0b27938f3d28ccd6884945d7e4f75f4e26a677bbf3cd39bbcb694f130f782aa9",
+        "path": "com/google/api/grpc/proto-google-common-protos/2.51.0/proto-google-common-protos-2.51.0.jar"
+    },
+    {
+        "url": "io/grpc/grpc-protobuf-lite/1.73.0/grpc-protobuf-lite-1.73.0.jar",
+        "hash": "de8ce5309713e72bb57d5ff2dabdb4c173ae4872bd1439b9c3d3f93430b407d9",
+        "path": "io/grpc/grpc-protobuf-lite/1.73.0/grpc-protobuf-lite-1.73.0.jar"
+    },
+    {
+        "url": "com/jetbrains/cloudconfig/cloudconfig/2023.9/cloudconfig-2023.9.jar",
+        "hash": "e51ee1761684a946b9d5a0caaec2b92cf4598860cf231dbaf495f268fda35d10",
+        "path": "com/jetbrains/cloudconfig/cloudconfig/2023.9/cloudconfig-2023.9.jar"
+    },
+    {
+        "url": "org/yaml/snakeyaml/2.4/snakeyaml-2.4.jar",
+        "hash": "ef779af5d29a9dde8cc70ce0341f5c6f7735e23edff9685ceaa9d35359b7bb7f",
+        "path": "org/yaml/snakeyaml/2.4/snakeyaml-2.4.jar"
+    },
+    {
+        "url": "org/tukaani/xz/1.10/xz-1.10.jar",
+        "hash": "95c63c1a55b22dd6453890a419cc1a640f790bbf7d8ae82db1e30aefefb08888",
+        "path": "org/tukaani/xz/1.10/xz-1.10.jar"
     },
     {
         "url": "org/apache/maven/maven-resolver-provider/3.9.9/maven-resolver-provider-3.9.9.jar",
@@ -970,6 +1820,121 @@
         "path": "org/apache/maven/resolver/maven-resolver-named-locks/1.9.22/maven-resolver-named-locks-1.9.22.jar"
     },
     {
+        "url": "org/apache/lucene/lucene-highlighter/10.3.0/lucene-highlighter-10.3.0.jar",
+        "hash": "acbf67631c42197791363ce8e8f155f62aeef51ade809e0847a89eba44785c7d",
+        "path": "org/apache/lucene/lucene-highlighter/10.3.0/lucene-highlighter-10.3.0.jar"
+    },
+    {
+        "url": "com/android/tools/smali/smali-dexlib2/3.0.3/smali-dexlib2-3.0.3.jar",
+        "hash": "11cc5e7b75b23feb65e41e28e5c225b4a77dbf7210d6cedd4bdb3f04c1f6ea24",
+        "path": "com/android/tools/smali/smali-dexlib2/3.0.3/smali-dexlib2-3.0.3.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-scripting-dependencies/2.3.20-ij253-45/kotlin-scripting-dependencies-2.3.20-ij253-45.jar",
+        "hash": "beeae35aaf0e3043b8202e081bbdeb55672a89dc8bbcc482dfa5cc21d26dc1de",
+        "path": "org/jetbrains/kotlin/kotlin-scripting-dependencies/2.3.20-ij253-45/kotlin-scripting-dependencies-2.3.20-ij253-45.jar"
+    },
+    {
+        "url": "io/ktor/ktor-server-host-common-jvm/3.1.3/ktor-server-host-common-jvm-3.1.3.jar",
+        "hash": "6f4932086ba785deeb74170140508156b21772cd2961a37e7b551eb5d2649a29",
+        "path": "io/ktor/ktor-server-host-common-jvm/3.1.3/ktor-server-host-common-jvm-3.1.3.jar"
+    },
+    {
+        "url": "com/esotericsoftware/kryo5/5.6.0/kryo5-5.6.0.jar",
+        "hash": "2ceef6a5a0527ad89ab6d1fd71bba4fef355cded510970c650d1443412b18dc5",
+        "path": "com/esotericsoftware/kryo5/5.6.0/kryo5-5.6.0.jar"
+    },
+    {
+        "url": "io/consensys/tuweni/tuweni-toml/2.7.1/tuweni-toml-2.7.1.jar",
+        "hash": "00cfcc187ff46ce8d702a0f2cb98d6a4f2a67f8f41242b5901e46efdcb7c84b7",
+        "path": "io/consensys/tuweni/tuweni-toml/2.7.1/tuweni-toml-2.7.1.jar"
+    },
+    {
+        "url": "org/antlr/antlr4-runtime/4.13.0/antlr4-runtime-4.13.0.jar",
+        "hash": "bd7f7b5d07bc0b047f10915b32ca4bb1de9e57d8049098882e4453c88c076a5d",
+        "path": "org/antlr/antlr4-runtime/4.13.0/antlr4-runtime-4.13.0.jar"
+    },
+    {
+        "url": "app/cash/turbine/turbine-jvm/1.0.0/turbine-jvm-1.0.0.jar",
+        "hash": "41984dffaf069b84b814fa787f740bf7ebdc90bf89f69d05bc4660c69874b49e",
+        "path": "app/cash/turbine/turbine-jvm/1.0.0/turbine-jvm-1.0.0.jar"
+    },
+    {
+        "url": "org/assertj/assertj-core/4.0.0-M1/assertj-core-4.0.0-M1.jar",
+        "hash": "03852ab5b4419c1b0b3689930cdc1ac4f0c437a0c8094a900370dcb170cfbb46",
+        "path": "org/assertj/assertj-core/4.0.0-M1/assertj-core-4.0.0-M1.jar"
+    },
+    {
+        "url": "io/ktor/ktor-server-cio-jvm/3.1.3/ktor-server-cio-jvm-3.1.3.jar",
+        "hash": "f1526fe94e8d76c5251b5a25e4b4bb72199a25d3e1f6045e4b9e42789293f069",
+        "path": "io/ktor/ktor-server-cio-jvm/3.1.3/ktor-server-cio-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/mockk/mockk-jvm/1.14.5/mockk-jvm-1.14.5.jar",
+        "hash": "74deb86cbab6871a3e4d0f97ba8eacbdae7aacd7537f142bcb083590465a6219",
+        "path": "io/mockk/mockk-jvm/1.14.5/mockk-jvm-1.14.5.jar"
+    },
+    {
+        "url": "io/mockk/mockk-dsl-jvm/1.14.5/mockk-dsl-jvm-1.14.5.jar",
+        "hash": "d01d6ce85f9824d8ddb22ea7f1bccd581b831ffad504f48a4f18abf9bc6f2eac",
+        "path": "io/mockk/mockk-dsl-jvm/1.14.5/mockk-dsl-jvm-1.14.5.jar"
+    },
+    {
+        "url": "io/mockk/mockk-agent-jvm/1.14.5/mockk-agent-jvm-1.14.5.jar",
+        "hash": "9f78e9988e84c98569edcf9a6225d5b7354939529642e54c2c58da3ef3913106",
+        "path": "io/mockk/mockk-agent-jvm/1.14.5/mockk-agent-jvm-1.14.5.jar"
+    },
+    {
+        "url": "io/mockk/mockk-agent-api-jvm/1.14.5/mockk-agent-api-jvm-1.14.5.jar",
+        "hash": "a919a8fec03dfb0c084cb43dafcebe2dd9351431c7a08c2fc8147037de1d06b7",
+        "path": "io/mockk/mockk-agent-api-jvm/1.14.5/mockk-agent-api-jvm-1.14.5.jar"
+    },
+    {
+        "url": "io/mockk/mockk-core-jvm/1.14.5/mockk-core-jvm-1.14.5.jar",
+        "hash": "060fffe7452e74f6e18bb9dfe1221e92c4ec0de29a84b022fb562ec6cd954691",
+        "path": "io/mockk/mockk-core-jvm/1.14.5/mockk-core-jvm-1.14.5.jar"
+    },
+    {
+        "url": "io/ktor/ktor-client-core-jvm/3.1.3/ktor-client-core-jvm-3.1.3.jar",
+        "hash": "746e2a3dece87379d64c40999401969001d373de1458fe851c0d2e0f880b42ef",
+        "path": "io/ktor/ktor-client-core-jvm/3.1.3/ktor-client-core-jvm-3.1.3.jar"
+    },
+    {
+        "url": "com/github/ajalt/clikt/clikt-jvm/3.5.4/clikt-jvm-3.5.4.jar",
+        "hash": "b58b4d93fc1870b99b2adb3e16e9c483c8e73766b2944bc3cff805c0be47d19e",
+        "path": "com/github/ajalt/clikt/clikt-jvm/3.5.4/clikt-jvm-3.5.4.jar"
+    },
+    {
+        "url": "io/github/smiley4/schema-kenerator-jsonschema/2.2.0/schema-kenerator-jsonschema-2.2.0.jar",
+        "hash": "81981241b8df2eeee48efac05798e7beaa2b8d6bd5d610b3f5a4fea07b0eff6e",
+        "path": "io/github/smiley4/schema-kenerator-jsonschema/2.2.0/schema-kenerator-jsonschema-2.2.0.jar"
+    },
+    {
+        "url": "info/cukes/cucumber-jvm-deps/1.0.5/cucumber-jvm-deps-1.0.5.jar",
+        "hash": "2a4e84a51defe9108579b3c0a86bb41e54f04e9042e83adf4348a974dcf1dee6",
+        "path": "info/cukes/cucumber-jvm-deps/1.0.5/cucumber-jvm-deps-1.0.5.jar"
+    },
+    {
+        "url": "javax/inject/javax.inject/1/javax.inject-1.jar",
+        "hash": "91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff",
+        "path": "javax/inject/javax.inject/1/javax.inject-1.jar"
+    },
+    {
+        "url": "io/grpc/grpc-netty-shaded/1.73.0/grpc-netty-shaded-1.73.0.jar",
+        "hash": "8328289ba6b73445e982a1cadf8e651ea65354e288c825a43e7c77f16da8a056",
+        "path": "io/grpc/grpc-netty-shaded/1.73.0/grpc-netty-shaded-1.73.0.jar"
+    },
+    {
+        "url": "io/grpc/grpc-util/1.73.0/grpc-util-1.73.0.jar",
+        "hash": "b7df6cbcc30b7a3219f06483a9a9d320a431beda8a1ace5b16d879f84112373f",
+        "path": "io/grpc/grpc-util/1.73.0/grpc-util-1.73.0.jar"
+    },
+    {
+        "url": "org/codehaus/groovy/groovy-templates/3.0.25/groovy-templates-3.0.25.jar",
+        "hash": "fd0e111cae80bd6285677759b72cb67e7da68ee779a90e51bee12a7011c28436",
+        "path": "org/codehaus/groovy/groovy-templates/3.0.25/groovy-templates-3.0.25.jar"
+    },
+    {
         "url": "io/netty/netty-codec-http2/4.2.0.RC2/netty-codec-http2-4.2.0.RC2.jar",
         "hash": "c542657efd81b268535fb77e1866c8234c5a22de416ecbd8aea0e06e2c1588de",
         "path": "io/netty/netty-codec-http2/4.2.0.RC2/netty-codec-http2-4.2.0.RC2.jar"
@@ -1010,99 +1975,14 @@
         "path": "io/netty/netty-codec-http/4.2.0.RC2/netty-codec-http-4.2.0.RC2.jar"
     },
     {
-        "url": "com/networknt/json-schema-validator/1.3.1/json-schema-validator-1.3.1.jar",
-        "hash": "81ad7bfe7e59de4cd047eacf24f979ec47db40eac6afc76e6f10288b456b14b1",
-        "path": "com/networknt/json-schema-validator/1.3.1/json-schema-validator-1.3.1.jar"
+        "url": "org/jetbrains/testDiscovery/test-discovery-plugin-base/0.1.191/test-discovery-plugin-base-0.1.191.jar",
+        "hash": "5ed74de192bd48546a6bc6e1c9f8f508663d8506ad9ef257aebbd6e829fdea36",
+        "path": "org/jetbrains/testDiscovery/test-discovery-plugin-base/0.1.191/test-discovery-plugin-base-0.1.191.jar"
     },
     {
-        "url": "org/hdrhistogram/HdrHistogram/2.2.2/HdrHistogram-2.2.2.jar",
-        "hash": "22d1d4316c4ec13a68b559e98c8256d69071593731da96136640f864fa14fad8",
-        "path": "org/hdrhistogram/HdrHistogram/2.2.2/HdrHistogram-2.2.2.jar"
-    },
-    {
-        "url": "org/assertj/assertj-core/4.0.0-M1/assertj-core-4.0.0-M1.jar",
-        "hash": "03852ab5b4419c1b0b3689930cdc1ac4f0c437a0c8094a900370dcb170cfbb46",
-        "path": "org/assertj/assertj-core/4.0.0-M1/assertj-core-4.0.0-M1.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlinx/kotlinx-serialization-json-jvm/1.8.1/kotlinx-serialization-json-jvm-1.8.1.jar",
-        "hash": "8769e5647557e3700919c32d508f5c5dad53c5d8234cd10846354fbcff14aa24",
-        "path": "org/jetbrains/kotlinx/kotlinx-serialization-json-jvm/1.8.1/kotlinx-serialization-json-jvm-1.8.1.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/analysis-api-impl-base-for-ide/2.3.20-ij253-45/analysis-api-impl-base-for-ide-2.3.20-ij253-45.jar",
-        "hash": "1ae230b0e5847a47838b871060b7271c9b2329febb85e1470d1490ffe2e28fd4",
-        "path": "org/jetbrains/kotlin/analysis-api-impl-base-for-ide/2.3.20-ij253-45/analysis-api-impl-base-for-ide-2.3.20-ij253-45.jar"
-    },
-    {
-        "url": "io/ktor/ktor-http-cio-jvm/3.1.3/ktor-http-cio-jvm-3.1.3.jar",
-        "hash": "b04aede18e9c008168096dc53a3fc016177b61a5ec3024afbf8caca0cd5dbf42",
-        "path": "io/ktor/ktor-http-cio-jvm/3.1.3/ktor-http-cio-jvm-3.1.3.jar"
-    },
-    {
-        "url": "org/jetbrains/intellij/deps/commons-imaging/1.0-RC-1/commons-imaging-1.0-RC-1.jar",
-        "hash": "ba1cb46e5494286940b016da372ae94a60d2dbc411b6dac5db1e40128725d501",
-        "path": "org/jetbrains/intellij/deps/commons-imaging/1.0-RC-1/commons-imaging-1.0-RC-1.jar"
-    },
-    {
-        "url": "com/intellij/platform/kotlinx-coroutines-core-jvm/1.10.1-intellij-5/kotlinx-coroutines-core-jvm-1.10.1-intellij-5.jar",
-        "hash": "e9b7e2b1262fd02fe63b08f636903ff36f453f08ae52190c78e3cbf19d777e42",
-        "path": "com/intellij/platform/kotlinx-coroutines-core-jvm/1.10.1-intellij-5/kotlinx-coroutines-core-jvm-1.10.1-intellij-5.jar"
-    },
-    {
-        "url": "io/github/z4kn4fein/semver-jvm/2.0.0/semver-jvm-2.0.0.jar",
-        "hash": "fbbf174a4e78aa5be1f1b7db73edc5c0a6a2e59e1562263e2c3a2e510fa1ba45",
-        "path": "io/github/z4kn4fein/semver-jvm/2.0.0/semver-jvm-2.0.0.jar"
-    },
-    {
-        "url": "org/apache/commons/commons-lang3/3.18.0/commons-lang3-3.18.0.jar",
-        "hash": "4eeeae8d20c078abb64b015ec158add383ac581571cddc45c68f0c9ae0230720",
-        "path": "org/apache/commons/commons-lang3/3.18.0/commons-lang3-3.18.0.jar"
-    },
-    {
-        "url": "org/codehaus/groovy/groovy-json/3.0.25/groovy-json-3.0.25.jar",
-        "hash": "511cea72a464809d7e376968910fa704f9fa5afa8f2a94b53672a061b45475bb",
-        "path": "org/codehaus/groovy/groovy-json/3.0.25/groovy-json-3.0.25.jar"
-    },
-    {
-        "url": "com/fasterxml/jackson/dataformat/jackson-dataformat-toml/2.19.0/jackson-dataformat-toml-2.19.0.jar",
-        "hash": "e6312d390c6bef67681f8e258f29ced2f3d0fa1d83a72e0bec1513b8c1c4f430",
-        "path": "com/fasterxml/jackson/dataformat/jackson-dataformat-toml/2.19.0/jackson-dataformat-toml-2.19.0.jar"
-    },
-    {
-        "url": "org/mockito/mockito-core/5.19.0/mockito-core-5.19.0.jar",
-        "hash": "d875ff234a4b72e0eedfe170dd804797a4b87ba4c76207c9659d6f46b527877b",
-        "path": "org/mockito/mockito-core/5.19.0/mockito-core-5.19.0.jar"
-    },
-    {
-        "url": "net/bytebuddy/byte-buddy-agent/1.17.6/byte-buddy-agent-1.17.6.jar",
-        "hash": "8a80959465bb09848cd41a89301490c55b9d940dc6ec30d8abac0f63b39fd5d0",
-        "path": "net/bytebuddy/byte-buddy-agent/1.17.6/byte-buddy-agent-1.17.6.jar"
-    },
-    {
-        "url": "org/objenesis/objenesis/3.3/objenesis-3.3.jar",
-        "hash": "02dfd0b0439a5591e35b708ed2f5474eb0948f53abf74637e959b8e4ef69bfeb",
-        "path": "org/objenesis/objenesis/3.3/objenesis-3.3.jar"
-    },
-    {
-        "url": "com/google/code/gson/gson/2.13.1/gson-2.13.1.jar",
-        "hash": "94855942d4992f112946d3de1c334e709237b8126d8130bf07807c018a4a2120",
-        "path": "com/google/code/gson/gson/2.13.1/gson-2.13.1.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-compiler-fe10-for-ide/2.3.20-ij253-45/kotlin-compiler-fe10-for-ide-2.3.20-ij253-45.jar",
-        "hash": "d1f296fae451d3e16f70a6812fe88024132422189a6cb8a74e4f62b1fa5f18fd",
-        "path": "org/jetbrains/kotlin/kotlin-compiler-fe10-for-ide/2.3.20-ij253-45/kotlin-compiler-fe10-for-ide-2.3.20-ij253-45.jar"
-    },
-    {
-        "url": "com/typesafe/config/1.4.4/config-1.4.4.jar",
-        "hash": "ab16decc45cc678b0cf17fb9668f380a73bfdf11b75af1fa1ddec5da82805aea",
-        "path": "com/typesafe/config/1.4.4/config-1.4.4.jar"
-    },
-    {
-        "url": "io/ktor/ktor-client-core-jvm/3.1.3/ktor-client-core-jvm-3.1.3.jar",
-        "hash": "746e2a3dece87379d64c40999401969001d373de1458fe851c0d2e0f880b42ef",
-        "path": "io/ktor/ktor-client-core-jvm/3.1.3/ktor-client-core-jvm-3.1.3.jar"
+        "url": "org/jetbrains/kotlin/kotlin-scripting-jvm/2.3.20-ij253-45/kotlin-scripting-jvm-2.3.20-ij253-45.jar",
+        "hash": "42d81993e1dd93ba47dc648cf6f8af88aa20ab276077086adcffcc51cd65e08d",
+        "path": "org/jetbrains/kotlin/kotlin-scripting-jvm/2.3.20-ij253-45/kotlin-scripting-jvm-2.3.20-ij253-45.jar"
     },
     {
         "url": "org/junit-pioneer/junit-pioneer/2.3.0/junit-pioneer-2.3.0.jar",
@@ -1110,9 +1990,414 @@
         "path": "org/junit-pioneer/junit-pioneer/2.3.0/junit-pioneer-2.3.0.jar"
     },
     {
-        "url": "org/junit/vintage/junit-vintage-engine/5.13.4/junit-vintage-engine-5.13.4.jar",
-        "hash": "066b702d850ebcde36f2a8181b46a2f0f1416129d1dc63c3a1e1531006e74739",
-        "path": "org/junit/vintage/junit-vintage-engine/5.13.4/junit-vintage-engine-5.13.4.jar"
+        "url": "com/github/lamba92/kotlinx-document-store-mvstore/0.0.4/kotlinx-document-store-mvstore-0.0.4.jar",
+        "hash": "956a4c7faad66e3471861adaa278d9486f3a050ac25fb6a99ca90809d379adfe",
+        "path": "com/github/lamba92/kotlinx-document-store-mvstore/0.0.4/kotlinx-document-store-mvstore-0.0.4.jar"
+    },
+    {
+        "url": "com/github/lamba92/kotlinx-document-store-core-jvm/0.0.4/kotlinx-document-store-core-jvm-0.0.4.jar",
+        "hash": "7e638082b4a14e3a96ca90f3f5db70ac65591e0b6c6670629e849d22ec34455f",
+        "path": "com/github/lamba92/kotlinx-document-store-core-jvm/0.0.4/kotlinx-document-store-core-jvm-0.0.4.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/gradle-api/9.0.0/gradle-api-9.0.0.jar",
+        "hash": "b21806c4075aa42d4534ba7257097aea091ab99c40466b0f850872cfc07e7507",
+        "path": "org/jetbrains/intellij/deps/gradle-api/9.0.0/gradle-api-9.0.0.jar"
+    },
+    {
+        "url": "io/opentelemetry/opentelemetry-extension-kotlin/1.48.0/opentelemetry-extension-kotlin-1.48.0.jar",
+        "hash": "2285ebfe8e0fd38e186b7033f6f6c542324c9bab23260b914b1b73eaf4492c5d",
+        "path": "io/opentelemetry/opentelemetry-extension-kotlin/1.48.0/opentelemetry-extension-kotlin-1.48.0.jar"
+    },
+    {
+        "url": "com/fasterxml/aalto-xml/1.3.3/aalto-xml-1.3.3.jar",
+        "hash": "28829eebb36863b058108fa1b9b8b5cfb94c1871346e4a4f73e69e1fe0a5f0f6",
+        "path": "com/fasterxml/aalto-xml/1.3.3/aalto-xml-1.3.3.jar"
+    },
+    {
+        "url": "org/codehaus/woodstox/stax2-api/4.2.2/stax2-api-4.2.2.jar",
+        "hash": "a61c48d553efad78bc01fffc4ac528bebbae64cbaec170b2a5e39cf61eb51abe",
+        "path": "org/codehaus/woodstox/stax2-api/4.2.2/stax2-api-4.2.2.jar"
+    },
+    {
+        "url": "com/jetbrains/rd/rd-framework/2025.3.1/rd-framework-2025.3.1.jar",
+        "hash": "85f2a329245e4a6a1e4552ac62db4c1f23b6f02bf3c96e4df8240668187c848a",
+        "path": "com/jetbrains/rd/rd-framework/2025.3.1/rd-framework-2025.3.1.jar"
+    },
+    {
+        "url": "org/apache/httpcomponents/httpmime/4.5.14/httpmime-4.5.14.jar",
+        "hash": "d401243d5c6eae928a37121b6e819158c8c32ea0584793e7285bb489ab2a3d17",
+        "path": "org/apache/httpcomponents/httpmime/4.5.14/httpmime-4.5.14.jar"
+    },
+    {
+        "url": "org/apache/httpcomponents/httpclient/4.5.14/httpclient-4.5.14.jar",
+        "hash": "c8bc7e1c51a6d4ce72f40d2ebbabf1c4b68bfe76e732104b04381b493478e9d6",
+        "path": "org/apache/httpcomponents/httpclient/4.5.14/httpclient-4.5.14.jar"
+    },
+    {
+        "url": "org/apache/httpcomponents/httpcore/4.4.16/httpcore-4.4.16.jar",
+        "hash": "6c9b3dd142a09dc468e23ad39aad6f75a0f2b85125104469f026e52a474e464f",
+        "path": "org/apache/httpcomponents/httpcore/4.4.16/httpcore-4.4.16.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-compiler-common-for-ide/2.3.20-ij253-45/kotlin-compiler-common-for-ide-2.3.20-ij253-45.jar",
+        "hash": "4af9a30fde5d143da69428bfef59e292c794927613bf0a5b111aaaa0ead01ba2",
+        "path": "org/jetbrains/kotlin/kotlin-compiler-common-for-ide/2.3.20-ij253-45/kotlin-compiler-common-for-ide-2.3.20-ij253-45.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-test/2.2.20/kotlin-test-2.2.20.jar",
+        "hash": "0054c51c672512a918440703e35ea946a8e7a210872f2196dbd6b9f2959198b0",
+        "path": "org/jetbrains/kotlin/kotlin-test/2.2.20/kotlin-test-2.2.20.jar"
+    },
+    {
+        "url": "com/google/protobuf/protobuf-java/3.24.4-jb.2/protobuf-java-3.24.4-jb.2.jar",
+        "hash": "6ba90d0d081c03c5c03d2d41497f75a183da7fb23cc2691f7b782dea77f73d21",
+        "path": "com/google/protobuf/protobuf-java/3.24.4-jb.2/protobuf-java-3.24.4-jb.2.jar"
+    },
+    {
+        "url": "org/apache/lucene/lucene-queryparser/10.3.0/lucene-queryparser-10.3.0.jar",
+        "hash": "b4b57bc3d56c5a1ccc674f55a16086c37700eb151fa749b45887e391ec0f26f9",
+        "path": "org/apache/lucene/lucene-queryparser/10.3.0/lucene-queryparser-10.3.0.jar"
+    },
+    {
+        "url": "com/github/ben-manes/caffeine/caffeine/3.2.2/caffeine-3.2.2.jar",
+        "hash": "c74a6c72221dfb76eb92f2bb40108ea561a7da2f315dc3b1e64afa8f077f210c",
+        "path": "com/github/ben-manes/caffeine/caffeine/3.2.2/caffeine-3.2.2.jar"
+    },
+    {
+        "url": "org/jetbrains/runtime/jbr-api/1.9.0/jbr-api-1.9.0.jar",
+        "hash": "7e37284e33b5b304ee6174dcaa92db949b257cc4c8991ca865e7daf5113d8279",
+        "path": "org/jetbrains/runtime/jbr-api/1.9.0/jbr-api-1.9.0.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/java-compatibility/1.0.1/java-compatibility-1.0.1.jar",
+        "hash": "1f799c9e7691a4dcddb1cb3e28e8517d5e6b27c2ac75093f39714afdc9216950",
+        "path": "org/jetbrains/intellij/deps/java-compatibility/1.0.1/java-compatibility-1.0.1.jar"
+    },
+    {
+        "url": "org/testcontainers/junit-jupiter/1.20.3/junit-jupiter-1.20.3.jar",
+        "hash": "3b0f0422993e571f3460d8436a0e56538bd474147084a6cbb244a6d5cb1a01a5",
+        "path": "org/testcontainers/junit-jupiter/1.20.3/junit-jupiter-1.20.3.jar"
+    },
+    {
+        "url": "org/jetbrains/packagesearch/packagesearch-api-client-jvm/3.4.0/packagesearch-api-client-jvm-3.4.0.jar",
+        "hash": "9d0f4c74e96787499fcc2462c32afeb7f4db97db30042e2578f205f61e5898fb",
+        "path": "org/jetbrains/packagesearch/packagesearch-api-client-jvm/3.4.0/packagesearch-api-client-jvm-3.4.0.jar"
+    },
+    {
+        "url": "org/jetbrains/packagesearch/packagesearch-http-models-jvm/3.4.0/packagesearch-http-models-jvm-3.4.0.jar",
+        "hash": "0318b967115de0c7c8fbd93bc6e3d279c82de2954f90794146962921de45972d",
+        "path": "org/jetbrains/packagesearch/packagesearch-http-models-jvm/3.4.0/packagesearch-http-models-jvm-3.4.0.jar"
+    },
+    {
+        "url": "org/jetbrains/packagesearch/packagesearch-api-models-jvm/3.4.0/packagesearch-api-models-jvm-3.4.0.jar",
+        "hash": "22022fe954980d8e183b252889719fc6ca71a13e91b8e869d92532da308e3da1",
+        "path": "org/jetbrains/packagesearch/packagesearch-api-models-jvm/3.4.0/packagesearch-api-models-jvm-3.4.0.jar"
+    },
+    {
+        "url": "org/jetbrains/packagesearch/packagesearch-version-utils-jvm/3.4.0/packagesearch-version-utils-jvm-3.4.0.jar",
+        "hash": "4c86546693efaeb889e02d043521cda15da5f10853b0471095b7db80dc0540e7",
+        "path": "org/jetbrains/packagesearch/packagesearch-version-utils-jvm/3.4.0/packagesearch-version-utils-jvm-3.4.0.jar"
+    },
+    {
+        "url": "com/soywiz/korlibs/krypto/krypto-jvm/4.0.10/krypto-jvm-4.0.10.jar",
+        "hash": "0fe8dcdf54b13b5ec56fdb5f63c057364264bb2f51b7f7bc3c271d5b1ba68dcb",
+        "path": "com/soywiz/korlibs/krypto/krypto-jvm/4.0.10/krypto-jvm-4.0.10.jar"
+    },
+    {
+        "url": "org/codehaus/plexus/plexus-utils/3.5.1/plexus-utils-3.5.1.jar",
+        "hash": "86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b",
+        "path": "org/codehaus/plexus/plexus-utils/3.5.1/plexus-utils-3.5.1.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlinx/kotlinx-io-core-jvm/0.7.0/kotlinx-io-core-jvm-0.7.0.jar",
+        "hash": "6ededc9be4d878aea80c7dd609f91bfc47fcd3d36cc91fd0f3f328fbd6656c8f",
+        "path": "org/jetbrains/kotlinx/kotlinx-io-core-jvm/0.7.0/kotlinx-io-core-jvm-0.7.0.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlinx/kotlinx-io-bytestring-jvm/0.7.0/kotlinx-io-bytestring-jvm-0.7.0.jar",
+        "hash": "ea38a66b0ff46ed82dded9e81d2dce70e5fbe03bd6cc52b4fc8869381dea7b7d",
+        "path": "org/jetbrains/kotlinx/kotlinx-io-bytestring-jvm/0.7.0/kotlinx-io-bytestring-jvm-0.7.0.jar"
+    },
+    {
+        "url": "com/fasterxml/jackson/module/jackson-module-kotlin/2.19.0/jackson-module-kotlin-2.19.0.jar",
+        "hash": "df967eebc2c87eaa3f55338607104ffc8fa62fb2e813d67f95ed4f7f9c6f8cee",
+        "path": "com/fasterxml/jackson/module/jackson-module-kotlin/2.19.0/jackson-module-kotlin-2.19.0.jar"
+    },
+    {
+        "url": "org/hamcrest/hamcrest/2.2/hamcrest-2.2.jar",
+        "hash": "5e62846a89f05cd78cd9c1a553f340d002458380c320455dd1f8fc5497a8a1c1",
+        "path": "org/hamcrest/hamcrest/2.2/hamcrest-2.2.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlinx/kotlinx-serialization-core-jvm/1.8.1/kotlinx-serialization-core-jvm-1.8.1.jar",
+        "hash": "3565b6d4d789bf70683c45566944287fc1d8dc75c23d98bd87d01059cc76f2b3",
+        "path": "org/jetbrains/kotlinx/kotlinx-serialization-core-jvm/1.8.1/kotlinx-serialization-core-jvm-1.8.1.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-gradle-plugin-idea/1.9.20-dev-8162/kotlin-gradle-plugin-idea-1.9.20-dev-8162.jar",
+        "hash": "8d1af87632d95148f122a9fa0ae2903c19ee6fab7d01e017f76e0d2c9a022c20",
+        "path": "org/jetbrains/kotlin/kotlin-gradle-plugin-idea/1.9.20-dev-8162/kotlin-gradle-plugin-idea-1.9.20-dev-8162.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlinx/kotlinx-serialization-json-io-jvm/1.8.1/kotlinx-serialization-json-io-jvm-1.8.1.jar",
+        "hash": "ab5ec8ea48815197c46a7df9f418a62791fe91cda5023b941ce4de872d810cc1",
+        "path": "org/jetbrains/kotlinx/kotlinx-serialization-json-io-jvm/1.8.1/kotlinx-serialization-json-io-jvm-1.8.1.jar"
+    },
+    {
+        "url": "io/modelcontextprotocol/kotlin-sdk-jvm/0.8.1/kotlin-sdk-jvm-0.8.1.jar",
+        "hash": "095e5d11868ae359bd640c922c2d1ed7a20ba519496599ee697e81c468761339",
+        "path": "io/modelcontextprotocol/kotlin-sdk-jvm/0.8.1/kotlin-sdk-jvm-0.8.1.jar"
+    },
+    {
+        "url": "io/modelcontextprotocol/kotlin-sdk-client-jvm/0.8.1/kotlin-sdk-client-jvm-0.8.1.jar",
+        "hash": "e88a667c25b8ebb7c81f76dd96cb34ea804754752b5533a842b99d0daea2be99",
+        "path": "io/modelcontextprotocol/kotlin-sdk-client-jvm/0.8.1/kotlin-sdk-client-jvm-0.8.1.jar"
+    },
+    {
+        "url": "io/modelcontextprotocol/kotlin-sdk-server-jvm/0.8.1/kotlin-sdk-server-jvm-0.8.1.jar",
+        "hash": "6086acf1d65bca24de344b493e3fc241f0db2b25fa0606057eee39e3a2264737",
+        "path": "io/modelcontextprotocol/kotlin-sdk-server-jvm/0.8.1/kotlin-sdk-server-jvm-0.8.1.jar"
+    },
+    {
+        "url": "io/modelcontextprotocol/kotlin-sdk-core-jvm/0.8.1/kotlin-sdk-core-jvm-0.8.1.jar",
+        "hash": "dd9a13ba6b0803040b6fea56b6db66bc9c4f31dacf678dac642aaaff8d88a543",
+        "path": "io/modelcontextprotocol/kotlin-sdk-core-jvm/0.8.1/kotlin-sdk-core-jvm-0.8.1.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-scripting-common/2.3.20-ij253-45/kotlin-scripting-common-2.3.20-ij253-45.jar",
+        "hash": "a06d90da5af5a992f93223d26976b81141edf5764dc798431352dbcd6606bce6",
+        "path": "org/jetbrains/kotlin/kotlin-scripting-common/2.3.20-ij253-45/kotlin-scripting-common-2.3.20-ij253-45.jar"
+    },
+    {
+        "url": "io/github/smiley4/schema-kenerator-core/2.2.0/schema-kenerator-core-2.2.0.jar",
+        "hash": "c1c197ed03acaf46773176a001836219b6299fe267dc4751c2c28ae98edfa0f3",
+        "path": "io/github/smiley4/schema-kenerator-core/2.2.0/schema-kenerator-core-2.2.0.jar"
+    },
+    {
+        "url": "nl/jqno/equalsverifier/equalsverifier/3.19.4/equalsverifier-3.19.4.jar",
+        "hash": "2bcbbf2f3227aa97527730eb92ca8724263e6d555b888fbb14aae52bc712d434",
+        "path": "nl/jqno/equalsverifier/equalsverifier/3.19.4/equalsverifier-3.19.4.jar"
+    },
+    {
+        "url": "org/objenesis/objenesis/3.4/objenesis-3.4.jar",
+        "hash": "95488102feaf2e2858adf6b299353677dac6c15294006f8ed1c5556f8e3cd251",
+        "path": "org/objenesis/objenesis/3.4/objenesis-3.4.jar"
+    },
+    {
+        "url": "net/bytebuddy/byte-buddy/1.17.5/byte-buddy-1.17.5.jar",
+        "hash": "71568c9f8396677219f650268fbf6493ded484edcdbdf2dae6129ca5be81e8db",
+        "path": "net/bytebuddy/byte-buddy/1.17.5/byte-buddy-1.17.5.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-tooling-core/1.9.20-dev-8162/kotlin-tooling-core-1.9.20-dev-8162.jar",
+        "hash": "8938eb97e36320daa3e6fb2a60fd2a05b232ff4a557173c5019f045b8832d9f4",
+        "path": "org/jetbrains/kotlin/kotlin-tooling-core/1.9.20-dev-8162/kotlin-tooling-core-1.9.20-dev-8162.jar"
+    },
+    {
+        "url": "org/codehaus/groovy/groovy-json/3.0.25/groovy-json-3.0.25.jar",
+        "hash": "511cea72a464809d7e376968910fa704f9fa5afa8f2a94b53672a061b45475bb",
+        "path": "org/codehaus/groovy/groovy-json/3.0.25/groovy-json-3.0.25.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlinx/lincheck-jvm/2.33/lincheck-jvm-2.33.jar",
+        "hash": "2dd9c390e2de0acbdd2fce1aabadd378fa75a9cf73ee723dd8cecbe5c8480457",
+        "path": "org/jetbrains/kotlinx/lincheck-jvm/2.33/lincheck-jvm-2.33.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-reflect/1.9.21/kotlin-reflect-1.9.21.jar",
+        "hash": "a133e049f0a4e249651582428e166de4dfac9546adf436b6172119255ede510f",
+        "path": "org/jetbrains/kotlin/kotlin-reflect/1.9.21/kotlin-reflect-1.9.21.jar"
+    },
+    {
+        "url": "org/ow2/asm/asm-commons/9.6/asm-commons-9.6.jar",
+        "hash": "7aefd0d5c0901701c69f7513feda765fb6be33af2ce7aa17c5781fc87657c511",
+        "path": "org/ow2/asm/asm-commons/9.6/asm-commons-9.6.jar"
+    },
+    {
+        "url": "org/ow2/asm/asm/9.6/asm-9.6.jar",
+        "hash": "3c6fac2424db3d4a853b669f4e3d1d9c3c552235e19a319673f887083c2303a1",
+        "path": "org/ow2/asm/asm/9.6/asm-9.6.jar"
+    },
+    {
+        "url": "org/ow2/asm/asm-tree/9.6/asm-tree-9.6.jar",
+        "hash": "c43ecf17b539c777e15da7b5b86553b377e2d39a683de6285567d5283888e7ef",
+        "path": "org/ow2/asm/asm-tree/9.6/asm-tree-9.6.jar"
+    },
+    {
+        "url": "org/ow2/asm/asm-util/9.6/asm-util-9.6.jar",
+        "hash": "c635a7402f4aa9bf66b2f4230cea62025a0fe1cd63e8729adefc9b1994fac4c3",
+        "path": "org/ow2/asm/asm-util/9.6/asm-util-9.6.jar"
+    },
+    {
+        "url": "org/ow2/asm/asm-analysis/9.6/asm-analysis-9.6.jar",
+        "hash": "d92832d7c37edc07c60e2559ac6118b31d642e337a6671edcb7ba9fae68edbbb",
+        "path": "org/ow2/asm/asm-analysis/9.6/asm-analysis-9.6.jar"
+    },
+    {
+        "url": "net/bytebuddy/byte-buddy/1.14.12/byte-buddy-1.14.12.jar",
+        "hash": "970636134d61c183b19f8f58fa631e30d2f2abca344b37848a393cac7863dd70",
+        "path": "net/bytebuddy/byte-buddy/1.14.12/byte-buddy-1.14.12.jar"
+    },
+    {
+        "url": "net/bytebuddy/byte-buddy-agent/1.14.12/byte-buddy-agent-1.14.12.jar",
+        "hash": "2b309a9300092e0b696f7c471fd51d9969001df784c8ab9f07997437d757ad6d",
+        "path": "net/bytebuddy/byte-buddy-agent/1.14.12/byte-buddy-agent-1.14.12.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlinx/atomicfu-jvm/0.20.2/atomicfu-jvm-0.20.2.jar",
+        "hash": "b3d9ec0298e84ed09e0448c52a643bfdad7f3d8096f1303592a3046e711551af",
+        "path": "org/jetbrains/kotlinx/atomicfu-jvm/0.20.2/atomicfu-jvm-0.20.2.jar"
+    },
+    {
+        "url": "org/opentest4j/opentest4j/1.3.0/opentest4j-1.3.0.jar",
+        "hash": "48e2df636cab6563ced64dcdff8abb2355627cb236ef0bf37598682ddf742f1b",
+        "path": "org/opentest4j/opentest4j/1.3.0/opentest4j-1.3.0.jar"
+    },
+    {
+        "url": "io/ktor/ktor-http-cio-jvm/3.1.3/ktor-http-cio-jvm-3.1.3.jar",
+        "hash": "b04aede18e9c008168096dc53a3fc016177b61a5ec3024afbf8caca0cd5dbf42",
+        "path": "io/ktor/ktor-http-cio-jvm/3.1.3/ktor-http-cio-jvm-3.1.3.jar"
+    },
+    {
+        "url": "org/objenesis/objenesis/3.4/objenesis-3.4.jar",
+        "hash": "95488102feaf2e2858adf6b299353677dac6c15294006f8ed1c5556f8e3cd251",
+        "path": "org/objenesis/objenesis/3.4/objenesis-3.4.jar"
+    },
+    {
+        "url": "org/testng/testng/7.8.0/testng-7.8.0.jar",
+        "hash": "dbbc43e2c64623661c3537f9d74061eb6c8fc3e5b4376f31fadb16de2b200f88",
+        "path": "org/testng/testng/7.8.0/testng-7.8.0.jar"
+    },
+    {
+        "url": "com/beust/jcommander/1.82/jcommander-1.82.jar",
+        "hash": "deeac157c8de6822878d85d0c7bc8467a19cc8484d37788f7804f039dde280b1",
+        "path": "com/beust/jcommander/1.82/jcommander-1.82.jar"
+    },
+    {
+        "url": "org/webjars/jquery/3.6.1/jquery-3.6.1.jar",
+        "hash": "da2381fbee4799631ba44d1f4d6487b886b22450c7fc85842c5fdfa03429b817",
+        "path": "org/webjars/jquery/3.6.1/jquery-3.6.1.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-compose-compiler-plugin/2.2.20/kotlin-compose-compiler-plugin-2.2.20.jar",
+        "hash": "d99052e257681e496590c5c724e1324eb511e4205f5fd413b5f503d8e932b698",
+        "path": "org/jetbrains/kotlin/kotlin-compose-compiler-plugin/2.2.20/kotlin-compose-compiler-plugin-2.2.20.jar"
+    },
+    {
+        "url": "io/netty/netty-buffer/4.2.0.RC2/netty-buffer-4.2.0.RC2.jar",
+        "hash": "74d953cec00048b892112f9602fc7b1113ea55337dc1ede32e449efcb2b231c7",
+        "path": "io/netty/netty-buffer/4.2.0.RC2/netty-buffer-4.2.0.RC2.jar"
+    },
+    {
+        "url": "io/netty/netty-common/4.2.0.RC2/netty-common-4.2.0.RC2.jar",
+        "hash": "cc65afe17daf2f9380d3c64460f5b10ec279f98b9461fbf0ccf62b3cb3ee6c37",
+        "path": "io/netty/netty-common/4.2.0.RC2/netty-common-4.2.0.RC2.jar"
+    },
+    {
+        "url": "org/junit/jupiter/junit-jupiter-api/6.0.0/junit-jupiter-api-6.0.0.jar",
+        "hash": "88d690d2d373cd66170770c317977196ce9e465f2388930f4bc9665e887385f6",
+        "path": "org/junit/jupiter/junit-jupiter-api/6.0.0/junit-jupiter-api-6.0.0.jar"
+    },
+    {
+        "url": "org/opentest4j/opentest4j/1.3.0/opentest4j-1.3.0.jar",
+        "hash": "48e2df636cab6563ced64dcdff8abb2355627cb236ef0bf37598682ddf742f1b",
+        "path": "org/opentest4j/opentest4j/1.3.0/opentest4j-1.3.0.jar"
+    },
+    {
+        "url": "org/junit/platform/junit-platform-commons/6.0.0/junit-platform-commons-6.0.0.jar",
+        "hash": "86e8faf87f3151a3d545850852a0f2cc55ea8a2434eee9e08f83881c52d55992",
+        "path": "org/junit/platform/junit-platform-commons/6.0.0/junit-platform-commons-6.0.0.jar"
+    },
+    {
+        "url": "org/apiguardian/apiguardian-api/1.1.2/apiguardian-api-1.1.2.jar",
+        "hash": "b509448ac506d607319f182537f0b35d71007582ec741832a1f111e5b5b70b38",
+        "path": "org/apiguardian/apiguardian-api/1.1.2/apiguardian-api-1.1.2.jar"
+    },
+    {
+        "url": "org/jspecify/jspecify/1.0.0/jspecify-1.0.0.jar",
+        "hash": "1fad6e6be7557781e4d33729d49ae1cdc8fdda6fe477bb0cc68ce351eafdfbab",
+        "path": "org/jspecify/jspecify/1.0.0/jspecify-1.0.0.jar"
+    },
+    {
+        "url": "org/assertj/assertj-swing/3.17.1/assertj-swing-3.17.1.jar",
+        "hash": "e36445438d72d83cc48015dcb3f14d9a97eaa42c4663a9826db2bb50e4c7713b",
+        "path": "org/assertj/assertj-swing/3.17.1/assertj-swing-3.17.1.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/studio-platform/2025.1.2-287/studio-platform-2025.1.2-287.jar",
+        "hash": "21a748abc565fd6d97d90f2547d0fd1da36810171050b2a337cbc02799cfe482",
+        "path": "org/jetbrains/intellij/deps/studio-platform/2025.1.2-287/studio-platform-2025.1.2-287.jar"
+    },
+    {
+        "url": "org/mockito/kotlin/mockito-kotlin/6.0.0/mockito-kotlin-6.0.0.jar",
+        "hash": "34d626ffa4a27ec49e47de7d760f1df30223ecb8944b6472941f5c73ec68dfbd",
+        "path": "org/mockito/kotlin/mockito-kotlin/6.0.0/mockito-kotlin-6.0.0.jar"
+    },
+    {
+        "url": "org/jruby/joni/joni/2.2.3/joni-2.2.3.jar",
+        "hash": "7ea54221f5f91deff2e860fe986eefe208b59fa04300e54c505c5c0c08d55e9a",
+        "path": "org/jruby/joni/joni/2.2.3/joni-2.2.3.jar"
+    },
+    {
+        "url": "org/jruby/jcodings/jcodings/1.0.61/jcodings-1.0.61.jar",
+        "hash": "3238c68a2f86cec53cc184ad26df8352db87bb22a419bd17fb4acdfbb0bc40f0",
+        "path": "org/jruby/jcodings/jcodings/1.0.61/jcodings-1.0.61.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/analysis-api-k2-tests-for-ide/2.3.20-ij253-45/analysis-api-k2-tests-for-ide-2.3.20-ij253-45.jar",
+        "hash": "7359f01e280d5d55781135956975278b3e4c1472e9628cce72bb0071705ce63b",
+        "path": "org/jetbrains/kotlin/analysis-api-k2-tests-for-ide/2.3.20-ij253-45/analysis-api-k2-tests-for-ide-2.3.20-ij253-45.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/lombok-compiler-plugin-for-ide/2.3.20-ij253-45/lombok-compiler-plugin-for-ide-2.3.20-ij253-45.jar",
+        "hash": "8bc0ca5c9bb47b4ae74ab75306e8c0481d2748b3165dc850165d72d199540653",
+        "path": "org/jetbrains/kotlin/lombok-compiler-plugin-for-ide/2.3.20-ij253-45/lombok-compiler-plugin-for-ide-2.3.20-ij253-45.jar"
+    },
+    {
+        "url": "org/apache/lucene/lucene-analysis-common/10.3.0/lucene-analysis-common-10.3.0.jar",
+        "hash": "124bddea3fa0683d3e174552fba5fcf0f24a2f57f1ccf6957010d010d246db8b",
+        "path": "org/apache/lucene/lucene-analysis-common/10.3.0/lucene-analysis-common-10.3.0.jar"
+    },
+    {
+        "url": "org/apache/sshd/sshd-osgi/2.15.0/sshd-osgi-2.15.0.jar",
+        "hash": "3c8a183f81e176d9c452c9bb94007574bc8188446b4fc98b527aa79074cd0dda",
+        "path": "org/apache/sshd/sshd-osgi/2.15.0/sshd-osgi-2.15.0.jar"
+    },
+    {
+        "url": "jetbrains/fleet/rhizomedb-compiler-plugin/2.2.20-0.1/rhizomedb-compiler-plugin-2.2.20-0.1.jar",
+        "hash": "eaaae0ef5b03c8cf3d3978699c517f3e2199f50191568efaff4d525be963f544",
+        "path": "jetbrains/fleet/rhizomedb-compiler-plugin/2.2.20-0.1/rhizomedb-compiler-plugin-2.2.20-0.1.jar"
+    },
+    {
+        "url": "org/apache/lucene/lucene-suggest/10.3.0/lucene-suggest-10.3.0.jar",
+        "hash": "4b53bf7160e8cdf2ae6bf1a27018bb4fbfdb1841fbdad988c5ff71c7920f4a84",
+        "path": "org/apache/lucene/lucene-suggest/10.3.0/lucene-suggest-10.3.0.jar"
+    },
+    {
+        "url": "com/fasterxml/jackson/datatype/jackson-datatype-joda/2.19.0/jackson-datatype-joda-2.19.0.jar",
+        "hash": "585fbc8bb26dffa4a3174d74352dd3e29cba990a9c1b06c1a547906aff2869ec",
+        "path": "com/fasterxml/jackson/datatype/jackson-datatype-joda/2.19.0/jackson-datatype-joda-2.19.0.jar"
+    },
+    {
+        "url": "joda-time/joda-time/2.12.7/joda-time-2.12.7.jar",
+        "hash": "385282b005818cfaccdbe8bd2429811e7e641782f2b88932a6b8ff51d668f616",
+        "path": "joda-time/joda-time/2.12.7/joda-time-2.12.7.jar"
+    },
+    {
+        "url": "org/apache/thrift/libthrift/0.19.0/libthrift-0.19.0.jar",
+        "hash": "2b6e6550b40467ede7b3034a1a9eb9148fbf920cfdae5bf0b1d2bb3d4e780625",
+        "path": "org/apache/thrift/libthrift/0.19.0/libthrift-0.19.0.jar"
+    },
+    {
+        "url": "com/jetbrains/rd/rd-text/2025.3.1/rd-text-2025.3.1.jar",
+        "hash": "e465ab42d9c79cdec7147c8210f8e65d5f816704d47b959ac9f2cfc3f68dedb5",
+        "path": "com/jetbrains/rd/rd-text/2025.3.1/rd-text-2025.3.1.jar"
+    },
+    {
+        "url": "com/jgoodies/forms/1.1-preview/forms-1.1-preview.jar",
+        "hash": "26b0fc745ea051b57462be22a150c7600dbac6716b24cc60a5ecc0e8085c41a0",
+        "path": "com/jgoodies/forms/1.1-preview/forms-1.1-preview.jar"
     },
     {
         "url": "org/testcontainers/testcontainers/1.20.3/testcontainers-1.20.3.jar",
@@ -1140,1309 +2425,24 @@
         "path": "com/github/docker-java/docker-java-transport/3.4.0/docker-java-transport-3.4.0.jar"
     },
     {
-        "url": "org/junit/platform/junit-platform-suite/1.13.4/junit-platform-suite-1.13.4.jar",
-        "hash": "8088a80b47f5a7e73fa107f466dfa6a86776ca496fc2e7724aba65202d467913",
-        "path": "org/junit/platform/junit-platform-suite/1.13.4/junit-platform-suite-1.13.4.jar"
-    },
-    {
-        "url": "org/junit/platform/junit-platform-suite-api/1.13.4/junit-platform-suite-api-1.13.4.jar",
-        "hash": "9a05bf77e128371f5b3e25ffc89f7af467a9f68dd365fdfced469ebcf533abc9",
-        "path": "org/junit/platform/junit-platform-suite-api/1.13.4/junit-platform-suite-api-1.13.4.jar"
-    },
-    {
-        "url": "org/junit/platform/junit-platform-suite-engine/1.13.4/junit-platform-suite-engine-1.13.4.jar",
-        "hash": "3b34fd8172d70d0d7c59155e487bd8e77d43bdbfdcfe1d78c2b4eea55e9acb92",
-        "path": "org/junit/platform/junit-platform-suite-engine/1.13.4/junit-platform-suite-engine-1.13.4.jar"
-    },
-    {
-        "url": "org/junit/platform/junit-platform-suite-commons/1.13.4/junit-platform-suite-commons-1.13.4.jar",
-        "hash": "e7dacfcfa3bc692c0a7a413cefd5f51ae420415a14d39091bdf88aebfdba70b6",
-        "path": "org/junit/platform/junit-platform-suite-commons/1.13.4/junit-platform-suite-commons-1.13.4.jar"
-    },
-    {
-        "url": "org/apache/lucene/lucene-suggest/10.3.0/lucene-suggest-10.3.0.jar",
-        "hash": "4b53bf7160e8cdf2ae6bf1a27018bb4fbfdb1841fbdad988c5ff71c7920f4a84",
-        "path": "org/apache/lucene/lucene-suggest/10.3.0/lucene-suggest-10.3.0.jar"
-    },
-    {
-        "url": "org/yaml/snakeyaml/2.4/snakeyaml-2.4.jar",
-        "hash": "ef779af5d29a9dde8cc70ce0341f5c6f7735e23edff9685ceaa9d35359b7bb7f",
-        "path": "org/yaml/snakeyaml/2.4/snakeyaml-2.4.jar"
-    },
-    {
-        "url": "com/jetbrains/rd/rd-core/2025.3.1/rd-core-2025.3.1.jar",
-        "hash": "05492a77e70f6a35f1ce19b60841ba39f2fcbe03b1b26eee7aea0c8745cc5e7e",
-        "path": "com/jetbrains/rd/rd-core/2025.3.1/rd-core-2025.3.1.jar"
-    },
-    {
-        "url": "io/opentelemetry/semconv/opentelemetry-semconv/1.30.0/opentelemetry-semconv-1.30.0.jar",
-        "hash": "99c2478a9b803b7d385d1624d5c1ab6f9a64cac5a2dc00f44a350744a1d858ac",
-        "path": "io/opentelemetry/semconv/opentelemetry-semconv/1.30.0/opentelemetry-semconv-1.30.0.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/parcelize-compiler-plugin-for-ide/2.3.20-ij253-45/parcelize-compiler-plugin-for-ide-2.3.20-ij253-45.jar",
-        "hash": "c4e51a757d46f19bdc2264c7be0cba0cc52eb52c9047c0be9b1df91eb8195f4e",
-        "path": "org/jetbrains/kotlin/parcelize-compiler-plugin-for-ide/2.3.20-ij253-45/parcelize-compiler-plugin-for-ide-2.3.20-ij253-45.jar"
-    },
-    {
-        "url": "javax/xml/bind/jaxb-api/2.3.1/jaxb-api-2.3.1.jar",
-        "hash": "88b955a0df57880a26a74708bc34f74dcaf8ebf4e78843a28b50eae945732b06",
-        "path": "javax/xml/bind/jaxb-api/2.3.1/jaxb-api-2.3.1.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/low-level-api-fir-for-ide/2.3.20-ij253-45/low-level-api-fir-for-ide-2.3.20-ij253-45.jar",
-        "hash": "635cd736b002e250cbb2165f5cb05b2a9750f403ec8eaf6e1be9fad67f3ec1aa",
-        "path": "org/jetbrains/kotlin/low-level-api-fir-for-ide/2.3.20-ij253-45/low-level-api-fir-for-ide-2.3.20-ij253-45.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-stdlib/2.2.20/kotlin-stdlib-2.2.20.jar",
-        "hash": "8836ccffd3585fadda9901244b20d42901d2f3cd581058d8434e2ffabcf3a3e7",
-        "path": "org/jetbrains/kotlin/kotlin-stdlib/2.2.20/kotlin-stdlib-2.2.20.jar"
-    },
-    {
-        "url": "org/jetbrains/compose/components/components-ui-tooling-preview-desktop/1.9.0/components-ui-tooling-preview-desktop-1.9.0.jar",
-        "hash": "ca0857dcde7cffff8eea3cce2940a285f219f673829f7f9a3381f767d224f411",
-        "path": "org/jetbrains/compose/components/components-ui-tooling-preview-desktop/1.9.0/components-ui-tooling-preview-desktop-1.9.0.jar"
-    },
-    {
-        "url": "com/jgoodies/jgoodies-common/1.4.0/jgoodies-common-1.4.0.jar",
-        "hash": "efd986ec851c3a5cd57907e72f27d1af9c1e5b1874b07a8b778588646d71d9fc",
-        "path": "com/jgoodies/jgoodies-common/1.4.0/jgoodies-common-1.4.0.jar"
-    },
-    {
-        "url": "io/vavr/vavr/0.10.4/vavr-0.10.4.jar",
-        "hash": "12622deeea2618b59b284051a9484f1def8ccbebc847c350358f12d325ba9dd5",
-        "path": "io/vavr/vavr/0.10.4/vavr-0.10.4.jar"
-    },
-    {
-        "url": "io/vavr/vavr-match/0.10.4/vavr-match-0.10.4.jar",
-        "hash": "d46f96bf59ccd5800261eec5869a6877ee0a37ea781312e6735be55539f50354",
-        "path": "io/vavr/vavr-match/0.10.4/vavr-match-0.10.4.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-compiler-fir-for-ide/2.3.20-ij253-45/kotlin-compiler-fir-for-ide-2.3.20-ij253-45.jar",
-        "hash": "51241b1d60e87ef52b69ad58dc530230dd832def0cec16ca3a57e705f7ecd9bc",
-        "path": "org/jetbrains/kotlin/kotlin-compiler-fir-for-ide/2.3.20-ij253-45/kotlin-compiler-fir-for-ide-2.3.20-ij253-45.jar"
-    },
-    {
-        "url": "org/testng/testng/7.8.0/testng-7.8.0.jar",
-        "hash": "dbbc43e2c64623661c3537f9d74061eb6c8fc3e5b4376f31fadb16de2b200f88",
-        "path": "org/testng/testng/7.8.0/testng-7.8.0.jar"
-    },
-    {
-        "url": "com/beust/jcommander/1.82/jcommander-1.82.jar",
-        "hash": "deeac157c8de6822878d85d0c7bc8467a19cc8484d37788f7804f039dde280b1",
-        "path": "com/beust/jcommander/1.82/jcommander-1.82.jar"
-    },
-    {
-        "url": "org/webjars/jquery/3.6.1/jquery-3.6.1.jar",
-        "hash": "da2381fbee4799631ba44d1f4d6487b886b22450c7fc85842c5fdfa03429b817",
-        "path": "org/webjars/jquery/3.6.1/jquery-3.6.1.jar"
-    },
-    {
-        "url": "net/java/dev/jna/jna-platform/5.17.0/jna-platform-5.17.0.jar",
-        "hash": "b7e3d46c87bad2eb409b0e704916bcd81206168e357312dfddd0e253679cd9e0",
-        "path": "net/java/dev/jna/jna-platform/5.17.0/jna-platform-5.17.0.jar"
-    },
-    {
-        "url": "net/java/dev/jna/jna/5.17.0/jna-5.17.0.jar",
-        "hash": "b3a9408e7c51e08ef0e3bfcc08f443f6ec0f6191ba8cd7c18d53d2b22e5bdbc0",
-        "path": "net/java/dev/jna/jna/5.17.0/jna-5.17.0.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlinx/kotlinx-serialization-cbor-jvm/1.8.1/kotlinx-serialization-cbor-jvm-1.8.1.jar",
-        "hash": "604c4130ca7a0e979a449cf550087a5c2c586485e8af01dcf24b03b7b287306d",
-        "path": "org/jetbrains/kotlinx/kotlinx-serialization-cbor-jvm/1.8.1/kotlinx-serialization-cbor-jvm-1.8.1.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlinx/kotlinx-io-core-jvm/0.7.0/kotlinx-io-core-jvm-0.7.0.jar",
-        "hash": "6ededc9be4d878aea80c7dd609f91bfc47fcd3d36cc91fd0f3f328fbd6656c8f",
-        "path": "org/jetbrains/kotlinx/kotlinx-io-core-jvm/0.7.0/kotlinx-io-core-jvm-0.7.0.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlinx/kotlinx-io-bytestring-jvm/0.7.0/kotlinx-io-bytestring-jvm-0.7.0.jar",
-        "hash": "ea38a66b0ff46ed82dded9e81d2dce70e5fbe03bd6cc52b4fc8869381dea7b7d",
-        "path": "org/jetbrains/kotlinx/kotlinx-io-bytestring-jvm/0.7.0/kotlinx-io-bytestring-jvm-0.7.0.jar"
-    },
-    {
-        "url": "org/imgscalr/imgscalr-lib/4.2/imgscalr-lib-4.2.jar",
-        "hash": "6f128a71c5e87a16f810513a73ad3c77d0ee0bb622ee0ce1ead115bccbc76d0a",
-        "path": "org/imgscalr/imgscalr-lib/4.2/imgscalr-lib-4.2.jar"
-    },
-    {
-        "url": "io/ktor/ktor-client-cio-jvm/3.1.3/ktor-client-cio-jvm-3.1.3.jar",
-        "hash": "9a86341588057a23d3ba4562fdc8afcef6facd071678a0c20b3b28a19ec35c88",
-        "path": "io/ktor/ktor-client-cio-jvm/3.1.3/ktor-client-cio-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-client-core-jvm/3.1.3/ktor-client-core-jvm-3.1.3.jar",
-        "hash": "746e2a3dece87379d64c40999401969001d373de1458fe851c0d2e0f880b42ef",
-        "path": "io/ktor/ktor-client-core-jvm/3.1.3/ktor-client-core-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-http-jvm/3.1.3/ktor-http-jvm-3.1.3.jar",
-        "hash": "8a50d94b46f91bd56580b9169272d6cd636f442032ba078a141da70413465946",
-        "path": "io/ktor/ktor-http-jvm/3.1.3/ktor-http-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-events-jvm/3.1.3/ktor-events-jvm-3.1.3.jar",
-        "hash": "da7069c6e78809d7c37d104e415613cbd4cd5cec1ed54a332cb64ef6a864a060",
-        "path": "io/ktor/ktor-events-jvm/3.1.3/ktor-events-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-websocket-serialization-jvm/3.1.3/ktor-websocket-serialization-jvm-3.1.3.jar",
-        "hash": "67f0f566e2ed51717f6ed55f6d2b4dee1c84be4ea2cd96fc636d0bdf0fd43067",
-        "path": "io/ktor/ktor-websocket-serialization-jvm/3.1.3/ktor-websocket-serialization-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-serialization-jvm/3.1.3/ktor-serialization-jvm-3.1.3.jar",
-        "hash": "0d704bc1148a8fd9a1f2005e0b5189cdaed3030efe24b8236459c41c356f5620",
-        "path": "io/ktor/ktor-serialization-jvm/3.1.3/ktor-serialization-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-sse-jvm/3.1.3/ktor-sse-jvm-3.1.3.jar",
-        "hash": "a2ae8a338bb1d446d16dcfea2189ef5a5be31a88123b3879562b7955667a5639",
-        "path": "io/ktor/ktor-sse-jvm/3.1.3/ktor-sse-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-http-cio-jvm/3.1.3/ktor-http-cio-jvm-3.1.3.jar",
-        "hash": "b04aede18e9c008168096dc53a3fc016177b61a5ec3024afbf8caca0cd5dbf42",
-        "path": "io/ktor/ktor-http-cio-jvm/3.1.3/ktor-http-cio-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-network-jvm/3.1.3/ktor-network-jvm-3.1.3.jar",
-        "hash": "fa4e6165b5ad4bf5db337ebd5f16f9b596dc5e401fbea343b9deacb6138240af",
-        "path": "io/ktor/ktor-network-jvm/3.1.3/ktor-network-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-io-jvm/3.1.3/ktor-io-jvm-3.1.3.jar",
-        "hash": "bb2fb6c00afaa34b539cb30e7584d37bfcba171c266bbdb9990e003579dc24c1",
-        "path": "io/ktor/ktor-io-jvm/3.1.3/ktor-io-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-websockets-jvm/3.1.3/ktor-websockets-jvm-3.1.3.jar",
-        "hash": "ef28b4f12054ee125765b72fe3230e215a60b73b2ff2072a5c280fcf09329077",
-        "path": "io/ktor/ktor-websockets-jvm/3.1.3/ktor-websockets-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-utils-jvm/3.1.3/ktor-utils-jvm-3.1.3.jar",
-        "hash": "33333937b98fc0c8e943ee4b10b3ea66b49782dfb569c44c142da4f32d85dffc",
-        "path": "io/ktor/ktor-utils-jvm/3.1.3/ktor-utils-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-network-tls-jvm/3.1.3/ktor-network-tls-jvm-3.1.3.jar",
-        "hash": "f67507a3e8bf52aa08d753682e6cdda0194e3abe750118b99c9336953e598be9",
-        "path": "io/ktor/ktor-network-tls-jvm/3.1.3/ktor-network-tls-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-client-java-jvm/3.1.3/ktor-client-java-jvm-3.1.3.jar",
-        "hash": "4449fa59e5f4f9a18e18b5ed10db95dba3f65a825cfc32d053097d8bffccfbf1",
-        "path": "io/ktor/ktor-client-java-jvm/3.1.3/ktor-client-java-jvm-3.1.3.jar"
-    },
-    {
-        "url": "com/jetbrains/fus/reporting/connection-client/171/connection-client-171.jar",
-        "hash": "ca8ebd17e33f333647b905d43fc8cce2ad16abd22bfa99b75cb8a499894648b8",
-        "path": "com/jetbrains/fus/reporting/connection-client/171/connection-client-171.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlinx/kotlinx-serialization-core-jvm/1.8.1/kotlinx-serialization-core-jvm-1.8.1.jar",
-        "hash": "3565b6d4d789bf70683c45566944287fc1d8dc75c23d98bd87d01059cc76f2b3",
-        "path": "org/jetbrains/kotlinx/kotlinx-serialization-core-jvm/1.8.1/kotlinx-serialization-core-jvm-1.8.1.jar"
-    },
-    {
-        "url": "com/intellij/platform/kotlinx-coroutines-debug/1.10.1-intellij-5/kotlinx-coroutines-debug-1.10.1-intellij-5.jar",
-        "hash": "f8f56f19d2b29da511809c3345d2f0bf283bfb94a0a0d83f5b630e1424625723",
-        "path": "com/intellij/platform/kotlinx-coroutines-debug/1.10.1-intellij-5/kotlinx-coroutines-debug-1.10.1-intellij-5.jar"
-    },
-    {
-        "url": "com/github/luben/zstd-jni/1.5.7-4/zstd-jni-1.5.7-4.jar",
-        "hash": "e7f064bf1eab83fa785cf587f657f09649e3b0af6f27caa5382416953b5a35f8",
-        "path": "com/github/luben/zstd-jni/1.5.7-4/zstd-jni-1.5.7-4.jar"
-    },
-    {
-        "url": "io/netty/netty-buffer/4.2.0.RC2/netty-buffer-4.2.0.RC2.jar",
-        "hash": "74d953cec00048b892112f9602fc7b1113ea55337dc1ede32e449efcb2b231c7",
-        "path": "io/netty/netty-buffer/4.2.0.RC2/netty-buffer-4.2.0.RC2.jar"
-    },
-    {
-        "url": "io/netty/netty-common/4.2.0.RC2/netty-common-4.2.0.RC2.jar",
-        "hash": "cc65afe17daf2f9380d3c64460f5b10ec279f98b9461fbf0ccf62b3cb3ee6c37",
-        "path": "io/netty/netty-common/4.2.0.RC2/netty-common-4.2.0.RC2.jar"
-    },
-    {
-        "url": "org/codehaus/groovy/groovy-templates/3.0.25/groovy-templates-3.0.25.jar",
-        "hash": "fd0e111cae80bd6285677759b72cb67e7da68ee779a90e51bee12a7011c28436",
-        "path": "org/codehaus/groovy/groovy-templates/3.0.25/groovy-templates-3.0.25.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-reflect/2.2.20/kotlin-reflect-2.2.20.jar",
-        "hash": "8209083a4a7c4e476d9842b078308fa96a96f07a6bd99f05f3586ee13289ab26",
-        "path": "org/jetbrains/kotlin/kotlin-reflect/2.2.20/kotlin-reflect-2.2.20.jar"
-    },
-    {
-        "url": "io/grpc/grpc-kotlin-stub/1.4.3/grpc-kotlin-stub-1.4.3.jar",
-        "hash": "4b5705f8cabd07e82c81dbce36f1554aa9d1740f03e369fd049a71f375dac2f0",
-        "path": "io/grpc/grpc-kotlin-stub/1.4.3/grpc-kotlin-stub-1.4.3.jar"
-    },
-    {
-        "url": "com/fasterxml/jackson/core/jackson-core/2.19.0/jackson-core-2.19.0.jar",
-        "hash": "da8e859bac94874528116a25f20c68560e4287acbf27628711b8a4f96b028430",
-        "path": "com/fasterxml/jackson/core/jackson-core/2.19.0/jackson-core-2.19.0.jar"
-    },
-    {
-        "url": "org/lz4/lz4-java/1.8.0/lz4-java-1.8.0.jar",
-        "hash": "d74a3334fb35195009b338a951f918203d6bbca3d1d359033dc33edd1cadc9ef",
-        "path": "org/lz4/lz4-java/1.8.0/lz4-java-1.8.0.jar"
-    },
-    {
-        "url": "io/ktor/ktor-utils-jvm/3.1.3/ktor-utils-jvm-3.1.3.jar",
-        "hash": "33333937b98fc0c8e943ee4b10b3ea66b49782dfb569c44c142da4f32d85dffc",
-        "path": "io/ktor/ktor-utils-jvm/3.1.3/ktor-utils-jvm-3.1.3.jar"
-    },
-    {
-        "url": "org/codehaus/plexus/plexus-utils/3.5.1/plexus-utils-3.5.1.jar",
-        "hash": "86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b",
-        "path": "org/codehaus/plexus/plexus-utils/3.5.1/plexus-utils-3.5.1.jar"
-    },
-    {
-        "url": "ai/grazie/grazie-rule-engine/0.3.11/grazie-rule-engine-0.3.11.jar",
-        "hash": "54b321650a50f78ceee6bd06653ee3cea0b19db5fe95e3c3a109e6af4a20126c",
-        "path": "ai/grazie/grazie-rule-engine/0.3.11/grazie-rule-engine-0.3.11.jar"
-    },
-    {
-        "url": "net/fellbaum/jemoji/1.3.1/jemoji-1.3.1.jar",
-        "hash": "80a2f8918240a07d3a6fc7cdcc543d278013f6943c080835e43a22fc90462a9f",
-        "path": "net/fellbaum/jemoji/1.3.1/jemoji-1.3.1.jar"
-    },
-    {
-        "url": "com/jetbrains/mlapi/mlapi-core/0.2.1/mlapi-core-0.2.1.jar",
-        "hash": "02da615dd0adac62f2d87db878f587529e8d2cb82b3a65ed8b5466a518324180",
-        "path": "com/jetbrains/mlapi/mlapi-core/0.2.1/mlapi-core-0.2.1.jar"
-    },
-    {
-        "url": "io/cucumber/cucumber-core/2.4.0/cucumber-core-2.4.0.jar",
-        "hash": "ac0f343d6fc0dca4c93f8b6a6266b3bf4cb4d61913b8a4cd2b3abf50025268cf",
-        "path": "io/cucumber/cucumber-core/2.4.0/cucumber-core-2.4.0.jar"
-    },
-    {
-        "url": "info/cukes/cucumber-html/0.2.6/cucumber-html-0.2.6.jar",
-        "hash": "e2167e99bdb018576cce9cc0aad154ad995fe67a4b0c36c63344f743865f96e7",
-        "path": "info/cukes/cucumber-html/0.2.6/cucumber-html-0.2.6.jar"
-    },
-    {
-        "url": "io/cucumber/cucumber-jvm-deps/1.0.6/cucumber-jvm-deps-1.0.6.jar",
-        "hash": "d1c2cc901dd702eb77a2258c0d1446e4a302d28da0d4b49cd11ff3d5929281fa",
-        "path": "io/cucumber/cucumber-jvm-deps/1.0.6/cucumber-jvm-deps-1.0.6.jar"
-    },
-    {
-        "url": "io/cucumber/gherkin/5.0.0/gherkin-5.0.0.jar",
-        "hash": "e35cfa4a16204bf59fa167bb6d45be0717d6b7cfba1c30f156d8f21cde2f4065",
-        "path": "io/cucumber/gherkin/5.0.0/gherkin-5.0.0.jar"
-    },
-    {
-        "url": "io/cucumber/tag-expressions/1.1.1/tag-expressions-1.1.1.jar",
-        "hash": "e5a0a71fb846752900c0e5a99aa13e5a1bbc3ec97e7faf26803648fa45215584",
-        "path": "io/cucumber/tag-expressions/1.1.1/tag-expressions-1.1.1.jar"
-    },
-    {
-        "url": "org/jmock/jmock/2.5.1/jmock-2.5.1.jar",
-        "hash": "d96425f4bab28798162e59fffbe7e16ea6c2aab303ee8dfb0a2ec38a5a4e2f36",
-        "path": "org/jmock/jmock/2.5.1/jmock-2.5.1.jar"
-    },
-    {
-        "url": "org/swinglabs/swingx-core/1.6.2-2/swingx-core-1.6.2-2.jar",
-        "hash": "0df80935d9bc3b3841bc621c6fef6615c93aaf80393ccaa196db11bf97784f18",
-        "path": "org/swinglabs/swingx-core/1.6.2-2/swingx-core-1.6.2-2.jar"
-    },
-    {
-        "url": "io/mockk/mockk/1.14.5/mockk-1.14.5.jar",
-        "hash": "089e24417bf9f6c34eec5720eebb2cbcc82ea2855ecef90133eb17e1079d5868",
-        "path": "io/mockk/mockk/1.14.5/mockk-1.14.5.jar"
-    },
-    {
-        "url": "io/mockk/mockk-dsl/1.14.5/mockk-dsl-1.14.5.jar",
-        "hash": "089e24417bf9f6c34eec5720eebb2cbcc82ea2855ecef90133eb17e1079d5868",
-        "path": "io/mockk/mockk-dsl/1.14.5/mockk-dsl-1.14.5.jar"
-    },
-    {
-        "url": "io/mockk/mockk-agent/1.14.5/mockk-agent-1.14.5.jar",
-        "hash": "089e24417bf9f6c34eec5720eebb2cbcc82ea2855ecef90133eb17e1079d5868",
-        "path": "io/mockk/mockk-agent/1.14.5/mockk-agent-1.14.5.jar"
-    },
-    {
-        "url": "io/mockk/mockk-agent-api/1.14.5/mockk-agent-api-1.14.5.jar",
-        "hash": "089e24417bf9f6c34eec5720eebb2cbcc82ea2855ecef90133eb17e1079d5868",
-        "path": "io/mockk/mockk-agent-api/1.14.5/mockk-agent-api-1.14.5.jar"
-    },
-    {
-        "url": "io/mockk/mockk-core/1.14.5/mockk-core-1.14.5.jar",
-        "hash": "089e24417bf9f6c34eec5720eebb2cbcc82ea2855ecef90133eb17e1079d5868",
-        "path": "io/mockk/mockk-core/1.14.5/mockk-core-1.14.5.jar"
-    },
-    {
-        "url": "com/jetbrains/infra/download-pgp-verifier/1.1.4/download-pgp-verifier-1.1.4.jar",
-        "hash": "2bbfa931b2864c4f5e1fd22046d001df8d9a8592a20255baab0d396ed71c854c",
-        "path": "com/jetbrains/infra/download-pgp-verifier/1.1.4/download-pgp-verifier-1.1.4.jar"
-    },
-    {
-        "url": "com/jetbrains/fus/reporting/model/171/model-171.jar",
-        "hash": "8aa0be7e7c1a46ef0827d98c026d328a6f9be27aed79b36692a7f38bacd41a6a",
-        "path": "com/jetbrains/fus/reporting/model/171/model-171.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/analysis-api-k2-tests-for-ide/2.3.20-ij253-45/analysis-api-k2-tests-for-ide-2.3.20-ij253-45.jar",
-        "hash": "7359f01e280d5d55781135956975278b3e4c1472e9628cce72bb0071705ce63b",
-        "path": "org/jetbrains/kotlin/analysis-api-k2-tests-for-ide/2.3.20-ij253-45/analysis-api-k2-tests-for-ide-2.3.20-ij253-45.jar"
-    },
-    {
-        "url": "com/jetbrains/mlapi/catboost-shadow-need-slf4j/1.2.5/catboost-shadow-need-slf4j-1.2.5.jar",
-        "hash": "94a06c3fdd4aa638df59c8c783a379ca43a5b933187760e219e09e84f1633d76",
-        "path": "com/jetbrains/mlapi/catboost-shadow-need-slf4j/1.2.5/catboost-shadow-need-slf4j-1.2.5.jar"
-    },
-    {
-        "url": "io/ktor/ktor-server-cio-jvm/3.1.3/ktor-server-cio-jvm-3.1.3.jar",
-        "hash": "f1526fe94e8d76c5251b5a25e4b4bb72199a25d3e1f6045e4b9e42789293f069",
-        "path": "io/ktor/ktor-server-cio-jvm/3.1.3/ktor-server-cio-jvm-3.1.3.jar"
-    },
-    {
-        "url": "org/mockito/kotlin/mockito-kotlin/6.0.0/mockito-kotlin-6.0.0.jar",
-        "hash": "34d626ffa4a27ec49e47de7d760f1df30223ecb8944b6472941f5c73ec68dfbd",
-        "path": "org/mockito/kotlin/mockito-kotlin/6.0.0/mockito-kotlin-6.0.0.jar"
-    },
-    {
-        "url": "com/android/tools/build/aapt2-proto/8.1.0-10154469/aapt2-proto-8.1.0-10154469.jar",
-        "hash": "6d8d14b91285cc7c1b73460f413bb3f80672dc34dc506ed578fba1f6dde8661e",
-        "path": "com/android/tools/build/aapt2-proto/8.1.0-10154469/aapt2-proto-8.1.0-10154469.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlinx-serialization-compiler-plugin-for-ide/2.3.20-ij253-45/kotlinx-serialization-compiler-plugin-for-ide-2.3.20-ij253-45.jar",
-        "hash": "7566ed7641a9eb3852d51a58f15f0815827c903b493ed0b7386a9ee4f83769ba",
-        "path": "org/jetbrains/kotlin/kotlinx-serialization-compiler-plugin-for-ide/2.3.20-ij253-45/kotlinx-serialization-compiler-plugin-for-ide-2.3.20-ij253-45.jar"
-    },
-    {
-        "url": "app/cash/turbine/turbine-jvm/1.0.0/turbine-jvm-1.0.0.jar",
-        "hash": "41984dffaf069b84b814fa787f740bf7ebdc90bf89f69d05bc4660c69874b49e",
-        "path": "app/cash/turbine/turbine-jvm/1.0.0/turbine-jvm-1.0.0.jar"
-    },
-    {
-        "url": "com/android/tools/smali/smali-baksmali/3.0.3/smali-baksmali-3.0.3.jar",
-        "hash": "ffd6f3fbba2453440e4c04add42b9f903d84151b5b71f7e6bbb181d8096397a4",
-        "path": "com/android/tools/smali/smali-baksmali/3.0.3/smali-baksmali-3.0.3.jar"
-    },
-    {
-        "url": "com/android/tools/smali/smali-util/3.0.3/smali-util-3.0.3.jar",
-        "hash": "8078a04709f42072a240a6fe7666b71755324745c505b39f86ededfd9c2b90c4",
-        "path": "com/android/tools/smali/smali-util/3.0.3/smali-util-3.0.3.jar"
-    },
-    {
-        "url": "io/github/smiley4/schema-kenerator-jsonschema/2.2.0/schema-kenerator-jsonschema-2.2.0.jar",
-        "hash": "81981241b8df2eeee48efac05798e7beaa2b8d6bd5d610b3f5a4fea07b0eff6e",
-        "path": "io/github/smiley4/schema-kenerator-jsonschema/2.2.0/schema-kenerator-jsonschema-2.2.0.jar"
-    },
-    {
-        "url": "io/ktor/ktor-client-okhttp-jvm/3.1.3/ktor-client-okhttp-jvm-3.1.3.jar",
-        "hash": "a3c111c85eabb8149c485c275768d57cd96a05b595ca1946781c0d4c5fb1654a",
-        "path": "io/ktor/ktor-client-okhttp-jvm/3.1.3/ktor-client-okhttp-jvm-3.1.3.jar"
-    },
-    {
-        "url": "com/google/truth/truth/0.42/truth-0.42.jar",
-        "hash": "dd652bdf0c4427c59848ac0340fd6b6d20c2cbfaa3c569a8366604dbcda5214c",
-        "path": "com/google/truth/truth/0.42/truth-0.42.jar"
-    },
-    {
-        "url": "com/googlecode/java-diff-utils/diffutils/1.3.0/diffutils-1.3.0.jar",
-        "hash": "61ba4dc49adca95243beaa0569adc2a23aedb5292ae78aa01186fa782ebdc5c2",
-        "path": "com/googlecode/java-diff-utils/diffutils/1.3.0/diffutils-1.3.0.jar"
-    },
-    {
-        "url": "io/opentelemetry/opentelemetry-extension-kotlin/1.48.0/opentelemetry-extension-kotlin-1.48.0.jar",
-        "hash": "2285ebfe8e0fd38e186b7033f6f6c542324c9bab23260b914b1b73eaf4492c5d",
-        "path": "io/opentelemetry/opentelemetry-extension-kotlin/1.48.0/opentelemetry-extension-kotlin-1.48.0.jar"
-    },
-    {
-        "url": "org/jsoup/jsoup/1.21.2/jsoup-1.21.2.jar",
-        "hash": "f05496e255734759f0d4b5632da7b24f81313147c78c69e90ad045d096191344",
-        "path": "org/jsoup/jsoup/1.21.2/jsoup-1.21.2.jar"
-    },
-    {
-        "url": "org/tukaani/xz/1.10/xz-1.10.jar",
-        "hash": "95c63c1a55b22dd6453890a419cc1a640f790bbf7d8ae82db1e30aefefb08888",
-        "path": "org/tukaani/xz/1.10/xz-1.10.jar"
-    },
-    {
-        "url": "com/charleskorn/kaml/kaml-jvm/0.80.1/kaml-jvm-0.80.1.jar",
-        "hash": "7e346b94d47fb4e4495ebd6161fd5c6d01659687e93c460bbfd320ba47bea852",
-        "path": "com/charleskorn/kaml/kaml-jvm/0.80.1/kaml-jvm-0.80.1.jar"
-    },
-    {
-        "url": "it/krzeminski/snakeyaml-engine-kmp-jvm/3.1.1/snakeyaml-engine-kmp-jvm-3.1.1.jar",
-        "hash": "733e1347e3ec909e8a7ee199e48a64d0180569461b3bc08c8a6bb1335f5ce1bd",
-        "path": "it/krzeminski/snakeyaml-engine-kmp-jvm/3.1.1/snakeyaml-engine-kmp-jvm-3.1.1.jar"
-    },
-    {
-        "url": "net/thauvin/erik/urlencoder/urlencoder-lib-jvm/1.6.0/urlencoder-lib-jvm-1.6.0.jar",
-        "hash": "8d0fd2aeb48d19dc49c563ebc00f274947e45f716c107535c12ead63decd688d",
-        "path": "net/thauvin/erik/urlencoder/urlencoder-lib-jvm/1.6.0/urlencoder-lib-jvm-1.6.0.jar"
-    },
-    {
-        "url": "jaxen/jaxen/1.2.0/jaxen-1.2.0.jar",
-        "hash": "70feef9dd75ad064def05a3ce8975aeba515ee7d1be146d12199c8828a64174c",
-        "path": "jaxen/jaxen/1.2.0/jaxen-1.2.0.jar"
-    },
-    {
-        "url": "com/jetbrains/intellij/devkit/devkit-runtime-module-repository-jps/252.21158/devkit-runtime-module-repository-jps-252.21158.jar",
-        "hash": "677e12f96a6c48b1b4c4234417cda17bbcb3c25f5c7178ec752ef2a831c65313",
-        "path": "com/jetbrains/intellij/devkit/devkit-runtime-module-repository-jps/252.21158/devkit-runtime-module-repository-jps-252.21158.jar"
-    },
-    {
-        "url": "com/jetbrains/intellij/platform/runtime-repository/252.21158/runtime-repository-252.21158.jar",
-        "hash": "3ad94d6402b94932f4341c908827016787cdc6ee3201ee64970822a610c55d34",
-        "path": "com/jetbrains/intellij/platform/runtime-repository/252.21158/runtime-repository-252.21158.jar"
-    },
-    {
-        "url": "org/bidib/com/github/markusbernhardt/proxy-vole/1.1.6/proxy-vole-1.1.6.jar",
-        "hash": "4b9fb2e5a13b37cf8bd62eebada8d3485c3dc17df752783b68d89d657bcc01fd",
-        "path": "org/bidib/com/github/markusbernhardt/proxy-vole/1.1.6/proxy-vole-1.1.6.jar"
-    },
-    {
-        "url": "org/javadelight/delight-rhino-sandbox/0.0.17/delight-rhino-sandbox-0.0.17.jar",
-        "hash": "e22941d77d0d01dfc6ee5612ad421860baae8a3a0dea2eeb67658061f34527b4",
-        "path": "org/javadelight/delight-rhino-sandbox/0.0.17/delight-rhino-sandbox-0.0.17.jar"
-    },
-    {
-        "url": "com/jetbrains/cloudconfig/cloudconfig/2023.9/cloudconfig-2023.9.jar",
-        "hash": "e51ee1761684a946b9d5a0caaec2b92cf4598860cf231dbaf495f268fda35d10",
-        "path": "com/jetbrains/cloudconfig/cloudconfig/2023.9/cloudconfig-2023.9.jar"
-    },
-    {
-        "url": "com/github/ajalt/clikt/clikt-jvm/3.5.4/clikt-jvm-3.5.4.jar",
-        "hash": "b58b4d93fc1870b99b2adb3e16e9c483c8e73766b2944bc3cff805c0be47d19e",
-        "path": "com/github/ajalt/clikt/clikt-jvm/3.5.4/clikt-jvm-3.5.4.jar"
-    },
-    {
-        "url": "com/github/oshi/oshi-core/6.8.2/oshi-core-6.8.2.jar",
-        "hash": "9403c2537ac0dd425e556dfc3434e5d9f9a9547312472f4c27b7ab2673e9e862",
-        "path": "com/github/oshi/oshi-core/6.8.2/oshi-core-6.8.2.jar"
-    },
-    {
-        "url": "net/sf/kxml/kxml2/2.3.0/kxml2-2.3.0.jar",
-        "hash": "f264dd9f79a1fde10ce5ecc53221eff24be4c9331c830b7d52f2f08a7b633de2",
-        "path": "net/sf/kxml/kxml2/2.3.0/kxml2-2.3.0.jar"
-    },
-    {
-        "url": "io/netty/netty-all/4.1.117.Final/netty-all-4.1.117.Final.jar",
-        "hash": "c78613ac0db94650c03a37b2a35b3238b2d018fcac9f10e5fe268c3887cf5e0b",
-        "path": "io/netty/netty-all/4.1.117.Final/netty-all-4.1.117.Final.jar"
-    },
-    {
-        "url": "io/netty/netty-buffer/4.1.117.Final/netty-buffer-4.1.117.Final.jar",
-        "hash": "7d01bf0334ffa3ab55f3828bb50188bf9969774a23791a3df1905e53bfeea8f5",
-        "path": "io/netty/netty-buffer/4.1.117.Final/netty-buffer-4.1.117.Final.jar"
-    },
-    {
-        "url": "io/netty/netty-codec/4.1.117.Final/netty-codec-4.1.117.Final.jar",
-        "hash": "0b93f01cff5bc2a64af829ca01c826e8e861a03b96a871fa2a240fa25681df78",
-        "path": "io/netty/netty-codec/4.1.117.Final/netty-codec-4.1.117.Final.jar"
-    },
-    {
-        "url": "io/netty/netty-codec-http/4.1.117.Final/netty-codec-http-4.1.117.Final.jar",
-        "hash": "a7e19945a6baa86ab285383a0bda632eae7703a889da1d20ea4eaad4c996cc21",
-        "path": "io/netty/netty-codec-http/4.1.117.Final/netty-codec-http-4.1.117.Final.jar"
-    },
-    {
-        "url": "io/netty/netty-common/4.1.117.Final/netty-common-4.1.117.Final.jar",
-        "hash": "5b4e125a341566b24d5030479da475b20ea1f6145bf7b3c3d69fe537088bb4c1",
-        "path": "io/netty/netty-common/4.1.117.Final/netty-common-4.1.117.Final.jar"
-    },
-    {
-        "url": "io/netty/netty-handler/4.1.117.Final/netty-handler-4.1.117.Final.jar",
-        "hash": "f3272149099883cf98ad8a2a82a08111a78d17e604aebc094c80592a730fcac5",
-        "path": "io/netty/netty-handler/4.1.117.Final/netty-handler-4.1.117.Final.jar"
-    },
-    {
-        "url": "io/netty/netty-resolver/4.1.117.Final/netty-resolver-4.1.117.Final.jar",
-        "hash": "0f5f7220d34d32751cc624bc9c47afdde7392f0d9551569c90a568309015d796",
-        "path": "io/netty/netty-resolver/4.1.117.Final/netty-resolver-4.1.117.Final.jar"
-    },
-    {
-        "url": "io/netty/netty-transport/4.1.117.Final/netty-transport-4.1.117.Final.jar",
-        "hash": "c07aac2ea55aa42c34fc6b53fbee661e0de077f45483133b6ca297c70a67a44a",
-        "path": "io/netty/netty-transport/4.1.117.Final/netty-transport-4.1.117.Final.jar"
-    },
-    {
-        "url": "org/fusesource/jansi/jansi/2.4.1/jansi-2.4.1.jar",
-        "hash": "2e5e775a9dc58ffa6bbd6aa6f099d62f8b62dcdeb4c3c3bbbe5cf2301bc2dcc1",
-        "path": "org/fusesource/jansi/jansi/2.4.1/jansi-2.4.1.jar"
-    },
-    {
-        "url": "org/openjdk/jmh/jmh-generator-annprocess/1.36/jmh-generator-annprocess-1.36.jar",
-        "hash": "c2a88cf8be1eb0870732a7b2e669972efc7f33a145998f568096137f16b20d79",
-        "path": "org/openjdk/jmh/jmh-generator-annprocess/1.36/jmh-generator-annprocess-1.36.jar"
-    },
-    {
-        "url": "org/glassfish/jaxb/jaxb-runtime/2.3.9/jaxb-runtime-2.3.9.jar",
-        "hash": "ba88e5bde7c0d878c3e1f2ec2fcabaf51d201eaf93b3bb9cfecfc1f11b2304d4",
-        "path": "org/glassfish/jaxb/jaxb-runtime/2.3.9/jaxb-runtime-2.3.9.jar"
-    },
-    {
-        "url": "org/glassfish/jaxb/txw2/2.3.9/txw2-2.3.9.jar",
-        "hash": "973018b87af911ecf6e6d861dd0d6a477e4d8ae6a883ec5d073d3df1330b87f0",
-        "path": "org/glassfish/jaxb/txw2/2.3.9/txw2-2.3.9.jar"
-    },
-    {
-        "url": "com/sun/istack/istack-commons-runtime/3.0.12/istack-commons-runtime-3.0.12.jar",
-        "hash": "27d85fc134c9271d5c79d3300fc4669668f017e72409727c428f54f2417f04cd",
-        "path": "com/sun/istack/istack-commons-runtime/3.0.12/istack-commons-runtime-3.0.12.jar"
-    },
-    {
-        "url": "com/sun/activation/jakarta.activation/1.2.2/jakarta.activation-1.2.2.jar",
-        "hash": "02156773e4ae9d048d14a56ad35d644bee9f1052a791d072df3ded3c656e6e1a",
-        "path": "com/sun/activation/jakarta.activation/1.2.2/jakarta.activation-1.2.2.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-scripting-jvm/2.3.20-ij253-45/kotlin-scripting-jvm-2.3.20-ij253-45.jar",
-        "hash": "42d81993e1dd93ba47dc648cf6f8af88aa20ab276077086adcffcc51cd65e08d",
-        "path": "org/jetbrains/kotlin/kotlin-scripting-jvm/2.3.20-ij253-45/kotlin-scripting-jvm-2.3.20-ij253-45.jar"
-    },
-    {
-        "url": "jetbrains/fleet/expects-compiler-plugin/2.2.20-0.1/expects-compiler-plugin-2.2.20-0.1.jar",
-        "hash": "ce4dc5b9232e9467373ef2e79cab9e3404db898ab45020ce14ef893944745331",
-        "path": "jetbrains/fleet/expects-compiler-plugin/2.2.20-0.1/expects-compiler-plugin-2.2.20-0.1.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-compiler-tests-for-ide/2.3.20-ij253-45/kotlin-compiler-tests-for-ide-2.3.20-ij253-45.jar",
-        "hash": "4b182e6689c0b5ff330195dc89d249df941a11a7027ce08e6e84163fa89d37d2",
-        "path": "org/jetbrains/kotlin/kotlin-compiler-tests-for-ide/2.3.20-ij253-45/kotlin-compiler-tests-for-ide-2.3.20-ij253-45.jar"
-    },
-    {
-        "url": "org/testcontainers/junit-jupiter/1.20.3/junit-jupiter-1.20.3.jar",
-        "hash": "3b0f0422993e571f3460d8436a0e56538bd474147084a6cbb244a6d5cb1a01a5",
-        "path": "org/testcontainers/junit-jupiter/1.20.3/junit-jupiter-1.20.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-client-mock-jvm/3.1.3/ktor-client-mock-jvm-3.1.3.jar",
-        "hash": "2ae0d57bb9fceb8ee2aeda6536acc6f3e1de355984b4c9da720566b85f1525e8",
-        "path": "io/ktor/ktor-client-mock-jvm/3.1.3/ktor-client-mock-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-http-jvm/3.1.3/ktor-http-jvm-3.1.3.jar",
-        "hash": "8a50d94b46f91bd56580b9169272d6cd636f442032ba078a141da70413465946",
-        "path": "io/ktor/ktor-http-jvm/3.1.3/ktor-http-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-utils-jvm/3.1.3/ktor-utils-jvm-3.1.3.jar",
-        "hash": "33333937b98fc0c8e943ee4b10b3ea66b49782dfb569c44c142da4f32d85dffc",
-        "path": "io/ktor/ktor-utils-jvm/3.1.3/ktor-utils-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-io-jvm/3.1.3/ktor-io-jvm-3.1.3.jar",
-        "hash": "bb2fb6c00afaa34b539cb30e7584d37bfcba171c266bbdb9990e003579dc24c1",
-        "path": "io/ktor/ktor-io-jvm/3.1.3/ktor-io-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-client-core-jvm/3.1.3/ktor-client-core-jvm-3.1.3.jar",
-        "hash": "746e2a3dece87379d64c40999401969001d373de1458fe851c0d2e0f880b42ef",
-        "path": "io/ktor/ktor-client-core-jvm/3.1.3/ktor-client-core-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-http-cio-jvm/3.1.3/ktor-http-cio-jvm-3.1.3.jar",
-        "hash": "b04aede18e9c008168096dc53a3fc016177b61a5ec3024afbf8caca0cd5dbf42",
-        "path": "io/ktor/ktor-http-cio-jvm/3.1.3/ktor-http-cio-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-network-jvm/3.1.3/ktor-network-jvm-3.1.3.jar",
-        "hash": "fa4e6165b5ad4bf5db337ebd5f16f9b596dc5e401fbea343b9deacb6138240af",
-        "path": "io/ktor/ktor-network-jvm/3.1.3/ktor-network-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-events-jvm/3.1.3/ktor-events-jvm-3.1.3.jar",
-        "hash": "da7069c6e78809d7c37d104e415613cbd4cd5cec1ed54a332cb64ef6a864a060",
-        "path": "io/ktor/ktor-events-jvm/3.1.3/ktor-events-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-websocket-serialization-jvm/3.1.3/ktor-websocket-serialization-jvm-3.1.3.jar",
-        "hash": "67f0f566e2ed51717f6ed55f6d2b4dee1c84be4ea2cd96fc636d0bdf0fd43067",
-        "path": "io/ktor/ktor-websocket-serialization-jvm/3.1.3/ktor-websocket-serialization-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-serialization-jvm/3.1.3/ktor-serialization-jvm-3.1.3.jar",
-        "hash": "0d704bc1148a8fd9a1f2005e0b5189cdaed3030efe24b8236459c41c356f5620",
-        "path": "io/ktor/ktor-serialization-jvm/3.1.3/ktor-serialization-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-websockets-jvm/3.1.3/ktor-websockets-jvm-3.1.3.jar",
-        "hash": "ef28b4f12054ee125765b72fe3230e215a60b73b2ff2072a5c280fcf09329077",
-        "path": "io/ktor/ktor-websockets-jvm/3.1.3/ktor-websockets-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-sse-jvm/3.1.3/ktor-sse-jvm-3.1.3.jar",
-        "hash": "a2ae8a338bb1d446d16dcfea2189ef5a5be31a88123b3879562b7955667a5639",
-        "path": "io/ktor/ktor-sse-jvm/3.1.3/ktor-sse-jvm-3.1.3.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/analysis-api-platform-interface-for-ide/2.3.20-ij253-45/analysis-api-platform-interface-for-ide-2.3.20-ij253-45.jar",
-        "hash": "33db5c2be1f298109a32c67efc9ff9f2351812cd18b1d3e3b6142b8c1f6562a0",
-        "path": "org/jetbrains/kotlin/analysis-api-platform-interface-for-ide/2.3.20-ij253-45/analysis-api-platform-interface-for-ide-2.3.20-ij253-45.jar"
-    },
-    {
-        "url": "io/ktor/ktor-client-core-jvm/3.1.3/ktor-client-core-jvm-3.1.3.jar",
-        "hash": "746e2a3dece87379d64c40999401969001d373de1458fe851c0d2e0f880b42ef",
-        "path": "io/ktor/ktor-client-core-jvm/3.1.3/ktor-client-core-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-http-jvm/3.1.3/ktor-http-jvm-3.1.3.jar",
-        "hash": "8a50d94b46f91bd56580b9169272d6cd636f442032ba078a141da70413465946",
-        "path": "io/ktor/ktor-http-jvm/3.1.3/ktor-http-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-http-cio-jvm/3.1.3/ktor-http-cio-jvm-3.1.3.jar",
-        "hash": "b04aede18e9c008168096dc53a3fc016177b61a5ec3024afbf8caca0cd5dbf42",
-        "path": "io/ktor/ktor-http-cio-jvm/3.1.3/ktor-http-cio-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-events-jvm/3.1.3/ktor-events-jvm-3.1.3.jar",
-        "hash": "da7069c6e78809d7c37d104e415613cbd4cd5cec1ed54a332cb64ef6a864a060",
-        "path": "io/ktor/ktor-events-jvm/3.1.3/ktor-events-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-websocket-serialization-jvm/3.1.3/ktor-websocket-serialization-jvm-3.1.3.jar",
-        "hash": "67f0f566e2ed51717f6ed55f6d2b4dee1c84be4ea2cd96fc636d0bdf0fd43067",
-        "path": "io/ktor/ktor-websocket-serialization-jvm/3.1.3/ktor-websocket-serialization-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-serialization-jvm/3.1.3/ktor-serialization-jvm-3.1.3.jar",
-        "hash": "0d704bc1148a8fd9a1f2005e0b5189cdaed3030efe24b8236459c41c356f5620",
-        "path": "io/ktor/ktor-serialization-jvm/3.1.3/ktor-serialization-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-websockets-jvm/3.1.3/ktor-websockets-jvm-3.1.3.jar",
-        "hash": "ef28b4f12054ee125765b72fe3230e215a60b73b2ff2072a5c280fcf09329077",
-        "path": "io/ktor/ktor-websockets-jvm/3.1.3/ktor-websockets-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-sse-jvm/3.1.3/ktor-sse-jvm-3.1.3.jar",
-        "hash": "a2ae8a338bb1d446d16dcfea2189ef5a5be31a88123b3879562b7955667a5639",
-        "path": "io/ktor/ktor-sse-jvm/3.1.3/ktor-sse-jvm-3.1.3.jar"
-    },
-    {
-        "url": "org/easymock/easymock/5.6.0/easymock-5.6.0.jar",
-        "hash": "63efc00da99774fb0253330ef9b5788b261022ba73f36bf76889ce7edf3d2b31",
-        "path": "org/easymock/easymock/5.6.0/easymock-5.6.0.jar"
-    },
-    {
-        "url": "com/jetbrains/fus/reporting/serialization-kotlin/171/serialization-kotlin-171.jar",
-        "hash": "83380929b70dc8e25db327be8680438f3d80087962a88f4dcf061c919ba2fc32",
-        "path": "com/jetbrains/fus/reporting/serialization-kotlin/171/serialization-kotlin-171.jar"
-    },
-    {
-        "url": "oro/oro/2.0.8/oro-2.0.8.jar",
-        "hash": "e00ccdad5df7eb43fdee44232ef64602bf63807c2d133a7be83ba09fd49af26e",
-        "path": "oro/oro/2.0.8/oro-2.0.8.jar"
-    },
-    {
-        "url": "io/grpc/grpc-core/1.73.0/grpc-core-1.73.0.jar",
-        "hash": "cffb55f1e7268e160647e88da142c09c6175ff72970c64f7cb411d78eb661663",
-        "path": "io/grpc/grpc-core/1.73.0/grpc-core-1.73.0.jar"
-    },
-    {
-        "url": "io/grpc/grpc-api/1.73.0/grpc-api-1.73.0.jar",
-        "hash": "bae13d4e4716a0955d316b5fcb75582504325e5b11ac946b13b64b4fce19bc6e",
-        "path": "io/grpc/grpc-api/1.73.0/grpc-api-1.73.0.jar"
-    },
-    {
-        "url": "com/google/android/annotations/4.1.1.4/annotations-4.1.1.4.jar",
-        "hash": "ba734e1e84c09d615af6a09d33034b4f0442f8772dec120efb376d86a565ae15",
-        "path": "com/google/android/annotations/4.1.1.4/annotations-4.1.1.4.jar"
-    },
-    {
-        "url": "org/codehaus/mojo/animal-sniffer-annotations/1.24/animal-sniffer-annotations-1.24.jar",
-        "hash": "c720e6e5bcbe6b2f48ded75a47bccdb763eede79d14330102e0d352e3d89ed92",
-        "path": "org/codehaus/mojo/animal-sniffer-annotations/1.24/animal-sniffer-annotations-1.24.jar"
-    },
-    {
-        "url": "io/perfmark/perfmark-api/0.27.0/perfmark-api-0.27.0.jar",
-        "hash": "c7b478503ec524e55df19b424d46d27c8a68aeb801664fadd4f069b71f52d0f6",
-        "path": "io/perfmark/perfmark-api/0.27.0/perfmark-api-0.27.0.jar"
-    },
-    {
-        "url": "io/grpc/grpc-context/1.73.0/grpc-context-1.73.0.jar",
-        "hash": "d8d6911e225b55501692651272ce961ba5be1f76662ceb7f0aa79ecce8f63f25",
-        "path": "io/grpc/grpc-context/1.73.0/grpc-context-1.73.0.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlinx/kotlinx-collections-immutable-jvm/0.4.0/kotlinx-collections-immutable-jvm-0.4.0.jar",
-        "hash": "d767014ad0c9a27d27d26fd38e7afa030aee0d141338f108781ff02ecf2fdab5",
-        "path": "org/jetbrains/kotlinx/kotlinx-collections-immutable-jvm/0.4.0/kotlinx-collections-immutable-jvm-0.4.0.jar"
-    },
-    {
-        "url": "org/jmock/jmock-legacy/2.5.1/jmock-legacy-2.5.1.jar",
-        "hash": "0c8d23755cd08d23c3ea194773a08b2c322d2b70cc8c86ac02b424d8a50c9118",
-        "path": "org/jmock/jmock-legacy/2.5.1/jmock-legacy-2.5.1.jar"
-    },
-    {
-        "url": "io/ktor/ktor-serialization-jvm/3.1.3/ktor-serialization-jvm-3.1.3.jar",
-        "hash": "0d704bc1148a8fd9a1f2005e0b5189cdaed3030efe24b8236459c41c356f5620",
-        "path": "io/ktor/ktor-serialization-jvm/3.1.3/ktor-serialization-jvm-3.1.3.jar"
-    },
-    {
-        "url": "org/jruby/joni/joni/2.2.3/joni-2.2.3.jar",
-        "hash": "7ea54221f5f91deff2e860fe986eefe208b59fa04300e54c505c5c0c08d55e9a",
-        "path": "org/jruby/joni/joni/2.2.3/joni-2.2.3.jar"
-    },
-    {
-        "url": "org/jruby/jcodings/jcodings/1.0.61/jcodings-1.0.61.jar",
-        "hash": "3238c68a2f86cec53cc184ad26df8352db87bb22a419bd17fb4acdfbb0bc40f0",
-        "path": "org/jruby/jcodings/jcodings/1.0.61/jcodings-1.0.61.jar"
-    },
-    {
-        "url": "com/sun/activation/javax.activation/1.2.0/javax.activation-1.2.0.jar",
-        "hash": "993302b16cd7056f21e779cc577d175a810bb4900ef73cd8fbf2b50f928ba9ce",
-        "path": "com/sun/activation/javax.activation/1.2.0/javax.activation-1.2.0.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-compose-compiler-plugin/2.2.20/kotlin-compose-compiler-plugin-2.2.20.jar",
-        "hash": "d99052e257681e496590c5c724e1324eb511e4205f5fd413b5f503d8e932b698",
-        "path": "org/jetbrains/kotlin/kotlin-compose-compiler-plugin/2.2.20/kotlin-compose-compiler-plugin-2.2.20.jar"
-    },
-    {
-        "url": "org/jetbrains/intellij/deps/intellij-test-discovery-agent/1.0.763/intellij-test-discovery-agent-1.0.763.jar",
-        "hash": "de175ebed73336e126ecba42c8b93a6566f65b169c6b4a4deb8099fe28e944de",
-        "path": "org/jetbrains/intellij/deps/intellij-test-discovery-agent/1.0.763/intellij-test-discovery-agent-1.0.763.jar"
-    },
-    {
-        "url": "org/java-websocket/Java-WebSocket/1.6.0/Java-WebSocket-1.6.0.jar",
-        "hash": "eae29213e4f16515639c28957200f011b3967fffcada1962cf0255d24919c22f",
-        "path": "org/java-websocket/Java-WebSocket/1.6.0/Java-WebSocket-1.6.0.jar"
-    },
-    {
-        "url": "io/ktor/ktor-io-jvm/3.1.3/ktor-io-jvm-3.1.3.jar",
-        "hash": "bb2fb6c00afaa34b539cb30e7584d37bfcba171c266bbdb9990e003579dc24c1",
-        "path": "io/ktor/ktor-io-jvm/3.1.3/ktor-io-jvm-3.1.3.jar"
-    },
-    {
-        "url": "com/ibm/icu/icu4j/77.1/icu4j-77.1.jar",
-        "hash": "b3640b9f416a4411fd33c59abbeea8fd57d024c23e1819bf9673220a97499fe3",
-        "path": "com/ibm/icu/icu4j/77.1/icu4j-77.1.jar"
-    },
-    {
-        "url": "com/google/guava/guava-testlib/33.0.0-jre/guava-testlib-33.0.0-jre.jar",
-        "hash": "79626019fed282b70eef91f645a9febd5f6b9f7be46484b6b328313a481f05f0",
-        "path": "com/google/guava/guava-testlib/33.0.0-jre/guava-testlib-33.0.0-jre.jar"
-    },
-    {
-        "url": "com/jetbrains/fus/reporting/ap-validation/171/ap-validation-171.jar",
-        "hash": "3c8c66663148ac5d2a953cb048a1939b96be543d4612c23e030a7c6fd20390cd",
-        "path": "com/jetbrains/fus/reporting/ap-validation/171/ap-validation-171.jar"
-    },
-    {
-        "url": "com/jetbrains/rd/rd-swing/2025.3.1/rd-swing-2025.3.1.jar",
-        "hash": "8103c08a017068f9ba79aa260471780b38e3a68bce8995ec1d5279b523ac87ca",
-        "path": "com/jetbrains/rd/rd-swing/2025.3.1/rd-swing-2025.3.1.jar"
-    },
-    {
-        "url": "org/jetbrains/teamcity/serviceMessages/2024.07/serviceMessages-2024.07.jar",
-        "hash": "5280d3e4bae23c4f1cc59bab77dab9f7a9626aeceeaa0bb07a9868bcedae2da9",
-        "path": "org/jetbrains/teamcity/serviceMessages/2024.07/serviceMessages-2024.07.jar"
-    },
-    {
-        "url": "com/fasterxml/aalto-xml/1.3.3/aalto-xml-1.3.3.jar",
-        "hash": "28829eebb36863b058108fa1b9b8b5cfb94c1871346e4a4f73e69e1fe0a5f0f6",
-        "path": "com/fasterxml/aalto-xml/1.3.3/aalto-xml-1.3.3.jar"
-    },
-    {
-        "url": "org/codehaus/woodstox/stax2-api/4.2.2/stax2-api-4.2.2.jar",
-        "hash": "a61c48d553efad78bc01fffc4ac528bebbae64cbaec170b2a5e39cf61eb51abe",
-        "path": "org/codehaus/woodstox/stax2-api/4.2.2/stax2-api-4.2.2.jar"
-    },
-    {
         "url": "com/jetbrains/mlapi/mlapi-catboost/0.2.1/mlapi-catboost-0.2.1.jar",
         "hash": "de75176f3c95433d8da2b95dcdd233b6d9e3cca39f6e2baedb01d4932f911c85",
         "path": "com/jetbrains/mlapi/mlapi-catboost/0.2.1/mlapi-catboost-0.2.1.jar"
     },
     {
-        "url": "org/slf4j/slf4j-api/2.0.13/slf4j-api-2.0.13.jar",
-        "hash": "e7c2a48e8515ba1f49fa637d57b4e2f590b3f5bd97407ac699c3aa5efb1204a9",
-        "path": "org/slf4j/slf4j-api/2.0.13/slf4j-api-2.0.13.jar"
+        "url": "io/netty/netty-codec-protobuf/4.2.0.RC2/netty-codec-protobuf-4.2.0.RC2.jar",
+        "hash": "c5fb188895ffdfd529473c5e7ba1c58da2f514a44134b15ad0d51efe3f28bb38",
+        "path": "io/netty/netty-codec-protobuf/4.2.0.RC2/netty-codec-protobuf-4.2.0.RC2.jar"
     },
     {
-        "url": "org/jetbrains/nativecerts/jvm-native-trusted-roots/1.1.7/jvm-native-trusted-roots-1.1.7.jar",
-        "hash": "8d715c487c8908a8b3b1d982f013f5ec39fb9033eb4272fdb251d648b5ede48c",
-        "path": "org/jetbrains/nativecerts/jvm-native-trusted-roots/1.1.7/jvm-native-trusted-roots-1.1.7.jar"
-    },
-    {
-        "url": "javax/inject/javax.inject/1/javax.inject-1.jar",
-        "hash": "91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff",
-        "path": "javax/inject/javax.inject/1/javax.inject-1.jar"
-    },
-    {
-        "url": "org/junit/jupiter/junit-jupiter-params/5.13.4/junit-jupiter-params-5.13.4.jar",
-        "hash": "3a8c6365716dbb698c0d49a05456c1e1ad05c406613c550f9dd50037872efc41",
-        "path": "org/junit/jupiter/junit-jupiter-params/5.13.4/junit-jupiter-params-5.13.4.jar"
-    },
-    {
-        "url": "commons-codec/commons-codec/1.18.0/commons-codec-1.18.0.jar",
-        "hash": "ba005f304cef92a3dede24a38ad5ac9b8afccf0d8f75839d6c1338634cf7f6e4",
-        "path": "commons-codec/commons-codec/1.18.0/commons-codec-1.18.0.jar"
-    },
-    {
-        "url": "io/ktor/ktor-network-tls-jvm/3.1.3/ktor-network-tls-jvm-3.1.3.jar",
-        "hash": "f67507a3e8bf52aa08d753682e6cdda0194e3abe750118b99c9336953e598be9",
-        "path": "io/ktor/ktor-network-tls-jvm/3.1.3/ktor-network-tls-jvm-3.1.3.jar"
-    },
-    {
-        "url": "commons-cli/commons-cli/1.10.0/commons-cli-1.10.0.jar",
-        "hash": "1b273d92160b9fa69c3e65389a5c4decd2f38a697e458e6f75080ae09e886404",
-        "path": "commons-cli/commons-cli/1.10.0/commons-cli-1.10.0.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-scripting-dependencies/2.3.20-ij253-45/kotlin-scripting-dependencies-2.3.20-ij253-45.jar",
-        "hash": "beeae35aaf0e3043b8202e081bbdeb55672a89dc8bbcc482dfa5cc21d26dc1de",
-        "path": "org/jetbrains/kotlin/kotlin-scripting-dependencies/2.3.20-ij253-45/kotlin-scripting-dependencies-2.3.20-ij253-45.jar"
-    },
-    {
-        "url": "com/google/protobuf/protobuf-java-util/3.24.4-jb.2/protobuf-java-util-3.24.4-jb.2.jar",
-        "hash": "bd30f6cf55c4f9f0891f8b6ea6601c1502b643543d2535c8b477ea0481809e99",
-        "path": "com/google/protobuf/protobuf-java-util/3.24.4-jb.2/protobuf-java-util-3.24.4-jb.2.jar"
-    },
-    {
-        "url": "org/junit/platform/junit-platform-launcher/6.0.0/junit-platform-launcher-6.0.0.jar",
-        "hash": "5f097b00c6714bb71ecfb5dec62b59bb4c2f789763fafd1ece96c4ef0e6c280f",
-        "path": "org/junit/platform/junit-platform-launcher/6.0.0/junit-platform-launcher-6.0.0.jar"
-    },
-    {
-        "url": "org/junit/platform/junit-platform-engine/6.0.0/junit-platform-engine-6.0.0.jar",
-        "hash": "6f81842e9c13e997cac66b44614522f3639419e2388ae2d000c4bc0a6b92d93f",
-        "path": "org/junit/platform/junit-platform-engine/6.0.0/junit-platform-engine-6.0.0.jar"
-    },
-    {
-        "url": "org/jspecify/jspecify/1.0.0/jspecify-1.0.0.jar",
-        "hash": "1fad6e6be7557781e4d33729d49ae1cdc8fdda6fe477bb0cc68ce351eafdfbab",
-        "path": "org/jspecify/jspecify/1.0.0/jspecify-1.0.0.jar"
-    },
-    {
-        "url": "io/github/oshai/kotlin-logging-jvm/7.0.3/kotlin-logging-jvm-7.0.3.jar",
-        "hash": "241daa21665dd0ca55576a4bc4d8e9ace8891ae3c698cc77f13bb4bdac372e94",
-        "path": "io/github/oshai/kotlin-logging-jvm/7.0.3/kotlin-logging-jvm-7.0.3.jar"
-    },
-    {
-        "url": "javax/annotation/javax.annotation-api/1.3.2/javax.annotation-api-1.3.2.jar",
-        "hash": "e04ba5195bcd555dc95650f7cc614d151e4bcd52d29a10b8aa2197f3ab89ab9b",
-        "path": "javax/annotation/javax.annotation-api/1.3.2/javax.annotation-api-1.3.2.jar"
-    },
-    {
-        "url": "com/google/guava/guava/33.4.8-jre/guava-33.4.8-jre.jar",
-        "hash": "f3d7f57f67fd622f4d468dfdd692b3a5e3909246c28017ac3263405f0fe617ed",
-        "path": "com/google/guava/guava/33.4.8-jre/guava-33.4.8-jre.jar"
-    },
-    {
-        "url": "com/google/guava/failureaccess/1.0.3/failureaccess-1.0.3.jar",
-        "hash": "cbfc3906b19b8f55dd7cfd6dfe0aa4532e834250d7f080bd8d211a3e246b59cb",
-        "path": "com/google/guava/failureaccess/1.0.3/failureaccess-1.0.3.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/allopen-compiler-plugin-for-ide/2.3.20-ij253-45/allopen-compiler-plugin-for-ide-2.3.20-ij253-45.jar",
-        "hash": "f7374912dbbcfc18686114a78804a7f4ba91aa54b6f3bf4be10a54bb643f8a61",
-        "path": "org/jetbrains/kotlin/allopen-compiler-plugin-for-ide/2.3.20-ij253-45/allopen-compiler-plugin-for-ide-2.3.20-ij253-45.jar"
-    },
-    {
-        "url": "org/jetbrains/jps/jps-javac-extension/10/jps-javac-extension-10.jar",
-        "hash": "86b9d2a2378cff951f3bd0750d56ff4cef64f78dbb33e9f7abd9c7e6e14d99de",
-        "path": "org/jetbrains/jps/jps-javac-extension/10/jps-javac-extension-10.jar"
-    },
-    {
-        "url": "io/ktor/ktor-server-host-common-jvm/3.1.3/ktor-server-host-common-jvm-3.1.3.jar",
-        "hash": "6f4932086ba785deeb74170140508156b21772cd2961a37e7b551eb5d2649a29",
-        "path": "io/ktor/ktor-server-host-common-jvm/3.1.3/ktor-server-host-common-jvm-3.1.3.jar"
-    },
-    {
-        "url": "org/jetbrains/intellij/deps/org.eclipse.jgit/6.6.1.202309021850-r-jb-202407181518/org.eclipse.jgit-6.6.1.202309021850-r-jb-202407181518.jar",
-        "hash": "84f1d58dbf19cd7d42a5301bd256d589af1f520b4c90b8836cee7747f8726992",
-        "path": "org/jetbrains/intellij/deps/org.eclipse.jgit/6.6.1.202309021850-r-jb-202407181518/org.eclipse.jgit-6.6.1.202309021850-r-jb-202407181518.jar"
-    },
-    {
-        "url": "com/googlecode/javaewah/JavaEWAH/1.2.3/JavaEWAH-1.2.3.jar",
-        "hash": "d65226949713c4c61a784f41c51167e7b0316f93764398ebba9e4336b3d954c2",
-        "path": "com/googlecode/javaewah/JavaEWAH/1.2.3/JavaEWAH-1.2.3.jar"
-    },
-    {
-        "url": "io/grpc/grpc-protobuf/1.73.0/grpc-protobuf-1.73.0.jar",
-        "hash": "5c0ca9e321c02845c47dc6edcef9f22e49015cef7753c54012f5398425163c08",
-        "path": "io/grpc/grpc-protobuf/1.73.0/grpc-protobuf-1.73.0.jar"
-    },
-    {
-        "url": "com/google/api/grpc/proto-google-common-protos/2.51.0/proto-google-common-protos-2.51.0.jar",
-        "hash": "0b27938f3d28ccd6884945d7e4f75f4e26a677bbf3cd39bbcb694f130f782aa9",
-        "path": "com/google/api/grpc/proto-google-common-protos/2.51.0/proto-google-common-protos-2.51.0.jar"
-    },
-    {
-        "url": "io/grpc/grpc-protobuf-lite/1.73.0/grpc-protobuf-lite-1.73.0.jar",
-        "hash": "de8ce5309713e72bb57d5ff2dabdb4c173ae4872bd1439b9c3d3f93430b407d9",
-        "path": "io/grpc/grpc-protobuf-lite/1.73.0/grpc-protobuf-lite-1.73.0.jar"
-    },
-    {
-        "url": "org/jetbrains/intellij/deps/ift/git-learning-project/212.0.2/git-learning-project-212.0.2.jar",
-        "hash": "648eaffe833416e2accea4bf82b980f0e91ae51ef065f5bc74fa3481c373e9fd",
-        "path": "org/jetbrains/intellij/deps/ift/git-learning-project/212.0.2/git-learning-project-212.0.2.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlinx/kotlinx-serialization-json-io-jvm/1.8.1/kotlinx-serialization-json-io-jvm-1.8.1.jar",
-        "hash": "ab5ec8ea48815197c46a7df9f418a62791fe91cda5023b941ce4de872d810cc1",
-        "path": "org/jetbrains/kotlinx/kotlinx-serialization-json-io-jvm/1.8.1/kotlinx-serialization-json-io-jvm-1.8.1.jar"
-    },
-    {
-        "url": "one/util/streamex/0.8.4/streamex-0.8.4.jar",
-        "hash": "c8bcde95bb6c659bd611a5bc464380f38118a10a0443f3fc15304d91e5c9dd81",
-        "path": "one/util/streamex/0.8.4/streamex-0.8.4.jar"
-    },
-    {
-        "url": "io/consensys/tuweni/tuweni-toml/2.7.1/tuweni-toml-2.7.1.jar",
-        "hash": "00cfcc187ff46ce8d702a0f2cb98d6a4f2a67f8f41242b5901e46efdcb7c84b7",
-        "path": "io/consensys/tuweni/tuweni-toml/2.7.1/tuweni-toml-2.7.1.jar"
-    },
-    {
-        "url": "org/antlr/antlr4-runtime/4.13.0/antlr4-runtime-4.13.0.jar",
-        "hash": "bd7f7b5d07bc0b047f10915b32ca4bb1de9e57d8049098882e4453c88c076a5d",
-        "path": "org/antlr/antlr4-runtime/4.13.0/antlr4-runtime-4.13.0.jar"
-    },
-    {
-        "url": "io/netty/netty-codec-compression/4.2.0.RC2/netty-codec-compression-4.2.0.RC2.jar",
-        "hash": "7251646a8ea8d56a2415311de6040159479ac0e35de36dab70b667ed899ac931",
-        "path": "io/netty/netty-codec-compression/4.2.0.RC2/netty-codec-compression-4.2.0.RC2.jar"
-    },
-    {
-        "url": "com/google/protobuf/protobuf-java/3.24.4-jb.2/protobuf-java-3.24.4-jb.2.jar",
-        "hash": "6ba90d0d081c03c5c03d2d41497f75a183da7fb23cc2691f7b782dea77f73d21",
-        "path": "com/google/protobuf/protobuf-java/3.24.4-jb.2/protobuf-java-3.24.4-jb.2.jar"
-    },
-    {
-        "url": "org/codehaus/groovy/groovy-jsr223/3.0.25/groovy-jsr223-3.0.25.jar",
-        "hash": "7d703a1d484ac1135b78b24a4880f5653161cda83454c0f484fa09e29311d3bd",
-        "path": "org/codehaus/groovy/groovy-jsr223/3.0.25/groovy-jsr223-3.0.25.jar"
-    },
-    {
-        "url": "org/junit/platform/junit-platform-launcher/1.13.4/junit-platform-launcher-1.13.4.jar",
-        "hash": "0b0beaeb6880a31149641d2d848b863712885469670c12099586d7f798522564",
-        "path": "org/junit/platform/junit-platform-launcher/1.13.4/junit-platform-launcher-1.13.4.jar"
-    },
-    {
-        "url": "org/junit/platform/junit-platform-engine/1.13.4/junit-platform-engine-1.13.4.jar",
-        "hash": "390c5f77b84283a64b644f88251b397e0b0debb80bdcc50f899881aecff43a5a",
-        "path": "org/junit/platform/junit-platform-engine/1.13.4/junit-platform-engine-1.13.4.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-test-junit/2.2.20/kotlin-test-junit-2.2.20.jar",
-        "hash": "6842753b11a1544198f4a14b0f8820728327939b859c23c50b5fd4179c693900",
-        "path": "org/jetbrains/kotlin/kotlin-test-junit/2.2.20/kotlin-test-junit-2.2.20.jar"
-    },
-    {
-        "url": "org/ec4j/core/ec4j-core/0.3.0/ec4j-core-0.3.0.jar",
-        "hash": "cadef0207077074b11a12be442f89ab6cf93fbc2f848702d9371a9611414d558",
-        "path": "org/ec4j/core/ec4j-core/0.3.0/ec4j-core-0.3.0.jar"
-    },
-    {
-        "url": "org/jetbrains/intellij/deps/studio-platform/2025.1.2-287/studio-platform-2025.1.2-287.jar",
-        "hash": "21a748abc565fd6d97d90f2547d0fd1da36810171050b2a337cbc02799cfe482",
-        "path": "org/jetbrains/intellij/deps/studio-platform/2025.1.2-287/studio-platform-2025.1.2-287.jar"
-    },
-    {
-        "url": "io/ktor/ktor-websockets-jvm/3.1.3/ktor-websockets-jvm-3.1.3.jar",
-        "hash": "ef28b4f12054ee125765b72fe3230e215a60b73b2ff2072a5c280fcf09329077",
-        "path": "io/ktor/ktor-websockets-jvm/3.1.3/ktor-websockets-jvm-3.1.3.jar"
-    },
-    {
-        "url": "org/ow2/asm/asm-analysis/9.8/asm-analysis-9.8.jar",
-        "hash": "e640732fbcd3c6271925a504f125e38384688f4dfbbf92c8622dfcee0d09edb9",
-        "path": "org/ow2/asm/asm-analysis/9.8/asm-analysis-9.8.jar"
-    },
-    {
-        "url": "org/ow2/asm/asm-tree/9.8/asm-tree-9.8.jar",
-        "hash": "14b7880cb7c85eed101e2710432fc3ffb83275532a6a894dc4c4095d49ad59f1",
-        "path": "org/ow2/asm/asm-tree/9.8/asm-tree-9.8.jar"
-    },
-    {
-        "url": "org/ow2/asm/asm/9.8/asm-9.8.jar",
-        "hash": "876eab6a83daecad5ca67eb9fcabb063c97b5aeb8cf1fca7a989ecde17522051",
-        "path": "org/ow2/asm/asm/9.8/asm-9.8.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-tooling-core/1.9.20-dev-8162/kotlin-tooling-core-1.9.20-dev-8162.jar",
-        "hash": "8938eb97e36320daa3e6fb2a60fd2a05b232ff4a557173c5019f045b8832d9f4",
-        "path": "org/jetbrains/kotlin/kotlin-tooling-core/1.9.20-dev-8162/kotlin-tooling-core-1.9.20-dev-8162.jar"
-    },
-    {
-        "url": "com/jetbrains/intellij/documentation/tips-pycharm-community/241.74/tips-pycharm-community-241.74.jar",
-        "hash": "7f9fd8e37ec4dfdef7bfc3bc6a687fa5a322976fc588432fa46d2feb1fefc966",
-        "path": "com/jetbrains/intellij/documentation/tips-pycharm-community/241.74/tips-pycharm-community-241.74.jar"
-    },
-    {
-        "url": "io/ktor/ktor-server-sse-jvm/3.1.3/ktor-server-sse-jvm-3.1.3.jar",
-        "hash": "4c172eb930db7d7cfef36cf3ba7d5094ce08dea6fde2b4be7746680a2ebd7c05",
-        "path": "io/ktor/ktor-server-sse-jvm/3.1.3/ktor-server-sse-jvm-3.1.3.jar"
-    },
-    {
-        "url": "org/bouncycastle/bcpkix-jdk18on/1.81/bcpkix-jdk18on-1.81.jar",
-        "hash": "b38c604871f3690109a3c00982d9145634125de3365a817ba16eb90d88e242c9",
-        "path": "org/bouncycastle/bcpkix-jdk18on/1.81/bcpkix-jdk18on-1.81.jar"
-    },
-    {
-        "url": "org/bouncycastle/bcutil-jdk18on/1.81/bcutil-jdk18on-1.81.jar",
-        "hash": "31a5fe3a7ba42e3457b83930f0ff8d679fb5b76eaadf2b51f5740c92a394bf52",
-        "path": "org/bouncycastle/bcutil-jdk18on/1.81/bcutil-jdk18on-1.81.jar"
-    },
-    {
-        "url": "org/bouncycastle/bcprov-jdk18on/1.81/bcprov-jdk18on-1.81.jar",
-        "hash": "249f396412b0c0ce67f25c8197da757b241b8be3ec4199386c00704a2457459b",
-        "path": "org/bouncycastle/bcprov-jdk18on/1.81/bcprov-jdk18on-1.81.jar"
-    },
-    {
-        "url": "org/objenesis/objenesis/3.4/objenesis-3.4.jar",
-        "hash": "95488102feaf2e2858adf6b299353677dac6c15294006f8ed1c5556f8e3cd251",
-        "path": "org/objenesis/objenesis/3.4/objenesis-3.4.jar"
-    },
-    {
-        "url": "com/android/tools/layoutlib/layoutlib/15.2.3/layoutlib-15.2.3.jar",
-        "hash": "e826a88e448a0c1d42abc30c9d047131badbac6fc3922b8e93ac3ea27bb0eb2c",
-        "path": "com/android/tools/layoutlib/layoutlib/15.2.3/layoutlib-15.2.3.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-compiler-ir-for-ide/2.3.20-ij253-45/kotlin-compiler-ir-for-ide-2.3.20-ij253-45.jar",
-        "hash": "230f801ec0de74e6363bf7553c71dbf085d1aaaadcf553afd1248ab51fbcfef1",
-        "path": "org/jetbrains/kotlin/kotlin-compiler-ir-for-ide/2.3.20-ij253-45/kotlin-compiler-ir-for-ide-2.3.20-ij253-45.jar"
+        "url": "org/jetbrains/intellij/deps/completion/ngram-slp/0.0.3/ngram-slp-0.0.3.jar",
+        "hash": "4ac10d8fb7e6326e09179fd83e664610a3362dc1d661fb32e5b2a19bcb9fc867",
+        "path": "org/jetbrains/intellij/deps/completion/ngram-slp/0.0.3/ngram-slp-0.0.3.jar"
     },
     {
         "url": "org/xerial/sqlite-jdbc/3.50.3.0/sqlite-jdbc-3.50.3.0.jar",
         "hash": "a3f53a2aa15ae9425a9e793bbe9c8e5288febeb4b65ef5c1a4e80d4c2045cf08",
         "path": "org/xerial/sqlite-jdbc/3.50.3.0/sqlite-jdbc-3.50.3.0.jar"
-    },
-    {
-        "url": "org/opentest4j/opentest4j/1.3.0/opentest4j-1.3.0.jar",
-        "hash": "48e2df636cab6563ced64dcdff8abb2355627cb236ef0bf37598682ddf742f1b",
-        "path": "org/opentest4j/opentest4j/1.3.0/opentest4j-1.3.0.jar"
-    },
-    {
-        "url": "org/apache/lucene/lucene-codecs/10.3.0/lucene-codecs-10.3.0.jar",
-        "hash": "0628a26040706fea7a222a91c8ca339aef9ea8ceda6d24527a817dc7e0ad5c92",
-        "path": "org/apache/lucene/lucene-codecs/10.3.0/lucene-codecs-10.3.0.jar"
-    },
-    {
-        "url": "org/sqlite/native/3.42.0-jb.1/native-3.42.0-jb.1.jar",
-        "hash": "491c4ae84a1bad34c85624682a80def4f3a3a0fb9d517121d05c2dfeb94966f8",
-        "path": "org/sqlite/native/3.42.0-jb.1/native-3.42.0-jb.1.jar"
-    },
-    {
-        "url": "io/opentelemetry/opentelemetry-exporter-otlp-common/1.48.0/opentelemetry-exporter-otlp-common-1.48.0.jar",
-        "hash": "9b3211ad7f1508f6453d16922aad6c7dce5b2f9a88b7e272171f63875ee78efd",
-        "path": "io/opentelemetry/opentelemetry-exporter-otlp-common/1.48.0/opentelemetry-exporter-otlp-common-1.48.0.jar"
-    },
-    {
-        "url": "io/opentelemetry/opentelemetry-exporter-common/1.48.0/opentelemetry-exporter-common-1.48.0.jar",
-        "hash": "bc7af4f3c4ba1a23c20a6e1945f3e17fd3f5719f6f17d62961b3167d939a18e2",
-        "path": "io/opentelemetry/opentelemetry-exporter-common/1.48.0/opentelemetry-exporter-common-1.48.0.jar"
-    },
-    {
-        "url": "io/ktor/ktor-websocket-serialization-jvm/3.1.3/ktor-websocket-serialization-jvm-3.1.3.jar",
-        "hash": "67f0f566e2ed51717f6ed55f6d2b4dee1c84be4ea2cd96fc636d0bdf0fd43067",
-        "path": "io/ktor/ktor-websocket-serialization-jvm/3.1.3/ktor-websocket-serialization-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/github/smiley4/schema-kenerator-serialization/2.2.0/schema-kenerator-serialization-2.2.0.jar",
-        "hash": "9c4a9713b2722b3b124210e89c3702c3e18c19156a3a06fa6bcef43a850299ca",
-        "path": "io/github/smiley4/schema-kenerator-serialization/2.2.0/schema-kenerator-serialization-2.2.0.jar"
-    },
-    {
-        "url": "info/cukes/cucumber-jvm-deps/1.0.5/cucumber-jvm-deps-1.0.5.jar",
-        "hash": "2a4e84a51defe9108579b3c0a86bb41e54f04e9042e83adf4348a974dcf1dee6",
-        "path": "info/cukes/cucumber-jvm-deps/1.0.5/cucumber-jvm-deps-1.0.5.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-dist-for-ide/2.2.20/kotlin-dist-for-ide-2.2.20.jar",
-        "hash": "0070e80f9fed930c7209b15a5590f178acfc56028f2b6dd447c2c7cae1fc058d",
-        "path": "org/jetbrains/kotlin/kotlin-dist-for-ide/2.2.20/kotlin-dist-for-ide-2.2.20.jar"
-    },
-    {
-        "url": "commons-logging/commons-logging/1.2/commons-logging-1.2.jar",
-        "hash": "daddea1ea0be0f56978ab3006b8ac92834afeefbd9b7e4e6316fca57df0fa636",
-        "path": "commons-logging/commons-logging/1.2/commons-logging-1.2.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-script-runtime/2.3.20-ij253-45/kotlin-script-runtime-2.3.20-ij253-45.jar",
-        "hash": "c35fd880ce45b252c0daee0bc644ea91a326a69c9dceda54151f4b2e13f3bdc3",
-        "path": "org/jetbrains/kotlin/kotlin-script-runtime/2.3.20-ij253-45/kotlin-script-runtime-2.3.20-ij253-45.jar"
-    },
-    {
-        "url": "com/google/zxing/core/3.5.1/core-3.5.1.jar",
-        "hash": "1ba7c0fbb6c267e2fb74e1497d855adae633ccc98edc8c75163aa64bc08e3059",
-        "path": "com/google/zxing/core/3.5.1/core-3.5.1.jar"
-    },
-    {
-        "url": "io/github/smiley4/schema-kenerator-core/2.2.0/schema-kenerator-core-2.2.0.jar",
-        "hash": "c1c197ed03acaf46773176a001836219b6299fe267dc4751c2c28ae98edfa0f3",
-        "path": "io/github/smiley4/schema-kenerator-core/2.2.0/schema-kenerator-core-2.2.0.jar"
-    },
-    {
-        "url": "org/jetbrains/marketplace-zip-signer/0.1.43/marketplace-zip-signer-0.1.43.jar",
-        "hash": "7db707d839949384760b0f3e58eff49bfedea05f822e4f3361c4b540aa5dcc16",
-        "path": "org/jetbrains/marketplace-zip-signer/0.1.43/marketplace-zip-signer-0.1.43.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/analysis-api-impl-base-tests-for-ide/2.3.20-ij253-45/analysis-api-impl-base-tests-for-ide-2.3.20-ij253-45.jar",
-        "hash": "c6deada2fac53b8ea6523dbda77597b128006674616f140f04df23264c6d1aa3",
-        "path": "org/jetbrains/kotlin/analysis-api-impl-base-tests-for-ide/2.3.20-ij253-45/analysis-api-impl-base-tests-for-ide-2.3.20-ij253-45.jar"
-    },
-    {
-        "url": "io/ktor/ktor-sse-jvm/3.1.3/ktor-sse-jvm-3.1.3.jar",
-        "hash": "a2ae8a338bb1d446d16dcfea2189ef5a5be31a88123b3879562b7955667a5639",
-        "path": "io/ktor/ktor-sse-jvm/3.1.3/ktor-sse-jvm-3.1.3.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/sam-with-receiver-compiler-plugin-for-ide/2.3.20-ij253-45/sam-with-receiver-compiler-plugin-for-ide-2.3.20-ij253-45.jar",
-        "hash": "98457d26126f1095049a8769d78168ff7d0907f0b472ee28967073709b4b4607",
-        "path": "org/jetbrains/kotlin/sam-with-receiver-compiler-plugin-for-ide/2.3.20-ij253-45/sam-with-receiver-compiler-plugin-for-ide-2.3.20-ij253-45.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-metadata-jvm/2.2.20/kotlin-metadata-jvm-2.2.20.jar",
-        "hash": "8524eac90f7e8e0f1366883f2c6c820c93bfa61df3d76857c8d3e803cf67315d",
-        "path": "org/jetbrains/kotlin/kotlin-metadata-jvm/2.2.20/kotlin-metadata-jvm-2.2.20.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-gradle-statistics-for-ide/2.3.20-ij253-45/kotlin-gradle-statistics-for-ide-2.3.20-ij253-45.jar",
-        "hash": "94ffb26541561992a8eb23937f28437782830f896b90a6eed6f97e479fffdfa0",
-        "path": "org/jetbrains/kotlin/kotlin-gradle-statistics-for-ide/2.3.20-ij253-45/kotlin-gradle-statistics-for-ide-2.3.20-ij253-45.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-compiler-cli-for-ide/2.3.20-ij253-45/kotlin-compiler-cli-for-ide-2.3.20-ij253-45.jar",
-        "hash": "fd9db5d6b301967133bc977935d22295e247ed2ccefc2583942ef7376fd598c1",
-        "path": "org/jetbrains/kotlin/kotlin-compiler-cli-for-ide/2.3.20-ij253-45/kotlin-compiler-cli-for-ide-2.3.20-ij253-45.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-gradle-plugin-idea/1.9.20-dev-8162/kotlin-gradle-plugin-idea-1.9.20-dev-8162.jar",
-        "hash": "8d1af87632d95148f122a9fa0ae2903c19ee6fab7d01e017f76e0d2c9a022c20",
-        "path": "org/jetbrains/kotlin/kotlin-gradle-plugin-idea/1.9.20-dev-8162/kotlin-gradle-plugin-idea-1.9.20-dev-8162.jar"
-    },
-    {
-        "url": "org/jetbrains/runtime/jbr-api/1.9.0/jbr-api-1.9.0.jar",
-        "hash": "7e37284e33b5b304ee6174dcaa92db949b257cc4c8991ca865e7daf5113d8279",
-        "path": "org/jetbrains/runtime/jbr-api/1.9.0/jbr-api-1.9.0.jar"
-    },
-    {
-        "url": "io/ktor/ktor-client-cio-jvm/3.1.3/ktor-client-cio-jvm-3.1.3.jar",
-        "hash": "9a86341588057a23d3ba4562fdc8afcef6facd071678a0c20b3b28a19ec35c88",
-        "path": "io/ktor/ktor-client-cio-jvm/3.1.3/ktor-client-cio-jvm-3.1.3.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlinx/kotlinx-serialization-protobuf-jvm/1.8.1/kotlinx-serialization-protobuf-jvm-1.8.1.jar",
-        "hash": "fbd174f72ea82364baa112069f2d7b361758f6b68bd81d2ac51b02c66a48e924",
-        "path": "org/jetbrains/kotlinx/kotlinx-serialization-protobuf-jvm/1.8.1/kotlinx-serialization-protobuf-jvm-1.8.1.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-compiler-common-for-ide/2.3.20-ij253-45/kotlin-compiler-common-for-ide-2.3.20-ij253-45.jar",
-        "hash": "4af9a30fde5d143da69428bfef59e292c794927613bf0a5b111aaaa0ead01ba2",
-        "path": "org/jetbrains/kotlin/kotlin-compiler-common-for-ide/2.3.20-ij253-45/kotlin-compiler-common-for-ide-2.3.20-ij253-45.jar"
-    },
-    {
-        "url": "com/jetbrains/intellij/platform/workspace-model-codegen/0.0.9/workspace-model-codegen-0.0.9.jar",
-        "hash": "78e527dfea8d79c16ea9ca875bd943d443b63bf9d0df1f253c233dc54366df35",
-        "path": "com/jetbrains/intellij/platform/workspace-model-codegen/0.0.9/workspace-model-codegen-0.0.9.jar"
-    },
-    {
-        "url": "dk/brics/automaton/1.12-4/automaton-1.12-4.jar",
-        "hash": "3941b48f2e9281aab7234395c549cbb399b3dc80fed2e13999a80db47f94b041",
-        "path": "dk/brics/automaton/1.12-4/automaton-1.12-4.jar"
-    },
-    {
-        "url": "nl/jqno/equalsverifier/equalsverifier/3.19.4/equalsverifier-3.19.4.jar",
-        "hash": "2bcbbf2f3227aa97527730eb92ca8724263e6d555b888fbb14aae52bc712d434",
-        "path": "nl/jqno/equalsverifier/equalsverifier/3.19.4/equalsverifier-3.19.4.jar"
-    },
-    {
-        "url": "org/objenesis/objenesis/3.4/objenesis-3.4.jar",
-        "hash": "95488102feaf2e2858adf6b299353677dac6c15294006f8ed1c5556f8e3cd251",
-        "path": "org/objenesis/objenesis/3.4/objenesis-3.4.jar"
-    },
-    {
-        "url": "net/bytebuddy/byte-buddy/1.17.5/byte-buddy-1.17.5.jar",
-        "hash": "71568c9f8396677219f650268fbf6493ded484edcdbdf2dae6129ca5be81e8db",
-        "path": "net/bytebuddy/byte-buddy/1.17.5/byte-buddy-1.17.5.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/lombok-compiler-plugin-for-ide/2.3.20-ij253-45/lombok-compiler-plugin-for-ide-2.3.20-ij253-45.jar",
-        "hash": "8bc0ca5c9bb47b4ae74ab75306e8c0481d2748b3165dc850165d72d199540653",
-        "path": "org/jetbrains/kotlin/lombok-compiler-plugin-for-ide/2.3.20-ij253-45/lombok-compiler-plugin-for-ide-2.3.20-ij253-45.jar"
-    },
-    {
-        "url": "org/apache/lucene/lucene-analysis-common/10.3.0/lucene-analysis-common-10.3.0.jar",
-        "hash": "124bddea3fa0683d3e174552fba5fcf0f24a2f57f1ccf6957010d010d246db8b",
-        "path": "org/apache/lucene/lucene-analysis-common/10.3.0/lucene-analysis-common-10.3.0.jar"
-    },
-    {
-        "url": "io/cucumber/cucumber-core/1.2.6/cucumber-core-1.2.6.jar",
-        "hash": "ace77c533236213a1aa9f68b8de10e564da809605371ef2f8c73cd8f4c71293a",
-        "path": "io/cucumber/cucumber-core/1.2.6/cucumber-core-1.2.6.jar"
-    },
-    {
-        "url": "info/cukes/gherkin/2.12.2/gherkin-2.12.2.jar",
-        "hash": "0a5ebc0506ab1e4a08af1ca150f797304ff53b953c5b1f6fcf1f81551d964aad",
-        "path": "info/cukes/gherkin/2.12.2/gherkin-2.12.2.jar"
-    },
-    {
-        "url": "io/grpc/grpc-stub/1.73.0/grpc-stub-1.73.0.jar",
-        "hash": "050fe139de47d8937e6b0080e8dff3d0f42df6782f147c10bb298c0e9cd94b2f",
-        "path": "io/grpc/grpc-stub/1.73.0/grpc-stub-1.73.0.jar"
-    },
-    {
-        "url": "com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar",
-        "hash": "766ad2a0783f2687962c8ad74ceecc38a28b9f72a2d085ee438b7813e928d0c7",
-        "path": "com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar"
-    },
-    {
-        "url": "org/jmock/jmock-junit4/2.5.1/jmock-junit4-2.5.1.jar",
-        "hash": "c53b16b999d3b2f1aa273bf5c560273d23e1fa21ce493ba7cbf5243118386b88",
-        "path": "org/jmock/jmock-junit4/2.5.1/jmock-junit4-2.5.1.jar"
-    },
-    {
-        "url": "jetbrains/fleet/noria-compiler-plugin/2.2.20-0.1/noria-compiler-plugin-2.2.20-0.1.jar",
-        "hash": "dda6a96d529f473c952ba7e8205509de29725ad40eff80af7d371df95ccb14c1",
-        "path": "jetbrains/fleet/noria-compiler-plugin/2.2.20-0.1/noria-compiler-plugin-2.2.20-0.1.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/scripting-compiler-plugin-for-ide/2.3.20-ij253-45/scripting-compiler-plugin-for-ide-2.3.20-ij253-45.jar",
-        "hash": "75048ae78a873e992533ba3c376a65701cff28fbcafd79d587efc999a638e0bd",
-        "path": "org/jetbrains/kotlin/scripting-compiler-plugin-for-ide/2.3.20-ij253-45/scripting-compiler-plugin-for-ide-2.3.20-ij253-45.jar"
-    },
-    {
-        "url": "com/esotericsoftware/kryo5/5.6.0/kryo5-5.6.0.jar",
-        "hash": "2ceef6a5a0527ad89ab6d1fd71bba4fef355cded510970c650d1443412b18dc5",
-        "path": "com/esotericsoftware/kryo5/5.6.0/kryo5-5.6.0.jar"
-    },
-    {
-        "url": "org/apache/sshd/sshd-osgi/2.15.0/sshd-osgi-2.15.0.jar",
-        "hash": "3c8a183f81e176d9c452c9bb94007574bc8188446b4fc98b527aa79074cd0dda",
-        "path": "org/apache/sshd/sshd-osgi/2.15.0/sshd-osgi-2.15.0.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-project-model/1.6.0/kotlin-project-model-1.6.0.jar",
-        "hash": "38135d3f995fc505d604aed2e82ac5ba858b2a6a3e476899c3b8be47fd222b68",
-        "path": "org/jetbrains/kotlin/kotlin-project-model/1.6.0/kotlin-project-model-1.6.0.jar"
-    },
-    {
-        "url": "com/android/tools/analytics-library/testing/31.5.0-alpha08/testing-31.5.0-alpha08.jar",
-        "hash": "a000df0643439bfc1a41cc35098491dcb5733766e629ecbed2d68adb473f8420",
-        "path": "com/android/tools/analytics-library/testing/31.5.0-alpha08/testing-31.5.0-alpha08.jar"
-    },
-    {
-        "url": "org/apache/lucene/lucene-highlighter/10.3.0/lucene-highlighter-10.3.0.jar",
-        "hash": "acbf67631c42197791363ce8e8f155f62aeef51ade809e0847a89eba44785c7d",
-        "path": "org/apache/lucene/lucene-highlighter/10.3.0/lucene-highlighter-10.3.0.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-test/2.2.20/kotlin-test-2.2.20.jar",
-        "hash": "0054c51c672512a918440703e35ea946a8e7a210872f2196dbd6b9f2959198b0",
-        "path": "org/jetbrains/kotlin/kotlin-test/2.2.20/kotlin-test-2.2.20.jar"
-    },
-    {
-        "url": "com/fasterxml/jackson/dataformat/jackson-dataformat-yaml/2.19.0/jackson-dataformat-yaml-2.19.0.jar",
-        "hash": "46e54dcbd39d4d12cda18ec9276e7b888e08fc765ea0c77e71662306f0d4abc4",
-        "path": "com/fasterxml/jackson/dataformat/jackson-dataformat-yaml/2.19.0/jackson-dataformat-yaml-2.19.0.jar"
     },
     {
         "url": "xalan/xalan/2.7.3/xalan-2.7.3.jar",


### PR DESCRIPTION
clion: 2025.3.1 -> 2025.3.1.1
datagrip: 2025.3.2 -> 2025.3.3
idea: 2025.3.1 -> 2025.3.1.1
pycharm-oss: 2025.3.1 -> 2025.3.1.1
pycharm: 2025.3.1 -> 2025.3.1.1
ruby-mine: 2025.3.1 -> 2025.3.1.1

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
