### PR TITLE
gscrabble: migrate to by-name, update to 1.6+ordissimo1

### DIFF
--- a/pkgs/by-name/gs/gscrabble/package.nix
+++ b/pkgs/by-name/gs/gscrabble/package.nix
@@ -1,26 +1,24 @@
 {
   lib,
-  buildPythonApplication,
+  python3Packages,
   fetchFromGitHub,
-  gtk3,
+  gtk4,
   wrapGAppsHook3,
   gst_all_1,
   gobject-introspection,
-  gst-python,
-  pygobject3,
   adwaita-icon-theme,
 }:
 
-buildPythonApplication {
+python3Packages.buildPythonApplication {
   pname = "gscrabble";
-  version = "unstable-2020-04-21";
-  format = "setuptools";
+  version = "1.6";
+  format = "other";
 
   src = fetchFromGitHub {
-    owner = "RaaH";
+    owner = "ThierryHFR";
     repo = "gscrabble";
-    rev = "aba37f062a6b183dcc084c453f395af1dc437ec8";
-    sha256 = "sha256-rYpPHgOlPRnlA+Nkvo/J+/8/vl24/Ssk55fTq9oNCz4=";
+    tag = "1.6+ordissimo1";
+    hash = "sha256-4xFwpmWFamMUbzesp0wLTw/jh4h201wI/a7TWqfao+k=";
   };
 
   doCheck = false;
@@ -36,13 +34,25 @@ buildPythonApplication {
     gst-plugins-ugly
     gst-plugins-bad
     adwaita-icon-theme
-    gtk3
+    gtk4
   ];
 
-  propagatedBuildInputs = [
-    gst-python
-    pygobject3
+  dependencies = [
+    python3Packages.gst-python
+    python3Packages.pygobject3
   ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/GScrabble
+    cp -r * $out/share/GScrabble/
+
+    mkdir -p $out/bin
+    install -m755 gscrabble $out/bin/gscrabble
+
+    runHook postInstall
+  '';
 
   preFixup = ''
     gappsWrapperArgs+=(
@@ -51,12 +61,8 @@ buildPythonApplication {
   '';
 
   meta = {
-    # Fails to build, probably incompatible with latest Python
-    # error: Multiple top-level packages discovered in a flat-layout
-    # https://github.com/RaaH/gscrabble/issues/13
-    broken = true;
     description = "Golden Scrabble crossword puzzle game";
-    homepage = "https://github.com/RaaH/gscrabble/";
+    homepage = "https://github.com/ThierryHFR/gscrabble/";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ onny ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12455,8 +12455,6 @@ with pkgs;
 
   freeciv_gtk = freeciv;
 
-  gscrabble = python3Packages.callPackage ../games/gscrabble { };
-
   ibmcloud-cli = callPackage ../tools/admin/ibmcloud-cli { stdenv = stdenvNoCC; };
 
   # used as base package for iortcw forks


### PR DESCRIPTION
This pull request updates and modernizes the packaging of the `gscrabble` game for Nixpkgs. The package has been moved to the `by-name` directory, updated to a newer upstream version, migrated to GTK4, and its build inputs and installation logic have been improved for better compatibility and maintainability.

Key changes:

**Package update and migration:**
* Updated `gscrabble` to version 1.6 from a new upstream repository and tag, replacing the old unstable version and owner.
* Migrated the package from `pkgs/games/gscrabble/default.nix` to `pkgs/by-name/gs/gscrabble/package.nix` as part of the by-name reorganization.

**Build system and dependencies:**
* Switched from using `buildPythonApplication` directly to `python3Packages.buildPythonApplication` and updated the build format and dependency handling (`dependencies` instead of `propagatedBuildInputs`). 

* Updated dependencies to use GTK4 instead of GTK3 and referenced Python dependencies from `python3Packages`. 

**Installation and packaging improvements:**
* Added a custom `installPhase` to ensure files are installed into appropriate locations and the executable is properly set up.
* Removed the `broken = true;` meta attribute, as the package is now updated and buildable.

**Top-level package list cleanup:**
* Removed the old top-level reference to `gscrabble` from `all-packages.nix`, as the package is now handled via the by-name mechanism.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
