### PR TITLE
olaris-server: unbreak by bumping to latest HEAD

### DIFF
--- a/pkgs/by-name/ol/olaris-server/package.nix
+++ b/pkgs/by-name/ol/olaris-server/package.nix
@@ -10,13 +10,13 @@
 
 buildGoModule rec {
   pname = "olaris-server";
-  version = "unstable-2022-06-11";
+  version = "unstable-2025-12-12";
 
   src = fetchFromGitLab {
     owner = "olaris";
     repo = "olaris-server";
-    rev = "bdb2aeb1595c941210249164a97c12404c1ae0d8";
-    hash = "sha256-Uhnh6GC85ORKnfHeYNtbSA40osuscxXDF5/kXJrF2Cs=";
+    rev = "d4b240e775225cb96ca1634f60faba8e4960ce67";
+    hash = "sha256-S3Qmoyha9ab/nRJbuPz2Rf8orZF43UFC+PFsPUcNoUY=";
   };
 
   preBuild =
@@ -39,7 +39,7 @@ buildGoModule rec {
     "-X gitlab.com/olaris/olaris-server/helpers.Version=${version}"
   ];
 
-  vendorHash = "sha256-bw8zvDGFBci9bELsxAD0otpNocBnO8aAcgyohLZ3Mv0=";
+  vendorHash = "sha256-z97hvJCq7ocWpoViq8+ZHtYp0AUGIEZxq0FPRnEYKSw=";
 
   nativeBuildInputs = [
     installShellFiles
@@ -58,8 +58,6 @@ buildGoModule rec {
   '';
 
   meta = {
-    # Marked broken 2025-11-28 because it has failed on Hydra for at least one year.
-    broken = true;
     description = "Media manager and transcoding server";
     homepage = "https://gitlab.com/olaris/olaris-server";
     changelog = "https://gitlab.com/olaris/olaris-server/-/releases/v${version}";


### PR DESCRIPTION
olaris-server was broken due to a segfault of a build tool. Updating to the current head from upstream fixes this.

The change upstream is solely "fix for current Go version" and is the only commit in 3 years: https://gitlab.com/olaris/olaris-server/-/commit/932294f2976962d01fc99afd929d3fa8a67fe1cb

I have built and started the server executable but not tested anything further.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
