### PR TITLE
sqlauncher: init at 0-unstable-2025-12-30; maintainers: add reylak

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22272,6 +22272,13 @@
     githubId = 44014925;
     name = "Rexx Larsson";
   };
+  reylak = {
+    name = "Joaquin Lopez";
+    email = "elreylak@proton.me";
+    github = "Reylak-dev";
+    githubId = 178049808;
+    matrix = "@reylak:unredacted.org";
+  };
   rgnns = {
     email = "jglievano@gmail.com";
     github = "rgnns";

--- a/pkgs/by-name/sq/sqlauncher/package.nix
+++ b/pkgs/by-name/sq/sqlauncher/package.nix
@@ -1,0 +1,48 @@
+{
+  stdenv,
+  fetchFromGitea,
+  cmake,
+  ninja,
+  qt6,
+  lib,
+}:
+
+stdenv.mkDerivation {
+  pname = "sqlauncher";
+  version = "0.0.0-unstable-2025-12-30";
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "ItsZariep";
+    repo = "SQLauncher";
+    rev = "4a82d0f5d1394f3ff850297939b62357f7f3ce0f";
+    hash = "sha256-9yMdJn+aMJQrkreEWkaTw0ZAtmNtTw50n2pXu3d9m6w=";
+  };
+
+  nativeBuildInputs = [
+    qt6.wrapQtAppsHook
+    cmake
+    ninja
+  ];
+  buildInputs = [
+    qt6.qtbase
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp sqlauncher $out/bin
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Simple QT6 Program Launcher";
+    homepage = "https://codeberg.org/ItsZariep/SQLauncher";
+    license = licenses.gpl3Only;
+    mainProgram = "sqlauncher";
+    platforms = platforms.linux;
+    maintainers = [ maintainers.reylak ];
+  };
+}


### PR DESCRIPTION
Packaging SQLauncher, a simple program launcher written in C++ and Qt6.
[Source code](https://codeberg.org/ItsZariep/SQLauncher)
[Developer](https://codeberg.org/ItsZariep)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.