### PR TITLE
maintainers: drop urandom

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27407,14 +27407,6 @@
     githubId = 619015;
     name = "Svintsov Dmitry";
   };
-  urandom = {
-    email = "colin@urandom.co.uk";
-    matrix = "@urandom0:matrix.org";
-    github = "urandom2";
-    githubId = 2526260;
-    keys = [ { fingerprint = "04A3 A2C6 0042 784A AEA7  D051 0447 A663 F7F3 E236"; } ];
-    name = "Colin Arnott";
-  };
   urbas = {
     email = "matej.urbas@gmail.com";
     github = "urbas";

--- a/pkgs/applications/networking/cluster/calico/default.nix
+++ b/pkgs/applications/networking/cluster/calico/default.nix
@@ -37,7 +37,7 @@ builtins.mapAttrs
         changelog = "https://github.com/projectcalico/calico/releases/tag/v${version}";
         description = "Cloud native networking and network security";
         license = lib.licenses.asl20;
-        maintainers = with lib.maintainers; [ urandom ];
+        maintainers = [ ];
         platforms = lib.platforms.linux;
         inherit mainProgram;
       };

--- a/pkgs/applications/networking/netmaker/default.nix
+++ b/pkgs/applications/networking/netmaker/default.nix
@@ -43,7 +43,6 @@ buildGoModule rec {
     changelog = "https://github.com/gravitl/netmaker/-/releases/v${version}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
-      urandom
       qjoly
     ];
     mainProgram = "netmaker";

--- a/pkgs/by-name/aa/aaxtomp3/package.nix
+++ b/pkgs/by-name/aa/aaxtomp3/package.nix
@@ -74,6 +74,6 @@ resholve.mkDerivation rec {
     description = "Convert Audible's .aax filetype to MP3, FLAC, M4A, or OPUS";
     homepage = "https://krumpetpirate.github.io/AAXtoMP3";
     license = lib.licenses.wtfpl;
-    maintainers = with lib.maintainers; [ urandom ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/al/allmark/package.nix
+++ b/pkgs/by-name/al/allmark/package.nix
@@ -36,7 +36,6 @@ buildGoModule rec {
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [
       luftmensch-luftmensch
-      urandom
     ];
     mainProgram = "allmark";
   };

--- a/pkgs/by-name/ar/argocd-vault-plugin/package.nix
+++ b/pkgs/by-name/ar/argocd-vault-plugin/package.nix
@@ -42,6 +42,6 @@ buildGoModule rec {
     description = "Argo CD plugin to retrieve secrets from Secret Management tools and inject them into Kubernetes secrets";
     mainProgram = "argocd-vault-plugin";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ urandom ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/av/avalanchego/package.nix
+++ b/pkgs/by-name/av/avalanchego/package.nix
@@ -44,7 +44,6 @@ buildGoModule (finalAttrs: {
     changelog = "https://github.com/ava-labs/avalanchego/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [
-      urandom
       qjoly
     ];
     mainProgram = "avalanchego";

--- a/pkgs/by-name/bo/booster/package.nix
+++ b/pkgs/by-name/bo/booster/package.nix
@@ -63,7 +63,7 @@ buildGoModule rec {
     description = "Fast and secure initramfs generator";
     homepage = "https://github.com/anatol/booster";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ urandom ];
+    maintainers = [ ];
     mainProgram = "init";
   };
 }

--- a/pkgs/by-name/co/coder/package.nix
+++ b/pkgs/by-name/co/coder/package.nix
@@ -104,7 +104,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [
       ghuntley
       kylecarbs
-      urandom
     ];
   };
 

--- a/pkgs/by-name/co/coreth/package.nix
+++ b/pkgs/by-name/co/coreth/package.nix
@@ -40,6 +40,6 @@ buildGoModule rec {
     homepage = "https://github.com/ava-labs/coreth";
     changelog = "https://github.com/ava-labs/coreth/releases/tag/v${version}";
     license = lib.licenses.lgpl3Only;
-    maintainers = with lib.maintainers; [ urandom ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/cr/crowdsec/package.nix
+++ b/pkgs/by-name/cr/crowdsec/package.nix
@@ -80,7 +80,6 @@ buildGoModule rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       jk
-      urandom
     ];
   };
 }

--- a/pkgs/by-name/de/deepgit/package.nix
+++ b/pkgs/by-name/de/deepgit/package.nix
@@ -90,7 +90,7 @@ stdenv.mkDerivation rec {
     homepage = "https://www.syntevo.com/deepgit";
     changelog = "https://www.syntevo.com/deepgit/changelog.txt";
     license = lib.licenses.unfree;
-    maintainers = with lib.maintainers; [ urandom ];
+    maintainers = [ ];
     platforms = lib.platforms.linux;
     mainProgram = "deepgit";
   };

--- a/pkgs/by-name/di/dissent/package.nix
+++ b/pkgs/by-name/di/dissent/package.nix
@@ -68,7 +68,6 @@ buildGoModule rec {
     mainProgram = "dissent";
     maintainers = with lib.maintainers; [
       hmenke
-      urandom
       aleksana
     ];
   };

--- a/pkgs/by-name/do/dockstarter/package.nix
+++ b/pkgs/by-name/do/dockstarter/package.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation {
     description = "Make it quick and easy to get up and running with Docker";
     homepage = "https://dockstarter.com";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ urandom ];
+    maintainers = [ ];
     mainProgram = "ds";
   };
 }

--- a/pkgs/by-name/em/emoji-picker/package.nix
+++ b/pkgs/by-name/em/emoji-picker/package.nix
@@ -22,7 +22,7 @@ buildGoModule rec {
     description = "CLI Emoji Picker";
     homepage = "https://github.com/bcongdon/ep";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ urandom ];
+    maintainers = [ ];
     mainProgram = "ep";
   };
 }

--- a/pkgs/by-name/em/emptty/package.nix
+++ b/pkgs/by-name/em/emptty/package.nix
@@ -29,7 +29,7 @@ buildGoModule rec {
     description = "Dead simple CLI Display Manager on TTY";
     homepage = "https://github.com/tvrzna/emptty";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ urandom ];
+    maintainers = [ ];
     # many undefined functions
     broken = stdenv.hostPlatform.isDarwin;
     mainProgram = "emptty";

--- a/pkgs/by-name/gn/gnostic/package.nix
+++ b/pkgs/by-name/gn/gnostic/package.nix
@@ -25,6 +25,6 @@ buildGoModule rec {
     description = "Compiler for APIs described by the OpenAPI Specification with plugins for code generation and other API support tasks";
     changelog = "https://github.com/google/gnostic/releases/tag/v${version}";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ urandom ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/go/gostatic/package.nix
+++ b/pkgs/by-name/go/gostatic/package.nix
@@ -21,7 +21,7 @@ buildGoModule rec {
     description = "Fast static site generator";
     homepage = "https://github.com/piranha/gostatic";
     license = lib.licenses.isc;
-    maintainers = with lib.maintainers; [ urandom ];
+    maintainers = [ ];
     mainProgram = "gostatic";
   };
 }

--- a/pkgs/by-name/go/gotags/package.nix
+++ b/pkgs/by-name/go/gotags/package.nix
@@ -36,6 +36,6 @@ buildGoModule {
     mainProgram = "gotags";
     homepage = "https://github.com/jstemmer/gotags";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ urandom ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/go/gotestfmt/package.nix
+++ b/pkgs/by-name/go/gotestfmt/package.nix
@@ -22,6 +22,6 @@ buildGoModule rec {
     homepage = "https://github.com/gotesttools/gotestfmt";
     changelog = "https://github.com/GoTestTools/gotestfmt/releases/tag/v${version}";
     license = lib.licenses.unlicense;
-    maintainers = with lib.maintainers; [ urandom ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/go/gotrue-supabase/package.nix
+++ b/pkgs/by-name/go/gotrue-supabase/package.nix
@@ -40,6 +40,6 @@ buildGoModule rec {
     mainProgram = "auth";
     changelog = "https://github.com/supabase/auth/releases/tag/v${version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ urandom ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/go/gotrue/package.nix
+++ b/pkgs/by-name/go/gotrue/package.nix
@@ -32,6 +32,6 @@ buildGoModule rec {
     mainProgram = "gotrue";
     changelog = "https://github.com/netlify/gotrue/releases/tag/v${version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ urandom ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/go/govers/package.nix
+++ b/pkgs/by-name/go/govers/package.nix
@@ -32,7 +32,6 @@ buildGoModule {
     mainProgram = "govers";
     maintainers = with lib.maintainers; [
       luftmensch-luftmensch
-      urandom
     ];
   };
 }

--- a/pkgs/by-name/im/imaginary/package.nix
+++ b/pkgs/by-name/im/imaginary/package.nix
@@ -49,7 +49,6 @@ buildGoModule rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       dotlambda
-      urandom
     ];
     mainProgram = "imaginary";
   };

--- a/pkgs/by-name/in/inframap/package.nix
+++ b/pkgs/by-name/in/inframap/package.nix
@@ -28,6 +28,6 @@ buildGoModule rec {
     homepage = "https://github.com/cycloidio/inframap";
     changelog = "https://github.com/cycloidio/inframap/releases/tag/${src.tag}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ urandom ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/iv/ivpn-service/package.nix
+++ b/pkgs/by-name/iv/ivpn-service/package.nix
@@ -98,7 +98,6 @@ buildGoModule (finalAttrs: {
     changelog = "https://github.com/ivpn/desktop-app/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [
-      urandom
       blenderfreaky
     ];
     mainProgram = "ivpn-service";

--- a/pkgs/by-name/iv/ivpn/package.nix
+++ b/pkgs/by-name/iv/ivpn/package.nix
@@ -42,7 +42,6 @@ buildGoModule (finalAttrs: {
     changelog = "https://github.com/ivpn/desktop-app/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [
-      urandom
       blenderfreaky
     ];
     mainProgram = "ivpn";

--- a/pkgs/by-name/jo/jobber/package.nix
+++ b/pkgs/by-name/jo/jobber/package.nix
@@ -40,7 +40,7 @@ buildGoModule rec {
     changelog = "https://github.com/dshearer/jobber/releases/tag/v${version}";
     description = "Alternative to cron, with sophisticated status-reporting and error-handling";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ urandom ];
+    maintainers = [ ];
     mainProgram = "jobber";
   };
 }

--- a/pkgs/by-name/js/json-plot/package.nix
+++ b/pkgs/by-name/js/json-plot/package.nix
@@ -34,7 +34,7 @@ buildGoModule rec {
     description = "Dead simple terminal plots from JSON (or CSV) data. Bar charts, line charts, scatter plots, histograms and heatmaps are supported";
     homepage = "https://github.com/sgreben/jp";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ urandom ];
+    maintainers = [ ];
     mainProgram = "jp";
   };
 }

--- a/pkgs/by-name/ka/karmor/package.nix
+++ b/pkgs/by-name/ka/karmor/package.nix
@@ -57,7 +57,6 @@ buildGoModule rec {
     changelog = "https://github.com/kubearmor/kubearmor-client/releases/v${version}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
-      urandom
       kashw2
     ];
   };

--- a/pkgs/by-name/ku/kubernetes-code-generator/package.nix
+++ b/pkgs/by-name/ku/kubernetes-code-generator/package.nix
@@ -27,6 +27,6 @@ buildGoModule rec {
     changelog = "https://github.com/kubernetes/code-generator/releases/tag/v${version}";
     description = "Kubernetes code generation";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ urandom ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/li/linx-server/package.nix
+++ b/pkgs/by-name/li/linx-server/package.nix
@@ -29,6 +29,6 @@ buildGoModule {
     description = "Self-hosted file/code/media sharing website";
     homepage = "https://put.icu";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ urandom ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/mg/mgmt/package.nix
+++ b/pkgs/by-name/mg/mgmt/package.nix
@@ -57,7 +57,6 @@ buildGoModule (finalAttrs: {
     homepage = "https://mgmtconfig.com";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [
-      urandom
       karpfediem
     ];
     mainProgram = "mgmt";

--- a/pkgs/by-name/ne/nex/package.nix
+++ b/pkgs/by-name/ne/nex/package.nix
@@ -33,6 +33,6 @@ buildGoModule {
     mainProgram = "nex";
     homepage = "https://github.com/blynn/nex";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ urandom ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/oh/oh-my-posh/package.nix
+++ b/pkgs/by-name/oh/oh-my-posh/package.nix
@@ -53,7 +53,6 @@ buildGoModule rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       lucperkins
-      urandom
     ];
   };
 }

--- a/pkgs/by-name/ol/olaris-server/package.nix
+++ b/pkgs/by-name/ol/olaris-server/package.nix
@@ -64,6 +64,6 @@ buildGoModule rec {
     homepage = "https://gitlab.com/olaris/olaris-server";
     changelog = "https://gitlab.com/olaris/olaris-server/-/releases/v${version}";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ urandom ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/os/osv-scanner/package.nix
+++ b/pkgs/by-name/os/osv-scanner/package.nix
@@ -46,7 +46,6 @@ buildGoModule rec {
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       stehessel
-      urandom
     ];
   };
 }

--- a/pkgs/by-name/ot/otel-cli/package.nix
+++ b/pkgs/by-name/ot/otel-cli/package.nix
@@ -45,7 +45,6 @@ buildGoModule rec {
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       emattiza
-      urandom
     ];
     mainProgram = "otel-cli";
   };

--- a/pkgs/by-name/pd/pdfmm/package.nix
+++ b/pkgs/by-name/pd/pdfmm/package.nix
@@ -53,7 +53,7 @@ resholve.mkDerivation {
     description = "Graphical assistant to reduce the size of a PDF file";
     homepage = "https://github.com/jpfleury/pdfmm";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ urandom ];
+    maintainers = [ ];
     mainProgram = "pdfmm";
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };

--- a/pkgs/by-name/po/popura/package.nix
+++ b/pkgs/by-name/po/popura/package.nix
@@ -32,7 +32,7 @@ buildGoModule rec {
     description = "Alternative Yggdrasil network client";
     homepage = "https://github.com/popura-network/popura";
     license = lib.licenses.lgpl3Only;
-    maintainers = with lib.maintainers; [ urandom ];
+    maintainers = [ ];
     mainProgram = "yggdrasil";
   };
 }

--- a/pkgs/by-name/pu/publii/package.nix
+++ b/pkgs/by-name/pu/publii/package.nix
@@ -103,7 +103,6 @@ stdenv.mkDerivation rec {
     changelog = "https://github.com/getpublii/publii/releases/tag/v${version}";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [
-      urandom
       sebtm
     ];
     platforms = [ "x86_64-linux" ];

--- a/pkgs/by-name/ri/rime-cli/package.nix
+++ b/pkgs/by-name/ri/rime-cli/package.nix
@@ -22,7 +22,7 @@ buildGoModule rec {
     changelog = "https://github.com/puddinging/rime-cli/releases/tag/v${version}";
     description = "Command line tool to add customized vocabulary for Rime IME";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ urandom ];
+    maintainers = [ ];
     mainProgram = "rime-cli";
   };
 }

--- a/pkgs/by-name/rk/rke/package.nix
+++ b/pkgs/by-name/rk/rke/package.nix
@@ -31,6 +31,6 @@ buildGoModule rec {
     mainProgram = "rke";
     changelog = "https://github.com/rancher/rke/releases/tag/v${version}";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ urandom ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/si/signal-desktop-bin/generic.nix
+++ b/pkgs/by-name/si/signal-desktop-bin/generic.nix
@@ -298,7 +298,6 @@ stdenv.mkDerivation rec {
     maintainers = with lib.maintainers; [
       mic92
       equirosa
-      urandom
       bkchr
       emily
       Gliczy

--- a/pkgs/by-name/st/steamtinkerlaunch/package.nix
+++ b/pkgs/by-name/st/steamtinkerlaunch/package.nix
@@ -112,7 +112,6 @@ stdenvNoCC.mkDerivation {
     homepage = "https://github.com/sonic2kk/steamtinkerlaunch";
     license = lib.licenses.gpl3;
     maintainers = with lib.maintainers; [
-      urandom
       surfaceflinger
     ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/to/toolbox/package.nix
+++ b/pkgs/by-name/to/toolbox/package.nix
@@ -56,7 +56,7 @@ buildGoModule rec {
     changelog = "https://github.com/containers/toolbox/releases/tag/${version}";
     description = "Tool for containerized command line environments on Linux";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ urandom ];
+    maintainers = [ ];
     mainProgram = "toolbox";
   };
 }

--- a/pkgs/by-name/vi/vitess/package.nix
+++ b/pkgs/by-name/vi/vitess/package.nix
@@ -30,6 +30,6 @@ buildGoModule rec {
     changelog = "https://github.com/vitessio/vitess/releases/tag/v${version}";
     description = "Database clustering system for horizontal scaling of MySQL";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ urandom ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/wg/wgnord/package.nix
+++ b/pkgs/by-name/wg/wgnord/package.nix
@@ -60,7 +60,7 @@ resholve.mkDerivation rec {
     description = "NordVPN Wireguard (NordLynx) client in POSIX shell";
     homepage = "https://github.com/phirecc/wgnord";
     changelog = "https://github.com/phirecc/wgnord/releases/tag/v${version}";
-    maintainers = with lib.maintainers; [ urandom ];
+    maintainers = [ ];
     license = lib.licenses.mit;
     mainProgram = "wgnord";
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/wt/wtwitch/package.nix
+++ b/pkgs/by-name/wt/wtwitch/package.nix
@@ -88,7 +88,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     description = "Terminal user interface for Twitch";
     homepage = "https://github.com/krathalan/wtwitch";
     license = lib.licenses.gpl3Only;
-    maintainers = [ lib.maintainers.urandom ];
+    maintainers = [ ];
     platforms = lib.platforms.all;
     mainProgram = "wtwitch";
   };

--- a/pkgs/by-name/zx/zxfer/package.nix
+++ b/pkgs/by-name/zx/zxfer/package.nix
@@ -82,7 +82,7 @@ resholve.mkDerivation rec {
     homepage = "https://github.com/allanjude/zxfer";
     changelog = "https://github.com/allanjude/zxfer/releases/tag/v${version}";
     license = lib.licenses.bsd2;
-    maintainers = with lib.maintainers; [ urandom ];
+    maintainers = [ ];
     mainProgram = "zxfer";
   };
 }

--- a/pkgs/development/tools/devbox/default.nix
+++ b/pkgs/development/tools/devbox/default.nix
@@ -43,7 +43,6 @@ buildGoModule (finalAttrs: {
     homepage = "https://www.jetify.com/devbox";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
-      urandom
       lagoja
       madeddie
     ];


### PR DESCRIPTION
No [pull requests](https://github.com/NixOS/nixpkgs/pulls?q=author%3Aurandom2) since 2024, no [comments](https://github.com/NixOS/nixpkgs/pulls?q=commenter%3Aurandom2) since 2024. Looking at his GitHub activity, he seems to be gone AWOL. Thus dropping per [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md)

@urandom2 if you object to being dropped please respond saying so within a week. Even if you don't make it, you are of course welcome back whenever you would like!

@NixOS/nixpkgs-core With removing him, there will be a lot of small packages without a maintainer. I guess, as long as they are not broken, they can be kept around. But for the following, I'd like your input:

For the following packages, I will file a removal PR:

- [x] olaris-server: marked broken; #480308
- [x] coreth: Darwin build broken since 2024; upstream has superceded this package by avalanchego, which is also part of nixpkgs #480207
- [ ] gotrue, gotrue-supabase: deprecated upstream (see https://github.com/NixOS/nixpkgs/pull/434687#issuecomment-3205551027); has a dependent library that needs bumping prior (#480059)

The following packages are marked as unmaintained upstream, so probably also fit for removal when there is no maintainer here:
- [ ] ~~jobber~~
- [ ] ~~aaxtomp3~~
- [x] popura #480330

For the following, I'm not sure:
- [ ] ~~dockstarter: Not updated in nixpkgs in years. As this deals with "easy setup with Docker", it is probably not used and can be removed~~
- [ ] ~~linx-server: unmaintained webserver software. Upstream mentions more active forks, but this needs more digging. Removal?~~

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
