### PR TITLE
pgformatter: enable tests, add version check, modernize

### DIFF
--- a/pkgs/by-name/pg/pgformatter/package.nix
+++ b/pkgs/by-name/pg/pgformatter/package.nix
@@ -34,9 +34,9 @@ perlPackages.buildPerlPackage rec {
       --replace-fail \
         "'INSTALLDIRS'  => \$INSTALLDIRS," \
         "'INSTALLDIRS'  => \$INSTALLDIRS, 'INSTALLVENDORLIB' => 'bin/lib', 'INSTALLVENDORBIN' => 'bin', 'INSTALLVENDORSCRIPT' => 'bin', 'INSTALLVENDORMAN1DIR' => 'share/man/man1', 'INSTALLVENDORMAN3DIR' => 'share/man/man3',"
-  '';
 
-  doCheck = false;
+    patchShebangs .
+  '';
 
   meta = {
     description = "PostgreSQL SQL syntax beautifier that can work as a console program or as a CGI";

--- a/pkgs/by-name/pg/pgformatter/package.nix
+++ b/pkgs/by-name/pg/pgformatter/package.nix
@@ -11,7 +11,7 @@ perlPackages.buildPerlPackage rec {
   src = fetchFromGitHub {
     owner = "darold";
     repo = "pgFormatter";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-G4Bbg8tNlwV8VCVKCamhlQ/pGf8hWCkABm6f8i5doos=";
   };
 
@@ -23,12 +23,17 @@ perlPackages.buildPerlPackage rec {
   installTargets = [ "pure_install" ];
 
   # Makefile.PL only accepts DESTDIR and INSTALLDIRS, but we need to set more to make this work for NixOS.
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace pg_format \
-      --replace "#!/usr/bin/env perl" "#!/usr/bin/perl"
+      --replace-fail "#!/usr/bin/env perl" "#!/usr/bin/perl"
+
     substituteInPlace Makefile.PL \
-      --replace "'DESTDIR'      => \$DESTDIR," "'DESTDIR'      => '$out/'," \
-      --replace "'INSTALLDIRS'  => \$INSTALLDIRS," "'INSTALLDIRS'  => \$INSTALLDIRS, 'INSTALLVENDORLIB' => 'bin/lib', 'INSTALLVENDORBIN' => 'bin', 'INSTALLVENDORSCRIPT' => 'bin', 'INSTALLVENDORMAN1DIR' => 'share/man/man1', 'INSTALLVENDORMAN3DIR' => 'share/man/man3',"
+      --replace-fail \
+        "'DESTDIR'      => \$DESTDIR," \
+        "'DESTDIR'      => '$out/'," \
+      --replace-fail \
+        "'INSTALLDIRS'  => \$INSTALLDIRS," \
+        "'INSTALLDIRS'  => \$INSTALLDIRS, 'INSTALLVENDORLIB' => 'bin/lib', 'INSTALLVENDORBIN' => 'bin', 'INSTALLVENDORSCRIPT' => 'bin', 'INSTALLVENDORMAN1DIR' => 'share/man/man1', 'INSTALLVENDORMAN3DIR' => 'share/man/man3',"
   '';
 
   doCheck = false;
@@ -36,7 +41,7 @@ perlPackages.buildPerlPackage rec {
   meta = {
     description = "PostgreSQL SQL syntax beautifier that can work as a console program or as a CGI";
     homepage = "https://github.com/darold/pgFormatter";
-    changelog = "https://github.com/darold/pgFormatter/releases/tag/v${version}";
+    changelog = "https://github.com/darold/pgFormatter/releases/tag/${src.tag}";
     maintainers = with lib.maintainers; [
       thunze
       mfairley

--- a/pkgs/by-name/pg/pgformatter/package.nix
+++ b/pkgs/by-name/pg/pgformatter/package.nix
@@ -2,6 +2,7 @@
   lib,
   perlPackages,
   fetchFromGitHub,
+  versionCheckHook,
 }:
 
 perlPackages.buildPerlPackage rec {
@@ -37,6 +38,10 @@ perlPackages.buildPerlPackage rec {
 
     patchShebangs .
   '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
 
   meta = {
     description = "PostgreSQL SQL syntax beautifier that can work as a console program or as a CGI";


### PR DESCRIPTION
- Enable tests
- Add version check via `versionCheckHook`
- Modernization
  - `src.rev` → `src.tag`
  - `patchPhase` → `postPatch` so that we don't silently ignore `{pre,post}Patch`
  - `--replace` → `--replace-fail` so that substitution fails with an error if the string to substitute cannot be found

I'm also working on adding `passthru.updateScript`, but that's a bit trickier due to `buildPerlPackage`. I'll follow up with a separate PR for that once I find a good solution.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
