### PR TITLE
weblate: 5.15.1 -> 5.15.2

### DIFF
--- a/pkgs/by-name/we/weblate/package.nix
+++ b/pkgs/by-name/we/weblate/package.nix
@@ -24,7 +24,7 @@ let
 in
 python.pkgs.buildPythonApplication rec {
   pname = "weblate";
-  version = "5.15.1";
+  version = "5.15.2";
 
   pyproject = true;
 
@@ -37,7 +37,7 @@ python.pkgs.buildPythonApplication rec {
     owner = "WeblateOrg";
     repo = "weblate";
     tag = "weblate-${version}";
-    hash = "sha256-9k6H9/XW7vbXix+zadxHCNl9UJ3yE1ONa/+VRvIGk28=";
+    hash = "sha256-qNv3aaPyQ/bOrPbK7u9vtq8R1MFqXLJzvLUZfVgjMK0=";
   };
 
   build-system = with python.pkgs; [ setuptools ];
@@ -65,10 +65,7 @@ python.pkgs.buildPythonApplication rec {
     '';
 
   pythonRelaxDeps = [
-    "celery"
     "certifi"
-    "cyrtranslit"
-    "django-appconf"
     "urllib3"
   ];
 
@@ -142,6 +139,7 @@ python.pkgs.buildPythonApplication rec {
       translate-toolkit
       translation-finder
       unidecode
+      urllib3
       user-agents
       weblate-language-data
       weblate-schemas

--- a/pkgs/development/python-modules/django-otp/default.nix
+++ b/pkgs/development/python-modules/django-otp/default.nix
@@ -12,14 +12,14 @@
 
 buildPythonPackage rec {
   pname = "django-otp";
-  version = "1.6.3";
+  version = "1.7.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "django-otp";
     repo = "django-otp";
     tag = "v${version}";
-    hash = "sha256-sYwt41YWQQN6nKXGmrrZ75t/i1XNVjIgRKVElVaCGRc=";
+    hash = "sha256-Tqi6FHXJToOJsGETgIRl8rOUTfkn3kBkG5/bI8CxT24=";
   };
 
   build-system = [ hatchling ];

--- a/pkgs/development/python-modules/translate-toolkit/default.nix
+++ b/pkgs/development/python-modules/translate-toolkit/default.nix
@@ -30,7 +30,7 @@
 
 buildPythonPackage rec {
   pname = "translate-toolkit";
-  version = "3.17.5";
+  version = "3.18.0";
 
   pyproject = true;
 
@@ -38,7 +38,7 @@ buildPythonPackage rec {
     owner = "translate";
     repo = "translate";
     tag = version;
-    hash = "sha256-I0HpVL/bH78oFGDWkXyRvZejXzjDHXFfdPu/+iMgAQw=";
+    hash = "sha256-wc8bSXdFHVSzm4CWZ9b27zEYNH0rbEXf0i947VNTg/8=";
   };
 
   build-system = [ setuptools-scm ];

--- a/pkgs/development/python-modules/weblate-language-data/default.nix
+++ b/pkgs/development/python-modules/weblate-language-data/default.nix
@@ -8,13 +8,13 @@
 
 buildPythonPackage rec {
   pname = "weblate-language-data";
-  version = "2025.10";
+  version = "2026.1";
   pyproject = true;
 
   src = fetchPypi {
     pname = "weblate_language_data";
     inherit version;
-    hash = "sha256-pSMeuIDUGYbAetXugmahtTeGIIXxPPPiYt2Jb80vxoQ=";
+    hash = "sha256-qImbiZzsNk3oSljSwdsK+uk/1ZUygwltTCkGNKxBeN4=";
   };
 
   build-system = [ setuptools ];


### PR DESCRIPTION
Closes https://github.com/NixOS/nixpkgs/pull/480019
Closes https://github.com/NixOS/nixpkgs/pull/479059
Closes https://github.com/NixOS/nixpkgs/pull/481299

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
