### PR TITLE
typst: 0.14.0 -> 0.14.2

### DIFF
--- a/pkgs/by-name/ty/typst/package.nix
+++ b/pkgs/by-name/ty/typst/package.nix
@@ -12,13 +12,13 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "typst";
-  version = "0.14.0";
+  version = "0.14.1";
 
   src = fetchFromGitHub {
     owner = "typst";
     repo = "typst";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Sdl60VNjrSVj8YFZR/b2WOzN8taZ6wsJx5FnED9XQbw=";
+    hash = "sha256-GAHG0TF+6rdgVolJLdFw7uVz/UBLsnibcaEvInRf7Jk=";
     leaveDotGit = true;
     postFetch = ''
       cd $out
@@ -27,7 +27,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     '';
   };
 
-  cargoHash = "sha256-6o7IbDBJU+FGYezfm37Z4eBBWa7G06vFbopI0FqJu7c=";
+  cargoHash = "sha256-UQAKvBlT+c5eUNAmN2lzbjZG1kBrE88CTx2t1F4tprQ=";
 
   nativeBuildInputs = [
     installShellFiles
@@ -64,6 +64,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
   '';
 
   cargoTestFlags = [ "--workspace" ];
+  # The following test fails when using `release`
+  # ❌ issue-7257-break-tags-show-par-none (tests/suite/pdftags/break.typ:29) not emitted
+  checkType = "debug";
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];

--- a/pkgs/by-name/ty/typst/package.nix
+++ b/pkgs/by-name/ty/typst/package.nix
@@ -12,13 +12,13 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "typst";
-  version = "0.14.1";
+  version = "0.14.2";
 
   src = fetchFromGitHub {
     owner = "typst";
     repo = "typst";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-GAHG0TF+6rdgVolJLdFw7uVz/UBLsnibcaEvInRf7Jk=";
+    hash = "sha256-EXcmL/KNj9vCChCs6RH1J/+aetYcXnEdGEhvVzGNNZA=";
     leaveDotGit = true;
     postFetch = ''
       cd $out
@@ -27,7 +27,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     '';
   };
 
-  cargoHash = "sha256-UQAKvBlT+c5eUNAmN2lzbjZG1kBrE88CTx2t1F4tprQ=";
+  cargoHash = "sha256-HDu7/kgpBgUe/CrHm17BkNlg3DYlegTevgAeBCXp6so=";
 
   nativeBuildInputs = [
     installShellFiles
@@ -64,9 +64,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
   '';
 
   cargoTestFlags = [ "--workspace" ];
-  # The following test fails when using `release`
-  # ❌ issue-7257-break-tags-show-par-none (tests/suite/pdftags/break.typ:29) not emitted
-  checkType = "debug";
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];


### PR DESCRIPTION
Changelog:
https://github.com/typst/typst/blob/main/docs/changelog/0.14.2.md Diff: https://github.com/typst/typst/compare/v0.14.1...v0.14.2 (cherry picked from commit b6e4a72e837aee46a59a76e1a3edcf10fa6eebb1)

Backport of typst update from 0.14.0 to 0.14.2. This includes a [security update](https://github.com/typst/typst/blob/main/docs/changelog/0.14.2.md#security).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
