### PR TITLE
emacsPackages.opencode: init at 0.0.1

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/opencode/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/opencode/package.nix
@@ -1,0 +1,38 @@
+{ lib
+, emacs
+, emacsPackages
+, fetchgit
+}:
+
+emacsPackages.melpaBuild (finalAttrs: {
+  pname = "opencode";
+  version = "0.1.0";
+
+  src = fetchgit {
+    url = "https://codeberg.org/sczi/opencode.el";
+    rev = "dad7f2c418018b991701255b79cfb3be842fdb0a";
+    sha256 = "sha256-+eJlOF4Fpm+dp5tqT6V7ktURF4BgEcKQkCkXChUiaPo=";
+  };
+
+
+  packageRequires = with emacsPackages; [
+    magit
+    markdown-mode
+    plz
+    plz-media-type
+    plz-event-source
+  ];
+
+  meta =  {
+    description = "Emacs integration for OpenCode AI tooling";
+    maintainers = with lib.maintainers; [ zstg ];
+    license = lib.licenses.gpl3;
+    platforms = [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+      "x86_64-windows"
+    ];
+  };
+})

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/opencode/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/opencode/package.nix
@@ -23,7 +23,7 @@ emacsPackages.melpaBuild (finalAttrs: {
     plz-event-source
   ];
 
-  meta =  {
+  meta = {
     description = "Emacs integration for OpenCode AI tooling";
     maintainers = with lib.maintainers; [ zstg ];
     license = lib.licenses.gpl3;

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/opencode/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/opencode/package.nix
@@ -1,7 +1,8 @@
-{ lib
-, emacs
-, emacsPackages
-, fetchgit
+{
+  lib,
+  emacs,
+  emacsPackages,
+  fetchgit,
 }:
 
 emacsPackages.melpaBuild (finalAttrs: {
@@ -13,7 +14,6 @@ emacsPackages.melpaBuild (finalAttrs: {
     rev = "dad7f2c418018b991701255b79cfb3be842fdb0a";
     sha256 = "sha256-+eJlOF4Fpm+dp5tqT6V7ktURF4BgEcKQkCkXChUiaPo=";
   };
-
 
   packageRequires = with emacsPackages; [
     magit


### PR DESCRIPTION
Packaged [emacsPackages.opencode](https://codeberg.org/sczi/opencode.el). This package provides an interface to Opencode from within Emacs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
