### PR TITLE
nixos/sshd: fix sshd.conf check referencing package's extra outputs

### DIFF
--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -847,7 +847,7 @@ in
       system.checks = [
         (pkgs.runCommand "check-sshd-config"
           {
-            nativeBuildInputs = [ validationPackage ];
+            nativeBuildInputs = [ validationPackage.out ];
           }
           ''
             ${lib.concatMapStringsSep "\n" (


### PR DESCRIPTION
The check derivation only needs the `sshd` binary (which is in the regular `out` output) and has no need for the validationPackage's other outputs that contain header files and man pages.

But when the validationPackage is added to the check derivation's nativeBuildInputs, the latter references all outputs of the former, or it at least requires the `dev` output to be present at build time.

This means that these outputs always need to present when rebuilding the system, even when making changes completely unrelated to SSH.

Because the derivations in `system.checks` are only a build time dependency of the system derivation but are not added to the system's runtime closure, and a NixOS configuration otherwise only references its ssh package's `out` output; the other outputs required at build time may be garbage-collected from the system at any time [^1][^2].

In the best-case scenario, this only results in the download of unnecessary store paths from a binary cache.

Other scenarios present larger issues:
- when using a custom package, the entire derivation has to be rebuild (recompilation) just to get the dev output back
  - even when the custom package or the system derivation containing it is stored on a binary cache, it won't have the output unless build time dependencies are pushed to it as well [^3].
- when there's no binary cache available (e.g. no internet connection), it might be impossible to rebuild the derivation because of other missing build time dependencies
  - again, the changes triggering a new NixOS build can be unrelated to SSH and might in themselves not requrie fetching any new store paths (e.g. updating a simple config file)

[^1]: Unless `keep-outputs = true` is set in nix.conf, but that is a
      non-default setting and affects the garbage-collection of other
      paths as well
[^2]: There's also the case that the validationPackage is a different
      package than the system's SSH package due to cross-compilation,
      in which case this fix wouldn't do much because even the `out`
      output is not part of the system closure.
[^3]: Users would have to know about it, but it's probably not desirable
      in most cases


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
