### PR TITLE
onetbb: always use hwloc built without CUDA support

### DIFF
--- a/pkgs/by-name/on/onetbb/package.nix
+++ b/pkgs/by-name/on/onetbb/package.nix
@@ -1,15 +1,20 @@
-{
+args@{
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   cmake,
-  hwloc,
+  hwloc, # Purposefully shadowed below
   ninja,
   pkg-config,
   ctestCheckHook,
 }:
-
+let
+  # The behavior of OneTBB does not change if it is built with hwloc with support for CUDA.
+  # However, the derivation *does* change, causing rebuilds of packages like Nix.
+  # To avoid these pointless rebuilds, we make sure to always use a version of hwloc with CUDA
+  # support disabled.
+  hwloc = args.hwloc.override { enableCuda = false; };
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "onetbb";
   version = "2022.3.0";


### PR DESCRIPTION
Aims to reduce rebuilds on systems with CUDA enabled. Nix transitively depends on hwloc through onetbb.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
