### PR TITLE
claude-code: 2.1.6 -> 2.1.7

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
@@ -8,8 +8,8 @@ vscode-utils.buildVscodeMarketplaceExtension {
   mktplcRef = {
     name = "claude-code";
     publisher = "anthropic";
-    version = "2.1.6";
-    hash = "sha256-xN87LR64kikBu0M5pST0PbV7+YwB1ncTzmfGk4PEwNs=";
+    version = "2.1.7";
+    hash = "sha256-Bj9VNhwgM0nO3b/Iptb70hkO2TjKxbEpxdYGyzFt3iA=";
   };
 
   postInstall = ''

--- a/pkgs/by-name/cl/claude-code/package-lock.json
+++ b/pkgs/by-name/cl/claude-code/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anthropic-ai/claude-code",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anthropic-ai/claude-code",
-      "version": "2.1.6",
+      "version": "2.1.7",
       "license": "SEE LICENSE IN README.md",
       "bin": {
         "claude": "cli.js"

--- a/pkgs/by-name/cl/claude-code/package.nix
+++ b/pkgs/by-name/cl/claude-code/package.nix
@@ -12,14 +12,14 @@
 }:
 buildNpmPackage (finalAttrs: {
   pname = "claude-code";
-  version = "2.1.6";
+  version = "2.1.7";
 
   src = fetchzip {
     url = "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-${finalAttrs.version}.tgz";
-    hash = "sha256-M2ZLGnrvNki7B2jOh4Uq2SfSxkICh76uRIFogq+kKZ8=";
+    hash = "sha256-s/XPemwJYPUNFBgWo00VQ6W6eFIy44y9lFoRN0Duk9I=";
   };
 
-  npmDepsHash = "sha256-Y+4ZcfEJJg4/XYc3vNLw4R5OJz3FlYvgQpkB739jKAQ=";
+  npmDepsHash = "sha256-BW3mW3fRXrv+TgW3q+Rc43o0q3t1ra/XUqlUSiA0hTU=";
 
   strictDeps = true;
 


### PR DESCRIPTION
## Summary
- Update claude-code from 2.1.6 to 2.1.7
- Update vscode-extensions.anthropic.claude-code from 2.1.6 to 2.1.7

## Changelog
https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md

## Build verification
Both packages build successfully:
- `nix-build -A claude-code`
- `nix-build -A vscode-extensions.anthropic.claude-code`