### PR TITLE
nebula: 1.10.0 -> 1.10.2

### DIFF
--- a/nixos/tests/nebula/connectivity.nix
+++ b/nixos/tests/nebula/connectivity.nix
@@ -445,8 +445,9 @@ in
       allowAny.fail("ping -c3 -W1 10.0.100.1")
       allowAny.fail("ping -c3 -W1 2001:db8::4")
       ${allowTrafficBetweenV4 "lighthouse" "allowAny"}
-      allowAny.wait_until_succeeds("ping -c1 -W1 10.0.100.1", timeout=10)
-      allowAny.wait_until_succeeds("ping -c1 -W1 10.0.100.4", timeout=10)
+      allowAny.wait_until_succeeds("ping -c1 -W1 192.168.1.1", timeout=10)
+      allowAny.wait_until_succeeds("ping -c1 -W1 10.0.100.1", timeout=15)
+      allowAny.wait_until_succeeds("ping -c1 -W1 10.0.100.4", timeout=15)
       ${allowTrafficBetweenV6 "lighthouse" "allowAny"}
       ${allowTrafficBetweenV6 "lighthouse" "allowToLighthouse"}
       ${allowTrafficBetweenV6 "allowAny" "allowToLighthouse"}

--- a/pkgs/by-name/ne/nebula/package.nix
+++ b/pkgs/by-name/ne/nebula/package.nix
@@ -8,16 +8,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "nebula";
-  version = "1.10.0";
+  version = "1.10.2";
 
   src = fetchFromGitHub {
     owner = "slackhq";
     repo = "nebula";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-p/2A1ZTBUPvrA8eAgLxjR7NSAfiIEkDcjX0Db8dCmfQ=";
+    hash = "sha256-hDszl6//hFVK79dadz6mBuYMRvwDUerUkPvzD5AcvfA=";
   };
 
-  vendorHash = "sha256-rod6YDosI9nBf2v6Q/rw/fT9p9N8Zo/lu989UhyL8/s=";
+  vendorHash = "sha256-CNYBqslUXJf3Nls3Lu6PbABhT9wTbIfBZxFkiUW59Kk=";
 
   subPackages = [
     "cmd/nebula"


### PR DESCRIPTION
Changelogs:
- https://github.com/slackhq/nebula/releases/tag/v1.10.1
- https://github.com/slackhq/nebula/releases/tag/v1.10.2

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

---

This also adjusts the nebula NixOS test. I've seen it locally as well as on hydra that the test fails at that point:

https://hydra.nixos.org/build/317819607
https://hydra.nixos.org/build/319318124

Not really sure whether this is an regression (if it is the reason doesn't appear to be a nebula update) or this was just always quite tight and it's "normal" that it can take so long.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
