### PR TITLE
sqlit-tui: 1.0.1 -> 1.2.6

### DIFF
--- a/pkgs/by-name/sq/sqlit-tui/package.nix
+++ b/pkgs/by-name/sq/sqlit-tui/package.nix
@@ -1,28 +1,30 @@
 {
-  lib,
   fetchFromGitHub,
+  lib,
   python3Packages,
   writableTmpDirAsHomeHook,
 }:
 
 python3Packages.buildPythonApplication rec {
   pname = "sqlit-tui";
-  version = "1.0.1";
+  version = "1.2.6";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Maxteabag";
     repo = "sqlit";
     tag = "v${version}";
-    hash = "sha256-O2/kbKXSjsdSrTFnnNwif2IfV0HG4IPYLrD1eznuhuo=";
+    hash = "sha256-5uGdKK7z/Rvb4VHZDJOjwPFXedX8l8RTvGvCQs7iAq8=";
   };
 
   build-system = with python3Packages; [
+    hatch-vcs
     hatchling
-    uv-build
+    setuptools-scm
   ];
 
   dependencies = with python3Packages; [
+    docker
     duckdb
     keyring
     mariadb
@@ -32,8 +34,10 @@ python3Packages.buildPythonApplication rec {
     psycopg2
     pyodbc
     pyperclip
+    sqlparse
     sshtunnel
     textual
+    textual-fastdatatable
   ];
 
   pythonRelaxDeps = [
@@ -41,19 +45,17 @@ python3Packages.buildPythonApplication rec {
   ];
 
   nativeCheckInputs = with python3Packages; [
-    pytestCheckHook
     pytest-asyncio
+    pytestCheckHook
     writableTmpDirAsHomeHook
   ];
 
-  pythonImportsCheck = [
-    "sqlit"
-  ];
+  pythonImportsCheck = [ "sqlit" ];
 
   disabledTests = [
-    # UI tests fail in the sandbox
-    "tests/ui/"
+    "tests/ui/" # UI tests fail in the sandbox
     "test_installer_cancel_terminates_process" # timeout error
+    "test_detect_strategy_pip_user_fallback" # AssertionError: assert 'externally-managed' == 'pip-user'
   ];
 
   meta = {


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Now that [fastdatatable has been merged](https://github.com/NixOS/nixpkgs/pull/478837), `sqlit-tui` can be updated (without needing to use pythonRelaxDeps like they had to do in [the upstream flake](https://github.com/Maxteabag/sqlit/blob/main/flake.nix)).

This PR superseeds the [auto-generated update PR to 1.0.2](https://github.com/NixOS/nixpkgs/pull/472535).

@SuperSandro2000 may I ask you a review ?

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
