### PR TITLE
immer: 0.8.1 -> 0.9.1, add passthru.tests

### DIFF
--- a/pkgs/by-name/im/immer/package.nix
+++ b/pkgs/by-name/im/immer/package.nix
@@ -1,44 +1,62 @@
 {
   lib,
   stdenv,
-  catch2,
+  catch2_3,
   fetchFromGitHub,
   cmake,
+  boehmgc,
+  boost,
+  fmt,
   nix-update-script,
 }:
-
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "immer";
-  version = "0.8.1";
+
+  version = "0.9.1";
 
   src = fetchFromGitHub {
     owner = "arximboldi";
     repo = "immer";
-    tag = "v${version}";
-    hash = "sha256-Tyj2mNyLhrcFNQEn4xHC8Gz7/jtA4Dnkjtk8AAXJEw8=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Qrr5mDbPF9cbLi9T2IVAKPN3CkTxffoivvqGNGLdkxE=";
   };
 
-  nativeBuildInputs = [
-    cmake
-  ];
+  nativeBuildInputs = [ cmake ];
 
-  buildInputs = [
-    catch2
-  ];
+  cmakeFlags = [ (lib.cmakeBool "immer_BUILD_TESTS" finalAttrs.finalPackage.doCheck) ];
+
+  # immer is a header only library
+  dontBuild = true;
+  buildInputs = [ ];
+  dontUseCmakeBuildDir = true;
+
+  doCheck = false;
 
   strictDeps = true;
 
-  dontBuild = true;
-  dontUseCmakeBuildDir = true;
-
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    tests.test = finalAttrs.finalPackage.overrideAttrs (attrs: {
+      pname = "${attrs.pname}-test";
+      doCheck = true;
+      checkInputs = [
+        catch2_3
+        boehmgc
+        boost
+        fmt
+      ];
+      checkPhase = ''
+        make check
+      '';
+    });
+    updateScript = nix-update-script { };
+  };
 
   meta = {
     description = "Postmodern immutable and persistent data structures for C++ — value semantics at scale";
     homepage = "https://sinusoid.es/immer";
-    changelog = "https://github.com/arximboldi/immer/releases/tag/v${version}";
+    changelog = "https://github.com/arximboldi/immer/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.boost;
     maintainers = with lib.maintainers; [ sifmelcara ];
     platforms = lib.platforms.all;
   };
-}
+})


### PR DESCRIPTION
## Things done

1. Update the version. New version requires `catch2_3` instead of `catch2`
2. Previously `catch2` was added to `nativeBuildInputs` to make cmake configure phase happy, now this mistake is corrected by explicitly disabling tests in cmake flag when `doCheck` is `false`.
3. Run tests in `passthru.tests.test`

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
