### PR TITLE
yaziPlugins: update on 2026-01-16

### DIFF
--- a/pkgs/by-name/ya/yazi/plugins/mime-ext/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/mime-ext/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "mime-ext.yazi";
-  version = "25.12.29-unstable-2026-01-07";
+  version = "0-unstable-2026-01-12";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "68f7d4898c19dcf50beda251f8143992c3e8371f";
-    hash = "sha256-6iA/C0dzbLPkEDbdEs8oAnVfG6W+L8/dYyjTuO5euOw=";
+    rev = "75f6f7276fadf306597c2d2b4e264335fa0937cf";
+    hash = "sha256-iiV6WSLdc7LPjXr+DRwVKzgJr+0Z8hO2eil5cdAgW4g=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/piper/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/piper/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "piper.yazi";
-  version = "25.9.15-unstable-2025-12-31";
+  version = "25.9.15-unstable-2026-01-12";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "398796d88fee7bf9c99c4dc29089b865d4f47722";
-    hash = "sha256-LOQ/0LYVrXsqQjeBeERKQ2M8BwN8xo3yej1mxNHphOU=";
+    rev = "c179ea49753b3a784935986d36b077a6df24bdb3";
+    hash = "sha256-0VKoUusTmKVxW8fJkYf0lm17bMjvkN1/tmx7+pNJdWI=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/time-travel/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/time-travel/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "time-travel.yazi";
-  version = "0-unstable-2025-02-14";
+  version = "0-unstable-2026-01-16";
 
   src = fetchFromGitHub {
     owner = "iynaix";
     repo = "time-travel.yazi";
-    rev = "7e0179e15a41a4a42b6d0b5fa6dd240c9b4cf0d2";
-    hash = "sha256-ZZgn5rsBzvZcnDWZfjMBPRg9QUz4FTq5UIPWfnwXHQs=";
+    rev = "aaec6e26e525bd146354a5137ec40f1f23257a4e";
+    hash = "sha256-/+KiuGUox763dMQvHl1l3+Ci3vL8NwRuKNu9pi3gjyE=";
   };
 
   meta = {


### PR DESCRIPTION
- mime-ext: 25.12.29-unstable-2026-01-07 → 0-unstable-2026-01-12
  Compare: https://github.com/yazi-rs/plugins/compare/68f7d4898c19dcf50beda251f8143992c3e8371f...75f6f7276fadf306597c2d2b4e264335fa0937cf
- piper: 25.9.15-unstable-2025-12-31 → 25.9.15-unstable-2026-01-12
  Compare: https://github.com/yazi-rs/plugins/compare/398796d88fee7bf9c99c4dc29089b865d4f47722...c179ea49753b3a784935986d36b077a6df24bdb3
- time-travel: 0-unstable-2025-02-14 → 0-unstable-2026-01-16
  Compare: https://github.com/iynaix/time-travel.yazi/compare/7e0179e15a41a4a42b6d0b5fa6dd240c9b4cf0d2...aaec6e26e525bd146354a5137ec40f1f23257a4e


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Looks like mime-ext has a weird setup now... updater won't be able to detect the yazi version properly. 

https://github.com/yazi-rs/plugins/commit/57f18631fde7ce9b5eb01f9c3996be296dec9a39

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
