### PR TITLE
nixos/network-interfaces: allow setting virtualOwner to null

### DIFF
--- a/nixos/modules/services/networking/tayga.nix
+++ b/nixos/modules/services/networking/tayga.nix
@@ -167,7 +167,7 @@ in
     networking.interfaces."${cfg.tunDevice}" = {
       virtual = true;
       virtualType = "tun";
-      virtualOwner = mkIf config.networking.useNetworkd "";
+      virtualOwner = null;
       ipv4 = {
         addresses = [
           {
@@ -205,9 +205,7 @@ in
         ExecReload = "${pkgs.coreutils}/bin/kill -SIGHUP $MAINPID";
         Restart = "always";
 
-        # Hardening Score:
-        #  - nixos-scripts: 2.1
-        #  - systemd-networkd: 1.6
+        # Hardening Score: 1.5
         ProtectHome = true;
         SystemCallFilter = [
           "@network-io"
@@ -216,9 +214,6 @@ in
           "~@resources"
         ];
         ProtectKernelLogs = true;
-        AmbientCapabilities = [
-          "CAP_NET_ADMIN"
-        ];
         CapabilityBoundingSet = "";
         RestrictAddressFamilies = [
           "AF_INET"
@@ -226,7 +221,7 @@ in
           "AF_NETLINK"
         ];
         StateDirectory = "tayga";
-        DynamicUser = mkIf config.networking.useNetworkd true;
+        DynamicUser = true;
         MemoryDenyWriteExecute = true;
         RestrictRealtime = true;
         RestrictSUIDSGID = true;

--- a/nixos/modules/tasks/network-interfaces-scripted.nix
+++ b/nixos/modules/tasks/network-interfaces-scripted.nix
@@ -322,7 +322,9 @@ let
               RemainAfterExit = true;
             };
             script = ''
-              ip tuntap add dev "${i.name}" mode "${i.virtualType}" user "${i.virtualOwner}"
+              ip tuntap add dev "${i.name}" mode "${i.virtualType}" ${
+                lib.optionalString (i.virtualOwner != null) ''user "${i.virtualOwner}"''
+              }
             '';
             postStop = ''
               ip link del dev ${i.name} || true

--- a/nixos/modules/tasks/network-interfaces.nix
+++ b/nixos/modules/tasks/network-interfaces.nix
@@ -348,9 +348,10 @@ let
 
         virtualOwner = mkOption {
           default = "root";
-          type = types.str;
+          type = types.nullOr types.str;
           description = ''
             In case of a virtual device, the user who owns it.
+            `null` will not set owner, allowing access to any user.
           '';
         };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR contains 2 commits.  The 2nd one can be seen as a real-world example that motivates this PR.  The first thing that motivates me to do this PR is https://github.com/ngi-nix/ngipkgs/pull/1944.

`nixosTests.tayga` passes.

- nixos/network-interfaces: allow setting virtualOwner to null
```
null will not set owner, allowing any user to access the virtual
device.  Previously, this behavior can be achieved by using
systemd.network.netdevs.* options direcly and leaving
systemd.network.netdevs.<name>.tapConfig.User unset.  With this patch,
this behavior can be achieved using the generic
networking.interfaces.* options by setting
networking.interfaces.<name>.virtualOwner to null.

If needed, we can change the default value from "root" to null in the
future to be consistent with systemd-networkd's default behavior.
```
- nixos/tayga: always set virtualOwner to null
```
Previously, due to the limitation of
networking.interfaces.*.virtualOwner, it is only set to null when
using systemd-networkd backend.  With this patch, virtualOwner is
always set to null.
```


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
