### PR TITLE
cudaPackages.tensorrt: use 10.13.0 for linux-sbsa on CUDA 12

### DIFF
--- a/pkgs/development/cuda-modules/_cuda/manifests/tensorrt/redistrib_10.13.0.json
+++ b/pkgs/development/cuda-modules/_cuda/manifests/tensorrt/redistrib_10.13.0.json
@@ -1,0 +1,36 @@
+{
+    "release_date": "2025-07-22",
+    "release_label": "10.13.0",
+    "release_product": "tensorrt",
+    "tensorrt": {
+        "name": "NVIDIA TensorRT",
+        "license": "TensorRT",
+        "version": "10.13.0.35",
+        "cuda_variant": [
+            "11",
+            "12"
+        ],
+        "linux-sbsa": {
+            "cuda12": {
+                "md5": "30ba514ad9252fbaec21d0a336fe5b0a",
+                "relative_path": "tensorrt/10.13.0/tars/TensorRT-10.13.0.35.Linux.aarch64-gnu.cuda-12.9.tar.gz",
+                "sha256": "b2f7c7ae6da3588729b7a64825246cc59b643adbe373684fb9c5713262ed46c2",
+                "size": "4377387760"
+            }
+        },
+        "linux-x86_64": {
+            "cuda11": {
+                "md5": "6388feec8573aeced9863a70091aad97",
+                "relative_path": "tensorrt/10.13.0/tars/TensorRT-10.13.0.35.Linux.x86_64-gnu.cuda-11.8.tar.gz",
+                "sha256": "4128dd4f40433b957c90f9d04d53311d1636ee046b66a241ab60492f4861de74",
+                "size": "4788315804"
+            },
+            "cuda12": {
+                "md5": "de94ac8efa527dfd7fa5700f368ebf74",
+                "relative_path": "tensorrt/10.13.0/tars/TensorRT-10.13.0.35.Linux.x86_64-gnu.cuda-12.9.tar.gz",
+                "sha256": "899ff39e237f1351fccac7f6891617f68cbab71c13a7d7c703184424bdbbf621",
+                "size": "6934362378"
+            }
+        }
+    }
+}

--- a/pkgs/top-level/cuda-packages.nix
+++ b/pkgs/top-level/cuda-packages.nix
@@ -11,9 +11,16 @@ let
       manifests = _cuda.lib.selectManifests manifestVersions;
     };
 
+  # NOTE:
+  # The manifests are largely the same except for TensorRT:
+  # - linux-x86_64 is generally the best supported and can use the latest release
+  # - linux-sbsa (post-Orin Jetson and ARM) comes in second; NVIDIA dropped support for CUDA 12 with 10.13.2 (there is no
+  #   10.13.1), so we use 10.13.0 for all CUDA 12 releases.
+  # - linux-aarch64 (pre-Thor Jetson) is historically least supported; we use the latest release available.
+
   cudaPackages_12_6 =
     let
-      inherit (cudaPackages_12_6.backendStdenv) hasJetsonCudaCapability;
+      inherit (cudaPackages_12_6.backendStdenv) hasJetsonCudaCapability hostPlatform;
     in
     mkCudaPackages {
       cublasmp = "0.6.0";
@@ -29,12 +36,18 @@ let
       nvjpeg2000 = "0.9.0";
       nvpl = "25.5";
       nvtiff = "0.5.1";
-      tensorrt = if hasJetsonCudaCapability then "10.7.0" else "10.14.1";
+      tensorrt =
+        if hasJetsonCudaCapability then
+          "10.7.0"
+        else if hostPlatform.isAarch64 then
+          "10.13.0"
+        else
+          "10.14.1";
     };
 
   cudaPackages_12_8 =
     let
-      inherit (cudaPackages_12_8.backendStdenv) hasJetsonCudaCapability;
+      inherit (cudaPackages_12_8.backendStdenv) hasJetsonCudaCapability hostPlatform;
     in
     mkCudaPackages {
       cublasmp = "0.6.0";
@@ -50,12 +63,18 @@ let
       nvjpeg2000 = "0.9.0";
       nvpl = "25.5";
       nvtiff = "0.5.1";
-      tensorrt = if hasJetsonCudaCapability then "10.7.0" else "10.14.1";
+      tensorrt =
+        if hasJetsonCudaCapability then
+          "10.7.0"
+        else if hostPlatform.isAarch64 then
+          "10.13.0"
+        else
+          "10.14.1";
     };
 
   cudaPackages_12_9 =
     let
-      inherit (cudaPackages_12_9.backendStdenv) hasJetsonCudaCapability;
+      inherit (cudaPackages_12_9.backendStdenv) hasJetsonCudaCapability hostPlatform;
     in
     mkCudaPackages {
       cublasmp = "0.6.0";
@@ -71,7 +90,13 @@ let
       nvjpeg2000 = "0.9.0";
       nvpl = "25.5";
       nvtiff = "0.5.1";
-      tensorrt = if hasJetsonCudaCapability then "10.7.0" else "10.14.1";
+      tensorrt =
+        if hasJetsonCudaCapability then
+          "10.7.0"
+        else if hostPlatform.isAarch64 then
+          "10.13.0"
+        else
+          "10.14.1";
     };
 
   # NOTE: Thor is supported from CUDA 13.0, so our check needs to capture whether pre-Thor devices were selected.


### PR DESCRIPTION
Roll back to the last TensorRT release which supports non-Jetson aarch64-linux (linux-sbsa in NVIDIA's terminology) on CUDA 12.

The JSON file is vendored (except for adding a newline to pass our CI's formatting checks) from https://github.com/nixos-cuda/cuda-legacy/blob/e236996718689d028e52b9aece3a19a09ed9cdc5/pkgs/development/cuda-modules/_cuda/manifests/tensorrt/redistrib_10.13.0.json.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
