### PR TITLE
dms-shell: 1.0.3 -> 1.2.0

### DIFF
--- a/nixos/modules/programs/wayland/dms-shell.nix
+++ b/nixos/modules/programs/wayland/dms-shell.nix
@@ -30,17 +30,14 @@ let
 
   optionalPackages =
     optionals cfg.enableSystemMonitoring [ pkgs.dgop ]
-    ++ optionals cfg.enableClipboard [
-      pkgs.cliphist
-      pkgs.wl-clipboard
-    ]
     ++ optionals cfg.enableVPN [
       pkgs.glib
       pkgs.networkmanager
     ]
     ++ optional cfg.enableDynamicTheming pkgs.matugen
     ++ optional cfg.enableAudioWavelength pkgs.cava
-    ++ optional cfg.enableCalendarEvents pkgs.khal;
+    ++ optional cfg.enableCalendarEvents pkgs.khal
+    ++ optional cfg.enableClipboardPaste pkgs.wtype;
 in
 {
   imports = [
@@ -49,6 +46,7 @@ in
     (lib.mkRemovedOptionModule (
       path ++ [ "enableSystemSound" ]
     ) "qtmultimedia is now included on dms-shell package.")
+    (lib.mkRemovedOptionModule (path ++ [ "enableClipboard" ]) builtInRemovedMsg)
   ];
 
   options.programs.dms-shell = {
@@ -99,17 +97,6 @@ in
       '';
     };
 
-    enableClipboard = mkOption {
-      type = types.bool;
-      default = true;
-      description = ''
-        Whether to install dependencies required for clipboard management widgets.
-        This enables clipboard history and clipboard manager functionality.
-
-        Requires: cliphist, wl-clipboard
-      '';
-    };
-
     enableVPN = mkOption {
       type = types.bool;
       default = true;
@@ -151,6 +138,17 @@ in
         This enables calendar widgets that display events and reminders via khal.
 
         Requires: khal
+      '';
+    };
+
+    enableClipboardPaste = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Whether to install dependencies required for pasting directly from the clipboard history support.
+        This enables pressing Shift+Return for pasting entries from the clipboard history.
+
+        Requires: wtype
       '';
     };
 

--- a/pkgs/by-name/dm/dms-shell/package.nix
+++ b/pkgs/by-name/dm/dms-shell/package.nix
@@ -26,18 +26,18 @@ buildGoModule (
   in
   {
     pname = "dms-shell";
-    version = "1.0.3";
+    version = "1.2.0";
 
     src = fetchFromGitHub {
       owner = "AvengeMedia";
       repo = "DankMaterialShell";
       tag = "v${finalAttrs.version}";
-      hash = "sha256-IT21E2XX83IlO6/dW0YmUdY2JW//+ZBHLqpKPGd6tx8=";
+      hash = "sha256-LNKeqhYWpx688ytSW//H+kdaupWf0pStPhfFLxAFV8k=";
     };
 
     sourceRoot = "${finalAttrs.src.name}/core";
 
-    vendorHash = "sha256-2PCqiW4frxME8IlmwWH5ktznhd/G1bah5Ae4dp0HPTQ=";
+    vendorHash = "sha256-9CnZFtjXXWYELRiBX2UbZvWopnl9Y1ILuK+xP6YQZ9U=";
 
     ldflags = [
       "-s"


### PR DESCRIPTION
## Things done

Updated package dms-shell to [v1.2.0](https://github.com/AvengeMedia/DankMaterialShell/releases/tag/v1.2.0). Also updated its module to match upstream changes.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
