### PR TITLE
nixos/limine: add resolution option for Linux boot entries

### DIFF
--- a/nixos/modules/system/boot/loader/limine/limine-install.py
+++ b/nixos/modules/system/boot/loader/limine/limine-install.py
@@ -291,6 +291,12 @@ def config_entry(levels: int, bootspec: BootSpec, label: str, time: str) -> str:
     entry += f'comment: {bootspec.label}, built on {time}\n'
     entry += 'kernel_path: ' + get_kernel_uri(bootspec.kernel) + '\n'
     entry += 'cmdline: ' + ' '.join(['init=' + bootspec.init] + bootspec.kernelParams).strip() + '\n'
+
+    # Set framebuffer resolution for Linux boot entries if configured
+    resolution = config('resolution')
+    if resolution is not None:
+        entry += f'resolution: {resolution}\n'
+
     if bootspec.initrd:
         entry += f'module_path: ' + get_kernel_uri(bootspec.initrd) + '\n'
 

--- a/nixos/modules/system/boot/loader/limine/limine.nix
+++ b/nixos/modules/system/boot/loader/limine/limine.nix
@@ -25,6 +25,7 @@ let
       force = cfg.force;
       enrollConfig = cfg.enrollConfig;
       style = cfg.style;
+      resolution = cfg.resolution;
       maxGenerations = if cfg.maxGenerations == null then 0 else cfg.maxGenerations;
       hostArchitecture = pkgs.stdenv.hostPlatform.parsed.cpu;
       timeout = if config.boot.loader.timeout != null then config.boot.loader.timeout else 10;
@@ -95,6 +96,27 @@ in
       '';
       description = ''
         A string which is appended to the end of limine.conf. The config format can be found [here](https://github.com/limine-bootloader/limine/blob/trunk/CONFIG.md).
+      '';
+    };
+
+    resolution = lib.mkOption {
+      default = null;
+      type = lib.types.nullOr lib.types.str;
+      example = "1920x1080x32";
+      description = ''
+        The framebuffer resolution to set when booting Linux entries.
+        This controls the GOP mode that Limine sets before handing off to the kernel,
+        which affects early boot graphics (e.g., simpledrm, efifb).
+
+        Format: `<width>x<height>` or `<width>x<height>x<bpp>`.
+        If bpp is omitted, defaults to 32.
+
+        Note: Refresh rate is not supported because the UEFI GOP protocol only
+        defines framebuffer dimensions and pixel format, not display timing.
+        Refresh rate is determined later by the GPU driver based on EDID.
+
+        This is distinct from {option}`boot.loader.limine.style.interface.resolution`
+        which only affects the Limine bootloader's own menu interface.
       '';
     };
 


### PR DESCRIPTION
Adds the NixOS option `boot.loader.limine.resolution` to control the framebuffer resolution that Limine sets via GOP before booting Linux. This affects early boot graphics drivers like `simpledrm` and `efifb`.

This is distinct from `style.interface.resolution` which only controls the Limine bootloader's own menu interface - the new option sets the per-entry "[resolution:](https://github.com/limine-bootloader/limine/blob/v10.x/CONFIG.md?plain=1#L223-L225)" directive in `limine.conf` which calls `gop->SetMode()` to change the actual framebuffer resolution before handing off to the kernel.

Example usage:

```
boot.loader.limine.resolution = "3840x1600x32";
```

This enables users to get native resolution early boot graphics instead of being limited to whatever GOP mode the UEFI firmware provides by default (often 1024x768).

I tested this on my system and it appears to work beautifully. I also ran the Limine NixOS tests.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test