### PR TITLE
mihomo-tui: init at 0.2.2

### DIFF
--- a/pkgs/by-name/mi/mihomo-tui/package.nix
+++ b/pkgs/by-name/mi/mihomo-tui/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "mihomo-tui";
+  version = "0.2.2";
+
+  src = fetchFromGitHub {
+    owner = "potoo0";
+    repo = "mihomo-tui";
+    rev = "v${version}";
+    hash = "sha256-8gWHExzt6f/enQSqgMUA5Y8fEwr7DXx0KfZw6d6xTp4=";
+  };
+
+  cargoHash = "sha256-NH4AX81kwwIAFlGBfPDBgDdLgKdgfnvYmMVzw9ry9D0=";
+
+  cargoBuildFlags = [ "--locked" ];
+
+  doCheck = false;
+  RUSTFLAGS = "--cfg tokio_unstable";
+
+  meta = {
+    description = "A simple TUI dashboard for monitoring and managing Mihomo via its REST API";
+    homepage = "https://github.com/potoo0/mihomo-tui";
+    changelog = "https://github.com/potoo0/mihomo-tui/blob/${src.rev}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      Oops418
+    ];
+    mainProgram = "mihomo-tui";
+  };
+}


### PR DESCRIPTION
Mihomo TUI Client.
https://github.com/potoo0/mihomo-tui

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
