### PR TITLE
nixos/i18n.inputMethod.ibus: add KDE to NotShowIn for ibusAutostart

### DIFF
--- a/nixos/modules/i18n/input-method/ibus.nix
+++ b/nixos/modules/i18n/input-method/ibus.nix
@@ -25,7 +25,9 @@ let
       Type=Application
       Exec=${ibusPackage}/bin/ibus-daemon --daemonize --xim ${impanel}
       # GNOME will launch ibus using systemd
-      NotShowIn=GNOME;
+      # ibus complains loudly when launched from this autoStart file under KDE
+      # KDE will launch ibus from kwin if enabled in keyboard -> virtual keyboard
+      NotShowIn=GNOME;KDE;
     '';
   };
 in


### PR DESCRIPTION
ibus on KDE should no longer be started automatically in this fashion, ibus will pop up an obtrusive notification on start asking to be added to KDE's virtual keyboard setting instead.

https://github.com/ibus/ibus/blob/0ed568768130920b28f3ae107ab3c99c1b9a231a/ui/gtk3/panel.vala#L1009-L1051

```
                  _("IBus should be called from the desktop session in " +
                      "%s. For KDE, you can launch '%s' " +
                      "utility and go to \"Input & Output\" -> \"Keyboard\" " +
                      "-> \"Virtual Keyboard\" section and select " +
                      "\"%s\" icon and click \"Apply\" button to " +
                      "configure IBus in %s. For other desktop " +
                      "sessions, you can run \"%s\" command. " +
                      "Please refer each document about the \"Wayland " +
                      "input method\" configuration. Before you configure " +
                      "the \"Wayland input method\", you should make sure " +
                      "that QT_IM_MODULE and GTK_IM_MODULE environment " +
                      "variables are unset in the desktop session.");
                message = format.printf(
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
