### PR TITLE
sabnzbd: bump version threshold for allowConfigWrite flag

### DIFF
--- a/nixos/modules/services/networking/sabnzbd/default.nix
+++ b/nixos/modules/services/networking/sabnzbd/default.nix
@@ -171,7 +171,7 @@ in
           a writeable configuration, such as quota tracking, enable
           this option.
         '';
-        default = lib.versionOlder config.system.stateVersion "25.11";
+        default = lib.versionOlder config.system.stateVersion "26.05";
       };
 
       settings = mkOption {


### PR DESCRIPTION
This was originally written with the goal of getting it merged in time for 25.11. Since it'll now only hit stable with 26.05, this should be bumped

