### PR TITLE
python3Packages.clu: disable test that becomes flaky under load

### DIFF
--- a/pkgs/development/python-modules/clu/default.nix
+++ b/pkgs/development/python-modules/clu/default.nix
@@ -69,6 +69,8 @@ buildPythonPackage rec {
   disabledTests = [
     # AssertionError: [Chex] Assertion assert_trees_all_close failed
     "test_collection_mixed_async"
+    # flaky under load
+    "test_async_execution"
   ];
 
   meta = {


### PR DESCRIPTION
```sh
┃        > FAILED clu/periodic_actions_test.py::PeriodicCallbackTest::test_async_execution - AssertionError: Lists differ: [0, 2, 1, 3] != [0, 1, 2, 3]
┃        >
┃        > First differing element 1:
┃        > 2
┃        > 1
┃        >
┃        > - [0, 2, 1, 3]
┃        > ?        ---
┃        >
┃        > + [0, 1, 2, 3]
┃        > ?     +++
```

Fails typically under load, though it's flaky.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
