### PR TITLE
vscode-extension-anthropic-claude-code Use nix version of claude-cli instead of dynamically-linked bundled version

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   vscode-utils,
+  claude-code,
 }:
 
 vscode-utils.buildVscodeMarketplaceExtension {
@@ -10,6 +11,11 @@ vscode-utils.buildVscodeMarketplaceExtension {
     version = "2.1.5";
     hash = "sha256-R7FRTvbadL12uSZjOHK2ggGlie6jDm+tV5Ei1LrVCZQ=";
   };
+
+  postInstall = ''
+    rm -f $out/share/vscode/extensions/anthropic.claude-code/resources/native-binary/claude
+    ln -s ${claude-code}/bin/claude $out/share/vscode/extensions/anthropic.claude-code/resources/native-binary/claude
+  '';
 
   meta = {
     description = "Harness the power of Claude Code without leaving your IDE";


### PR DESCRIPTION
Add post-install script to manage native binary symlink.

With this change the vscode claude code extension will use the nixpackage claude code binary instead of the bundled, dynamically linked version from anthropic.

```sh
user@nixos:~/Source/nixpkgs]$ ls -alg /nix/store/HASH-vscode-extension-anthropic-claude-code-2.1.5/ \
share/vscode/extensions/anthropic.claude-code/resources/native-binary/
total 12
dr-xr-xr-x 2 root 4096 Dec 31  1969 .
dr-xr-xr-x 4 root 4096 Dec 31  1969 ..
lrwxrwxrwx 1 root   72 Dec 31  1969 claude -> /nix/store/HASH-claude-code-2.1.5/ \
bin/claude
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
