### PR TITLE
nixos/systemd-networkd: Add missing DHCP/RA "use" options

### DIFF
--- a/nixos/modules/system/boot/networkd.nix
+++ b/nixos/modules/system/boot/networkd.nix
@@ -1143,6 +1143,7 @@ let
           "UseDNS"
           "UseDNR"
           "UseNTP"
+          "UseSIP"
           "SendHostname"
           "UseHostname"
           "Hostname"
@@ -1170,6 +1171,7 @@ let
         (assertValueOneOf "UseDNS" boolValues)
         (assertValueOneOf "UseDNR" boolValues)
         (assertValueOneOf "UseNTP" boolValues)
+        (assertValueOneOf "UseSIP" boolValues)
         (assertValueOneOf "SendHostname" boolValues)
         (assertValueOneOf "UseHostname" boolValues)
         (assertValueOneOf "UseDomains" (boolValues ++ [ "route" ]))

--- a/nixos/modules/system/boot/networkd.nix
+++ b/nixos/modules/system/boot/networkd.nix
@@ -1224,6 +1224,7 @@ let
           "NetLabel"
           "NFTSet"
           "UseCaptivePortal"
+          "UseRedirect"
         ])
         (assertValueOneOf "UseDNS" boolValues)
         (assertValueOneOf "UseDomains" (boolValues ++ [ "route" ]))
@@ -1236,6 +1237,7 @@ let
         (assertValueOneOf "UseRoutePrefix" boolValues)
         (assertValueOneOf "UsePREF64" boolValues)
         (assertValueOneOf "UseCaptivePortal" boolValues)
+        (assertValueOneOf "UseRedirect" boolValues)
       ];
 
       sectionDHCPServer = checkUnitConfig "DHCPServer" [

--- a/nixos/modules/system/boot/networkd.nix
+++ b/nixos/modules/system/boot/networkd.nix
@@ -1097,6 +1097,7 @@ let
           "Use6RD"
           "NetLabel"
           "NFTSet"
+          "UseCaptivePortal"
         ])
         (assertValueOneOf "UseDNS" boolValues)
         (assertValueOneOf "RoutesToDNS" boolValues)
@@ -1131,6 +1132,7 @@ let
           "infinity"
         ])
         (assertValueOneOf "Use6RD" boolValues)
+        (assertValueOneOf "UseCaptivePortal" boolValues)
       ];
 
       sectionDHCPv6 = checkUnitConfig "DHCPv6" [
@@ -1159,6 +1161,7 @@ let
           "SendRelease"
           "NetLabel"
           "NFTSet"
+          "UseCaptivePortal"
         ])
         (assertValueOneOf "UseAddress" boolValues)
         (assertValueOneOf "UseDNS" boolValues)
@@ -1177,6 +1180,7 @@ let
         (assertInt "IAID")
         (assertValueOneOf "UseDelegatedPrefix" boolValues)
         (assertValueOneOf "SendRelease" boolValues)
+        (assertValueOneOf "UseCaptivePortal" boolValues)
       ];
 
       sectionDHCPPrefixDelegation = checkUnitConfig "DHCPPrefixDelegation" [
@@ -1219,6 +1223,7 @@ let
           "UsePREF64"
           "NetLabel"
           "NFTSet"
+          "UseCaptivePortal"
         ])
         (assertValueOneOf "UseDNS" boolValues)
         (assertValueOneOf "UseDomains" (boolValues ++ [ "route" ]))
@@ -1230,6 +1235,7 @@ let
         (assertValueOneOf "UseGateway" boolValues)
         (assertValueOneOf "UseRoutePrefix" boolValues)
         (assertValueOneOf "UsePREF64" boolValues)
+        (assertValueOneOf "UseCaptivePortal" boolValues)
       ];
 
       sectionDHCPServer = checkUnitConfig "DHCPServer" [

--- a/nixos/modules/system/boot/networkd.nix
+++ b/nixos/modules/system/boot/networkd.nix
@@ -1060,6 +1060,7 @@ let
       sectionDHCPv4 = checkUnitConfig "DHCPv4" [
         (assertOnlyFields [
           "UseDNS"
+          "UseDNR"
           "RoutesToDNS"
           "UseNTP"
           "UseSIP"
@@ -1100,6 +1101,7 @@ let
           "UseCaptivePortal"
         ])
         (assertValueOneOf "UseDNS" boolValues)
+        (assertValueOneOf "UseDNR" boolValues)
         (assertValueOneOf "RoutesToDNS" boolValues)
         (assertValueOneOf "UseNTP" boolValues)
         (assertValueOneOf "UseSIP" boolValues)
@@ -1139,6 +1141,7 @@ let
         (assertOnlyFields [
           "UseAddress"
           "UseDNS"
+          "UseDNR"
           "UseNTP"
           "SendHostname"
           "UseHostname"
@@ -1165,6 +1168,7 @@ let
         ])
         (assertValueOneOf "UseAddress" boolValues)
         (assertValueOneOf "UseDNS" boolValues)
+        (assertValueOneOf "UseDNR" boolValues)
         (assertValueOneOf "UseNTP" boolValues)
         (assertValueOneOf "SendHostname" boolValues)
         (assertValueOneOf "UseHostname" boolValues)
@@ -1204,6 +1208,7 @@ let
       sectionIPv6AcceptRA = checkUnitConfig "IPv6AcceptRA" [
         (assertOnlyFields [
           "UseDNS"
+          "UseDNR"
           "UseDomains"
           "RouteTable"
           "UseAutonomousPrefix"
@@ -1227,6 +1232,7 @@ let
           "UseRedirect"
         ])
         (assertValueOneOf "UseDNS" boolValues)
+        (assertValueOneOf "UseDNR" boolValues)
         (assertValueOneOf "UseDomains" (boolValues ++ [ "route" ]))
         (assertRange "RouteTable" 0 4294967295)
         (assertValueOneOf "UseAutonomousPrefix" boolValues)

--- a/nixos/modules/system/boot/networkd.nix
+++ b/nixos/modules/system/boot/networkd.nix
@@ -1230,6 +1230,7 @@ let
           "NFTSet"
           "UseCaptivePortal"
           "UseRedirect"
+          "UseHopLimit"
         ])
         (assertValueOneOf "UseDNS" boolValues)
         (assertValueOneOf "UseDNR" boolValues)
@@ -1244,6 +1245,7 @@ let
         (assertValueOneOf "UsePREF64" boolValues)
         (assertValueOneOf "UseCaptivePortal" boolValues)
         (assertValueOneOf "UseRedirect" boolValues)
+        (assertValueOneOf "UseHopLimit" boolValues)
       ];
 
       sectionDHCPServer = checkUnitConfig "DHCPServer" [

--- a/nixos/modules/system/boot/networkd.nix
+++ b/nixos/modules/system/boot/networkd.nix
@@ -1232,6 +1232,7 @@ let
           "UseRedirect"
           "UseHopLimit"
           "UseReachableTime"
+          "UseRetransmissionTime"
         ])
         (assertValueOneOf "UseDNS" boolValues)
         (assertValueOneOf "UseDNR" boolValues)
@@ -1248,6 +1249,7 @@ let
         (assertValueOneOf "UseRedirect" boolValues)
         (assertValueOneOf "UseHopLimit" boolValues)
         (assertValueOneOf "UseReachableTime" boolValues)
+        (assertValueOneOf "UseRetransmissionTime" boolValues)
       ];
 
       sectionDHCPServer = checkUnitConfig "DHCPServer" [

--- a/nixos/modules/system/boot/networkd.nix
+++ b/nixos/modules/system/boot/networkd.nix
@@ -1231,6 +1231,7 @@ let
           "UseCaptivePortal"
           "UseRedirect"
           "UseHopLimit"
+          "UseReachableTime"
         ])
         (assertValueOneOf "UseDNS" boolValues)
         (assertValueOneOf "UseDNR" boolValues)
@@ -1246,6 +1247,7 @@ let
         (assertValueOneOf "UseCaptivePortal" boolValues)
         (assertValueOneOf "UseRedirect" boolValues)
         (assertValueOneOf "UseHopLimit" boolValues)
+        (assertValueOneOf "UseReachableTime" boolValues)
       ];
 
       sectionDHCPServer = checkUnitConfig "DHCPServer" [


### PR DESCRIPTION
This PR adds the following "use" options:

- IPv6 RA (only):
    - UseRetransmissionTime
    - UseReachableTime
    - UseHopLimit
    - UseRedirect
- IPv6 RA, IPv6 DHCP, IPv4 DHCP:
    - UseDNR
    - UseCaptivePortal
- IPv6 DHCP
    - UseSIP

Tested by setting these options in my config and confirming that they're allowed.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
