### PR TITLE
mlx42: 2.4.1 -> 2.4.2

### DIFF
--- a/pkgs/by-name/ml/mlx42/package.nix
+++ b/pkgs/by-name/ml/mlx42/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   cmake,
   glfw,
   enableShared ? !stdenv.hostPlatform.isStatic,
@@ -11,31 +10,17 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "mlx42";
-  version = "2.4.1";
+  version = "2.4.2";
 
   src = fetchFromGitHub {
     owner = "codam-coding-college";
     repo = "MLX42";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-/HCP6F7N+J97n4orlLxg/4agEoq4+rJdpeW/3q+DI1I=";
+    hash = "sha256-IMwDdWtbu882N43oTr/c6Fq34TduCuUt34Vh2Hx/TJY=";
   };
-
-  patches = [
-    # clang no longer allows using -Ofast
-    # see: https://github.com/codam-coding-college/MLX42/issues/147
-    (fetchpatch {
-      name = "replace-ofast-with-o3.patch";
-      url = "https://github.com/codam-coding-college/MLX42/commit/ce254c3a19af8176787601a2ac3490100a5c4c61.patch";
-      hash = "sha256-urL/WVOXinf7hWR5kH+bAVTcAzldkkWfY0+diSf7jHE=";
-    })
-  ];
 
   postPatch = ''
     patchShebangs --build ./tools
-  ''
-  + lib.optionalString enableShared ''
-    substituteInPlace CMakeLists.txt \
-      --replace-fail "mlx42 STATIC" "mlx42 SHARED"
   '';
 
   strictDeps = true;
@@ -44,7 +29,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [ glfw ];
 
-  cmakeFlags = [ (lib.cmakeBool "DEBUG" enableDebug) ];
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_SHARED_LIBS" enableShared)
+    (lib.cmakeBool "DEBUG" enableDebug)
+  ];
 
   postInstall = ''
     mkdir -p $out/lib/pkgconfig


### PR DESCRIPTION
https://github.com/codam-coding-college/MLX42/releases/tag/v2.4.2

I could remove several patches
I did not succeed in properly making the python bindings work, so I just left them out for now.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
