### PR TITLE
[25.11] paperless-ngx: add patches for GHSA-24x5-wp64-9fcc, GHSA-7cq3-mhxq-w946, GHSA-28cf-xvcf-hw6m

### DIFF
--- a/pkgs/by-name/pa/paperless-ngx/package.nix
+++ b/pkgs/by-name/pa/paperless-ngx/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitHub,
   fetchPypi,
+  fetchpatch,
   node-gyp,
   nodejs_20,
   nixosTests,
@@ -156,6 +157,14 @@ python.pkgs.buildPythonApplication rec {
   pyproject = true;
 
   inherit version src;
+
+  patches = [
+    (fetchpatch {
+      name = "GHSA-24x5-wp64-9fcc.patch";
+      url = "https://github.com/paperless-ngx/paperless-ngx/commit/9bdbfd362f4a15f8de109ca959f04e3a7d8a39d0.patch";
+      hash = "sha256-1iiOeWKvBoHFLa1QySkXYTbX5CVF3VQDWno6A/SinCs=";
+    })
+  ];
 
   postPatch = ''
     # pytest-xdist with to many threads makes the tests flaky

--- a/pkgs/by-name/pa/paperless-ngx/package.nix
+++ b/pkgs/by-name/pa/paperless-ngx/package.nix
@@ -169,6 +169,11 @@ python.pkgs.buildPythonApplication rec {
       url = "https://github.com/paperless-ngx/paperless-ngx/commit/bf38ae98f1ac3bae2c6006888a8705e42fbb804f.patch";
       hash = "sha256-ATjtB7dmrXk/R+zjc0y2jJkmvVN7Gmqf0aWMRG9EN7I=";
     })
+    (fetchpatch {
+      name = "GHSA-28cf-xvcf-hw6m.patch";
+      url = "https://github.com/paperless-ngx/paperless-ngx/commit/7c457466b76d7a4abeca521043de69d3c1f4eb11.patch";
+      hash = "sha256-t2/3lnhj1eywGiX1zmo7aJ+aOEdTWr0xe7yaFj8NeMs=";
+    })
   ];
 
   postPatch = ''

--- a/pkgs/by-name/pa/paperless-ngx/package.nix
+++ b/pkgs/by-name/pa/paperless-ngx/package.nix
@@ -164,6 +164,11 @@ python.pkgs.buildPythonApplication rec {
       url = "https://github.com/paperless-ngx/paperless-ngx/commit/9bdbfd362f4a15f8de109ca959f04e3a7d8a39d0.patch";
       hash = "sha256-1iiOeWKvBoHFLa1QySkXYTbX5CVF3VQDWno6A/SinCs=";
     })
+    (fetchpatch {
+      name = "GHSA-7cq3-mhxq-w946.patch";
+      url = "https://github.com/paperless-ngx/paperless-ngx/commit/bf38ae98f1ac3bae2c6006888a8705e42fbb804f.patch";
+      hash = "sha256-ATjtB7dmrXk/R+zjc0y2jJkmvVN7Gmqf0aWMRG9EN7I=";
+    })
   ];
 
   postPatch = ''
@@ -252,6 +257,7 @@ python.pkgs.buildPythonApplication rec {
       pyzbar
       rapidfuzz
       redis
+      regex
       scikit-learn
       setproctitle
       tika-client


### PR DESCRIPTION
GHSA-24x5-wp64-9fcc
GHSA-7cq3-mhxq-w946
https://github.com/paperless-ngx/paperless-ngx/security/advisories/GHSA-28cf-xvcf-hw6m
backport for #470544, #472259, #480318
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
