### PR TITLE
python3Packages.tensorflow: avoid deprecated override of pybind11

### DIFF
--- a/pkgs/development/python-modules/tensorflow/default.nix
+++ b/pkgs/development/python-modules/tensorflow/default.nix
@@ -330,8 +330,10 @@ let
       jsoncpp
       libjpeg_turbo
       libpng
-      (pybind11.overridePythonAttrs (_: {
-        inherit stdenv;
+      (pybind11.override (prev: {
+        buildPythonPackage = prev.buildPythonPackage.override {
+          inherit stdenv;
+        };
       }))
       snappy-cpp
       sqlite


### PR DESCRIPTION
This change is necessary after #476384 to avoid the warning shown below.

```shellsession
$ NIXPKGS_ALLOW_BROKEN=1 nix eval --impure --experimental-features 'nix-command flakes' github:NixOS/nixpkgs/110493e24696e74e793ce4da869b44c0581197ec#libtensorflow
evaluation warning: pybind11: Passing `stdenv` directly to `buildPythonPackage` or `buildPythonApplication` is deprecated. You should use their `.override` function instead, e.g:
                      buildPythonPackage.override { stdenv = customStdenv; } { }
«derivation /nix/store/fhf64r49xvf00rx30mw3sy5jnj0fg7z9-tensorflow-2.13.0.drv»
$ NIXPKGS_ALLOW_BROKEN=1 nix eval --impure --experimental-features 'nix-command flakes' github:NixOS/nixpkgs/4d8ab9da2b93d936961827440656b384689d8d80#libtensorflow
«derivation /nix/store/fhf64r49xvf00rx30mw3sy5jnj0fg7z9-tensorflow-2.13.0.drv»
```

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc