### PR TITLE
python3Packages.compliance-trestle: 3.9.1 -> 3.11.0

### DIFF
--- a/pkgs/development/python-modules/compliance-trestle/default.nix
+++ b/pkgs/development/python-modules/compliance-trestle/default.nix
@@ -1,54 +1,74 @@
 {
-  attrs,
+  lib,
   buildPythonPackage,
+  fetchFromGitHub,
+  pythonAtLeast,
+
+  # build-system
+  hatchling,
+
+  # dependencies
+  attrs,
   cmarkgfm,
   cryptography,
   defusedxml,
-  datamodel-code-generator,
-  email-validator,
-  fetchFromGitHub,
   furl,
   ilcli,
   importlib-resources,
   jinja2,
-  lib,
-  mypy,
   openpyxl,
   orjson,
   paramiko,
-  pytestCheckHook,
   pydantic,
   python-dotenv,
   python-frontmatter,
   requests,
   ruamel-yaml,
-  setuptools,
-  setuptools-scm,
+
+  # tests
+  datamodel-code-generator,
+  pytestCheckHook,
+  mypy,
 }:
 
-buildPythonPackage rec {
+let
+  # nist-content is a git submodule, but using fetchSubmodules in src fails while recursing into
+  # nist-content itself.
+  # Thus we simply inject it after the fact in postPatch.
+  nist-content = fetchFromGitHub {
+    name = "nist-content";
+    owner = "usnistgov";
+    repo = "oscal-content";
+    rev = "941c978d14c57379fbf6f7fb388f675067d5bff7";
+    hash = "sha256-sDvNMheZZhk09YEfY5ocmZmAC3t3KenqD3PaNsi0mMU=";
+  };
+in
+buildPythonPackage (finalAttrs: {
   pname = "compliance-trestle";
-  version = "3.9.1";
+  version = "3.11.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "oscal-compass";
     repo = "compliance-trestle";
-    tag = "v${version}";
-    hash = "sha256-AJ1luN2X6Q4dp4fna14x6HgUw1uX4X87BXkVBPVIn9k=";
-    fetchSubmodules = true;
+    tag = "v${finalAttrs.version}";
+    # TODO: Try to fall back to fetchSubmodules at the next release
+    # fetchSubmodules = true;
+    hash = "sha256-vhRD2NTt9F/7lgbmrjp5AWSUIs/iaqUAAAxs8T4Ap4A=";
   };
-
-  pythonRelaxDeps = true;
 
   postPatch = ''
     substituteInPlace tests/trestle/misc/mypy_test.py \
-      --replace-fail "trestle'," "${placeholder "out"}/bin/trestle'," \
+      --replace-fail "trestle'," "${placeholder "out"}/bin/trestle',"
+  ''
+  # Replace the expected nist-content git submodule with the pre-fetched path.
+  + ''
+    rmdir ./nist-content
+    ln -s ${nist-content} ./nist-content
   '';
 
   build-system = [
-    setuptools
-    setuptools-scm
+    hatchling
   ];
 
   dependencies = [
@@ -56,8 +76,6 @@ buildPythonPackage rec {
     cmarkgfm
     cryptography
     defusedxml
-    datamodel-code-generator
-    email-validator
     furl
     ilcli
     importlib-resources
@@ -70,11 +88,13 @@ buildPythonPackage rec {
     python-frontmatter
     requests
     ruamel-yaml
-  ];
+  ]
+  ++ pydantic.optional-dependencies.email;
 
   nativeCheckInputs = [
-    pytestCheckHook
+    datamodel-code-generator
     mypy
+    pytestCheckHook
   ];
 
   disabledTests = [
@@ -88,11 +108,26 @@ buildPythonPackage rec {
     "test_ssp_assemble_fedramp_profile"
     "test_ssp_generate_aggregates_no_cds"
     "test_ssp_generate_aggregates_no_param_value_orig"
+  ]
+  ++ lib.optionals (pythonAtLeast "3.14") [
+    # AssertionError: assert 1 == 0
+    # AttributeError: 'AliasTracker' object has no attribute 'aliases'
+    "test_arguments"
+    "test_get_list_cli"
+    "test_load_custom_config"
+    "test_load_default_config"
+    "test_split_catalog_star"
+    "test_split_comp_def"
   ];
 
   disabledTestPaths = [
     # Requires network access
     "tests/trestle/core/remote"
+  ]
+  ++ lib.optionals (pythonAtLeast "3.14") [
+    # pydantic.v1.errors.ConfigError: unable to infer type for attribute "poam"
+    "tests/trestle/core/models/interfaces_test.py"
+    "tests/trestle/tasks/ocp4_cis_profile_to_oscal_catalog_test.py"
   ];
 
   pythonImportsCheck = [ "trestle" ];
@@ -100,9 +135,9 @@ buildPythonPackage rec {
   meta = {
     description = "Opinionated tooling platform for managing compliance as code, using continuous integration and NIST's OSCAL standard";
     homepage = "https://github.com/oscal-compass/compliance-trestle";
-    changelog = "https://github.com/oscal-compass/compliance-trestle/blob/${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/oscal-compass/compliance-trestle/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ tochiaha ];
     mainProgram = "trestle";
   };
-}
+})


### PR DESCRIPTION
## Things done

Diff: https://github.com/oscal-compass/compliance-trestle/compare/v3.9.1...v3.11.0
Changelog: https://github.com/oscal-compass/compliance-trestle/blob/v3.11.0/CHANGELOG.md

cc @Tochiaha

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
