### PR TITLE
python3Packages.datalad, python3Packages.datalad-gooey: disable broken test on python 3.14

### DIFF
--- a/pkgs/development/python-modules/datalad-gooey/default.nix
+++ b/pkgs/development/python-modules/datalad-gooey/default.nix
@@ -3,6 +3,7 @@
   lib,
   git,
   fetchFromGitHub,
+  pythonAtLeast,
   setuptools,
   git-annex,
   pyside6,
@@ -53,6 +54,10 @@ buildPythonPackage {
     pytest-qt
     git
     git-annex
+  ];
+
+  disabledTests = lib.optionals (pythonAtLeast "3.14") [
+    "test_lsfiles"
   ];
 
   pythonImportsCheck = [ "datalad_gooey" ];

--- a/pkgs/development/python-modules/datalad/default.nix
+++ b/pkgs/development/python-modules/datalad/default.nix
@@ -4,9 +4,9 @@
   setuptools,
   stdenv,
   fetchFromGitHub,
+  pythonAtLeast,
   installShellFiles,
   git,
-  coreutils,
   versioneer,
   # core
   platformdirs,
@@ -218,6 +218,17 @@ buildPythonPackage rec {
 
     # CommandError: 'git -c diff.ignoreSubmodules=none -c core.quotepath=false ls-files -z -m -d' failed with exitcode 128
     "test_subsuperdataset_save"
+  ]
+  ++ lib.optionals (pythonAtLeast "3.14") [
+    # For all: https://github.com/datalad/datalad/issues/7781
+    # AssertionError: `assert 1 == 0` (refcount error)
+    "test_GitRepo_flyweight"
+    "test_Dataset_flyweight"
+    "test_AnnexRepo_flyweight"
+    # TypeError: cannot pickle '_thread.lock' object
+    "test_popen_invocation"
+    # datalad.runner.exception.CommandError: '/python3.14 -i -u -q -']' timed out after 0.5 seconds
+    "test_asyncio_loop_noninterference1"
   ];
 
   nativeCheckInputs = [


### PR DESCRIPTION
`datalad` and `datalad-gooey`: Conditionally disabled broken tests on python 3.14

Tracking: #475732

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
