### PR TITLE
nixosTests.attr: init

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -249,6 +249,7 @@ in
   atd = runTest ./atd.nix;
   atop = import ./atop.nix { inherit pkgs runTest; };
   atticd = runTest ./atticd.nix;
+  attr = pkgs.callPackage ./attr.nix { };
   atuin = runTest ./atuin.nix;
   audiobookshelf = runTest ./audiobookshelf.nix;
   audit = runTest ./audit.nix;

--- a/nixos/tests/attr.nix
+++ b/nixos/tests/attr.nix
@@ -1,0 +1,28 @@
+# The reason this lives in nixos/tests is because `attr` is a bootstrap package,
+# and it's very non-trivial to use `vmTools` in its passthru.
+#
+# The reason we need vmTools in the first place is because we don't allow
+# extended attributes in the sandbox.
+{
+  lib,
+  vmTools,
+  attr,
+  perl,
+}:
+vmTools.runInLinuxVM (
+  attr.overrideAttrs (oa: {
+    nativeCheckInputs = [ perl ];
+    preCheck = "patchShebangs test";
+
+    # FIXME(balsoft): half of the test suite is skipped because the hacky test
+    # harness doesn't know that we're root even though we are (it's looking for
+    # /etc/group, which we don't have). Probably best to submit a fix upstream
+    # rather than patch it ourselves.
+    doCheck = true;
+    memSize = 4096;
+
+    meta = oa.meta // {
+      maintainers = oa.meta.maintainers or [ ] ++ [ lib.maintainers.balsoft ];
+    };
+  })
+)

--- a/pkgs/development/libraries/attr/default.nix
+++ b/pkgs/development/libraries/attr/default.nix
@@ -37,6 +37,9 @@ stdenv.mkDerivation rec {
     done
   '';
 
+  # See nixos/tests/attr.nix
+  doCheck = false;
+
   meta = {
     homepage = "https://savannah.nongnu.org/projects/attr/";
     description = "Library and tools for manipulating extended attributes";


### PR DESCRIPTION
Runs the upstream test suite for attr.

See also the comment in nixos/tests/attr.nix for why it's part of the
NixOS tests.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
