### PR TITLE
youtrack: 2025.1.86199 -> 2025.3.116116

### DIFF
--- a/pkgs/by-name/yo/youtrack/package.nix
+++ b/pkgs/by-name/yo/youtrack/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenvNoCC,
-  fetchzip,
+  dockerTools,
   makeBinaryWrapper,
   jdk21_headless,
   gawk,
@@ -10,12 +10,22 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "youtrack";
-  version = "2025.1.86199";
+  version = "2025.3.121962";
 
-  src = fetchzip {
-    url = "https://download.jetbrains.com/charisma/youtrack-${finalAttrs.version}.zip";
-    hash = "sha256-+sHxagy9+H6DEnpdtRTNMy6GLSSCopaeqlXWJodAim0=";
+  src = dockerTools.exportImage {
+    diskSize = 8192;
+    fromImage = dockerTools.pullImage {
+      imageName = "jetbrains/youtrack";
+      arch = "amd64";
+      imageDigest = "sha256:90b641d623cb30f4915bd4a0bdba088bab25cf14314231e0333b8564bc353161";
+      hash = "sha256-WkEKJKfG5lagfgn4hbpEqIUPXGJYcYbwMjb1c5BNvp8=";
+    };
   };
+  unpackPhase = ''
+    mkdir source
+    tar -C source -xvf $src ./opt/youtrack
+    cd source
+  '';
 
   nativeBuildInputs = [ makeBinaryWrapper ];
 
@@ -25,12 +35,13 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   installPhase = ''
     runHook preInstall
     mkdir -p $out
-    cp -r * $out
+    cp -r opt/youtrack/* $out
     makeWrapper $out/bin/youtrack.sh $out/bin/youtrack \
       --prefix PATH : "${lib.makeBinPath [ gawk ]}" \
       --set JRE_HOME ${jdk21_headless}
     rm -rf $out/internal/java
     mv $out/conf $out/conf.orig
+    rmdir $out/{backups,data,logs,temp}
     ln -s ${statePath}/backups $out/backups
     ln -s ${statePath}/conf $out/conf
     ln -s ${statePath}/data $out/data
@@ -45,6 +56,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     description = "Issue tracking and project management tool for developers";
     maintainers = [ lib.maintainers.leona ];
     sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
+    platforms = [ "x86_64-linux" ];
     # https://www.jetbrains.com/youtrack/buy/license.html
     license = lib.licenses.unfree;
   };


### PR DESCRIPTION
## Things done

The zip file download is no longer available, and the Docker image is now the only official installation method.
However, the structure within the docker image still looks very similar.

I have tested that the package builds (which does not mean a lot, since it only extracts and wraps some binaries) but not that it runs within the NixOS module.

The build process is suboptimal, as the implementation of dockerTools.exportImage is inefficient.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
