### PR TITLE
python3Packages.sigstore: cleanup

### DIFF
--- a/pkgs/development/python-modules/sigstore/default.nix
+++ b/pkgs/development/python-modules/sigstore/default.nix
@@ -1,20 +1,21 @@
 {
   lib,
-  appdirs,
   buildPythonPackage,
-  cryptography,
   fetchFromGitHub,
+
+  # build-system
   flit-core,
+
+  # dependencies
+  appdirs,
+  cryptography,
   id,
   importlib-resources,
-  nix-update-script,
   platformdirs,
-  pretend,
   pyasn1,
   pydantic,
   pyjwt,
   pyopenssl,
-  pytestCheckHook,
   requests,
   rfc3161-client,
   rfc8785,
@@ -24,10 +25,17 @@
   sigstore-protobuf-specs,
   sigstore-rekor-types,
   tuf,
+
+  # tests
+  pretend,
+  pytestCheckHook,
   writableTmpDirAsHomeHook,
+
+  # passthru
+  nix-update-script,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "sigstore";
   version = "4.1.0";
   pyproject = true;
@@ -35,32 +43,29 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "sigstore";
     repo = "sigstore-python";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-Wt9ZoMHTiMlbAab9p8/WF38/OiyCaqHPS5R7/fTAfxw=";
   };
 
+  build-system = [ flit-core ];
+
   pythonRelaxDeps = [
     "sigstore-models"
-    "sigstore-rekor-types"
-    "rfc3161-client"
-    "cryptography"
   ];
-
-  build-system = [ flit-core ];
 
   dependencies = [
     appdirs
     cryptography
     id
     importlib-resources
+    platformdirs
+    pyasn1
     pydantic
     pyjwt
     pyopenssl
-    pyasn1
-    rfc8785
-    rfc3161-client
-    platformdirs
     requests
+    rfc3161-client
+    rfc8785
     rich
     securesystemslib
     sigstore-models
@@ -100,9 +105,9 @@ buildPythonPackage rec {
   meta = {
     description = "Codesigning tool for Python packages";
     homepage = "https://github.com/sigstore/sigstore-python";
-    changelog = "https://github.com/sigstore/sigstore-python/blob/${version}/CHANGELOG.md";
+    changelog = "https://github.com/sigstore/sigstore-python/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ bot-wxt1221 ];
     mainProgram = "sigstore";
   };
-}
+})


### PR DESCRIPTION
## Things done

cc @Bot-wxt1221

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc