### PR TITLE
autotiling: migrate to by-name and switch to PEP 517

### DIFF
--- a/pkgs/by-name/au/autotiling/package.nix
+++ b/pkgs/by-name/au/autotiling/package.nix
@@ -1,26 +1,28 @@
 {
   lib,
-  buildPythonApplication,
+  python3Packages,
   fetchFromGitHub,
-  i3ipc,
-  importlib-metadata,
 }:
 
-buildPythonApplication rec {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "autotiling";
   version = "1.9.3";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "nwg-piotr";
     repo = "autotiling";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-k+UiAGMB/fJiE+C737yGdyTpER1ciZrMkZezkcn/4yk=";
   };
 
-  propagatedBuildInputs = [
-    i3ipc
-    importlib-metadata
+  build-system = [
+    python3Packages.setuptools
+  ];
+
+  dependencies = [
+    python3Packages.i3ipc
+    python3Packages.importlib-metadata
   ];
   doCheck = false;
 
@@ -32,4 +34,4 @@ buildPythonApplication rec {
     maintainers = with lib.maintainers; [ artturin ];
     mainProgram = "autotiling";
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13366,8 +13366,6 @@ with pkgs;
 
   antimicrox = libsForQt5.callPackage ../tools/misc/antimicrox { };
 
-  autotiling = python3Packages.callPackage ../misc/autotiling { };
-
   brgenml1lpr = pkgsi686Linux.callPackage ../misc/cups/drivers/brgenml1lpr { };
 
   foomatic-db-ppds-withNonfreeDb = callPackage ../by-name/fo/foomatic-db-ppds/package.nix {


### PR DESCRIPTION
This pull request reorganizes the packaging for the `autotiling` Python application in Nixpkgs, updating its build approach and moving its package definition to a new location. The most important changes are grouped below:

**Package relocation and reference update:**

* Renamed the package file from `pkgs/misc/autotiling/default.nix` to `pkgs/by-name/au/autotiling/package.nix` for better organization and consistency with naming conventions.
* Updated the reference in `pkgs/top-level/all-packages.nix` to use the new package path, removing the old reference.

**Build system modernization:**

* Migrated the build process to use `python3Packages.buildPythonApplication` with the `pyproject` format, replacing the older `setuptools`-based approach. This change modernizes the package to align with current Python packaging practices.
* Updated dependency specification to use the `build-system` and `dependencies` attributes, referencing dependencies from `python3Packages` for improved clarity and maintainability.
* Refactored the package definition to use the function argument `finalAttrs`, simplifying version and attribute handling. 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
