### PR TITLE
nixos/wordpress: add finalPackage attribute

### DIFF
--- a/nixos/modules/services/web-apps/wordpress.nix
+++ b/nixos/modules/services/web-apps/wordpress.nix
@@ -157,6 +157,15 @@ let
     {
       options = {
         package = mkPackageOption pkgs "wordpress" { };
+        finalPackage = mkOption {
+          type = types.package;
+          readOnly = true;
+          default = pkg name config;
+          defaultText = literalExpression "pkg name config";
+          description = ''
+            WordPress package with bundled configuration, plugins and themes.
+          '';
+        };
 
         uploadsDir = mkOption {
           type = types.path;
@@ -489,9 +498,9 @@ in
           mkMerge [
             cfg.virtualHost
             {
-              documentRoot = mkForce "${pkg hostName cfg}/share/wordpress";
+              documentRoot = mkForce "${cfg.finalPackage}/share/wordpress";
               extraConfig = ''
-                <Directory "${pkg hostName cfg}/share/wordpress">
+                <Directory "${cfg.finalPackage}/share/wordpress">
                   <FilesMatch "\.php$">
                     <If "-f %{REQUEST_FILENAME}">
                       SetHandler "proxy:unix:${
@@ -571,7 +580,7 @@ in
         enable = true;
         virtualHosts = mapAttrs (hostName: cfg: {
           serverName = mkDefault hostName;
-          root = "${pkg hostName cfg}/share/wordpress";
+          root = "${cfg.finalPackage}/share/wordpress";
           extraConfig = ''
             index index.php;
           '';
@@ -628,7 +637,7 @@ in
           hostName: cfg:
           (nameValuePair hostName {
             extraConfig = ''
-              root    * /${pkg hostName cfg}/share/wordpress
+              root    * /${cfg.finalPackage}/share/wordpress
               file_server
 
               php_fastcgi unix/${config.services.phpfpm.pools."wordpress-${hostName}".socket}


### PR DESCRIPTION
Previously, the derivation wasn't exposed to the public. This parameter will be helpful for integrations that are outside of Nixpkgs.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
