### PR TITLE
haskellPackages: iserv-proxy fixes for pkgsCross.ucrt64 

### DIFF
--- a/pkgs/applications/emulators/wine/sources.nix
+++ b/pkgs/applications/emulators/wine/sources.nix
@@ -92,6 +92,14 @@ let
     })
   ];
 
+  patches-add-dll-accept-device-paths-wine-older-than-11_1 = [
+    (pkgs.fetchpatch {
+      name = "add-dll-accept-device-paths";
+      url = "https://gitlab.winehq.org/wine/wine/-/commit/401910ae25a11032f2da7baa1666d71e8bca2496.patch";
+      hash = "sha256-2726u9/vhhx39Tq7vOw24hslmeyZZEbxRRqe7JMFvCU";
+    })
+  ];
+
   inherit (pkgs) writeShellScript;
 in
 rec {
@@ -123,7 +131,8 @@ rec {
     patches = [
       # Also look for root certificates at $NIX_SSL_CERT_FILE
       ./cert-path.patch
-    ];
+    ]
+    ++ patches-add-dll-accept-device-paths-wine-older-than-11_1;
 
     updateScript = writeShellScript "update-wine-stable" ''
       ${updateScriptPreamble}

--- a/pkgs/development/haskell-modules/configuration-windows.nix
+++ b/pkgs/development/haskell-modules/configuration-windows.nix
@@ -8,11 +8,16 @@ with haskellLib;
 
 (self: super: {
   # cabal2nix doesn't properly add dependencies conditional on os(windows)
-  network =
-    if pkgs.stdenv.hostPlatform.isWindows then
-      addBuildDepends [ self.temporary ] super.network
-    else
-      super.network;
+  network = lib.pipe super.network [
+    (addBuildDepends [ self.temporary ])
+
+    # https://github.com/haskell/network/pull/605
+    (appendPatch (fetchpatch {
+      name = "dont-frag-wine.patch";
+      url = "https://github.com/haskell/network/commit/ecd94408696117d34d4c13031c30d18033504827.patch";
+      sha256 = "sha256-8LtAkBmgMMMIW6gPYDVuwYck/4fcOf08Hp2zLmsRW2w=";
+    }))
+  ];
 
   # Workaround for
   #   Mingw-w64 runtime failure:

--- a/pkgs/development/haskell-modules/configuration-windows.nix
+++ b/pkgs/development/haskell-modules/configuration-windows.nix
@@ -14,6 +14,13 @@ with haskellLib;
     else
       super.network;
 
+  # Workaround for
+  #   Mingw-w64 runtime failure:
+  #   32 bit pseudo relocation at 00000001400EB99E out of range, targeting 00006FFFFFEB8170, yielding the value 00006FFEBFDCC7CE.
+  # Root cause seems to be undefined references to libffi as shown by linking errors if we instead use "-Wl,--disable-auto-import"
+  # See https://github.com/rust-lang/rust/issues/132226#issuecomment-2445100058
+  iserv-proxy = appendConfigureFlag "--ghc-option=-optl=-Wl,--disable-runtime-pseudo-reloc" super.iserv-proxy;
+
   # Avoids a cycle by disabling use of the external interpreter for the packages that are dependencies of iserv-proxy.
   # See configuration-nix.nix, where iserv-proxy and network are handled.
   # On Windows, network depends on temporary (see above), which depends on random, which depends on splitmix.

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -36,7 +36,9 @@ let
               enableExecutableProfiling = enableProfiling;
             };
             buildProxy = lib.getExe' iserv-proxy.build "iserv-proxy";
-            hostProxy = lib.getExe' (overrides iserv-proxy.host) "iserv-proxy-interpreter";
+            hostProxy = lib.getExe' (overrides iserv-proxy.host) (
+              "iserv-proxy-interpreter" + stdenv.hostPlatform.extensions.executable
+            );
           in
           buildPackages.writeShellScriptBin ("iserv-wrapper" + lib.optionalString enableProfiling "-prof") ''
             set -euo pipefail

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -41,6 +41,7 @@ let
           buildPackages.writeShellScriptBin ("iserv-wrapper" + lib.optionalString enableProfiling "-prof") ''
             set -euo pipefail
             PORT=$((5000 + $RANDOM % 5000))
+            ${lib.optionalString stdenv.hostPlatform.isWindows "export WINEPREFIX=$TMP"}
             (>&2 echo "---> Starting interpreter on port $PORT")
             ${emulator} ${hostProxy} tmp $PORT &
             RISERV_PID="$!"

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -44,7 +44,7 @@ let
           buildPackages.writeShellScriptBin ("iserv-wrapper" + lib.optionalString enableProfiling "-prof") ''
             set -euo pipefail
             PORT=$((5000 + $RANDOM % 5000))
-            ${lib.optionalString stdenv.hostPlatform.isWindows "export WINEPREFIX=$TMP"}
+            ${lib.optionalString stdenv.hostPlatform.isWindows "export WINEDEBUG=-all WINEPREFIX=$TMP"}
             (>&2 echo "---> Starting interpreter on port $PORT")
             ${emulator} ${hostProxy} tmp $PORT &
             RISERV_PID="$!"

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -13,6 +13,7 @@
   haskellLib,
   iserv-proxy,
   nodejs,
+  windows,
   writeShellScriptBin,
 }:
 
@@ -358,11 +359,17 @@ let
   ++ optional (allPkgconfigDepends != [ ]) "--with-pkg-config=${pkg-config.targetPrefix}pkg-config"
 
   ++ optionals enableExternalInterpreter (
-    map (opt: "--ghc-option=${opt}") [
-      "-fexternal-interpreter"
-      "-pgmi"
-      crossSupport.iservWrapper
-    ]
+    map (opt: "--ghc-option=${opt}") (
+      [
+        "-fexternal-interpreter"
+        "-pgmi"
+        crossSupport.iservWrapper
+      ]
+      ++ lib.optionals stdenv.hostPlatform.isWindows [
+        "-L${windows.pthreads}/bin"
+        "-L${windows.pthreads}/lib"
+      ]
+    )
   );
 
   makeGhcOptions = opts: lib.concatStringsSep " " (map (opt: "--ghc-option=${opt}") opts);


### PR DESCRIPTION
```
$ nix-build -A pkgsCross.ucrt64.haskell.packages.native-bignum.ghc912.th-orphans 
/nix/store/2z4kx993l66wfghi1qpgip3s8nh0gwmv-th-orphans-x86_64-w64-mingw32-0.13.16
```

Added the errors fixed under respective commit messages.

Adapted from 
- https://github.com/input-output-hk/haskell.nix/blob/master/overlays/mingw_w64.nix
- https://github.com/input-output-hk/haskell.nix/blob/master/overlays/windows.nix
- https://github.com/input-output-hk/haskell.nix/blob/master/overlays/wine.nix


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
