### PR TITLE
treewide: remove usage of zig.hook

### DIFF
--- a/pkgs/by-name/bl/blackshades/package.nix
+++ b/pkgs/by-name/bl/blackshades/package.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
     } $ZIG_GLOBAL_CACHE_DIR/p
   '';
 
-  nativeBuildInputs = [ zig_0_14.hook ];
+  nativeBuildInputs = [ zig_0_14 ];
 
   buildInputs = [
     glfw

--- a/pkgs/by-name/bo/bold/package.nix
+++ b/pkgs/by-name/bo/bold/package.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   nativeBuildInputs = [
-    zig.hook
+    zig
   ];
 
   doInstallCheck = true;

--- a/pkgs/by-name/bo/bork/package.nix
+++ b/pkgs/by-name/bo/bork/package.nix
@@ -22,7 +22,7 @@ stdenvNoCC.mkDerivation {
   };
 
   nativeBuildInputs = [
-    zig.hook
+    zig
   ];
 
   buildInputs = [

--- a/pkgs/by-name/cr/creek/package.nix
+++ b/pkgs/by-name/cr/creek/package.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
   depsBuildBuild = [ pkg-config ];
 
   nativeBuildInputs = [
-    zig.hook
+    zig
     pkg-config
     wayland-scanner
   ];

--- a/pkgs/by-name/dt/dt/package.nix
+++ b/pkgs/by-name/dt/dt/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-pfTlOMJpOPbXZaJJvOKDUyCZxFHNLRRUteJFWT9IKOU=";
   };
 
-  nativeBuildInputs = [ zig_0_13.hook ];
+  nativeBuildInputs = [ zig_0_13 ];
 
   passthru.tests.version = testers.testVersion { package = finalAttrs.finalPackage; };
 

--- a/pkgs/by-name/fa/fancy-cat/package.nix
+++ b/pkgs/by-name/fa/fancy-cat/package.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [ ./0001-changes.patch ];
 
   nativeBuildInputs = [
-    zig_0_14.hook
+    zig_0_14
   ];
 
   zigBuildFlags = [ "--release=fast" ];

--- a/pkgs/by-name/fi/findup/package.nix
+++ b/pkgs/by-name/fi/findup/package.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-6/rQ4xNfzJQwJgrpvFRuirqlx6fVn7sLXfVRFsG3fUw=";
   };
 
-  nativeBuildInputs = [ zig.hook ];
+  nativeBuildInputs = [ zig ];
 
   passthru.tests.version = testers.testVersion { package = finalAttrs.finalPackage; };
 

--- a/pkgs/by-name/gh/ghostty/package.nix
+++ b/pkgs/by-name/gh/ghostty/package.nix
@@ -24,8 +24,7 @@
   wrapGAppsHook4,
   zig_0_14,
 
-  # Usually you would override `zig.hook` with this, but we do that internally
-  # since upstream recommends a non-default level
+  # Upstream recommends a non-default level
   # https://github.com/ghostty-org/ghostty/blob/4b4d4062dfed7b37424c7210d1230242c709e990/PACKAGING.md#build-options
   optimizeLevel ? "ReleaseFast",
 }:

--- a/pkgs/by-name/gl/glsl_analyzer/package.nix
+++ b/pkgs/by-name/gl/glsl_analyzer/package.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   nativeBuildInputs = [
-    zig.hook
+    zig
   ];
 
   postPatch = ''

--- a/pkgs/by-name/he/hevi/package.nix
+++ b/pkgs/by-name/he/hevi/package.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   nativeBuildInputs = [
-    zig.hook
+    zig
   ];
 
   postPatch = ''

--- a/pkgs/by-name/li/linuxwave/package.nix
+++ b/pkgs/by-name/li/linuxwave/package.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     installShellFiles
-    zig.hook
+    zig
   ];
 
   postInstall = ''

--- a/pkgs/by-name/ls/lsr/package.nix
+++ b/pkgs/by-name/ls/lsr/package.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     installShellFiles
-    zig.hook
+    zig
   ];
 
   doInstallCheck = true;

--- a/pkgs/by-name/ly/ly/package.nix
+++ b/pkgs/by-name/ly/ly/package.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     makeBinaryWrapper
-    zig_0_15.hook
+    zig_0_15
   ];
   buildInputs = [
     linux-pam

--- a/pkgs/by-name/me/mepo/package.nix
+++ b/pkgs/by-name/me/mepo/package.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     pkg-config
-    zig_0_14.hook
+    zig_0_14
     makeWrapper
   ];
 

--- a/pkgs/by-name/mi/minizign/package.nix
+++ b/pkgs/by-name/mi/minizign/package.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   nativeBuildInputs = [
-    zig.hook
+    zig
   ];
 
   meta = {

--- a/pkgs/by-name/nc/ncdu/package.nix
+++ b/pkgs/by-name/nc/ncdu/package.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   nativeBuildInputs = [
-    zig_0_15.hook
+    zig_0_15
     installShellFiles
     pkg-config
   ];

--- a/pkgs/by-name/od/odiff/package.nix
+++ b/pkgs/by-name/od/odiff/package.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     installShellFiles
-    zig.hook
+    zig
     nasm
   ];
 

--- a/pkgs/by-name/ou/outfieldr/package.nix
+++ b/pkgs/by-name/ou/outfieldr/package.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   nativeBuildInputs = [
-    zig.hook
+    zig
   ];
 
   meta = {

--- a/pkgs/by-name/po/poop/package.nix
+++ b/pkgs/by-name/po/poop/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   nativeBuildInputs = [
-    zig_0_13.hook
+    zig_0_13
   ];
 
   meta = {

--- a/pkgs/by-name/ri/river-bedload/package.nix
+++ b/pkgs/by-name/ri/river-bedload/package.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     pkg-config
-    zig.hook
+    zig
   ];
 
   buildInputs = [

--- a/pkgs/by-name/ri/river-classic/package.nix
+++ b/pkgs/by-name/ri/river-classic/package.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
     wayland-scanner
     xwayland
-    zig_0_15.hook
+    zig_0_15
   ]
   ++ lib.optional withManpages scdoc;
 

--- a/pkgs/by-name/ri/river-ultitile/package.nix
+++ b/pkgs/by-name/ri/river-ultitile/package.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   nativeBuildInputs = [
-    zig.hook
+    zig
     pkg-config
     wayland
     wayland-scanner

--- a/pkgs/by-name/ri/rivercarro/package.nix
+++ b/pkgs/by-name/ri/rivercarro/package.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation (finalAttrs: {
     wayland
     wayland-protocols
     wayland-scanner
-    zig.hook
+    zig
   ];
 
   postPatch = ''

--- a/pkgs/by-name/su/superhtml/package.nix
+++ b/pkgs/by-name/su/superhtml/package.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   nativeBuildInputs = [
-    zig.hook
+    zig
   ];
 
   postPatch = ''

--- a/pkgs/by-name/tu/tuatara/package.nix
+++ b/pkgs/by-name/tu/tuatara/package.nix
@@ -19,7 +19,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   strictDeps = true;
 
-  nativeBuildInputs = [ zig_0_13.hook ];
+  nativeBuildInputs = [ zig_0_13 ];
 
   preBuild = ''
     export ZIG_LOCAL_CACHE_DIR=$TMPDIR/zig-cache

--- a/pkgs/by-name/wa/waylock/package.nix
+++ b/pkgs/by-name/wa/waylock/package.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
     scdoc
     wayland-scanner
-    zig_0_15.hook
+    zig_0_15
   ];
 
   buildInputs = [

--- a/pkgs/by-name/wa/wayprompt/package.nix
+++ b/pkgs/by-name/wa/wayprompt/package.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
   deps = callPackage ./build.zig.zon.nix { };
 
   nativeBuildInputs = [
-    zig_0_13.hook
+    zig_0_13
     pkg-config
     wayland
     wayland-scanner

--- a/pkgs/by-name/zi/zig-zlint/package.nix
+++ b/pkgs/by-name/zi/zig-zlint/package.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   nativeBuildInputs = [
-    zig_0_14.hook
+    zig_0_14
   ];
 
   zigBuildFlags = [

--- a/pkgs/by-name/zi/zigfetch/package.nix
+++ b/pkgs/by-name/zi/zigfetch/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   nativeBuildInputs = [
-    zig.hook
+    zig
   ];
 
   buildInputs = [

--- a/pkgs/by-name/zi/zigimports/package.nix
+++ b/pkgs/by-name/zi/zigimports/package.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   nativeBuildInputs = [
-    zig_0_13.hook
+    zig_0_13
   ];
 
   # Remove the system suffix on the program name.

--- a/pkgs/by-name/zo/zon2nix/package.nix
+++ b/pkgs/by-name/zo/zon2nix/package.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   nativeBuildInputs = [
-    zig_0_14.hook
+    zig_0_14
   ];
 
   zigBuildFlags = [

--- a/pkgs/by-name/zs/zsnow/package.nix
+++ b/pkgs/by-name/zs/zsnow/package.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   nativeBuildInputs = [
-    zig.hook
+    zig
     pkg-config
     wayland-scanner
   ];

--- a/pkgs/by-name/zt/ztags/package.nix
+++ b/pkgs/by-name/zt/ztags/package.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     scdoc
-    zig.hook
+    zig
   ];
 
   postInstall = ''

--- a/pkgs/development/compilers/arocc/package.nix
+++ b/pkgs/development/compilers/arocc/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "arocc";
   inherit version src;
 
-  nativeBuildInputs = [ zig.hook ];
+  nativeBuildInputs = [ zig ];
 
   passthru = {
     inherit zig;

--- a/pkgs/development/tools/zls/default.nix
+++ b/pkgs/development/tools/zls/default.nix
@@ -38,7 +38,7 @@ lib.mapAttrs (_: extension: stdenv.mkDerivation (lib.extends common extension)) 
       hash = "sha256-A5Mn+mfIefOsX+eNBRHrDVkqFDVrD3iXDNsUL4TPhKo=";
     };
 
-    nativeBuildInputs = [ zig_0_14.hook ];
+    nativeBuildInputs = [ zig_0_14 ];
 
     postPatch = ''
       ln -s ${callPackage ./deps_0_14.nix { }} $ZIG_GLOBAL_CACHE_DIR/p
@@ -56,7 +56,7 @@ lib.mapAttrs (_: extension: stdenv.mkDerivation (lib.extends common extension)) 
       hash = "sha256-6IkRtQkn+qUHDz00QvCV/rb2yuF6xWEXug41CD8LLw8=";
     };
 
-    nativeBuildInputs = [ zig_0_15.hook ];
+    nativeBuildInputs = [ zig_0_15 ];
 
     postPatch = ''
       ln -s ${callPackage ./deps_0_15.nix { }} $ZIG_GLOBAL_CACHE_DIR/p


### PR DESCRIPTION
With recent changes to the zig setup hook, it is no longer necessary to include zig.hook in the derivation inputs.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
