### PR TITLE
mcp-deadmansnitch: init at 1.0.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11748,6 +11748,12 @@
     github = "james-atkins";
     githubId = 9221409;
   };
+  jamesbrink = {
+    name = "James Brink";
+    email = "brink.james@gmail.com";
+    github = "jamesbrink";
+    githubId = 646361;
+  };
   jamesward = {
     email = "james@jamesward.com";
     name = "James Ward";

--- a/pkgs/by-name/mc/mcp-deadmansnitch/package.nix
+++ b/pkgs/by-name/mc/mcp-deadmansnitch/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "mcp-deadmansnitch";
+  version = "1.0.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "jamesbrink";
+    repo = "mcp-deadmansnitch";
+    tag = "v${version}";
+    hash = "sha256-BWJ7N63uIZ72/ZGHscz8AuTHPrc5RBKuAIjWmbRvQLQ=";
+  };
+
+  build-system = [ python3Packages.hatchling ];
+
+  dependencies = with python3Packages; [
+    fastmcp
+    httpx
+    python-dotenv
+  ];
+
+  nativeCheckInputs = with python3Packages; [
+    pytestCheckHook
+    pytest-asyncio
+    pytest-cov
+  ];
+
+  disabledTestPaths = [
+    # Requires DEADMANSNITCH_API_KEY
+    "tests/test_integration.py"
+  ];
+
+  pythonImportsCheck = [ "mcp_deadmansnitch" ];
+
+  meta = {
+    description = "MCP server for Dead Man's Snitch cron job monitoring";
+    homepage = "https://github.com/jamesbrink/mcp-deadmansnitch";
+    changelog = "https://github.com/jamesbrink/mcp-deadmansnitch/releases/tag/${src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ jamesbrink ];
+    mainProgram = "mcp-deadmansnitch";
+  };
+}


### PR DESCRIPTION
## Summary

Add mcp-deadmansnitch, an MCP (Model Context Protocol) server for Dead Man's Snitch cron job monitoring.

- **Version**: 1.0.1
- **License**: MIT
- **Homepage**: https://github.com/jamesbrink/mcp-deadmansnitch

### Features
- Monitor cron jobs and scheduled tasks via Dead Man's Snitch API
- Integrates with MCP-compatible AI assistants (Claude, etc.)
- Built on FastMCP framework

## Test plan

- [x] `nix-build -A mcp-deadmansnitch` succeeds
- [x] Binary runs: `./result/bin/mcp-deadmansnitch` starts MCP server
- [x] 118 unit tests pass
- [x] `pythonImportsCheck` passes
- [x] Code formatted with `nix fmt`

## Notes

- Includes new maintainer entry (jamesbrink) in first commit per contributing guidelines
- Integration tests disabled as they require `DEADMANSNITCH_API_KEY`