### PR TITLE
ocamlPackages.owl: fix for GCC 15

### DIFF
--- a/pkgs/development/ocaml-modules/owl-base/default.nix
+++ b/pkgs/development/ocaml-modules/owl-base/default.nix
@@ -2,17 +2,27 @@
   lib,
   buildDunePackage,
   fetchurl,
+  fetchpatch,
+  applyPatches,
 }:
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "owl-base";
   version = "1.2";
 
-  duneVersion = "3";
+  src = applyPatches {
+    src = fetchurl {
+      url = "https://github.com/owlbarn/owl/releases/download/${finalAttrs.version}/owl-${finalAttrs.version}.tbz";
+      hash = "sha256-OBei5DkZIsiiIltOM8qV2mgJJGmU5r8pGjAMgtjKxsU=";
+    };
 
-  src = fetchurl {
-    url = "https://github.com/owlbarn/owl/releases/download/${version}/owl-${version}.tbz";
-    hash = "sha256-OBei5DkZIsiiIltOM8qV2mgJJGmU5r8pGjAMgtjKxsU=";
+    patches = [
+      # Compatibility with GCC 15
+      (fetchpatch {
+        url = "https://github.com/owlbarn/owl/commit/3e66ccb0b1d21b73fa703f3d3f416ec0107860a4.patch";
+        hash = "sha256-0bV0ogTvtDoO8kEvE5QcJFRWqOJ1qiXGjXY9Ekp30M0=";
+      })
+    ];
   };
 
   minimalOCamlVersion = "4.10";
@@ -25,4 +35,4 @@ buildDunePackage rec {
     maintainers = [ lib.maintainers.bcdarwin ];
     license = lib.licenses.mit;
   };
-}
+})


### PR DESCRIPTION
This package has been broken since the gcc 14 → 15 change.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
