### PR TITLE
gpd-pocket-4-pipewire: init at 0-unstable-2025-04-08

### DIFF
--- a/pkgs/by-name/gp/gpd-pocket-4-pipewire/package.nix
+++ b/pkgs/by-name/gp/gpd-pocket-4-pipewire/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  bankstown-lv2,
+  lsp-plugins,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "gpd-pocket-4-pipewire";
+  version = "0.0.1";
+
+  src = fetchFromGitHub {
+    owner = "Manawyrm";
+    repo = "gpd-pocket-4-pipewire";
+    tag = finalAttrs.version;
+    hash = "sha256-FNnEfY1a3CeFCH+dRwb7NyOeDPeHDnwacw/8jLawDK0=";
+  };
+
+  postPatch = ''
+    substituteInPlace pipewire.conf.d/sink-gpd-pocket-4.conf \
+      --replace-fail /usr/share/pipewire/pipewire.conf.d $out/share/pipewire/pipewire.conf.d
+  '';
+
+  installPhase = ''
+    install -dDm0755 "$out/share/pipewire/pipewire.conf.d/"
+    install -v -D -m0644 "pipewire.conf.d/gpd-pocket-4-mp-48k-l.wav" "$out/share/pipewire/pipewire.conf.d/gpd-pocket-4-mp-48k-l.wav"
+    install -v -D -m0644 "pipewire.conf.d/gpd-pocket-4-mp-48k-r.wav" "$out/share/pipewire/pipewire.conf.d/gpd-pocket-4-mp-48k-r.wav"
+    install -v -D -m0644 "pipewire.conf.d/sink-gpd-pocket-4.conf" "$out/share/pipewire/pipewire.conf.d/sink-gpd-pocket-4.conf"
+  '';
+
+  passthru.requiredLv2Packages = [
+    bankstown-lv2
+    lsp-plugins
+  ];
+
+  meta = {
+    description = "Pipewire audio DSP for internal speakers of GPD Pocket 4";
+    license = lib.licenses.mit;
+    homepage = "https://github.com/Manawyrm/gpd-pocket-4-pipewire/";
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ marcel ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This can be applied with:

```nix
services.pipewire.configPackages = with pkgs; [
  gpd-pocket-4-pipewire
];
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
