### PR TITLE
sparrow: 2.2.3 -> 2.3.1

### DIFF
--- a/pkgs/by-name/sp/sparrow/package.nix
+++ b/pkgs/by-name/sp/sparrow/package.nix
@@ -25,7 +25,7 @@
 
 let
   pname = "sparrow";
-  version = "2.2.3";
+  version = "2.3.1";
 
   openjdk = zulu25.override { enableJavaFX = true; };
 
@@ -41,8 +41,8 @@ let
     url = "https://github.com/sparrowwallet/${pname}/releases/download/${version}/sparrowwallet-${version}-${sparrowArch}.tar.gz";
     hash =
       {
-        x86_64-linux = "sha256-MsERgfJGpxRkQm4Ww30Tc95kThjlgI+nO4bq2zNGdeU=";
-        aarch64-linux = "sha256-31x4Ck/+Fa6CvBb6o9ncVH99Zeh0DUVv/hqVN31ysHk=";
+        x86_64-linux = "sha256-AcGjSLxjv9IWs4WIuAq/6R8K6cq750wod9y9qhbBUkI=";
+        aarch64-linux = "sha256-5bVfkbGDlWGFJeRHmDOy8YD45Iex+NmWh9Uoequ6AxI=";
       }
       ."${stdenvNoCC.hostPlatform.system}";
 
@@ -73,12 +73,12 @@ let
 
   manifest = fetchurl {
     url = "https://github.com/sparrowwallet/${pname}/releases/download/${version}/${pname}-${version}-manifest.txt";
-    hash = "sha256-qPIllqFqe84BSIcYYYa+rKJvSpN/QnomHnsOoTxlyl4=";
+    hash = "sha256-cq/XtWdkdRgUC9HPYRfSe9/RXuNYW6AjAgcgff57Q+E=";
   };
 
   manifestSignature = fetchurl {
     url = "https://github.com/sparrowwallet/${pname}/releases/download/${version}/${pname}-${version}-manifest.txt.asc";
-    hash = "sha256-PpruG9l7MhI30b6dd96KAkkQvyMNuh36GtmEdYaRgac=";
+    hash = "sha256-KzlrP11EWypL3fxRZ7RNVivfBueIUXHzBeBcob2xg68=";
   };
 
   publicKey = ./publickey.asc;
@@ -117,6 +117,9 @@ let
       --add-reads=com.sparrowwallet.merged.module=com.fasterxml.jackson.annotation
       --add-reads=com.sparrowwallet.merged.module=com.fasterxml.jackson.core
       --add-reads=com.sparrowwallet.merged.module=co.nstant.in.cbor
+      --add-reads=com.sparrowwallet.merged.module=jdk.jfr
+      --add-opens=jdk.jfr/jdk.jfr=com.sparrowwallet.merged.module
+      --add-opens=jdk.jfr/jdk.jfr.internal=com.sparrowwallet.merged.module
       --add-reads=kotlin.stdlib=kotlinx.coroutines.core
       -m com.sparrowwallet.sparrow
     )
@@ -176,6 +179,8 @@ let
 
       # Delete unneeded native libs.
 
+      rm -fR com.sparrowwallet.merged.module/com/sun/jna/dragonflybsd-x86-64
+      rm -fR com.sparrowwallet.merged.module/com/sun/jna/freebsd-aarch64
       rm -fR com.sparrowwallet.merged.module/com/sun/jna/freebsd-x86-64
       rm -fR com.sparrowwallet.merged.module/com/sun/jna/freebsd-x86
       rm -fR com.sparrowwallet.merged.module/com/sun/jna/linux-arm
@@ -183,6 +188,8 @@ let
       rm -fR com.sparrowwallet.merged.module/com/sun/jna/linux-mips64el
       rm -fR com.sparrowwallet.merged.module/com/sun/jna/linux-ppc
       rm -fR com.sparrowwallet.merged.module/com/sun/jna/linux-ppc64le
+      rm -fR com.sparrowwallet.merged.module/com/sun/jna/linux-loongarch64
+      rm -fR com.sparrowwallet.merged.module/com/sun/jna/linux-riscv64
       rm -fR com.sparrowwallet.merged.module/com/sun/jna/linux-s390x
       rm -fR com.sparrowwallet.merged.module/com/sun/jna/linux-x86
       rm -fR com.sparrowwallet.merged.module/com/sun/jna/openbsd-x86-64


### PR DESCRIPTION
## Description
Update Sparrow Bitcoin wallet to version 2.3.1.

## Changes
- Version bump 2.2.3 → 2.3.1
- Added removal of new platform-specific native libs (DragonFlyBSD x86-64, FreeBSD aarch64, LoongArch, RISC-V)
- Added JFR module access required by updated JDBI dependency

## Testing
- [x] Built on x86_64-linux
- [ ] Built on aarch64-linux
- [x] Application launches successfully
- [x] Wallet operations work (open wallet tested)

cc @msgilligan @_1000101