### PR TITLE
polymake: enable polydb

### DIFF
--- a/pkgs/by-name/po/polymake/package.nix
+++ b/pkgs/by-name/po/polymake/package.nix
@@ -15,6 +15,7 @@
   ninja,
   ant,
   openjdk,
+  mongoc,
   perl,
   perlPackages,
   makeWrapper,
@@ -55,6 +56,7 @@ stdenv.mkDerivation rec {
     lrs
     nauty
     openjdk
+    mongoc
   ]
   ++ (with perlPackages; [
     JSON
@@ -62,6 +64,10 @@ stdenv.mkDerivation rec {
     TermReadKey
     XMLSAX
   ]);
+
+  configureFlags = [
+    "--with-mongoc=${mongoc}"
+  ];
 
   ninjaFlags = [
     "-C"


### PR DESCRIPTION
As suggested by @mkoeppe in https://github.com/passagemath/passagemath/pull/1978. It wasn't built before because a dependency was missing. Ideally polymake should find `libmongoc-1.0` automatically using `pkg-config`, but it didn't so I'm passing the library location manually via a configure flag.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
