### PR TITLE
top-level/packages-info: add pname fallback

### DIFF
--- a/pkgs/top-level/packages-info.nix
+++ b/pkgs/top-level/packages-info.nix
@@ -16,16 +16,18 @@ let
             {
               name = lib.showAttrPath path;
               value = {
-                ${if value ? "meta" then "meta" else null} = value.meta;
-                ${if value ? "name" then "name" else null} = value.name;
-                ${if value ? "outputName" then "outputName" else null} = value.outputName;
+                inherit (value)
+                  meta
+                  name
+                  outputName
+                  system
+                  ;
                 ${if value ? "outputs" then "outputs" else null} = lib.listToAttrs (
                   lib.map (x: {
                     name = x;
                     value = null;
                   }) value.outputs
                 );
-                ${if value ? "system" then "system" else null} = value.system;
                 # TODO: Remove the following two fallbacks when all packages have been fixed.
                 # Note: pname and version are *required* by repology, so do not change to
                 # the optional pattern from above.

--- a/pkgs/top-level/packages-info.nix
+++ b/pkgs/top-level/packages-info.nix
@@ -25,9 +25,12 @@ let
                     value = null;
                   }) value.outputs
                 );
-                ${if value ? "pname" then "pname" else null} = value.pname;
                 ${if value ? "system" then "system" else null} = value.system;
-                ${if value ? "version" then "version" else null} = value.version;
+                # TODO: Remove the following two fallbacks when all packages have been fixed.
+                # Note: pname and version are *required* by repology, so do not change to
+                # the optional pattern from above.
+                pname = value.pname or value.name;
+                version = value.version or "";
               };
             }
           ]


### PR DESCRIPTION
A [recent change](https://github.com/NixOS/nixpkgs/pull/451424) broke the repology updater, because it relies on pname and version fields. We can fallback to *some* values temporarily, but the right fix is to make sure pname is available on all packages in Nixpkgs. That effort is ongoing, once it is complete, we should remove the fallbacks.

Fixes https://github.com/NixOS/nixpkgs/pull/451424#issuecomment-3752281712

Related: https://github.com/repology/repology-updater/issues/1565

## Things done

- Built on platform:
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
