### PR TITLE
maintainers: add grishy

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9908,6 +9908,12 @@
     github = "grindhold";
     githubId = 2592640;
   };
+  grishy = {
+    name = "Sergei G.";
+    email = "mailgrishy@gmail.com";
+    github = "grishy";
+    githubId = 13949080;
+  };
   grnnja = {
     email = "grnnja@gmail.com";
     github = "grnnja";


### PR DESCRIPTION
Adding myself as a maintainer to maintain [go-avahi-cname](https://github.com/grishy/go-avahi-cname) package.   
[PR to link](https://github.com/grishy/go-avahi-cname/pull/40).

## Things done
 - [x] Fits [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md)