### PR TITLE
eca: init at 0.105.0

### DIFF
--- a/pkgs/by-name/ec/eca/package.nix
+++ b/pkgs/by-name/ec/eca/package.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  buildGraalvmNativeImage,
+  fetchurl,
+  fetchFromGitHub,
+  writeScript,
+  writableTmpDirAsHomeHook,
+  versionCheckHook,
+  testers,
+}:
+
+buildGraalvmNativeImage (finalAttrs: {
+  pname = "eca";
+  version = "0.105.0";
+
+  src = fetchurl {
+    url = "https://github.com/editor-code-assistant/eca/releases/download/${finalAttrs.version}/eca.jar";
+    hash = "sha256-pgo7h7MbRiZd6g3HQNyE4ZFnklEu47MmFFLytcm1LxM=";
+  };
+
+  extraNativeImageBuildArgs = [
+    # These build args mirror the build.clj upstream
+    # ref: https://github.com/editor-code-assistant/eca/blob/0.93.2/build.clj#L84-L86
+    "--no-fallback"
+    "--native-image-info"
+    "--features=clj_easy.graal_build_time.InitClojureClasses"
+  ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    writableTmpDirAsHomeHook
+    versionCheckHook
+  ];
+
+  passthru.updateScript = writeScript "update-eca" ''
+    #!/usr/bin/env nix-shell
+    #!nix-shell -i bash -p curl common-updater-scripts gnused jq
+
+    set -eu -o pipefail
+
+    old_version="$(nix-instantiate --strict --json --eval -A eca.version | jq -r .)"
+    latest_version="$(curl -s https://api.github.com/repos/editor-code-assistant/eca/releases/latest | jq -r .tag_name)"
+
+    if [[ $latest_version == $old_version ]]; then
+      echo "Already at latest version $old_version"
+      exit 0
+    fi
+
+    old_jar_hash="$(nix-instantiate --strict --json --eval -A eca.jar.drvAttrs.outputHash | jq -r .)"
+
+    curl -o eca.jar -sL "https://github.com/editor-code-assistant/eca/releases/download/$latest_version/eca.jar"
+    new_jar_hash="$(nix-hash --flat --type sha256 eca.jar | xargs -n1 nix --extra-experimental-features nix-command hash convert --hash-algo sha256)"
+
+    rm -f eca.jar
+
+    update-source-version eca "$latest_version" "$new_jar_hash"
+  '';
+
+  meta = {
+    description = "AI pair programming capabilities agnostic of editor";
+    homepage = "https://eca.dev";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ crimeminister ];
+    platforms = lib.platforms.unix;
+    mainProgram = "eca";
+  };
+})


### PR DESCRIPTION
Adds [eca.dev](https://eca.dev/), the Editor Code Assistant, at version 0.105.0.

This is an editor-agnostic server that exposes a common interface to various LLM tools. Combined with an editor-specific front-end (based on a common protocol that any editor can support), it allows the user to ask questions, review code, and enables native tool support via MCPs configured by the user.

- [x] builds the `eca` binary
  - built using `babashka`, `clojure`, `java` and `graalvm`
- [ ] defines a systemd unit to enable the program to be run as a service  

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
