### PR TITLE
samba: avoid shebang patching by using correct wrapPython

### DIFF
--- a/pkgs/servers/samba/4.x.nix
+++ b/pkgs/servers/samba/4.x.nix
@@ -317,6 +317,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   disallowedReferences = lib.optionals isCross [
     buildPackages.python3Packages.python
+    buildPackages.runtimeShellPackage
   ];
 
   passthru.tests = {

--- a/pkgs/servers/samba/4.x.nix
+++ b/pkgs/servers/samba/4.x.nix
@@ -311,7 +311,10 @@ stdenv.mkDerivation (finalAttrs: {
     # Samba does its own shebang patching, but uses build Python
     find $out/bin -type f -executable | while read file; do
       isScript "$file" || continue
-      sed -i 's^${lib.getBin buildPackages.python3Packages.python}^${lib.getBin python3Packages.python}^' "$file"
+      substituteInPlace "$file" \
+        --replace-fail \
+          ${lib.getBin buildPackages.python3Packages.python} \
+          ${lib.getBin python3Packages.python}
     done
   '';
 

--- a/pkgs/servers/samba/4.x.nix
+++ b/pkgs/servers/samba/4.x.nix
@@ -122,6 +122,7 @@ stdenv.mkDerivation (finalAttrs: {
     perl.pkgs.ParseYapp
     perl.pkgs.JSON
     libxslt
+    libtasn1 # Needed also natively for `asn1Parser` program
     docbook_xsl
     docbook_xml_dtd_45
     cmocka
@@ -266,6 +267,8 @@ stdenv.mkDerivation (finalAttrs: {
     python3Packages.markdown
     tdb
   ];
+
+  strictDeps = true;
 
   preBuild = ''
     export MAKEFLAGS="-j $NIX_BUILD_CORES"

--- a/pkgs/servers/samba/4.x.nix
+++ b/pkgs/servers/samba/4.x.nix
@@ -35,6 +35,7 @@
   rpcsvc-proto,
   bash,
   python3Packages,
+  pkgsHostTarget,
   nixosTests,
   libiconv,
   testers,
@@ -113,7 +114,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     python3Packages.python
-    python3Packages.wrapPython
+    # Not `python3Packages.wrapPython` to workaround
+    # `python3Packages.wrapPython.__spliced.buildHost` having the wrong
+    # `pythonHost`. See https://github.com/NixOS/nixpkgs/issues/434307
+    pkgsHostTarget.python3Packages.wrapPython
     wafHook
     pkg-config
     bison
@@ -310,15 +314,6 @@ stdenv.mkDerivation (finalAttrs: {
 
     # Fix PYTHONPATH for some tools
     wrapPythonPrograms
-
-    # Samba does its own shebang patching, but uses build Python
-    find $out/bin -type f -executable | while read file; do
-      isScript "$file" || continue
-      substituteInPlace "$file" \
-        --replace-fail \
-          ${lib.getBin buildPackages.python3Packages.python} \
-          ${lib.getBin python3Packages.python}
-    done
   '';
 
   disallowedReferences = lib.optionals isCross [


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc