### PR TITLE
nixos/getty: do not conditionalize on console.

### DIFF
--- a/nixos/modules/services/ttys/getty.nix
+++ b/nixos/modules/services/ttys/getty.nix
@@ -131,7 +131,7 @@ in
 
   ###### implementation
 
-  config = mkIf config.console.enable {
+  config = {
     # Note: this is set here rather than up there so that changing
     # nixos.label would not rebuild manual pages
     services.getty.greetingLine = mkDefault ''<<< Welcome to ${config.system.nixos.distroName} ${config.system.nixos.label} (\m) - \l >>>'';

--- a/nixos/modules/virtualisation/nspawn-container/default.nix
+++ b/nixos/modules/virtualisation/nspawn-container/default.nix
@@ -109,9 +109,6 @@ in
       }
     ];
 
-    # TODO(arianvp): Remove after https://github.com/NixOS/nixpkgs/pull/480686 is merged
-    console.enable = true;
-
     virtualisation.systemd-nspawn.options = [
       "--private-network"
       "--machine=${config.system.name}"


### PR DESCRIPTION
## What this fixes: 

Currently ; logging in to nixos containers is broken as they do not get spawned a login shell at all. This was noticed in https://github.com/NixOS/nixpkgs/pull/470248.  Also no login shell is spawned when the bashless profile is enabled. 

##  How it fixes this

It makes it so that `console.enable` really just controls whether virtual console setup is done or not.

all the tty units are just unconditionally included as before instead of masked.

Systemd already takes care of not starting them up when they're not needed through `Condition` clauses and through the `systemd-getty-generator`.   There is no reason to manually mask (what is what `enable =  false; does) getty units. systemd already does the right thing.

## How we got here:

We have `modules/config/console.nix` . This module is what sets up the **virtual console**. That is; the graphical console that Linux ships with that by default is on `/dev/tty1` (and thus on `/dev/console` on single-user instances).

This module used to disable `systemd-vconsole-setup` when `isContainer`  was `true` as  nspawn containers do not have a virtual console; instead `/dev/console`  is a PTS device that gets mounted into the container.

https://github.com/NixOS/nixpkgs/pull/197867/changes  was then merged that made it so that the entire module gets disabled in containers. This is nice because this means we don't install `kbd` package etc in container profile which reduces the footprint.

Somebody commented that they expected this module to also disable TTY services when set to disable due to the wording being `enable virtual console`.   

However, getty services and virtual console have nothing to do with eachother. This module is to configure the virtual console fonts; not to configure gettys!    

It's perfectly possible to have TTYs without having a virtual console!  Namely serial consoles and hypervisors consoles `ttyS0`, `ttyAMA0`, `hvc0` .

A comment was made by  @rnhmjoj  correctly pointing this out

> > Tried out false, does not disable the getty target/services.
> 
> It's not mean to: this module solely takes care of configuring the console (keymap, font, colors, ...), not providing one. That's why I say the "enable virtual console" description is misleading.
https://github.com/NixOS/nixpkgs/pull/197867#issuecomment-1294204444 

However, instead of thus just merging as is; a change was made to start disabling _some_ getty services.  However (probably by accident); `console-getty.service` and `container-getty@.service` were *not* disabled. So nixos-containers kept working.

> Ok, that makes sense.
> 
> I think if this goes in it either needs a doc change like you asked for, or to also toggle the getty service so it does what the current docs imply.

https://github.com/NixOS/nixpkgs/pull/197867#issuecomment-1294383386

At this point; disabling the virtual console module would break setups that don't have a virtual console in the first place!  This includes: servers, containers, anything without a graphical display. However; because the tty list was incomplete and `console-getty.service` was *not* disabled; containers kept working.

A follow-up PR was then made (even though the original code was not correct) that added the remaining gettys https://github.com/NixOS/nixpkgs/pull/363533 . This meant all the use-cases where there is no virtual console and disable the virtual console are now properly broken. 

To date that is the [bashless profile](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/profiles/bashless.nix) and the [container profile](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/virtualisation/container-config.nix)

This then got noticed by  https://github.com/NixOS/nixpkgs/pull/470248 as it uncovered that login shells are not being spawned anymore inside nspawn containers.  

I then started looking into the PRs and backtracked how we got here.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
