### PR TITLE
nixos/oci-image: add copyChannel option

### DIFF
--- a/nixos/modules/virtualisation/oci-image.nix
+++ b/nixos/modules/virtualisation/oci-image.nix
@@ -26,6 +26,7 @@ in
     system.build.OCIImage = import ../../lib/make-disk-image.nix {
       inherit config lib pkgs;
       inherit (config.virtualisation) diskSize;
+      inherit (cfg) copyChannel;
       name = "oci-image";
       baseName = config.image.baseName;
       configFile = ./oci-config-user.nix;

--- a/nixos/modules/virtualisation/oci-options.nix
+++ b/nixos/modules/virtualisation/oci-options.nix
@@ -27,6 +27,22 @@
           Whether the OCI instance is using EFI.
         '';
       };
+
+      copyChannel = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = ''
+          Whether to copy the NixOS channel into the image.
+
+          When enabled, the nixpkgs source tree is bundled into the image at
+          `/nix/var/nix/profiles/per-user/root/channels/nixos`, allowing
+          `nix-channel`, `nixos-rebuild`, and `<nixpkgs>` to work without
+          network access.
+
+          Disable this to reduce image size by ~300-400MB, especially when
+          using flakes where channels are not needed.
+        '';
+      };
     };
   };
 }


### PR DESCRIPTION
Expose the `copyChannel` parameter from `make-disk-image.nix` as the `oci.copyChannel` option.

This allows users to disable bundling the NixOS channel into OCI images, reducing image size by ~300-400MB. This is particularly useful for flake-based deployments where channels are not needed.

The option defaults to `true` for backwards compatibility.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
