### PR TITLE
drasl: init at 3.4.2

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -40,6 +40,8 @@
 
 - [Shoko](https://shokoanime.com), an anime management system. Available as [services.shoko](#opt-services.shoko.enable).
 
+- [Drasl](https://github.com/unmojang/drasl), an alternative authentication server for Minecraft. Available as [services.drasl](#opt-services.drasl.enable).
+
 ## Backward Incompatibilities {#sec-release-26.05-incompatibilities}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1604,6 +1604,7 @@
   ./services/web-apps/docuseal.nix
   ./services/web-apps/dokuwiki.nix
   ./services/web-apps/dolibarr.nix
+  ./services/web-apps/drasl.nix
   ./services/web-apps/drupal.nix
   ./services/web-apps/echoip.nix
   ./services/web-apps/eintopf.nix

--- a/nixos/modules/services/web-apps/drasl.nix
+++ b/nixos/modules/services/web-apps/drasl.nix
@@ -1,0 +1,167 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  cfg = config.services.drasl;
+  format = pkgs.formats.toml { };
+  filterAttrs = x: lib.filterAttrs (n: v: n != "ClientSecretFile" || v != null) x;
+  getIndex =
+    item:
+    builtins.toString (lib.lists.findFirstIndex (x: x == item) null cfg.settings.RegistrationOIDC);
+  secretFiles = lib.filter (
+    x: lib.hasAttr "ClientSecretFile" (filterAttrs x)
+  ) cfg.settings.RegistrationOIDC;
+  settings = format.generate "drasl-config.toml" (
+    if cfg.settings.RegistrationOIDC == [ ] then
+      lib.filterAttrs (n: v: n != "RegistrationOIDC" || v != [ ]) cfg.settings
+    else
+      lib.recursiveUpdate cfg.settings {
+        RegistrationOIDC = map (
+          x:
+          if lib.hasAttr "ClientSecretFile" (filterAttrs x) then
+            lib.recursiveUpdate (filterAttrs x) {
+              ClientSecretFile = "$CREDENTIALS_DIRECTORY/${getIndex x}";
+            }
+          else
+            filterAttrs x
+        ) cfg.settings.RegistrationOIDC;
+      }
+  );
+in
+{
+  options.services.drasl = {
+    enable = lib.mkEnableOption "Drasl";
+    package = lib.mkPackageOption pkgs "drasl" { };
+    enableDebug = lib.mkEnableOption "debugging";
+    settings = lib.mkOption {
+      description = ''
+        Configuration for Drasl. See the
+        [Drasl documentation](https://github.com/unmojang/drasl/blob/master/doc/configuration.md)
+        for possible options.
+      '';
+      type = lib.types.submodule {
+        freeformType = format.type;
+        options = {
+          RegistrationOIDC = lib.mkOption {
+            default = [ ];
+            description = "List of OpenID connect providers.";
+            type = lib.types.listOf (
+              lib.types.submodule {
+                freeformType = format.type;
+                options = {
+                  ClientSecretFile = lib.mkOption {
+                    default = null;
+                    description = ''
+                      Path to a file containing the OIDC client secret.
+
+                      ::: {.note}
+                      The NixOS module will automatically load this file using
+                      systemd's LoadCredential. Make sure this file is only
+                      readable by the root user.
+                      :::
+                    '';
+                    type = lib.types.nullOr lib.types.path;
+                  };
+                };
+              }
+            );
+          };
+        };
+      };
+    };
+  };
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = lib.allUnique cfg.settings.RegistrationOIDC;
+        message = "All items in `services.drasl.settings.RegistrationOIDC` must be unique.";
+      }
+      {
+        assertion = lib.all (
+          x: (lib.hasAttr "ClientSecretFile" (filterAttrs x)) -> !(lib.hasAttr "ClientSecret" (filterAttrs x))
+        ) cfg.settings.RegistrationOIDC;
+        message =
+          "Do not set both `services.drasl.settings.RegistrationOIDC.*.ClientSecret` "
+          + "and `services.drasl.settings.RegistrationOIDC.*.ClientSecretFile`";
+      }
+    ];
+    systemd.services.drasl = {
+      description = "Drasl";
+      after = [
+        "network-online.target"
+        "nss-lookup.target"
+      ];
+      wants = [ "network-online.target" ];
+      wantedBy = [ "multi-user.target" ];
+      environment = lib.mkIf cfg.enableDebug { DRASL_DEBUG = "1"; };
+      serviceConfig = {
+        ExecStart = "${lib.getExe cfg.package} -config ${settings}";
+        DynamicUser = true;
+        RuntimeDirectory = "drasl";
+        RuntimeDirectoryMode = "0700";
+        StateDirectory = "drasl";
+        LoadCredential = lib.mkIf (secretFiles != [ ]) (
+          map (x: "${getIndex x}:${x.ClientSecretFile}") secretFiles
+        );
+        # Hardening
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        PrivateMounts = true;
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        RemoveIPC = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        CapabilityBoundingSet = "CAP_NET_BIND_SERVICE";
+        AmbientCapabilities = "CAP_NET_BIND_SERVICE";
+        PrivateTmp = "disconnected";
+        ProcSubset = "pid";
+        ProtectProc = "invisible";
+        ProtectSystem = "strict";
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+        ];
+        RestrictNamespaces = [
+          "~cgroup"
+          "~ipc"
+          "~mnt"
+          "~net"
+          "~pid"
+          "~user"
+          "~uts"
+        ];
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "~@clock"
+          "~@cpu-emulation"
+          "~@debug"
+          "~@module"
+          "~@mount"
+          "~@obsolete"
+          "~@privileged"
+          "~@raw-io"
+          "~@reboot"
+          "~@resources"
+          "~@swap"
+        ];
+        UMask = "0077";
+      };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [
+    evan-goode
+    ungeskriptet
+  ];
+}

--- a/pkgs/by-name/dr/drasl/package.nix
+++ b/pkgs/by-name/dr/drasl/package.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  fetchNpmDeps,
+  npmHooks,
+  go-swag,
+  nodejs,
+  nix-update-script,
+}:
+buildGoModule (finalAttrs: {
+  pname = "drasl";
+  version = "3.4.2";
+
+  src = fetchFromGitHub {
+    owner = "unmojang";
+    repo = "drasl";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-SOH6WXhBBx5JShr18Q0SyDFYVE7LMRUONdCJ1NB2HRQ=";
+  };
+
+  nativeBuildInputs = [
+    go-swag
+    nodejs
+    npmHooks.npmConfigHook
+  ];
+
+  npmDeps = fetchNpmDeps {
+    inherit (finalAttrs) src;
+    hash = "sha256-L0y04zLgno5kKUACyokma8uk/fNY2mwdMwsq217SCqI=";
+  };
+
+  vendorHash = "sha256-4Rk59bnDFYpraoGvkBUW6Z5fiXUmm2RLwS1wxScWAMQ=";
+
+  overrideModAttrs = oldAttrs: {
+    nativeBuildInputs = lib.filter (drv: drv != npmHooks.npmConfigHook) oldAttrs.nativeBuildInputs;
+    preBuild = null;
+  };
+
+  postPatch = ''
+    substituteInPlace build_config.go --replace-fail "\"/usr/share/drasl\"" "\"$out/share/drasl\""
+  '';
+
+  preBuild = ''
+    make prebuild
+  '';
+
+  postInstall = ''
+    mkdir -p "$out/share/drasl"
+    cp -R ./{assets,view,public,locales} "$out/share/drasl"
+  '';
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Yggdrasil-compatible API server for Minecraft";
+    homepage = "https://github.com/unmojang/drasl";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [
+      evan-goode
+      ungeskriptet
+    ];
+    mainProgram = "drasl";
+  };
+})


### PR DESCRIPTION
Add Drasl, an alternative authentication server for Minecraft.

Cc @evan-goode: Would you like to be added as a maintainer for the package and module as well?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
