### PR TITLE
 aalib: Allow shared library creation on POWER Linux

### DIFF
--- a/pkgs/by-name/aa/aalib/package.nix
+++ b/pkgs/by-name/aa/aalib/package.nix
@@ -31,7 +31,6 @@ stdenv.mkDerivation rec {
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [ ./darwin.patch ];
 
-  # The fuloong2f is not supported by aalib still
   preConfigure =
     # The configure script does the correct thing when 'system' is already set
     # Export it explicitly in case __structuredAttrs is true.

--- a/pkgs/by-name/aa/aalib/package.nix
+++ b/pkgs/by-name/aa/aalib/package.nix
@@ -32,15 +32,24 @@ stdenv.mkDerivation rec {
   ++ lib.optionals stdenv.hostPlatform.isDarwin [ ./darwin.patch ];
 
   # The fuloong2f is not supported by aalib still
-  preConfigure = ''
+  preConfigure =
     # The configure script does the correct thing when 'system' is already set
     # Export it explicitly in case __structuredAttrs is true.
-    export system
-    appendToVar configureFlags \
-      "--bindir=$bin/bin" \
-      "--includedir=$dev/include" \
-      "--libdir=$out/lib"
-  '';
+    ''
+      export system
+      appendToVar configureFlags \
+        "--bindir=$bin/bin" \
+        "--includedir=$dev/include" \
+        "--libdir=$out/lib"
+    ''
+    # There is a check for linux-gnu on POWER that disables shared library creation if /lib/ld.so.1 doesn't exists
+    # (which it never does for us), because it assumes that it is then running on / targeting MkLinux, which supposedly
+    # didn't support shared libraries.
+    # MkLinux is discontinued, regular Linux supports POWER now. Delete the case and allow shared libraries to be made.
+    + ''
+      substituteInPlace ltconfig \
+        --replace-fail 'powerpc*) dynamic_linker=no ;;' ""
+    '';
 
   buildInputs = [ ncurses ];
 


### PR DESCRIPTION
There is code here that checks on `linux-gnu` targets if `/lib/ld.so.1` exists. If it doesn't (always the case for us), it checks what the host CPU is. If it's anything POWER, it thinks that it's targeting MkLinux and disables shared library creation, otherwise it assumes there's a Linux-y ld.so.

*What is MkLinux, you ask?*

![dpenguin](https://mklinux.org/graphics/dpenguin.gif)

https://mklinux.org/
https://en.wikipedia.org/wiki/MkLinux

A joint effort between the Open Source Foundation and Apple Computer from 1995 to ~2002 to bring Linux to Power Machintoshes, by running the Linux kernel in userspace below the Mach microkernel.

![dpenguin](https://mklinux.org/graphics/dpenguin.gif)

…*nothing that's relevant to us*. A relic of a different time in computing. Shared libraries obviously function on normal Linux.

On the other side: Static-only aalib causes `gst_all_1.gst-plugins-good` to fail because it only finds a static aalib, and linking against that also requires linking against libm, which gst-plugins-good doesn't consider: #474092

So patch out the CPU check, and treat Linux on POWER like Linux on any other arch.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] powerpc64-linux (native)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
