### PR TITLE
atuin-desktop: 0.2.11 -> 0.2.19

### DIFF
--- a/pkgs/by-name/at/atuin-desktop/0001-fix-Remove-duplicate-dependency-entry-for-tauri-build.patch
+++ b/pkgs/by-name/at/atuin-desktop/0001-fix-Remove-duplicate-dependency-entry-for-tauri-build.patch
@@ -1,0 +1,53 @@
+From 7534c427f720ce2134a4fba7b7c3f8cddadf9069 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?David=20Chocholat=C3=BD?= <chocholaty.david@protonmail.com>
+Date: Sat, 31 Jan 2026 11:04:04 +0100
+Subject: [PATCH] fix: Remove duplicate dependency entry for tauri-build
+
+---
+ Cargo.lock | 23 -----------------------
+ 1 file changed, 23 deletions(-)
+
+diff --git a/Cargo.lock b/Cargo.lock
+index 80a7920f..92a7bef6 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -590,7 +590,6 @@ dependencies = [
+  "sqlx",
+  "syntect",
+  "tauri",
+- "tauri-build 2.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+  "tauri-plugin-deep-link",
+  "tauri-plugin-dialog",
+  "tauri-plugin-fs",
+@@ -8932,28 +8931,6 @@ dependencies = [
+  "windows 0.61.1",
+ ]
+ 
+-[[package]]
+-name = "tauri-build"
+-version = "2.5.3"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "17fcb8819fd16463512a12f531d44826ce566f486d7ccd211c9c8cebdaec4e08"
+-dependencies = [
+- "anyhow",
+- "cargo_toml",
+- "dirs 6.0.0",
+- "glob",
+- "heck 0.5.0",
+- "json-patch",
+- "schemars",
+- "semver",
+- "serde",
+- "serde_json",
+- "tauri-utils",
+- "tauri-winres",
+- "toml 0.9.8",
+- "walkdir",
+-]
+-
+ [[package]]
+ name = "tauri-build"
+ version = "2.5.3"
+-- 
+2.51.2
+


### PR DESCRIPTION
This PR updates atuin-desktop to 0.2.14. [Changelog 0.2.12](https://github.com/atuinsh/desktop/releases/tag/v0.2.12), [changelog 0.2.13](https://github.com/atuinsh/desktop/releases/tag/v0.2.13), [changelog 0.2.14](https://github.com/atuinsh/desktop/releases/tag/v0.2.14), [changelog 0.2.15](https://github.com/atuinsh/desktop/releases/tag/v0.2.15), [changelog 0.2.16](https://github.com/atuinsh/desktop/releases/tag/v0.2.16), [changelog 0.2.17](https://github.com/atuinsh/desktop/releases/tag/v0.2.17), [changelog 0.2.18](https://github.com/atuinsh/desktop/releases/tag/v0.2.18), [changelog 0.2.19](https://github.com/atuinsh/desktop/releases/tag/v0.2.19).

The project has switched from `pnpm` to `bun` for the compilation of the dependencies. `bun` applications must be packaged manually until #376299 is merged.

The project contains duplicate entries for `tauri-build` dependency in its `Cargo.lock`. An issue has been filed upstream (https://github.com/atuinsh/desktop/issues/364). Until it is resolved, a temporary patch has been added to the derivation.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
