### PR TITLE
jetbrains.jdk: fix fallback to default X11 cursor

### DIFF
--- a/pkgs/development/compilers/jetbrains-jdk/17.nix
+++ b/pkgs/development/compilers/jetbrains-jdk/17.nix
@@ -60,7 +60,7 @@ openjdk17.overrideAttrs (oldAttrs: rec {
     hash = "sha256-Ckv2SNugHK75Af+ZzI91+QodOHIa5TMcjVQYsO45mQo=";
   };
 
-  env = {
+  env = (oldAttrs.env or { }) // {
     BOOT_JDK = openjdk17-bootstrap.home;
     # run `git log -1 --pretty=%ct` in jdk repo for new value on update
     SOURCE_DATE_EPOCH = 1745907200;

--- a/pkgs/development/compilers/jetbrains-jdk/default.nix
+++ b/pkgs/development/compilers/jetbrains-jdk/default.nix
@@ -62,7 +62,7 @@ jdk.overrideAttrs (oldAttrs: rec {
     hash = "sha256-P2boCbGB66X8LB4sZHGFO8lqHbv6F4kqGVMGBd9yKu0=";
   };
 
-  env = {
+  env = (oldAttrs.env or { }) // {
     BOOT_JDK = jdk.home;
     # run `git log -1 --pretty=%ct` in jdk repo for new value on update
     SOURCE_DATE_EPOCH = 1765114563;


### PR DESCRIPTION
The cursor theme in all JetBrains products on X11 has been broken since the `__structuredAttrs` changes were introduced (see https://github.com/NixOS/nixpkgs/pull/425529#issuecomment-3081334246):

<img width="602" height="246" alt="Screenshot_20260113_172030-1" src="https://github.com/user-attachments/assets/10e10a43-e5c0-4f06-bc57-1fab276cd2db" />

The root cause seems to be a complete `env` override of the original JDK package. These changes fix the cursor theme in both PyCharm and CLion for me.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
