### PR TITLE
circt: 1.138.0 -> 1.139.0

### DIFF
--- a/pkgs/by-name/ci/circt/circt-llvm.nix
+++ b/pkgs/by-name/ci/circt/circt-llvm.nix
@@ -94,6 +94,7 @@ stdenv.mkDerivation {
 
     for file in "$out"/bin/* "$lib"/lib/*.dylib; do
       if [ -L "$file" ]; then continue; fi
+      if [[ "$file" == *.py ]]; then continue; fi
       echo "$file: fixing dylib references"
       # note that -id does nothing on binaries
       install_name_tool -id "$file" "''${flags[@]}" "$file"

--- a/pkgs/by-name/ci/circt/package.nix
+++ b/pkgs/by-name/ci/circt/package.nix
@@ -27,12 +27,12 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "circt";
-  version = "1.138.0";
+  version = "1.139.0";
   src = fetchFromGitHub {
     owner = "llvm";
     repo = "circt";
     rev = "firtool-${version}";
-    hash = "sha256-yx6sk6FO7MHNuRFBMhOXTSjtDQ0B6XyhGHb4uHSXx/8=";
+    hash = "sha256-Yj9BqmmotIaTUHIUslaOmRXYC4ujQ9GNjEmaAfLgLgU=";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
Updates circt, and fixes build for Darwin platforms.
The new version introduces Python scripts in the output, which were causing build failure in the fixup phase.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
