### PR TITLE
lepton-jpeg-util: init at 0.5.3

### DIFF
--- a/pkgs/by-name/le/lepton-jpeg-util/package.nix
+++ b/pkgs/by-name/le/lepton-jpeg-util/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "lepton-jpeg-util";
+  version = "0.5.3";
+
+  src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = "lepton_jpeg_rust";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-DfVgQGGnrOOa/UdkYHSENbtxkbR0cTe08uglUM2hfGI=";
+  };
+
+  cargoHash = "sha256-AryHUFB6EWSUvKs+lBI16+A27VfRsr6aUtrwsiZxT28=";
+
+  buildAndTestSubdir = "util";
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Port of DropBox Lepton compression to Rust";
+    changelog = "https://github.com/microsoft/lepton_jpeg_rust/releases/tag/v${finalAttrs.version}";
+    mainProgram = "lepton_jpeg_util";
+    homepage = "https://github.com/microsoft/lepton_jpeg_rust";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ skohtv ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
- https://github.com/microsoft/lepton_jpeg_rust

https://github.com/dropbox/lepton is deprecated and archived, https://github.com/microsoft/lepton_jpeg_rust is the replacement

I'd like to deprecate https://github.com/dropbox/lepton, but https://github.com/leijurv/gb depends on it
Noteworthy, `lepton` doesn't even build right now, due to CMake4 issue https://github.com/NixOS/nixpkgs/issues/445447, so `gb-backup` doesn't either

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
