### PR TITLE
pocket-tts: init at 1.0.1

### DIFF
--- a/pkgs/by-name/po/pocket-tts/package.nix
+++ b/pkgs/by-name/po/pocket-tts/package.nix
@@ -1,0 +1,1 @@
+{ python3Packages }: with python3Packages; toPythonApplication pocket-tts

--- a/pkgs/development/python-modules/pocket-tts/default.nix
+++ b/pkgs/development/python-modules/pocket-tts/default.nix
@@ -1,0 +1,78 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  hatchling,
+
+  # dependencies
+  beartype,
+  einops,
+  fastapi,
+  huggingface-hub,
+  numpy,
+  pydantic,
+  python-multipart,
+  requests,
+  safetensors,
+  scipy,
+  sentencepiece,
+  torch,
+  typer,
+  typing-extensions,
+  uvicorn,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pocket-tts";
+  version = "1.0.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "kyutai-labs";
+    repo = "pocket-tts";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-VFLpUsHnQYSr5RgNKJOX1TD30o1A8rG4cs2VeZWriaU=";
+  };
+
+  build-system = [
+    hatchling
+  ];
+
+  pythonRelaxDeps = [
+    "beartype"
+    "python-multipart"
+  ];
+  dependencies = [
+    beartype
+    einops
+    fastapi
+    huggingface-hub
+    numpy
+    pydantic
+    python-multipart
+    requests
+    safetensors
+    scipy
+    sentencepiece
+    torch
+    typer
+    typing-extensions
+    uvicorn
+  ];
+
+  pythonImportsCheck = [ "pocket_tts" ];
+
+  # All tests are failing as the model cannot be downloaded from the sandbox
+  doCheck = false;
+
+  meta = {
+    description = "Lightweight text-to-speech (TTS) application designed to run efficiently on CPUs";
+    homepage = "https://github.com/kyutai-labs/pocket-tts";
+    changelog = "https://github.com/kyutai-labs/pocket-tts/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+    mainProgram = "pocket-tts";
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12378,6 +12378,8 @@ self: super: with self; {
 
   pocket = callPackage ../development/python-modules/pocket { };
 
+  pocket-tts = callPackage ../development/python-modules/pocket-tts { };
+
   pocketsphinx = callPackage ../development/python-modules/pocketsphinx {
     inherit (pkgs) pocketsphinx;
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Add [pocket-tts](https://github.com/kyutai-labs/pocket-tts), a lightweight text-to-speech (TTS) application designed to run efficiently on CPUs.

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
