### PR TITLE
tmuxPlugins.tmux-powerkit: init at 5.12.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6903,6 +6903,12 @@
     githubId = 131907205;
     name = "David Thievon";
   };
+  dokkodo = {
+    email = "dokkodo1@proton.me";
+    github = "dokkodo1";
+    githubId = 89461793;
+    name = "Callum McDonald";
+  };
   dolphindalt = {
     email = "dolphindalt@gmail.com";
     github = "dolphindalt";

--- a/pkgs/misc/tmux-plugins/default.nix
+++ b/pkgs/misc/tmux-plugins/default.nix
@@ -1183,6 +1183,30 @@ in
     };
   };
 
+  tmux-powerkit = mkTmuxPlugin rec {
+    pluginName = "tmux-powerkit";
+    rtpFilePath = "tmux-powerkit.tmux";
+    version = "5.12.0";
+    src = fetchFromGitHub {
+      owner = "fabioluciano";
+      repo = "tmux-powerkit";
+      tag = "v${version}";
+      hash = "sha256-RIgU4200z8wJNXfxHKbkfrn5MuG1KpxNwlBvXrrtL5s=";
+    };
+    meta = {
+      homepage = "https://github.com/fabioluciano/tmux-powerkit";
+      description = "The Ultimate tmux Status Bar Framework";
+      longDescription = ''
+        A comprehensive status bar framework for tmux with 42 production-ready plugins,
+        37 themes with 61 variants, and 9 separator styles. Features smart caching
+        with Stale-While-Revalidate lazy loading.
+      '';
+      license = lib.licenses.mit;
+      platforms = lib.platforms.unix;
+      maintainers = with lib.maintainers; [ dokkodo ];
+    };
+  };
+
   tmux-toggle-popup = mkTmuxPlugin rec {
     pluginName = "tmux-toggle-popup";
     rtpFilePath = "toggle-popup.tmux";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
### Motivation

Adding tmux-powerkit, a comprehensive tmux status bar framework
https://github.com/fabioluciano/tmux-powerkit
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ x ] x86_64-linux
  - [ ] aarch64-linux
  - [ x ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ x ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ x ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
