### PR TITLE
nexusmods-app: mark as discontinued upstream

### DIFF
--- a/pkgs/by-name/ne/nexusmods-app/package.nix
+++ b/pkgs/by-name/ne/nexusmods-app/package.nix
@@ -230,5 +230,8 @@ buildDotnetModule (finalAttrs: {
           ''
       }
     '';
+    knownVulnerabilities = [
+      "NexusMods.App has been discontinued upstream: https://www.nexusmods.com/news/15424"
+    ];
   };
 })


### PR DESCRIPTION
Nexus Mods have stopped work on NexusMods.App, instead reassigning dev teams to work on their existing mod manager Vortex. See https://www.nexusmods.com/news/15424

Currently, the package still functions as intended, so I've not marked it as `broken`. Looking around, it seems `meta.knownVulnerabilities` is commonly used to indicate a package is abandoned upstream. As NM.A is a network-facing application that will not receive security updates, this seems appropriate.

NM.A was an ambitious project and significant portions remain unfinished. A full-time dev team would likely be needed for work to continue, so I don't see a maintained fork appearing as a likely scenario. That said, I don't want to rush into dropping it from Nixpkgs and prematurely inconveniencing users. Let's have the "drop it if still unmaintained" conversation during the 26.11 cycle.

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md

## For end-users

Currently, with a few exceptions such as Minecraft, there aren't many good options for game modding on Linux. One option is [`limo`](https://search.nixos.org/packages?channel=unstable&show=limo), a native mod manager packaged in Nixpkgs. Another option is [NaK](https://github.com/SulfurNitride/NaK), a rust project that handles installing and managing Windows mod mangers (MO2 and Vortex) directly within a game's Proton prefix. It installs various utility scripts in the games' install folder and installs a system URI handler for NMM download links, which proxies to the relevant game's mod manager.

For games that reached a "supported" state in NM.A, users can of course continue to use NM.A until it eventually drifts out of sync with NM API changes. With this PR users will have to acknowledge that the package is potentially insecure, e.g. with:

```nix
nixpkgs.config = {
  permittedInsecurePackages = [
    "nexusmods-app-0.21.1"
  ];
};
```

or

```nix
nixpkgs.config = {
  allowInsecurePredicate = pkg: builtins.elem (lib.getName pkg) [
    "nexusmods-app"
  ];
};
```

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
