### PR TITLE
nixos/cgit: make checkExportOkFiles not nullable again

### DIFF
--- a/nixos/modules/services/networking/cgit.nix
+++ b/nixos/modules/services/networking/cgit.nix
@@ -217,8 +217,7 @@ in
                   When enabled you must also configure `strict-export = "git-daemon-export-ok"`
                   in `settings` to make cgit check for the same files.
                 '';
-                type = lib.types.nullOr lib.types.bool;
-                default = null;
+                type = lib.types.bool;
               };
             };
           }
@@ -233,11 +232,6 @@ in
         {
           assertion = !cfg.enable || (cfg.scanPath == null) != (cfg.repos == { });
           message = "Misconfigured services.cgit.${vhost}: Exactly one of scanPath or repos must be set.";
-        }
-        {
-          assertion =
-            cfg.enable -> cfg.gitHttpBackend.enable -> cfg.gitHttpBackend.checkExportOkFiles != null;
-          message = "Misconfigured services.cgit.${vhost}: When gitHttpBackend.enable is true then gitHttpBackend.checkExportOkFiles must be set, see the documentation for the option for further information.";
         }
         {
           assertion =


### PR DESCRIPTION
When I introduced the checkExportOkFiles option in a722a999d1af37d9f3760680dc50fc598fce01a6 I missed `(cfg.settings ? strict-export)` in the assertions. This was fixed in bf9ccd1a685070e5532191e34858e870d3543aa1 but that also made the option nullable (which is confusing for a required option) and introduced a small type error. This now makes the option not nullable again and also fixes the type error.

Fixes #478320.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
