### PR TITLE
formiko: migrate to by-name, switch to PEP 517, and update GTK deps

### DIFF
--- a/pkgs/by-name/fo/formiko/package.nix
+++ b/pkgs/by-name/fo/formiko/package.nix
@@ -1,44 +1,50 @@
 {
   lib,
-  buildPythonApplication,
+  python3Packages,
   fetchFromGitHub,
   wrapGAppsHook3,
   gobject-introspection,
   gtk3,
-  docutils,
-  gtksourceview,
+  gtksourceview4,
   gtkspell3,
   librsvg,
-  pygobject3,
   webkitgtk_4_1,
 }:
 
-buildPythonApplication (finalAttrs: {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "formiko";
   version = "1.5.0";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ondratu";
     repo = "formiko";
     tag = finalAttrs.version;
-    sha256 = "sha256-slfpkckCvxHJ/jlBP7QAhzaf9TAcS6biDQBZcBTyTKI=";
+    hash = "sha256-slfpkckCvxHJ/jlBP7QAhzaf9TAcS6biDQBZcBTyTKI=";
   };
+
+  build-system = [
+    python3Packages.setuptools
+  ];
 
   nativeBuildInputs = [
     wrapGAppsHook3
     gobject-introspection
     gtk3
   ];
-  propagatedBuildInputs = [
-    docutils
+
+  buildInputs = [
     gobject-introspection
     gtk3
-    gtksourceview
+    gtksourceview4
     gtkspell3
     librsvg
-    pygobject3
     webkitgtk_4_1
+  ];
+
+  dependencies = [
+    python3Packages.pygobject3
+    python3Packages.docutils
   ];
 
   # Needs a display

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9498,12 +9498,6 @@ with pkgs;
     pname = "floorp-bin";
   };
 
-  formiko =
-    with python3Packages;
-    callPackage ../applications/editors/formiko {
-      inherit buildPythonApplication;
-    };
-
   inherit
     ({
       freeoffice = callPackage ../applications/office/softmaker/freeoffice.nix { };


### PR DESCRIPTION
This pull request updates the packaging for the `formiko` Python application to modernize its build approach and move it to the new package set structure. The changes migrate the package to use `python3Packages`, update dependencies, and relocate the package file for consistency with the repository's organization.

**Migration to new package set and build system:**
- Moved the `formiko` package definition from `pkgs/applications/editors/formiko/default.nix` to `pkgs/by-name/fo/formiko/package.nix`, aligning it with the new by-name package structure.
- Updated the build process to use `python3Packages.buildPythonApplication` with `pyproject` support, and switched to using the `python3Packages` set for dependencies.
- Changed the dependency from `gtksourceview` to `gtksourceview4`, and added `python3Packages.pygobject3` as a dependency in the new format.

**Repository organization and cleanup:**
- Removed the old `formiko` package entry from `pkgs/top-level/all-packages.nix` as it is now managed under the new structure.

**Syntax and structure updates:**
- Updated the Nix expression syntax to use the new function style and attributes, improving maintainability and consistency.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
