### PR TITLE
pkgs/: Remove kranzes from maintainers of multiple packages

### DIFF
--- a/pkgs/applications/video/jellyfin-desktop/default.nix
+++ b/pkgs/applications/video/jellyfin-desktop/default.nix
@@ -93,7 +93,6 @@ stdenv.mkDerivation rec {
     ];
     maintainers = with lib.maintainers; [
       jojosch
-      kranzes
       paumr
     ];
     mainProgram = "jellyfin-desktop";

--- a/pkgs/by-name/ag/age-plugin-tpm/package.nix
+++ b/pkgs/by-name/ag/age-plugin-tpm/package.nix
@@ -50,7 +50,6 @@ buildGoModule rec {
     license = lib.licenses.mit;
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [
-      kranzes
       sgo
     ];
   };

--- a/pkgs/by-name/ca/cargo-wizard/package.nix
+++ b/pkgs/by-name/ca/cargo-wizard/package.nix
@@ -27,7 +27,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/kobzol/cargo-wizard";
     changelog = "https://github.com/kobzol/cargo-wizard/blob/${src.rev}/CHANGELOG.md";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ kranzes ];
+    maintainers = [ ];
     mainProgram = "cargo-wizard";
   };
 }

--- a/pkgs/by-name/cr/crate2nix/package.nix
+++ b/pkgs/by-name/cr/crate2nix/package.nix
@@ -62,7 +62,6 @@ rustPlatform.buildRustPackage rec {
     maintainers = with lib.maintainers; [
       kolloch
       cole-h
-      kranzes
     ];
   };
 }

--- a/pkgs/by-name/ed/edwood/package.nix
+++ b/pkgs/by-name/ed/edwood/package.nix
@@ -46,7 +46,7 @@ buildGoModule rec {
       mit
       bsd3
     ];
-    maintainers = with lib.maintainers; [ kranzes ];
+    maintainers = [ ];
     mainProgram = "edwood";
   };
 }

--- a/pkgs/by-name/gr/grafana-to-ntfy/package.nix
+++ b/pkgs/by-name/gr/grafana-to-ntfy/package.nix
@@ -22,7 +22,7 @@ rustPlatform.buildRustPackage {
     homepage = "https://github.com/kittyandrew/grafana-to-ntfy";
     license = lib.licenses.agpl3Only;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ kranzes ];
+    maintainers = [ ];
     mainProgram = "grafana-to-ntfy";
   };
 }

--- a/pkgs/by-name/ko/komorebi/package.nix
+++ b/pkgs/by-name/ko/komorebi/package.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Beautiful and customizable wallpaper manager for Linux";
     homepage = "https://github.com/Komorebi-Fork/komorebi";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ kranzes ];
+    maintainers = [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/li/libdovi/package.nix
+++ b/pkgs/by-name/li/libdovi/package.nix
@@ -47,6 +47,6 @@ rustPlatform.buildRustPackage rec {
     description = "C library for Dolby Vision metadata parsing and writing";
     homepage = "https://crates.io/crates/dolby_vision";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ kranzes ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/li/libfreeaptx/package.nix
+++ b/pkgs/by-name/li/libfreeaptx/package.nix
@@ -48,6 +48,6 @@ stdenv.mkDerivation rec {
     license = lib.licenses.lgpl21Plus;
     homepage = "https://github.com/iamthehorker/libfreeaptx";
     platforms = lib.platforms.unix;
-    maintainers = with lib.maintainers; [ kranzes ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/ma/mattermost/package.nix
+++ b/pkgs/by-name/ma/mattermost/package.nix
@@ -262,7 +262,6 @@ buildMattermost rec {
     maintainers = with lib.maintainers; [
       ryantm
       numinit
-      kranzes
       mgdelacroix
     ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/mp/mpd-discord-rpc/package.nix
+++ b/pkgs/by-name/mp/mpd-discord-rpc/package.nix
@@ -32,7 +32,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/JakeStanger/mpd-discord-rpc/";
     changelog = "https://github.com/JakeStanger/mpd-discord-rpc/blob/${src.rev}/CHANGELOG.md";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ kranzes ];
+    maintainers = [ ];
     mainProgram = "mpd-discord-rpc";
   };
 }

--- a/pkgs/by-name/ne/nextcloud-client/package.nix
+++ b/pkgs/by-name/ne/nextcloud-client/package.nix
@@ -100,7 +100,6 @@ stdenv.mkDerivation rec {
     homepage = "https://nextcloud.com";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [
-      kranzes
       SuperSandro2000
     ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/pa/pam_rssh/package.nix
+++ b/pkgs/by-name/pa/pam_rssh/package.nix
@@ -74,7 +74,6 @@ rustPlatform.buildRustPackage rec {
     license = lib.licenses.mit;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [
-      kranzes
       xyenon
     ];
   };

--- a/pkgs/by-name/ri/ristate/package.nix
+++ b/pkgs/by-name/ri/ristate/package.nix
@@ -24,7 +24,7 @@ rustPlatform.buildRustPackage {
     description = "River-status client written in Rust";
     homepage = "https://gitlab.com/snakedye/ristate";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ kranzes ];
+    maintainers = [ ];
     mainProgram = "ristate";
   };
 }

--- a/pkgs/by-name/ru/rush-parallel/package.nix
+++ b/pkgs/by-name/ru/rush-parallel/package.nix
@@ -27,7 +27,7 @@ buildGoModule rec {
     homepage = "https://github.com/shenwei356/rush";
     changelog = "https://github.com/shenwei356/rush/blob/${src.rev}/CHANGELOG.md";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ kranzes ];
+    maintainers = [ ];
     mainProgram = "rush-parallel";
   };
 }

--- a/pkgs/by-name/sz/szyszka/package.nix
+++ b/pkgs/by-name/sz/szyszka/package.nix
@@ -55,7 +55,7 @@ rustPlatform.buildRustPackage rec {
     description = "Simple but powerful and fast bulk file renamer";
     homepage = "https://github.com/qarmin/szyszka";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ kranzes ];
+    maintainers = [ ];
     mainProgram = "szyszka";
   };
 }

--- a/pkgs/by-name/vi/vial/package.nix
+++ b/pkgs/by-name/vi/vial/package.nix
@@ -30,7 +30,7 @@ appimageTools.wrapType2 {
     homepage = "https://get.vial.today";
     license = lib.licenses.gpl2Plus;
     mainProgram = "Vial";
-    maintainers = with lib.maintainers; [ kranzes ];
+    maintainers = [ ];
     platforms = [ "x86_64-linux" ];
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };

--- a/pkgs/development/libraries/pipewire/default.nix
+++ b/pkgs/development/libraries/pipewire/default.nix
@@ -269,7 +269,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.mit;
     platforms = lib.platforms.linux ++ lib.platforms.freebsd;
     maintainers = with lib.maintainers; [
-      kranzes
       k900
     ];
     pkgConfigModules = [

--- a/pkgs/development/python-modules/aiohttp-sse-client/default.nix
+++ b/pkgs/development/python-modules/aiohttp-sse-client/default.nix
@@ -45,6 +45,6 @@ buildPythonPackage rec {
     description = "Server-Sent Event python client base on aiohttp";
     homepage = "https://pypi.org/project/aiohttp-sse-client/";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ kranzes ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/calysto-scheme/default.nix
+++ b/pkgs/development/python-modules/calysto-scheme/default.nix
@@ -33,6 +33,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/Calysto/calysto_scheme";
     changelog = "https://github.com/Calysto/calysto_scheme/blob/${src.rev}/ChangeLog.md";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ kranzes ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/calysto/default.nix
+++ b/pkgs/development/python-modules/calysto/default.nix
@@ -38,6 +38,6 @@ buildPythonPackage rec {
     description = "Tools for Jupyter and Python";
     homepage = "https://github.com/Calysto/calysto";
     license = lib.licenses.bsd2;
-    maintainers = with lib.maintainers; [ kranzes ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/cryptolyzer/default.nix
+++ b/pkgs/development/python-modules/cryptolyzer/default.nix
@@ -72,7 +72,7 @@ buildPythonPackage rec {
     changelog = "https://gitlab.com/coroner/cryptolyzer/-/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.mpl20;
     mainProgram = "cryptolyze";
-    maintainers = with lib.maintainers; [ kranzes ];
+    maintainers = [ ];
     teams = with lib.teams; [ ngi ];
   };
 }

--- a/pkgs/development/python-modules/cryptoparser/default.nix
+++ b/pkgs/development/python-modules/cryptoparser/default.nix
@@ -62,7 +62,7 @@ buildPythonPackage rec {
     homepage = "https://gitlab.com/coroner/cryptoparser";
     changelog = "https://gitlab.com/coroner/cryptoparser/-/blob/${src.tag}/CHANGELOG.md";
     license = lib.licenses.mpl20;
-    maintainers = with lib.maintainers; [ kranzes ];
+    maintainers = [ ];
     teams = with lib.teams; [ ngi ];
   };
 }

--- a/pkgs/development/python-modules/githubkit/default.nix
+++ b/pkgs/development/python-modules/githubkit/default.nix
@@ -84,6 +84,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/yanyongyu/githubkit";
     changelog = "https://github.com/yanyongyu/githubkit/releases/tag/${src.tag}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ kranzes ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/glad2/default.nix
+++ b/pkgs/development/python-modules/glad2/default.nix
@@ -30,6 +30,6 @@ buildPythonPackage rec {
     mainProgram = "glad";
     homepage = "https://github.com/Dav1dde/glad";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ kranzes ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/hid-parser/default.nix
+++ b/pkgs/development/python-modules/hid-parser/default.nix
@@ -32,6 +32,6 @@ buildPythonPackage rec {
     description = "Typed pure Python library to parse HID report descriptors";
     homepage = "https://github.com/usb-tools/python-hid-parser";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ kranzes ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/image-go-nord/default.nix
+++ b/pkgs/development/python-modules/image-go-nord/default.nix
@@ -44,6 +44,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/Schrodinger-Hat/ImageGoNord-pip";
     changelog = "https://github.com/Schroedinger-Hat/ImageGoNord-pip/releases/tag/v${version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ kranzes ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/moddb/default.nix
+++ b/pkgs/development/python-modules/moddb/default.nix
@@ -37,6 +37,6 @@ buildPythonPackage rec {
     description = "Python scrapper to access ModDB mods, games and more as objects";
     homepage = "https://github.com/ClementJ18/moddb";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ kranzes ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/oauth2-client/default.nix
+++ b/pkgs/development/python-modules/oauth2-client/default.nix
@@ -34,6 +34,6 @@ buildPythonPackage rec {
     description = "Client library for OAuth2";
     homepage = "https://pypi.org/project/oauth2-client/";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ kranzes ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pyrate-limiter/default.nix
+++ b/pkgs/development/python-modules/pyrate-limiter/default.nix
@@ -82,6 +82,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/vutran1710/PyrateLimiter";
     changelog = "https://github.com/vutran1710/PyrateLimiter/blob/${src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ kranzes ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/yasi/default.nix
+++ b/pkgs/development/python-modules/yasi/default.nix
@@ -38,6 +38,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/nkmathew/yasi-sexp-indenter";
     changelog = "https://github.com/nkmathew/yasi-sexp-indenter/blob/${src.rev}/CHANGELOG.md";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ kranzes ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/tools/misc/sshx/default.nix
+++ b/pkgs/tools/misc/sshx/default.nix
@@ -43,7 +43,6 @@ let
           license = lib.licenses.mit;
           maintainers = with lib.maintainers; [
             pinpox
-            kranzes
           ];
           mainProgram = pname;
         };


### PR DESCRIPTION
Affected packages:
- **jellyfin-desktop: Remove kranzes from maintainers**
- **age-plugin-tpm: Remove kranzes from maintainers**
- **cargo-wizard: Remove kranzes from maintainers**
- **crate2nix: Remove kranzes from maintainers**
- **edwood: Remove kranzes from maintainers**
- **grafana-to-ntfy: Remove kranzes from maintainers**
- **komorebi: Remove kranzes from maintainers**
- **libdovi: Remove kranzes from maintainers**
- **libfreeaptx: Remove kranzes from maintainers**
- **mattermost: Remove kranzes from maintainers**
- **mpd-discord-rpc: Remove kranzes from maintainers**
- **nextcloud-client: Remove kranzes from maintainers**
- **pam_rssh: Remove kranzes from maintainers**
- **ristate: Remove kranzes from maintainers**
- **rush-parallel: Remove kranzes from maintainers**
- **szyszka: Remove kranzes from maintainers**
- **vial: Remove kranzes from maintainers**
- **pipewire: Remove kranzes from maintainers**
- **python3Packages.aiohttp-sse-client: Remove kranzes from maintainers**
- **python3Packages.calysto-scheme: Remove kranzes from maintainers**
- **python3Packages.calysto: Remove kranzes from maintainers**
- **python3Packages.cryptolyzer: Remove kranzes from maintainers**
- **python3Packages.cryptoparser: Remove kranzes from maintainers**
- **python3Packages.githubkit: Remove kranzes from maintainers**
- **python3Packages.glad2: Remove kranzes from maintainers**
- **python3Packages.hid-parser: Remove kranzes from maintainers**
- **python3Packages.image-go-nord: Remove kranzes from maintainers**
- **python3Packages.moddb: Remove kranzes from maintainers**
- **python3Packages.oauth2-client: Remove kranzes from maintainers**
- **python3Packages.pyrate-limiter: Remove kranzes from maintainers**
- **python3Packages.yasi: Remove kranzes from maintainers**
- **sshx: Remove kranzes from maintainers**


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->


These are packages which I no longer use (for the most part). I will slowly pick up new packages to maintain.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
