### PR TITLE
csso-cli: init at 4.0.2

### DIFF
--- a/pkgs/by-name/cs/csso-cli/package.nix
+++ b/pkgs/by-name/cs/csso-cli/package.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+}:
+buildNpmPackage (finalAttrs: {
+  pname = "csso-cli";
+  version = "4.0.2";
+
+  src = fetchFromGitHub {
+    owner = "css";
+    repo = "csso";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-uPjRSBOFEl55gyObKEZMXGQ6eaQ3tBB48k5JgLGrbTw=";
+  };
+
+  npmDepsHash = "sha256-rGqj1vCswUfAQwM1Lk1qCWgUfzeefBONHeEn0NusOoc=";
+
+  dontNpmBuild = true;
+
+  meta = {
+    description = "Command line interface for CSSO, a CSS minifier with structural optimizations";
+    homepage = "https://github.com/css/csso-cli";
+    changelog = "https://github.com/css/csso-cli/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    mainProgram = "csso";
+    maintainers = with lib.maintainers; [ ners ];
+  };
+})


### PR DESCRIPTION


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
