### PR TITLE
various: migrate qt6 packages to finalAttrs

### DIFF
--- a/pkgs/by-name/ba/backintime-common/package.nix
+++ b/pkgs/by-name/ba/backintime-common/package.nix
@@ -30,15 +30,15 @@ let
     encfs
   ];
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "backintime-common";
   version = "1.5.6";
 
   src = fetchFromGitHub {
     owner = "bit-team";
     repo = "backintime";
-    rev = "v${version}";
-    sha256 = "sha256-y9uo/6R9OXK9hqUD0pCLJXF2B80lr2gXf6v8+Ca6u5M=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-y9uo/6R9OXK9hqUD0pCLJXF2B80lr2gXf6v8+Ca6u5M=";
   };
 
   nativeBuildInputs = [
@@ -81,4 +81,4 @@ stdenv.mkDerivation rec {
       done by taking snapshots of a specified set of directories.
     '';
   };
-}
+})

--- a/pkgs/by-name/ti/tipp10/package.nix
+++ b/pkgs/by-name/ti/tipp10/package.nix
@@ -6,14 +6,14 @@
   qt6,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "tipp10";
   version = "3.3.4";
 
   src = fetchFromGitLab {
     owner = "tipp10";
     repo = "tipp10";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-q5D+8Z9dNpCXgRQtVC+0RBHK2szv7M+dwlmW4H7j2qg=";
   };
 
@@ -35,4 +35,4 @@ stdenv.mkDerivation rec {
     maintainers = with lib.maintainers; [ sigmanificient ];
     platforms = lib.platforms.all;
   };
-}
+})


### PR DESCRIPTION
This pull request updates the packaging of the `backintime-qt` and `tipp10` applications to use the new Qt6 infrastructure and relocates their package definitions to the `pkgs/by-name` directory. The changes improve maintainability and ensure compatibility with the latest Qt6 packaging conventions.

**Migration to Qt6 infrastructure:**
* Updated `backintime-qt` and `tipp10` packages to use `qt6` and its submodules (`qtbase`, `qtwayland`, `qttools`, `qtmultimedia`, `wrapQtAppsHook`) instead of individual Qt5 components. This change simplifies dependency management and ensures both packages are built with Qt6.

**Package definition refactoring:**
* Moved `backintime-qt` from `pkgs/applications/networking/sync/backintime/qt.nix` to `pkgs/by-name/ba/backintime-qt/package.nix` and `tipp10` from `pkgs/applications/misc/tipp10/default.nix` to `pkgs/by-name/ti/tipp10/package.nix` to align with the new `by-name` directory structure.

* Refactored the `tipp10` package definition to use the `stdenv.mkDerivation (finalAttrs: { ... })` pattern and updated the `src` attribute to use `tag` instead of `rev` for GitLab fetches.

**Cleanup of legacy references:**
* Removed old references to the previous package locations and Qt5 packaging from `pkgs/top-level/all-packages.nix`, ensuring that `backintime-qt` and `tipp10` are now only referenced via their new locations and Qt6 infrastructure.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
