### PR TITLE
ringing-lib: 0-unstable-2025-07-16 -> 0-unstable-2026-05-12

### DIFF
--- a/pkgs/by-name/ri/ringing-lib/package.nix
+++ b/pkgs/by-name/ri/ringing-lib/package.nix
@@ -31,6 +31,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   doCheck = true;
 
+  strictDeps = true;
+
   passthru.updateScript = unstableGitUpdater { hardcodeZeroVersion = true; };
   meta = {
     description = "Library of C++ classes and utilities for change ringing";

--- a/pkgs/by-name/ri/ringing-lib/package.nix
+++ b/pkgs/by-name/ri/ringing-lib/package.nix
@@ -2,7 +2,6 @@
   stdenv,
   fetchFromGitHub,
   lib,
-  autoreconfHook,
   pkg-config,
   readline,
   xercesc,
@@ -11,23 +10,24 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "ringing-lib";
-  version = "0-unstable-2025-07-16";
+  version = "0-unstable-2026-05-12";
 
   src = fetchFromGitHub {
     owner = "ringing-lib";
     repo = "ringing-lib";
-    rev = "838d13edb3231d8c122d3222da1b465e2018757f";
-    hash = "sha256-MO5FerQMyWDV/cV2hrY/L+JyhMojtaqPQkw8efaVu1I=";
+    rev = "6d7533186fb89497ab059b91d0e7bd7911cd3f71";
+    hash = "sha256-yxf9w8USn9SVL4QW6XUWwR1rObvbj6Z69O3he3JiGT4=";
   };
 
   nativeBuildInputs = [
-    autoreconfHook
     pkg-config
   ];
   buildInputs = [
     readline
     xercesc
   ];
+
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
 
   doCheck = true;
 


### PR DESCRIPTION
It seems that GCC 15 is stricter about its overload resolution and ringing-lib will no longer compile.  I've opened a bug [upstream][0], since there are also a lot of warnings emitted with the new compiler.

[0]: https://github.com/ringing-lib/ringing-lib/issues/7


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
