### PR TITLE
 dotnet: improve package fallbacks

### DIFF
--- a/pkgs/by-name/er/ersatztv/nuget-deps.json
+++ b/pkgs/by-name/er/ersatztv/nuget-deps.json
@@ -310,11 +310,6 @@
     "hash": "sha256-THQ8Z7DAoMDEqAS7feAmAt82NvU7H90Y+jYwC7NwL+0="
   },
   {
-    "pname": "Microsoft.AspNetCore.App.Internal.Assets",
-    "version": "10.0.2",
-    "hash": "sha256-nh+JRXHTI01RUDFeEw4yep4iMxci5R7zKyRX2Tkd/mc="
-  },
-  {
     "pname": "Microsoft.AspNetCore.Authentication.JwtBearer",
     "version": "10.0.1",
     "hash": "sha256-x30FL5t31tGtbgTTHZlIEIky+J2Slba5YuLqytt56l4="

--- a/pkgs/development/compilers/dotnet/packages.nix
+++ b/pkgs/development/compilers/dotnet/packages.nix
@@ -94,8 +94,10 @@ let
     (mkPackage "Microsoft.DotNet.ILCompiler" runtime.version)
     (mkPackage "Microsoft.NET.ILLink.Tasks" runtime.version)
     (mkPackage "Microsoft.NETCore.App.Crossgen2.${hostRid}" runtime.version)
-    (mkPackage "runtime.${hostRid}.Microsoft.DotNet.ILCompiler" runtime.version)
   ]
+  ++ lib.optional vmr.hasILCompiler (
+    mkPackage "runtime.${hostRid}.Microsoft.DotNet.ILCompiler" runtime.version
+  )
   ++ lib.optionals (lib.versionOlder runtime.version "9") [
     (mkPackage "Microsoft.NETCore.DotNetHost" runtime.version)
     (mkPackage "Microsoft.NETCore.DotNetHostPolicy" runtime.version)

--- a/pkgs/development/compilers/dotnet/packages.nix
+++ b/pkgs/development/compilers/dotnet/packages.nix
@@ -114,6 +114,9 @@ let
       (mkPackage "runtime.${targetRid}.Microsoft.NETCore.DotNetHost" runtime.version)
       (mkPackage "runtime.${targetRid}.Microsoft.NETCore.DotNetHostPolicy" runtime.version)
       (mkPackage "runtime.${targetRid}.Microsoft.NETCore.DotNetHostResolver" runtime.version)
+    ]
+    ++ lib.optionals (lib.versionAtLeast runtime.version "10") [
+      (mkPackage "Microsoft.NETCore.App.Runtime.NativeAOT.${targetRid}" runtime.version)
     ];
   };
 

--- a/pkgs/development/compilers/dotnet/update.sh
+++ b/pkgs/development/compilers/dotnet/update.sh
@@ -128,6 +128,12 @@ aspnetcore_packages () {
         Microsoft.AspNetCore.App.Ref
     )
 
+    if versionAtLeast "$version" 10; then
+        pkgs+=(
+            Microsoft.AspNetCore.App.Internal.Assets
+        )
+    fi
+
     generate_package_list "$version" '    ' "${pkgs[@]}"
 }
 

--- a/pkgs/development/compilers/dotnet/versions/10.0.nix
+++ b/pkgs/development/compilers/dotnet/versions/10.0.nix
@@ -15,6 +15,11 @@ let
       hash = "sha512-MeDkxsB9ir694B2z0nIG7ZZ6DISLmbU7aOwCusO6AadYjitxjv+e9TuY1Y0ijwuYNjxukBIj45nF/fCEg6CGHw==";
     })
     (fetchNupkg {
+      pname = "Microsoft.AspNetCore.App.Internal.Assets";
+      version = "10.0.2";
+      hash = "sha512-v9Au9ZSo3ZOe77StttCPCtOZkY7xSFXSyyWMR9Y0Kx3ZKegVp4zg7TJwz4osTgQp7EKyXlbDpvjUbgly51XbmA==";
+    })
+    (fetchNupkg {
       pname = "Microsoft.NETCore.DotNetAppHost";
       version = "10.0.2";
       hash = "sha512-dlgigLX+tCuYRg5TcnOTg+UyNlIK0queBF5EWmPw8jpX3J0iqXUs9Nb+4BriG57QoNRiZCXaEB81TDeKb56xxw==";

--- a/pkgs/development/compilers/dotnet/wrapper.nix
+++ b/pkgs/development/compilers/dotnet/wrapper.nix
@@ -33,6 +33,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       license
       maintainers
       platforms
+      broken
       ;
   };
 


### PR DESCRIPTION
Cc: @NixOS/dotnet 

This will sync the available packages in source and binary SDKs, by falling back to the binary SDK.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
