### PR TITLE
systemtap-unwrapped: fix 32bit build

### DIFF
--- a/pkgs/by-name/sy/systemtap-unwrapped/package.nix
+++ b/pkgs/by-name/sy/systemtap-unwrapped/package.nix
@@ -20,6 +20,13 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-11ecQFiBaWOZcbS5Qqf/41heiJM1wSttx0eMoVQImZc=";
   };
 
+  patches = lib.optionals stdenv.hostPlatform.is32bit [
+    # Fix 32bit build
+    # https://sourceware.org/git/?p=systemtap.git;a=commit;h=94efb7c4eb02de0e3565cb165b53963602d3dcb6
+    # does not apply with fetchpatch because of gitweb encoding issues
+    ./systemtap-elaborate-fix-32bit-build.patch
+  ];
+
   nativeBuildInputs = [
     pkg-config
     cpio

--- a/pkgs/by-name/sy/systemtap-unwrapped/systemtap-elaborate-fix-32bit-build.patch
+++ b/pkgs/by-name/sy/systemtap-unwrapped/systemtap-elaborate-fix-32bit-build.patch
@@ -1,0 +1,102 @@
+From 94efb7c4eb02de0e3565cb165b53963602d3dcb6 Mon Sep 17 00:00:00 2001
+From: Sergei Trofimovich <slyich@gmail.com>
+Date: Sun, 30 Nov 2025 20:58:01 +0000
+Subject: [PATCH] elaborate.cxx: fix 32-bit build
+
+Without the change the build fails on i686-linux as:
+
+    elaborate.cxx:5119:33: error:
+      format '%ld' expects argument of type 'long int',
+      but argument 2 has type 'int64_t' {aka 'long long int'} [-Werror=format=]
+     5119 |       session.print_warning (_F("Collapsing unresolved @define to %ld [stapprobes]", value), e->tok);
+          |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+---
+ elaborate.cxx    | 2 +-
+ po/cs.po         | 2 +-
+ po/en.po         | 2 +-
+ po/fr.po         | 2 +-
+ po/pl.po         | 2 +-
+ po/systemtap.pot | 2 +-
+ 6 files changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/elaborate.cxx b/elaborate.cxx
+index 93ecffa1a..3ad3614e7 100644
+--- a/elaborate.cxx
++++ b/elaborate.cxx
+@@ -5116,7 +5116,7 @@ const_folder::visit_defined_op (defined_op* e)
+       // Don't be greedy... we'll only collapse one at a time so type
+       // resolution can have another go at it.
+       relaxed_p = false;
+-      session.print_warning (_F("Collapsing unresolved @define to %ld [stapprobes]", value), e->tok);
++      session.print_warning (_F("Collapsing unresolved @define to %lld [stapprobes]", (long long)value), e->tok);
+       literal_number* n = new literal_number (value);
+       n->tok = e->tok;
+       n->visit (this);
+diff --git a/po/cs.po b/po/cs.po
+index df6412772..92fdef7ad 100644
+--- a/po/cs.po
++++ b/po/cs.po
+@@ -2039,7 +2039,7 @@ msgstr "Zahazuji kontrolu '@defined' bez vedlejších účinků "
+ 
+ #: elaborate.cxx:5119
+ #, fuzzy, c-format
+-msgid "Collapsing unresolved @define to %ld [stapprobes]"
++msgid "Collapsing unresolved @define to %lld [stapprobes]"
+ msgstr "Zahazuji kontrolu '@defined' bez vedlejších účinků "
+ 
+ #: elaborate.cxx:5127
+diff --git a/po/en.po b/po/en.po
+index 8847639e8..1db2292bd 100644
+--- a/po/en.po
++++ b/po/en.po
+@@ -2050,7 +2050,7 @@ msgstr ""
+ 
+ #: elaborate.cxx:5119
+ #, c-format
+-msgid "Collapsing unresolved @define to %ld [stapprobes]"
++msgid "Collapsing unresolved @define to %lld [stapprobes]"
+ msgstr ""
+ 
+ #: elaborate.cxx:5127
+diff --git a/po/fr.po b/po/fr.po
+index b8677707b..55e409919 100644
+--- a/po/fr.po
++++ b/po/fr.po
+@@ -2090,7 +2090,7 @@ msgstr ""
+ 
+ #: elaborate.cxx:5119
+ #, c-format
+-msgid "Collapsing unresolved @define to %ld [stapprobes]"
++msgid "Collapsing unresolved @define to %lld [stapprobes]"
+ msgstr ""
+ 
+ #: elaborate.cxx:5127
+diff --git a/po/pl.po b/po/pl.po
+index e3b6700ee..0b35880c1 100644
+--- a/po/pl.po
++++ b/po/pl.po
+@@ -1977,7 +1977,7 @@ msgstr ""
+ 
+ #: elaborate.cxx:5119
+ #, c-format
+-msgid "Collapsing unresolved @define to %ld [stapprobes]"
++msgid "Collapsing unresolved @define to %lld [stapprobes]"
+ msgstr ""
+ 
+ #: elaborate.cxx:5127
+diff --git a/po/systemtap.pot b/po/systemtap.pot
+index 32ddb2290..4ec0d9a8c 100644
+--- a/po/systemtap.pot
++++ b/po/systemtap.pot
+@@ -1973,7 +1973,7 @@ msgstr ""
+ 
+ #: elaborate.cxx:5119
+ #, c-format
+-msgid "Collapsing unresolved @define to %ld [stapprobes]"
++msgid "Collapsing unresolved @define to %lld [stapprobes]"
+ msgstr ""
+ 
+ #: elaborate.cxx:5127
+-- 
+2.52.0
+


### PR DESCRIPTION
- add patch from merged upstream commit:
https://sourceware.org/git/?p=systemtap.git;a=commit;h=94efb7c4eb02de0e3565cb165b53963602d3dcb6

Does not apply with `fetchpatch` because of some problem with diff encoding on gitweb side for `po/cs.po` file.

Proper diff as shown on html page of gitweb and from local git repo:
```
--- a/po/cs.po
+++ b/po/cs.po
@@ -2039,7 +2039,7 @@ msgstr "Zahazuji kontrolu '@defined' bez vedlejších účinků "
 
 #: elaborate.cxx:5119
 #, fuzzy, c-format
-msgid "Collapsing unresolved @define to %ld [stapprobes]"
+msgid "Collapsing unresolved @define to %lld [stapprobes]"
 msgstr "Zahazuji kontrolu '@defined' bez vedlejších účinků "
 
 #: elaborate.cxx:5127
```

Diff with `patch` or `commitdiff_plain` from gitweb:
https://sourceware.org/git/?p=systemtap.git;a=patch;h=94efb7c4eb02de0e3565cb165b53963602d3dcb6 
https://sourceware.org/git/?p=systemtap.git;a=commitdiff_plain;h=94efb7c4eb02de0e3565cb165b53963602d3dcb6
```
--- a/po/cs.po
+++ b/po/cs.po
@@ -2039,7 +2039,7 @@ msgstr "Zahazuji kontrolu '@defined' bez vedlejÅ¡Ã­ch ÃºÄinkÅ¯ "
 
 #: elaborate.cxx:5119
 #, fuzzy, c-format
-msgid "Collapsing unresolved @define to %ld [stapprobes]"
+msgid "Collapsing unresolved @define to %lld [stapprobes]"
 msgstr "Zahazuji kontrolu '@defined' bez vedlejÅ¡Ã­ch ÃºÄinkÅ¯ "
 
 #: elaborate.cxx:5127
```

Fixes build failure on 32bit platforms:
```
elaborate.cxx: In member function 'virtual void const_folder::visit_defined_op(defined_op*)':
elaborate.cxx:5119:33: error: format '%ld' expects argument of type
'long int', but argument 2 has type 'int64_t' {aka 'long long int'}
[-Werror=format=]
 5119 |       session.print_warning (_F("Collapsing unresolved @define to %ld [stapprobes]", value), e->tok);
      |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
staputil.h:54:27: note: in definition of macro '_'
   54 | #define _(string) gettext(string)
      |                           ^~~~~~
elaborate.cxx:5119:30: note: in expansion of macro '_F'
 5119 |       session.print_warning (_F("Collapsing unresolved @define to %ld [stapprobes]", value), e->tok);
      |                              ^~
elaborate.cxx:5119:69: note: format string is defined here
 5119 |       session.print_warning (_F("Collapsing unresolved @define to %ld [stapprobes]", value), e->tok);
      |                                                                   ~~^
      |                                                                     |
      |                                                                     long int
      |                                                                   %lld
```

---

Logs on hydra from `staging-next` (#479279) - as dependency of `winePackages.stagingFull.x86_64-linux`:
https://hydra.nixos.org/build/319403006
https://cache.nixos.org/log/5qzpmk16ad1fmwlkxh0cjcrm5fk9p6gb-systemtap-5.4.drv

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
