### PR TITLE
insomnia: 11.6.0 -> 12.2.0

### DIFF
--- a/pkgs/by-name/in/insomnia/package.nix
+++ b/pkgs/by-name/in/insomnia/package.nix
@@ -7,22 +7,22 @@
 }:
 let
   pname = "insomnia";
-  version = "11.6.0";
+  version = "12.2.0";
 
   src =
     fetchurl
       {
         aarch64-darwin = {
           url = "https://github.com/Kong/insomnia/releases/download/core%40${version}/Insomnia.Core-${version}.dmg";
-          hash = "sha256-9/Xkwgwyi/CqqmrroxhJ9IhvVK83qKROfCEF5IS5r+w=";
+          hash = "sha256-ISQVIhR5TWY/Xk6sXeL89/srxppqBS7wdoRINwuoQqg=";
         };
         x86_64-darwin = {
           url = "https://github.com/Kong/insomnia/releases/download/core%40${version}/Insomnia.Core-${version}.dmg";
-          hash = "sha256-9/Xkwgwyi/CqqmrroxhJ9IhvVK83qKROfCEF5IS5r+w=";
+          hash = "sha256-ISQVIhR5TWY/Xk6sXeL89/srxppqBS7wdoRINwuoQqg=";
         };
         x86_64-linux = {
           url = "https://github.com/Kong/insomnia/releases/download/core%40${version}/Insomnia.Core-${version}.AppImage";
-          hash = "sha256-xHqRCR6D1ahqTyWA9icVK5oykABMp5qcgk35w1jzB2s=";
+          hash = "sha256-/0fJmbXhjrcVVSFvxd847mSKrzrZRK3Sqi6rjyaBOUw=";
         };
       }
       .${stdenv.system} or (throw "Unsupported system: ${stdenv.system}");


### PR DESCRIPTION
##### Motivation

Version bump for Insomnia from 11.6.0 to 12.2.0

##### Changelog

**Release notes:** https://github.com/Kong/insomnia/releases/tag/core@12.2.0

- Force the dropdown to be positioned below the input, adjust styles
- Fix style issue  
- Fix: revert structuredClone method used for clone in context menu
- Add fuzzy match for searching repos and branches

##### Checklist

- [x] Built on platform(s): x86_64-linux
- ~~[ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside nixos/tests)~~ - N/A (no tests exist for insomnia)
- [x] Tested compilation of all packages that depend on this change using `nixpkgs-review`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Built on sandboxed environment
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)

##### Notes

- Updated hashes for all platforms (x86_64-linux, x86_64-darwin, aarch64-darwin)
- Package builds successfully and binary executes
- Application reports correct version: 12.2.0