### PR TITLE
moonlight: 1.3.33 -> 1.3.37

### DIFF
--- a/pkgs/by-name/mo/moonlight/disable_updates.patch
+++ b/pkgs/by-name/mo/moonlight/disable_updates.patch
@@ -26,7 +26,7 @@ index 6bb7b62..71b57b9 100644
  
        entries.splice(i + 1, 0, {
 diff --git i/packages/core-extensions/src/moonbase/native.ts w/packages/core-extensions/src/moonbase/native.ts
-index c6e068f..0adc765 100644
+index 51e347c..a6bdc58 100644
 --- i/packages/core-extensions/src/moonbase/native.ts
 +++ w/packages/core-extensions/src/moonbase/native.ts
 @@ -39,24 +39,7 @@ export default function getNatives(): MoonbaseNatives {
@@ -56,13 +56,13 @@ index c6e068f..0adc765 100644
  
      async updateMoonlight(overrideBranch?: MoonlightBranch) {
 diff --git i/packages/core-extensions/src/moonbase/webpackModules/ui/config/index.tsx w/packages/core-extensions/src/moonbase/webpackModules/ui/config/index.tsx
-index 133a98f..9414e7a 100644
+index 49d7fcb..a65b57c 100644
 --- i/packages/core-extensions/src/moonbase/webpackModules/ui/config/index.tsx
 +++ w/packages/core-extensions/src/moonbase/webpackModules/ui/config/index.tsx
-@@ -106,16 +106,6 @@ function ArrayFormItem({ config }: { config: "repositories" | "devSearchPaths" }
+@@ -107,16 +107,6 @@ function ArrayFormItem({ config }: { config: "repositories" | "devSearchPaths" }
  export default function ConfigPage() {
    return (
-     <>
+     <ErrorBoundary>
 -      <div className={Margins.marginTop20}>
 -        <FormSwitch
 -          checked={MoonbaseSettingsStore.getExtensionConfigRaw<boolean>("moonbase", "updateChecking", true) ?? true}

--- a/pkgs/by-name/mo/moonlight/package.nix
+++ b/pkgs/by-name/mo/moonlight/package.nix
@@ -1,10 +1,10 @@
 {
   lib,
   stdenv,
-  pnpm_10,
+  pnpm,
   fetchPnpmDeps,
   pnpmConfigHook,
-  nodejs_22,
+  nodejs,
   fetchFromGitHub,
   nix-update-script,
   discord,
@@ -12,32 +12,27 @@
   discord-canary,
   discord-development,
 }:
-let
-  pnpm' = pnpm_10.override { nodejs = nodejs_22; };
-in
 stdenv.mkDerivation (finalAttrs: {
   pname = "moonlight";
-  version = "1.3.33";
+  version = "1.3.37";
 
   src = fetchFromGitHub {
     owner = "moonlight-mod";
     repo = "moonlight";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-lQpl6ecQfQ7KzEIytH3k4hLtvq+KkTL+3IR2ZukdZWM=";
+    hash = "sha256-4cz1icY7i8RFdh/HhG/y6UzR/zkhsp4+G2dplm4g+wo=";
   };
 
   nativeBuildInputs = [
-    nodejs_22
+    nodejs
     pnpmConfigHook
-    pnpm'
+    pnpm
   ];
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
-    pnpm = pnpm';
-
-    fetcherVersion = 2;
-    hash = "sha256-PRlgwyePFpFdQRcojGDEC4ESZEGTJf1Ad9EFgm8hmKY=";
+    fetcherVersion = 3;
+    hash = "sha256-sU0EBSNwpjqyBsvyJim8Qz90dht7xc6f52HaY0sBPds=";
   };
 
   env = {


### PR DESCRIPTION
supersedes https://github.com/NixOS/nixpkgs/pull/465239

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
