### PR TITLE
tsgolint: fix version field, add updateScript, 0.10.1 -> 0.11.0

### DIFF
--- a/pkgs/by-name/ts/tsgolint/package.nix
+++ b/pkgs/by-name/ts/tsgolint/package.nix
@@ -9,13 +9,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "tsgolint";
-  version = "v0.10.1";
+  version = "0.10.1";
 
   src = applyPatches rec {
     src = fetchFromGitHub {
       owner = "oxc-project";
       repo = "tsgolint";
-      tag = finalAttrs.version;
+      tag = "v${finalAttrs.version}";
       hash = "sha256-6cDQjYVNfujIh3s+9pNCfqUEtfdvgx66oZoENqpJ7jE=";
       fetchSubmodules = true;
     };

--- a/pkgs/by-name/ts/tsgolint/package.nix
+++ b/pkgs/by-name/ts/tsgolint/package.nix
@@ -9,13 +9,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "tsgolint";
-  version = "0.10.1";
+  version = "0.11.0";
 
   src = fetchFromGitHub {
     owner = "oxc-project";
     repo = "tsgolint";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-6cDQjYVNfujIh3s+9pNCfqUEtfdvgx66oZoENqpJ7jE=";
+    hash = "sha256-AVyZ/2jjAq9rqLvvzaiZrSYwhGoc/stADvrnh7hCwNk=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/by-name/ts/tsgolint/package.nix
+++ b/pkgs/by-name/ts/tsgolint/package.nix
@@ -3,48 +3,50 @@
   buildGoModule,
   fetchFromGitHub,
   findutils,
-  applyPatches,
   go,
+  nix-update-script,
 }:
 
 buildGoModule (finalAttrs: {
   pname = "tsgolint";
   version = "0.10.1";
 
-  src = applyPatches rec {
-    src = fetchFromGitHub {
-      owner = "oxc-project";
-      repo = "tsgolint";
-      tag = "v${finalAttrs.version}";
-      hash = "sha256-6cDQjYVNfujIh3s+9pNCfqUEtfdvgx66oZoENqpJ7jE=";
-      fetchSubmodules = true;
-    };
-    prePatch = ''
-      cd typescript-go
-    '';
-    # These patches are applied to the typescript-go submodule in justfile's "init" target upstream.
-    patches = [
-      (src + "/patches/0001-Parallel-readDirectory-visitor.patch")
-      (src + "/patches/0002-Adapt-project-service-for-single-run-mode.patch")
-      (src + "/patches/0003-patch-expose-more-functions-via-the-shim-with-type-f.patch")
-      (src + "/patches/0004-feat-improve-panic-message-for-extracting-TS-extensi.patch")
-      (src + "/patches/0005-fix-early-return-from-invalid-tsconfig-for-better-er.patch")
-    ];
-    # We don't want to build with go.work, so we add the replacement to
-    # the local module to the go.mod instead.
-    postPatch = ''
-      cd ..
-      ${lib.getExe go} mod edit --replace=github.com/microsoft/typescript-go=./typescript-go
-    '';
+  src = fetchFromGitHub {
+    owner = "oxc-project";
+    repo = "tsgolint";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-6cDQjYVNfujIh3s+9pNCfqUEtfdvgx66oZoENqpJ7jE=";
+    fetchSubmodules = true;
   };
 
   nativeBuildInputs = [ findutils ];
 
-  # From justfile's "init" target upstream.
-  postPatch = ''
-    rm go.work{,.sum}
-    mkdir -p internal/collections && find ./typescript-go/internal/collections -type f ! -name '*_test.go' -exec cp {} internal/collections/ \;
+  prePatch = ''
+    pushd typescript-go
   '';
+
+  # These patches are applied to the typescript-go submodule in justfile's "init" target upstream.
+  patches = [
+    (finalAttrs.src + "/patches/0001-Parallel-readDirectory-visitor.patch")
+    (finalAttrs.src + "/patches/0002-Adapt-project-service-for-single-run-mode.patch")
+    (finalAttrs.src + "/patches/0003-patch-expose-more-functions-via-the-shim-with-type-f.patch")
+    (finalAttrs.src + "/patches/0004-feat-improve-panic-message-for-extracting-TS-extensi.patch")
+    (finalAttrs.src + "/patches/0005-fix-early-return-from-invalid-tsconfig-for-better-er.patch")
+  ];
+
+  postPatch =
+    # We don't want to build with go.work, so we add the replacement to
+    # the local module to the go.mod instead.
+    ''
+      popd
+      ${lib.getExe go} mod edit --replace=github.com/microsoft/typescript-go=./typescript-go
+    ''
+    +
+    # From justfile's "init" target upstream.
+    ''
+      rm go.work{,.sum}
+      mkdir -p internal/collections && find ./typescript-go/internal/collections -type f ! -name '*_test.go' -exec cp {} internal/collections/ \;
+    '';
 
   proxyVendor = true;
   vendorHash = "sha256-t1qyCdMeA5rh5/9yQ9LAhRO+0nSiMyFHp3sSPOJQWQA=";
@@ -52,6 +54,10 @@ buildGoModule (finalAttrs: {
   subPackages = [ "cmd/tsgolint" ];
 
   env.GOEXPERIMENT = "greenteagc";
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
 
   meta = {
     description = "Type aware linting for oxlint";


### PR DESCRIPTION
Changelog: https://github.com/oxc-project/tsgolint/releases/tag/v0.11.0
Diff: https://github.com/oxc-project/tsgolint/compare/v0.10.1...v0.11.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
