### PR TITLE
q4wine: migrate to by-name, modernize

### DIFF
--- a/pkgs/by-name/q4/q4wine/package.nix
+++ b/pkgs/by-name/q4/q4wine/package.nix
@@ -4,10 +4,7 @@
   stdenv,
   cmake,
   sqlite,
-  qtbase,
-  qtsvg,
-  qttools,
-  wrapQtAppsHook,
+  qt6,
   icoutils, # build and runtime deps.
   wget,
   fuseiso,
@@ -29,14 +26,14 @@ stdenv.mkDerivation rec {
   buildInputs = [
     sqlite
     icoutils
-    qtbase
-    qtsvg
-    qttools
+    qt6.qtbase
+    qt6.qtsvg
+    qt6.qttools
   ];
 
   nativeBuildInputs = [
     cmake
-    wrapQtAppsHook
+    qt6.wrapQtAppsHook
   ];
 
   # Add runtime deps.

--- a/pkgs/by-name/q4/q4wine/package.nix
+++ b/pkgs/by-name/q4/q4wine/package.nix
@@ -12,15 +12,15 @@
   which, # runtime deps.
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "q4wine";
   version = "1.4.2";
 
   src = fetchFromGitHub {
     owner = "brezerk";
     repo = "q4wine";
-    rev = "v${version}";
-    sha256 = "sha256-5rj+EDsOZib78gWT003a4IN23cZQftnhVggIdLN6f7I=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-5rj+EDsOZib78gWT003a4IN23cZQftnhVggIdLN6f7I=";
   };
 
   buildInputs = [
@@ -57,4 +57,4 @@ stdenv.mkDerivation rec {
     maintainers = with lib.maintainers; [ rkitover ];
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9598,8 +9598,6 @@ with pkgs;
   graphicsmagick_q16 = graphicsmagick.override { quantumdepth = 16; };
   graphicsmagick-imagemagick-compat = graphicsmagick.imagemagick-compat;
 
-  q4wine = kdePackages.callPackage ../applications/misc/q4wine { };
-
   googleearth-pro = libsForQt5.callPackage ../applications/misc/googleearth-pro { };
 
   gpsbabel-gui = gpsbabel.override {


### PR DESCRIPTION
This pull request refactors the packaging of `q4wine` by moving its package definition to a new standardized location and updating its dependencies to use the `kdePackages` set. This helps to align the package with current best practices for KDE/Qt applications in Nixpkgs and improves maintainability.

**Refactoring and migration:**
* Renamed and moved the package definition from `pkgs/applications/misc/q4wine/default.nix` to `pkgs/by-name/q4/q4wine/package.nix`, adopting the new naming convention for easier discoverability and consistency.

**Dependency updates:**
* Updated Qt-related dependencies to use `kdePackages` (e.g., `kdePackages.qtbase` instead of `qtbase`), ensuring the package uses the latest and properly wrapped KDE/Qt libraries.

**API modernization:**
* Refactored `stdenv.mkDerivation` usage to the newer lambda-style argument passing (`stdenv.mkDerivation (finalAttrs: { ... })`) for better future compatibility and code clarity. 

**Package registration cleanup:**
* Removed the old `q4wine` registration from `pkgs/top-level/all-packages.nix` to avoid duplicate or outdated references, as the new location and dependency handling make this unnecessary.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
