### PR TITLE
zashboard: init at 3.4.0

### DIFF
--- a/pkgs/by-name/za/zashboard/package.nix
+++ b/pkgs/by-name/za/zashboard/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  pnpm_10,
+  pnpm ? pnpm_10,
+  fetchPnpmDeps,
+  pnpmConfigHook,
+  nix-update-script,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "zashboard";
+  version = "3.4.0";
+
+  src = fetchFromGitHub {
+    owner = "Zephyruso";
+    repo = "zashboard";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-S5NrXjD34UwbsYQrHWMAgLc10/R1U2ZZ1gW0zkUXg6w=";
+  };
+
+  npmDeps = null;
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    inherit pnpm;
+    fetcherVersion = 3;
+    hash = "sha256-DMR9vNgsWdBK0BbSGzxEZUBZpa4szF2NIFO/GePwIUw=";
+  };
+
+  nativeBuildInputs = [ pnpm ];
+  npmConfigHook = pnpmConfigHook;
+
+  postPatch = ''
+    substituteInPlace vite.config.ts \
+      --replace-fail "getGitCommitId()" '""'
+  '';
+
+  __darwinAllowLocalNetworking = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    cp -r dist $out
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Dashboard Using Clash API";
+    homepage = "https://github.com/Zephyruso/zashboard";
+    changelog = "https://github.com/Zephyruso/zashboard/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ chillcicada ];
+  };
+})

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -2491,7 +2491,6 @@ mapAliases {
   zabbix72 = throw "'zabbix72' was removed as it has reached its end of life"; # Added 2026-02-11
   zandronum-alpha = throw "'zandronum-alpha' has been removed as it was broken and the stable version has caught up"; # Added 2025-10-19
   zandronum-alpha-server = throw "'zandronum-alpha-server' has been removed as it was broken and the stable version has caught up"; # Added 2025-10-19
-  zashboard = throw "'zashboard' has been removed because upstream repository source code has been deleted"; # Added 2025-12-29
   zbackup = throw "'zbackup' has been removed due to being unmaintained upstream"; # Added 2025-08-22
   zdoom = throw "'zdoom' has been removed as it was broken and unmaintained upstream. Consider using UZDoom instead."; # Added 2026-04-04
   zeal-qt5 = warnAlias "'zeal-qt5' has been removed from nixpkgs. Please use 'zeal' instead" zeal; # Added 2025-08-31


### PR DESCRIPTION
~~For some reason, Zashboard has hidden and archived the main branch, but it is still [under development](https://github.com/Zephyruso/zashboard/tree/main).~~

refer to https://github.com/NixOS/nixpkgs/pull/470588#issuecomment-3748742582

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
