### PR TITLE
rofimoji: Allow usage on Darwin platforms

### DIFF
--- a/pkgs/by-name/ro/rofimoji/package.nix
+++ b/pkgs/by-name/ro/rofimoji/package.nix
@@ -3,9 +3,10 @@
   python3Packages,
   fetchFromGitHub,
   installShellFiles,
+  stdenv,
 
-  waylandSupport ? true,
-  x11Support ? true,
+  waylandSupport ? stdenv.isLinux,
+  x11Support ? stdenv.isLinux,
 
   wl-clipboard,
   wtype,
@@ -60,7 +61,7 @@ python3Packages.buildPythonApplication rec {
     homepage = "https://github.com/fdw/rofimoji";
     changelog = "https://github.com/fdw/rofimoji/blob/${src.rev}/CHANGELOG.md";
     license = lib.licenses.mit;
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
     maintainers = with lib.maintainers; [ justinlovinger ];
   };
 }

--- a/pkgs/by-name/ro/rofimoji/package.nix
+++ b/pkgs/by-name/ro/rofimoji/package.nix
@@ -5,8 +5,8 @@
   installShellFiles,
   stdenv,
 
-  waylandSupport ? stdenv.isLinux,
-  x11Support ? stdenv.isLinux,
+  waylandSupport ? (!stdenv.hostPlatform.isDarwin),
+  x11Support ? (!stdenv.hostPlatform.isDarwin),
 
   wl-clipboard,
   wtype,


### PR DESCRIPTION
Support of Darwin platform was introduced in Rofimoji 6.6.0

This patch proposes to allow Darwin in addition to the Linux one.

See: https://github.com/fdw/rofimoji/pull/224
And: https://github.com/fdw/rofimoji/releases/tag/6.6.0

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
