### PR TITLE
claude-code-router: use `nodejs` instead of `nodejs_20`

### DIFF
--- a/pkgs/by-name/cl/claude-code-router/package.nix
+++ b/pkgs/by-name/cl/claude-code-router/package.nix
@@ -3,18 +3,14 @@
   fetchFromGitHub,
   lib,
   makeBinaryWrapper,
-  nodejs_20,
-  pnpm_10,
+  nodejs,
+  pnpm,
   fetchPnpmDeps,
   pnpmConfigHook,
   versionCheckHook,
 }:
-let
-  nodejs = nodejs_20;
-  buildNpmPackage' = buildNpmPackage.override { inherit nodejs; };
-  pnpm' = pnpm_10.override { inherit nodejs; };
-in
-buildNpmPackage' (finalAttrs: {
+
+buildNpmPackage (finalAttrs: {
   pname = "claude-code-router";
   version = "2.0.0";
 
@@ -32,15 +28,15 @@ buildNpmPackage' (finalAttrs: {
 
   npmDeps = null;
   pnpmDeps = fetchPnpmDeps {
+    inherit pnpm;
     inherit (finalAttrs) pname src;
-    pnpm = pnpm';
     fetcherVersion = 3;
     hash = "sha256-8184F3ShoC6j7nov35CSZWz2dzPFQC7Bty1iTNs1qzc=";
   };
 
   nativeBuildInputs = [
     makeBinaryWrapper
-    pnpm'
+    pnpm
   ];
 
   npmConfigHook = pnpmConfigHook;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
