### PR TITLE
gerrit: Make use of finalAttrs and add changelog link to meta data

### DIFF
--- a/pkgs/by-name/ge/gerrit/package.nix
+++ b/pkgs/by-name/ge/gerrit/package.nix
@@ -6,18 +6,18 @@
   nixosTests,
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "gerrit";
   version = "3.13.1";
 
   src = fetchurl {
-    url = "https://gerrit-releases.storage.googleapis.com/gerrit-${version}.war";
+    url = "https://gerrit-releases.storage.googleapis.com/gerrit-${finalAttrs.version}.war";
     hash = "sha256-4+Z1q1cHEM5IaG+SAS7JgiCypfjM8W2Zaa25/KGaoqw=";
   };
 
   buildCommand = ''
     mkdir -p "$out"/webapps/
-    ln -s ${src} "$out"/webapps/gerrit-${version}.war
+    ln -s ${finalAttrs.src} "$out"/webapps/gerrit-${finalAttrs.version}.war
   '';
 
   passthru = {
@@ -58,4 +58,4 @@ stdenvNoCC.mkDerivation rec {
     ];
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/by-name/ge/gerrit/package.nix
+++ b/pkgs/by-name/ge/gerrit/package.nix
@@ -50,6 +50,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     homepage = "https://www.gerritcodereview.com/index.md";
     license = lib.licenses.asl20;
     description = "Web based code review and repository management for the git version control system";
+    changelog = "https://www.gerritcodereview.com/${lib.versions.majorMinor finalAttrs.version}.html";
     sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     maintainers = with lib.maintainers; [
       flokli


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
