### PR TITLE
protobuf: patch bug when compiling with nvcc

### DIFF
--- a/pkgs/by-name/on/onnxruntime/package.nix
+++ b/pkgs/by-name/on/onnxruntime/package.nix
@@ -39,29 +39,6 @@ let
 
   cudaArchitecturesString = cudaPackages.flags.cmakeCudaArchitecturesString;
 
-  # While onnxruntime suggests using (3 year-old) protobuf 21.12
-  # https://github.com/microsoft/onnxruntime/blob/v1.23.2/cmake/deps.txt#L40, using a newer
-  # protobuf version is possible.
-  # We still need to patch the nixpkgs protobuf (32.1) to address the following test failure that
-  # occurs when cudaSupport is enabled:
-  # [libprotobuf ERROR /build/source/src/google/protobuf/descriptor_database.cc:642] File already exists in database: onnx/onnx-ml.proto
-  # [libprotobuf FATAL /build/source/src/google/protobuf/descriptor.cc:1986] CHECK failed: GeneratedDatabase()->Add(encoded_file_descriptor, size):
-  # terminate called after throwing an instance of 'google::protobuf::FatalException'
-  #   what():  CHECK failed: GeneratedDatabase()->Add(encoded_file_descriptor, size):
-  #
-  #
-  # Caused by: https://github.com/protocolbuffers/protobuf/commit/8f7aab29b21afb89ea0d6e2efeafd17ca71486a9
-  # Reported upstream: https://github.com/protocolbuffers/protobuf/issues/21542
-  protobuf' = protobuf.overrideAttrs (old: {
-    patches = (old.patches or [ ]) ++ [
-      (fetchpatch {
-        name = "Workaround nvcc bug in message_lite.h";
-        url = "https://raw.githubusercontent.com/conda-forge/protobuf-feedstock/737a13ea0680484c08e8e0ab0144dab82c10c1b3/recipe/patches/0010-Workaround-nvcc-bug-in-message_lite.h.patch";
-        hash = "sha256-joK50Il4mrwIc6zuNW9gDIfOx9LuA4FlusJuzUf9kqI=";
-      })
-    ];
-  });
-
   # TODO: update the following dependencies according to:
   # https://github.com/microsoft/onnxruntime/blob/v<VERSION>/cmake/deps.txt
 
@@ -157,7 +134,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     cmake
     pkg-config
     python3Packages.python
-    protobuf'
+    protobuf
   ]
   ++ lib.optionals pythonSupport (
     with python3Packages;
@@ -272,7 +249,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_SAFEINT" "${safeint-src}")
     (lib.cmakeFeature "FETCHCONTENT_TRY_FIND_PACKAGE_MODE" "ALWAYS")
     # fails to find protoc on darwin, so specify it
-    (lib.cmakeFeature "ONNX_CUSTOM_PROTOC_EXECUTABLE" (lib.getExe protobuf'))
+    (lib.cmakeFeature "ONNX_CUSTOM_PROTOC_EXECUTABLE" (lib.getExe protobuf))
     (lib.cmakeBool "onnxruntime_BUILD_SHARED_LIB" true)
     (lib.cmakeBool "onnxruntime_BUILD_UNIT_TESTS" finalAttrs.doCheck)
     (lib.cmakeBool "onnxruntime_USE_FULL_PROTOBUF" withFullProtobuf)
@@ -378,7 +355,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     inherit cudaSupport cudaPackages ncclSupport; # for the python module
-    protobuf = protobuf';
+    inherit protobuf;
     tests = lib.optionalAttrs pythonSupport {
       python = python3Packages.onnxruntime;
     };

--- a/pkgs/development/libraries/protobuf/generic.nix
+++ b/pkgs/development/libraries/protobuf/generic.nix
@@ -9,11 +9,11 @@
   cmake,
   fetchFromGitHub,
   fetchpatch,
+  fetchurl,
   gtest,
   zlib,
   version,
   hash,
-  replaceVars,
   versionCheckHook,
 
   # downstream dependencies
@@ -57,6 +57,18 @@ stdenv.mkDerivation (finalAttrs: {
       (fetchpatch {
         url = "https://github.com/protocolbuffers/protobuf/commit/0e9d0f6e77280b7a597ebe8361156d6bb1971dca.patch";
         hash = "sha256-rIP+Ft/SWVwh9Oy8y8GSUBgP6CtLCLvGmr6nOqmyHhY=";
+      })
+    ]
+    ++ lib.optionals (lib.versionAtLeast version "30") [
+      # workaround nvcc bug in message_lite.h
+      # https://github.com/protocolbuffers/protobuf/issues/21542
+      # Caused by: https://github.com/protocolbuffers/protobuf/commit/8f7aab29b21afb89ea0d6e2efeafd17ca71486a9
+      #
+      # A specific consequence of this bug is a test failure when building onnxruntime with cudaSupport
+      # See https://github.com/NixOS/nixpkgs/pull/450587#discussion_r2698215974
+      (fetchurl {
+        url = "https://raw.githubusercontent.com/conda-forge/protobuf-feedstock/737a13ea0680484c08e8e0ab0144dab82c10c1b3/recipe/patches/0010-Workaround-nvcc-bug-in-message_lite.h.patch";
+        hash = "sha256-uXm/j0r5ya/Hsc6/wAZDHLV2sn9Iv/79oOCmDjiU9UE=";
       })
     ];
 


### PR DESCRIPTION
## Things done

This was discovered [while working on the `onnxruntime` update](https://github.com/NixOS/nixpkgs/pull/450587#discussion_r2698215974).

The patch comes from conda: https://github.com/conda-forge/protobuf-feedstock/pull/256.

The issue was introduced in https://github.com/protocolbuffers/protobuf/commit/8f7aab29b21afb89ea0d6e2efeafd17ca71486a9.
[This issue](https://github.com/protocolbuffers/protobuf/issues/21542) discusses the build failure with nvcc specifically.

cc @yuyuyureka @mweinelt

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
