### PR TITLE
avahi: fix static build

### DIFF
--- a/pkgs/by-name/av/avahi/package.nix
+++ b/pkgs/by-name/av/avahi/package.nix
@@ -11,6 +11,7 @@
   expat,
   gettext,
   glib,
+  autoconf-archive,
   autoreconfHook,
   libiconv,
   libevent,
@@ -142,6 +143,12 @@ stdenv.mkDerivation rec {
     })
   ];
 
+  postPatch = ''
+    # Remove the vendored ACX_PTHREAD macro in favor of the more up-to-date
+    # implementation from autoconf-archive, especially to support static builds.
+    rm common/acx_pthread.m4
+  '';
+
   depsBuildBuild = [
     pkg-config
   ];
@@ -150,6 +157,7 @@ stdenv.mkDerivation rec {
     pkg-config
     gettext
     glib
+    autoconf-archive
     autoreconfHook
   ];
 


### PR DESCRIPTION
fixes `nix-build -A pkgsStatic.avahi`.

tested with `./result/bin/avahi-browse -a --resolve`, which shows the same entries on both `pkgs.avahi` and `pkgsStatic.avahi`.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
