### PR TITLE
b2sum: migrate to by-name and fix openmp usage

### DIFF
--- a/pkgs/by-name/b2/b2sum/package.nix
+++ b/pkgs/by-name/b2/b2sum/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  openmp ? null,
+  llvmPackages,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -12,8 +12,8 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "BLAKE2";
     repo = "BLAKE2";
-    rev = finalAttrs.version;
-    sha256 = "sha256-6BVl3Rh+CRPQq3QxcUlk5ArvjIj/IcPCA2/Ok0Zu7UI=";
+    tag = finalAttrs.version;
+    hash = "sha256-6BVl3Rh+CRPQq3QxcUlk5ArvjIj/IcPCA2/Ok0Zu7UI=";
   };
 
   # Use the generic C implementation rather than the SSE optimised version on non-x86 platforms
@@ -25,9 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   sourceRoot = "${finalAttrs.src.name}/b2sum";
 
-  buildInputs = [ openmp ];
-
-  buildFlags = [ (lib.optional (openmp == null) "NO_OPENMP=1") ];
+  buildInputs = lib.optionals stdenv.cc.isClang [ llvmPackages.openmp ];
 
   # clang builds require at least C99 or the build fails with:
   # error: unknown type name 'inline'

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1720,10 +1720,6 @@ with pkgs;
     enableExtraPlugins = true;
   };
 
-  b2sum = callPackage ../tools/security/b2sum {
-    inherit (llvmPackages) openmp;
-  };
-
   beamerpresenter-mupdf = beamerpresenter;
   beamerpresenter-poppler = beamerpresenter.override {
     useMupdf = false;


### PR DESCRIPTION
This pull request updates the packaging for `b2sum`, including moving its package file, updating its dependencies to use `llvmPackages.openmp`, and cleaning up its usage in the top-level package list.

**Package restructuring and dependency updates:**

* Renamed and moved the `b2sum` package file from `pkgs/tools/security/b2sum/default.nix` to `pkgs/by-name/b2/b2sum/package.nix`, aligning with the by-name package structure.
* Updated the dependency from a generic `openmp` to `llvmPackages.openmp` throughout the package definition, ensuring consistent use of LLVM's OpenMP implementation.

* Changed the `fetchFromGitHub` parameters from `rev`/`sha256` to `tag`/`hash` for clarity and alignment with modern Nixpkgs conventions.

**Top-level package list cleanup:**

* Removed the explicit `b2sum` entry and its special handling from `all-packages.nix`, as the new structure no longer requires passing `openmp` manually.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
