### PR TITLE
gemini-cli-bin: fix build on x86_64-darwin

### DIFF
--- a/pkgs/by-name/ge/gemini-cli-bin/package.nix
+++ b/pkgs/by-name/ge/gemini-cli-bin/package.nix
@@ -3,6 +3,7 @@
   stdenvNoCC,
   fetchurl,
   nodejs,
+  sysctl,
   writableTmpDirAsHomeHook,
   nix-update-script,
 }:
@@ -42,6 +43,9 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   doInstallCheck = true;
   nativeInstallCheckInputs = [
     writableTmpDirAsHomeHook
+  ]
+  ++ lib.optionals (with stdenvNoCC.hostPlatform; isDarwin && isx86_64) [
+    sysctl
   ];
   # versionCheckHook cannot be used because the reported version might be incorrect (e.g., 0.6.1 returns 0.6.0).
   installCheckPhase = ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Fix build error which reported in https://github.com/NixOS/nixpkgs/pull/479314#issuecomment-3738232861

```console
> hydra-check gemini-cli-bin --arch x86_64-darwin
Build Status for gemini-cli-bin.x86_64-darwin on jobset nixpkgs/unstable
https://hydra.nixos.org/job/nixpkgs/unstable/gemini-cli-bin.x86_64-darwin
✖ (Failed)     gemini-cli-bin-0.22.5  2026-01-11  https://hydra.nixos.org/build/318300484
✖ (Failed)     gemini-cli-bin-0.22.4  2025-12-31  https://hydra.nixos.org/build/317994170
✖ (Failed)     gemini-cli-bin-0.22.4  2025-12-27  https://hydra.nixos.org/build/317386958
✖ (Failed)     gemini-cli-bin-0.22.2  2025-12-23  https://hydra.nixos.org/build/317025636
✖ (Failed)     gemini-cli-bin-0.20.2  2025-12-15  https://hydra.nixos.org/build/316242889
✖ (Failed)     gemini-cli-bin-0.19.4  2025-12-08  https://hydra.nixos.org/build/316062586
✖ (Failed)     gemini-cli-bin-0.18.4  2025-11-28  https://hydra.nixos.org/build/315185013
✖ (Failed)     gemini-cli-bin-0.17.1  2025-11-24  https://hydra.nixos.org/build/314332312
⏹ (Cancelled)  gemini-cli-bin-0.16.0  2025-11-23  https://hydra.nixos.org/build/314122425
⏹ (Cancelled)  gemini-cli-bin-0.16.0  2025-11-21  https://hydra.nixos.org/build/314081434
```

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

cc: @ljxfstorm

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
