### PR TITLE
python3Packages.pyvista: fix python 3.14 compatibility

### DIFF
--- a/pkgs/development/python-modules/pyvista/default.nix
+++ b/pkgs/development/python-modules/pyvista/default.nix
@@ -24,6 +24,13 @@ buildPythonPackage rec {
     hash = "sha256-FFrnLiGiP6LSwaoEHx4tih6XPdKCZ/9tjvz00NQDU0Q=";
   };
 
+  patches = [
+    # Fix Python 3.14 compatibility: Convert Union to | syntax and use TypeAlias
+    # Based on https://github.com/pyvista/pyvista/pull/8102 which doesn't apply
+    # to 0.46.4
+    ./python314-compat.patch
+  ];
+
   build-system = [ setuptools ];
 
   dependencies = [

--- a/pkgs/development/python-modules/pyvista/python314-compat.patch
+++ b/pkgs/development/python-modules/pyvista/python314-compat.patch
@@ -1,0 +1,212 @@
+diff --git a/pyvista/core/_typing_core/_aliases.py b/pyvista/core/_typing_core/_aliases.py
+index f114370..e9d5e25 100644
+--- a/pyvista/core/_typing_core/_aliases.py
++++ b/pyvista/core/_typing_core/_aliases.py
+@@ -6,7 +6,7 @@ import os
+ from typing import TYPE_CHECKING
+ from typing import Literal
+ from typing import NamedTuple
+-from typing import Union
++from typing import TypeAlias
+ 
+ from pyvista.core import _vtk_core as _vtk
+ 
+@@ -34,38 +34,15 @@ else:
+ #
+ # Long or complex type aliases (e.g. a union of 4 or more base types) should
+ # always be added to the dictionary and documented
+-Number = Union[int, float]
+-
+-VectorLike = _ArrayLike1D[NumberType]
+-VectorLike.__doc__ = """One-dimensional array-like object with numerical values.
+-
+-Includes sequences and numpy arrays.
+-"""
+-
+-MatrixLike = _ArrayLike2D[NumberType]
+-MatrixLike.__doc__ = """Two-dimensional array-like object with numerical values.
+-
+-Includes singly-nested sequences and numpy arrays.
+-"""
+-
+-ArrayLike = _ArrayLike[NumberType]
+-ArrayLike.__doc__ = """Any-dimensional array-like object with numerical values.
+-
+-Includes sequences, nested sequences, and numpy arrays. Scalar values are not included.
+-"""
++Number: TypeAlias = int | float
++VectorLike: TypeAlias = _ArrayLike1D[NumberType]
++MatrixLike: TypeAlias = _ArrayLike2D[NumberType]
++ArrayLike: TypeAlias = _ArrayLike[NumberType]
+ if Rotation is not None:
+-    RotationLike = Union[MatrixLike[float], _vtk.vtkMatrix3x3, Rotation]
++    RotationLike: TypeAlias = MatrixLike[float] | _vtk.vtkMatrix3x3 | Rotation
+ else:
+-    RotationLike = Union[MatrixLike[float], _vtk.vtkMatrix3x3]  # type: ignore[misc]
+-RotationLike.__doc__ = """Array or object representing a spatial rotation.
+-
+-Includes 3x3 arrays and SciPy Rotation objects.
+-"""
+-
+-TransformLike = Union[RotationLike, _vtk.vtkMatrix4x4, _vtk.vtkTransform]
+-TransformLike.__doc__ = """Array or object representing a spatial transformation.
+-
+-Includes 3x3 and 4x4 arrays as well as SciPy Rotation objects."""
++    RotationLike = MatrixLike[float] | _vtk.vtkMatrix3x3  # type: ignore[misc]
++TransformLike: TypeAlias = RotationLike | _vtk.vtkMatrix4x4 | _vtk.vtkTransform
+ 
+ 
+ class BoundsTuple(NamedTuple):
+@@ -111,15 +88,11 @@ class BoundsTuple(NamedTuple):
+         return f'{name}({joined_lines})'
+ 
+ 
+-CellsLike = Union[MatrixLike[int], VectorLike[int]]
++CellsLike: TypeAlias = MatrixLike[int] | VectorLike[int]
+ 
+-CellArrayLike = Union[CellsLike, _vtk.vtkCellArray]
++CellArrayLike: TypeAlias = CellsLike | _vtk.vtkCellArray
+ 
+ # Undocumented alias - should be expanded in docs
+-_ArrayLikeOrScalar = Union[NumberType, ArrayLike[NumberType]]
+-
+-InteractionEventType = Union[Literal['end', 'start', 'always'], _vtk.vtkCommand.EventIds]
+-InteractionEventType.__doc__ = """Interaction event mostly used for widgets.
++_ArrayLikeOrScalar: TypeAlias = NumberType | ArrayLike[NumberType]
+ 
+-Includes both strings such as `end`, 'start' and `always` and `_vtk.vtkCommand.EventIds`.
+-"""
++InteractionEventType: TypeAlias = Literal['end', 'start', 'always'] | _vtk.vtkCommand.EventIds
+diff --git a/pyvista/core/_typing_core/_array_like.py b/pyvista/core/_typing_core/_array_like.py
+index a9b708e..e69b035 100644
+--- a/pyvista/core/_typing_core/_array_like.py
++++ b/pyvista/core/_typing_core/_array_like.py
+@@ -24,8 +24,8 @@ Some key differences include:
+ from __future__ import annotations
+ 
+ from collections.abc import Sequence
++from typing import TypeAlias
+ from typing import TypeVar
+-from typing import Union
+ 
+ import numpy as np
+ import numpy.typing as npt
+@@ -33,7 +33,7 @@ import numpy.typing as npt
+ # Define numeric types
+ NumberType = TypeVar(
+     'NumberType',
+-    bound=Union[np.floating, np.integer, np.bool_, float, int, bool],
++    bound=np.floating | np.integer | np.bool_ | float | int | bool,
+ )
+ NumberType.__doc__ = """Type variable for numeric data types."""
+ 
+@@ -41,47 +41,47 @@ NumberType.__doc__ = """Type variable for numeric data types."""
+ # Its definition should be identical to `NumberType`
+ _NumberType = TypeVar(  # noqa: PYI018
+     '_NumberType',
+-    bound=Union[np.floating, np.integer, np.bool_, float, int, bool],
++    bound=np.floating | np.integer | np.bool_ | float | int | bool,
+ )
+ 
+-NumpyArray = npt.NDArray[NumberType]
++NumpyArray: TypeAlias = npt.NDArray[NumberType]
+ 
+-_FiniteNestedList = Union[
+-    list[NumberType],
+-    list[list[NumberType]],
+-    list[list[list[NumberType]]],
+-    list[list[list[list[NumberType]]]],
+-]
+-_FiniteNestedTuple = Union[
+-    tuple[NumberType],
+-    tuple[tuple[NumberType]],
+-    tuple[tuple[tuple[NumberType]]],
+-    tuple[tuple[tuple[tuple[NumberType]]]],
+-]
++_FiniteNestedList: TypeAlias = (
++    list[NumberType]
++    | list[list[NumberType]]
++    | list[list[list[NumberType]]]
++    | list[list[list[list[NumberType]]]]
++)
++_FiniteNestedTuple: TypeAlias = (
++    tuple[NumberType]
++    | tuple[tuple[NumberType]]
++    | tuple[tuple[tuple[NumberType]]]
++    | tuple[tuple[tuple[tuple[NumberType]]]]
++)
+ 
+-_ArrayLike1D = Union[
+-    NumpyArray[NumberType],
+-    Sequence[NumberType],
+-    Sequence[NumpyArray[NumberType]],
+-]
+-_ArrayLike2D = Union[
+-    NumpyArray[NumberType],
+-    Sequence[Sequence[NumberType]],
+-    Sequence[Sequence[NumpyArray[NumberType]]],
+-]
+-_ArrayLike3D = Union[
+-    NumpyArray[NumberType],
+-    Sequence[Sequence[Sequence[NumberType]]],
+-    Sequence[Sequence[Sequence[NumpyArray[NumberType]]]],
+-]
+-_ArrayLike4D = Union[
+-    NumpyArray[NumberType],
+-    Sequence[Sequence[Sequence[Sequence[NumberType]]]],
+-    Sequence[Sequence[Sequence[Sequence[NumpyArray[NumberType]]]]],
+-]
+-_ArrayLike = Union[
+-    _ArrayLike1D[NumberType],
+-    _ArrayLike2D[NumberType],
+-    _ArrayLike3D[NumberType],
+-    _ArrayLike4D[NumberType],
+-]
++_ArrayLike1D: TypeAlias = (
++    NumpyArray[NumberType]
++    | Sequence[NumberType]
++    | Sequence[NumpyArray[NumberType]]
++)
++_ArrayLike2D: TypeAlias = (
++    NumpyArray[NumberType]
++    | Sequence[Sequence[NumberType]]
++    | Sequence[Sequence[NumpyArray[NumberType]]]
++)
++_ArrayLike3D: TypeAlias = (
++    NumpyArray[NumberType]
++    | Sequence[Sequence[Sequence[NumberType]]]
++    | Sequence[Sequence[Sequence[NumpyArray[NumberType]]]]
++)
++_ArrayLike4D: TypeAlias = (
++    NumpyArray[NumberType]
++    | Sequence[Sequence[Sequence[Sequence[NumberType]]]]
++    | Sequence[Sequence[Sequence[Sequence[NumpyArray[NumberType]]]]]
++)
++_ArrayLike: TypeAlias = (
++    _ArrayLike1D[NumberType]
++    | _ArrayLike2D[NumberType]
++    | _ArrayLike3D[NumberType]
++    | _ArrayLike4D[NumberType]
++)
+diff --git a/pyvista/plotting/_typing.py b/pyvista/plotting/_typing.py
+index 8af8937..1053a86 100644
+--- a/pyvista/plotting/_typing.py
++++ b/pyvista/plotting/_typing.py
+@@ -54,9 +54,6 @@ ColorLike = Union[
+     'Color',
+     _vtk.vtkColor3ub,
+ ]
+-# Overwrite default docstring, as sphinx is not able to capture the docstring
+-# when it is put beneath the definition somehow?
+-ColorLike.__doc__ = 'Any object convertible to a :class:`Color`.'
+ Chart = Union['Chart2D', 'ChartBox', 'ChartPie', 'ChartMPL']
+ FontFamilyOptions = Literal['courier', 'times', 'arial']
+ OpacityOptions = Literal[
+@@ -89,7 +86,6 @@ CameraPositionOptions = Union[
+     CameraPosition,
+ ]
+ 
+-
+ class BackfaceArgs(TypedDict, total=False):
+     theme: Theme
+     interpolation: Literal['Physically based rendering', 'pbr', 'Phong', 'Gouraud', 'Flat']


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

The upstream patch from PR #8102 doesn't apply cleanly to version
0.46.4.
Created a local patch that:
  - Converts Union to | syntax (PEP 604)
  - Adds TypeAlias annotations (PEP 613)
  - Removes dynamic __doc__ assignments on type aliases



<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
