### PR TITLE
pixinsight: rewrite

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14345,6 +14345,11 @@
     githubId = 629430;
     keys = [ { fingerprint = "2843 750C B1AB E256 94BE  40E2 D843 D30B 42CA 0E2D"; } ];
   };
+  kulczwoj = {
+    name = "Wojciech Kulczycki";
+    github = "kulczwoj";
+    githubId = 58049191;
+  };
   KunyaKud = {
     name = "KunyaKud";
     email = "wafuu@posteo.net";

--- a/pkgs/by-name/pi/pixinsight/default.nix
+++ b/pkgs/by-name/pi/pixinsight/default.nix
@@ -1,0 +1,89 @@
+{
+  lib,
+  stdenv,
+  requireFile,
+  bubblewrap,
+  fakeroot,
+  unixtools,
+  cudaSupport,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "pixinsight";
+  version = "1.9.3-20250402";
+
+  src = requireFile {
+    name = "PI-linux-x64-${finalAttrs.version}-c.tar.xz";
+    url = "http://pixinsight.com";
+    hash = "sha256-MOAWH64A13vVLeNiBC9nO78P0ELmXXHR5ilh5uUhWhs=";
+  };
+
+  nativeBuildInputs = [
+    bubblewrap
+    fakeroot
+    unixtools.script
+  ];
+
+  sourceRoot = ".";
+
+  # Patch installer binary with correct interpreter and rpath
+  postPatch = ''
+    patchelf ./installer \
+      --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+      --set-rpath ${lib.getLib stdenv.cc.cc}/lib
+  '';
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    # Prepare output directories
+    mkdir -p $out/opt
+    mkdir -p $out/share/{applications,mime/packages}
+    for i in 16 24 32 48 64 128 256 512; do
+      mkdir -p $out/share/icons/hicolor/"$i"x"$i"/apps
+    done
+    mkdir -p $out/share/icons/hicolor/scalable/apps
+
+    # Install using proper bind-mounts
+    bwrap \
+      --bind /build /build \
+      --bind $out/opt /opt \
+      --bind /nix /nix \
+      --dev /dev \
+      fakeroot script -ec "./installer \
+        --yes \
+        --install-desktop-dir=$out/share/applications \
+        --install-mime-dir=$out/share/mime \
+        --install-icons-dir=$out/share/icons/hicolor \
+        --no-bin-launcher"
+  ''
+  + lib.optionalString cudaSupport ''
+    # Remove bundled libtensorflow-cpu files
+    rm -f $out/opt/PixInsight/bin/lib/libtensorflow*
+  ''
+  + ''
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    # Patch desktop entry for downstream compatibility
+    substituteInPlace $out/share/applications/PixInsight.desktop \
+      --replace-fail "Exec=/opt/PixInsight/bin/PixInsight.sh" "Exec=pixinsight"
+  '';
+
+  meta = {
+    description = "Scientific image processing program for astrophotography";
+    homepage = "https://pixinsight.com/";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [
+      sheepforce
+      kulczwoj
+    ];
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    hydraPlatforms = [ ];
+  };
+})

--- a/pkgs/by-name/pi/pixinsight/libtensorflow-gpu.nix
+++ b/pkgs/by-name/pi/pixinsight/libtensorflow-gpu.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  cudaPackages,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libtensorflow-gpu";
+  version = "2.18.1";
+
+  src = fetchurl {
+    url = "https://storage.googleapis.com/tensorflow/versions/${finalAttrs.version}/${finalAttrs.pname}-linux-x86_64.tar.gz";
+    hash = "sha256-9k7DA53E/hh9zzMhX0D6BZOZWwOoiNEi/tdYHONIFeU=";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+  ];
+
+  buildInputs = with cudaPackages; [
+    cudatoolkit
+    cudnn
+  ];
+
+  sourceRoot = ".";
+
+  # Unpack tarball to subdir, preventing copying `env-vars` to $out in `installPhase`
+  preUnpack = ''
+    mkdir source
+    cd source
+  '';
+
+  dontPatch = true;
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    cp -pr --reflink=auto -- . $out
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Computation using data flow graphs for scalable machine learning";
+    homepage = "http://tensorflow.org";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ kulczwoj ];
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Rewrite `pixinsight` to provide out of the box the following main functionality missing from current implementation ([`ad363ba`](https://github.com/NixOS/nixpkgs/commit/ad363bafd4b131b1360d3195241212c15ac3cc37)):
- support self-updates and plugins: on entering `FHSEnv` create (via `extraPreBwrapCmds`) user-mutable location (`$HOME/.local/share/pixinsight/opt`) and deploy immutable `PixInsight` installation files (from unwrapped derivation) to it (auto-(re)deployment whenever `unwrapped` changes to remain synced with `/nix/store`), and bind-mount it (via `extraBwrapArgs`) to `/opt` — `PixInsight` requires to detect itself under `/opt/PixInsight` (`ad363ba` did introduce `FHSEnv`, but with no deployment to `/opt`, which means that app is unusable without extra setup)
> **Note:** Deployment script in `extraPreBwrapCmds` is conservative (it follows default behavior of `PixInsight` `installer` during upgrade/reinstall) — it removes previous deployment before redeployment; and as is the case when upgrading/reinstalling on classic Linux distro: all plugins added via `PixInsight` repos (which is the main and recommended way to add plugins; and vast majority of plugins provide `PixInsight` repos) get redownloaded automatically by `PixInsightUpdater` after redeployment, while plugins added manually must be re-added manually
- add CUDA support (use added here `libtensorflow-bin`, as explained below), verified working for popular [RC Astro](https://www.rc-astro.com/) plugins
- fix desktop integration files (in current implementation icons don't install properly): ensure all files install by creating required folders, and expose them in top-level package (in `ad363ba` top-level package doesn't do it)
- provide upstream-compatible CLI alias {command}`PixInsight` (`ad363ba` implementation provides only {command}`pixinsight`)

Additionally:
- expose `unwrapped` via `passthru` for easier maintenance and better access to immutable installation files
- use correct `meta.mainProgram`: for `buildFHSEnv` with `pname` the default `executableName` is `pname`, which is "pixinsight" (`ad363ba` inherits "PixInsight" from unwrapped derivation)

This rewrite follows patterns from `steam`, `davinci-resolve`, `zoom-us`

> **Note**: I've created this rewrite 7 months ago in my private flake and used it regularly and reliably on 3 different machines ever since, with CUDA support added  5 months ago and working reliably for all RC Astro plugins: `BlurXTerminator`, `NoiseXTerminator`, and `StarXTerminator`.

#### libtensorflow-bin: init at 2.18.1

Standalone binary distribution of TensorFlow libraries
    
Standalone distributions ship `libtensorflow.so` with embedded `VERS_1.0` string, which is required by e.g. RC Astro plugins for `PixInsight`.

Binary distributions of TensorFlow used in `tensorflow-bin` ship `libtensorflow_cc.so` without embedded `VERS_1.0` string, while source build package `tensorflow` (and thus also based on it `libtensorflow` package) is broken and outdated.

> **Note:** Publishing standalone `libtensorflow` packages was dropped in [TensorFlow 2.19.0](https://github.com/tensorflow/tensorflow/releases/tag/v2.19.0), so the binary version used in this package is the latest one.

Homepage: https://www.tensorflow.org/
Release notes: https://github.com/tensorflow/tensorflow/releases/tag/v2.18.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
