### PR TITLE
python3Packages.kagglehub: 0.3.13 -> 0.4.0

### DIFF
--- a/pkgs/development/python-modules/kagglehub/default.nix
+++ b/pkgs/development/python-modules/kagglehub/default.nix
@@ -2,11 +2,13 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  pythonAtLeast,
 
   # build-system
   hatchling,
 
   # dependencies
+  kagglesdk,
   packaging,
   pyyaml,
   requests,
@@ -35,16 +37,16 @@
   writableTmpDirAsHomeHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "kagglehub";
-  version = "0.3.13";
+  version = "0.4.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Kaggle";
     repo = "kagglehub";
-    tag = "v${version}";
-    hash = "sha256-pwQZhNtps2wZeLlMMsX0M8t6qBuEdL3m/Kjf0Qdk0PM=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-R9yV29Yrq9it21K2GZLXMNM8MjBAG1iYb1o1azrAghM=";
   };
 
   build-system = [
@@ -52,6 +54,7 @@ buildPythonPackage rec {
   ];
 
   dependencies = [
+    kagglesdk
     packaging
     pyyaml
     requests
@@ -90,7 +93,7 @@ buildPythonPackage rec {
     pytestCheckHook
     writableTmpDirAsHomeHook
   ]
-  ++ optional-dependencies.pandas-datasets;
+  ++ finalAttrs.passthru.optional-dependencies.pandas-datasets;
 
   disabledTestPaths = [
     # Require internet access
@@ -100,6 +103,13 @@ buildPythonPackage rec {
   disabledTests = [
     # Requires internet access
     "test_model_signing"
+  ]
+  ++ lib.optionals (pythonAtLeast "3.14") [
+    # TypeError: Pickler._batch_setitems() takes 2 positional arguments but 3 were given
+    "test_hf_dataset_succeeds"
+    "test_hf_dataset_with_other_loader_kwargs_prints_warning"
+    "test_hf_dataset_with_splits_succeeds"
+    "test_hf_dataset_with_valid_kwargs_succeeds"
   ];
 
   __darwinAllowLocalNetworking = true;
@@ -107,8 +117,8 @@ buildPythonPackage rec {
   meta = {
     description = "Python library to access Kaggle resources";
     homepage = "https://github.com/Kaggle/kagglehub";
-    changelog = "https://github.com/Kaggle/kagglehub/blob/${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/Kaggle/kagglehub/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ GaetanLepage ];
   };
-}
+})

--- a/pkgs/development/python-modules/kagglesdk/default.nix
+++ b/pkgs/development/python-modules/kagglesdk/default.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  hatchling,
+
+  # dependencies
+  protobuf,
+  requests,
+
+  # tests
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "kagglesdk";
+  version = "0.1.15";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Kaggle";
+    repo = "kagglesdk";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-u945sytmPUEYRNvT8v/O3HBhJoLnECPAT3GdvtBkBV4=";
+  };
+
+  build-system = [
+    hatchling
+  ];
+
+  dependencies = [
+    protobuf
+    requests
+  ];
+
+  pythonImportsCheck = [ "kagglesdk" ];
+
+  # The two available tests fail with:
+  # AssertionError: 'https://api.kaggle.com' != 'https://www.kaggle.com'
+  doCheck = false;
+
+  meta = {
+    description = "Bindings to access Kaggle endpoints";
+    homepage = "https://github.com/Kaggle/kagglesdk";
+    changelog = "https://github.com/Kaggle/kagglesdk/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8007,6 +8007,8 @@ self: super: with self; {
 
   kagglehub = callPackage ../development/python-modules/kagglehub { };
 
+  kagglesdk = callPackage ../development/python-modules/kagglesdk { };
+
   kahip = toPythonModule (
     pkgs.kahip.override {
       pythonSupport = true;


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/Kaggle/kagglehub/compare/v0.3.13...v0.4.0
Changelog: https://github.com/Kaggle/kagglehub/blob/v0.4.0/CHANGELOG.md

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc