### PR TITLE
ankiAddons.anki-draw: init at v1.2.2

### DIFF
--- a/pkgs/by-name/an/anki/addons/anki-draw/default.nix
+++ b/pkgs/by-name/an/anki/addons/anki-draw/default.nix
@@ -1,0 +1,24 @@
+{
+  lib,
+  anki-utils,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+anki-utils.buildAnkiAddon (finalAttrs: {
+  pname = "anki-draw";
+  version = "1.2.2";
+  src = fetchFromGitHub {
+    owner = "Rytisgit";
+    repo = "Anki-StylusDraw";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-snLYfujXXRake0QVvEUv5nm9VSFY9CUheX1AdZpISds=";
+  };
+  sourceRoot = "${finalAttrs.src.name}/AnkiDraw";
+  passthru.updateScript = nix-update-script { };
+  meta = {
+    description = "Draw and write using mouse and stylus with pressure support";
+    homepage = "https://github.com/Rytisgit/Anki-StylusDraw";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ euank ];
+  };
+})

--- a/pkgs/by-name/an/anki/addons/default.nix
+++ b/pkgs/by-name/an/anki/addons/default.nix
@@ -8,6 +8,8 @@
 
   anki-connect = callPackage ./anki-connect { };
 
+  anki-draw = callPackage ./anki-draw { };
+
   anki-quizlet-importer-extended = callPackage ./anki-quizlet-importer-extended { };
 
   image-occlusion-enhanced = callPackage ./image-occlusion-enhanced { };


### PR DESCRIPTION
This adds the `anki-draw` addon for anki.

The thing I'm most unsure about is what to name the addon attribute. I observe:

1. The addon on ankiweb is [AnkiDraw](https://ankiweb.net/shared/info/1868980340)
2. The repo name is [Anki-StylusDraw](https://github.com/Rytisgit/Anki-StylusDraw)
3. The [manifest name](https://github.com/Rytisgit/Anki-StylusDraw/blob/dd8c82b670ff3fabec5e1035405b7afa796c38e9/AnkiDraw/manifest.json#L3C12-L3C22) is `AnkiDraw`
4. Other addons are using kebab-case over PascalCase

And that's what led me to 'anki-draw'.

Beyond that, I've verified the AnkiDraw addon, when installed this way, works for my usage (which is to say drawing stuff on my cards while answering).

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
