### PR TITLE
dprint-plugins: update

### DIFF
--- a/pkgs/by-name/dp/dprint/plugins/dprint-plugin-biome.nix
+++ b/pkgs/by-name/dp/dprint/plugins/dprint-plugin-biome.nix
@@ -1,6 +1,6 @@
 { mkDprintPlugin }:
 mkDprintPlugin {
-  description = "Biome (JS/TS) wrapper plugin";
+  description = "Biome (JS/TS/JSON) wrapper plugin";
   hash = "sha256-P5mAFdr+vw6ogju0Qg6E9sbuTASaZD1Wr4BHt70lCy8=";
   initConfig = {
     configExcludes = [ "**/node_modules" ];
@@ -12,6 +12,7 @@ mkDprintPlugin {
       "jsx"
       "cjs"
       "mjs"
+      "json"
     ];
   };
   pname = "dprint-plugin-biome";

--- a/pkgs/by-name/dp/dprint/plugins/dprint-plugin-jupyter.nix
+++ b/pkgs/by-name/dp/dprint/plugins/dprint-plugin-jupyter.nix
@@ -1,7 +1,7 @@
 { mkDprintPlugin }:
 mkDprintPlugin {
   description = "Jupyter notebook code block formatter";
-  hash = "sha256-IlGwt2TnKeH9NwmUmU1keaTInXgYQVLIPNnr30A9lsM=";
+  hash = "sha256-7qM9MTTvvuPfx3WScO3jR0GEb8L0kHg24BJLsJYBiZg=";
   initConfig = {
     configExcludes = [ ];
     configKey = "jupyter";
@@ -9,6 +9,6 @@ mkDprintPlugin {
   };
   pname = "dprint-plugin-jupyter";
   updateUrl = "https://plugins.dprint.dev/dprint/jupyter/latest.json";
-  url = "https://plugins.dprint.dev/jupyter-0.2.0.wasm";
-  version = "0.2.0";
+  url = "https://plugins.dprint.dev/jupyter-0.2.1.wasm";
+  version = "0.2.1";
 }

--- a/pkgs/by-name/dp/dprint/plugins/dprint-plugin-mago.nix
+++ b/pkgs/by-name/dp/dprint/plugins/dprint-plugin-mago.nix
@@ -1,0 +1,14 @@
+{ mkDprintPlugin }:
+mkDprintPlugin {
+  description = "Mago (PHP) wrapper plugin";
+  hash = "sha256-QnQ82e+AGqVCJQiMqYOxGl9vDwnqTCu6aFRwOK39QTM=";
+  initConfig = {
+    configExcludes = [ ];
+    configKey = "mago";
+    fileExtensions = [ "php" ];
+  };
+  pname = "dprint-plugin-mago";
+  updateUrl = "https://plugins.dprint.dev/dprint/mago/latest.json";
+  url = "https://plugins.dprint.dev/mago-0.0.1.wasm";
+  version = "0.0.1";
+}

--- a/pkgs/by-name/dp/dprint/plugins/dprint-plugin-oxc.nix
+++ b/pkgs/by-name/dp/dprint/plugins/dprint-plugin-oxc.nix
@@ -1,0 +1,21 @@
+{ mkDprintPlugin }:
+mkDprintPlugin {
+  description = "Oxc (JS/TS) wrapper plugin";
+  hash = "sha256-BctJI87x82s3gpCovPSbGp+PfdBuYRZnXeCWWyFHpRs=";
+  initConfig = {
+    configExcludes = [ "**/node_modules" ];
+    configKey = "oxc";
+    fileExtensions = [
+      "ts"
+      "tsx"
+      "js"
+      "jsx"
+      "cjs"
+      "mjs"
+    ];
+  };
+  pname = "dprint-plugin-oxc";
+  updateUrl = "https://plugins.dprint.dev/dprint/oxc/latest.json";
+  url = "https://plugins.dprint.dev/oxc-0.2.0.wasm";
+  version = "0.2.0";
+}

--- a/pkgs/by-name/dp/dprint/plugins/dprint-plugin-ruff.nix
+++ b/pkgs/by-name/dp/dprint/plugins/dprint-plugin-ruff.nix
@@ -1,7 +1,7 @@
 { mkDprintPlugin }:
 mkDprintPlugin {
   description = "Ruff (Python) wrapper plugin";
-  hash = "sha256-qT+6zPbX3KrONXshwzLoGTWRXM93VKO0lN9ycJujEDM=";
+  hash = "sha256-kKdkIV4QbJZ8njBd8jVhwQsi7I3+PqWT/e3ORqWV7yQ=";
   initConfig = {
     configExcludes = [ ];
     configKey = "ruff";
@@ -12,6 +12,6 @@ mkDprintPlugin {
   };
   pname = "dprint-plugin-ruff";
   updateUrl = "https://plugins.dprint.dev/dprint/ruff/latest.json";
-  url = "https://plugins.dprint.dev/ruff-0.6.1.wasm";
-  version = "0.6.1";
+  url = "https://plugins.dprint.dev/ruff-0.6.12.wasm";
+  version = "0.6.12";
 }

--- a/pkgs/by-name/dp/dprint/plugins/g-plane-malva.nix
+++ b/pkgs/by-name/dp/dprint/plugins/g-plane-malva.nix
@@ -1,7 +1,7 @@
 { mkDprintPlugin }:
 mkDprintPlugin {
   description = "CSS, SCSS, Sass and Less formatter";
-  hash = "sha256-IAIix6c9/GNDZsRk95T/rpvMh7HqFgBoq5KDVYHHOjU=";
+  hash = "sha256-6ioZNF6j8y0ObHbPdNrjz3eH+WMQdry4s624eTDLnX8=";
   initConfig = {
     configExcludes = [ "**/node_modules" ];
     configKey = "malva";
@@ -14,6 +14,6 @@ mkDprintPlugin {
   };
   pname = "g-plane-malva";
   updateUrl = "https://plugins.dprint.dev/g-plane/malva/latest.json";
-  url = "https://plugins.dprint.dev/g-plane/malva-v0.14.3.wasm";
-  version = "0.14.3";
+  url = "https://plugins.dprint.dev/g-plane/malva-v0.15.1.wasm";
+  version = "0.15.1";
 }

--- a/pkgs/by-name/dp/dprint/plugins/g-plane-markup_fmt.nix
+++ b/pkgs/by-name/dp/dprint/plugins/g-plane-markup_fmt.nix
@@ -1,7 +1,7 @@
 { mkDprintPlugin }:
 mkDprintPlugin {
   description = "HTML, Vue, Svelte, Astro, Angular, Jinja, Twig, Nunjucks, and Vento formatter";
-  hash = "sha256-TQxHIw5IXZwFA/WzIJ33ZckJNkHwW67lnh0cCGkgmrs=";
+  hash = "sha256-bw7cMRYmqzWYqkp7RjT+HtL5jO6+GW9h/yOGQmw+bbU=";
   initConfig = {
     configExcludes = [ ];
     configKey = "markup";
@@ -19,6 +19,6 @@ mkDprintPlugin {
   };
   pname = "g-plane-markup_fmt";
   updateUrl = "https://plugins.dprint.dev/g-plane/markup_fmt/latest.json";
-  url = "https://plugins.dprint.dev/g-plane/markup_fmt-v0.24.0.wasm";
-  version = "0.24.0";
+  url = "https://plugins.dprint.dev/g-plane/markup_fmt-v0.25.3.wasm";
+  version = "0.25.3";
 }

--- a/pkgs/by-name/dp/dprint/plugins/g-plane-pretty_yaml.nix
+++ b/pkgs/by-name/dp/dprint/plugins/g-plane-pretty_yaml.nix
@@ -1,7 +1,7 @@
 { mkDprintPlugin }:
 mkDprintPlugin {
   description = "YAML formatter";
-  hash = "sha256-iSh5SRrjQB1hJoKkkup7R+Durcu+cxePa7GDVjwnexU=";
+  hash = "sha256-QKL92nBAMX6xsjUg86AHaaVXHu2wScTKkXXBue66Aa4=";
   initConfig = {
     configExcludes = [ ];
     configKey = "yaml";
@@ -12,6 +12,6 @@ mkDprintPlugin {
   };
   pname = "g-plane-pretty_yaml";
   updateUrl = "https://plugins.dprint.dev/g-plane/pretty_yaml/latest.json";
-  url = "https://plugins.dprint.dev/g-plane/pretty_yaml-v0.5.1.wasm";
-  version = "0.5.1";
+  url = "https://plugins.dprint.dev/g-plane/pretty_yaml-v0.6.0.wasm";
+  version = "0.6.0";
 }


### PR DESCRIPTION

```bash
nix-shell --run 'pkgs/by-name/dp/dprint/plugins/update-plugins.py'
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
