### PR TITLE
treewide: prefer meta.broken over disabled by platform

### DIFF
--- a/pkgs/development/python-modules/mahotas/default.nix
+++ b/pkgs/development/python-modules/mahotas/default.nix
@@ -49,10 +49,11 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "mahotas" ];
 
-  disabled = stdenv.hostPlatform.isi686; # Failing tests
-
   meta = {
-    broken = (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64);
+    broken =
+      (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64)
+      # Failing tests
+      || stdenv.hostPlatform.isi686;
     description = "Computer vision package based on numpy";
     homepage = "https://mahotas.readthedocs.io/";
     maintainers = with lib.maintainers; [ luispedro ];

--- a/pkgs/development/python-modules/ospd/default.nix
+++ b/pkgs/development/python-modules/ospd/default.nix
@@ -9,15 +9,12 @@
   paramiko,
   psutil,
   pytestCheckHook,
-  pythonOlder,
 }:
 
 buildPythonPackage rec {
   pname = "ospd";
   version = "21.4.4";
   format = "setuptools";
-
-  disabled = pythonOlder "3.7" || stdenv.hostPlatform.isDarwin;
 
   src = fetchFromGitHub {
     owner = "greenbone";
@@ -44,5 +41,6 @@ buildPythonPackage rec {
     changelog = "https://github.com/greenbone/ospd/releases/tag/v${version}";
     license = with lib.licenses; [ agpl3Plus ];
     maintainers = with lib.maintainers; [ fab ];
+    broken = stdenv.hostPlatform.isDarwin;
   };
 }

--- a/pkgs/development/python-modules/soundfile/default.nix
+++ b/pkgs/development/python-modules/soundfile/default.nix
@@ -15,8 +15,7 @@ buildPythonPackage rec {
   pname = "soundfile";
   version = "0.13.1";
   pyproject = true;
-  # https://github.com/bastibe/python-soundfile/issues/157
-  disabled = isPyPy || stdenv.hostPlatform.isi686;
+  disabled = isPyPy;
 
   src = fetchPypi {
     inherit pname version;
@@ -45,5 +44,7 @@ buildPythonPackage rec {
     description = "Audio library based on libsndfile, CFFI and NumPy";
     license = lib.licenses.bsd3;
     homepage = "https://github.com/bastibe/python-soundfile";
+    # https://github.com/bastibe/python-soundfile/issues/157
+    broken = stdenv.hostPlatform.isi686;
   };
 }


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/479981#discussion_r2689891487

I grepped for `disabled = .*stdenv` and narrowed down those few results to python packages.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
