### PR TITLE
yosys: fix plugin module flags and update environment variable

### DIFF
--- a/pkgs/by-name/yo/yosys/package.nix
+++ b/pkgs/by-name/yo/yosys/package.nix
@@ -62,9 +62,13 @@ let
     plugins:
     let
       paths = lib.closePropagation plugins;
+      libExt = stdenv.hostPlatform.extensions.sharedLibrary;
+      pluginPath = "$out/share/yosys/plugins";
       module_flags =
         with builtins;
-        concatStringsSep " " (map (n: "--add-flags -m --add-flags ${n.plugin}") plugins);
+        concatStringsSep " " (
+          map (n: "--add-flags -m --add-flags ${pluginPath}/${n.plugin}${libExt}") plugins
+        );
     in
     lib.appendToName "with-plugins" (symlinkJoin {
       inherit (yosys) name;
@@ -72,7 +76,7 @@ let
       nativeBuildInputs = [ makeWrapper ];
       postBuild = ''
         wrapProgram $out/bin/yosys \
-          --set NIX_YOSYS_PLUGIN_DIRS $out/share/yosys/plugins \
+          --set YOSYS_PATH $out/share/yosys \
           ${module_flags}
       '';
       meta.mainProgram = "yosys";


### PR DESCRIPTION
Yosys's handling of plugins changed considerably since 0.56. This can fix `withPlugins` on current yosys version.

See the previous conversation: https://github.com/NixOS/nixpkgs/pull/471062#discussion_r2684695828

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
