### PR TITLE
[TEST] workflows/eval: evaluate ci/pinned.json changes at their commit

### DIFF
--- a/.github/actions/checkout/action.yml
+++ b/.github/actions/checkout/action.yml
@@ -20,6 +20,7 @@ runs:
         PIN_BUMP_SHA: ${{ inputs.untrusted-pin-bump }}
       with:
         script: |
+          const { rm, writeFile } = require('node:fs/promises')
           const { spawn } = require('node:child_process')
           const { join } = require('node:path')
 
@@ -55,10 +56,19 @@ runs:
             return pinned.pins.nixpkgs.revision
           }
 
-          const pin_bump_sha = process.env.PIN_BUMP_SHA
+          // Getting the pin-bump diff via the API avoids issues with `git fetch`
+          // thin-packs not having enough base objects to be applied locally.
+          // Returns a unified diff suitable for `git apply`.
+          async function getPinBumpDiff(ref) {
+            const { data } = await github.rest.repos.getCommit({
+              mediaType: { format: 'diff' },
+              ...context.repo,
+              ref,
+            })
+            return data
+          }
 
-          // When dealing with a pin bump commit, we need `--depth=2` to view & apply its diff
-          const depth = pin_bump_sha ? 2 : 1
+          const pin_bump_sha = process.env.PIN_BUMP_SHA
 
           const commits = [
             {
@@ -76,17 +86,14 @@ runs:
             {
               sha: await getPinnedSha(process.env.TARGET_SHA),
               path: 'trusted-pinned'
-            },
-            {
-              sha: pin_bump_sha
             }
           ].filter(({ sha }) => Boolean(sha))
 
-          console.log('Fetching the following commits:', commits)
+          console.log('Checking out the following commits:', commits)
 
           // Fetching all commits at once is much faster than doing multiple checkouts.
           // This would fail without --refetch, because the we had a partial clone before, but changed it above.
-          await run('git', 'fetch', `--depth=${depth}`, '--refetch', 'origin', ...(commits.map(({ sha }) => sha)))
+          await run('git', 'fetch', '--depth=1', '--refetch', 'origin', ...(commits.map(({ sha }) => sha)))
 
           // Checking out onto tmpfs takes 1s and is faster by at least factor 10x.
           await run('mkdir', 'nixpkgs')
@@ -101,20 +108,21 @@ runs:
 
           // Create all worktrees in parallel.
           await Promise.all(
-            commits
-              .filter(({ path }) => Boolean(path))
-              .map(async ({ sha, path }) => {
-                await run('git', 'worktree', 'add', join('nixpkgs', path), sha, '--no-checkout')
-                await run('git', '-C', join('nixpkgs', path), 'sparse-checkout', 'disable')
-                await run('git', '-C', join('nixpkgs', path), 'checkout', '--progress')
-              })
+            commits.map(async ({ sha, path }) => {
+              await run('git', 'worktree', 'add', join('nixpkgs', path), sha, '--no-checkout')
+              await run('git', '-C', join('nixpkgs', path), 'sparse-checkout', 'disable')
+              await run('git', '-C', join('nixpkgs', path), 'checkout', '--progress')
+            })
           )
 
           // Apply pin bump to untrusted worktree
           if (pin_bump_sha) {
-            console.log('Applying untrusted ci/pinned.json bump:', pin_bump_sha)
+            console.log('Fetching ci/pinned.json bump commit:', pin_bump_sha)
+            await writeFile('pin-bump.patch', await getPinBumpDiff(pin_bump_sha))
+
+            console.log('Applying untrusted ci/pinned.json bump to ./nixpkgs/untrusted')
             try {
-              await run('git', '-C', join('nixpkgs', 'untrusted'), 'cherry-pick', '--no-commit', pin_bump_sha)
+              await run('git', '-C', join('nixpkgs', 'untrusted'), 'apply', '--3way', '../../pin-bump.patch')
             } catch {
               core.setFailed([
                 `Failed to apply ci/pinned.json bump commit ${pin_bump_sha}.`,
@@ -122,5 +130,7 @@ runs:
                 `Please rebase the PR or ensure the pin bump is standalone.`
               ].join(' '))
               return
+            } finally {
+              await rm('pin-bump.patch')
             }
           }

--- a/.github/actions/checkout/action.yml
+++ b/.github/actions/checkout/action.yml
@@ -122,7 +122,7 @@ runs:
 
             console.log('Applying untrusted ci/pinned.json bump to ./nixpkgs/untrusted')
             try {
-              await run('git', '-C', join('nixpkgs', 'untrusted'), 'apply', '--3way', '../../pin-bump.patch')
+              await run('git', '-C', join('nixpkgs', 'untrusted'), 'apply', '--3way', join('..', '..', 'pin-bump.patch'))
             } catch {
               core.setFailed([
                 `Failed to apply ci/pinned.json bump commit ${pin_bump_sha}.`,

--- a/ci/pinned.json
+++ b/ci/pinned.json
@@ -9,9 +9,9 @@
       },
       "branch": "nixpkgs-unstable",
       "submodules": false,
-      "revision": "ee09932cedcef15aaf476f9343d1dea2cb77e261",
-      "url": "https://github.com/NixOS/nixpkgs/archive/ee09932cedcef15aaf476f9343d1dea2cb77e261.tar.gz",
-      "hash": "1xz5pa6la2fyj5b1cfigmg3nmml11fyf9ah0rnr4zfgmnwimn2gn"
+      "revision": "c6245e83d836d0433170a16eb185cefe0572f8b8",
+      "url": "https://github.com/NixOS/nixpkgs/archive/c6245e83d836d0433170a16eb185cefe0572f8b8.tar.gz",
+      "hash": "1dvhyaddi7d4fkj63hns1xrdqcmyyq24y89k0cdwxs8s3619bx8v"
     },
     "treefmt-nix": {
       "type": "Git",

--- a/pkgs/by-name/he/hello/package.nix
+++ b/pkgs/by-name/he/hello/package.nix
@@ -21,6 +21,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = lib.optional stdenv.hostPlatform.isCygwin gnulib.patches.memcpy-fix-backport-250512;
 
+  TEST = 123;
+
   # The GNU Hello `configure` script detects how to link libiconv but fails to actually make use of that.
   # Unfortunately, this cannot be a patch to `Makefile.am` because `autoreconfHook` causes a gettext
   # infrastructure mismatch error when trying to build `hello`.


### PR DESCRIPTION
This PR tests #480395 in production

EDIT: later used to test #482470 too.

<details><summary>Outdated notes</summary>
<p>

### Test 1 (43b219898e70) should "fail":
- Bumps nixpkgs to a 2025-12-18 revision.
- Reverts the earlier bump.
- Reapplies it

This [failed as expected](https://github.com/NixOS/nixpkgs/actions/runs/21043436894/job/60511275081?pr=480436#step:4:56):
```
Error: Error: Multiple commits touch ci/pinned.json in this PR:
d40b6518bace95ce0abe78304c3d9ebebbb9fb3e
cac5910069516f8122a2836fec8221a3e005ada5
43b219898e706d5dbae968621e88078e4c62d1a8
18065c8c13cd173a7911f1b67ec346ffc7f72182
Please ensure only a single commit modifies ci/pinned.json for accurate version matrix evaluation.
```

### Test 2 (cd0b73f24f46b64ed0d25f340f43a8b0f07f3779) should be "ok":
- Bumps nixpkgs to a 2025-12-18 revision.

<details><summary>Attempt 1</summary>
<p>

This [failed unexpectedly](https://github.com/NixOS/nixpkgs/actions/runs/21044001823/job/60513284413?pr=480436#step:4:56), finding an additional commit that is not part of this PR:
```
Error: Error: Multiple commits touch ci/pinned.json in this PR:
d40b6518bace95ce0abe78304c3d9ebebbb9fb3e
05d622cced19c0f67c73b4afe85014b1e06f3c50
Please ensure only a single commit modifies ci/pinned.json for accurate version matrix evaluation.
```

It lists d40b6518bace95ce0abe78304c3d9ebebbb9fb3e from this PR and  05d622cced19c0f67c73b4afe85014b1e06f3c50 the merge commit. See https://github.com/NixOS/nixpkgs/pull/480395/changes#r2695743434.

</p>
</details> 

Attempt 2 (with the PR updated to use HEAD SHA) seems to work:
https://github.com/NixOS/nixpkgs/actions/runs/21045169842/job/60517468599?pr=480436#step:4:61
```
Found pinned.json commit: cd0b73f24f46b64ed0d25f340f43a8b0f07f3779
```

However the `report` job unexpectedly finds changed outPaths:
https://github.com/NixOS/nixpkgs/actions/runs/21045169842/job/60525175036?pr=480436#step:3:82
```
Error: lixPackageSets.git.lix on aarch64-linux has changed outpaths!
Note: This indicates that commit cd0b73f24f46b64ed0d25f340f43a8b0f07f3779 (which modified ci/pinned.json) also contains other changes that affect package outputs. Please ensure ci/pinned.json is updated in a standalone commit.
```

Despite eval's comparison reporting _zero_ changes.

### Test 3 (827ad3708fbb98cbddcd3eac86ce5be2565f5568) should be "ok":
- Bumps nixpkgs to a 2025-12-18 revision.
- Modifies an unrelated package in a separate commit

Attempt 1: fails unexpectedly:
- `versions` finds the correct commit:
  https://github.com/NixOS/nixpkgs/actions/runs/21045403802/job/60518361251?pr=480436#step:4:61
  ```
  Found pinned.json commit: cd0b73f24f46b64ed0d25f340f43a8b0f07f3779
  ```
- `report` complains that 827ad3708fbb98cbddcd3eac86ce5be2565f5568's parent (cd0b73f24f46b64ed0d25f340f43a8b0f07f3779) has rebuilds:
  https://github.com/NixOS/nixpkgs/actions/runs/21045403802/job/60519795391?pr=480436#step:3:82
  ```
  Error: lixPackageSets.git.lix on aarch64-linux has changed outpaths!
  Note: This indicates that commit cd0b73f24f46b64ed0d25f340f43a8b0f07f3779 (which modified ci/pinned.json) also contains other changes that affect package outputs. Please ensure ci/pinned.json is updated in a standalone commit.
  ```


</p>
</details> 