### PR TITLE
kdePackages.powerdevil: improve reproducibility by adding explicit dep

### DIFF
--- a/pkgs/kde/plasma/powerdevil/default.nix
+++ b/pkgs/kde/plasma/powerdevil/default.nix
@@ -10,6 +10,8 @@ mkKdeDerivation {
   patches = [
     # https://invent.kde.org/plasma/powerdevil/-/merge_requests/595
     ./rb-brightness.patch
+    # https://invent.kde.org/plasma/powerdevil/-/merge_requests/595
+    ./rb-batterymonitor.patch
   ];
   extraNativeBuildInputs = [ pkg-config ];
   extraBuildInputs = [

--- a/pkgs/kde/plasma/powerdevil/rb-batterymonitor.patch
+++ b/pkgs/kde/plasma/powerdevil/rb-batterymonitor.patch
@@ -1,0 +1,10 @@
+diff --git a/applets/batterymonitor/CMakeLists.txt b/applets/batterymonitor/CMakeLists.txt
+index 28e52d26..3f2bf985 100644
+--- a/applets/batterymonitor/CMakeLists.txt
++++ b/applets/batterymonitor/CMakeLists.txt
+@@ -19,3 +19,5 @@ plasma_add_applet(org.kde.plasma.battery
+         main.xml
+     GENERATE_APPLET_CLASS
+ )
++
++add_dependencies(org.kde.plasma.battery batterymonitorplugin)


### PR DESCRIPTION
Fixes #467100


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
