### PR TITLE
testkube: 2.2.6 -> 2.5.7

### DIFF
--- a/pkgs/by-name/te/testkube/package.nix
+++ b/pkgs/by-name/te/testkube/package.nix
@@ -5,13 +5,13 @@
 }:
 buildGoModule rec {
   pname = "testkube";
-  version = "2.5.4";
+  version = "2.5.7";
 
   src = fetchFromGitHub {
     owner = "kubeshop";
     repo = "testkube";
     rev = "${version}";
-    hash = "sha256-B3n9g65VU+7G9YKc3zuT4qX/RJWUvvnbYVrdg2DBUxQ=";
+    hash = "sha256-5Fc/esXmwTMS929k6HXhmzGGlGaCWp/dKQUZm+kIz7M=";
   };
 
   vendorHash = "sha256-e2lyJdD3j87494S6oif2/OnjzRY8AEiLZxd9KeMO7UE=";

--- a/pkgs/by-name/te/testkube/package.nix
+++ b/pkgs/by-name/te/testkube/package.nix
@@ -5,16 +5,16 @@
 }:
 buildGoModule rec {
   pname = "testkube";
-  version = "2.2.6";
+  version = "2.5.4";
 
   src = fetchFromGitHub {
     owner = "kubeshop";
     repo = "testkube";
-    rev = "v${version}";
-    hash = "sha256-aAE3Mb39ddy9I4Ftzb5WKRlcIv7iTrZ8mRsjjyyZv9Y=";
+    rev = "${version}";
+    hash = "sha256-B3n9g65VU+7G9YKc3zuT4qX/RJWUvvnbYVrdg2DBUxQ=";
   };
 
-  vendorHash = "sha256-WaanaknTuCnjBjxIi39ZHTqh3C92rLQAPRFx0o7dwZY=";
+  vendorHash = "sha256-e2lyJdD3j87494S6oif2/OnjzRY8AEiLZxd9KeMO7UE=";
 
   ldflags = [
     "-X main.version=${version}"


### PR DESCRIPTION
Update testkube from 2.2.6 to 2.5.7.

Github revision pattern changed from vX.X.X to X.X.X.
Tested against an actual testkube server instance.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
