### PR TITLE
nixos/display-managers: move "generic" DM unit to its own option set

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -611,6 +611,7 @@
   ./services/display-managers/default.nix
   ./services/display-managers/dms-greeter.nix
   ./services/display-managers/gdm.nix
+  ./services/display-managers/generic.nix
   ./services/display-managers/greetd.nix
   ./services/display-managers/lemurs.nix
   ./services/display-managers/ly.nix

--- a/nixos/modules/services/display-managers/default.nix
+++ b/nixos/modules/services/display-managers/default.nix
@@ -40,26 +40,7 @@ in
 {
   options = {
     services.displayManager = {
-      enable = lib.mkEnableOption "systemd's display-manager service";
-
-      preStart = lib.mkOption {
-        type = lib.types.lines;
-        default = "";
-        example = "rm -f /var/log/my-display-manager.log";
-        description = "Script executed before the display manager is started.";
-      };
-
-      execCmd = lib.mkOption {
-        type = lib.types.str;
-        example = lib.literalExpression ''"''${pkgs.lightdm}/bin/lightdm"'';
-        description = "Command to start the display manager.";
-      };
-
-      environment = lib.mkOption {
-        type = with lib.types; attrsOf unspecified;
-        default = { };
-        description = "Additional environment variables needed by the display manager.";
-      };
+      enable = lib.mkEnableOption "shared display manager integration";
 
       hiddenUsers = lib.mkOption {
         type = with lib.types; listOf str;
@@ -249,51 +230,6 @@ in
           lib.head cfg.sessionData.sessionNames
         else
           null;
-    };
-
-    # so that the service won't be enabled when only startx is used
-    systemd.services.display-manager.enable =
-      let
-        dmConf = config.services.xserver.displayManager;
-        noDmUsed =
-          !(
-            cfg.gdm.enable
-            || cfg.sddm.enable
-            || dmConf.xpra.enable
-            || dmConf.lightdm.enable
-            || cfg.ly.enable
-            || cfg.lemurs.enable
-          );
-      in
-      lib.mkIf noDmUsed (lib.mkDefault false);
-
-    systemd.services.display-manager = {
-      description = "Display Manager";
-      after = [
-        "acpid.service"
-        "systemd-logind.service"
-        "systemd-user-sessions.service"
-        "autovt@tty1.service"
-      ];
-      conflicts = [
-        "autovt@tty1.service"
-      ];
-      restartIfChanged = false;
-
-      environment = cfg.environment;
-
-      preStart = cfg.preStart;
-      script = lib.mkIf (config.systemd.services.display-manager.enable == true) cfg.execCmd;
-
-      # Stop restarting if the display manager stops (crashes) 2 times
-      # in one minute. Starting X typically takes 3-4s.
-      startLimitIntervalSec = 30;
-      startLimitBurst = 3;
-      serviceConfig = {
-        Restart = "always";
-        RestartSec = "200ms";
-        SyslogIdentifier = "display-manager";
-      };
     };
   };
 }

--- a/nixos/modules/services/display-managers/generic.nix
+++ b/nixos/modules/services/display-managers/generic.nix
@@ -1,0 +1,83 @@
+{ config, lib, ... }:
+let
+  cfg = config.services.displayManager.generic;
+in
+{
+  imports = [
+    (lib.mkRenamedOptionModule
+      [ "services" "displayManager" "preStart" ]
+      [ "services" "displayManager" "generic" "preStart" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "displayManager" "execCmd" ]
+      [ "services" "displayManager" "generic" "execCmd" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "displayManager" "environment" ]
+      [ "services" "displayManager" "generic" "environment" ]
+    )
+  ];
+
+  options = {
+    services.displayManager.generic = {
+      enable = lib.mkEnableOption "generic display manager integration - deprecated";
+
+      preStart = lib.mkOption {
+        type = lib.types.lines;
+        default = "";
+        example = "rm -f /var/log/my-display-manager.log";
+        description = "Script executed before the display manager is started.";
+      };
+
+      execCmd = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        example = lib.literalExpression ''"''${pkgs.lightdm}/bin/lightdm"'';
+        description = "Command to start the display manager.";
+      };
+
+      environment = lib.mkOption {
+        type = with lib.types; attrsOf unspecified;
+        default = { };
+        description = "Additional environment variables needed by the display manager.";
+      };
+    };
+  };
+  config = lib.mkIf (cfg.enable || cfg.execCmd != null) {
+    warnings = [
+      (lib.mkIf (!cfg.enable) ''
+        Enabling display-manager.service implicitly due to `services.displayManager.generic.execCmd` being set; this will be removed eventually.
+        Please set `services.displayManager.generic.enable` explicitly, or switch your display manager to use upstream systemd units (preferred).
+      '')
+    ];
+
+    systemd.services.display-manager = {
+      description = "Display Manager";
+      after = [
+        "acpid.service"
+        "systemd-logind.service"
+        "systemd-user-sessions.service"
+        "autovt@tty1.service"
+      ];
+      conflicts = [
+        "autovt@tty1.service"
+      ];
+      restartIfChanged = false;
+
+      environment = cfg.environment;
+
+      preStart = cfg.preStart;
+      script = cfg.execCmd;
+
+      # Stop restarting if the display manager stops (crashes) 2 times
+      # in one minute. Starting X typically takes 3-4s.
+      startLimitIntervalSec = 30;
+      startLimitBurst = 3;
+      serviceConfig = {
+        Restart = "always";
+        RestartSec = "200ms";
+        SyslogIdentifier = "display-manager";
+      };
+    };
+  };
+}

--- a/nixos/modules/services/display-managers/lemurs.nix
+++ b/nixos/modules/services/display-managers/lemurs.nix
@@ -76,7 +76,10 @@ in
       };
       displayManager = {
         enable = true;
-        execCmd = "exec ${lib.getExe cfg.package} --config ${settingsFormat.generate "config.toml" cfg.settings}";
+        generic = {
+          enable = true;
+          execCmd = "exec ${lib.getExe cfg.package} --config ${settingsFormat.generate "config.toml" cfg.settings}";
+        };
         # set default settings
         lemurs.settings =
           let

--- a/nixos/modules/services/display-managers/ly.nix
+++ b/nixos/modules/services/display-managers/ly.nix
@@ -107,7 +107,10 @@ in
 
       displayManager = {
         enable = true;
-        execCmd = "exec /run/current-system/sw/bin/ly";
+        generic = {
+          enable = true;
+          execCmd = "exec /run/current-system/sw/bin/ly";
+        };
 
         # Set this here instead of 'defaultConfig' so users get eval
         # errors when they change it.

--- a/nixos/modules/services/display-managers/sddm.nix
+++ b/nixos/modules/services/display-managers/sddm.nix
@@ -361,7 +361,10 @@ in
 
     services.displayManager = {
       enable = true;
-      execCmd = "exec /run/current-system/sw/bin/sddm";
+      generic = {
+        enable = true;
+        execCmd = "exec /run/current-system/sw/bin/sddm";
+      };
     };
 
     security.pam.services = {

--- a/nixos/modules/services/ttys/getty.nix
+++ b/nixos/modules/services/ttys/getty.nix
@@ -151,11 +151,9 @@ in
     # We can't just rely on 'Conflicts=autovt@tty1.service' because
     # 'switch-to-configuration switch' will start 'autovt@tty1.service'
     # and kill the display manager.
-    systemd.targets.getty.wants =
-      lib.mkIf (!(config.systemd.services.display-manager.enable or false))
-        [
-          "autovt@tty1.service"
-        ];
+    systemd.targets.getty.wants = lib.mkIf (!config.services.displayManager.enable) [
+      "autovt@tty1.service"
+    ];
 
     systemd.services."getty@" = {
       serviceConfig.ExecStart = [

--- a/nixos/modules/services/x11/display-managers/lightdm.nix
+++ b/nixos/modules/services/x11/display-managers/lightdm.nix
@@ -215,22 +215,24 @@ in
 
     # Set default session in session chooser to a specified values – basically ignore session history.
     # Auto-login is already covered by a config value.
-    services.displayManager.preStart =
+    services.displayManager.generic.preStart =
       optionalString (!dmcfg.autoLogin.enable && dmcfg.defaultSession != null)
         ''
           ${setSessionScript}/bin/set-session ${dmcfg.defaultSession}
         '';
 
     # setSessionScript needs session-files in XDG_DATA_DIRS
-    services.displayManager.environment.XDG_DATA_DIRS = "${dmcfg.sessionData.desktops}/share/";
+    services.displayManager.generic.environment.XDG_DATA_DIRS = "${dmcfg.sessionData.desktops}/share/";
 
     # setSessionScript wants AccountsService
     systemd.services.display-manager.wants = [
       "accounts-daemon.service"
     ];
 
+    services.displayManager.generic.enable = true;
+
     # lightdm relaunches itself via just `lightdm`, so needs to be on the PATH
-    services.displayManager.execCmd = ''
+    services.displayManager.generic.execCmd = ''
       export PATH=${lightdm}/sbin:$PATH
       exec ${lightdm}/sbin/lightdm
     '';

--- a/nixos/modules/services/x11/display-managers/xpra.nix
+++ b/nixos/modules/services/x11/display-managers/xpra.nix
@@ -300,7 +300,8 @@ in
       VideoRam 192000
     '';
 
-    services.displayManager.execCmd = ''
+    services.displayManager.generic.enable = true;
+    services.displayManager.generic.execCmd = ''
       ${optionalString (cfg.pulseaudio) "export PULSE_COOKIE=/run/pulse/.config/pulse/cookie"}
       exec ${pkgs.xpra}/bin/xpra ${
         if cfg.desktop == null then "start" else "start-desktop --start=${cfg.desktop}"

--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -849,35 +849,10 @@ in
 
     environment.pathsToLink = [ "/share/X11" ];
 
-    systemd.services.display-manager = {
-      description = "Display Manager";
-
-      after = [
-        "acpid.service"
-        "systemd-logind.service"
-        "systemd-user-sessions.service"
-      ];
-
-      restartIfChanged = false;
-
-      environment = config.services.displayManager.environment;
-
-      preStart = ''
-        ${config.services.displayManager.preStart}
-
-        rm -f /tmp/.X0-lock
-      '';
-
-      # Stop restarting if the display manager stops (crashes) 2 times
-      # in one minute. Starting X typically takes 3-4s.
-      startLimitIntervalSec = 30;
-      startLimitBurst = 3;
-      serviceConfig = {
-        Restart = "always";
-        RestartSec = "200ms";
-        SyslogIdentifier = "display-manager";
-      };
-    };
+    # FIXME: what
+    services.displayManager.generic.preStart = ''
+      rm -f /tmp/.X0-lock
+    '';
 
     services.xserver.displayManager.xserverArgs = [
       "-config ${configFile}"


### PR DESCRIPTION
This is the first step towards deprecating it.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
