### PR TITLE
lazymake: init at 0.2.0

### DIFF
--- a/pkgs/by-name/la/lazymake/package.nix
+++ b/pkgs/by-name/la/lazymake/package.nix
@@ -36,7 +36,7 @@ buildGoModule rec {
     homepage = "https://github.com/rshelekhov/lazymake";
     changelog = "https://github.com/rshelekhov/lazymake/releases/tag/v${version}";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = [ ltpie123 ];
     mainProgram = "lazymake";
     platforms = lib.platforms.unix;
   };

--- a/pkgs/by-name/la/lazymake/package.nix
+++ b/pkgs/by-name/la/lazymake/package.nix
@@ -11,7 +11,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "rshelekhov";
     repo = "lazymake";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-fEAU3ehb4ClsJiKknDcZMik0ux5zyYU+JoAfEpwNUe8=";
   };
 

--- a/pkgs/by-name/la/lazymake/package.nix
+++ b/pkgs/by-name/la/lazymake/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule rec {
+  pname = "lazymake";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "rshelekhov";
+    repo = "lazymake";
+    rev = "v${version}";
+    hash = "sha256-fEAU3ehb4ClsJiKknDcZMik0ux5zyYU+JoAfEpwNUe8=";
+  };
+
+  vendorHash = "sha256-X/n7eoughxIP42JcLfifnbyqjYzRQBGsQvvCvFElotY=";
+
+  subPackages = [ "cmd/lazymake" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${version}"
+  ];
+
+  meta = {
+    description = "Modern TUI for Makefiles with interactive target selection and dependency visualization";
+    longDescription = ''
+      Lazymake is a terminal UI for browsing and running Makefile targets.
+      Features include fuzzy search, execution history, dependency graphs,
+      variable inspection, syntax highlighting, safety warnings, and
+      performance tracking.
+    '';
+    homepage = "https://github.com/rshelekhov/lazymake";
+    changelog = "https://github.com/rshelekhov/lazymake/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = [ ];
+    mainProgram = "lazymake";
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION
## Description of changes

Add `lazymake`, a modern TUI for Makefiles with interactive target selection and dependency visualization.

## Things done

- [x] Built on platform(s)
  - [x] x86_64-linux
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside nixos/tests)
  - N/A - no existing tests for this type of package
- [x] Tested compilation of all packages that depend on this change using `nixpkgs-review`
  - N/A - new package with no dependents
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  - [x] `lazymake --help` works
  - [x] `lazymake` launches TUI successfully
- [x] Added package to pkgs/by-name structure
- [x] Package follows pkgs/by-name conventions
- [x] Fits CONTRIBUTING.md

## Package Details

- **Package name:** lazymake
- **Version:** 0.2.0
- **Homepage:** https://github.com/rshelekhov/lazymake
- **License:** MIT
- **Language:** Go
- **Platforms:** unix (Linux, macOS)

## Features

- Interactive TUI for browsing and running Makefile targets
- Fuzzy search for targets
- Dependency graph visualization  
- Execution history tracking
- Variable inspection
- Syntax highlighting
- Safety warnings for dangerous commands
- Performance tracking

## Testing

```bash
nix-build -A lazymake
./result/bin/lazymake --help
```

Built successfully and executes correctly.

---

**Note:** This package is also being submitted to NUR for faster availability while this PR is under review.