### PR TITLE
ltfs: init at 2.4.8.3-10521

### DIFF
--- a/pkgs/by-name/lt/ltfs/package.nix
+++ b/pkgs/by-name/lt/ltfs/package.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nix-update-script,
+  autoconf,
+  automake,
+  autoreconfHook,
+  fuse,
+  icu66,
+  libtool,
+  libxml2,
+  libuuid,
+  net-snmp,
+  pkg-config,
+  python3,
+}:
+stdenv.mkDerivation (finalattrs: {
+  pname = "ltfs";
+  version = "2.4.8.3-10521";
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "LinearTapeFileSystem";
+    repo = "ltfs";
+    tag = "v${finalattrs.version}";
+    hash = "sha256-O1BwzUsGtFPqpSZJqmYOVQAdYW7FBr2G61ZBimbrXMo=";
+    fetchSubmodules = true;
+  };
+
+  env.NIX_CFLAGS_COMPILE = "-Wno-error=declaration-after-statement";
+
+  nativeBuildInputs = [
+    autoconf
+    automake
+    autoreconfHook
+    icu66
+    libtool
+    net-snmp
+    pkg-config
+  ];
+
+  buildInputs = [
+    fuse
+    libxml2
+    libuuid
+    (python3.withPackages (ps: with ps; [ xattr ]))
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Reference implementation of the LTFS format Spec for stand alone tape drive";
+    homepage = "https://github.com/LinearTapeFileSystem/ltfs";
+    changelog = "https://github.com/LinearTapeFileSystem/ltfs/releases/tag/v${finalattrs.version}";
+    license = lib.licenses.bsd3;
+    maintainers = [ lib.maintainers.amadejkastelic ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
https://github.com/LinearTapeFileSystem/ltfs

Enables working with LTO drives.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
