### PR TITLE
python3Packages.riscv-model: init at 0.6.6

### DIFF
--- a/pkgs/development/python-modules/riscv-model/default.nix
+++ b/pkgs/development/python-modules/riscv-model/default.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  setuptools-scm,
+  pytestCheckHook,
+  pyyaml,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "riscv-model";
+  version = "0.6.6";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "wallento";
+    repo = "riscv-python-model";
+    tag = finalAttrs.version;
+    hash = "sha256-H4N9Z8aK/xV5gCCdsL+oiR+XQfYtCfBRBGLqvuztX+o=";
+  };
+
+  env.SETUPTOOLS_SCM_PRETEND_VERSION = finalAttrs.version;
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    pyyaml
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "riscvmodel"
+    "riscvmodel.insn"
+    "riscvmodel.variant"
+  ];
+
+  meta = {
+    description = "Formal RISC-V architecture model in Python";
+    homepage = "https://github.com/wallento/riscv-python-model";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.gonsolo ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16563,6 +16563,8 @@ self: super: with self; {
 
   riscv-isac = callPackage ../development/python-modules/riscv-isac { };
 
+  riscv-model = callPackage ../development/python-modules/riscv-model { };
+
   ritassist = callPackage ../development/python-modules/ritassist { };
 
   rivet = toPythonModule (pkgs.rivet.override { python3 = python; });


### PR DESCRIPTION
- Built on platform:
  - [x] x86_64-linux
- Tested, as applicable:
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
