### PR TITLE
emoji-runner: init at 3.0.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13965,6 +13965,13 @@
     github = "kkoniuszy";
     githubId = 120419423;
   };
+  Kladki = {
+    name = "Matthias Ahouansou";
+    email = "matthias@ahouansou.cz";
+    github = "Kladki";
+    githubId = 158313939;
+    matrix = "@matthias:ahouansou.cz";
+  };
   klchen0112 = {
     name = "klchen0112";
     email = "klchen0112@gmail.com";

--- a/pkgs/by-name/em/emoji-runner/package.nix
+++ b/pkgs/by-name/em/emoji-runner/package.nix
@@ -1,0 +1,56 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  cmake,
+  kdePackages,
+  nix-update-script,
+  gettext,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "emoji-runner";
+  version = "3.0.5";
+
+  src = fetchFromGitHub {
+    owner = "alex1701c";
+    repo = "EmojiRunner";
+    tag = finalAttrs.version;
+    hash = "sha256-Rt7Z0uEbzqRKxV1EpDr//RYaVr3D+Nj+7JS3EAO+hsM=";
+  };
+
+  dontWrapQtApps = true;
+
+  buildInputs = with kdePackages; [
+    ki18n
+    kservice
+    krunner
+    ktextwidgets
+    kcmutils
+    kconfigwidgets
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    gettext
+    kdePackages.extra-cmake-modules
+  ];
+
+  strictDeps = true;
+
+  cmakeFlags = [
+    "-DBUILD_TESTING=OFF"
+    "-DBUILD_WITH_QT6=ON"
+    "-DQT_MAJOR_VERSION=6"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    changelog = "https://github.com/alex1701c/EmojiRunner/releases/tag/${finalAttrs.version}";
+    description = "Search for emojis in Krunner and copy/paste them";
+    homepage = "https://github.com/alex1701c/EmojiRunner";
+    license = lib.licenses.lgpl3Only;
+    maintainers = with lib.maintainers; [ Kladki ];
+    inherit (kdePackages.krunner.meta) platforms;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
