### PR TITLE
[25.11] nixops_unstable_minimal: 1.7.0 (2024-02-28) -> 2.0.0 (2025-12-28)

### DIFF
--- a/pkgs/applications/networking/cluster/nixops/unwrapped.nix
+++ b/pkgs/applications/networking/cluster/nixops/unwrapped.nix
@@ -14,20 +14,17 @@
 
 buildPythonApplication rec {
   pname = "nixops";
-  version = "1.7-unstable-2024-02-28";
+  version = "2.0.0-unstable-2025-12-28";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "NixOS";
     repo = "nixops";
-    rev = "08feccb14074c5434f3e483d19a7f7d9bfcdb669";
-    hash = "sha256-yWeF5apQJdChjYVSOyH6LYjJYGa1RL68LRHrSgZ9l8U=";
+    rev = "fd4b8031dbaf753545188b7c380194e47604dbac";
+    hash = "sha256-BYCCULov1/Mu5Tp4N1voQFPVWsWVyKhlQoH+I7IJnuE=";
   };
 
   postPatch = ''
-    substituteInPlace pyproject.toml --replace-fail \
-      'include = ["nix/*.nix", "nixops/py.typed" ]' \
-      'include = [ { path = "nix/*.nix", format = "wheel" }, { path = "nixops/py.typed", format = "wheel" } ]'
     substituteInPlace nixops/args.py --replace-fail "@version@" "${version}-pre-${
       lib.substring 0 7 src.rev or "dirty"
     }"


### PR DESCRIPTION
Original PR to master: https://github.com/NixOS/nixpkgs/pull/477448

From original PR:

> Update nixops to latest commit on Github to fix currently broken nixops on NixOS 25.11: fixes https://github.com/NixOS/nixpkgs/issues/467844
>Changes between current included version of nixops and updated version: https://github.com/NixOS/nixops/compare/08feccb14074c5434f3e483d19a7f7d9bfcdb669..fd4b8031dbaf753545188b7c380194e47604dbac

Fixes #467844 where nixops currently does not work under NixOS 25.11

(cherry picked from commit 1db736f)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
