### PR TITLE
python3Packages.betterproto: disable broken tests on python 3.14

### DIFF
--- a/pkgs/development/python-modules/betterproto/default.nix
+++ b/pkgs/development/python-modules/betterproto/default.nix
@@ -1,6 +1,7 @@
 {
   buildPythonPackage,
   fetchFromGitHub,
+  pythonAtLeast,
   lib,
   poetry-core,
   grpclib,
@@ -79,6 +80,14 @@ buildPythonPackage rec {
     "test_service_with_deprecated_method"
     # Test is flaky
     "test_binary_compatibility"
+  ];
+
+  disabledTestPaths = lib.optionals (pythonAtLeast "3.14") [
+    # Outdated access to metadata
+    # https://github.com/danielgtaylor/python-betterproto/issues/680
+    "tests/test_inputs.py::test_message_can_instantiated[namespace_builtin_types]"
+    "tests/test_inputs.py::test_message_equality[namespace_builtin_types]"
+    "tests/test_inputs.py::test_message_json[namespace_builtin_types]"
   ];
 
   meta = {


### PR DESCRIPTION
1. Disabled broken tests under Python 3.14 (tried to access class metadata the obsolete way)
2. Filed https://github.com/danielgtaylor/python-betterproto/issues/679

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
