### PR TITLE
bign-handheld-thumbnailer: build with meson

### DIFF
--- a/pkgs/by-name/bi/bign-handheld-thumbnailer/package.nix
+++ b/pkgs/by-name/bi/bign-handheld-thumbnailer/package.nix
@@ -1,15 +1,20 @@
 {
   lib,
   bign-handheld-thumbnailer,
+  cargo,
   fetchFromGitHub,
   glib,
+  meson,
+  ninja,
   nix-update-script,
   pkg-config,
   rustPlatform,
+  rustc,
+  stdenv,
   testers,
 }:
 
-rustPlatform.buildRustPackage (finalAttrs: {
+stdenv.mkDerivation (finalAttrs: {
   pname = "bign-handheld-thumbnailer";
   version = "1.2.0";
 
@@ -20,13 +25,27 @@ rustPlatform.buildRustPackage (finalAttrs: {
     hash = "sha256-+iWf5ybCUHlZz3Ybw3bwLKzlsmiVwep2alVDvL9bG2A=";
   };
 
-  cargoHash = "sha256-vfTbfg1CAbc//UZtI5trw6znqnNGy6AiCSQNE68vch8=";
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-vfTbfg1CAbc//UZtI5trw6znqnNGy6AiCSQNE68vch8=";
+  };
 
   strictDeps = true;
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [
+    cargo
+    meson
+    ninja
+    pkg-config
+    rustPlatform.cargoSetupHook
+    rustc
+  ];
 
   buildInputs = [ glib ];
+
+  mesonFlags = [
+    "-Dupdate_mime_database=false"
+  ];
 
   passthru = {
     tests.version = testers.testVersion {


### PR DESCRIPTION
The derivation have additional files under `share/` when built with `meson`:
```bash
/nix/store/jgpw5cl12l7hy7riah2yd4078p3dha33-bign-handheld-thumbnailer-1.2.0
├── bin
│   └── bign-handheld-thumbnailer
└── share
    ├── mime
    │   └── packages
    │       └── bign-handheld-thumbnailer.xml
    └── thumbnailers
        └── bign-handheld-thumbnailer.thumbnailer
``` 
which were missing previously.

Upstream instruction for manual installation: https://github.com/MateusRodCosta/bign-handheld-thumbnailer/tree/main?tab=readme-ov-file#manual
Section from Nixpkgs manual about building Rust packages with meson: https://github.com/NixOS/nixpkgs/blob/master/doc/languages-frameworks/rust.section.md#rust-package-built-with-meson-rust-package-built-with-meson

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
