### PR TITLE
chisel-client: init add chisel-client Service

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -20427,6 +20427,13 @@
     github = "peret";
     githubId = 617977;
   };
+  peritia = {
+     name = "Peritia";
+     github = "Peritia-System";
+     githubId = 199906147;
+     email = "peritia@peritia.space";
+     matrix = "@peritia:matrix.org";
+  };
   perstark = {
     email = "perstark.se@gmail.com";
     github = "perstarkse";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -20428,11 +20428,11 @@
     githubId = 617977;
   };
   peritia = {
-     name = "Peritia";
-     github = "Peritia-System";
-     githubId = 199906147;
-     email = "peritia@peritia.space";
-     matrix = "@peritia:matrix.org";
+    name = "Peritia";
+    github = "Peritia-System";
+    githubId = 199906147;
+    email = "peritia@peritia.space";
+    matrix = "@peritia:matrix.org";
   };
   perstark = {
     email = "perstark.se@gmail.com";

--- a/nixos/modules/services/networking/chisel-client.nix
+++ b/nixos/modules/services/networking/chisel-client.nix
@@ -3,9 +3,11 @@
   lib,
   pkgs,
   ...
-}: let
+}:
+let
   cfg = config.services.chisel-client;
-in {
+in
+{
   options.services.chisel-client = {
     enable = lib.mkEnableOption "Chisel tunnel client";
 
@@ -65,8 +67,11 @@ in {
 
     headers = lib.mkOption {
       type = lib.types.listOf lib.types.str;
-      default = [];
-      example = ["Foo: Bar" "Hello: World"];
+      default = [ ];
+      example = [
+        "Foo: Bar"
+        "Hello: World"
+      ];
       description = "Custom HTTP headers.";
     };
 
@@ -78,7 +83,7 @@ in {
 
     extraArgs = lib.mkOption {
       type = lib.types.listOf lib.types.str;
-      default = [];
+      default = [ ];
       description = "Additional raw command-line arguments.";
     };
   };
@@ -86,8 +91,8 @@ in {
   config = lib.mkIf cfg.enable {
     systemd.services.chisel-client = {
       description = "Chisel Tunnel Client";
-      wantedBy = ["network-online.target"];
-      after = ["network-online.target"];
+      wantedBy = [ "network-online.target" ];
+      after = [ "network-online.target" ];
 
       serviceConfig = {
         ExecStart =
@@ -98,9 +103,9 @@ in {
             ++ lib.optional (cfg.authfile != null) "--authfile ${cfg.authfile}"
             ++ lib.optional (cfg.keepalive != null) "--keepalive ${cfg.keepalive}"
             ++ lib.optional (cfg.proxy != null) "--proxy ${cfg.proxy}"
-            ++ lib.concatMap (h: ["--header ${h}"]) cfg.headers
+            ++ lib.concatMap (h: [ "--header ${h}" ]) cfg.headers
             ++ cfg.extraArgs
-            ++ [cfg.server]
+            ++ [ cfg.server ]
             ++ cfg.remotes
           );
 
@@ -137,5 +142,5 @@ in {
     };
   };
 
-  meta.maintainers = with lib.maintainers; [peritia];
+  meta.maintainers = with lib.maintainers; [ peritia ];
 }

--- a/nixos/modules/services/networking/chisel-client.nix
+++ b/nixos/modules/services/networking/chisel-client.nix
@@ -1,0 +1,141 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  cfg = config.services.chisel-client;
+in {
+  options.services.chisel-client = {
+    enable = lib.mkEnableOption "Chisel tunnel client";
+
+    server = lib.mkOption {
+      type = lib.types.str;
+      example = "https://chisel.example.com:443";
+      description = "Chisel server URL.";
+    };
+
+    remotes = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      example = [
+        "3000"
+        "R:2222:localhost:22"
+        "127.0.0.1:1080:socks"
+      ];
+      description = ''
+        Chisel remote definitions.
+
+        Examples:
+          3000
+          example.com:3000
+          3000:google.com:80
+          R:2222:localhost:22
+          socks
+          R:socks
+          1.1.1.1:53/udp
+      '';
+    };
+
+    fingerprint = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      example = "abcDEF123...=";
+      description = "Server public key fingerprint (strongly recommended). See official Documentation";
+    };
+
+    authfile = lib.mkOption {
+      description = "Path to auth.json file";
+      type = with lib.types; nullOr path;
+      default = null;
+    };
+
+    keepalive = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      example = "25s";
+      description = "Keepalive interval (e.g. 5s, 2m, 0s).";
+    };
+
+    proxy = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      example = "http://user:pass@proxy:8080";
+      description = "HTTP CONNECT or SOCKS5 proxy URL.";
+    };
+
+    headers = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [];
+      example = ["Foo: Bar" "Hello: World"];
+      description = "Custom HTTP headers.";
+    };
+
+    tlsSkipVerify = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Skip TLS certificate verification.";
+    };
+
+    extraArgs = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [];
+      description = "Additional raw command-line arguments.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.chisel-client = {
+      description = "Chisel Tunnel Client";
+      wantedBy = ["network-online.target"];
+      after = ["network-online.target"];
+
+      serviceConfig = {
+        ExecStart =
+          "${pkgs.chisel}/bin/chisel client "
+          + lib.concatStringsSep " " (
+            lib.optional cfg.tlsSkipVerify "--tls-skip-verify"
+            ++ lib.optional (cfg.fingerprint != null) "--fingerprint ${cfg.fingerprint}"
+            ++ lib.optional (cfg.authfile != null) "--authfile ${cfg.authfile}"
+            ++ lib.optional (cfg.keepalive != null) "--keepalive ${cfg.keepalive}"
+            ++ lib.optional (cfg.proxy != null) "--proxy ${cfg.proxy}"
+            ++ lib.concatMap (h: ["--header ${h}"]) cfg.headers
+            ++ cfg.extraArgs
+            ++ [cfg.server]
+            ++ cfg.remotes
+          );
+
+        # Security Hardening
+        # Refer to systemd.exec(5) for option descriptions.
+        CapabilityBoundingSet = "";
+
+        # implies RemoveIPC=, PrivateTmp=, NoNewPrivileges=, RestrictSUIDSGID=,
+        # ProtectSystem=strict, ProtectHome=read-only
+        DynamicUser = true;
+        LockPersonality = true;
+        PrivateDevices = true;
+        PrivateUsers = true;
+        ProcSubset = "pid";
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectProc = "invisible";
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_UNIX"
+        ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = "~@clock @cpu-emulation @debug @mount @obsolete @reboot @swap @privileged @resources";
+        UMask = "0077";
+      };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [peritia];
+}


### PR DESCRIPTION
I have added services.chisel-client inspired by the already existing services.chisel-server. 
It creates a SystemD service running the chisel client.

this is the Hompage of the official documentation: [Github](https://github.com/jpillora/chisel)
this is the already exsisting service for the client:  [Module](https://github.com/NixOS/nixpkgs/blob/nixos-25.11/nixos/modules/services/networking/chisel-server.nix)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ X ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ X ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ X ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
