### PR TITLE
ggml: init at 0.9.5, python3Packages.ggml-python: init at 0.0.37

### DIFF
--- a/pkgs/by-name/gg/ggml/package.nix
+++ b/pkgs/by-name/gg/ggml/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ggml";
+  version = "0.9.5";
+
+  src = fetchFromGitHub {
+    owner = "ggml-org";
+    repo = "ggml";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-lNrON8vKUJU7cxfpRKsVCIWqZj3xtkaf/Fv8zNZFN6o=";
+  };
+
+  # The cmake package does not handle absolute CMAKE_INSTALL_LIBDIR and CMAKE_INSTALL_INCLUDEDIR
+  # correctly.
+  # Tracking: https://github.com/NixOS/nixpkgs/issues/144170
+  postPatch = ''
+    substituteInPlace ggml.pc.in \
+      --replace-fail \
+        "\''${prefix}/@CMAKE_INSTALL_INCLUDEDIR@" \
+        "@CMAKE_INSTALL_FULL_INCLUDEDIR@" \
+      --replace-fail \
+        "\''${prefix}/@CMAKE_INSTALL_LIBDIR@" \
+        "@CMAKE_INSTALL_FULL_LIBDIR@"
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  meta = {
+    description = "Tensor library for machine learning";
+    homepage = "https://github.com/ggml-org/ggml";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/development/python-modules/ggml-python/default.nix
+++ b/pkgs/development/python-modules/ggml-python/default.nix
@@ -1,0 +1,102 @@
+{
+  lib,
+  stdenv,
+  buildPythonPackage,
+  fetchFromGitHub,
+  replaceVars,
+
+  # build-system
+  cmake,
+  ninja,
+  scikit-build-core,
+
+  # buildInputs
+  ggml,
+
+  # dependencies
+  numpy,
+  typing-extensions,
+
+  # optional-dependencies
+  accelerate,
+  sentencepiece,
+  torch,
+  torchaudio,
+  torchvision,
+  transformers,
+  cairosvg,
+  mkdocs,
+  mkdocs-material,
+  mkdocstrings,
+  pillow,
+
+  # tests
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "ggml-python";
+  version = "0.0.37";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "abetlen";
+    repo = "ggml-python";
+    tag = "v${finalAttrs.version}";
+    # ggml-python expects an older version of ggml than pkgs.ggml's
+    fetchSubmodules = true;
+    hash = "sha256-QFpUGQ8m4c0SpHWnHhoyPdQkcywBToeLahDtG+JMcmA=";
+  };
+
+  build-system = [
+    cmake
+    ninja
+    scikit-build-core
+  ];
+  dontUseCmakeConfigure = true;
+
+  buildInputs = [
+    ggml
+  ];
+
+  dependencies = [
+    numpy
+    typing-extensions
+  ];
+
+  optional-dependencies = {
+    convert = [
+      accelerate
+      numpy
+      sentencepiece
+      torch
+      torchaudio
+      torchvision
+      transformers
+    ];
+    docs = [
+      cairosvg
+      mkdocs
+      mkdocs-material
+      mkdocstrings
+      pillow
+    ];
+  };
+
+  pythonImportsCheck = [ "ggml" ];
+
+  preCheck = ''
+    rm -rf ggml
+  '';
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  meta = {
+    description = "Python bindings for ggml";
+    homepage = "https://github.com/abetlen/ggml-python";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6111,6 +6111,8 @@ self: super: with self; {
 
   gftools = callPackage ../development/python-modules/gftools { };
 
+  ggml-python = callPackage ../development/python-modules/ggml-python { };
+
   gguf = callPackage ../development/python-modules/gguf { };
 
   ghapi = callPackage ../development/python-modules/ghapi { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- **ggml: init at 0.9.5**
- **python3Packages.ggml-python: init at 0.0.37**

Add [ggml](https://github.com/ggml-org/ggml), a tensor library for machine learning and its python bindings [ggml-python](https://ggml-python.readthedocs.io/en/latest).

Unfortunately, I couldn't make `python3Packages.ggml-python` load `libggml.so` from `pkgs.ggml` as it expects an older version.

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
