### PR TITLE
vscode-extensions.ms-vscode.vscode-speech: init at 0.16.0

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -3407,6 +3407,8 @@ let
 
       ms-vscode.vscode-js-profile-table = callPackage ./ms-vscode.vscode-js-profile-table { };
 
+      ms-vscode.vscode-speech = callPackage ./ms-vscode.vscode-speech { };
+
       ms-vscode-remote.remote-containers = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "remote-containers";

--- a/pkgs/applications/editors/vscode/extensions/ms-vscode.vscode-speech/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/ms-vscode.vscode-speech/default.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  vscode-utils,
+  vscode-extension-update-script,
+  autoPatchelfHook,
+  stdenv,
+  alsa-lib,
+  libuuid,
+}:
+
+vscode-utils.buildVscodeMarketplaceExtension {
+  mktplcRef =
+    let
+      sources = {
+        "x86_64-linux" = {
+          arch = "linux-x64";
+          hash = "sha256-dZwOBehoYEqaYskvcPB55IKnG1CMToioyUJXlndqorA=";
+        };
+        "x86_64-darwin" = {
+          arch = "darwin-x64";
+          hash = "sha256-b6LobvVngC0TFuWTC9JBQrECkoX7ewLNCpCROkXHk20=";
+        };
+        "aarch64-linux" = {
+          arch = "linux-arm64";
+          hash = "sha256-/EaOfoubfq1ufwB7TTQ2hqmh1ZJiZ1+B6QeYu3MoFPI=";
+        };
+        "aarch64-darwin" = {
+          arch = "darwin-arm64";
+          hash = "sha256-JhZWNlGXljsjmT3/xDi9Z7I4a2vsi/9EkWYbnlteE98=";
+        };
+      };
+    in
+    {
+      name = "vscode-speech";
+      publisher = "ms-vscode";
+      version = "0.16.0";
+    }
+    // sources.${stdenv.hostPlatform.system}
+      or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    autoPatchelfHook
+  ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    stdenv.cc.cc.lib
+    alsa-lib
+    libuuid
+  ];
+
+  # Prevent fixup phase from shrinking RPATHs - we need the Release directory
+  # in the RPATH for dlopen to find libMicrosoft.CognitiveServices.Speech.extension.audio.sys.so
+  dontPatchELF = true;
+
+  # libMicrosoft.CognitiveServices.Speech.core.so uses dlopen to load audio.sys.so at runtime.
+  # autoPatchelfHook patches direct dependencies but can't detect dlopen calls,
+  # so we add the Release directory to RPATH.
+  appendRunpaths = lib.optionals stdenv.hostPlatform.isLinux [
+    "${placeholder "out"}/share/vscode/extensions/ms-vscode.vscode-speech/node_modules/@vscode/node-speech/build/Release"
+  ];
+
+  passthru.updateScript = vscode-extension-update-script { };
+
+  meta = {
+    description = "Enables speech-to-text and text-to-speech capabilities in VS Code";
+    downloadPage = "https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-speech";
+    homepage = "https://github.com/microsoft/vscode";
+    license = lib.licenses.unfree;
+    platforms = [
+      "x86_64-linux"
+      "x86_64-darwin"
+      "aarch64-linux"
+      "aarch64-darwin"
+    ];
+    maintainers = with lib.maintainers; [ pathob ];
+  };
+}


### PR DESCRIPTION
Enables speech-to-text and text-to-speech capabilities in VS Code.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
