### PR TITLE
cadical: 2.2.0 -> 3.0.0

### DIFF
--- a/pkgs/by-name/ca/cadical/package.nix
+++ b/pkgs/by-name/ca/cadical/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   copyPkgconfigItems,
   makePkgconfigItem,
-  version ? "2.2.0",
+  version ? "3.0.0",
 }:
 
 stdenv.mkDerivation rec {
@@ -17,7 +17,8 @@ stdenv.mkDerivation rec {
     rev = "rel-${version}";
     hash =
       {
-        "2.2.0" = "sha256-6O0lz0YJzk1eJblQ0/f9PnSYqD8WoendIZioQiGUpCg=";
+        "3.0.0" = "sha256-pymbSC6bwQQ0YCtJd3xWZiC22UEkFiKSLObSOnoQj9I=";
+        "2.2.1" = "sha256-dYRaw9DI63Nqz0IJkfQYU4y00KSfq1Xv0xZuL1G15CY=";
         "2.1.3" = "sha256-W3kO+6nVzkmJXyHJU+NZWP0oatK3gon4EWF1/03rgL4=";
         "2.0.0" = "sha256-qoeEM9SdpuFuBPeQlCzuhPLcJ+bMQkTUTGiT8QdU8rc=";
       }

--- a/pkgs/by-name/ca/cadical_2/package.nix
+++ b/pkgs/by-name/ca/cadical_2/package.nix
@@ -1,0 +1,6 @@
+{
+  cadical,
+  version ? "2.2.1",
+}:
+
+cadical.override { inherit version; }

--- a/pkgs/by-name/st/stp/package.nix
+++ b/pkgs/by-name/st/stp/package.nix
@@ -15,7 +15,7 @@
   minisat,
   cryptominisat,
   gmp,
-  cadical,
+  cadical_2,
   gtest,
   lit,
   outputcheck,
@@ -85,8 +85,8 @@ stdenv.mkDerivation (finalAttrs: {
       cadicalDependency = symlinkJoin {
         name = "stp-${finalAttrs.version}-cadical";
         paths = [
-          cadical.lib
-          cadical.dev
+          cadical_2.lib
+          cadical_2.dev
         ];
       };
     in


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Supersedes #475349 as it contains a fix for the `stp` build failure by pinning CaDiCaL to `2.2.1` for `stp`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
