### PR TITLE
.github/PULL_REQUEST_TEMPLATE: remove +1 footer

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -38,10 +38,3 @@ For new packages please briefly describe the package or provide a link to its ho
 [nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
 [pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
 [pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
-
----
-
-Add a :+1: [reaction] to [pull requests you find important].
-
-[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
-[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc


### PR DESCRIPTION
Resurrection of #426306

The footer has the following problems:
- It's not consistently added in all PRs, for example backports or those where the template is not used. Inconsistency in a voting skews the results.
- It's arguably not effective, because people use reactions naturally to interact with PRs anyway. As long as there are multiple different reaction types, what does it mean that one PR has 20 :+1:, but another has 22 :tada:? The latter won't show up in the ranking for :+1:, so at the minimum confusing. Same for :heart:.
- It's not useful to determine priority as in "higher number of votes should be merged". A PR's quality should be determined independently of votes - when it's good, it will be merged. The currently most upvoted PR has serious issues, so this invites drive-by questions like "Why isn't this merged, given the number of upvotes?".

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
