### PR TITLE
gungraun-runner: init at 0.17.0

### DIFF
--- a/pkgs/by-name/gu/gungraun-runner/package.nix
+++ b/pkgs/by-name/gu/gungraun-runner/package.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  makeWrapper,
+  valgrind-light,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "gungraun-runner";
+  version = "0.17.0";
+
+  src = fetchFromGitHub {
+    owner = "gungraun";
+    repo = "gungraun";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-8AuC5AqsiqXFomIEVPbRh1aYf/HQRg7oEVGiH6gdHFg=";
+  };
+
+  cargoHash = "sha256-ERBYOFMkd+jy6u/mpSCvm0GMOYPYRO6ZwH9iVhttJng=";
+
+  cargoBuildFlags = [
+    "--package"
+    "gungraun-runner"
+  ];
+
+  cargoTestFlags = [
+    "--package"
+    "gungraun-runner"
+  ];
+
+  nativeBuildInputs = [
+    makeWrapper
+    valgrind-light
+  ];
+
+  # Suppress warning about preferring GUNGRAUN_LOG over RUST_LOG
+  preCheck = ''
+    unset RUST_LOG
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/gungraun-runner \
+      --prefix PATH : ${lib.makeBinPath [ valgrind-light ]}
+  '';
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Binary runner for Gungraun, a high-precision, one-shot and consistent benchmarking framework/harness for Rust";
+    homepage = "https://github.com/gungraun/gungraun";
+    changelog = "https://github.com/gungraun/gungraun/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = with lib.licenses; [
+      asl20
+      mit
+    ];
+    maintainers = with lib.maintainers; [ cathalmullan ];
+    mainProgram = "gungraun-runner";
+    platforms = valgrind-light.meta.platforms;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds the [gungraun CLI](https://gungraun.github.io/gungraun/latest/html/index.html), a wrapper around valgrind used for Rust benchmarks.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
