### PR TITLE
wivrn: allow building only the client library

### DIFF
--- a/pkgs/by-name/wi/wivrn/package.nix
+++ b/pkgs/by-name/wi/wivrn/package.nix
@@ -130,7 +130,6 @@ stdenv.mkDerivation (finalAttrs: {
     libXrandr
     nlohmann_json
     openxr-loader
-    onnxruntime
     pipewire
     qt6.qtbase
     qt6.qtsvg

--- a/pkgs/by-name/wi/wivrn/package.nix
+++ b/pkgs/by-name/wi/wivrn/package.nix
@@ -50,6 +50,9 @@
   vulkan-loader,
   x264,
   xrizer,
+  # Only build the OpenXR client library. Useful for building the client library for a different architecture,
+  # e.g. 32-bit library while running 64-bit service on host, so 32-bit apps can connect to the runtime
+  clientLibOnly ? false,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "wivrn";
@@ -98,6 +101,8 @@ stdenv.mkDerivation (finalAttrs: {
     librsvg
     pkg-config
     python3
+  ]
+  ++ lib.optionals (!clientLibOnly) [
     qt6.wrapQtAppsHook
   ]
   ++ lib.optionals cudaSupport [
@@ -105,14 +110,25 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    avahi
-    boost
-    cli11
     eigen
-    ffmpeg
     freetype
     glm
     harfbuzz
+    libGL
+    libX11
+    libXrandr
+    openxr-loader
+    shaderc
+    systemd
+    udev
+    vulkan-headers
+    vulkan-loader
+  ]
+  ++ lib.optionals (!clientLibOnly) [
+    avahi
+    boost
+    cli11
+    ffmpeg
     kdePackages.kcoreaddons
     kdePackages.ki18n
     kdePackages.kiconthemes
@@ -121,32 +137,34 @@ stdenv.mkDerivation (finalAttrs: {
     kdePackages.qqc2-desktop-style
     libarchive
     libdrm
-    libGL
     libnotify
     libpulseaudio
     librsvg
     libva
-    libX11
-    libXrandr
     nlohmann_json
-    openxr-loader
     pipewire
     qt6.qtbase
     qt6.qtsvg
     qt6.qttools
-    shaderc
-    spdlog
-    systemd
-    udev
-    vulkan-headers
-    vulkan-loader
     x264
   ]
-  ++ lib.optionals cudaSupport [
+  ++ lib.optionals (cudaSupport && !clientLibOnly) [
     cudaPackages.cudatoolkit
   ];
 
   cmakeFlags = [
+    (lib.cmakeBool "WIVRN_BUILD_CLIENT" false)
+    (lib.cmakeBool "WIVRN_BUILD_DASHBOARD" (!clientLibOnly))
+    (lib.cmakeBool "WIVRN_BUILD_SERVER" (!clientLibOnly))
+    (lib.cmakeBool "WIVRN_BUILD_SERVER_LIBRARY" true)
+    (lib.cmakeBool "WIVRN_BUILD_WIVRNCTL" (!clientLibOnly))
+    (lib.cmakeBool "FETCHCONTENT_FULLY_DISCONNECTED" true)
+    (lib.cmakeFeature "WIVRN_OPENXR_MANIFEST_TYPE" "absolute")
+    (lib.cmakeBool "WIVRN_OPENXR_MANIFEST_ABI" clientLibOnly)
+    (lib.cmakeFeature "GIT_DESC" "v${finalAttrs.version}")
+    (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_MONADO" "${finalAttrs.monado}")
+  ]
+  ++ lib.optionals (!clientLibOnly) [
     (lib.cmakeBool "WIVRN_USE_NVENC" cudaSupport)
     (lib.cmakeBool "WIVRN_USE_VAAPI" true)
     (lib.cmakeBool "WIVRN_USE_VULKAN_ENCODE" true)
@@ -154,26 +172,20 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "WIVRN_USE_PIPEWIRE" true)
     (lib.cmakeBool "WIVRN_USE_PULSEAUDIO" true)
     (lib.cmakeBool "WIVRN_FEATURE_STEAMVR_LIGHTHOUSE" true)
-    (lib.cmakeBool "WIVRN_BUILD_CLIENT" false)
-    (lib.cmakeBool "WIVRN_BUILD_DASHBOARD" true)
-    (lib.cmakeBool "FETCHCONTENT_FULLY_DISCONNECTED" true)
-    (lib.cmakeFeature "WIVRN_OPENXR_MANIFEST_TYPE" "absolute")
     (lib.cmakeFeature "OVR_COMPAT_SEARCH_PATH" ovrCompatSearchPaths)
-    (lib.cmakeFeature "GIT_DESC" "v${finalAttrs.version}")
-    (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_MONADO" "${finalAttrs.monado}")
   ]
-  ++ lib.optionals cudaSupport [
+  ++ lib.optionals (cudaSupport && !clientLibOnly) [
     (lib.cmakeFeature "CUDA_TOOLKIT_ROOT_DIR" "${cudaPackages.cudatoolkit}")
   ];
 
   dontWrapQtApps = true;
 
-  preFixup = ''
+  preFixup = lib.optional (!clientLibOnly) ''
     wrapQtApp "$out/bin/wivrn-dashboard" \
       --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ vulkan-loader ]}
   '';
 
-  desktopItems = [
+  desktopItems = lib.optionals (!clientLibOnly) [
     (makeDesktopItem {
       name = "WiVRn Server";
       desktopName = "WiVRn Server";

--- a/pkgs/by-name/wi/wivrn/package.nix
+++ b/pkgs/by-name/wi/wivrn/package.nix
@@ -157,7 +157,6 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "WIVRN_FEATURE_STEAMVR_LIGHTHOUSE" true)
     (lib.cmakeBool "WIVRN_BUILD_CLIENT" false)
     (lib.cmakeBool "WIVRN_BUILD_DASHBOARD" true)
-    (lib.cmakeBool "WIVRN_CHECK_CAPSYSNICE" false)
     (lib.cmakeBool "FETCHCONTENT_FULLY_DISCONNECTED" true)
     (lib.cmakeFeature "WIVRN_OPENXR_MANIFEST_TYPE" "absolute")
     (lib.cmakeFeature "OVR_COMPAT_SEARCH_PATH" ovrCompatSearchPaths)


### PR DESCRIPTION
Adds `clientLibOnly` argument to only build the OpenXR client library. This could be used to build a 32-bit OpenXR client library while running 64-bit service.

Closes #448128

@PassiveLemon 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
