### PR TITLE
python3Packages.sembr: init at 0.2.3-unstable-2025-08-03

### DIFF
--- a/pkgs/development/python-modules/sembr/default.nix
+++ b/pkgs/development/python-modules/sembr/default.nix
@@ -1,0 +1,86 @@
+{
+  lib,
+  stdenv,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  accelerate,
+  fastmcp,
+  flask,
+  magika,
+  mcp,
+  numpy,
+  pydantic,
+  requests,
+  torch,
+  tqdm,
+  transformers,
+  tree-sitter,
+  tree-sitter-markdown,
+
+  cudaSupport ? torch.cudaSupport,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "sembr";
+  version = "0.2.3-unstable-2025-08-03"; # no tagged release upstream yet
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "admk";
+    repo = "sembr";
+    rev = "8cd0e83615b6b94fd09aa67d191cf4c07466c41a";
+    hash = "sha256-mnigzatTsYpub3paizkKp9PmIpKm/F2owQBFzkiJM+8=";
+  };
+
+  postPatch = ''
+    # Fix setuptools package discovery to include processors subpackage
+    substituteInPlace pyproject.toml \
+      --replace-fail 'include = ["sembr"]' 'include = ["sembr", "sembr.*"]'
+  '';
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    accelerate
+    fastmcp
+    flask
+    magika
+  ]
+  ++ mcp.optional-dependencies.cli
+  ++ [
+    numpy
+    pydantic
+    requests
+    torch
+    tqdm
+    transformers
+    tree-sitter
+    tree-sitter-markdown
+  ];
+
+  pythonImportsCheck = [
+    "sembr"
+    "sembr.processors"
+  ];
+
+  passthru = {
+    inherit cudaSupport;
+  };
+
+  meta = {
+    description = "Semantic line breaker powered by transformers";
+    homepage = "https://github.com/admk/sembr";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ daniel-fahey ];
+    mainProgram = "sembr";
+    # thrift tests fail on x86_64-darwin, breaking the transformers dependency chain
+    broken = stdenv.hostPlatform.system == "x86_64-darwin";
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17051,6 +17051,8 @@ self: super: with self; {
 
   semaphore-bot = callPackage ../development/python-modules/semaphore-bot { };
 
+  sembr = callPackage ../development/python-modules/sembr { };
+
   semchunk = callPackage ../development/python-modules/semchunk { };
 
   semgrep = callPackage ../development/python-modules/semgrep {


### PR DESCRIPTION
This adds [SemBr](https://github.com/admk/sembr), "a command-line tool powered by [Transformer](https://huggingface.co/learn/nlp-course/chapter1/4) [models](https://lilianweng.github.io/posts/2020-04-07-the-transformer-family/) that performs [semantic linebreaks](https://github.com/admk/sembr#what-are-semantic-line-breaks) to breaks lines in a text file at semantic boundaries. It supports multiple file types including LaTeX, Markdown, and plain text, with automatic file type detection."

> [!NOTE]
> There is no tagged release upstream yet. This package tracks the `main` branch.

> [!TIP]
> CPU smoke test:
> ```bash
> nix-shell --pure \
> --include nixpkgs=https://github.com/daniel-fahey/nixpkgs/archive/init/python3Packages.sembr.tar.gz \
> --packages python313Packages.sembr curl \
> --run "curl -s https://raw.githubusercontent.com/mlschmitt/classic-books-markdown/refs/heads/main/\
> James%20Joyce/Dubliners.md | sembr"
> ```
> CUDA smoke test:
> ```bash
> nix-shell --pure \
> --arg config '{ allowUnfree = true; cudaSupport = true; }' \
> --include nixpkgs=https://github.com/daniel-fahey/nixpkgs/archive/init/python3Packages.sembr.tar.gz \
> --packages python313Packages.sembr curl \
> --run "curl -s https://raw.githubusercontent.com/mlschmitt/classic-books-markdown/refs/heads/main/\
> James%20Joyce/Dubliners.md | sembr"
> ```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
