### PR TITLE
gnu-cim: fix build with CFLAG

### DIFF
--- a/pkgs/by-name/gn/gnu-cim/package.nix
+++ b/pkgs/by-name/gn/gnu-cim/package.nix
@@ -29,13 +29,7 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  # lib.escapeShellArgs does not work
-  env.CFLAGS = lib.concatStringsSep " " [
-    "-Wno-error=implicit-function-declaration"
-    "-Wno-error=implicit-int"
-    "-Wno-error=return-mismatch"
-    "-Wno-error=incompatible-pointer-types"
-  ];
+  env.CFLAGS = "-std=gnu89";
 
   doCheck = true;
 


### PR DESCRIPTION
fixes https://hydra.nixos.org/build/317838491

Found the fix in the openbsd package https://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/lang/cim/Makefile?rev=1.5&ipk=PQM7sf3SiSEG1jUJvk-paD5SFNOVe-Tn2sNUu8Ly4Qs&content-type=text/x-cvsweb-markup

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
