### PR TITLE
gdb: fix build with `hostCpuOnly = true`

### DIFF
--- a/pkgs/by-name/gd/gdb/package.nix
+++ b/pkgs/by-name/gd/gdb/package.nix
@@ -181,7 +181,7 @@ stdenv.mkDerivation (finalAttrs: {
     (withFeatureAs true "auto-load-safe-path" (builtins.concatStringsSep ":" safePaths))
     (withFeature enableDebuginfod "debuginfod")
     (enableFeature (!stdenv.hostPlatform.isMusl) "nls")
-    (enableFeature (!hostCpuOnly) "targets=all")
+    (optional (!hostCpuOnly) "--enable-targets=all")
     (enableFeature (!stdenv.hostPlatform.isStatic) "inprocess-agent")
   ]
   # Workaround for Apple Silicon, "--target" must be "faked", see eg: https://github.com/Homebrew/homebrew-core/pull/209753


### PR DESCRIPTION
- change `--enable-targets=all` flag from `enableFeature`
back to `optional` string.

Current `enableFeature` flag with `hostCpuOnly = true` changes to
incorrect `--disable-targets=all` and build fails in `configurePhase`

Related to `gdb` refactor where flag changed to `enableFeature`:
https://github.com/NixOS/nixpkgs/commit/51d5cc87917458313c05c965e1c0520cfaf721a1

Fixes build failure of `gdbHostCpuOnly`:
```
configure flags:
--prefix=/nix/store/iwqsff7npq7pxw9nhzcmlr3qzv6fkx4s-gdb-host-cpu-only-17.1
--program-prefix= --enable-werror --enable-64-bit-bfd
--disable-install-libbfd --enable-tui --with-curses --disable-shared
--enable-static --with-system-readline --with-system-zlib --with-expat
--with-libexpat-prefix=/nix/store/6vwhdd1hzqdx5v1z1p5g5n8z5ljvna6f-expat-2.7.3-dev
--with-gmp=/nix/store/fy6kfb982l4aalzlj00fzdmy1i481pjj-gmp-with-cxx-6.3.0-dev
--with-mpfr=/nix/store/g3p48clv29ck5mmhj5qkq6f5yww3kfb6-mpfr-4.2.2-dev
--with-python --without-guile --disable-sim --disable-ubsan
--with-system-gdbinit=/etc/gdb/gdbinit
--with-system-gdbinit-dir=/etc/gdb/gdbinit.d
--with-auto-load-safe-path=\$debugdir:\$datadir/auto-load:/nix/store/j2kgllgds4w7na8zqv1msi0mpvpjxda8-gcc-15.2.0-lib
--with-debuginfod --enable-nls --disable-targets=all
--enable-inprocess-agent --build=x86_64-unknown-linux-gnu
--host=x86_64-unknown-linux-gnu --target=x86_64-unknown-linux-gnu
configure: error: invalid feature name: targets=all
```

---

Refactor PR that changed it to `enableFeature`: #470156

Build on hydra for current `staging-next` (#479279) - "Scheduled to be built" at the moment:
https://hydra.nixos.org/build/318955003

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
