### PR TITLE
ocaml: Enable tests for the ocaml compilers

### DIFF
--- a/pkgs/development/compilers/ocaml/4.09.nix
+++ b/pkgs/development/compilers/ocaml/4.09.nix
@@ -7,6 +7,9 @@ import ./generic.nix {
   # Breaks build with Clang
   hardeningDisable = [ "strictoverflow" ];
 
+  # Tests do not seem to run on this old version
+  doCheck = false;
+
   patches = [
     ./4.09.1-Werror.patch
     # Compatibility with Glibc 2.34

--- a/pkgs/development/compilers/ocaml/4.10.nix
+++ b/pkgs/development/compilers/ocaml/4.10.nix
@@ -3,6 +3,10 @@ import ./generic.nix {
   minor_version = "10";
   patch_version = "2";
   sha256 = "sha256-locUYQeCgtXbAiB32JveJchfteN2YStE+MN9ToTwAOM=";
+
+  # Tests do not seem to run on this old version
+  doCheck = false;
+
   patches = [
     ./glibc-2.34-for-ocaml-4.10-and-11.patch
   ];

--- a/pkgs/development/compilers/ocaml/generic.nix
+++ b/pkgs/development/compilers/ocaml/generic.nix
@@ -3,6 +3,7 @@
   major_version,
   patch_version,
   patches ? [ ],
+  doCheck ? true,
   ...
 }@args:
 let
@@ -83,6 +84,7 @@ let
 in
 
 stdenv.mkDerivation (
+  finalArgs:
   args
   // {
 
@@ -115,7 +117,9 @@ stdenv.mkDerivation (
         "-host ${stdenv.hostPlatform.config}"
         "-target ${stdenv.targetPlatform.config}"
       ]
-      ++ optional noNakedPointers (flags "--disable-naked-pointers" "-no-naked-pointers");
+      ++ optional noNakedPointers (flags "--disable-naked-pointers" "-no-naked-pointers")
+      ++ optional finalArgs.doCheck "--enable-ocamltest";
+
     dontAddStaticConfigureFlags = lib.versionOlder version "4.08";
 
     env =
@@ -194,6 +198,9 @@ stdenv.mkDerivation (
     passthru = {
       nativeCompilers = useNativeCompilers;
     };
+
+    checkTarget = "tests";
+    inherit doCheck;
 
     meta = {
       homepage = "https://ocaml.org/";

--- a/pkgs/development/compilers/ocaml/generic.nix
+++ b/pkgs/development/compilers/ocaml/generic.nix
@@ -204,6 +204,8 @@ stdenv.mkDerivation (
       ];
       description = "OCaml is an industrial-strength programming language supporting functional, imperative and object-oriented styles";
 
+      maintainers = [ lib.maintainers.georgyo ];
+
       longDescription = ''
         OCaml is a general purpose programming language with an emphasis on expressiveness and safety. Developed for more than 20 years at Inria by a group of leading researchers, it has an advanced type system that helps catch your mistakes without getting in your way. It's used in environments where a single mistake can cost millions and speed matters, is supported by an active community, and has a rich set of libraries and development tools. It's widely used in teaching for its power and simplicity.
 


### PR DESCRIPTION
The ocaml compiler was not running its test suite. There really isn't a good reason why it shouldn't, so now it does by default.

Also it seems that the ocaml compilers also didn't have any maintainers at all, so I've added myself to them. 

## Things done

There are a lot of versions of the ocaml compiler, I only tested 4.14, 5.3, and 5.4. But the tests run smoothly on all of those. I also built the following, which builds ~80 ocaml libraries each on both x86_64 and aarch64 linux:
 - ocaml-ng.ocamlPackages_4_14.core
 - ocaml-ng.ocamlPackages_5_3.core (5.3 is the current default for ocamlPackages)
 - ocaml-ng.ocamlPackages_5_4.core

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
