### PR TITLE
utm: switch to `finalAttrs`

### DIFF
--- a/pkgs/by-name/ut/utm/package.nix
+++ b/pkgs/by-name/ut/utm/package.nix
@@ -6,12 +6,12 @@
   stdenvNoCC,
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "utm";
   version = "4.7.5";
 
   src = fetchurl {
-    url = "https://github.com/utmapp/UTM/releases/download/v${version}/UTM.dmg";
+    url = "https://github.com/utmapp/UTM/releases/download/v${finalAttrs.version}/UTM.dmg";
     hash = "sha256-qENck8+1+Lv+6ksTTPrRrGa2djK3XkOMY7GorgQ77w4=";
   };
 
@@ -61,7 +61,7 @@ stdenvNoCC.mkDerivation rec {
       See https://docs.getutm.app/ for more information.
     '';
     homepage = "https://mac.getutm.app/";
-    changelog = "https://github.com/utmapp/utm/releases/tag/v${version}";
+    changelog = "https://github.com/utmapp/utm/releases/tag/v${finalAttrs.version}";
     mainProgram = "UTM";
     license = lib.licenses.asl20;
     platforms = lib.platforms.darwin; # 11.3 is the minimum supported version as of UTM 4.
@@ -71,4 +71,4 @@ stdenvNoCC.mkDerivation rec {
       wegank
     ];
   };
-}
+})


### PR DESCRIPTION
Allows me to do:

```
self: super: {
  utm = super.utm.overrideAttrs (old: {
    version = "5.0.0";

    src = old.src.overrideAttrs {
      hash = "...";
    };
  });
}
```

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc