### PR TITLE
nixosTests.nixos-rebuild-install-bootloader: handleTest -> runTest

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1095,9 +1095,9 @@ in
   };
   nixops = handleTest ./nixops/default.nix { };
   nixos-generate-config = runTest ./nixos-generate-config.nix;
-  nixos-rebuild-install-bootloader = handleTestOn [
+  nixos-rebuild-install-bootloader = runTestOn [
     "x86_64-linux"
-  ] ./nixos-rebuild-install-bootloader.nix { };
+  ] ./nixos-rebuild-install-bootloader.nix;
   nixos-rebuild-specialisations = runTestOn [ "x86_64-linux" ] {
     imports = [ ./nixos-rebuild-specialisations.nix ];
   };

--- a/nixos/tests/nixos-rebuild-install-bootloader.nix
+++ b/nixos/tests/nixos-rebuild-install-bootloader.nix
@@ -1,81 +1,79 @@
-import ./make-test-python.nix (
-  { pkgs, lib, ... }:
-  {
-    name = "nixos-rebuild-install-bootloader";
+{ hostPkgs, ... }:
+{
+  name = "nixos-rebuild-install-bootloader";
 
-    nodes = {
-      machine =
-        { lib, pkgs, ... }:
-        {
-          imports = [
-            ../modules/profiles/installation-device.nix
-            ../modules/profiles/base.nix
-          ];
+  nodes.machine =
+    { lib, ... }:
+    {
+      imports = [
+        ../modules/profiles/installation-device.nix
+        ../modules/profiles/base.nix
+      ];
 
-          nix.settings = {
-            substituters = lib.mkForce [ ];
-            hashed-mirrors = null;
-            connect-timeout = 1;
-          };
+      nix.settings = {
+        substituters = lib.mkForce [ ];
+        hashed-mirrors = null;
+        connect-timeout = 1;
+      };
 
-          system.includeBuildDependencies = true;
+      # nixos/modules/misc/nixpkgs/read-only.nix
+      nixpkgs.overlays = lib.mkForce [ ];
 
-          virtualisation = {
-            cores = 2;
-            memorySize = 2048;
-          };
+      system.includeBuildDependencies = true;
 
-          virtualisation.useBootLoader = true;
-        };
+      virtualisation = {
+        cores = 2;
+        memorySize = 2048;
+      };
+
+      virtualisation.useBootLoader = true;
     };
 
-    testScript =
-      let
-        configFile =
-          pkgs.writeText "configuration.nix" # nix
-            ''
-              { lib, pkgs, ... }: {
-                imports = [
-                  ./hardware-configuration.nix
-                  <nixpkgs/nixos/modules/testing/test-instrumentation.nix>
-                ];
+  testScript =
+    let
+      configFile =
+        hostPkgs.writeText "configuration.nix" # nix
+          ''
+            { lib, pkgs, ... }: {
+              imports = [
+                ./hardware-configuration.nix
+                <nixpkgs/nixos/modules/testing/test-instrumentation.nix>
+              ];
 
-                boot.loader.grub = {
-                  enable = true;
-                  device = "/dev/vda";
-                  forceInstall = true;
-                };
+              boot.loader.grub = {
+                enable = true;
+                device = "/dev/vda";
+                forceInstall = true;
+              };
 
-                documentation.enable = false;
-              }
-            '';
+              documentation.enable = false;
+            }
+          '';
+    in
+    # python
+    ''
+      machine.start()
+      machine.succeed("udevadm settle")
+      machine.wait_for_unit("multi-user.target")
 
-      in
-      # python
-      ''
-        machine.start()
-        machine.succeed("udevadm settle")
-        machine.wait_for_unit("multi-user.target")
+      machine.succeed("nixos-generate-config")
+      machine.copy_from_host(
+          "${configFile}",
+          "/etc/nixos/configuration.nix",
+      )
+      machine.succeed("nixos-rebuild switch")
 
-        machine.succeed("nixos-generate-config")
-        machine.copy_from_host(
-            "${configFile}",
-            "/etc/nixos/configuration.nix",
-        )
-        machine.succeed("nixos-rebuild switch")
-
-        # Need to run `nixos-rebuild` twice because the first run will install
-        # GRUB anyway
-        with subtest("Switch system again and install bootloader"):
-            result = machine.succeed("nixos-rebuild switch --install-bootloader 2>&1")
-            # install-grub2.pl messages
-            assert "updating GRUB 2 menu..." in result
-            assert "installing the GRUB 2 boot loader on /dev/vda..." in result
-            # GRUB message
-            assert "Installation finished. No error reported." in result
-            # at this point we've tested regression #262724, but haven't tested the bootloader itself
-            # TODO: figure out how to how to tell the test driver to start the bootloader instead of
-            # booting into the kernel directly.
-      '';
-  }
-)
+      # Need to run `nixos-rebuild` twice because the first run will install
+      # GRUB anyway
+      with subtest("Switch system again and install bootloader"):
+          result = machine.succeed("nixos-rebuild switch --install-bootloader 2>&1")
+          # install-grub2.pl messages
+          assert "updating GRUB 2 menu..." in result
+          assert "installing the GRUB 2 boot loader on /dev/vda..." in result
+          # GRUB message
+          assert "Installation finished. No error reported." in result
+          # at this point we've tested regression #262724, but haven't tested the bootloader itself
+          # TODO: figure out how to how to tell the test driver to start the bootloader instead of
+          # booting into the kernel directly.
+    '';
+}


### PR DESCRIPTION
Related to #386873.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
