### PR TITLE
caddyfile-language-server: init at 0.4.0

### DIFF
--- a/pkgs/by-name/ca/caddyfile-language-server/package.nix
+++ b/pkgs/by-name/ca/caddyfile-language-server/package.nix
@@ -1,0 +1,73 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchPnpmDeps,
+  pnpm_8,
+  nodejs,
+  pnpmConfigHook,
+  makeBinaryWrapper,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "caddyfile-language-server";
+  version = "0.4.0";
+
+  src = fetchFromGitHub {
+    owner = "caddyserver";
+    repo = "vscode-caddyfile";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-IusP9Z3e8mQ0mEhI1o1zIqPDB/i0pqlMfnt6M8bzb2w=";
+  };
+
+  pnpmWorkspaces = [ "@caddyserver/caddyfile-language-server" ];
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs)
+      pname
+      version
+      src
+      pnpmWorkspaces
+      ;
+    pnpm = pnpm_8;
+    fetcherVersion = 3;
+    hash = "sha256-D9kYFkmFlvg4r6vR9PHHAwF0qglHsTuRae0Z7CzDq1M=";
+  };
+
+  nativeBuildInputs = [
+    pnpm_8
+    pnpmConfigHook
+    nodejs
+    makeBinaryWrapper
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    pnpm --filter=@caddyserver/caddyfile-language-server run build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    rm -rf node_modules packages/server/node_modules
+    pnpm install --production --offline --force --filter=@caddyserver/caddyfile-language-server
+    mkdir -p $out/lib/node_modules/caddyfile-language-server/
+    mv packages/server/dist/* $out/lib/node_modules/caddyfile-language-server/
+
+    makeWrapper ${lib.getExe nodejs} $out/bin/caddyfile-language-server \
+      --add-flags "$out/lib/node_modules/caddyfile-language-server/index.js"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    changelog = "https://github.com/caddyserver/vscode-caddyfile/releases/tag/v${finalAttrs.version}";
+    description = "Basic language server for caddyfile";
+    homepage = "https://github.com/caddyserver/vscode-caddyfile";
+    mainProgram = "caddyfile-language-server";
+    maintainers = with lib.maintainers; [ pyrox0 ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
Language server from https://github.com/caddyserver/vscode-caddyfile/tree/master/packages/server, gives basic information(nothing complicated)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
