### PR TITLE
lima-additional-guestagents: remove unused inputs

### DIFF
--- a/pkgs/by-name/li/lima/additional-guestagents.nix
+++ b/pkgs/by-name/li/lima/additional-guestagents.nix
@@ -1,9 +1,7 @@
 {
   lib,
-  stdenv,
   buildGoModule,
   callPackage,
-  apple-sdk_15,
   findutils,
 }:
 
@@ -14,15 +12,12 @@ buildGoModule (finalAttrs: {
   # nixpkgs-update: no auto update
   inherit (callPackage ./source.nix { }) version src vendorHash;
 
-  buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
-    apple-sdk_15
-  ];
+  env.CGO_ENABLED = "0";
 
   buildPhase =
     let
       makeFlags = [
         "VERSION=v${finalAttrs.version}"
-        "CC=${stdenv.cc.targetPrefix}cc"
       ];
     in
     ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

`lima-additional-guestagents` is separated from the `lima` package for upstream advice, but they share the same repository and version.
~I updated the `meta` section so that they sync the same maintainers and most attributes.~ => Conflicted to another PR. I'll omit it in this PR.

<details><summary>Package tests at passthru.tests</summary>

Linux x86_64 logs from [GHA](https://github.com/kachick/nixpkgs-reviewing-workspace/actions/runs/20946135803/job/60189406614)

```console
> nix-build --attr 'pkgs.pkgs.lima.passthru.tests'

building '/nix/store/1hs6l6viwj884vw9qbh2jl8gqw93hxwc-lima-additional-guestagents-1.2.2.drv'...
Running phase: unpackPhase
unpacking source archive /nix/store/1pil93jvg2m97s6p43b78qwn2bdyg2bp-source
source root is source
Running phase: patchPhase
Running phase: updateAutotoolsGnuConfigScriptsPhase
Running phase: configurePhase
copying path '/nix/store/b8yh75piga3lw6bq4m239ns92ik19blg-diffoscope-309' from 'https://cache.nixos.org'...
Running phase: buildPhase
make: git: No such file or directory
cp config.mk .config
make: git: No such file or directory
Guestagents are unzipped each time to check the build configuration; they may be gunzipped afterward.
mkdir -p _output/share/lima
CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags="-s=true -w -X github.com/lima-vm/lima/pkg/version.Version=v1.2.2"  -o _output/share/lima/lima-guestagent.Linux-aarch64 ./cmd/lima-guestagent
copying path '/nix/store/3ss9lcjfx6w8cic8cc2g6avvd0am8s2z-lima-1.2.2' from 'https://cache.nixos.org'...
building '/nix/store/n0jqwaiirhj24g2a7w6wad31dsbwnkxi-actual.drv'...
WARN[0000] unable to determine host timezone, falling back to default value 
WARN[0000] unable to determine host timezone, falling back to default value 
building '/nix/store/358xkws9dllcmx6ihnsm01i71y456dzg-equal-contents-limactl-only-detects-host-s-architecture-guest-agent-by-default.drv'...
Checking:
limactl only detects host's architecture guest agent by default
expected /nix/store/7kq9ls9n862xc4ama4pis2r34zfa4r4l-expected and actual /nix/store/v31aw2svc2vzi4h1l4qhj90p40b3xh2f-actual match.
OK
chmod 644 _output/share/lima/lima-guestagent.Linux-aarch64
+ gzip _output/share/lima/lima-guestagent.Linux-aarch64
CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=7 go build -ldflags="-s=true -w -X github.com/lima-vm/lima/pkg/version.Version=v1.2.2"  -o _output/share/lima/lima-guestagent.Linux-armv7l ./cmd/lima-guestagent
chmod 644 _output/share/lima/lima-guestagent.Linux-armv7l
+ gzip _output/share/lima/lima-guestagent.Linux-armv7l
CGO_ENABLED=0 GOOS=linux GOARCH=ppc64le go build -ldflags="-s=true -w -X github.com/lima-vm/lima/pkg/version.Version=v1.2.2"  -o _output/share/lima/lima-guestagent.Linux-ppc64le ./cmd/lima-guestagent
chmod 644 _output/share/lima/lima-guestagent.Linux-ppc64le
+ gzip _output/share/lima/lima-guestagent.Linux-ppc64le
CGO_ENABLED=0 GOOS=linux GOARCH=riscv64 go build -ldflags="-s=true -w -X github.com/lima-vm/lima/pkg/version.Version=v1.2.2"  -o _output/share/lima/lima-guestagent.Linux-riscv64 ./cmd/lima-guestagent
chmod 644 _output/share/lima/lima-guestagent.Linux-riscv64
+ gzip _output/share/lima/lima-guestagent.Linux-riscv64
CGO_ENABLED=0 GOOS=linux GOARCH=s390x go build -ldflags="-s=true -w -X github.com/lima-vm/lima/pkg/version.Version=v1.2.2"  -o _output/share/lima/lima-guestagent.Linux-s390x ./cmd/lima-guestagent
chmod 644 _output/share/lima/lima-guestagent.Linux-s390x
+ gzip _output/share/lima/lima-guestagent.Linux-s390x
buildPhase completed in 4 minutes 52 seconds
Running phase: checkPhase
/nix/store/n1k7lm072r5k3g6v6wb91d2q4sxcxddm-stdenv-linux/setup: line 1760: getGoDirs: command not found
Running phase: installPhase
Running phase: fixupPhase
shrinking RPATHs of ELF executables and libraries in /nix/store/xd9h5bn70gshs2q2hnghbwzhqdv2rayq-lima-additional-guestagents-1.2.2
checking for references to /build/ in /nix/store/xd9h5bn70gshs2q2hnghbwzhqdv2rayq-lima-additional-guestagents-1.2.2...
patching script interpreter paths in /nix/store/xd9h5bn70gshs2q2hnghbwzhqdv2rayq-lima-additional-guestagents-1.2.2
Running phase: installCheckPhase
building '/nix/store/6s9493b36kf87cv5qxlj0x8i4qa2xam8-lima-1.2.2.drv'...
Using versionCheckHook
Running phase: unpackPhase
unpacking source archive /nix/store/1pil93jvg2m97s6p43b78qwn2bdyg2bp-source
source root is source
Running phase: patchPhase
Running phase: updateAutotoolsGnuConfigScriptsPhase
Running phase: configurePhase
Running phase: buildPhase
make: git: No such file or directory
cp config.mk .config
make: git: No such file or directory
Guestagents are unzipped each time to check the build configuration; they may be gunzipped afterward.
rm -rf _output
CGO_ENABLED=1 GOOS="linux" GOARCH="amd64" CC="cc" go build -ldflags="-s=true -w -X github.com/lima-vm/lima/pkg/version.Version=v1.2.2"  -o _output/bin/limactl ./cmd/limactl
cp -aL templates/rocky-8.yaml _output/share/lima/templates/rocky-8.yaml
cp -aL templates/rocky-9.yaml _output/share/lima/templates/rocky-9.yaml
cp -aL templates/rocky.yaml _output/share/lima/templates/rocky.yaml
cp -aL templates/ubuntu-20.04.yaml _output/share/lima/templates/ubuntu-20.04.yaml
cp -aL templates/ubuntu-22.04.yaml _output/share/lima/templates/ubuntu-22.04.yaml
cp -aL templates/ubuntu-24.04.yaml _output/share/lima/templates/ubuntu-24.04.yaml
cp -aL templates/ubuntu-24.10.yaml _output/share/lima/templates/ubuntu-24.10.yaml
cp -aL templates/ubuntu-25.04.yaml _output/share/lima/templates/ubuntu-25.04.yaml
cp -aL templates/ubuntu-lts.yaml _output/share/lima/templates/ubuntu-lts.yaml
cp -aL templates/ubuntu.yaml _output/share/lima/templates/ubuntu.yaml
mkdir -p _output/share/lima/templates/experimental
cp -aL templates/experimental/alsa.yaml _output/share/lima/templates/experimental/alsa.yaml
cp -aL templates/experimental/debian-13.yaml _output/share/lima/templates/experimental/debian-13.yaml
cp -aL templates/experimental/debian-sid.yaml _output/share/lima/templates/experimental/debian-sid.yaml
cp -aL templates/experimental/debian-testing.yaml _output/share/lima/templates/experimental/debian-testing.yaml
cp -aL templates/experimental/gentoo.yaml _output/share/lima/templates/experimental/gentoo.yaml
cp -aL templates/experimental/opensuse-tumbleweed.yaml _output/share/lima/templates/experimental/opensuse-tumbleweed.yaml
cp -aL templates/experimental/rke2.yaml _output/share/lima/templates/experimental/rke2.yaml
cp -aL templates/experimental/u7s.yaml _output/share/lima/templates/experimental/u7s.yaml
cp -aL templates/experimental/ubuntu-25.10.yaml _output/share/lima/templates/experimental/ubuntu-25.10.yaml
cp -aL templates/experimental/ubuntu-next.yaml _output/share/lima/templates/experimental/ubuntu-next.yaml
cp -aL templates/experimental/vnc.yaml _output/share/lima/templates/experimental/vnc.yaml
cp -aL templates/experimental/wsl2.yaml _output/share/lima/templates/experimental/wsl2.yaml
buildPhase completed in 1 minutes 24 seconds
Running phase: checkPhase
/nix/store/n1k7lm072r5k3g6v6wb91d2q4sxcxddm-stdenv-linux/setup: line 1760: getGoDirs: command not found
Running phase: installPhase
Running phase: fixupPhase
shrinking RPATHs of ELF executables and libraries in /nix/store/9m4m97n9k24qmbjj8864ra9w5wggv6dv-lima-1.2.2
shrinking /nix/store/9m4m97n9k24qmbjj8864ra9w5wggv6dv-lima-1.2.2/bin/.limactl-wrapped
checking for references to /build/ in /nix/store/9m4m97n9k24qmbjj8864ra9w5wggv6dv-lima-1.2.2...
patching script interpreter paths in /nix/store/9m4m97n9k24qmbjj8864ra9w5wggv6dv-lima-1.2.2
stripping (with command strip and flags -S -p) in  /nix/store/9m4m97n9k24qmbjj8864ra9w5wggv6dv-lima-1.2.2/bin
Running phase: installCheckPhase
Executing versionCheckPhase
Successfully managed to find version 1.2.2 in the output of the command /nix/store/9m4m97n9k24qmbjj8864ra9w5wggv6dv-lima-1.2.2/bin/limactl --version
limactl version 1.2.2
Finished versionCheckPhase
WARN[0000] unable to determine host timezone, falling back to default value 
INFO[0000] "templates/default.yaml": OK                 
building '/nix/store/89wdj603blzwdlmmxnk81h2ldbk86npc-actual.drv'...
WARN[0000] unable to determine host timezone, falling back to default value 
WARN[0000] unable to determine host timezone, falling back to default value 
building '/nix/store/a7j6amm9379cjwhd2vprqqlqq1rkpzbw-equal-contents-limactl-also-detects-additional-guest-agents-if-specified.drv'...
Checking:
limactl also detects additional guest agents if specified
expected /nix/store/4p3fnx0a4hhj7ysbgvjpj1rzrg8r20dv-expected and actual /nix/store/4d1x3cd1q2b1clyffhxxn9rndf03p4m2-actual match.
OK
/nix/store/q6l4q93hlghxxpwayvs1z4sgi5518ma8-equal-contents-limactl-also-detects-additional-guest-agents-if-specified
/nix/store/lfbrgqzrxx2jr67y37wzrc8hvssjal2k-equal-contents-limactl-only-detects-host-s-architecture-guest-agent-by-default
```

</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

cc: @voanhduy1512

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
