### PR TITLE
silverbullet: 2.3.0 -> 2.4.1

### DIFF
--- a/pkgs/by-name/si/silverbullet/package.nix
+++ b/pkgs/by-name/si/silverbullet/package.nix
@@ -1,45 +1,20 @@
 {
   autoPatchelfHook,
+  common-updater-scripts,
   fetchzip,
   lib,
   nixosTests,
   stdenv,
   stdenvNoCC,
+  writeShellScript,
 }:
-let
-  platformMap = {
-    "x86_64-linux" = {
-      os = "linux";
-      arch = "x86_64";
-      hash = "sha256-IGks7vmJd/xuJzqhogR5aLVM6eUUe6bACe5VuAWJOWA=";
-    };
-    "aarch64-linux" = {
-      os = "linux";
-      arch = "aarch64";
-      hash = "sha256-brqotISLIwD1t/2E2oyI7HSkfPpVgUODaNZJcc9o6zI=";
-    };
-    "x86_64-darwin" = {
-      os = "darwin";
-      arch = "x86_64";
-      hash = "sha256-n8GN2ZmeYEpZ0DB7zwEkXnSUZkAySNAGVn5BLw46fZI=";
-    };
-    "aarch64-darwin" = {
-      os = "darwin";
-      arch = "aarch64";
-      hash = "sha256-BISrkxLuxlo7KQiW9cUipJpEhOm94gL3GvyivO6LaBU=";
-    };
-  };
-  platform = platformMap.${stdenvNoCC.hostPlatform.system};
-in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "silverbullet";
-  version = "2.3.0";
+  version = "2.4.1";
 
-  src = fetchzip {
-    url = "https://github.com/silverbulletmd/silverbullet/releases/download/${finalAttrs.version}/silverbullet-server-${platform.os}-${platform.arch}.zip";
-    hash = platform.hash;
-    stripRoot = false;
-  };
+  src =
+    finalAttrs.passthru.sources.${stdenv.hostPlatform.system}
+      or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
 
   nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
 
@@ -52,8 +27,40 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  passthru.tests = {
-    inherit (nixosTests) silverbullet;
+  passthru = {
+    sources = {
+      "x86_64-linux" = fetchzip {
+        url = "https://github.com/silverbulletmd/silverbullet/releases/download/${finalAttrs.version}/silverbullet-server-linux-x86_64.zip";
+        hash = "sha256-1jUN22T7BABBEiXp1LwMUaw/ELR7CZS2iKLaoiYKeLk=";
+        stripRoot = false;
+      };
+      "aarch64-linux" = fetchzip {
+        url = "https://github.com/silverbulletmd/silverbullet/releases/download/${finalAttrs.version}/silverbullet-server-linux-aarch64.zip";
+        hash = "sha256-F0CTVbVK2xaqNlHX1If8EhlDRqb+XIZlWmzkEYFGS3M=";
+        stripRoot = false;
+      };
+      "x86_64-darwin" = fetchzip {
+        url = "https://github.com/silverbulletmd/silverbullet/releases/download/${finalAttrs.version}/silverbullet-server-darwin-x86_64.zip";
+        hash = "sha256-lWUTNGt5u7q5cs7xoNP/k7GYUq/A3xHI6rza8HYOK5Y=";
+        stripRoot = false;
+      };
+      "aarch64-darwin" = fetchzip {
+        url = "https://github.com/silverbulletmd/silverbullet/releases/download/${finalAttrs.version}/silverbullet-server-darwin-aarch64.zip";
+        hash = "sha256-1lPGipv6jW0Awjy7V9HORK5oh5RDpBBrT4zZk0oSVWY=";
+        stripRoot = false;
+      };
+    };
+
+    updateScript = writeShellScript "update-silverbullet" ''
+      NEW_VERSION="$1"
+      for platform in ${lib.escapeShellArgs finalAttrs.meta.platforms}; do
+        ${lib.getExe' common-updater-scripts "update-source-version"} "silverbullet" "$NEW_VERSION" --ignore-same-version --source-key="sources.$platform"
+      done
+    '';
+
+    tests = {
+      inherit (nixosTests) silverbullet;
+    };
   };
 
   meta = {
@@ -63,6 +70,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ aorith ];
     mainProgram = "silverbullet";
-    platforms = builtins.attrNames platformMap;
+    platforms = builtins.attrNames finalAttrs.passthru.sources;
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
