### PR TITLE
yosys: 0.60 -> 0.61

### DIFF
--- a/pkgs/by-name/yo/yosys/package.nix
+++ b/pkgs/by-name/yo/yosys/package.nix
@@ -20,7 +20,6 @@
   iverilog,
 
   # passthru
-  # plugins
   symlinkJoin,
   yosys,
   makeWrapper,
@@ -31,33 +30,7 @@
   enablePython ? true, # enable python binding
 }:
 
-# NOTE: as of late 2020, yosys has switched to an automation robot that
-# automatically tags their repository Makefile with a new build number every
-# day when changes are committed. please MAKE SURE that the version number in
-# the 'version' field exactly matches the YOSYS_VER field in the Yosys
-# makefile!
-#
-# if a change in yosys isn't yet available under a build number like this (i.e.
-# it was very recently merged, within an hour), wait a few hours for the
-# automation robot to tag the new version, like so:
-#
-#     https://github.com/YosysHQ/yosys/commit/71ca9a825309635511b64b3ec40e5e5e9b6ad49b
-#
-# note that while most nix packages for "unstable versions" use a date-based
-# version scheme, synchronizing the nix package version here with the unstable
-# yosys version number helps users report better bugs upstream, and is
-# ultimately less confusing than using dates.
-
 let
-
-  # Provides a wrapper for creating a yosys with the specified plugins preloaded
-  #
-  # Example:
-  #
-  #     my_yosys = yosys.withPlugins (with yosys.allPlugins; [
-  #        fasm
-  #        bluespec
-  #     ]);
   withPlugins =
     plugins:
     let
@@ -87,30 +60,18 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "yosys";
-  version = "0.60";
+  version = "0.61";
 
   src = fetchFromGitHub {
     owner = "YosysHQ";
     repo = "yosys";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-BVrSq9nWbdu/PIXfwLW7ZkHTz6SrmsqJMSkVa6CsBm8=";
+    hash = "sha256-p7QewbeJtJRRkqYqWW1QzIe71OR5LD+0qsHHgl/cq2w=";
     fetchSubmodules = true;
-    leaveDotGit = true;
-    postFetch = ''
-      # set up git hashes as if we used the tarball
-
-      pushd $out
-      git rev-parse HEAD > .gitcommit
-      cd $out/abc
-      git rev-parse HEAD > .gitcommit
-      popd
-
-      # remove .git now that we are through with it
-      find "$out" -name .git -print0 | xargs -0 rm -rf
-    '';
   };
 
   enableParallelBuilding = true;
+
   nativeBuildInputs = [
     bison
     flex
@@ -134,11 +95,23 @@ stdenv.mkDerivation (finalAttrs: {
     python3.pkgs.boost
   ];
 
-  makeFlags = [ "PREFIX=${placeholder "out"}" ];
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+    "YOSYS_VER=${finalAttrs.version}"
+  ];
 
   postPatch = ''
-    substituteInPlace ./Makefile \
-      --replace-fail 'echo UNKNOWN' 'echo ${builtins.substring 0 10 finalAttrs.src.rev}'
+    substituteInPlace Makefile \
+      --replace-fail 'GIT_REV := $(shell GIT_DIR=$(YOSYS_SRC)/.git git rev-parse --short=9 HEAD || echo UNKNOWN)' 'GIT_REV := v${finalAttrs.version}' \
+      --replace-fail 'GIT_DIRTY := $(shell GIT_DIR=$(YOSYS_SRC)/.git git diff --exit-code --quiet 2>/dev/null; if [ $$? -ne 0 ]; then echo "-dirty"; fi)' 'GIT_DIRTY := ""'
+
+    substituteInPlace Makefile \
+      --replace-fail "| check-git-abc" ""
+
+    substituteInPlace Makefile \
+      --replace-fail 'new=$$(cd abc 2>/dev/null && git rev-parse HEAD 2>/dev/null || echo none)' 'new=none'
+
+    sed -i 's/^YOSYS_VER :=.*/YOSYS_VER := ${finalAttrs.version}/' Makefile
 
     patchShebangs tests ./misc/yosys-config.in
   '';
@@ -147,8 +120,8 @@ stdenv.mkDerivation (finalAttrs: {
     chmod -R u+w .
     make config-${if stdenv.cc.isClang or false then "clang" else "gcc"}
 
-    if ! grep -q "YOSYS_VER := $version" Makefile; then
-      echo "ERROR: yosys version in Makefile isn't equivalent to version of the nix package (allegedly ${finalAttrs.version}), failing."
+    if ! grep -q "YOSYS_VER := ${finalAttrs.version}" Makefile; then
+      echo "ERROR: yosys version in Makefile isn't equivalent to version of the nix package, failing."
       exit 1
     fi
   ''
@@ -160,9 +133,6 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   preCheck = ''
-    # autotest.sh automatically compiles a utility during startup if it's out of date.
-    # having N check jobs race to do that creates spurious codesigning failures on macOS.
-    # run it once without asking it to do anything so that compilation is done before the jobs start.
     tests/tools/autotest.sh
   '';
 


### PR DESCRIPTION
Upgrade to 0.61.

Fix version computation.

- Built on platform:
  - [x] x86_64-linux
- Tested, as applicable:
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
