### PR TITLE
llm.tests: fix the eval

### DIFF
--- a/pkgs/development/python-modules/llm/default.nix
+++ b/pkgs/development/python-modules/llm/default.nix
@@ -259,7 +259,7 @@ let
       };
 
       # include tests for all the plugins
-      tests = lib.mergeAttrsList (map (name: python.pkgs.${name}.tests) withPluginsArgNames);
+      tests = lib.mergeAttrsList (map (name: python.pkgs.${name}.tests or { }) withPluginsArgNames);
     };
 
     meta = {


### PR DESCRIPTION
Without the change `llm.tests` fails the eval on `master` as:

    $ nix build --no-link -f. llm.tests
    error:
       … in the right operand of the update (//) operator
         at lib/attrsets.nix:1619:60:
         1618|           # The invariant is satisfied because each half will have at least 1 element
         1619|           binaryMerge start (start + (end - start) / 2) // binaryMerge (start + (end - start) / 2) end
             |                                                            ^
         1620|         else

       … in the left operand of the update (//) operator
         at lib/attrsets.nix:1619:11:
         1618|           # The invariant is satisfied because each half will have at least 1 element
         1619|           binaryMerge start (start + (end - start) / 2) // binaryMerge (start + (end - start) / 2) end
             |           ^
         1620|         else

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: attribute 'tests' missing
       at pkgs/development/python-modules/llm/default.nix:262:46:
          261|       # include tests for all the plugins
          262|       tests = lib.mergeAttrsList (map (name: python.pkgs.${name}.tests) withPluginsArgNames);
             |                                              ^
          263|     };

It happens because `python.pkgs.llm-lmstudio.tests` attribute does not exist. THe change adds a fallback for packages without tests attributes.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
