### PR TITLE
openssh: compile and install contrib GTK3 askpass

### DIFF
--- a/pkgs/tools/networking/openssh/common.nix
+++ b/pkgs/tools/networking/openssh/common.nix
@@ -46,6 +46,7 @@
   withLinuxMemlock ? (stdenv.hostPlatform.isLinux && !withPAM),
   linkOpenssl ? true,
   isNixos ? stdenv.hostPlatform.isLinux,
+  gtk3,
 }:
 
 # libaudit support requires Linux
@@ -124,6 +125,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     zlib
     libedit
+    gtk3
   ]
   ++ [ (if linkOpenssl then openssl else libxcrypt) ]
   ++ lib.optional withFIDO libfido2
@@ -247,6 +249,9 @@ stdenv.mkDerivation (finalAttrs: {
         --replace-fail /usr/local/lib/softhsm/libsofthsm2.so ${lib.getLib softhsm}/lib/softhsm/libsofthsm2.so
     ''
   );
+  postBuild = ''
+    make -C contrib gnome-ssh-askpass3
+  '';
   # integration tests hard to get working on darwin with its shaky
   # sandbox
   # t-exec tests fail on musl
@@ -263,6 +268,8 @@ stdenv.mkDerivation (finalAttrs: {
     ];
 
   postInstall = ''
+    mkdir -p $out/libexec
+    cp -a contrib/gnome-ssh-askpass3 $out/libexec/gtk-ssh-askpass
     # Install ssh-copy-id, it's very useful.
     cp contrib/ssh-copy-id $out/bin/
     chmod +x $out/bin/ssh-copy-id


### PR DESCRIPTION
initially done as a separate package on https://github.com/NixOS/nixpkgs/pull/478773

main reasoning for the change is:

1. it uses the official openssh (contrib) sources;
2. the package uses the contrib `ssh-copy-id` too;
3. doesn't rely on 3rd-party github projects;
4. looks more modern than the likes of x11_ssh_askpass;
5. other distros such as alpine provide it as well

still in the process of learning so not sure if this is the right approach of tackling this, but works in my box
