### PR TITLE
chromium,chromedriver: 143.0.7499.192 -> 144.0.7559.59

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -1,28 +1,28 @@
 {
   "chromium": {
-    "version": "143.0.7499.192",
+    "version": "144.0.7559.59",
     "chromedriver": {
-      "version": "143.0.7499.193",
-      "hash_darwin": "sha256-ZLNIyAmQS4dMcd+sz3Mz/m5HdhkJA/PIFnfr0GCXGBA=",
-      "hash_darwin_aarch64": "sha256-A5qycNQNb+Tw+YIx+RfndcG4vJ82EU/xlj9pW+AyeEY="
+      "version": "144.0.7559.60",
+      "hash_darwin": "sha256-t7iNI8tGDo5BMUGtgqIQ/9uk7LYxp5IdWrP/8KMe2YY=",
+      "hash_darwin_aarch64": "sha256-g5dieRsXshJ//Nta/dOkO87JsIgV8DW1SAVlc/Sxxz0="
     },
     "deps": {
       "depot_tools": {
-        "rev": "e2bb3cd55899346cc68bbfd5139e59c9d85a6984",
-        "hash": "sha256-Qlc0UAdGRm1C0DNAqBsssND8PQZUVkj6aDaeExjwi2E="
+        "rev": "2e88a3f08bd8c4a0014eae82729beca935f7f188",
+        "hash": "sha256-UhEzt9TBZiyuEjPVyHyTEg/idVj9EaAfrHHw2iRuIro="
       },
       "gn": {
-        "version": "0-unstable-2025-10-08",
-        "rev": "07d3c6f4dc290fae5ca6152ebcb37d6815c411ab",
-        "hash": "sha256-kIPhfuJBQSISdRjloe0N2JrqvuVrEkNijb92/9zSE9I="
+        "version": "0-unstable-2025-12-01",
+        "rev": "6e0b557db44b3c164094e57687d20ba036a80667",
+        "hash": "sha256-04h38X/hqWwMiAOVsVu4OUrt8N+S7yS/JXc5yvRGo1I="
       },
-      "npmHash": "sha256-HF6B4abJJJ9JDVbovtAdaHIvqE1zHJZ2a+g2Cudx8Pw="
+      "npmHash": "sha256-13sgV/5BD7QvDLBAEmoLN5vongw+S5v5znvZcctxhWc="
     },
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "be2c1f4fd451578a9ada68a0ac12d659362b44bf",
-        "hash": "sha256-YbYtW4UmlFoqXUSvPc7H+Fe0hUM+t9JwpBHKC98pY98=",
+        "rev": "cd1d73dd77daadf4581dc29ca73482fc241e079d",
+        "hash": "sha256-K/dmiy5u+XJIpS6AOTaXDLVYp5qAtfUbfSbGCpt9Cv8=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {
@@ -32,28 +32,28 @@
       },
       "src/third_party/compiler-rt/src": {
         "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/compiler-rt.git",
-        "rev": "08611c39bbfc52cc034904eb88817c6209b828f9",
-        "hash": "sha256-AfVP7cm7eNGl0JPnMkixMFgloDTHh0KSOAwXDEcl5MU="
+        "rev": "cb2de163a470f2e9d56ec8a4f912f644378b7191",
+        "hash": "sha256-Wl18dFoXfwe266yCKDYviOI46OimFLfstke/+baPzgM="
       },
       "src/third_party/libc++/src": {
         "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libcxx.git",
-        "rev": "8cd54f6b0741cdef08299711668e6b25fef26406",
-        "hash": "sha256-AJx0Oz1sNubo2JNPjeXO5f9SnoXewOsPlgFrRXiCEKg="
+        "rev": "07572e7b169225ef3a999584cba9d9004631ae66",
+        "hash": "sha256-fhaWlbzkvsbz02yqJ9nf6/lVrKDYBaIYNlx++A0JFTU="
       },
       "src/third_party/libc++abi/src": {
         "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libcxxabi.git",
-        "rev": "a02fa0058d8d52aca049868d229808a3e5dadbad",
-        "hash": "sha256-iNV7NtVviRBDjt6mK/DK3WfYd/QNGejRaSvpgEXmLqY="
+        "rev": "83a852080747b9a362e8f9e361366b7a601f302c",
+        "hash": "sha256-iRVRMcK8mKyHe+8Oh5qfl3Y8HYwVwK2NlgNE7WxbKJM="
       },
       "src/third_party/libunwind/src": {
         "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libunwind.git",
-        "rev": "b7c3dda13e46ced88a6f7230e271ebd633b4cef2",
-        "hash": "sha256-eWxGIMxMBRvQVJ6uc3ZWaKO7oXLLCXTi8sVR8v3H4MM="
+        "rev": "c65639bf792928e0d38aed822dc34d3e72066a6c",
+        "hash": "sha256-C5gUvzQIO00UbB8yotxbbjbrkqe7pXVzMeLlcSH0/Bg="
       },
       "src/third_party/llvm-libc/src": {
         "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libc.git",
-        "rev": "796bfb264a22264b11acda9feaffdffb168c7e12",
-        "hash": "sha256-J/FiUpmwkFVZcLmeXABl4FE9rzGFsbo/Lc1Rjy5wdOU="
+        "rev": "fe97633934c21742a74962d52c17b3bcba7ad824",
+        "hash": "sha256-mqj2ee9F2UDMZQSD9ZAP/g5r2P56Awq+grCdcypUqFE="
       },
       "src/chrome/test/data/perf/canvas_bench": {
         "url": "https://chromium.googlesource.com/chromium/canvas_bench.git",
@@ -72,8 +72,8 @@
       },
       "src/docs/website": {
         "url": "https://chromium.googlesource.com/website.git",
-        "rev": "2acb551cf58ff3b6e6a093fe36deb8c625046900",
-        "hash": "sha256-HaNA1Es8t3A/WR9aXdEoFOdeNO6c6ydPDF1CCBb0Bu4="
+        "rev": "d9a0c174b535ee5165fb8ef278324be9efa49352",
+        "hash": "sha256-LnLvIl4L3IFim5LA5ZFYSE6kpBMF8cL1dC/os7QmhHI="
       },
       "src/media/cdm/api": {
         "url": "https://chromium.googlesource.com/chromium/cdm.git",
@@ -82,8 +82,8 @@
       },
       "src/net/third_party/quiche/src": {
         "url": "https://quiche.googlesource.com/quiche.git",
-        "rev": "42cbfedd76691c19af012a3d717fca07d7b09cc9",
-        "hash": "sha256-ik5NjHWC8LHJiOde7Jdqq2C/NOofQwtPT4ubAqc8D4A="
+        "rev": "901d0a7b4dbb141f2ad4eb8e1f00eb87f945044e",
+        "hash": "sha256-yjHB2BYtSJiK34zIda1t2kcY+netDUIiaQ0vVtglYfw="
       },
       "src/testing/libfuzzer/fuzzers/wasm_corpus": {
         "url": "https://chromium.googlesource.com/v8/fuzzer_wasm_corpus.git",
@@ -92,8 +92,8 @@
       },
       "src/third_party/angle": {
         "url": "https://chromium.googlesource.com/angle/angle.git",
-        "rev": "2dfb5b7603d09c1d06f9d7a894752431d98b9a3e",
-        "hash": "sha256-3F2K3UO3BHC0mJGUgc/q5AuxwL32O98PloF1cwyZLqU="
+        "rev": "a96fca8d5ee2ca61e8de419e38cd577579281c9e",
+        "hash": "sha256-JOIeH+nMIS6BqS+8LKzRKHFiyZd8Stbybx6a08dixEE="
       },
       "src/third_party/angle/third_party/glmark2/src": {
         "url": "https://chromium.googlesource.com/external/github.com/glmark2/glmark2",
@@ -107,8 +107,8 @@
       },
       "src/third_party/angle/third_party/VK-GL-CTS/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/VK-GL-CTS",
-        "rev": "53f6cec6c0a81fc4e712cd3ec87a1a39b802f5d5",
-        "hash": "sha256-KC9sHWRrPI5R10z5Epq3e7BW7+Ez0AoYe+bKPYL58jg="
+        "rev": "4a7c2fcd1b1a3701295f7d3fe42719e867c1b793",
+        "hash": "sha256-nOsbMbfBKzyRN+QzOb09LKYIRIoTjTDdsSaR78g3Puk="
       },
       "src/third_party/anonymous_tokens/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/anonymous-tokens.git",
@@ -132,8 +132,8 @@
       },
       "src/third_party/dawn": {
         "url": "https://dawn.googlesource.com/dawn.git",
-        "rev": "479f62d2194fd6e44c37d07654ca6e41c42bd332",
-        "hash": "sha256-rzZn9l0EFcir6k8Xv2svIrhRPwe/rq48H7CX/3yfgFE="
+        "rev": "a8d1e554a9bd35b0418ba7fd6b0bc005250a7703",
+        "hash": "sha256-GJuT3rqNxvKkRTMvoMi8/QYda0y0RTkZLhb5v9QkwGA="
       },
       "src/third_party/dawn/third_party/glfw": {
         "url": "https://chromium.googlesource.com/external/github.com/glfw/glfw",
@@ -142,8 +142,8 @@
       },
       "src/third_party/dawn/third_party/dxc": {
         "url": "https://chromium.googlesource.com/external/github.com/microsoft/DirectXShaderCompiler",
-        "rev": "c522461221759f1785b3434ce52ae89d6b66855a",
-        "hash": "sha256-UqgsxtEdvGs3fOueXJU6DJcESmgkEGAjdnMig78qKzE="
+        "rev": "3f85295cfc982e5447f9faaa36f345366faca11d",
+        "hash": "sha256-LS4+U+GdWXDSkEXMIibeSvjA1079kvQyrASq+5N8gYw="
       },
       "src/third_party/dawn/third_party/dxheaders": {
         "url": "https://chromium.googlesource.com/external/github.com/microsoft/DirectX-Headers",
@@ -162,13 +162,13 @@
       },
       "src/third_party/dawn/third_party/webgpu-cts": {
         "url": "https://chromium.googlesource.com/external/github.com/gpuweb/cts",
-        "rev": "95042527d1555325b90dbb745a29d32eb9fad14a",
-        "hash": "sha256-Ofi/XfzyQrt2gUHaJpOyUUD7DXTWWmvXXJQP7C6AN8w="
+        "rev": "3314e4108692d0c201f0d381bf10ddc8dbbc7b69",
+        "hash": "sha256-bMo94M5Io0S76REatQvA/nC9QRvxy5rpKjeItFvZr4k="
       },
       "src/third_party/dawn/third_party/webgpu-headers/src": {
         "url": "https://chromium.googlesource.com/external/github.com/webgpu-native/webgpu-headers",
-        "rev": "ca7071cd5dd8a67cb8ca4f8614fd006ff3d93bde",
-        "hash": "sha256-ucRkEY1bZ3WyK55FW0pujl9LWFENmEzZvxO2QKYXmhc="
+        "rev": "079d4e5153eaabc4033584cc399c27f1acbb2548",
+        "hash": "sha256-4ARtN5+4yxMoFGKvPvQgJGYqAqQLjHlrrxlTmka/UhE="
       },
       "src/third_party/highway/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/highway.git",
@@ -177,8 +177,8 @@
       },
       "src/third_party/google_benchmark/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/benchmark.git",
-        "rev": "761305ec3b33abf30e08d50eb829e19a802581cc",
-        "hash": "sha256-cH8s1gP6kCcojAAfTt5iQCVqiAaSooNk4BdaILujM3w="
+        "rev": "188e8278990a9069ffc84441cb5a024fd0bede37",
+        "hash": "sha256-GfqY2d+Nd7ovNrXxzTRm/AYWj7GuxIO6FawzUEzwOVA="
       },
       "src/third_party/libpfm4/src": {
         "url": "https://chromium.googlesource.com/external/git.code.sf.net/p/perfmon2/libpfm4.git",
@@ -187,8 +187,8 @@
       },
       "src/third_party/boringssl/src": {
         "url": "https://boringssl.googlesource.com/boringssl.git",
-        "rev": "58da9b0d721fd807279f4e3898741c92cf43bdbd",
-        "hash": "sha256-uvsW0p3wo7L1tQqelRk5QJ65Jt5cpv6ORZRorZjHqrw="
+        "rev": "b94d71f87ff943a617d77f3ff029f9a01a1ec6bc",
+        "hash": "sha256-i+HP5Q1UmBCLmDdGvSKPts6nwo/9vGUh5wMdmmQ7qLU="
       },
       "src/third_party/breakpad/breakpad": {
         "url": "https://chromium.googlesource.com/breakpad/breakpad.git",
@@ -202,8 +202,8 @@
       },
       "src/third_party/catapult": {
         "url": "https://chromium.googlesource.com/catapult.git",
-        "rev": "ddb5845c3f7d88d8698e602547bd854b36f0604f",
-        "hash": "sha256-N+h99EL03NL6sAGJJM/aZEdVibn7SziLJp5G09y0EOc="
+        "rev": "a202c86635d505fa893d73bad1e220a66bb644e6",
+        "hash": "sha256-FumPjVoqe6OLULHlduuMZgJTn2cau7QMAQz6gv1gAnU="
       },
       "src/third_party/ced/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/compact_enc_det.git",
@@ -227,8 +227,8 @@
       },
       "src/third_party/cpuinfo/src": {
         "url": "https://chromium.googlesource.com/external/github.com/pytorch/cpuinfo.git",
-        "rev": "877328f188a3c7d1fa855871a278eb48d530c4c0",
-        "hash": "sha256-JW83AgI1cWv4TSpXNe9sv/hNYAA7MOdUeTHY8+0lHgc="
+        "rev": "161a9ec374884f4b3e85725cb22e05f9458fdc93",
+        "hash": "sha256-uzo6QpNfzTcqOpDse14e2OoxNyKDU8jSx+/wPLxmpJg="
       },
       "src/third_party/crc32c/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/crc32c.git",
@@ -237,13 +237,13 @@
       },
       "src/third_party/cros_system_api": {
         "url": "https://chromium.googlesource.com/chromiumos/platform2/system_api.git",
-        "rev": "2c31c25519405d3d2b107844fd5e8c8bc397dbf7",
-        "hash": "sha256-Ew7gk1XxZccztYLZc4sOrzyKjNTkFPG8g+oOLy4/g1Q="
+        "rev": "5f1ffac5e855229e27c6e4356ffb189f3010283f",
+        "hash": "sha256-dWWNvPtZ90quSvu/ZfOHd40UosOG9EwPCF3QklHUvA0="
       },
       "src/third_party/crossbench": {
         "url": "https://chromium.googlesource.com/crossbench.git",
-        "rev": "e4937b062fe8b9130ea0fc02c406c045b5cb7b31",
-        "hash": "sha256-C//wuupFwZL4m8mMutY/SxCmg7mcfw2Sj5eS4c95+XE="
+        "rev": "77240be1ccd1dc99b73be332223a8856641a2073",
+        "hash": "sha256-PHP2En509QS+LAvb7zt4l+34VGy7kik0X87n1fKH5tw="
       },
       "src/third_party/crossbench-web-tests": {
         "url": "https://chromium.googlesource.com/chromium/web-tests.git",
@@ -252,13 +252,13 @@
       },
       "src/third_party/depot_tools": {
         "url": "https://chromium.googlesource.com/chromium/tools/depot_tools.git",
-        "rev": "e2bb3cd55899346cc68bbfd5139e59c9d85a6984",
-        "hash": "sha256-Qlc0UAdGRm1C0DNAqBsssND8PQZUVkj6aDaeExjwi2E="
+        "rev": "2e88a3f08bd8c4a0014eae82729beca935f7f188",
+        "hash": "sha256-UhEzt9TBZiyuEjPVyHyTEg/idVj9EaAfrHHw2iRuIro="
       },
       "src/third_party/devtools-frontend/src": {
         "url": "https://chromium.googlesource.com/devtools/devtools-frontend",
-        "rev": "e4dd1d1d96b706a33ae7d60237d3cdcd58294e4c",
-        "hash": "sha256-6to/NYTcx7H5OXF1u6YT55uCHwf8RU1uJaSXvuFsQ/c="
+        "rev": "d5efa4236f8676254c9f39ccfef18bd633de5fd3",
+        "hash": "sha256-BmwsvTjgYQayFnyT9EfFzpCfbgdTt9xZlsUba0uJelg="
       },
       "src/third_party/dom_distiller_js/dist": {
         "url": "https://chromium.googlesource.com/chromium/dom-distiller/dist.git",
@@ -272,8 +272,8 @@
       },
       "src/third_party/eigen3/src": {
         "url": "https://chromium.googlesource.com/external/gitlab.com/libeigen/eigen.git",
-        "rev": "cd4f989f8f9288ab5aed1643ecb04c7be021021e",
-        "hash": "sha256-qkdtS4kz8m5ZW30SQpDCbgM3WvfCGc+WGsv59J4FYpQ="
+        "rev": "49623d0c4e1af3c680845191948d10f6d3e92f8a",
+        "hash": "sha256-6K6CqifDPVYSs6g6AbG38sP3w7W7/q6bhLgm873Z9bk="
       },
       "src/third_party/farmhash/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/farmhash.git",
@@ -292,8 +292,8 @@
       },
       "src/third_party/ffmpeg": {
         "url": "https://chromium.googlesource.com/chromium/third_party/ffmpeg.git",
-        "rev": "9e751092c9498b84bbb77e2e0689ef9f50fe608f",
-        "hash": "sha256-ZeFzrCE9LkDcp3VTMJkm5ypX29RGZCyZkp3tEr7yFKU="
+        "rev": "e18f48eba6b367ac68b9c477ae6cbe224e36b031",
+        "hash": "sha256-ecfRGFHkLcly874w6m5/oIO99MRgXftOJAb8KCc51ZU="
       },
       "src/third_party/flac": {
         "url": "https://chromium.googlesource.com/chromium/deps/flac.git",
@@ -307,8 +307,8 @@
       },
       "src/third_party/fontconfig/src": {
         "url": "https://chromium.googlesource.com/external/fontconfig.git",
-        "rev": "f0ed9c3f43161d3555f6f7a5234b22fe7ca60727",
-        "hash": "sha256-2h0dWn7MxAX+4o2tMZLyjRFAES+FTMaGaf8M7ySkSV8="
+        "rev": "23b3fc6e58a13d126b9c30fafc9a16f8bd7143e9",
+        "hash": "sha256-+vd+Q6NzoWA7Ou+hkgIRhUZ0A1G+rZAh7JrP84f0wnQ="
       },
       "src/third_party/fp16/src": {
         "url": "https://chromium.googlesource.com/external/github.com/Maratyszcza/FP16.git",
@@ -322,8 +322,8 @@
       },
       "src/third_party/freetype/src": {
         "url": "https://chromium.googlesource.com/chromium/src/third_party/freetype2.git",
-        "rev": "ae63cc0d13318f2f93fd440cce277388d1b30a49",
-        "hash": "sha256-Tx5MbwMk+d2OZGd4CxJhJtP1pQyRJ0pe358OdKuWiRU="
+        "rev": "32fc0af22206327ffd06e1d025f13b11fd8d1a46",
+        "hash": "sha256-gUW2+dn13kexIGfU5DAY3EEzVtPzZzqjPnvDhUZXzQA="
       },
       "src/third_party/fxdiv/src": {
         "url": "https://chromium.googlesource.com/external/github.com/Maratyszcza/FXdiv.git",
@@ -337,8 +337,8 @@
       },
       "src/third_party/ink/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/ink.git",
-        "rev": "f70052a0bbae22fe52b630844e9651b27db92ed2",
-        "hash": "sha256-Mvxbdn4m/H3HBss31Z9nz0LphqpFeBHcX/kbFxJQPqM="
+        "rev": "11ca89062782d7e5a57741a303a925f510b91015",
+        "hash": "sha256-Z4cxFSJHyARUbeAnW51Ar7zuTMyMzi52Z9R1anN4d74="
       },
       "src/third_party/ink_stroke_modeler/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/ink-stroke-modeler.git",
@@ -372,13 +372,13 @@
       },
       "src/third_party/googletest/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/googletest.git",
-        "rev": "b2b9072ecbe874f5937054653ef8f2731eb0f010",
-        "hash": "sha256-cTPx19WAXlyXDK4nY0pxbMI4oRojaARgIeASA+MB3NY="
+        "rev": "4fe3307fb2d9f86d19777c7eb0e4809e9694dde7",
+        "hash": "sha256-gJhv3DQQSP5BQ6GmDobq42/Gkx4AbOg/ZS80bM0WpEw="
       },
       "src/third_party/hunspell_dictionaries": {
         "url": "https://chromium.googlesource.com/chromium/deps/hunspell_dictionaries.git",
-        "rev": "41cdffd71c9948f63c7ad36e1fb0ff519aa7a37e",
-        "hash": "sha256-67mvpJRFFa9eMfyqFMURlbxOaTJBICnk+gl0b0mEHl8="
+        "rev": "cccf64a8acc951afe3f47fee023908e55699bc58",
+        "hash": "sha256-mYDPXa64IOKLMNiBiMqDrQMR7gDPI+vdyVc+M7E+ddc="
       },
       "src/third_party/icu": {
         "url": "https://chromium.googlesource.com/chromium/deps/icu.git",
@@ -402,8 +402,8 @@
       },
       "src/third_party/fuzztest/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/fuzztest.git",
-        "rev": "7940ee9a7ebce6419c6391eef8b289524b16f198",
-        "hash": "sha256-uIb2nzPzMU/FZGYs3cFQwc4QNTNRmz01uF6XDCLrgDk="
+        "rev": "7406afb783ff5e7f3a1a66aebb81090622716412",
+        "hash": "sha256-PjeVtPCRoyRtXX0Q5x+EbT6tE9/FiYGdJjRqIVL29i0="
       },
       "src/third_party/domato/src": {
         "url": "https://chromium.googlesource.com/external/github.com/googleprojectzero/domato.git",
@@ -417,13 +417,13 @@
       },
       "src/third_party/libaom/source/libaom": {
         "url": "https://aomedia.googlesource.com/aom.git",
-        "rev": "93233d27eb23ac3f1f13da1b19c5380bacc75baa",
-        "hash": "sha256-wDW+YXxIaenDtqf3zdpMT2hbwEMEswC88+Q2ylfzHw0="
+        "rev": "5d80673d723a5e2e268b124d81d425053823d875",
+        "hash": "sha256-jVbneofb6JsFKBVwafMTPZBlNkqalkFdQvexZjCmxlA="
       },
       "src/third_party/crabbyavif/src": {
         "url": "https://chromium.googlesource.com/external/github.com/webmproject/CrabbyAvif.git",
-        "rev": "3ba05863e84fd3acb4f4af2b4545221b317a2e55",
-        "hash": "sha256-HUGkuQWfUGsE6crsluI7l5H2DYalruoDKqBjbVfE7BM="
+        "rev": "640d2758f8d2e59d1a55ae0933673f0f65de68c4",
+        "hash": "sha256-5nU1QDY6irjmufd7nO70dTS74EchC7NXX2MBNz3LNPw="
       },
       "src/third_party/nearby/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/nearby-connections.git",
@@ -437,8 +437,8 @@
       },
       "src/third_party/jetstream/main": {
         "url": "https://chromium.googlesource.com/external/github.com/WebKit/JetStream.git",
-        "rev": "0debbb0b94486d4c78162ad5a102279b96dc79d3",
-        "hash": "sha256-w1oBQrjYK8ze02MRNPO8PsV5rNHiLzToCQjoSm+NagI="
+        "rev": "f88580ef6265b59295f37eb0c6666466b11a0e74",
+        "hash": "sha256-ai1OYU+O3xsrKWIH6iw09KZrMJOFPfe3GQpdDDtfxXQ="
       },
       "src/third_party/jetstream/v2.2": {
         "url": "https://chromium.googlesource.com/external/github.com/WebKit/JetStream.git",
@@ -447,8 +447,8 @@
       },
       "src/third_party/speedometer/main": {
         "url": "https://chromium.googlesource.com/external/github.com/WebKit/Speedometer.git",
-        "rev": "d90b6fde07041d9d19ab71de32b461b613c899a1",
-        "hash": "sha256-/S8YBNfxbQe6Wt0h2Otuw7+bkObBtvmtb6ZO6nsce6E="
+        "rev": "e2e2538900938c5d6819e9456bf33d48f806c96c",
+        "hash": "sha256-oF8ELo2qmkgaTpNzBLaC3A6gyf2iFv+FQNPGwdGqzVU="
       },
       "src/third_party/speedometer/v3.1": {
         "url": "https://chromium.googlesource.com/external/github.com/WebKit/Speedometer.git",
@@ -497,8 +497,8 @@
       },
       "src/third_party/libjpeg_turbo": {
         "url": "https://chromium.googlesource.com/chromium/deps/libjpeg_turbo.git",
-        "rev": "e14cbfaa85529d47f9f55b0f104a579c1061f9ad",
-        "hash": "sha256-Ig+tmprZDvlf/M72/DTar2pbxat9ZElgSqdXdoM0lPs="
+        "rev": "6383cf609c1f63c18af0f59b2738caa0c6c7e379",
+        "hash": "sha256-chUqHiT1HMmFRaCOgjGLVU+LxeN/iUq7y6ckrcqFYFI="
       },
       "src/third_party/liblouis/src": {
         "url": "https://chromium.googlesource.com/external/liblouis-github.git",
@@ -532,8 +532,8 @@
       },
       "src/third_party/libvpx/source/libvpx": {
         "url": "https://chromium.googlesource.com/webm/libvpx.git",
-        "rev": "4c1801be20dd53900d2a7cd74f6fc91a9ae353be",
-        "hash": "sha256-8k8KWkDS3kvJjHWVlOlTW/By7rQLiT7TrOtxwEOCXgk="
+        "rev": "9a7674e1a83d1261a49776c8794b87c9bccc85d7",
+        "hash": "sha256-PdRZyXurQkw3UWOH1MkkuzggJkt9Uxq472L4LkxaYtw="
       },
       "src/third_party/libwebm/source": {
         "url": "https://chromium.googlesource.com/webm/libwebm.git",
@@ -547,8 +547,8 @@
       },
       "src/third_party/libyuv": {
         "url": "https://chromium.googlesource.com/libyuv/libyuv.git",
-        "rev": "900da61d3cadba86ec593c8226de736b5e6b2c43",
-        "hash": "sha256-vqPiv1HJe883aDOjzLBNXGA/b/F/frcW3Iml3ZUyHlY="
+        "rev": "4825d9b29eea4dac24607245db7ec7d4c41c1964",
+        "hash": "sha256-FZufzbDupdGhlSNGjSC6XlYiTCl677vfr9VHYot4t8g="
       },
       "src/third_party/lss": {
         "url": "https://chromium.googlesource.com/linux-syscall-support.git",
@@ -567,8 +567,8 @@
       },
       "src/third_party/nasm": {
         "url": "https://chromium.googlesource.com/chromium/deps/nasm.git",
-        "rev": "e2c93c34982b286b27ce8b56dd7159e0b90869a2",
-        "hash": "sha256-TxzAcp+CoKnnM0lCGjm+L3h6M30vYHjM07vW6zUe/vY="
+        "rev": "af5eeeb054bebadfbb79c7bcd100a95e2ad4525f",
+        "hash": "sha256-vH3OUzfLZbaPY4DMAvSW0jKYRJmOa7aE8EfIJtZ1/Xs="
       },
       "src/third_party/neon_2_sse/src": {
         "url": "https://chromium.googlesource.com/external/github.com/intel/ARM_NEON_2_x86_SSE.git",
@@ -582,13 +582,13 @@
       },
       "src/third_party/openscreen/src": {
         "url": "https://chromium.googlesource.com/openscreen",
-        "rev": "279b21edd27132609d2f46b702c42455ea05c4a8",
-        "hash": "sha256-BxS1VaDK6ZwS7tXjimeBPNqdPKsIOosH29cL6EmWEM4="
+        "rev": "734877394201dcfcc786b3c8ea057b7607a56993",
+        "hash": "sha256-DIn/qjmbuFeqzXOwyDf0/GStKv6VuCYGN/AATpD+9zM="
       },
       "src/third_party/openscreen/src/buildtools": {
         "url": "https://chromium.googlesource.com/chromium/src/buildtools",
-        "rev": "077a66f30fcf281b066fafb6dfc60818c238efb6",
-        "hash": "sha256-WnbgaCzZ/BJli6M60kP9e4mVPFDx0yu3eCac5wmQ7iM="
+        "rev": "5df641722f2e50623646d702e0046fb68c0f5ce1",
+        "hash": "sha256-AHPwOX5Z0R3rl49OvFsW92jlvCKvScsMYkfOJeBnWZ8="
       },
       "src/third_party/openscreen/src/third_party/tinycbor/src": {
         "url": "https://chromium.googlesource.com/external/github.com/intel/tinycbor.git",
@@ -597,13 +597,13 @@
       },
       "src/third_party/pdfium": {
         "url": "https://pdfium.googlesource.com/pdfium.git",
-        "rev": "f5c376f93d33709ecd6b0dc8147b14a651ddbfeb",
-        "hash": "sha256-Rfpdow3S3HTHVEEAmCyiKU7XfuUoxvtHeWV+wfarvF8="
+        "rev": "66c6bc40966122935d37eef739deb988581214d4",
+        "hash": "sha256-PX3jg11+zGfEIiOewgO4s9Knfw5a1shhFl8BZfioXng="
       },
       "src/third_party/perfetto": {
         "url": "https://chromium.googlesource.com/external/github.com/google/perfetto.git",
-        "rev": "ac7792a0f3f1cbfffb071e8b97cd9a5168900e03",
-        "hash": "sha256-9vpds/Xgw65uW5TG0kenqFVEh/NM1V3OpRdkGd0pMk4="
+        "rev": "fdb95badca57068440acc569169f602acee51d7a",
+        "hash": "sha256-qhZ8ghbw3AuJh8uUbH+cCreqJs55v9PxxsykhSpXfks="
       },
       "src/third_party/protobuf-javascript/src": {
         "url": "https://chromium.googlesource.com/external/github.com/protocolbuffers/protobuf-javascript",
@@ -612,8 +612,8 @@
       },
       "src/third_party/pthreadpool/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/pthreadpool.git",
-        "rev": "0e6ca13779b57d397a5ba6bfdcaa8a275bc8ea2e",
-        "hash": "sha256-FPUKjWARY4TdUq7ni48tnszEdmVYxPXIgtddPBHn/U0="
+        "rev": "d90cd6f1493e09d12c407243f7f331a8cda55efb",
+        "hash": "sha256-VdgC6LMzcfhH2Y65Gu+Osi6BXxIq01Fmw5AehsBlX70="
       },
       "src/third_party/pyelftools": {
         "url": "https://chromium.googlesource.com/chromiumos/third_party/pyelftools.git",
@@ -622,8 +622,8 @@
       },
       "src/third_party/quic_trace/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/quic-trace.git",
-        "rev": "e5c4ef17d934e078644e65d667ca6d86fe020d49",
-        "hash": "sha256-LFZ5qFQoyBKta05wJUtJh3oIvaBYlzOozFpDulrQ/no="
+        "rev": "352288a06d2c83ae68b5a402b2219f4678be9f39",
+        "hash": "sha256-JmK7nmHg/BfXvFNG2oMpOV83EF+LwVLdwL6qX5FGREs="
       },
       "src/third_party/pywebsocket3/src": {
         "url": "https://chromium.googlesource.com/external/github.com/GoogleChromeLabs/pywebsocket3.git",
@@ -632,23 +632,23 @@
       },
       "src/third_party/re2/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/re2.git",
-        "rev": "61c4644171ee6b480540bf9e569cba06d9090b4b",
-        "hash": "sha256-fRnjrP6Bz33eW+bOta5v3k9gqgN+gBvRH+t1i7b+eXA="
+        "rev": "e7aec5985072c1dbe735add802653ef4b36c231a",
+        "hash": "sha256-WOwDr0VEjvJyEmvrpw0YmlAnHJP0+0q28fUVpl4E7Eg="
       },
       "src/third_party/ruy/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/ruy.git",
-        "rev": "9940fbf1e0c0863907e77e0600b99bb3e2bc2b9f",
-        "hash": "sha256-fV0El2ZgjxLqstKVN35SL72+diHNK0FkBmG5UwVZFrk="
+        "rev": "1e6e50872655a73b5250f954d7b9da9a87292fd3",
+        "hash": "sha256-+GNd+hU/fYAsgeaPnWWg90uw8rKKxTTvPS5aOpYa8zM="
       },
       "src/third_party/search_engines_data/resources": {
         "url": "https://chromium.googlesource.com/external/search_engines_data.git",
-        "rev": "94eb2a9a225078cb5f40e82fd890bce387c8121a",
-        "hash": "sha256-WWkOOnOI3ohPuO+M9/x53hyDO11P6E6Z6ZZvKmQEyjI="
+        "rev": "97355b69daee73d74ac38f2227788458bd95d372",
+        "hash": "sha256-ZT9Vbvh2hI7DJziwwvU2C2CVx37CycyzdQke4E3eipg="
       },
       "src/third_party/skia": {
         "url": "https://skia.googlesource.com/skia.git",
-        "rev": "da51f0d60ea2b14e845a823dc11b405dbeef42d8",
-        "hash": "sha256-thUbelru/6nPF7haXJtW6ncT6sIQzYqi0BCAJ+BWNY0="
+        "rev": "ee20d565acb08dece4a32e3f209cdd41119015ca",
+        "hash": "sha256-0LiFK/8873gei70iVhNGRlcFeGIp7tjDEfxTBz1LYv8="
       },
       "src/third_party/smhasher/src": {
         "url": "https://chromium.googlesource.com/external/smhasher.git",
@@ -667,8 +667,8 @@
       },
       "src/third_party/swiftshader": {
         "url": "https://swiftshader.googlesource.com/SwiftShader.git",
-        "rev": "3d536c0fc62b1cdea0f78c3c38d79be559855b88",
-        "hash": "sha256-mlKoTdZgqfMzKGB7dUaETCd6NIQm5dne59w09/0bnGE="
+        "rev": "04fbb7daf5a53689e067190e7ef1047c5d49e292",
+        "hash": "sha256-kg0beZH6AKT9TqPWF9aZRRTGHbTSVYm1pffuERv0eG4="
       },
       "src/third_party/text-fragments-polyfill/src": {
         "url": "https://chromium.googlesource.com/external/github.com/GoogleChromeLabs/text-fragments-polyfill.git",
@@ -677,18 +677,18 @@
       },
       "src/third_party/tflite/src": {
         "url": "https://chromium.googlesource.com/external/github.com/tensorflow/tensorflow.git",
-        "rev": "5fcf510a862fb6d3c0d34906044389095a180ff6",
-        "hash": "sha256-iXt3IutfZxiH9j7/mnx+YeZwak44+nhNo2rbDxtgKTg="
+        "rev": "247b0cf254fbbf3d326feed3820ec24503a353a5",
+        "hash": "sha256-iWUx5GFHhdo3It/djUO2rc+zb5VpIVwyiMYKjB2RIE0="
       },
       "src/third_party/vulkan-deps": {
         "url": "https://chromium.googlesource.com/vulkan-deps",
-        "rev": "224a52b06d0e019c7f7c006c2306de095207f77f",
-        "hash": "sha256-/RkiBLiXo7Z+FUIjHIrvvcU8Mg6vX9vJUn8Cz1fI2OE="
+        "rev": "327bc9dec2a42806ad78c284829363657bb728dc",
+        "hash": "sha256-Ky1pMR6W0bgBq2ifVB/1b72dk2aZbIjF44Vc2Ho3iEg="
       },
       "src/third_party/glslang/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/glslang",
-        "rev": "36b4d078576ad465e85b4b0502695ac5f3edb2e6",
-        "hash": "sha256-A2D6fSfHpeXsYnXZs9l7DRE4ELUHbNQxr7HaokFByDQ="
+        "rev": "7a47e2531cb334982b2a2dd8513dca0a3de4373d",
+        "hash": "sha256-BXfe5SgjPy5a+FJh4KIe5kwvKVBvo773OfIZpOsDBLo="
       },
       "src/third_party/spirv-cross/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/SPIRV-Cross",
@@ -697,38 +697,38 @@
       },
       "src/third_party/spirv-headers/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/SPIRV-Headers",
-        "rev": "6bb105b6c4b3a246e1e6bb96366fe14c6dbfde83",
-        "hash": "sha256-rgLhWf3U7gMjB+mpwq4EgQdRS6yP2/Q71Ns42ZDu7cc="
+        "rev": "b824a462d4256d720bebb40e78b9eb8f78bbb305",
+        "hash": "sha256-HjJjMuqTrYv5LUOWcexzPHb8nhOT4duooDAhDsd44Zo="
       },
       "src/third_party/spirv-tools/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/SPIRV-Tools",
-        "rev": "05b0ab1253db43c3ea29efd593f3f13dfa621ab1",
-        "hash": "sha256-OmvvBOBacp8ZgY+tcV1a7OmdGL607rrH89bu9uLj1L4="
+        "rev": "f410b3c178740f9f5bd28d5b22a71d4bc10acd49",
+        "hash": "sha256-HSqI9VkDBgivSqEAAkSXf+u2CT1OZcPU2YcH2BF1Y9o="
       },
       "src/third_party/vulkan-headers/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Headers",
-        "rev": "df274657d83f3bd8c77aef816c1cbf27352a948b",
-        "hash": "sha256-/YXVD60zaSRgqkAFGZs0D0T2LoXRgMnYcO/RkQznW+I="
+        "rev": "2fa203425eb4af9dfc6b03f97ef72b0b5bcb8350",
+        "hash": "sha256-DIePLzDoImnaso0WYUv819wSDeA7Zy1I/tYAbsALXKg="
       },
       "src/third_party/vulkan-loader/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Loader",
-        "rev": "e1cad037970cfeeb86051c49d00ead75311acbec",
-        "hash": "sha256-/xnxL+S6Z04FLHLv1V/YBcDu4fzhXvAqfHgS5cgeVhg="
+        "rev": "052ac24611eced7b0ca62cc5cca2eeeb2051fa28",
+        "hash": "sha256-43eoTxe2O7MxwsC16nv1R1Xf4WkNNsTf0G5Mo46oipk="
       },
       "src/third_party/vulkan-tools/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Tools",
-        "rev": "7f6326618226225269a274869ac638b870c8fe2b",
-        "hash": "sha256-hInSJsfPuI7U74rEqFQf6De1QoBkFjAnGLFE91uyJ5s="
+        "rev": "48b5d246b2d0b1a41ee7ea1b69525ae7bb38a2ae",
+        "hash": "sha256-uT3KUUiYZzgaAjfUhhqPsjTXE4B6XuSt/zSWE8R9lS0="
       },
       "src/third_party/vulkan-utility-libraries/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Utility-Libraries",
-        "rev": "ea43e2f5e51e9ad958a40fdce981f2f0abf09cb5",
-        "hash": "sha256-7SYRTJLLkC1OXDZ/llNRpVKhQeNak2IFxrHNJKRfrLk="
+        "rev": "c010c19e796035e92fb3b0462cb887518a41a7c1",
+        "hash": "sha256-lDO0B7wEYT6cc/t/ZW5OAxxgRfDORoGd+pF5r5R7yoQ="
       },
       "src/third_party/vulkan-validation-layers/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-ValidationLayers",
-        "rev": "0cb2d651931455e44aa898585d7d78a9d90d31c5",
-        "hash": "sha256-IxxvrY90d/NJWRNcvMIaUjg2o7LZEHi2gmOe+eyJmHI="
+        "rev": "5e175a92548d1a507bd81fdc5db6fa1d2572a6ea",
+        "hash": "sha256-ZxLoVN0e58eA5ySn0MknTRMSD/bjCebFnwo2WgtrPYc="
       },
       "src/third_party/vulkan_memory_allocator": {
         "url": "https://chromium.googlesource.com/external/github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator.git",
@@ -767,18 +767,18 @@
       },
       "src/third_party/webgpu-cts/src": {
         "url": "https://chromium.googlesource.com/external/github.com/gpuweb/cts.git",
-        "rev": "eefe6f33964beec1bd1534b1d9065ad027b71740",
-        "hash": "sha256-g+zg7SpK/BztfgT+y45Ygb9+7izQpkgAM3vRX5iKkbU="
+        "rev": "e7cad0143f136c69b345024d0a60e0d859dd7503",
+        "hash": "sha256-0Bn319fWpTERI31a9WahXiWi63v62rxI9aA/VUMzuAw="
       },
       "src/third_party/webpagereplay": {
         "url": "https://chromium.googlesource.com/webpagereplay.git",
-        "rev": "ab0ca8075f0cc5d40fed25e08ddabb144c29fc08",
-        "hash": "sha256-hZ2TH5AsPPqxxShDTG1hhgpZWqXccD7TsoPfXcdhIUg="
+        "rev": "052833a44dd2f538b85936092bad545b6062e193",
+        "hash": "sha256-wrA3iN0HEXqIg53tprARRR7ekSYFXVbqaDIt1zZeTP4="
       },
       "src/third_party/webrtc": {
         "url": "https://webrtc.googlesource.com/src.git",
-        "rev": "4e31d1a1ff41bb1b79609c83f998458a111a149c",
-        "hash": "sha256-3tfB6jNsTLYozYqBfAmYNmq94wQ3OFxBSlOfRaj6wxc="
+        "rev": "8f3537ef5b85b4c7dabed2676d4b72214c69c494",
+        "hash": "sha256-rs/miFkNVNCGOTSEvSRdWWf8zg1+WU+L/Pt+TblSGy4="
       },
       "src/third_party/wuffs/src": {
         "url": "https://skia.googlesource.com/external/github.com/google/wuffs-mirror-release-c.git",
@@ -797,18 +797,18 @@
       },
       "src/third_party/xnnpack/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/XNNPACK.git",
-        "rev": "98a027498845d3e2acd0e983fff6950714edbfc2",
-        "hash": "sha256-MwzgJN/QE3pLI+5UZNz2oepBibQq5j4CKLDQ1jFyi2w="
+        "rev": "d3efd0a2fcd944931416811da6d24222c91ddd9d",
+        "hash": "sha256-f3Bcapnbzg3wjrKJY8Yq9aGm7PHttJQt3ri6blRhEBk="
       },
       "src/third_party/zstd/src": {
         "url": "https://chromium.googlesource.com/external/github.com/facebook/zstd.git",
-        "rev": "89d685e42dbcf815a16ed0fcd7d050ef74ccad96",
-        "hash": "sha256-xFObjxA4LKOnCugxaYek3cU4ld3JwLj5jFoRJ20hje4="
+        "rev": "a25c1fc96f431e69abea38f52cb31e6bc074e9f1",
+        "hash": "sha256-W1pQwaVAPqr9QsNmQXoefPJASXB5OsFxx7TUUXRJkjU="
       },
       "src/v8": {
         "url": "https://chromium.googlesource.com/v8/v8.git",
-        "rev": "326f5f8cad3f0e436c8ea8f82a6894936a32e860",
-        "hash": "sha256-crTEZnN5iWTXOxpAkvIDPQ6hyfF54F1/ImoKrdmO2K4="
+        "rev": "ad25f9ae50a53bee50f459bfee25fb1e6f64adc3",
+        "hash": "sha256-vyOtnPA3tAeorNOGTDuAnwJ/UtpjeO8z+RSjx9RIFFc="
       }
     }
   },

--- a/pkgs/applications/networking/browsers/chromium/patches/chromium-144-rustc_nightly_capability.patch
+++ b/pkgs/applications/networking/browsers/chromium/patches/chromium-144-rustc_nightly_capability.patch
@@ -1,0 +1,13 @@
+diff --git a/build/config/rust.gni b/build/config/rust.gni
+index ef45a4a9a6daa45859df27fa00bd17d6ee87aa21..b46cb483330133dd0a02e9b276979dc3a94f2520 100644
+--- a/build/config/rust.gni
++++ b/build/config/rust.gni
+@@ -112,7 +112,7 @@ use_chromium_rust_toolchain = rust_sysroot_absolute == ""
+ # `rustc_nightly_capability = false` will make the build avoid the use of
+ # Rust nightly features. There are no bots that test this and there is no
+ # guarantee it will work, but we accept patches for this configuration.
+-rustc_nightly_capability = use_chromium_rust_toolchain
++rustc_nightly_capability = true
+ 
+ # Platform support for the Rust toolchain.
+ chromium_toolchain_supports_platform = !is_wasm


### PR DESCRIPTION
https://developer.chrome.com/blog/new-in-chrome-144

https://developer.chrome.com/release-notes/144

https://chromereleases.googleblog.com/2026/01/stable-channel-update-for-desktop_13.html

This update includes 10 security fixes.

CVEs:
CVE-2026-0899 CVE-2026-0900 CVE-2026-0901 CVE-2026-0902 CVE-2026-0903 CVE-2026-0904 CVE-2026-0905 CVE-2026-0906 CVE-2026-0907 CVE-2026-0908

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
