### PR TITLE
python3Packages.geojson: fix build for python3.14

### DIFF
--- a/pkgs/development/python-modules/geojson/default.nix
+++ b/pkgs/development/python-modules/geojson/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  fetchpatch,
   buildPythonPackage,
   fetchFromGitHub,
   setuptools,
@@ -18,6 +19,14 @@ buildPythonPackage rec {
     hash = "sha256-0p8FW9alcWCSdi66wanS/F9IgO714WIRQIXvg3f9op8=";
   };
 
+  patches = [
+    (fetchpatch {
+      name = "allow-install-python314";
+      url = "https://github.com/jazzband/geojson/commit/2584c0de5651bd694499449f9da5321b15597270.patch";
+      hash = "sha256-64LPEwC1qc83wF48878fH31CVFn2txTmSxxr0cnQbRg=";
+    })
+  ];
+
   build-system = [ setuptools ];
 
   pythonImportsCheck = [ "geojson" ];
@@ -30,5 +39,6 @@ buildPythonPackage rec {
     description = "Python bindings and utilities for GeoJSON";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ oxzi ];
+    teams = [ lib.teams.geospatial ];
   };
 }


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
