### PR TITLE
lib.systems: correct and simplify canExecute condition regarding march

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -102,13 +102,10 @@ let
             # assume compatible cpu have all the instructions included
             final.parsed.cpu == platform.parsed.cpu
             ->
-              # if both have gcc.arch defined, check whether final can execute the given platform
+              # if platform has gcc.arch, final must also have and can execute the gcc.arch of platform
               (
-                (final ? gcc.arch && platform ? gcc.arch)
-                -> architectures.canExecute final.gcc.arch platform.gcc.arch
+                platform ? gcc.arch -> final ? gcc.arch && architectures.canExecute final.gcc.arch platform.gcc.arch
               )
-              # if platform has gcc.arch defined but final doesn't, don't assume it can be executed
-              || (platform ? gcc.arch -> !(final ? gcc.arch))
           );
 
         isCompatible =


### PR DESCRIPTION
Fixes #479317

To reproduce:

Before fix:

```
nix-repl> p = import ./. { localSystem = { system = "x86_64-linux"; }; crossSystem = { system = "x86_64-linux"; gcc.arch = "x86-64-v3"; }; }

nix-repl> p.stdenv.buildPlatform.canExecute p.stdenv.hostPlatform
true

nix-repl> p.stdenv.hostPlatform.canExecute p.stdenv.hostPlatform
true

nix-repl> p.stdenv.hostPlatform.canExecute p.stdenv.buildPlatform
true

nix-repl> p.stdenv.buildPlatform.canExecute p.stdenv.buildPlatform
true
```

After fix:

```
nix-repl> p = import ./. { localSystem = { system = "x86_64-linux"; }; crossSystem = { system = "x86_64-linux"; gcc.arch = "x86-64-v3"; }; }

nix-repl> p.stdenv.buildPlatform.canExecute p.stdenv.hostPlatform
false

nix-repl> p.stdenv.hostPlatform.canExecute p.stdenv.hostPlatform
true

nix-repl> p.stdenv.hostPlatform.canExecute p.stdenv.buildPlatform
true

nix-repl> p.stdenv.buildPlatform.canExecute p.stdenv.buildPlatform
true
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
