### PR TITLE
powerline-go: 1.25 -> 1.26

### DIFF
--- a/pkgs/by-name/po/powerline-go/package.nix
+++ b/pkgs/by-name/po/powerline-go/package.nix
@@ -4,25 +4,29 @@
   fetchFromGitHub,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "powerline-go";
-  version = "1.25";
+  version = "1.26";
 
   src = fetchFromGitHub {
     owner = "justjanne";
     repo = "powerline-go";
-    rev = "v${version}";
-    hash = "sha256-DLw/6jnJo0IAh0/Y21mfCLP4GgTFlUGvuwyWJwhzYFU=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Hrg55Ot+0SpTjWM1Ulc3EZhV14EbjEF3jRSmMfC9jLw=";
   };
 
   vendorHash = "sha256-W7Lf9s689oJy4U5sQlkLt3INJwtvzU2pot3EFimp7Jw=";
 
+  ldflags = [
+    "-X github.com/justjanne/powerline-go/powerline.Version=${finalAttrs.version}"
+  ];
+
   meta = {
     description = "Powerline like prompt for Bash, ZSH and Fish";
     homepage = "https://github.com/justjanne/powerline-go";
-    changelog = "https://github.com/justjanne/powerline-go/releases/tag/v${version}";
+    changelog = "https://github.com/justjanne/powerline-go/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ sifmelcara ];
     mainProgram = "powerline-go";
   };
-}
+})


### PR DESCRIPTION
## Things done

supersede #480128 

Upstream adds a `-version` flag in https://github.com/justjanne/powerline-go/pull/385 and now we need to specify the version in build (`-X github.com/justjanne/powerline-go/powerline.Version=`), otherwise `powerline-go -version` prints "development" instead of actual version

```
$ ./result/bin/powerline-go -version
1.26
```

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
