### PR TITLE
various: use absolute path in thumbnailer files

### DIFF
--- a/pkgs/by-name/at/atril/package.nix
+++ b/pkgs/by-name/at/atril/package.nix
@@ -88,6 +88,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
+  postInstall = ''
+    substituteInPlace $out/share/thumbnailers/atril.thumbnailer \
+      --replace-fail "TryExec=atril-thumbnailer" "TryExec=$out/bin/atril-thumbnailer" \
+      --replace-fail "Exec=atril-thumbnailer" "Exec=$out/bin/atril-thumbnailer"
+  '';
+
   passthru.updateScript = gitUpdater {
     rev-prefix = "v";
     odd-unstable = true;

--- a/pkgs/by-name/co/cosmic-player/package.nix
+++ b/pkgs/by-name/co/cosmic-player/package.nix
@@ -72,6 +72,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   preFixup = ''
     libcosmicAppWrapperArgs+=(--prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0")
+
+    substituteInPlace $out/share/thumbnailers/com.system76.CosmicPlayer.thumbnailer \
+      --replace-fail "TryExec=cosmic-player" "TryExec=$out/bin/cosmic-player" \
+      --replace-fail "Exec=cosmic-player" "Exec=$out/bin/cosmic-player"
   '';
 
   passthru = {

--- a/pkgs/by-name/co/cosmic-reader/package.nix
+++ b/pkgs/by-name/co/cosmic-reader/package.nix
@@ -66,6 +66,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "target/${stdenv.hostPlatform.rust.cargoShortTarget}"
   ];
 
+  postInstall = ''
+    substituteInPlace $out/share/thumbnailers/com.system76.CosmicReader.thumbnailer \
+      --replace-fail "TryExec=cosmic-reader" "TryExec=$out/bin/cosmic-reader" \
+      --replace-fail "Exec=cosmic-reader" "Exec=$out/bin/cosmic-reader"
+  '';
+
   passthru.updateScript = nix-update-script {
     extraArgs = [
       "--version"

--- a/pkgs/by-name/cr/crosswords/package.nix
+++ b/pkgs/by-name/cr/crosswords/package.nix
@@ -45,6 +45,12 @@ stdenv.mkDerivation (finalAttrs: {
     libipuz
   ];
 
+  postInstall = ''
+    substituteInPlace $out/share/thumbnailers/crosswords.thumbnailer \
+      --replace-fail "TryExec=crosswords-thumbnailer" "TryExec=$out/bin/crosswords-thumbnailer" \
+      --replace-fail "Exec=crosswords-thumbnailer" "Exec=$out/bin/crosswords-thumbnailer"
+  '';
+
   passthru.updateScript = nix-update-script { };
 
   meta = {

--- a/pkgs/by-name/di/dia/package.nix
+++ b/pkgs/by-name/di/dia/package.nix
@@ -98,6 +98,12 @@ stdenv.mkDerivation {
     gtk-mac-integration-gtk3
   ];
 
+  postInstall = ''
+    substituteInPlace $out/share/thumbnailers/org.gnome.Dia.thumbnailer \
+      --replace-fail "TryExec=dia" "TryExec=$out/bin/dia" \
+      --replace-fail "Exec=dia" "Exec=$out/bin/dia"
+  '';
+
   meta = {
     description = "Gnome Diagram drawing software";
     mainProgram = "dia";

--- a/pkgs/by-name/ev/evince/package.nix
+++ b/pkgs/by-name/ev/evince/package.nix
@@ -126,6 +126,12 @@ stdenv.mkDerivation (finalAttrs: {
     "-DHAVE_STDLIB_H"
   ];
 
+  postInstall = ''
+    substituteInPlace $out/share/thumbnailers/evince.thumbnailer \
+      --replace-fail "TryExec=evince-thumbnailer" "TryExec=$out/bin/evince-thumbnailer" \
+      --replace-fail "Exec=evince-thumbnailer" "Exec=$out/bin/evince-thumbnailer"
+  '';
+
   preFixup = ''
     gappsWrapperArgs+=(--prefix XDG_DATA_DIRS : "${shared-mime-info}/share")
   '';

--- a/pkgs/by-name/f3/f3d/package.nix
+++ b/pkgs/by-name/f3/f3d/package.nix
@@ -84,6 +84,14 @@ stdenv.mkDerivation rec {
     "-DF3D_PLUGIN_BUILD_USD=ON"
   ];
 
+  postInstall = ''
+    for thumbnailer in $out/share/thumbnailers/f3d-plugin-*.thumbnailer; do
+      substituteInPlace $thumbnailer \
+        --replace-fail "TryExec=f3d" "TryExec=$out/bin/f3d" \
+        --replace-fail "Exec=f3d" "Exec=$out/bin/f3d"
+    done
+  '';
+
   meta = {
     description = "Fast and minimalist 3D viewer using VTK";
     homepage = "https://f3d-app.github.io/f3d";

--- a/pkgs/by-name/fr/freecad/package.nix
+++ b/pkgs/by-name/fr/freecad/package.nix
@@ -138,6 +138,12 @@ freecad-utils.makeCustomizable (
         "--prefix PYTHONPATH : ${python3Packages.makePythonPath pythonDeps}"
       ];
 
+    postInstall = ''
+      substituteInPlace $out/share/thumbnailers/FreeCAD.thumbnailer \
+        --replace-fail "TryExec=freecad-thumbnailer" "TryExec=$out/bin/freecad-thumbnailer" \
+        --replace-fail "Exec=freecad-thumbnailer" "Exec=$out/bin/freecad-thumbnailer"
+    '';
+
     postFixup = ''
       mv $out/share/doc $out
       ln -s $out/doc $out/share/doc

--- a/pkgs/by-name/gl/glslviewer/package.nix
+++ b/pkgs/by-name/gl/glslviewer/package.nix
@@ -43,6 +43,13 @@ stdenv.mkDerivation (finalAttrs: {
     ffmpeg_7
     python3
   ];
+
+  postInstall = ''
+    substituteInPlace $out/share/thumbnailers/glslViewer.thumbnailer \
+      --replace-fail "TryExec=glslThumbnailer" "TryExec=$out/bin/glslThumbnailer" \
+      --replace-fail "Exec=glslThumbnailer" "Exec=$out/bin/glslThumbnailer"
+  '';
+
   meta = {
     description = "Live GLSL coding renderer";
     homepage = "https://patriciogonzalezvivo.com/2015/glslViewer/";

--- a/pkgs/by-name/gn/gnome-font-viewer/package.nix
+++ b/pkgs/by-name/gn/gnome-font-viewer/package.nix
@@ -47,6 +47,12 @@ stdenv.mkDerivation (finalAttrs: {
     fribidi
   ];
 
+  postInstall = ''
+    substituteInPlace $out/share/thumbnailers/gnome-font-viewer.thumbnailer \
+      --replace-fail "TryExec=gnome-thumbnail-font" "TryExec=$out/bin/gnome-thumbnail-font" \
+      --replace-fail "Exec=gnome-thumbnail-font" "Exec=$out/bin/gnome-thumbnail-font"
+  '';
+
   passthru = {
     updateScript = gnome.updateScript {
       packageName = "gnome-font-viewer";

--- a/pkgs/by-name/ic/icoextract/package.nix
+++ b/pkgs/by-name/ic/icoextract/package.nix
@@ -30,6 +30,9 @@ python3Packages.buildPythonApplication (finalAttrs: {
 
   postInstall = ''
     install -Dm644 exe-thumbnailer.thumbnailer -t $out/share/thumbnailers
+
+    substituteInPlace $out/share/thumbnailers/exe-thumbnailer.thumbnailer \
+      --replace-fail "Exec=exe-thumbnailer" "Exec=$out/bin/exe-thumbnailer"
   '';
 
   meta = {

--- a/pkgs/by-name/li/libgsf/package.nix
+++ b/pkgs/by-name/li/libgsf/package.nix
@@ -83,6 +83,12 @@ stdenv.mkDerivation (finalAttrs: {
     patchShebangs ./tests/
   '';
 
+  postInstall = ''
+    substituteInPlace $out/share/thumbnailers/gsf-office.thumbnailer \
+      --replace-fail "TryExec=gsf-office-thumbnailer" "TryExec=$out/bin/gsf-office-thumbnailer" \
+      --replace-fail "Exec=gsf-office-thumbnailer" "Exec=$out/bin/gsf-office-thumbnailer"
+  '';
+
   passthru = {
     updateScript = gnome.updateScript {
       packageName = finalAttrs.pname;

--- a/pkgs/by-name/li/libresprite/package.nix
+++ b/pkgs/by-name/li/libresprite/package.nix
@@ -87,6 +87,10 @@ stdenv.mkDerivation (finalAttrs: {
       dst="$out"/share/icons/hicolor/"$size"x"$size"
       install -Dm644 "$src"/doc"$size".png "$dst"/mimetypes/aseprite.png
     done
+
+    substituteInPlace $out/share/thumbnailers/libresprite.thumbnailer \
+      --replace-fail "TryExec=libresprite-thumbnailer" "TryExec=$out/bin/libresprite-thumbnailer" \
+      --replace-fail "Exec=libresprite-thumbnailer" "Exec=$out/bin/libresprite-thumbnailer"
   '';
 
   passthru.tests = {

--- a/pkgs/by-name/ma/mate-control-center/package.nix
+++ b/pkgs/by-name/ma/mate-control-center/package.nix
@@ -89,6 +89,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   configureFlags = [ "--disable-update-mimedb" ];
 
+  postInstall = ''
+    substituteInPlace $out/share/thumbnailers/mate-font-viewer.thumbnailer \
+      --replace-fail "TryExec=mate-thumbnail-font" "TryExec=$out/bin/mate-thumbnail-font" \
+      --replace-fail "Exec=mate-thumbnail-font" "Exec=$out/bin/mate-thumbnail-font"
+  '';
+
   preFixup = ''
     gappsWrapperArgs+=(
       # WM keyboard shortcuts

--- a/pkgs/by-name/my/mypaint/package.nix
+++ b/pkgs/by-name/my/mypaint/package.nix
@@ -161,6 +161,12 @@ buildPythonApplication (finalAttrs: {
     runHook postCheck
   '';
 
+  postInstall = ''
+    substituteInPlace $out/share/thumbnailers/mypaint-ora.thumbnailer \
+      --replace-fail "TryExec=mypaint-ora-thumbnailer" "TryExec=$out/bin/mypaint-ora-thumbnailer" \
+      --replace-fail "Exec=mypaint-ora-thumbnailer" "Exec=$out/bin/mypaint-ora-thumbnailer"
+  '';
+
   meta = {
     description = "Graphics application for digital painters";
     homepage = "http://mypaint.org/";

--- a/pkgs/by-name/re/renderdoc/package.nix
+++ b/pkgs/by-name/re/renderdoc/package.nix
@@ -142,6 +142,12 @@ stdenv.mkDerivation (finalAttrs: {
      )
   '';
 
+  postInstall = ''
+    substituteInPlace $out/share/thumbnailers/renderdoc.thumbnailer \
+      --replace-fail "TryExec=/usr/bin/renderdoccmd" "TryExec=$out/bin/renderdoccmd" \
+      --replace-fail "Exec=/usr/bin/renderdoccmd" "Exec=$out/bin/renderdoccmd"
+  '';
+
   preFixup =
     let
       libPath = lib.makeLibraryPath [

--- a/pkgs/by-name/rn/rnote/package.nix
+++ b/pkgs/by-name/rn/rnote/package.nix
@@ -80,6 +80,12 @@ stdenv.mkDerivation (finalAttrs: {
     patchShebangs build-aux
   '';
 
+  postInstall = ''
+    substituteInPlace $out/share/thumbnailers/rnote.thumbnailer \
+      --replace-fail "TryExec=rnote-cli" "TryExec=$out/bin/rnote-cli" \
+      --replace-fail "Exec=rnote-cli" "Exec=$out/bin/rnote-cli"
+  '';
+
   env = lib.optionalAttrs stdenv.cc.isClang {
     NIX_CFLAGS_COMPILE = "-Wno-error=incompatible-function-pointer-types";
   };

--- a/pkgs/by-name/sa/sameboy/package.nix
+++ b/pkgs/by-name/sa/sameboy/package.nix
@@ -48,6 +48,12 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail '"libgtk-3.so"' '"${gtk3}/lib/libgtk-3.so"'
   '';
 
+  postInstall = ''
+    substituteInPlace $out/share/thumbnailers/sameboy.thumbnailer \
+      --replace-fail "TryExec=sameboy-thumbnailer" "TryExec=$out/bin/sameboy-thumbnailer" \
+      --replace-fail "Exec=sameboy-thumbnailer" "Exec=$out/bin/sameboy-thumbnailer"
+  '';
+
   meta = {
     homepage = "https://sameboy.github.io";
     description = "Game Boy, Game Boy Color, and Super Game Boy emulator";

--- a/pkgs/by-name/ti/tiled/package.nix
+++ b/pkgs/by-name/ti/tiled/package.nix
@@ -76,6 +76,12 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
+  postInstall = ''
+    substituteInPlace $out/share/thumbnailers/tiled.thumbnailer \
+      --replace-fail "TryExec=tmxrasterizer" "TryExec=$out/bin/tmxrasterizer" \
+      --replace-fail "Exec=tmxrasterizer" "Exec=$out/bin/tmxrasterizer"
+  '';
+
   meta = {
     description = "Free, easy to use and flexible tile map editor";
     homepage = "https://www.mapeditor.org/";

--- a/pkgs/by-name/xo/xournalpp/package.nix
+++ b/pkgs/by-name/xo/xournalpp/package.nix
@@ -67,6 +67,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildFlags = [ "translations" ];
 
+  postInstall = ''
+    substituteInPlace $out/share/thumbnailers/com.github.xournalpp.xournalpp.thumbnailer \
+      --replace-fail "Exec=xournalpp-thumbnailer" "Exec=$out/bin/xournalpp-thumbnailer"
+  '';
+
   preFixup = ''
     gappsWrapperArgs+=(
       --prefix XDG_DATA_DIRS : "${adwaita-icon-theme}/share"

--- a/pkgs/by-name/xr/xreader/package.nix
+++ b/pkgs/by-name/xr/xreader/package.nix
@@ -79,6 +79,12 @@ stdenv.mkDerivation (finalAttrs: {
     djvulibre
   ];
 
+  postInstall = ''
+    substituteInPlace $out/share/thumbnailers/xreader.thumbnailer \
+      --replace-fail "TryExec=xreader-thumbnailer" "TryExec=$out/bin/xreader-thumbnailer" \
+      --replace-fail "Exec=xreader-thumbnailer" "Exec=$out/bin/xreader-thumbnailer"
+  '';
+
   preFixup = ''
     gappsWrapperArgs+=(
       --prefix XDG_DATA_DIRS : "${lib.makeSearchPath "share" [ xapp-symbolic-icons ]}"


### PR DESCRIPTION
Without the absolute paths in the files, the thumbnailers installed with home-manager won't be usable by Gnome Files (Nautilus) due to the bubblewrap isolation.

See #377661 for the explanation of the problem in more detail.

## alternate solutions
The alternate, which might be considered more future-proof[^1], might be extending the [bubblewrap patch in here](https://github.com/NixOS/nixpkgs/blob/2d6dc3daf2cd6e5ba4412f7eb15c7fc4d192bcbb/pkgs/by-name/gn/gnome-desktop/bubblewrap-paths.patch) to also bind `~/.nix-profile/bin`; instead of "fixing" every thumbnailer like this.

---

I verified the fix for these ones myself:
- gnome-font-viewer
- icoextract
- libgsf
- sameboy

while only made sure the rest is built successfully.

[^1]: Automatically handling any future thumbnailers to be added.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
