### PR TITLE
gh-review-conductor: init at 1.3.0

### DIFF
--- a/pkgs/by-name/gh/gh-review-conductor/package.nix
+++ b/pkgs/by-name/gh/gh-review-conductor/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "gh-review-conductor";
+  version = "1.3.0";
+
+  src = fetchFromGitHub {
+    owner = "gh-tui-tools";
+    repo = "gh-review-conductor";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-gNQmO+Sa9n+hfy5CBSPqSXhHTzZz8D1sLrNqs+z9Rx4=";
+  };
+
+  vendorHash = "sha256-xAOTSdyNRZDKDPnCrvaepBOTDrnHLEA53K5TBxkqbDM=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/gh-tui-tools/gh-review-conductor/cmd.version=${finalAttrs.version}"
+  ];
+
+  # Tests require GitHub authentication and network access
+  doCheck = false;
+
+  __structuredAttrs = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "GitHub CLI extension to apply PR review comments and suggestions directly to your local code";
+    homepage = "https://github.com/gh-tui-tools/gh-review-conductor";
+    changelog = "https://github.com/gh-tui-tools/gh-review-conductor/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      vdemeester
+      chmouel
+    ];
+    mainProgram = "gh-prreview";
+  };
+})


### PR DESCRIPTION
New package: GitHub CLI extension to apply PR review comments and suggestions directly to your local code.

**Package**: gh-prreview v1.3.0
**Homepage**: https://github.com/gh-tui-tools/gh-review-conductor
**License**: Apache 2.0

## Description

gh-review-conductor is a GitHub CLI extension that allows developers to manage PR reviews entirely from the terminal, including:
- Listing and browsing review comments
- Previewing and applying review suggestions interactively or in batch mode
- Resolving comment threads
- Replying to comments
- Optional AI-assisted application for challenging cases

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] NixOS tests in nixos/tests.
  - [ ] Package tests at `passthru.tests`.
  - [ ] Tests in lib/tests or pkgs/test for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See nixpkgs-review usage.
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits CONTRIBUTING.md, pkgs/README.md, maintainers/README.md and other READMEs.

## Additional Notes

- Package uses modern `finalAttrs` pattern
- Tests disabled (require GitHub authentication and network access)
- Includes automatic update script via `nix-update-script`
- Maintainers: @vdemeester @chmouel