### PR TITLE
{cc,bintools}-wrapper: use executable extension when set

### DIFF
--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -92,6 +92,7 @@ let
   # TODO(@Ericson2314) Make unconditional, or optional but always true by
   # default.
   targetPrefix = optionalString (targetPlatform != hostPlatform) (targetPlatform.config + "-");
+  exeSuffix = stdenvNoCC.hostPlatform.extensions.executable;
 
   bintoolsVersion = getVersion bintools;
   bintoolsName = removePrefix targetPrefix (getName bintools);
@@ -257,17 +258,17 @@ stdenvNoCC.mkDerivation {
   + ''
     for binary in objdump objcopy size strings as ar nm gprof dwp c++filt addr2line \
         ranlib readelf elfedit dlltool dllwrap windmc windres; do
-      if [ -e $ldPath/${targetPrefix}''${binary} ]; then
-        ln -s $ldPath/${targetPrefix}''${binary} $out/bin/${targetPrefix}''${binary}
+      if [ -e $ldPath/${targetPrefix}''${binary}${exeSuffix} ]; then
+        ln -s $ldPath/${targetPrefix}''${binary}${exeSuffix} $out/bin/${targetPrefix}''${binary}${exeSuffix}
       fi
     done
 
-    if [ -e ''${ld:-$ldPath/${targetPrefix}ld} ]; then
-      wrap ${targetPrefix}ld ${./ld-wrapper.sh} ''${ld:-$ldPath/${targetPrefix}ld}
+    if [ -e ''${ld:-$ldPath/${targetPrefix}ld}${exeSuffix} ]; then
+      wrap ${targetPrefix}ld ${./ld-wrapper.sh} ''${ld:-$ldPath/${targetPrefix}ld}${exeSuffix}
     fi
 
-    for variant in $ldPath/${targetPrefix}ld.*; do
-      basename=$(basename "$variant")
+    for variant in $ldPath/${targetPrefix}ld.*${exeSuffix}; do
+      basename=$(basename "${if exeSuffix != "" then "\${variant%${exeSuffix}}" else "$variant"}")
       wrap $basename ${./ld-wrapper.sh} $variant
     done
   '';

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -118,6 +118,7 @@ let
   #
   # TODO(@Ericson2314) Make unconditional, or optional but always true by default.
   targetPrefix = optionalString (targetPlatform != hostPlatform) (targetPlatform.config + "-");
+  exeSuffix = stdenvNoCC.hostPlatform.extensions.executable;
 
   ccVersion = getVersion cc;
   ccName = removePrefix targetPrefix (getName cc);
@@ -524,34 +525,34 @@ stdenvNoCC.mkDerivation {
     export named_cc=${targetPrefix}cc
     export named_cxx=${targetPrefix}c++
 
-    if [ -e $ccPath/${targetPrefix}gcc ]; then
-      wrap ${targetPrefix}gcc $wrapper $ccPath/${targetPrefix}gcc
+    if [ -e $ccPath/${targetPrefix}gcc${exeSuffix} ]; then
+      wrap ${targetPrefix}gcc $wrapper $ccPath/${targetPrefix}gcc${exeSuffix}
       ln -s ${targetPrefix}gcc $out/bin/${targetPrefix}cc
       export named_cc=${targetPrefix}gcc
       export named_cxx=${targetPrefix}g++
-    elif [ -e $ccPath/clang ]; then
-      wrap ${targetPrefix}clang $wrapper $ccPath/clang
+    elif [ -e $ccPath/clang${exeSuffix} ]; then
+      wrap ${targetPrefix}clang $wrapper $ccPath/clang${exeSuffix}
       ln -s ${targetPrefix}clang $out/bin/${targetPrefix}cc
       export named_cc=${targetPrefix}clang
       export named_cxx=${targetPrefix}clang++
-    elif [ -e $ccPath/arocc ]; then
-      wrap ${targetPrefix}arocc $wrapper $ccPath/arocc
+    elif [ -e $ccPath/arocc${exeSuffix} ]; then
+      wrap ${targetPrefix}arocc $wrapper $ccPath/arocc${exeSuffix}
       ln -s ${targetPrefix}arocc $out/bin/${targetPrefix}cc
       export named_cc=${targetPrefix}arocc
     fi
 
-    if [ -e $ccPath/${targetPrefix}g++ ]; then
-      wrap ${targetPrefix}g++ $wrapper $ccPath/${targetPrefix}g++
+    if [ -e $ccPath/${targetPrefix}g++${exeSuffix} ]; then
+      wrap ${targetPrefix}g++ $wrapper $ccPath/${targetPrefix}g++${exeSuffix}
       ln -s ${targetPrefix}g++ $out/bin/${targetPrefix}c++
-    elif [ -e $ccPath/clang++ ]; then
-      wrap ${targetPrefix}clang++ $wrapper $ccPath/clang++
+    elif [ -e $ccPath/clang++${exeSuffix} ]; then
+      wrap ${targetPrefix}clang++ $wrapper $ccPath/clang++${exeSuffix}
       ln -s ${targetPrefix}clang++ $out/bin/${targetPrefix}c++
     fi
 
-    if [ -e $ccPath/${targetPrefix}cpp ]; then
-      wrap ${targetPrefix}cpp $wrapper $ccPath/${targetPrefix}cpp
-    elif [ -e $ccPath/cpp ]; then
-      wrap ${targetPrefix}cpp $wrapper $ccPath/cpp
+    if [ -e $ccPath/${targetPrefix}cpp${exeSuffix} ]; then
+      wrap ${targetPrefix}cpp $wrapper $ccPath/${targetPrefix}cpp${exeSuffix}
+    elif [ -e $ccPath/cpp${exeSuffix} ]; then
+      wrap ${targetPrefix}cpp $wrapper $ccPath/cpp${exeSuffix}
     fi
   ''
 


### PR DESCRIPTION
On windows platforms we want links to executables to have the .exe extension, but wrapper scripts shouldn't.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
