### PR TITLE
dnschef: migrate to by-name and update Python packaging

### DIFF
--- a/pkgs/by-name/dn/dnschef/package.nix
+++ b/pkgs/by-name/dn/dnschef/package.nix
@@ -1,11 +1,10 @@
 {
-  buildPythonApplication,
+  python3Packages,
   fetchFromGitHub,
-  dnslib,
   lib,
 }:
 
-buildPythonApplication {
+python3Packages.buildPythonApplication {
   pname = "dnschef";
   version = "0.4";
 
@@ -13,7 +12,7 @@ buildPythonApplication {
     owner = "iphelix";
     repo = "dnschef";
     rev = "a395411ae1f5c262d0b80d06a45a445f696f3243";
-    sha256 = "0ll3hw6w5zhzyqc2p3c9443gcp12sx6ddybg5rjpl01dh3svrk1q";
+    hash = "sha256-OMy89YAtAHplLm/51kzXIlz2BiGJjSsY9h/+wg2Hg1I=";
   };
 
   pyproject = false;
@@ -21,7 +20,7 @@ buildPythonApplication {
     install -D ./dnschef.py $out/bin/dnschef
   '';
 
-  propagatedBuildInputs = [ dnslib ];
+  dependencies = [ python3Packages.dnslib ];
 
   meta = {
     homepage = "https://github.com/iphelix/dnschef";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1826,8 +1826,6 @@ with pkgs;
     gst-plugins-good = gst_all_1.gst-plugins-good.override { gtkSupport = true; };
   };
 
-  dnschef = python3Packages.callPackage ../tools/networking/dnschef { };
-
   inherit (ocamlPackages) dot-merlin-reader;
 
   inherit (ocamlPackages) dune-release;


### PR DESCRIPTION
This pull request reorganizes and updates the packaging for the `dnschef` tool in Nixpkgs. The main change is moving the package to a new location and updating its build configuration to use modern Nixpkgs Python packaging conventions.

**Package reorganization and modernization:**

* Moved the `dnschef` package from `pkgs/tools/networking/dnschef/default.nix` to `pkgs/by-name/dn/dnschef/package.nix`, following the new package naming structure.
* Updated the build to use `python3Packages.buildPythonApplication` and the `dependencies` attribute, replacing the older `buildPythonApplication` and `propagatedBuildInputs` approach.

**Top-level package list cleanup:**

* Removed the legacy inclusion of `dnschef` from the top-level `all-packages.nix` file, reflecting the move to the by-name structure.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
