### PR TITLE
matrix-continuwuity: 0.5.1 -> 0.5.3

### DIFF
--- a/pkgs/by-name/ma/matrix-continuwuity/package.nix
+++ b/pkgs/by-name/ma/matrix-continuwuity/package.nix
@@ -10,20 +10,15 @@
   nix-update-script,
   testers,
   matrix-continuwuity,
-  enableBlurhashing ? true,
-  # upstream continuwuity enables jemalloc by default, so we follow suit
-  enableJemalloc ? true,
   rust-jemalloc-sys-unprefixed,
-  enableLiburing ? stdenv.hostPlatform.isLinux,
   liburing,
   nixosTests,
 }:
 let
   rocksdb' =
     (rocksdb.override {
-      inherit enableLiburing;
       # rocksdb does not support prefixed jemalloc, which is required on darwin
-      enableJemalloc = enableJemalloc && !stdenv.hostPlatform.isDarwin;
+      enableJemalloc = !stdenv.hostPlatform.isDarwin;
       jemalloc = rust-jemalloc-sys-unprefixed;
     }).overrideAttrs
       (
@@ -97,42 +92,15 @@ rustPlatform.buildRustPackage (finalAttrs: {
   buildInputs = [
     bzip2
     zstd
-  ]
-  ++ lib.optional enableJemalloc [
     rust-jemalloc-sys-unprefixed
-  ]
-  ++ lib.optional enableLiburing liburing;
+    liburing
+  ];
 
   env = {
     ZSTD_SYS_USE_PKG_CONFIG = true;
     ROCKSDB_INCLUDE_DIR = "${rocksdb'}/include";
     ROCKSDB_LIB_DIR = "${rocksdb'}/lib";
   };
-
-  buildNoDefaultFeatures = true;
-  # See https://forgejo.ellis.link/continuwuation/continuwuity/src/branch/main/Cargo.toml
-  # for available features.
-  # We enable all default features except jemalloc, blurhashing, and io_uring, which
-  # we guard behind our own (default-enabled) flags.
-  buildFeatures = [
-    "brotli_compression"
-    "direct_tls"
-    "element_hacks"
-    "gzip_compression"
-    "media_thumbnail"
-    "release_max_log_level"
-    "systemd"
-    "url_preview"
-    "zstd_compression"
-    "bindgen-runtime"
-    "ldap"
-  ]
-  ++ lib.optional enableBlurhashing "blurhashing"
-  ++ lib.optional enableJemalloc [
-    "jemalloc"
-    "jemalloc_conf"
-  ]
-  ++ lib.optional enableLiburing "io_uring";
 
   passthru = {
     rocksdb = rocksdb'; # make used rocksdb version available (e.g., for backup scripts)

--- a/pkgs/by-name/ma/matrix-continuwuity/package.nix
+++ b/pkgs/by-name/ma/matrix-continuwuity/package.nix
@@ -77,17 +77,17 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "matrix-continuwuity";
-  version = "0.5.1";
+  version = "0.5.3";
 
   src = fetchFromGitea {
     domain = "forgejo.ellis.link";
     owner = "continuwuation";
     repo = "continuwuity";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-g2KidOlYvJgGsiX2qq9pmJjLmzVgbJHv8VaulYIiKKo=";
+    hash = "sha256-9gDVhBuWBiXkzOxx0DyJFRV32QFwkKKpORb4I4xtdKw=";
   };
 
-  cargoHash = "sha256-nOawYriRWw6O890J6V/InKlijCO6CqwvIuOOTjorJns=";
+  cargoHash = "sha256-seJ9zaFMfSm/77n33SJ60/Ux1ovWUbkyi5M8x3kuBhU=";
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
in this change we also remove the custom feature picking since it breaks everytime the featurelist changes upstream
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
