### PR TITLE
keycloak.plugins: add new plugins from extensions page

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14219,6 +14219,12 @@
     githubId = 160317;
     name = "Kristoffer Søholm";
   };
+  krit = {
+    email = "dasskrit@gmail.com";
+    github = "kritdass";
+    githubId = 68750861;
+    name = "Krit Dass";
+  };
   kritnich = {
     email = "kritnich@kritni.ch";
     github = "Kritnich";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12071,18 +12071,18 @@
     githubId = 1198065;
     name = "Jeffrey David Johnson";
   };
-  jefflabonte = {
-    email = "jean-francois.labonte@brightonlabs.ai";
-    github = "JeffLabonte";
-    githubId = 9425955;
-    name = "Jean-François Labonté";
-  };
   jefferyoo = {
     email = "oojefferywm@proton.me";
     github = "jefferyoo";
     githubId = 237098253;
     name = "Jeffery Oo";
     keys = [ { fingerprint = "7129 408E 3D97 47EB FCE1  A6D5 1999 2BEC E706 CC59"; } ];
+  };
+  jefflabonte = {
+    email = "jean-francois.labonte@brightonlabs.ai";
+    github = "JeffLabonte";
+    githubId = 9425955;
+    name = "Jean-François Labonté";
   };
   jemand771 = {
     email = "willy@jemand771.net";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12077,6 +12077,13 @@
     githubId = 9425955;
     name = "Jean-François Labonté";
   };
+  jefferyoo = {
+    email = "oojefferywm@proton.me";
+    github = "jefferyoo";
+    githubId = 237098253;
+    name = "Jeffery Oo";
+    keys = [ { fingerprint = "7129 408E 3D97 47EB FCE1  A6D5 1999 2BEC E706 CC59"; } ];
+  };
   jemand771 = {
     email = "willy@jemand771.net";
     github = "jemand771";

--- a/pkgs/by-name/ke/keycloak/all-plugins.nix
+++ b/pkgs/by-name/ke/keycloak/all-plugins.nix
@@ -13,6 +13,7 @@
   keycloak-metrics-spi = callPackage ./keycloak-metrics-spi { };
   keycloak-restrict-client-auth = callPackage ./keycloak-restrict-client-auth { };
   keycloak-remember-me-authenticator = callPackage ./keycloak-remember-me-authenticator { };
+  keycloak-2fa-sms-authenticator = callPackage ./keycloak-2fa-sms-authenticator { };
 
   # junixsocket provides Unix domain socket support for JDBC connections,
   # which is required for connecting to PostgreSQL via Unix socket.

--- a/pkgs/by-name/ke/keycloak/all-plugins.nix
+++ b/pkgs/by-name/ke/keycloak/all-plugins.nix
@@ -15,6 +15,7 @@
   keycloak-remember-me-authenticator = callPackage ./keycloak-remember-me-authenticator { };
   keycloak-2fa-sms-authenticator = callPackage ./keycloak-2fa-sms-authenticator { };
   keycloak-enforce-mfa-authenticator = callPackage ./keycloak-enforce-mfa-authenticator { };
+  keycloak-orgs = callPackage ./keycloak-orgs { };
 
   # junixsocket provides Unix domain socket support for JDBC connections,
   # which is required for connecting to PostgreSQL via Unix socket.

--- a/pkgs/by-name/ke/keycloak/all-plugins.nix
+++ b/pkgs/by-name/ke/keycloak/all-plugins.nix
@@ -14,6 +14,7 @@
   keycloak-orgs = callPackage ./keycloak-orgs { };
   keycloak-remember-me-authenticator = callPackage ./keycloak-remember-me-authenticator { };
   keycloak-restrict-client-auth = callPackage ./keycloak-restrict-client-auth { };
+  keycloak-secrets-vault-provider = callPackage ./keycloak-secrets-vault-provider { };
   scim-for-keycloak = callPackage ./scim-for-keycloak { };
   scim-keycloak-user-storage-spi = callPackage ./scim-keycloak-user-storage-spi { };
 

--- a/pkgs/by-name/ke/keycloak/all-plugins.nix
+++ b/pkgs/by-name/ke/keycloak/all-plugins.nix
@@ -14,6 +14,7 @@
   keycloak-restrict-client-auth = callPackage ./keycloak-restrict-client-auth { };
   keycloak-remember-me-authenticator = callPackage ./keycloak-remember-me-authenticator { };
   keycloak-2fa-sms-authenticator = callPackage ./keycloak-2fa-sms-authenticator { };
+  keycloak-enforce-mfa-authenticator = callPackage ./keycloak-enforce-mfa-authenticator { };
 
   # junixsocket provides Unix domain socket support for JDBC connections,
   # which is required for connecting to PostgreSQL via Unix socket.

--- a/pkgs/by-name/ke/keycloak/all-plugins.nix
+++ b/pkgs/by-name/ke/keycloak/all-plugins.nix
@@ -6,16 +6,16 @@
 }:
 
 {
-  scim-for-keycloak = callPackage ./scim-for-keycloak { };
-  scim-keycloak-user-storage-spi = callPackage ./scim-keycloak-user-storage-spi { };
+  keycloak-2fa-sms-authenticator = callPackage ./keycloak-2fa-sms-authenticator { };
   keycloak-discord = callPackage ./keycloak-discord { };
+  keycloak-enforce-mfa-authenticator = callPackage ./keycloak-enforce-mfa-authenticator { };
   keycloak-magic-link = callPackage ./keycloak-magic-link { };
   keycloak-metrics-spi = callPackage ./keycloak-metrics-spi { };
-  keycloak-restrict-client-auth = callPackage ./keycloak-restrict-client-auth { };
-  keycloak-remember-me-authenticator = callPackage ./keycloak-remember-me-authenticator { };
-  keycloak-2fa-sms-authenticator = callPackage ./keycloak-2fa-sms-authenticator { };
-  keycloak-enforce-mfa-authenticator = callPackage ./keycloak-enforce-mfa-authenticator { };
   keycloak-orgs = callPackage ./keycloak-orgs { };
+  keycloak-remember-me-authenticator = callPackage ./keycloak-remember-me-authenticator { };
+  keycloak-restrict-client-auth = callPackage ./keycloak-restrict-client-auth { };
+  scim-for-keycloak = callPackage ./scim-for-keycloak { };
+  scim-keycloak-user-storage-spi = callPackage ./scim-keycloak-user-storage-spi { };
 
   # junixsocket provides Unix domain socket support for JDBC connections,
   # which is required for connecting to PostgreSQL via Unix socket.

--- a/pkgs/by-name/ke/keycloak/all-plugins.nix
+++ b/pkgs/by-name/ke/keycloak/all-plugins.nix
@@ -4,9 +4,9 @@
   junixsocket-common,
   junixsocket-native-common,
 }:
-
 {
   keycloak-2fa-sms-authenticator = callPackage ./keycloak-2fa-sms-authenticator { };
+  keycloak-config-cli = callPackage ./keycloak-config-cli { };
   keycloak-discord = callPackage ./keycloak-discord { };
   keycloak-enforce-mfa-authenticator = callPackage ./keycloak-enforce-mfa-authenticator { };
   keycloak-magic-link = callPackage ./keycloak-magic-link { };

--- a/pkgs/by-name/ke/keycloak/keycloak-2fa-sms-authenticator/default.nix
+++ b/pkgs/by-name/ke/keycloak/keycloak-2fa-sms-authenticator/default.nix
@@ -30,7 +30,7 @@ maven.buildMavenPackage rec {
   installPhase = ''
     runHook preInstall
     install -Dm644 sms-authenticator/target/netzbegruenung.sms-authenticator-v${version}.jar \
-      $out/share/java/keycloak/keycloak-2fa-sms-authenticator.jar
+      $out/keycloak-2fa-sms-authenticator.jar
     runHook postInstall
   '';
 

--- a/pkgs/by-name/ke/keycloak/keycloak-2fa-sms-authenticator/default.nix
+++ b/pkgs/by-name/ke/keycloak/keycloak-2fa-sms-authenticator/default.nix
@@ -1,0 +1,43 @@
+{
+  stdenv,
+  maven,
+  lib,
+  fetchFromGitHub,
+}:
+maven.buildMavenPackage rec {
+  pname = "keycloak-2fa-sms-authenticator";
+  version = "26.4.10";
+
+  src = fetchFromGitHub {
+    owner = "netzbegruenung";
+    repo = "keycloak-mfa-plugins";
+    tag = "v${version}";
+    hash = "sha256-J7t/SRfK/LTcW7Y+D6bkHcXK+lKqUYLEqSpNWJUC3kQ=";
+  };
+
+  mvnHash =
+    let
+      mvnHashes = {
+        "aarch64-darwin" = "sha256-eRlu24SYe+PBOTKoAQPd5MoM7VUxHZx4/uiW6mV2PZI=";
+        "x86_64-darwin" = "sha256-p+XpCjXiEPMJnXIrbD2Qse/csZfv8YZ6h+sNZitCyro=";
+        "aarch64-linux" = "sha256-4P9qM3X99dEy3ssr1+vp65QUJikRfE4EoK6LOta9IFs=";
+        "x86_64-linux" = "sha256-wxgEHC1xJahyoizozvRfRZAWTjrYmYNM42yk+ZRke5A=";
+      };
+    in
+    mvnHashes.${stdenv.hostPlatform.system}
+      or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm644 sms-authenticator/target/netzbegruenung.sms-authenticator-v${version}.jar \
+      $out/share/java/keycloak/keycloak-2fa-sms-authenticator.jar
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://github.com/netzbegruenung/keycloak-mfa-plugins";
+    description = "Keycloak authentication provider for 2FA via SMS";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ anish ];
+  };
+}

--- a/pkgs/by-name/ke/keycloak/keycloak-config-cli/default.nix
+++ b/pkgs/by-name/ke/keycloak/keycloak-config-cli/default.nix
@@ -21,7 +21,7 @@ maven.buildMavenPackage rec {
 
   installPhase = ''
     runHook preInstall
-    install -Dm444 target/keycloak-config-cli.jar "$out/keycloak-config-cli.jar"
+    install -Dm444 -t "$out" target/keycloak-config-cli.jar
     runHook postInstall
   '';
 

--- a/pkgs/by-name/ke/keycloak/keycloak-config-cli/default.nix
+++ b/pkgs/by-name/ke/keycloak/keycloak-config-cli/default.nix
@@ -1,0 +1,37 @@
+{
+  maven,
+  lib,
+  fetchFromGitHub,
+}:
+maven.buildMavenPackage rec {
+  pname = "keycloak-config-cli";
+  version = "6.4.0";
+
+  src = fetchFromGitHub {
+    owner = "adorsys";
+    repo = "keycloak-config-cli";
+    tag = "v${version}";
+    hash = "sha256-Vg56Dz9U0eAJw+7u90MSZWmMIZttWYGXAwsXZsEfTj8=";
+  };
+
+  mvnHash = "sha256-tdh8hRqGXI3zuwy55dC3La9dm2naqeCEZT4qcw37iDI=";
+
+  # Tests use MockServer which needs to bind to a local port
+  __darwinAllowLocalNetworking = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm444 target/keycloak-config-cli.jar "$out/keycloak-config-cli.jar"
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://github.com/adorsys/keycloak-config-cli/";
+    description = "Import YAML/JSON-formatted configuration files into Keycloak";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      jefferyoo
+      anish
+    ];
+  };
+}

--- a/pkgs/by-name/ke/keycloak/keycloak-discord/default.nix
+++ b/pkgs/by-name/ke/keycloak/keycloak-discord/default.nix
@@ -29,7 +29,7 @@ maven.buildMavenPackage rec {
 
   installPhase = ''
     runHook preInstall
-    install -Dm444 target/keycloak-discord-${version}.jar "$out/keycloak-discord-${version}.jar"
+    install -Dm444 -t "$out" target/keycloak-discord-${version}.jar
     runHook postInstall
   '';
 

--- a/pkgs/by-name/ke/keycloak/keycloak-enforce-mfa-authenticator/default.nix
+++ b/pkgs/by-name/ke/keycloak/keycloak-enforce-mfa-authenticator/default.nix
@@ -1,0 +1,43 @@
+{
+  stdenv,
+  maven,
+  lib,
+  fetchFromGitHub,
+}:
+maven.buildMavenPackage rec {
+  pname = "keycloak-enforce-mfa-authenticator";
+  version = "26.4.10";
+
+  src = fetchFromGitHub {
+    owner = "netzbegruenung";
+    repo = "keycloak-mfa-plugins";
+    tag = "v${version}";
+    hash = "sha256-J7t/SRfK/LTcW7Y+D6bkHcXK+lKqUYLEqSpNWJUC3kQ=";
+  };
+
+  mvnHash =
+    let
+      mvnHashes = {
+        "aarch64-darwin" = "sha256-eRlu24SYe+PBOTKoAQPd5MoM7VUxHZx4/uiW6mV2PZI=";
+        "x86_64-darwin" = "sha256-p+XpCjXiEPMJnXIrbD2Qse/csZfv8YZ6h+sNZitCyro=";
+        "aarch64-linux" = "sha256-4P9qM3X99dEy3ssr1+vp65QUJikRfE4EoK6LOta9IFs=";
+        "x86_64-linux" = "sha256-wxgEHC1xJahyoizozvRfRZAWTjrYmYNM42yk+ZRke5A=";
+      };
+    in
+    mvnHashes.${stdenv.hostPlatform.system}
+      or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm644 enforce-mfa/target/netzbegruenung.enforce-mfa-v${version}.jar \
+      $out/share/java/keycloak/keycloak-enforce-mfa-authenticator.jar
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://github.com/netzbegruenung/keycloak-mfa-plugins";
+    description = "Keycloak authenticator that enforces MFA";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ anish ];
+  };
+}

--- a/pkgs/by-name/ke/keycloak/keycloak-enforce-mfa-authenticator/default.nix
+++ b/pkgs/by-name/ke/keycloak/keycloak-enforce-mfa-authenticator/default.nix
@@ -30,7 +30,7 @@ maven.buildMavenPackage rec {
   installPhase = ''
     runHook preInstall
     install -Dm644 enforce-mfa/target/netzbegruenung.enforce-mfa-v${version}.jar \
-      $out/share/java/keycloak/keycloak-enforce-mfa-authenticator.jar
+      $out/keycloak-enforce-mfa-authenticator.jar
     runHook postInstall
   '';
 

--- a/pkgs/by-name/ke/keycloak/keycloak-orgs/default.nix
+++ b/pkgs/by-name/ke/keycloak/keycloak-orgs/default.nix
@@ -1,0 +1,34 @@
+{
+  maven,
+  lib,
+  fetchFromGitHub,
+}:
+maven.buildMavenPackage rec {
+  pname = "keycloak-orgs";
+  version = "0.126";
+
+  src = fetchFromGitHub {
+    owner = "p2-inc";
+    repo = "keycloak-orgs";
+    tag = "v${version}";
+    hash = "sha256-AQvIkmm8YJoNMcN+85OEbBud7YDLAlk5NfC05js1k2Y=";
+  };
+
+  mvnHash = "sha256-lq3N0XBRyR9I6U0gvjsjJ9r6fZINSsTWAMvdDEIsT0g=";
+
+  # Tell buildnumber-maven-plugin to use a fallback value because git/.git aren't present
+  mvnParameters = "-Dmaven.buildNumber.revisionOnScmFailure=v${version} -DskipTests";
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm644 target/keycloak-orgs-${version}.jar $out/share/java/keycloak/keycloak-orgs.jar
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://github.com/p2-inc/keycloak-orgs";
+    description = "Multi-tenancy on a single Keycloak realm via first-class organization objects";
+    license = lib.licenses.elastic20;
+    maintainers = with lib.maintainers; [ anish ];
+  };
+}

--- a/pkgs/by-name/ke/keycloak/keycloak-orgs/default.nix
+++ b/pkgs/by-name/ke/keycloak/keycloak-orgs/default.nix
@@ -21,7 +21,7 @@ maven.buildMavenPackage rec {
 
   installPhase = ''
     runHook preInstall
-    install -Dm644 target/keycloak-orgs-${version}.jar $out/share/java/keycloak/keycloak-orgs.jar
+    install -Dm644 -t "$out" target/keycloak-orgs-${version}.jar
     runHook postInstall
   '';
 

--- a/pkgs/by-name/ke/keycloak/keycloak-restrict-client-auth/default.nix
+++ b/pkgs/by-name/ke/keycloak/keycloak-restrict-client-auth/default.nix
@@ -11,7 +11,7 @@ maven.buildMavenPackage rec {
   src = fetchFromGitHub {
     owner = "sventorben";
     repo = "keycloak-restrict-client-auth";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-nQ2AwXhSUu5RY/BbxXE2OXgEb7Zf6FfrGP5tfbgAXk8=";
   };
 

--- a/pkgs/by-name/ke/keycloak/keycloak-secrets-vault-provider/default.nix
+++ b/pkgs/by-name/ke/keycloak/keycloak-secrets-vault-provider/default.nix
@@ -18,7 +18,7 @@ maven.buildMavenPackage rec {
 
   installPhase = ''
     runHook preInstall
-    install -Dm644 target/secrets-provider-${version}.jar $out/share/java/keycloak/keycloak-secrets-vault-provider.jar
+    install -Dm644 -t "$out/keycloak-secrets-vault-provider.jar" target/secrets-provider-${version}.jar
     runHook postInstall
   '';
 

--- a/pkgs/by-name/ke/keycloak/keycloak-secrets-vault-provider/default.nix
+++ b/pkgs/by-name/ke/keycloak/keycloak-secrets-vault-provider/default.nix
@@ -16,8 +16,6 @@ maven.buildMavenPackage rec {
 
   mvnHash = "sha256-AJwt6JnNAffXzazWI2fIUMp5j/Fm5LRhO31bOUOl7g0=";
 
-  mvnParameters = "-Dmaven.test.skip";
-
   installPhase = ''
     runHook preInstall
     install -Dm644 target/secrets-provider-${version}.jar $out/share/java/keycloak/keycloak-secrets-vault-provider.jar
@@ -28,6 +26,9 @@ maven.buildMavenPackage rec {
     homepage = "https://github.com/Nordix/keycloak-secrets-vault-provider";
     description = "Keycloak Vault SPI provider for OpenBao and HashiCorp Vault";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ krit ];
+    maintainers = with lib.maintainers; [
+      krit
+      anish
+    ];
   };
 }

--- a/pkgs/by-name/ke/keycloak/keycloak-secrets-vault-provider/default.nix
+++ b/pkgs/by-name/ke/keycloak/keycloak-secrets-vault-provider/default.nix
@@ -1,0 +1,33 @@
+{
+  maven,
+  lib,
+  fetchFromGitHub,
+}:
+maven.buildMavenPackage rec {
+  pname = "keycloak-secrets-vault-provider";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "Nordix";
+    repo = "keycloak-secrets-vault-provider";
+    tag = "v${version}";
+    hash = "sha256-7ttjTm3D+dDiw+00pK4yvDFNCuXFmapPKnOY7vfa2Ac=";
+  };
+
+  mvnHash = "sha256-AJwt6JnNAffXzazWI2fIUMp5j/Fm5LRhO31bOUOl7g0=";
+
+  mvnParameters = "-Dmaven.test.skip";
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm644 target/secrets-provider-${version}.jar $out/share/java/keycloak/keycloak-secrets-vault-provider.jar
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://github.com/Nordix/keycloak-secrets-vault-provider";
+    description = "Keycloak Vault SPI provider for OpenBao and HashiCorp Vault";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ krit ];
+  };
+}

--- a/pkgs/by-name/ke/keycloak/package.nix
+++ b/pkgs/by-name/ke/keycloak/package.nix
@@ -102,6 +102,8 @@ stdenv.mkDerivation (finalAttrs: {
       nickcao
       leona
       anish
+      krit
+      jefferyoo
     ];
   };
 })

--- a/pkgs/by-name/ke/keycloak/scim-for-keycloak/default.nix
+++ b/pkgs/by-name/ke/keycloak/scim-for-keycloak/default.nix
@@ -11,7 +11,7 @@ maven.buildMavenPackage rec {
   src = fetchFromGitHub {
     owner = "Captain-P-Goldfish";
     repo = "scim-for-keycloak";
-    rev = version;
+    tag = version;
     hash = "sha256-kHjCVkcD8C0tIaMExDlyQmcWMhypisR1nyG93laB8WU=";
   };
 


### PR DESCRIPTION
Adds four plugins to the Keycloak package set from the list on their [extensions page](https://keycloak.org/extensions):
- `keycloak-2fa-sms-authenticator` is authentication provider for 2FA via SMS
- `keycloak-enforce-mfa-authenticator` is an authenticator that enforces MFA, by detecting users with no second factor enabled and allows choosing one available in the flow
- `keycloak-orgs` allows for multi-tenancy on a single realm via first-class organization objects
- `keycloak-secrets-vault-provider` provides a Vault SPI provider that allows Keycloak to retrieve secrets from OpenBao/HashiCorp Vault
- `keycloak-config-cli` lets you import YAML/JSON-formatted configuration files into Keycloak as a form of IaC

These plugins all have active upstreams.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
