### PR TITLE
roman: 2.0.0 -> 5.2, modernize, adopt

### DIFF
--- a/pkgs/development/python-modules/roman/default.nix
+++ b/pkgs/development/python-modules/roman/default.nix
@@ -31,6 +31,7 @@ buildPythonPackage (finalAttrs: {
     changelog = "https://github.com/zopefoundation/roman/blob/${finalAttrs.version}/CHANGES.rst";
     homepage = "https://pypi.python.org/pypi/roman";
     license = lib.licenses.psfl;
+    maintainers = with lib.maintainers; [ sigmanificient ];
     mainProgram = "roman";
   };
 })

--- a/pkgs/development/python-modules/roman/default.nix
+++ b/pkgs/development/python-modules/roman/default.nix
@@ -1,23 +1,36 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
+  setuptools,
+  pytestCheckHook,
 }:
 
-buildPythonPackage rec {
-  version = "2.0.0";
-  format = "setuptools";
+buildPythonPackage (finalAttrs: {
+  version = "5.2";
   pname = "roman";
+  pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    extension = "zip";
-    sha256 = "90e83b512b44dd7fc83d67eb45aa5eb707df623e6fc6e66e7f273abd4b2613ae";
+  src = fetchFromGitHub {
+    owner = "zopefoundation";
+    repo = "roman";
+    tag = finalAttrs.version;
+    hash = "sha256-ZtwHlS3V18EqDXJxTTwfUdtOvyQg9GbSArV7sOs1b38=";
   };
+
+  build-system = [ setuptools ];
+
+  pythonImportsCheck = [ "roman" ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  enabledTestPaths = [ "src/tests.py" ];
 
   meta = {
     description = "Integer to Roman numerals converter";
+    changelog = "https://github.com/zopefoundation/roman/blob/${finalAttrs.version}/CHANGES.rst";
     homepage = "https://pypi.python.org/pypi/roman";
     license = lib.licenses.psfl;
+    mainProgram = "roman";
   };
-}
+})


### PR DESCRIPTION
Almost the whole changelog is relevant:
- https://github.com/zopefoundation/roman/blob/5.2/CHANGES.rst

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
