### PR TITLE
tuxedo-drivers: fix udev settings evaluation

### DIFF
--- a/nixos/modules/hardware/tuxedo-drivers.nix
+++ b/nixos/modules/hardware/tuxedo-drivers.nix
@@ -94,16 +94,16 @@ in
     boot.extraModulePackages = [ tuxedo-drivers ];
     services.udev.packages = [
       tuxedo-drivers
-      lib.mkIf
-      (lib.any (v: v != null) cfg.settings)
-      (pkgs.writeTextDir "etc/udev/rules.d/90-tuxedo.rules" (
+    ]
+    ++ lib.optional (lib.any (v: v != null) (lib.attrValues cfg.settings)) (
+      pkgs.writeTextDir "etc/udev/rules.d/90-tuxedo.rules" (
         lib.concatLines (
           [ "# Custom rules for TUXEDO laptops" ]
           ++ (optUdevRule "charging_profile/charging_profile" cfg.settings.charging-profile)
           ++ (optUdevRule "charging_priority/charging_prio" cfg.settings.charging-priority)
           ++ (optUdevRule "fn_lock" cfg.settings.fn-lock)
         )
-      ))
-    ];
+      )
+    );
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixes the evaluation of the udev rules for the tuxedo-drivers module introduced by #410921, due to `lib.any` being used in a set:

```
error: expected a list but found a set: { charging-priority = «thunk»; charging-profile = «thunk»; fn-lock = «thunk»; }
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
