### PR TITLE
hdapsd: fix build with modern GCC

### DIFF
--- a/pkgs/by-name/hd/hdapsd/package.nix
+++ b/pkgs/by-name/hd/hdapsd/package.nix
@@ -2,19 +2,21 @@
   lib,
   stdenv,
   fetchurl,
+  pkg-config,
   udevCheckHook,
 }:
 
 stdenv.mkDerivation rec {
   pname = "hdapsd";
-  version = "20141203";
+  version = "20250908";
 
   src = fetchurl {
-    url = "https://github.com/evgeni/hdapsd/releases/download/${version}/hdapsd-${version}.tar.gz";
-    sha256 = "0ppgrfabd0ivx9hyny3c3rv4rphjyxcdsd5svx5pgfai49mxnl36";
+    url = "https://github.com/linux-thinkpad/hdapsd/releases/download/${version}/hdapsd-${version}.tar.gz";
+    hash = "sha256-qENcOFJ9x5CkN72ZkTx/OL+gpwAYJlJomKvAjTklDYQ=";
   };
 
   nativeBuildInputs = [
+    pkg-config
     udevCheckHook
   ];
 
@@ -25,7 +27,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Hard Drive Active Protection System Daemon";
     mainProgram = "hdapsd";
-    homepage = "http://hdaps.sf.net/";
+    homepage = "https://github.com/linux-thinkpad/hdapsd";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux;
   };


### PR DESCRIPTION
The `usage()` function was declared without parameters but called with `argv`, causing a compilation error with modern GCC which treats implicit function declarations as errors.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test