### PR TITLE
mole-cleaner: init at 1.21.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6791,6 +6791,12 @@
     githubId = 10913120;
     name = "Dje4321";
   };
+  djedlajn = {
+    email = "hi@uros.dev";
+    github = "djedlajn";
+    githubId = 9012882;
+    name = "Uros Karic";
+  };
   djwf = {
     email = "dave@weller-fahy.com";
     github = "djwf";

--- a/pkgs/by-name/mo/mole-cleaner/package.nix
+++ b/pkgs/by-name/mo/mole-cleaner/package.nix
@@ -1,0 +1,102 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  fetchurl,
+  coreutils,
+  gawk,
+  gdu,
+  versionCheckHook,
+  writableTmpDirAsHomeHook,
+}:
+
+let
+  version = "1.21.0";
+
+  binaries = {
+    aarch64-darwin = fetchurl {
+      url = "https://github.com/tw93/Mole/releases/download/V${version}/binaries-darwin-arm64.tar.gz";
+      hash = "sha256-cIZslu8rxPpP516f/PAtytuR9lJIbB9jOrY2Bnl8ilY=";
+    };
+    x86_64-darwin = fetchurl {
+      url = "https://github.com/tw93/Mole/releases/download/V${version}/binaries-darwin-amd64.tar.gz";
+      hash = "sha256-YVJJrU2rCw8L5cNT2agBXIY3KDDqHEZdMOWa0rG0vYA=";
+    };
+  };
+
+in
+stdenvNoCC.mkDerivation {
+  pname = "mole-cleaner";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "tw93";
+    repo = "Mole";
+    tag = "V${version}";
+    hash = "sha256-HAKlivpOIpQ6vtEmyiFT33j4LzXahAqQGA3DwrU2bis=";
+  };
+
+  dontBuild = true;
+
+  postPatch = ''
+    substituteInPlace mole \
+      --replace-fail 'set -euo pipefail' \
+        'set -euo pipefail
+    export PATH="${
+      lib.makeBinPath [
+        coreutils
+        gawk
+        gdu
+      ]
+    }:$PATH"' \
+      --replace-fail 'SCRIPT_DIR="$(cd "$(dirname "''${BASH_SOURCE[0]}")" && pwd)"' \
+        'SCRIPT_DIR="@out@/libexec/mole"'
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/libexec/mole $out/bin
+
+    # Substitute @out@ placeholder in the script
+    substituteInPlace mole --replace-fail '@out@' "$out"
+
+    # Install main script, lib, and bin shell scripts
+    cp mole $out/libexec/mole/
+    chmod +x $out/libexec/mole/mole
+    cp -r lib $out/libexec/mole/
+    cp -r bin $out/libexec/mole/
+    chmod +x $out/libexec/mole/bin/*.sh
+
+    # Install pre-built Go binaries to bin/ subdirectory and rename them
+    tar -xzf ${binaries.${stdenvNoCC.hostPlatform.system}} -C $out/libexec/mole/bin
+    mv $out/libexec/mole/bin/analyze-* $out/libexec/mole/bin/analyze-go
+    mv $out/libexec/mole/bin/status-* $out/libexec/mole/bin/status-go
+
+    # Create symlink in bin
+    ln -s $out/libexec/mole/mole $out/bin/mole
+
+    runHook postInstall
+  '';
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    writableTmpDirAsHomeHook
+  ];
+  doInstallCheck = true;
+  versionCheckKeepEnvironment = [ "HOME" ];
+  versionCheckProgramArg = "--version";
+
+  meta = {
+    description = "CLI tool for cleaning and optimizing macOS";
+    homepage = "https://github.com/tw93/Mole";
+    changelog = "https://github.com/tw93/Mole/releases/tag/V${version}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.djedlajn ];
+    platforms = [
+      "aarch64-darwin"
+      "x86_64-darwin"
+    ];
+    mainProgram = "mole";
+  };
+}


### PR DESCRIPTION
[Mole](https://github.com/tw93/Mole) - A CLI tool for cleaning and optimizing macOS by [@tw93](https://github.com/tw93).

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc