### PR TITLE
ocamlPackages.curl(_lwt): init at 0.10.0, mark ocurl as deprecated

### DIFF
--- a/pkgs/development/ocaml-modules/curl/default.nix
+++ b/pkgs/development/ocaml-modules/curl/default.nix
@@ -1,0 +1,34 @@
+{
+  buildDunePackage,
+  pkg-config,
+  dune-configurator,
+  fetchurl,
+  lib,
+  curl,
+}:
+
+buildDunePackage (finalAttrs: {
+  pname = "curl";
+  version = "0.10.0";
+  minimalOCamlVersion = "4.11";
+  src = fetchurl {
+    url = "https://github.com/ygrek/ocurl/releases/download/${finalAttrs.version}/curl-${finalAttrs.version}.tbz";
+    hash = "sha256-wU4hX9p/lCkqdY2a6Q97y8IVZMkZGQBkAR/M3PehKRQ=";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ dune-configurator ];
+  propagatedBuildInputs = [
+    curl
+  ];
+
+  checkInputs = [ ];
+  doCheck = true;
+
+  meta = {
+    description = "Bindings to libcurl";
+    homepage = "https://ygrek.org/p/ocurl/";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.vog ];
+  };
+})

--- a/pkgs/development/ocaml-modules/curl/lwt.nix
+++ b/pkgs/development/ocaml-modules/curl/lwt.nix
@@ -1,0 +1,23 @@
+{
+  buildDunePackage,
+  curl,
+  lib,
+  lwt,
+}:
+
+buildDunePackage (finalAttrs: {
+  pname = "curl_lwt";
+  inherit (curl) version src;
+
+  propagatedBuildInputs = [
+    curl
+    lwt
+  ];
+
+  checkInputs = [ ];
+  doCheck = true;
+
+  meta = curl.meta // {
+    description = "Bindings to libcurl (lwt variant)";
+  };
+})

--- a/pkgs/development/ocaml-modules/ocurl/default.nix
+++ b/pkgs/development/ocaml-modules/ocurl/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
 
   createFindlibDestdir = true;
   meta = {
-    description = "OCaml bindings to libcurl";
+    description = "OCaml bindings to libcurl (deprecated)";
     license = lib.licenses.mit;
     homepage = "http://ygrek.org.ua/p/ocurl/";
     maintainers = with lib.maintainers; [

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -358,6 +358,9 @@ let
 
         cudf = callPackage ../development/ocaml-modules/cudf { };
 
+        curl = callPackage ../development/ocaml-modules/curl { inherit (pkgs) curl; };
+        curl_lwt = callPackage ../development/ocaml-modules/curl/lwt.nix { };
+
         curly = callPackage ../development/ocaml-modules/curly {
           inherit (pkgs) curl;
         };
@@ -1606,7 +1609,7 @@ let
 
         octavius = callPackage ../development/ocaml-modules/octavius { };
 
-        ocurl = callPackage ../development/ocaml-modules/ocurl { };
+        ocurl = callPackage ../development/ocaml-modules/ocurl { inherit (pkgs) curl; };
 
         odate = callPackage ../development/ocaml-modules/odate { };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
