### PR TITLE
python3Packages.pytensor: add setuptools runtime dependency

### DIFF
--- a/pkgs/development/python-modules/pytensor/default.nix
+++ b/pkgs/development/python-modules/pytensor/default.nix
@@ -61,6 +61,7 @@ buildPythonPackage rec {
     numba
     numpy
     scipy
+    setuptools
   ];
 
   nativeCheckInputs = [


### PR DESCRIPTION
## Description

Adds `setuptools` to pytensor's runtime dependencies to fix `ModuleNotFoundError` when using pytensor or packages that depend on it (e.g., pymc).

## Problem
> [!IMPORTANT]
> **PyTensor is currently broken due to missing setuptools runtime dependency**.

PyTensor imports setuptools at runtime during JIT/C compilation:
- [`pytensor/link/c/cmodule.py:1710`](https://github.com/pymc-devs/pytensor/blob/a314476f233f2c771a1f9d75ddf4959dbb2d5646/pytensor/link/c/cmodule.py#L1710): `from setuptools._distutils.sysconfig import get_config_vars, get_python_inc`
- [`pytensor/link/c/exceptions.py:1`](https://github.com/pymc-devs/pytensor/blob/a314476f233f2c771a1f9d75ddf4959dbb2d5646/pytensor/link/c/exceptions.py#L1): `from setuptools.errors import CompileError`

Without setuptools in the runtime environment, any use of pytensor that triggers compilation fails with:
```
ModuleNotFoundError: No module named 'setuptools'
```

## Root Cause

Upstream pytensor declares `setuptools>=59.0.0` as a runtime dependency in their pyproject.toml:
https://github.com/pymc-devs/pytensor/blob/a314476f233f2c771a1f9d75ddf4959dbb2d5646/pyproject.toml#L50

The nixpkgs package currently has setuptools only in `build-system`, but pytensor needs it at runtime for its JIT compilation functionality.

## Solution

Move setuptools from build-time only to runtime `dependencies` list, aligning with upstream's declared requirements.

## Testing

Reproduction case and testing available at:
https://github.com/sergioahp/pytensor-nix-issue-reproduction

Reproduction:
Using 3.12 because tensorflow-bin doesn't support Python 3.13 yet

This takes ~20 minutes because of the tests
```bash
nix-shell -p 'python312.withPackages (ps: [ps.pytensor])'
```
so instead one can do the following:
```
nix-shell -p 'python312.withPackages (ps: [(ps.pytensor.overridePythonAttrs (old: { doCheck = false; }))])'
```
then
```
python -c "import pytensor.tensor as pt; import pytensor; x = pt.dscalar('x'); f = pytensor.function([x], x ** 2)"
```

It fails with `ModuleNotFoundError`

## Quick workaround:


```bash
nix-shell -p 'python312.withPackages (ps: [(ps.pytensor.overridePythonAttrs (old: {
  dependencies = (old.dependencies or []) ++ [ ps.setuptools ];
  doCheck = false; # takes 20 minutes otherwise
}))])'
```
Then, do
```bash
python -c "import pytensor.tensor as pt; from pytensor import function; x = pt.dscalar('x'); f = function([x], x ** 2); print(f(3.0))"
```

Notifying the relevant maintainer @bcdarwin :pray:

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
