### PR TITLE
hyprlog: init at 0.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10009,6 +10009,12 @@
     githubId = 28863828;
     name = "guserav";
   };
+  gusjengis = {
+    name = "Anthony Green";
+    email = "anthony.j.green@outlook.com";
+    github = "gusjengis";
+    githubId = 107908374;
+  };
   guttermonk = {
     github = "guttermonk";
     githubId = 4753752;

--- a/pkgs/by-name/hy/hyprlog/package.nix
+++ b/pkgs/by-name/hy/hyprlog/package.nix
@@ -15,7 +15,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     hash = "sha256-nHTUa7UpdlsO4TUrQfGo82KlgXkG3RxC9iyfiDOmOyQ=";
   };
 
-  cargoHash = "sha256-nHTUa7UpdlsO4TUrQfGo82KlgXkG3RxC9iyfiDOmOyQ=";
+  cargoHash = "sha256-+YHTBBwc638GoGg/owYyw0cPvhb9sswBvh5Mkjma9jo=";
 
   meta = {
     description = "Hyprland focus/activity logger";

--- a/pkgs/by-name/hy/hyprlog/package.nix
+++ b/pkgs/by-name/hy/hyprlog/package.nix
@@ -2,6 +2,7 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
+  finalAttrs,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -11,15 +12,13 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "gusjengis";
     repo = "hyprlog";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-nHTUa7UpdlsO4TUrQfGo82KlgXkG3RxC9iyfiDOmOyQ=";
   };
 
-  cargoLock = {
-    lockFile = "${src}/Cargo.lock";
-  };
+  cargoHash = "sha256-nHTUa7UpdlsO4TUrQfGo82KlgXkG3RxC9iyfiDOmOyQ=";
 
-  meta = with lib; {
+  meta = {
     description = "Hyprland focus/activity logger";
     homepage = "https://github.com/gusjengis/hyprlog";
     license = licenses.mit;

--- a/pkgs/by-name/hy/hyprlog/package.nix
+++ b/pkgs/by-name/hy/hyprlog/package.nix
@@ -21,9 +21,9 @@ rustPlatform.buildRustPackage rec {
   meta = {
     description = "Hyprland focus/activity logger";
     homepage = "https://github.com/gusjengis/hyprlog";
-    license = licenses.mit;
+    license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ gusjengis ];
     mainProgram = "hyprlog";
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/hy/hyprlog/package.nix
+++ b/pkgs/by-name/hy/hyprlog/package.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "hyprlog";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "gusjengis";
+    repo = "hyprlog";
+    rev = "v${version}";
+    hash = "sha256-nHTUa7UpdlsO4TUrQfGo82KlgXkG3RxC9iyfiDOmOyQ=";
+  };
+
+  cargoLock = {
+    lockFile = "${src}/Cargo.lock";
+  };
+
+  meta = with lib; {
+    description = "Hyprland focus/activity logger";
+    homepage = "https://github.com/gusjengis/hyprlog";
+    license = licenses.mit;
+    maintainers = [ maintainers.gusjengis ];
+    mainProgram = "hyprlog";
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/by-name/hy/hyprlog/package.nix
+++ b/pkgs/by-name/hy/hyprlog/package.nix
@@ -23,7 +23,7 @@ rustPlatform.buildRustPackage rec {
     description = "Hyprland focus/activity logger";
     homepage = "https://github.com/gusjengis/hyprlog";
     license = licenses.mit;
-    maintainers = [ maintainers.gusjengis ];
+    maintainers = with lib.maintainers; [ gusjengis ];
     mainProgram = "hyprlog";
     platforms = platforms.linux;
   };

--- a/pkgs/by-name/hy/hyprlog/package.nix
+++ b/pkgs/by-name/hy/hyprlog/package.nix
@@ -2,10 +2,9 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
-  finalAttrs,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "hyprlog";
   version = "0.1.0";
 
@@ -26,4 +25,4 @@ rustPlatform.buildRustPackage rec {
     mainProgram = "hyprlog";
     platforms = lib.platforms.linux;
   };
-}
+})


### PR DESCRIPTION
Added a package.nix for [hyprlog](https://github.com/gusjengis/hyprlog/).

This installs two binaries, hyprlog and hyprlogd.
hyprlogd: Records changes in window focus in CSV files.
hyprlog: CLI, reads CSV files and generates an activity report consisting of a unicode timeline(s) and a table.

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
