### PR TITLE
nixos/services.picom: use libconfig to generate the config

### DIFF
--- a/nixos/modules/services/x11/picom.nix
+++ b/nixos/modules/services/x11/picom.nix
@@ -20,43 +20,8 @@ let
 
   mkDefaultAttrs = mapAttrs (n: v: mkDefault v);
 
-  # Basically a tinkered lib.generators.mkKeyValueDefault
-  # It either serializes a top-level definition "key: { values };"
-  # or an expression "key = { values };"
-  mkAttrsString =
-    top:
-    mapAttrsToList (
-      k: v:
-      let
-        sep = if (top && isAttrs v) then ":" else "=";
-      in
-      "${escape [ sep ] k}${sep}${mkValueString v};"
-    );
-
-  # This serializes a Nix expression to the libconfig format.
-  mkValueString =
-    v:
-    if types.bool.check v then
-      boolToString v
-    else if types.int.check v then
-      toString v
-    else if types.float.check v then
-      toString v
-    else if types.str.check v then
-      "\"${escape [ "\"" ] v}\""
-    else if builtins.isList v then
-      "[ ${concatMapStringsSep " , " mkValueString v} ]"
-    else if types.attrs.check v then
-      "{ ${concatStringsSep " " (mkAttrsString false v)} }"
-    else
-      throw ''
-        invalid expression used in option services.picom.settings:
-        ${v}
-      '';
-
-  toConf = attrs: concatStringsSep "\n" (mkAttrsString true cfg.settings);
-
-  configFile = pkgs.writeText "picom.conf" (toConf cfg.settings);
+  libconfig = pkgs.formats.libconfig { };
+  configFile = libconfig.generate "picom.conf" cfg.settings;
 
 in
 {
@@ -279,56 +244,22 @@ in
       '';
     };
 
-    settings =
-      with types;
-      let
-        scalar =
-          oneOf [
-            bool
-            int
-            float
-            str
-          ]
-          // {
-            description = "scalar types";
+    settings = mkOption {
+      type = libconfig.type;
+      default = { };
+      example = literalExpression ''
+        blur =
+          { method = "gaussian";
+            size = 10;
+            deviation = 5.0;
           };
-
-        libConfig =
-          oneOf [
-            scalar
-            (listOf libConfig)
-            (attrsOf libConfig)
-          ]
-          // {
-            description = "libconfig type";
-          };
-
-        topLevel = attrsOf libConfig // {
-          description = ''
-            libconfig configuration. The format consists of an attributes
-            set (called a group) of settings. Each setting can be a scalar type
-            (boolean, integer, floating point number or string), a list of
-            scalars or a group itself
-          '';
-        };
-
-      in
-      mkOption {
-        type = topLevel;
-        default = { };
-        example = literalExpression ''
-          blur =
-            { method = "gaussian";
-              size = 10;
-              deviation = 5.0;
-            };
-        '';
-        description = ''
-          Picom settings. Use this option to configure Picom settings not exposed
-          in a NixOS option or to bypass one.  For the available options see the
-          CONFIGURATION FILES section at {manpage}`picom(1)`.
-        '';
-      };
+      '';
+      description = ''
+        Picom settings. Use this option to configure Picom settings not exposed
+        in a NixOS option or to bypass one.  For the available options see the
+        CONFIGURATION FILES section at {manpage}`picom(1)`.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {


### PR DESCRIPTION
This PR switches away from the custom libconfig format functions/types to `pkgs.formats.libconfig`. The custom formatter didn't correctly handle arrays (of primitives) versus lists (of composit types), which made it impossible to use the new picom rules system.

Tested by generating my own picom config.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test