### PR TITLE
Update fortran-fpm version to 0.12.0

### DIFF
--- a/pkgs/by-name/fo/fortran-fpm/package.nix
+++ b/pkgs/by-name/fo/fortran-fpm/package.nix
@@ -10,11 +10,11 @@
 stdenv.mkDerivation (finalAttrs: {
   pname = "fortran-fpm";
 
-  version = "0.11.0";
+  version = "0.12.0";
 
   src = fetchurl {
     url = "https://github.com/fortran-lang/fpm/releases/download/v${finalAttrs.version}/fpm-${finalAttrs.version}.F90";
-    hash = "sha256-mIozF+4kSO5yB9CilBDwinnIa92sMxSyoXWAGpz1jSc=";
+    hash = "sha256-YVZ6yBDY6o+PyR/bE3ANNLkb824ZOzXXRPxjUtIRRq0=";
   };
 
   dontUnpack = true;


### PR DESCRIPTION
Changelog: 
This pull request updates the `fortran-fpm` package to the latest upstream release. The main change is a version bump and an updated source hash to match the new release.

* Version bump: Updated `version` in `package.nix` from `0.11.0` to `0.12.0` to use the latest release.
* Source integrity: Updated the `hash` field to match the new source file for version `0.12.0`.

https://github.com/fortran-lang/fpm/releases/tag/v0.12.0

Bumping version to the latest release.

I've downloaded the sha256

```
61567ac810d8ea8f8fc91fdb13700d34b91bf36e193b35d744fc6352d21146ad  fpm-0.12.0.F90
```

then converted to sri

```
$ nix hash convert --hash-algo sha256 --to sri 61567ac810d8ea8f8fc91fdb13700d34b91bf36e193b35d744fc6352d21146ad

sha256-YVZ6yBDY6o+PyR/bE3ANNLkb824ZOzXXRPxjUtIRRq0=
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
