### PR TITLE
[staging-next] qt6.qtdeclarative: backport another common Plasma crash fix

### DIFF
--- a/pkgs/development/libraries/qt-6/modules/qtdeclarative/another-crash-fix.patch
+++ b/pkgs/development/libraries/qt-6/modules/qtdeclarative/another-crash-fix.patch
@@ -1,0 +1,16 @@
+--- a/src/qml/jsruntime/qv4qobjectwrapper.cpp
++++ b/src/qml/jsruntime/qv4qobjectwrapper.cpp
+@@ -1583,10 +1583,9 @@
+                     o->deleteLater();
+             } else {
+                 // If the object is C++-owned, we still have to release the weak reference we have
+-                // to it.
+-                ddata->jsWrapper.clear();
+-                if (lastCall && ddata->propertyCache)
+-                    ddata->propertyCache.reset();
++                // to it. If the "main" wrapper is not ours, we should leave it alone, though.
++                if (ddata->jsWrapper.as<QObjectWrapper>() == this)
++                    ddata->jsWrapper.clear();
+             }
+         }
+     }

--- a/pkgs/development/libraries/qt-6/modules/qtdeclarative/default.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtdeclarative/default.nix
@@ -44,6 +44,11 @@ qtModule {
       hash = "sha256-KMFurA9Q84qwuyBraU3ZdoFWs8uO3uoUcinfcfh/ps8=";
     })
 
+    # Backport of https://codereview.qt-project.org/c/qt/qtdeclarative/+/704031
+    # Fixes common Plasma crash
+    # FIXME: remove in 6.10.3
+    ./another-crash-fix.patch
+
     # https://qt-project.atlassian.net/browse/QTBUG-137440
     (fetchpatch {
       name = "rb-dialogs-link-labsfolderlistmodel-into-quickdialogs2quickimpl.patch";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
