### PR TITLE
python3Packages.mlx-lm: enable on linux

### DIFF
--- a/pkgs/development/python-modules/mlx-lm/default.nix
+++ b/pkgs/development/python-modules/mlx-lm/default.nix
@@ -62,13 +62,11 @@ buildPythonPackage (finalAttrs: {
     # Requires network access to huggingface.co
     "tests/test_datsets.py"
     "tests/test_generate.py"
+    "tests/test_prompt_cache.py::TestPromptCache"
     "tests/test_server.py"
     "tests/test_tokenizers.py"
     "tests/test_utils.py::TestUtils::test_convert"
     "tests/test_utils.py::TestUtils::test_load"
-    "tests/test_prompt_cache.py::TestPromptCache::test_cache_to_quantized"
-    "tests/test_prompt_cache.py::TestPromptCache::test_cache_with_generate"
-    "tests/test_prompt_cache.py::TestPromptCache::test_trim_cache_with_generate"
 
     # RuntimeError: [metal_kernel] No GPU back-end.
     "tests/test_losses.py"
@@ -84,8 +82,5 @@ buildPythonPackage (finalAttrs: {
     homepage = "https://github.com/ml-explore/mlx-lm";
     changelog = "https://github.com/ml-explore/mlx-lm/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
-    platforms = [
-      "aarch64-darwin"
-    ];
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

I don't know why some tests under `tests/test_models.py::TestModels::` pass on darwin but fail with a network issue on linux...

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
