### PR TITLE
python313Packages.pywbem: 1.7.3 -> 1.8.1, run tests

### DIFF
--- a/pkgs/development/python-modules/pywbem/default.nix
+++ b/pkgs/development/python-modules/pywbem/default.nix
@@ -14,7 +14,7 @@
   nocaselist,
   pbr,
   ply,
-  pytest,
+  pytestCheckHook,
   pytz,
   pyyaml,
   requests,
@@ -62,13 +62,18 @@ buildPythonPackage rec {
     httpretty
     libxml2
     lxml
-    pytest
+    pytestCheckHook
     pytz
     requests-mock
     testfixtures
   ];
 
   pythonImportsCheck = [ "pywbem" ];
+
+  disabledTestPaths = [
+    "tests/leaktest" # requires 'yagot'
+    "tests/end2endtest" # requires 'pytest_easy_server'
+  ];
 
   meta = {
     description = "Support for the WBEM standard for systems management";

--- a/pkgs/development/python-modules/pywbem/default.nix
+++ b/pkgs/development/python-modules/pywbem/default.nix
@@ -3,6 +3,8 @@
   buildPythonPackage,
   decorator,
   fetchPypi,
+  setuptools,
+  setuptools-scm,
   formencode,
   httpretty,
   libxml2,
@@ -24,13 +26,23 @@
 
 buildPythonPackage rec {
   pname = "pywbem";
-  version = "1.7.3";
+  version = "1.8.1";
   pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-0fCi69T/7e+NBnrzhVIW21GQx/byfI0tzUZ+CXAckLA=";
+    hash = "sha256-P+/sNPckpVHkLKOJ0ILQKf7QO0/xSsyO9cfLkv3aE1s=";
   };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "setuptools-scm>=9.2.0" "setuptools-scm"
+  '';
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
 
   propagatedBuildInputs = [
     mock


### PR DESCRIPTION
- tests were not run due to `nativeCheckInputs` using `pytest` instead of `pytestCheckHook`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
