### PR TITLE
openconnect: 9.12-unstable-2025-01-14 -> 9.12-unstable-2025-11-03

### DIFF
--- a/pkgs/tools/networking/openconnect/default.nix
+++ b/pkgs/tools/networking/openconnect/default.nix
@@ -7,12 +7,12 @@ let
 in
 rec {
   openconnect = common {
-    version = "9.12-unstable-2025-01-14";
+    version = "9.12-unstable-2025-11-03";
     src = fetchFromGitLab {
       owner = "openconnect";
       repo = "openconnect";
-      rev = "f17fe20d337b400b476a73326de642a9f63b59c8";
-      hash = "sha256-OBEojqOf7cmGtDa9ToPaJUHrmBhq19/CyZ5agbP7WUw=";
+      rev = "0dcdff87db65daf692dc323732831391d595d98d";
+      hash = "sha256-AvowUEDkXvR+QkhJbZU759fZjIqj/mO8HjP2Ka3lH1U=";
     };
   };
 


### PR DESCRIPTION
Since official releases do not happen frequently, I suggest to bump `openconnect` to latest commit.

## Changes
  - **Version**: 9.12-unstable-2025-01-14 -> 9.12-unstable-2025-11-03
  - **Important fix**: Adds compatibility with newer Cisco Meraki/MX servers ([e4d2ee61](https://gitlab.com/openconnect/openconnect/-/commit/e4d2ee611760b8f00e8fab3440d238ee85cee890))
    - Without this commit, connections to these servers are refused
    - Works through `networkmanager-openconnect` with SAML authentication

This unblocks people in #306647 who must use this update to connect to their VPN on NixOS.

## References

* [Changelog](https://www.infradead.org/openconnect/changelog.html) 
* [Commit history](https://gitlab.com/openconnect/openconnect/-/commits/master?ref_type=heads)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
