### PR TITLE
revive: 1.11.0 -> 1.13.0

### DIFF
--- a/pkgs/by-name/re/revive/package.nix
+++ b/pkgs/by-name/re/revive/package.nix
@@ -4,17 +4,23 @@
   go,
   lib,
   makeWrapper,
+  stdenvNoCC,
 }:
 
 buildGoModule rec {
   pname = "revive";
-  version = "1.11.0";
+  version = "1.13.0";
 
   src = fetchFromGitHub {
     owner = "mgechev";
     repo = "revive";
     tag = "v${version}";
-    hash = "sha256-89BlSc2tgxAJUGZM951fF+0H+SOsl0+xz/G18neRZxI=";
+    # The hash differs between darwin and linux.
+    hash =
+      if stdenvNoCC.hostPlatform.isDarwin then
+        "sha256-BwiZSLg9amqFCK2W66WY3Xhn6cR2dW11d2YUfcwCYqk="
+      else
+        "sha256-ni/YDivXo9THcEsef5fAnoMrjVagSXOEvRmVVO1OO4w=";
     # populate values that require us to use git. By doing this in postFetch we
     # can delete .git afterwards and maintain better reproducibility of the src.
     leaveDotGit = true;
@@ -24,7 +30,15 @@ buildGoModule rec {
       rm -rf $out/.git
     '';
   };
-  vendorHash = "sha256-ZxTBGcGSRWlYFBz0+5wR/9d8p7lvjJjyId5VNIVW9rQ=";
+  vendorHash = "sha256-cYvOOD+6ETmOwzbJwTTnODykGRhXlMWri1dWF4nDV6M=";
+
+  postPatch = ''
+    # Package `tools` is only a placeholder, which helps `renovate` discover
+    # all indirect dependencies. It should not be imported in production code,
+    # otherwise the build will fail with
+    # `main module (github.com/mgechev/revive) does not contain package github.com/mgechev/revive/tools`.
+    rm -rf tools
+  '';
 
   ldflags = [
     "-s"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Closes https://github.com/NixOS/nixpkgs/issues/479986.

Changlog: https://github.com/mgechev/revive/releases/tag/v1.13.0

Note for changes in the derivation: I don't know why the source produced by `fetchFromGitHub` differs between Linux and Darwin platforms after this update. I simply specified two hash separately for each platform. Not sure whether it would work for other Unix platforms.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
