### PR TITLE
shaka-packager: fix GCC15 build

### DIFF
--- a/pkgs/by-name/sh/shaka-packager/package.nix
+++ b/pkgs/by-name/sh/shaka-packager/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  fetchpatch,
   fetchFromGitHub,
   testers,
   cmake,
@@ -46,6 +47,15 @@ stdenv.mkDerivation (finalAttrs: {
     # The last step is necessary to keep the patch size to a minimum, otherwise we'd have
     # to add the namespace identifiers everywhere a dependency is used.
     ./0002-Unvendor-dependencies.patch
+    # GCC15 build fixes
+    # Taken from https://github.com/shaka-project/shaka-packager/pull/1506,
+    # but excludes the changes to the shell script as we do not use it.
+    (fetchpatch {
+      name = "GCC15-cstdint-includes";
+      url = "https://github.com/shaka-project/shaka-packager/commit/b1c79e50521b8725117dfe0a45fe44c2f2dbd4fb.patch";
+      excludes = [ "packager/testing/test_dockers.sh" ];
+      hash = "sha256-8dBQ+eENZKFB9ONjmPBlxy8P/iinyeUS8zhlxz6rnQ4=";
+    })
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
Part of #475479

Requires adding cstdlib includes wherever plain uintN_t types are used


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
