### PR TITLE
python3Packages.aioimaplib: patch tests for Python 3.14

### DIFF
--- a/pkgs/development/python-modules/aioimaplib/default.nix
+++ b/pkgs/development/python-modules/aioimaplib/default.nix
@@ -24,6 +24,11 @@ buildPythonPackage rec {
     hash = "sha256-njzSpKPis033eLoRKXL538ljyMOB43chslio1wodrKU=";
   };
 
+  patches = [
+    # https://github.com/iroco-co/aioimaplib/issues/125
+    ./event-loop.patch
+  ];
+
   build-system = [ poetry-core ];
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/aioimaplib/event-loop.patch
+++ b/pkgs/development/python-modules/aioimaplib/event-loop.patch
@@ -1,0 +1,25 @@
+diff --git a/aioimaplib/imap_testing_server.py b/aioimaplib/imap_testing_server.py
+index b303aa3..419b808 100644
+--- a/aioimaplib/imap_testing_server.py
++++ b/aioimaplib/imap_testing_server.py
+@@ -198,12 +198,18 @@ class ImapProtocol(asyncio.Protocol):
+     DEFAULT_QUOTA = 5000
+ 
+     def __init__(self, server_state, fetch_chunk_size=0, capabilities=CAPABILITIES,
+-                 loop=asyncio.get_event_loop()):
++                 loop=None):
+         self.uidvalidity = int(datetime.now().timestamp())
+         self.capabilities = capabilities
+         self.state_to_send = list()
+         self.delay_seconds = 0
+-        self.loop = loop
++        if loop is None:
++            try:
++                self.loop = asyncio.get_running_loop()
++            except RuntimeError:
++                self.loop = asyncio.new_event_loop()
++        else:
++            self.loop = loop
+         self.fetch_chunk_size = fetch_chunk_size
+         self.transport = None
+         self.server_state = server_state


### PR DESCRIPTION
The upstream code isn't set up to use pytest-asyncio and fails at test collection on Python 3.14. Patched to fix.

Filed https://github.com/iroco-co/aioimaplib/issues/125

Tracking: #475732 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
