### PR TITLE
python3Packages.datalad: 1.2.3 -> 1.3.0; fixes, adopt

### DIFF
--- a/pkgs/development/python-modules/datalad/default.nix
+++ b/pkgs/development/python-modules/datalad/default.nix
@@ -42,6 +42,7 @@
   importlib-metadata,
   typing-extensions,
   # tests
+  pytest-retry,
   pytest-xdist,
   pytestCheckHook,
   p7zip,
@@ -127,9 +128,13 @@ buildPythonPackage rec {
   preCheck = ''
     export HOME=$TMPDIR
     export DATALAD_TESTS_NONETWORK=1
+    export PATH="$PATH:$out/bin"
   '';
 
-  # tests depend on apps in $PATH which only will get installed after the test
+  disabledTestMarks = [
+    "flaky"
+  ];
+
   disabledTests = [
     # No such file or directory: 'datalad'
     "test_script_shims"
@@ -147,59 +152,17 @@ buildPythonPackage rec {
     # Tries to run `git` and fails
     "test_reckless"
     "test_create"
+    "test_subsuperdataset_save"
 
-    #  No such file or directory: 'git-annex-remote-[...]"
-    "test_ensure_datalad_remote_maybe_enable"
+    # Tries to spawn a subshell and fails
+    "test_shell_completion_source"
 
-    # "git-annex: unable to use external special remote git-annex-remote-datalad"
-    "test_ria_postclonecfg"
-    "test_ria_postclone_noannex"
-    "test_ria_push"
-    "test_basic_scenario"
-    "test_annex_get_from_subdir"
-    "test_ensure_datalad_remote_init_and_enable_needed"
-    "test_ensure_datalad_remote_maybe_enable[False]"
-    "test_ensure_datalad_remote_maybe_enable[True]"
-    "test_create_simple"
-    "test_create_alias"
-    "test_storage_only"
-    "test_initremote"
-    "test_read_access"
-    "test_ephemeral"
-    "test_initremote_basic_fileurl"
-    "test_initremote_basic_httpurl"
-    "test_remote_layout"
-    "test_version_check"
-    "test_gitannex_local"
-    "test_push_url"
-    "test_url_keys"
-    "test_obtain_permission_root"
-    "test_source_candidate_subdataset"
-    "test_update_fetch_all"
-    "test_add_archive_dirs"
-    "test_add_archive_content"
-    "test_add_archive_content_strip_leading"
-    "test_add_archive_content_zip"
-    "test_add_archive_content_absolute_path"
-    "test_add_archive_use_archive_dir"
-    "test_add_archive_single_file"
-    "test_add_delete"
-    "test_add_archive_leading_dir"
-    "test_add_delete_after_and_drop"
-    "test_add_delete_after_and_drop_subdir"
-    "test_override_existing_under_git"
-    "test_copy_file_datalad_specialremote"
-    "test_download_url_archive"
-    "test_download_url_archive_from_subdir"
-    "test_download_url_archive_trailing_separator"
-    "test_download_url_need_datalad_remote"
-    "test_datalad_credential_helper - assert False"
-
+    # Times out
+    "test_rerun_unrelated_nonrun_left_run_right"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # pbcopy not found
     "test_wtf"
-
-    # CommandError: 'git -c diff.ignoreSubmodules=none -c core.quotepath=false ls-files -z -m -d' failed with exitcode 128
-    "test_subsuperdataset_save"
   ]
   ++ lib.optionals (pythonAtLeast "3.14") [
     # For all: https://github.com/datalad/datalad/issues/7781
@@ -215,6 +178,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     p7zip
+    pytest-retry
     pytest-xdist
     pytestCheckHook
     git-annex

--- a/pkgs/development/python-modules/datalad/default.nix
+++ b/pkgs/development/python-modules/datalad/default.nix
@@ -161,17 +161,6 @@ buildPythonPackage (finalAttrs: {
     "test_wtf"
     # hangs
     "test_keyring"
-  ]
-  ++ lib.optionals (pythonAtLeast "3.14") [
-    # For all: https://github.com/datalad/datalad/issues/7781
-    # AssertionError: `assert 1 == 0` (refcount error)
-    "test_GitRepo_flyweight"
-    "test_Dataset_flyweight"
-    "test_AnnexRepo_flyweight"
-    # TypeError: cannot pickle '_thread.lock' object
-    "test_popen_invocation"
-    # datalad.runner.exception.CommandError: '/python3.14 -i -u -q -']' timed out after 0.5 seconds
-    "test_asyncio_loop_noninterference1"
   ];
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/datalad/default.nix
+++ b/pkgs/development/python-modules/datalad/default.nix
@@ -50,7 +50,7 @@
   httpretty,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "datalad";
   version = "1.2.3";
   pyproject = true;
@@ -58,7 +58,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "datalad";
     repo = "datalad";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-C3e9k4RDFfDMaimZ/7TtAJNzdlfVrKoTHVl0zKL9EjI=";
   };
 
@@ -78,7 +78,9 @@ buildPythonPackage rec {
   ];
 
   dependencies =
-    optional-dependencies.core ++ optional-dependencies.downloaders ++ optional-dependencies.publish;
+    finalAttrs.passthru.optional-dependencies.core
+    ++ finalAttrs.passthru.optional-dependencies.downloaders
+    ++ finalAttrs.passthru.optional-dependencies.publish;
 
   optional-dependencies = {
     core = [
@@ -183,10 +185,11 @@ buildPythonPackage rec {
   meta = {
     description = "Keep code, data, containers under control with git and git-annex";
     homepage = "https://www.datalad.org";
+    changelog = "https://github.com/datalad/datalad/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       renesat
       malik
     ];
   };
-}
+})

--- a/pkgs/development/python-modules/datalad/default.nix
+++ b/pkgs/development/python-modules/datalad/default.nix
@@ -152,6 +152,8 @@ buildPythonPackage (finalAttrs: {
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # pbcopy not found
     "test_wtf"
+    # hangs
+    "test_keyring"
   ]
   ++ lib.optionals (pythonAtLeast "3.14") [
     # For all: https://github.com/datalad/datalad/issues/7781
@@ -179,6 +181,9 @@ buildPythonPackage (finalAttrs: {
     # Deprecated in 3.13. Use exc_type_str instead.
     "-Wignore::DeprecationWarning"
   ];
+
+  # Tests use ports on localhost
+  __darwinAllowLocalNetworking = true;
 
   pythonImportsCheck = [ "datalad" ];
 

--- a/pkgs/development/python-modules/datalad/default.nix
+++ b/pkgs/development/python-modules/datalad/default.nix
@@ -126,6 +126,7 @@ buildPythonPackage rec {
 
   preCheck = ''
     export HOME=$TMPDIR
+    export DATALAD_TESTS_NONETWORK=1
   '';
 
   # tests depend on apps in $PATH which only will get installed after the test
@@ -143,8 +144,11 @@ buildPythonPackage rec {
     "test_status_custom_summary_no_repeats"
     "test_quoting"
 
-    #  No such file or directory: 'git-annex-remote-[...]"
+    # Tries to run `git` and fails
+    "test_reckless"
     "test_create"
+
+    #  No such file or directory: 'git-annex-remote-[...]"
     "test_ensure_datalad_remote_maybe_enable"
 
     # "git-annex: unable to use external special remote git-annex-remote-datalad"
@@ -190,28 +194,6 @@ buildPythonPackage rec {
     "test_download_url_archive_trailing_separator"
     "test_download_url_need_datalad_remote"
     "test_datalad_credential_helper - assert False"
-
-    # need internet access
-    "test_clone_crcns"
-    "test_clone_datasets_root"
-    "test_reckless"
-    "test_autoenabled_remote_msg"
-    "test_ria_http_storedataladorg"
-    "test_gin_cloning"
-    "test_nonuniform_adjusted_subdataset"
-    "test_install_datasets_root"
-    "test_install_simple_local"
-    "test_install_dataset_from_just_source"
-    "test_install_dataset_from_just_source_via_path"
-    "test_datasets_datalad_org"
-    "test_get_cached_dataset"
-    "test_cached_dataset"
-    "test_cached_url"
-    "test_anonymous_s3"
-    "test_protocols"
-    "test_get_versioned_url_anon"
-    "test_install_recursive_github"
-    "test_failed_install_multiple"
 
     # pbcopy not found
     "test_wtf"

--- a/pkgs/development/python-modules/datalad/default.nix
+++ b/pkgs/development/python-modules/datalad/default.nix
@@ -190,6 +190,7 @@ buildPythonPackage (finalAttrs: {
     maintainers = with lib.maintainers; [
       renesat
       malik
+      sarahec
     ];
   };
 })

--- a/pkgs/development/python-modules/datalad/default.nix
+++ b/pkgs/development/python-modules/datalad/default.nix
@@ -136,19 +136,6 @@ buildPythonPackage rec {
   ];
 
   disabledTests = [
-    # No such file or directory: 'datalad'
-    "test_script_shims"
-    "test_cfg_override"
-    "test_completion"
-    "test_nested_pushclone_cycle_allplatforms"
-    "test_create_sub_gh3463"
-    "test_create_sub_dataset_dot_no_path"
-    "test_cfg_passthrough"
-    "test_addurls_stdin_input_command_line"
-    "test_run_datalad_help"
-    "test_status_custom_summary_no_repeats"
-    "test_quoting"
-
     # Tries to run `git` and fails
     "test_reckless"
     "test_create"

--- a/pkgs/development/python-modules/datalad/default.nix
+++ b/pkgs/development/python-modules/datalad/default.nix
@@ -52,14 +52,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "datalad";
-  version = "1.2.3";
+  version = "1.3.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "datalad";
     repo = "datalad";
     tag = finalAttrs.version;
-    hash = "sha256-C3e9k4RDFfDMaimZ/7TtAJNzdlfVrKoTHVl0zKL9EjI=";
+    hash = "sha256-aTpiwcwRJyUF68+OsT+u9j/cibZEDhmL45I1MSY3Q7E=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/datalad/default.nix
+++ b/pkgs/development/python-modules/datalad/default.nix
@@ -148,6 +148,13 @@ buildPythonPackage (finalAttrs: {
 
     # Times out
     "test_rerun_unrelated_nonrun_left_run_right"
+
+    # Top five slowest (2/3 of total runtime)
+    "test_files_split"
+    "test_gitannex_local"
+    "test_save_hierarchy"
+    "test_recurse_existing"
+    "test_source_candidate_subdataset"
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # pbcopy not found


### PR DESCRIPTION
Based on the discussion in https://github.com/datalad/datalad/issues/7781

1. Set `DATALAD_TESTS_NONETWORK=1` to disable network tests and remove corresponding from `disabledTests`.
2. Put `$out/bin` on `PATH` before testing to allow testing wrapped tools. Removed corresponding from `disabledTests`.
3. Audited the remaining disabled tests and found they were fine. Removed from `disabledTests`.
4. Made a test with a Darwin-specific failure only run on Darwin (`pbcopy` is a Darwin tool)
5. Applied `finalAttrs:` fix
6. Added self as maintainer due to the extent of changes.
7. Enabled local networking on Darwin to enable tests (and confirmed which tests to run)
8. Disabled five tests that take up 75% of the total test time.
9. **new** Bumped to 1.3.0 release that fixes Python 3.14 issues. https://github.com/datalad/datalad/releases/tag/1.3.0
10. **new** Removed Python 3.14 test exclusions.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
