### PR TITLE
cudaPackages: fixup expressions for libcudla and tensorrt-samples's testers

### DIFF
--- a/pkgs/development/cuda-modules/packages/cuda-samples.nix
+++ b/pkgs/development/cuda-modules/packages/cuda-samples.nix
@@ -17,6 +17,7 @@
   flags,
   lib,
   libcublas,
+  libcudla,
   libcufft,
   libcurand,
   libcusolver,
@@ -197,6 +198,7 @@ backendStdenv.mkDerivation (finalAttrs: {
     libnvjitlink
     libnvjpeg
   ]
+  ++ lib.optionals libcudla.meta.available [ libcudla ]
   ++ lib.optionals (cudaAtLeast "13") [ cuda_culibos ];
 
   cmakeFlags = [

--- a/pkgs/development/cuda-modules/packages/libcudla.nix
+++ b/pkgs/development/cuda-modules/packages/libcudla.nix
@@ -1,7 +1,7 @@
 {
   backendStdenv,
   buildRedist,
-  cudaMajorMinorVersion,
+  cudaOlder,
   lib,
 }:
 buildRedist {
@@ -19,7 +19,7 @@ buildRedist {
   autoPatchelfIgnoreMissingDeps = [
     "libnvcudla.so"
   ]
-  ++ lib.optionals (cudaMajorMinorVersion == "11.8") [
+  ++ lib.optionals (cudaOlder "12") [
     "libcuda.so.1"
     "libnvdla_runtime.so"
   ];
@@ -27,12 +27,7 @@ buildRedist {
   platformAssertions = [
     {
       message = "Only Xavier (7.2) and Orin (8.7) Jetson devices are supported";
-      assertion =
-        let
-          inherit (backendStdenv) hasJetsonCudaCapability requestedJetsonCudaCapabilities;
-        in
-        hasJetsonCudaCapability
-        -> (lib.subtractLists [ "7.2" "8.7" ] requestedJetsonCudaCapabilities == [ ]);
+      assertion = lib.subtractLists [ "7.2" "8.7" ] backendStdenv.cudaCapabilities == [ ];
     }
   ];
 }

--- a/pkgs/development/cuda-modules/packages/tensorrt-samples/testers/sample_algorithm_selector.nix
+++ b/pkgs/development/cuda-modules/packages/tensorrt-samples/testers/sample_algorithm_selector.nix
@@ -1,4 +1,5 @@
 {
+  atLeast,
   backendStdenv,
   lib,
   mkTester,
@@ -26,15 +27,16 @@ lib.optionalAttrs (older "10.8") (
       "--datadir=${sample-data.outPath + "/mnist"}"
       "--fp16"
     ];
-
+  }
+  // lib.optionalAttrs (atLeast "10") {
     bf16 = mkTester "sample_algorithm_selector-bf16" [
       "sample_algorithm_selector"
       "--datadir=${sample-data.outPath + "/mnist"}"
       "--bf16"
     ];
   }
-  # Only Orin has a DLA
-  // lib.optionalAttrs (lib.elem "8.7" backendStdenv.cudaCapabilities) {
+  # Only Xavier and Orin have a DLA
+  // lib.optionalAttrs (lib.subtractLists [ "7.2" "8.7" ] backendStdenv.cudaCapabilities == [ ]) {
     dla = mkTester "sample_algorithm_selector-dla" [
       "sample_algorithm_selector"
       "--datadir=${sample-data.outPath + "/mnist"}"

--- a/pkgs/development/cuda-modules/packages/tensorrt-samples/testers/sample_dynamic_reshape.nix
+++ b/pkgs/development/cuda-modules/packages/tensorrt-samples/testers/sample_dynamic_reshape.nix
@@ -1,4 +1,6 @@
 {
+  atLeast,
+  lib,
   mkTester,
   sample-data,
   ...
@@ -21,7 +23,8 @@
     "--datadir=${sample-data.outPath + "/mnist"}"
     "--fp16"
   ];
-
+}
+// lib.optionalAttrs (atLeast "10") {
   bf16 = mkTester "sample_dynamic_reshape-bf16" [
     "sample_dynamic_reshape"
     "--datadir=${sample-data.outPath + "/mnist"}"

--- a/pkgs/development/cuda-modules/packages/tensorrt-samples/testers/sample_int8_api.nix
+++ b/pkgs/development/cuda-modules/packages/tensorrt-samples/testers/sample_int8_api.nix
@@ -12,8 +12,8 @@
     "--data=${sample-data.outPath + "/int8_api"}"
   ];
 }
-# Only Orin has a DLA
-// lib.optionalAttrs (lib.elem "8.7" backendStdenv.cudaCapabilities) {
+# Only Xavier and Orin have a DLA
+// lib.optionalAttrs (lib.subtractLists [ "7.2" "8.7" ] backendStdenv.cudaCapabilities == [ ]) {
   dla = mkTester "sample_int8_api-dla" [
     "sample_int8_api"
     "--model=${sample-data.outPath + "/resnet50/ResNet50.onnx"}"

--- a/pkgs/development/cuda-modules/packages/tensorrt-samples/testers/sample_io_formats.nix
+++ b/pkgs/development/cuda-modules/packages/tensorrt-samples/testers/sample_io_formats.nix
@@ -11,8 +11,8 @@
     "--datadir=${sample-data.outPath + "/mnist"}"
   ];
 }
-# Only Orin has a DLA
-// lib.optionalAttrs (lib.elem "8.7" backendStdenv.cudaCapabilities) {
+# Only Xavier and Orin have a DLA
+// lib.optionalAttrs (lib.subtractLists [ "7.2" "8.7" ] backendStdenv.cudaCapabilities == [ ]) {
   dla = mkTester "sample_io_formats-dla" [
     "sample_io_formats"
     "--datadir=${sample-data.outPath + "/mnist"}"

--- a/pkgs/development/cuda-modules/packages/tensorrt-samples/testers/sample_non_zero_plugin.nix
+++ b/pkgs/development/cuda-modules/packages/tensorrt-samples/testers/sample_non_zero_plugin.nix
@@ -1,27 +1,28 @@
 {
   atLeast,
-  finalAttrs,
   lib,
   mkTester,
   sample-data,
   ...
 }:
-{
-  default = mkTester "sample_non_zero_plugin" [
-    "sample_non_zero_plugin"
-    "--datadir=${sample-data.outPath + "/mnist"}"
-  ];
+lib.optionalAttrs (atLeast "10") (
+  {
+    default = mkTester "sample_non_zero_plugin" [
+      "sample_non_zero_plugin"
+      "--datadir=${sample-data.outPath + "/mnist"}"
+    ];
 
-  fp16 = mkTester "sample_non_zero_plugin-fp16" [
-    "sample_non_zero_plugin"
-    "--datadir=${sample-data.outPath + "/mnist"}"
-    "--fp16"
-  ];
-}
-// lib.optionalAttrs (atLeast "10.0.1") {
-  columnOrder = mkTester "sample_non_zero_plugin-columnOrder" [
-    "sample_non_zero_plugin"
-    "--datadir=${sample-data.outPath + "/mnist"}"
-    "--columnOrder"
-  ];
-}
+    fp16 = mkTester "sample_non_zero_plugin-fp16" [
+      "sample_non_zero_plugin"
+      "--datadir=${sample-data.outPath + "/mnist"}"
+      "--fp16"
+    ];
+  }
+  // lib.optionalAttrs (atLeast "10.0.1") {
+    columnOrder = mkTester "sample_non_zero_plugin-columnOrder" [
+      "sample_non_zero_plugin"
+      "--datadir=${sample-data.outPath + "/mnist"}"
+      "--columnOrder"
+    ];
+  }
+)

--- a/pkgs/development/cuda-modules/packages/tensorrt-samples/testers/sample_onnx_mnist.nix
+++ b/pkgs/development/cuda-modules/packages/tensorrt-samples/testers/sample_onnx_mnist.nix
@@ -1,4 +1,5 @@
 {
+  atLeast,
   backendStdenv,
   lib,
   mkTester,
@@ -22,15 +23,16 @@
     "--datadir=${sample-data.outPath + "/mnist"}"
     "--fp16"
   ];
-
+}
+// lib.optionalAttrs (atLeast "10") {
   bf16 = mkTester "sample_onnx_mnist-bf16" [
     "sample_onnx_mnist"
     "--datadir=${sample-data.outPath + "/mnist"}"
     "--bf16"
   ];
 }
-# Only Orin has a DLA
-// lib.optionalAttrs (lib.elem "8.7" backendStdenv.cudaCapabilities) {
+# Only Xavier and Orin have a DLA
+// lib.optionalAttrs (lib.subtractLists [ "7.2" "8.7" ] backendStdenv.cudaCapabilities == [ ]) {
   dla = mkTester "sample_onnx_mnist-dla" [
     "sample_onnx_mnist"
     "--datadir=${sample-data.outPath + "/mnist"}"

--- a/pkgs/development/cuda-modules/packages/tensorrt-samples/testers/sample_onnx_mnist_coord_conv_ac.nix
+++ b/pkgs/development/cuda-modules/packages/tensorrt-samples/testers/sample_onnx_mnist_coord_conv_ac.nix
@@ -25,8 +25,8 @@ lib.optionalAttrs false (
       "--fp16"
     ];
   }
-  # Only Orin has a DLA
-  // lib.optionalAttrs (lib.elem "8.7" backendStdenv.cudaCapabilities) {
+  # Only Xavier and Orin have a DLA
+  // lib.optionalAttrs (lib.subtractLists [ "7.2" "8.7" ] backendStdenv.cudaCapabilities == [ ]) {
     dla = mkTester "sample_onnx_mnist_coord_conv_ac-dla" [
       "sample_onnx_mnist_coord_conv_ac"
       "--datadir=${sample-data.outPath + "/mnist"}"

--- a/pkgs/development/cuda-modules/packages/tensorrt-samples/testers/sample_progress_monitor.nix
+++ b/pkgs/development/cuda-modules/packages/tensorrt-samples/testers/sample_progress_monitor.nix
@@ -25,8 +25,8 @@ lib.optionalAttrs false (
       "--fp16"
     ];
   }
-  # Only Orin has a DLA
-  // lib.optionalAttrs (lib.elem "8.7" backendStdenv.cudaCapabilities) {
+  # Only Xavier and Orin have a DLA
+  // lib.optionalAttrs (lib.subtractLists [ "7.2" "8.7" ] backendStdenv.cudaCapabilities == [ ]) {
     dla = mkTester "sample_progress_monitor-dla" [
       "sample_progress_monitor"
       "--datadir=${sample-data.outPath + "/mnist"}"


### PR DESCRIPTION
- The `autoPatchelfIgnoreMissingDeps` for `libcudla` is valid for releases prior to 12.0, not just 11.8.
- Made `mkTester` available through `tensorrt-samples.passthru` to enable out-of-tree re-use
- Filtered `tensorrt-samples.passthru.testers` to avoid empty attribute sets
- Added more conditional inclusion in `tensorrt-samples.passthru.testers` for individual tests (e.g., checking for Xavier/Orin for DLA tester or for 10-series release for BF16)
- Guarded inclusion of `sample_non_zero_plugin` testers on 10-series release (they are not available earlier)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
