### PR TITLE
wivrn: allow specifying a config file for wivrn

### DIFF
--- a/nixos/modules/services/video/wivrn.nix
+++ b/nixos/modules/services/video/wivrn.nix
@@ -60,7 +60,9 @@ let
     optionalAttrs applicationCheck { application = applicationConcat; }
   );
   configFile = configFormat.generate "config.json" applicationUpdate;
-  enabledConfig = optionalString cfg.config.enable "-f ${configFile}";
+
+  # config.file, by default, points to configFile
+  enabledConfig = optionalString cfg.config.enable "-f ${cfg.config.file}";
 
   # Manage server executables and flags
   serverExec = concatStringsSep " " (
@@ -145,6 +147,14 @@ in
               ];
               application = [ pkgs.wlx-overlay-s ];
             }
+          '';
+        };
+        file = lib.mkOption {
+          type = lib.types.path;
+          default = configFile;
+          defaultText = lib.literalExpression "configFile";
+          description = ''
+            Overridable config file to use for WiVRn. By default, uses a generated file through `config.json`.
           '';
         };
       };


### PR DESCRIPTION
Based off how [nixos/modules/services/networking/bind.nix](https://github.com/NixOS/nixpkgs/blob/1412caf7bf9e660f2f962917c14b1ea1c3bc695e/nixos/modules/services/networking/bind.nix) handles configuration

---

For a bit more context, this was born out of [WiVRn/WiVRn#1de1b19](https://github.com/WiVRn/WiVRn/commit/1de1b1920100045c62890e2a179b851e696e0e4b) breaking nix-community/nixpkgs-xr (nix-community/nixpkgs-xr#613) and there not being a good escape hatch out of the situation since I prefer to declare my WiVRn configuration.

For those who get caught in the situation (and this PR does get merged) and would like a copy-paste,
```nix
systemd.user.services.wivrn.serviceConfig.ExecStart = lib.mkForce
  "${pkgs.wivrn} -f ${config.services.wivrn.config.file}";
```
or if `highPriority`
```nix
systemd.user.services.wivrn.serviceConfig.ExecStart = lib.mkForce
  "${config.security.wrapperDir}/wivrn-server -f ${config.services.wivrn.config.file}";
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
