### PR TITLE
dotnet: fix CS7035 error in azure-activedirectory-identitymodel for .NET 9

### DIFF
--- a/pkgs/development/compilers/dotnet/fix-azure-activedirectory-cs7035-warning.patch
+++ b/pkgs/development/compilers/dotnet/fix-azure-activedirectory-cs7035-warning.patch
@@ -1,0 +1,30 @@
+diff --git a/pkgs/development/compilers/dotnet/vmr.nix b/pkgs/development/compilers/dotnet/vmr.nix
+index 0000000..1111111 100644
+--- a/pkgs/development/compilers/dotnet/vmr.nix
++++ b/pkgs/development/compilers/dotnet/vmr.nix
+@@ -184,6 +184,16 @@ stdenv.mkDerivation rec {
+       src/source-build-externals/src/application-insights/.props/_GlobalStaticVersion.props
+   ''
+   + lib.optionalString (lib.versionAtLeast version "9") ''
++    # Fix CS7035 error in azure-activedirectory-identitymodel-extensions-for-dotnet
++    # The version string '8.0.0.70116' doesn't conform to the recommended format
++    mkdir -p src/source-build-externals/src/azure-activedirectory-identitymodel-extensions-for-dotnet/src/
++    cat > src/source-build-externals/src/azure-activedirectory-identitymodel-extensions-for-dotnet/src/Directory.Build.props << EOF
++<Project>
++  <PropertyGroup>
++    <NoWarn>\$(NoWarn);CS7035</NoWarn>
++  </PropertyGroup>
++</Project>
++EOF
++  ''
++  + ''
+
+     # this fixes compile errors with clang 15 (e.g. darwin)
+     substituteInPlace \
+@@ -397,6 +407,7 @@ stdenv.mkDerivation rec {
+     releaseManifestFile
+   ]
+   ++ lib.optionals (lib.versionAtLeast version "9") [
++    "-p:NoWarn=CS7035"
+     "--source-build"
+   ]

--- a/pkgs/development/compilers/dotnet/vmr.nix
+++ b/pkgs/development/compilers/dotnet/vmr.nix
@@ -138,6 +138,7 @@ stdenv.mkDerivation {
     lib.optionals (lib.versionAtLeast version "9" && lib.versionOlder version "10") [
       ./UpdateNuGetConfigPackageSourcesMappings-don-t-add-em.patch
       ./vmr-compiler-opt-v9.patch
+      ./fix-azure-activedirectory-cs7035-warning.patch
     ]
     ++ lib.optionals (lib.versionOlder version "9") [
       ./fix-aspnetcore-portable-build.patch


### PR DESCRIPTION
## Problem

When building dotnet-sdk_9, the build fails with error CS7035:

```
error CS7035: The specified version string '8.0.0.70116' does not conform to the recommended format - major.minor.build.revision
```

This error occurs in the azure-activedirectory-identitymodel-extensions-for-dotnet dependency during the source-build-externals step. The issue is that the fourth component of the version number (70116) exceeds the 16-bit limit (65535) for .NET version components.

## Solution

This PR adds a patch file that:

1. Adds a NoWarn=CS7035 parameter to the build flags
2. Creates a Directory.Build.props file in the azure-activedirectory-identitymodel-extensions-for-dotnet source directory with a NoWarn property

These changes tell the .NET compiler to ignore the CS7035 warning about the version format, allowing the build to proceed while maintaining the original version information.

## Notes

This issue highlights an inconsistency within Microsoft's own ecosystem, where the Azure Active Directory Identity Model Extensions library uses a version format that violates .NET's own versioning constraints (16-bit limit on version components).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
