### PR TITLE
hyprlog v0.1.0

### DIFF
--- a/pkgs/by-name/hy/hyprlog/package.nix
+++ b/pkgs/by-name/hy/hyprlog/package.nix
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage rec {
     owner = "gusjengis";
     repo = "hyprlog";
     rev = "v${version}";
-    hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+    hash = "sha256-HvsJGBQd9TRSBJtvai4uHnRGtciN19BL2xnUMBqh5pg=";
   };
 
   cargoLock = {

--- a/pkgs/by-name/hy/hyprlog/package.nix
+++ b/pkgs/by-name/hy/hyprlog/package.nix
@@ -11,7 +11,7 @@ let
     owner = "oxalica";
     repo = "rust-overlay";
     rev = "master";
-    hash = lib.fakeHash;
+    hash = "sha256-Tg/kL8eKMpZtceDvBDQYU8zowgpr7ucFRnpP/AtfuRM=";
   };
 
   rustOverlay = import rustOverlaySrc;

--- a/pkgs/by-name/hy/hyprlog/package.nix
+++ b/pkgs/by-name/hy/hyprlog/package.nix
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage rec {
     owner = "gusjengis";
     repo = "hyprlog";
     rev = "v${version}";
-    hash = "sha256-EnGGHN35Zd2hkTcFuKhHK2bpZJrxFIbkheGcLIRZY6b=";
+    hash = "sha256-GQ/vF5Ebp3l2C6GgCqSFMK25xHTgJINByqV8ksm/Vl0=";
   };
 
   cargoLock = {

--- a/pkgs/by-name/hy/hyprlog/package.nix
+++ b/pkgs/by-name/hy/hyprlog/package.nix
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage rec {
     owner = "gusjengis";
     repo = "hyprlog";
     rev = "v${version}";
-    hash = "sha256-bvsJGBQd9TRSBJtvai4uHnRGtciN19BL2xnUMBqh5pg=";
+    hash = "sha256-EnGGHN35Zd2hkTcFuKhHK2bpZJrxFIbkheGcLIRZY6Q=";
   };
 
   cargoLock = {

--- a/pkgs/by-name/hy/hyprlog/package.nix
+++ b/pkgs/by-name/hy/hyprlog/package.nix
@@ -16,7 +16,7 @@ rustPlatform.buildRustPackage rec {
   };
 
   cargoLock = {
-    lockFile = ./Cargo.lock;
+    lockFile = "${src}/Cargo.lock";
   };
 
   meta = with lib; {

--- a/pkgs/by-name/hy/hyprlog/package.nix
+++ b/pkgs/by-name/hy/hyprlog/package.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "hyprlog";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "gusjengis";
+    repo = "hyprlog";
+    rev = "v${version}";
+    hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+  };
+
+  cargoLock = {
+    lockFile = ./Cargo.lock;
+  };
+
+  meta = with lib; {
+    description = "Hyprland focus/activity logger";
+    homepage = "https://github.com/gusjengis/hyprlog";
+    license = licenses.mit;
+    maintainers = [ maintainers.gusjengis ];
+    mainProgram = "hyprlog";
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/by-name/hy/hyprlog/package.nix
+++ b/pkgs/by-name/hy/hyprlog/package.nix
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage rec {
     owner = "gusjengis";
     repo = "hyprlog";
     rev = "v${version}";
-    hash = "sha256-EnGGHN35Zd2hkTcFuKhHK2bpZJrxFIbkheGcLIRZY6Q=";
+    hash = "sha256-EnGGHN35Zd2hkTcFuKhHK2bpZJrxFIbkheGcLIRZY6b=";
   };
 
   cargoLock = {

--- a/pkgs/by-name/hy/hyprlog/package.nix
+++ b/pkgs/by-name/hy/hyprlog/package.nix
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage rec {
     owner = "gusjengis";
     repo = "hyprlog";
     rev = "v${version}";
-    hash = "sha256-HvsJGBQd9TRSBJtvai4uHnRGtciN19BL2xnUMBqh5pg=";
+    hash = "sha256-bvsJGBQd9TRSBJtvai4uHnRGtciN19BL2xnUMBqh5pg=";
   };
 
   cargoLock = {

--- a/pkgs/by-name/hy/hyprlog/package.nix
+++ b/pkgs/by-name/hy/hyprlog/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchFromGitHub,
   rustPlatform,
   ...
 }:


### PR DESCRIPTION
## Changes to repo
I added package for a hyprland activity logger I made. The only thing I had to do that you may object to is I had to use a newer version of cargo than is currently standard. One of my dependencies needed the edition 2024 feature, so to make the program build I requested version 1.92.0 of cargo. I'm sure any version of cargo that supports the 2024 edition of rust would work, I just went with the version that I had installed locally. It is a stable release, so I trust that version of cargo to work, but if you for some reason want a different version let me know. 
Otherwise, this is tested working on my x86_64 desktop and my aarch64 Asahi Linux Macbook. I think this is okay to merge, but this is my first time contributing to nixpkgs or making a package.nix file. Looking forward to your feedback and getting this merged.


## Description of package
This package installs two binaries. The first is hyprlogd, which is a daemon that records changes in window focus in csv files. The second is hyprlog, which is a CLI that reads these CSV files and generates a report of activity for some given interval. I've been using this for a while and it seems to be reliable and functional enough to release. I'd like to update it later with slightly more detailed tracking and a TUI interface.

[hyprlog repo](https://github.com/gusjengis/hyprlog)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
