### PR TITLE
nixos/pantheon: Start io.elementary.settings-daemon

### DIFF
--- a/nixos/modules/services/desktop-managers/pantheon.nix
+++ b/nixos/modules/services/desktop-managers/pantheon.nix
@@ -208,6 +208,22 @@ in
         "org.gnome.SettingsDaemon.XSettings.service"
       ];
 
+      # https://github.com/elementary/settings-daemon/issues/217
+      systemd.user.services.elementary-settings-daemon = {
+        description = "elementary Settings Daemon";
+        wantedBy = [ "gnome-session-initialized.target" ];
+        after = [ "gnome-session-initialized.target" ];
+
+        # The daemon might launch external applications via g_app_info_launch.
+        environment.PATH = lib.mkForce null;
+
+        serviceConfig = {
+          Slice = "session.slice";
+          ExecStart = "${pkgs.pantheon.elementary-settings-daemon}/bin/io.elementary.settings-daemon";
+          Restart = "on-failure";
+        };
+      };
+
       # Global environment
       environment.systemPackages =
         (with pkgs.pantheon; [

--- a/nixos/tests/pantheon.nix
+++ b/nixos/tests/pantheon.nix
@@ -85,6 +85,7 @@
               # https://github.com/elementary/gala/pull/2140
               "${pkgs.pantheon.gnome-settings-daemon}/libexec/gsd-xsettings",
               "${pkgs.pantheon.pantheon-agent-polkit}/libexec/policykit-1-pantheon/io.elementary.desktop.agent-polkit",
+              "${pkgs.pantheon.elementary-settings-daemon}/bin/io.elementary.settings-daemon",
               "${pkgs.pantheon.elementary-files}/libexec/io.elementary.files.xdg-desktop-portal"
           ]
           for i in pgrep_list:
@@ -100,6 +101,11 @@
           machine.succeed(f"{cmd} | grep '__NIXOS_SET_ENVIRONMENT_DONE' | grep '1'")
           # Hopefully from gcr-ssh-agent.
           machine.succeed(f"{cmd} | grep 'SSH_AUTH_SOCK' | grep 'gcr'")
+
+      with subtest("Ensure custom keyboard shortcuts can launch external apps via settings-daemon"):
+          cmd = "xargs --null --max-args=1 echo < /proc/$(pgrep -xf ${pkgs.pantheon.elementary-settings-daemon}/bin/io.elementary.settings-daemon)/environ"
+          machine.succeed(f"{cmd} | grep '^PATH=' | grep '/run/current-system/sw/bin'")
+          machine.succeed(f"{cmd} | grep '^XDG_DATA_DIRS=' | grep '/run/current-system/sw/share'")
 
       with subtest("Wait for elementary videos autostart"):
           machine.wait_until_succeeds("pgrep -xf /run/current-system/sw/bin/io.elementary.videos")


### PR DESCRIPTION
To test this, change your wallpaper and see if the change is reflected in greeter as well (the daemon syncs the wallpaper to `/var/lib/AccountsService/users/$USER`).

- ref: https://github.com/elementary/settings-daemon/issues/217
- closes: #478319

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
