### PR TITLE
dotnet: fix Y2026 FileVersion overflow (backport dotnet/dotnet#4043)

### DIFF
--- a/pkgs/development/compilers/dotnet/fix-y2026-common-props.patch
+++ b/pkgs/development/compilers/dotnet/fix-y2026-common-props.patch
@@ -1,0 +1,40 @@
+From: mulatta <67085791+mulatta@users.noreply.github.com>
+Subject: [PATCH] Fix FileVersion calculation overflow in 2026
+
+The old formula Year(Now-2019)+MMdd overflows UInt16 max (65535) in 2026
+(7*10000 + 0112 = 70112 > 65535), causing CS7035 build errors.
+
+Backport of dotnet/dotnet#4043.
+---
+ build/common.props | 19 ++++++++++++++++++-
+ 1 file changed, 18 insertions(+), 1 deletion(-)
+
+diff --git a/build/common.props b/build/common.props
+--- a/build/common.props
++++ b/build/common.props
+@@ -42,7 +42,24 @@
+     <VersionSuffix Condition="'$(WilsonVersion)' == ''">$(PreviewVersionSuffix)</VersionSuffix>
+     <VersionPrefix Condition="'$(WilsonVersion)' == ''">$(WilsonCurrentVersion)</VersionPrefix>
+     <FileVersion Condition="'$(WilsonVersion)' != '' and '$(IsCustomPreview)' != 'true' ">$(WilsonVersion).$([System.DateTime]::Now.AddYears(-2019).Year)$([System.DateTime]::Now.ToString("MMdd"))</FileVersion>
+-    <FileVersion Condition="'$(WilsonVersion)' == ''">$(WilsonCurrentVersion).$([System.DateTime]::Now.AddYears(-2019).Year)$([System.DateTime]::Now.ToString("MMdd"))</FileVersion>
++    <!-- TODO: Makes sure that the revision is higher than what's in already shipped packages (> 61231).
++         This will overflow in 2029 though and needs a long term fix. -->
++    <FileVersion Condition="'$(WilsonVersion)' == ''">$(WilsonCurrentVersion).$([MSBuild]::Add(
++      61232,
++      $([MSBuild]::Add(
++        $([MSBuild]::Add(
++          $([MSBuild]::Multiply(
++            $([System.DateTime]::Now.AddYears(-2019).Year),
++            416
++          )),
++          $([MSBuild]::Multiply(
++            $([System.DateTime]::Now.ToString("MM")),
++            32
++          ))
++        )),
++        $([System.DateTime]::Now.ToString("dd"))
++      ))
++    ))</FileVersion>
+   </PropertyGroup>
+ 
+   <PropertyGroup>

--- a/pkgs/development/compilers/dotnet/fix-y2026-updateassemblyinfo.patch
+++ b/pkgs/development/compilers/dotnet/fix-y2026-updateassemblyinfo.patch
@@ -1,0 +1,41 @@
+From: mulatta <67085791+mulatta@users.noreply.github.com>
+Subject: [PATCH] Fix FileVersion calculation overflow in 2026
+
+The old formula Year(Now-2019)+MMdd overflows UInt16 max (65535) in 2026
+(7*10000 + 0112 = 70112 > 65535), causing CS7035 build errors.
+
+Backport of dotnet/dotnet#4043.
+---
+ updateAssemblyInfo.sh | 13 ++++++++++++-
+ 1 file changed, 12 insertions(+), 1 deletion(-)
+
+diff --git a/updateAssemblyInfo.sh b/updateAssemblyInfo.sh
+--- a/updateAssemblyInfo.sh
++++ b/updateAssemblyInfo.sh
+@@ -5,6 +5,17 @@ scriptroot=$(cd -P "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+ 
+ packageType=${1:-preview}
+ 
++# Get current date components
++year=$(date '+%Y')
++year_offset=$((year - 2019))
++month=$(date '+%m')
++day=$(date '+%d')
++
++# Calculate revision using the new formula that prevents overflow
++# Base: 61232 (ensures revision is higher than already shipped packages)
++# This will overflow in 2029 and needs a long term fix
++revision=$((61232 + (year_offset * 416) + (10#$month * 32) + 10#$day))
++
+ date=$(date '+%y%m%d%H%M%S')
+ # Formats the date by replacing the 4-digit year with a 2-digit value and then subtract 19
+ dateTimeStamp=$(echo $((10#${date:0:2}-19)))${date:2}
+@@ -12,7 +23,7 @@ dateTimeStamp=$(echo $((10#${date:0:2}-19)))${date:2}
+ commitSha=$(git rev-parse HEAD)
+ 
+ assemblyVersion=$(sed -n 's/.*<assemblyVersion>\([^<]*\)<.*/\1/p' ${scriptroot}/buildConfiguration.xml)
+-assemblyFileVersion="$assemblyVersion.${dateTimeStamp::$((${#dateTimeStamp} - 6))}" # Trim minutes/seconds
++assemblyFileVersion="$assemblyVersion.$revision"
+ assemblyInformationalVersion="$assemblyVersion.$dateTimeStamp.$commitSha"
+ 
+ echo "assemblyVersion: $assemblyVersion"

--- a/pkgs/development/compilers/dotnet/vmr.nix
+++ b/pkgs/development/compilers/dotnet/vmr.nix
@@ -176,12 +176,30 @@ stdenv.mkDerivation rec {
       src/source-build-reference-packages/src/referencePackages/Directory.Build.props
 
   ''
+  + lib.optionalString (lib.versionAtLeast version "10") ''
+    # Y2026 fix: FileVersion calculation overflow (dotnet/dotnet#4043)
+    mkdir -p src/source-build-reference-packages/src/externalPackages/patches/azure-activedirectory-identitymodel-extensions-for-dotnet
+    cp ${./fix-y2026-common-props.patch} \
+      src/source-build-reference-packages/src/externalPackages/patches/azure-activedirectory-identitymodel-extensions-for-dotnet/0002-Fix-assembly-version-calculation-in-2026.patch
+  ''
   + lib.optionalString (lib.versionOlder version "10") ''
     # https://github.com/microsoft/ApplicationInsights-dotnet/issues/2848
     xmlstarlet ed \
       --inplace \
       -u //_:Project/_:PropertyGroup/_:BuildNumber -v 0 \
       src/source-build-externals/src/application-insights/.props/_GlobalStaticVersion.props
+
+  ''
+  + lib.optionalString (lib.versionOlder version "9") ''
+    # Y2026 fix for dotnet 8: Add patch to patches directory (dotnet/dotnet#4043)
+    # Must be 0003 to apply after existing 0002-Remove-commit-SHA patch
+    cp ${./fix-y2026-updateassemblyinfo.patch} \
+      src/source-build-externals/patches/azure-activedirectory-identitymodel-extensions-for-dotnet/0003-Fix-assembly-version-calculation-in-2026.patch
+  ''
+  + lib.optionalString (lib.versionAtLeast version "9" && lib.versionOlder version "10") ''
+    # Y2026 fix for dotnet 9: patch build/common.props (dotnet/dotnet#4043)
+    patch -p1 -d src/source-build-externals/src/azure-activedirectory-identitymodel-extensions-for-dotnet \
+      < ${./fix-y2026-common-props.patch}
   ''
   + ''
 


### PR DESCRIPTION
# Description of changes

Fixes #479348

Starting in 2026, the FileVersion calculation formula `(Year-2019)*10000+MMdd` in azure-activedirectory-identitymodel-extensions-for-dotnet exceeds UInt16 max (65535), causing CS7035 build errors.

## Impact

**All platforms are affected** (x86_64-linux, aarch64-linux, x86_64-darwin, aarch64-darwin), but the severity varies:

- **x86_64-linux**: Binary cache availability masks the issue for most users. Pre-built binaries from cache (built in late 2025, 1-2 months ago) work fine. Users only encounter failures on pure source builds or after cache expiry.
- **aarch64-linux / aarch64-darwin**: Limited cache coverage means these users attempt source builds more frequently and were the first to discover this issue.

Example error (2026-01-13):
error CS7035: The specified version string '8.0.0.70113' does not conform to the recommended format
Calculation: `7*10000 + 0113 = 70113 > 65535` (UInt16 overflow)

## Solution

This PR backports the upstream fix from https://github.com/dotnet/dotnet/pull/4043 with version-specific patches:

- **dotnet 8**: Patches `updateAssemblyInfo.sh` in patches directory as 0003 (applied after existing 0002-Remove-commit-SHA patch)
- **dotnet 9**: Patches `build/common.props` directly via postPatch
- **dotnet 10**: Uses `externalPackages/patches/` mechanism

New formula: `61232 + (year_offset * 416) + (month * 32) + day`
- Prevents overflow until 2029 (long-term fix needed upstream)
- Maintains version monotonicity with already-shipped packages

---

### x86_64-linux (before patch, without binary cache)
```
...
dotnet-stage0-vmr>     'azure-activedirectory-identitymodel-extensions-for-dotnet' failed during build.
dotnet-stage0-vmr>     See '/build/dotnet-10.0.101/src/source-build-reference-packages/artifacts/log/Release/azure-activedirectory-identitymodel-extensions-for-dotnet/azure-activedirectory-identitymodel-extensions-for-dotnet.log' for more information.
dotnet-stage0-vmr>     [13:19:31.34] Building 'MSBuildLocator'...done
dotnet-stage0-vmr>     [13:19:32.61] Building 'humanizer'...done
dotnet-stage0-vmr>     [13:19:33.83] Building 'application-insights'...done
dotnet-stage0-vmr>
dotnet-stage0-vmr>   Build FAILED.
dotnet-stage0-vmr>
dotnet-stage0-vmr>   /build/dotnet-10.0.101/src/source-build-reference-packages/src/externalPackages/projects/azure-activedirectory-identitymodel-extensions-for-dotnet.proj(29,5): error MSB3073: The command "/build/dotnet-10.0.101/.dotnet/dotnet build /bl:/build/dotnet-10.0.101/src/source-build-reference-packages/artifacts/log/Release/azure-activedirectory-identitymodel-extensions-for-dotnet/build.binlog /build/dotnet-10.0.101/src/source-build-reference-packages/src/externalPackages/src/azure-activedirectory-identitymodel-extensions-for-dotnet/artifacts/clone/src/System.IdentityModel.Tokens.Jwt/System.IdentityModel.Tokens.Jwt.csproj  /p:Configuration=Release /v:minimal > /build/dotnet-10.0.101/src/source-build-reference-packages/artifacts/log/Release/azure-activedirectory-identitymodel-extensions-for-dotnet/azure-activedirectory-identitymodel-extensions-for-dotnet.log 2>&1 /p:Version=8.0.1" exited with code 1.
dotnet-stage0-vmr>       0 Warning(s)
dotnet-stage0-vmr>       1 Error(s)
```

### x86_64-linux (after patch)

#### dotnet 8

```
┏━ Dependency Graph:
┃       ┌─ ✔ dotnet-runtime-8.0.22
┃    ┌─ ✔ dotnet-runtime-wrapped-8.0.22
┃    │     ┌─ ✔ dotnet-vmr-8.0.22 ⏱ 34m45s
┃    │  ┌─ ✔ dotnet-aspnetcore-runtime-8.0.22
┃    ├─ ✔ dotnet-aspnetcore-runtime-wrapped-8.0.22
┃ ┌─ ✔ dotnet-sdk-8.0.416 ⏱ 3s
┃ ✔ dotnet-sdk-wrapped-8.0.416
┣━━━ Builds
┗━ ∑ ⏵ 0 │ ✔ 9 │ ⏸ 0 │ Finished at 17:18:28 after 1h12m41s
/nix/store/39n9ra4fcsiwh33cshy5kyj33hs9kn3r-dotnet-sdk-wrapped-8.0.416
```

#### dotnet 9 (with marksman for helix editor LSP)

```
┏━ Dependency Graph:
┃          ┌─ ✔ dotnet-vmr-9.0.11 ⏱ 23m29s
┃       ┌─ ✔ dotnet-runtime-9.0.11
┃    ┌─ ✔ dotnet-runtime-wrapped-9.0.11
┃ ┌─ ✔ dotnet-hook
┃ ✔ marksman-2025-12-13 ⏱ 49s
┣━━━ Builds
┗━ ∑ ⏵ 0 │ ✔ 5 │ ⏸ 0 │ Finished at 16:42:29 after 24m21s
/nix/store/nwfpcd8aycs5hngs02846rm3mh5lqkxm-marksman-2025-12-13
```

#### dotnet 10

```
┏━ Dependency Graph:
┃          ┌─ ✔ dotnet-stage0-vmr-10.0.1 ⏱ 28m7s
┃       ┌─ ✔ dotnet-stage0-sdk-10.0.101 ⏱ 42s
┃    ┌─ ✔ dotnet-vmr-10.0.1 ⏱ 24m52s
┃ ┌─ ✔ dotnet-sdk-10.0.101 ⏱ 40s
┃ ✔ dotnet-sdk-wrapped-10.0.101
┣━━━ Builds
┗━ ∑ ⏵ 0 │ ✔ 5 │ ⏸ 0 │ Finished at 17:15:37 after 54m24s
/nix/store/qp0kflbxfqs4nlwiaa6fa00lp60w5irn-dotnet-sdk-wrapped-10.0.101-man
/nix/store/sfrjw2mxqshsqbmwdiqdhzwwpxdsz6r9-dotnet-sdk-wrapped-10.0.101
```

### aarch64-linux (after patch)

#### dotnet 9 (with marksman LSP for helix editor)

```
home-manager-files> building '/nix/store/rb8hcipikc2nqf9g1h97kbqhks4h5dby-home-manager-files.drv'
home-manager-generation> building '/nix/store/lgb7cvjzd8mbnsbww6sd0xv7pjvmkkrg-home-manager-generation.drv'
┏━ Dependency Graph:
┃ ┌─ ✔ activation-script
┃ │  ┌─ ✔ helix-languages-config
┃ │  ├─ ✔ home-manager-applications
┃ │  │  ┌─ ✔ home-manager-fonts
┃ │  ├─ ✔ hm_LibraryFonts.homemanagerfontsversion
┃ │  │  ┌─ ✔ helix-wrapped-25.07.1-fish-completions
┃ │  ├─ ✔ seungwon-fish-completions
┃ │  │  ┌─ ✔ home-manager-path ⏱ 3s
┃ │  ├─ ✔ hm_fontconfigconf.d10hmfonts.conf
┃ │  │           ┌─ ✔ marksman-2025-12-13 ⏱ 34s
┃ │  │        ┌─ ✔ helix-wrapped-25.07.1
┃ │  │     ┌─ ✔ man-paths
┃ │  │  ┌─ ✔ man-cache ⏱ 16s
┃ │  ├─ ✔ hm_.manpath
┃ ├─ ✔ home-manager-files ⏱ 2s
┃ ✔ home-manager-generation
┣━━━ Builds
┗━ ∑ ⏵ 0 │ ✔ 25 │ ⏸ 0 │ Finished at 19:17:01 after 1h46m14s
<<< /Users/seungwon/.local/state/nix/profiles/home-manager
>>> /nix/store/jq2da39y7nbxqh0vw38j2b09f3skkrlq-home-manager-generation
```

---

## Things done

- Built on platform:
  - [x] x86_64-linux (dotnet 8, 9, 10)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin (dotnet 9 with marksman)
- Tested, as applicable:
  - [x] Built without substitutes (`--option substitute false`)
  - [x] Tested downstream package (marksman LSP)
- [ ] Ran `nixpkgs-review` on this PR
- [ ] Fits [CONTRIBUTING.md]

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
