### PR TITLE
yaziPlugins.nav-parent-panel: init at 0-unstable-2025-09-15

### DIFF
--- a/pkgs/by-name/ya/yazi/plugins/nav-parent-panel/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/nav-parent-panel/default.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkYaziPlugin,
+}:
+mkYaziPlugin {
+  pname = "nav-parent-panel";
+  version = "0-unstable-2025-09-15";
+
+  src = fetchFromGitHub {
+    owner = "yaqihou";
+    repo = "nav-parent-panel.yazi";
+    rev = "e72b944cf58d227a80bbd816031068870b20178f";
+    hash = "sha256-jKCCggyldQrdw88DaNXNuLbEq88HgoWc0oCCWTtQF2g=";
+  };
+
+  meta = {
+    description = "Yazi plugin to navigate between sibling directories";
+    longDescription = ''
+      This plugin allows you to cycle through sibling directories (same level
+      as the current directory) without having to go up to the parent directory.
+
+      For a visual demonstration, check
+      [this example](https://github.com/yaqihou/nav-parent-panel.yazi#example).
+    '';
+    homepage = "https://github.com/yaqihou/nav-parent-panel.yazi";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ eljamm ];
+  };
+}


### PR DESCRIPTION
This adds the [`nav-parent-panel.yazi`](https://github.com/yaqihou/nav-parent-panel.yazi) plugin.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
