### PR TITLE
nixos/kea: add option to include database CLI tools in PATH

### DIFF
--- a/ci/OWNERS
+++ b/ci/OWNERS
@@ -326,7 +326,7 @@ pkgs/development/python-modules/buildcatrust/ @ajs124 @lukegb @mweinelt
 /nixos/modules/services/networking/knot.nix @mweinelt
 /nixos/modules/services/monitoring/prometheus/exporters/kea.nix @mweinelt
 /nixos/tests/babeld.nix @mweinelt
-/nixos/tests/kea.nix @mweinelt
+/nixos/tests/kea @mweinelt
 /nixos/tests/knot.nix @mweinelt
 
 # Web servers

--- a/ci/OWNERS
+++ b/ci/OWNERS
@@ -318,7 +318,7 @@ pkgs/development/python-modules/buildcatrust/ @ajs124 @lukegb @mweinelt
 /nixos/modules/services/networking/knot.nix @mweinelt
 /nixos/modules/services/monitoring/prometheus/exporters/kea.nix @mweinelt
 /nixos/tests/babeld.nix @mweinelt
-/nixos/tests/kea.nix @mweinelt
+/nixos/tests/kea @mweinelt
 /nixos/tests/knot.nix @mweinelt
 
 # Web servers

--- a/nixos/modules/services/networking/kea.nix
+++ b/nixos/modules/services/networking/kea.nix
@@ -29,6 +29,23 @@ let
       DhcpDdns = cfg.dhcp-ddns.settings;
     }
   );
+
+  dbLibraries = [
+    "libdhcp_pgsql.so"
+    "libdhcp_mysql.so"
+  ];
+  mkEnableDatabaseOption =
+    srv:
+    lib.mkOption {
+      type = lib.types.bool;
+      default = lib.any (hook: lib.elem (hook.library or "") dbLibraries) (
+        cfg.${srv}.settings.hooks-libraries or [ ]
+      );
+      defaultText = lib.literalExpression ''
+        lib.any (hook: lib.elem (hook.library or "") ${toString dbLibraries}) (cfg.${srv}.settings.hooks-libraries or [ ]);
+      '';
+      description = "Enable utilities required for database support.";
+    };
 in
 {
   imports = [
@@ -101,6 +118,8 @@ in
               Kea DHCP4 configuration as an attribute set, see <https://kea.readthedocs.io/en/kea-${cfg.package.version}/arm/dhcp4-srv.html>.
             '';
           };
+
+          enableDatabase = mkEnableDatabaseOption "dhcp4";
         };
       };
     };
@@ -167,6 +186,8 @@ in
               Kea DHCP6 configuration as an attribute set, see <https://kea.readthedocs.io/en/kea-${cfg.package.version}/arm/dhcp6-srv.html>.
             '';
           };
+
+          enableDatabase = mkEnableDatabaseOption "dhcp6";
         };
       };
     };
@@ -254,7 +275,10 @@ in
     lib.mkIf (cfg.dhcp4.enable || cfg.dhcp6.enable || cfg.dhcp-ddns.enable) (
       lib.mkMerge [
         {
-          environment.systemPackages = [ cfg.package ];
+          environment.systemPackages = [
+            cfg.package
+          ]
+          ++ lib.optionals (cfg.dhcp4.enableDatabase || cfg.dhcp6.enableDatabase) [ cfg.package.db ];
 
           users.users.kea = {
             isSystemUser = true;
@@ -292,6 +316,8 @@ in
             ];
 
             environment = commonEnvironment;
+
+            path = lib.optionals cfg.dhcp4.enableDatabase [ cfg.package.db ];
 
             restartTriggers = [
               dhcp4Config
@@ -349,6 +375,8 @@ in
             ];
 
             environment = commonEnvironment;
+
+            path = lib.optionals cfg.dhcp6.enableDatabase [ cfg.package.db ];
 
             restartTriggers = [
               dhcp6Config

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -818,7 +818,7 @@ in
   kavita = runTest ./kavita.nix;
   kbd-setfont-decompress = runTest ./kbd-setfont-decompress.nix;
   kbd-update-search-paths-patch = runTest ./kbd-update-search-paths-patch.nix;
-  kea = runTest ./kea.nix;
+  kea = import ./kea { inherit runTest; };
   keepalived = runTest ./keepalived.nix;
   keepassxc = runTest ./keepassxc.nix;
   kerberos = handleTest ./kerberos/default.nix { };

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -887,7 +887,7 @@ in
   kavita = runTest ./kavita.nix;
   kbd-setfont-decompress = runTest ./kbd-setfont-decompress.nix;
   kbd-update-search-paths-patch = runTest ./kbd-update-search-paths-patch.nix;
-  kea = runTest ./kea.nix;
+  kea = import ./kea { inherit runTest; };
   keepalived = discoverTests (import ./keepalived.nix);
   keepassxc = runTest ./keepassxc.nix;
   kerberos = handleTest ./kerberos/default.nix { };

--- a/nixos/tests/kea/default.nix
+++ b/nixos/tests/kea/default.nix
@@ -1,0 +1,5 @@
+{ runTest }:
+{
+  dhcp4-ddns = runTest ./dhcp4-ddns.nix;
+  dhcp6-postgres = runTest ./dhcp6-postgres.nix;
+}

--- a/nixos/tests/kea/dhcp4-ddns.nix
+++ b/nixos/tests/kea/dhcp4-ddns.nix
@@ -13,7 +13,7 @@
 {
   meta.maintainers = with lib.maintainers; [ hexa ];
 
-  name = "kea";
+  name = "dhcp4-ddns";
 
   nodes = {
     router =

--- a/nixos/tests/kea/dhcp4-ddns.nix
+++ b/nixos/tests/kea/dhcp4-ddns.nix
@@ -12,7 +12,7 @@
 {
   meta.maintainers = with lib.maintainers; [ hexa ];
 
-  name = "kea";
+  name = "dhcp4-ddns";
 
   containers = {
     router =

--- a/nixos/tests/kea/dhcp6-postgres.nix
+++ b/nixos/tests/kea/dhcp6-postgres.nix
@@ -1,0 +1,201 @@
+# This test verifies DHCPv6 interaction between a client and a router.
+# The DHCPv6 server uses a PostgreSQL database, where a reservation is
+# made through the control socket.
+# We then verify whether client and router can ping each other.
+
+{
+  pkgs,
+  lib,
+  ...
+}:
+{
+  meta.maintainers = with lib.maintainers; [ wfdewith ];
+
+  name = "dhcp6-postgres";
+
+  nodes = {
+    router =
+      { config, pkgs, ... }:
+      {
+        virtualisation.interfaces.eth1 = {
+          vlan = 1;
+          assignIP = false;
+        };
+
+        networking = {
+          useDHCP = false;
+          firewall.enable = false;
+        };
+
+        systemd.network = {
+          enable = true;
+          networks = {
+            "01-eth1" = {
+              name = "eth1";
+              networkConfig = {
+                Address = "fc00:c0de::1/64";
+                IPv6SendRA = true;
+              };
+              ipv6Prefixes = [
+                {
+                  Prefix = "fc00:c0de::/64";
+                  AddressAutoconfiguration = false;
+                }
+              ];
+              ipv6SendRAConfig.Managed = true;
+            };
+          };
+        };
+
+        services.postgresql = {
+          enable = true;
+          settings = {
+            password_encryption = "md5";
+          };
+          initialScript = pkgs.writeText "init-kea-db" ''
+            CREATE ROLE kea WITH LOGIN PASSWORD 'kea';
+            CREATE DATABASE kea OWNER kea;
+          '';
+        };
+
+        services.kea.dhcp6 = {
+          enable = true;
+          settings = {
+            valid-lifetime = 3600;
+            renew-timer = 900;
+            rebind-timer = 1800;
+
+            hooks-libraries = [
+              { library = "libdhcp_pgsql.so"; }
+              { library = "libdhcp_host_cmds.so"; }
+            ];
+
+            lease-database = {
+              type = "postgresql";
+              name = "kea";
+              user = "kea";
+              password = "kea";
+              host = "localhost";
+            };
+
+            hosts-databases = [
+              {
+                type = "postgresql";
+                name = "kea";
+                user = "kea";
+                password = "kea";
+                host = "localhost";
+              }
+            ];
+
+            control-socket = {
+              socket-type = "unix";
+              socket-name = "/run/kea/dhcp6.sock";
+            };
+
+            interfaces-config = {
+              interfaces = [
+                "eth1"
+              ];
+            };
+
+            subnet6 = [
+              {
+                id = 1;
+                subnet = "fc00:c0de::/64";
+                interface = "eth1";
+                pools = [
+                  {
+                    pool = "fc00:c0de::dead - fc00:c0de::dead";
+                  }
+                ];
+              }
+            ];
+          };
+        };
+
+        services.kea.ctrl-agent = {
+          enable = true;
+          settings = {
+            http-host = "127.0.0.1";
+            http-port = 8000;
+            control-sockets.dhcp6 = {
+              socket-type = "unix";
+              socket-name = "/run/kea/dhcp6.sock";
+            };
+          };
+        };
+
+        services.prometheus.exporters.kea = {
+          enable = true;
+          controlSocketPaths = [
+            "http://127.0.0.1:8000"
+          ];
+        };
+
+        environment.systemPackages = with pkgs; [ jq ];
+      };
+
+    client =
+      { config, pkgs, ... }:
+      {
+        virtualisation.interfaces.eth1 = {
+          vlan = 1;
+          assignIP = false;
+        };
+
+        systemd.services.systemd-networkd.environment.SYSTEMD_LOG_LEVEL = "debug";
+        networking = {
+          useDHCP = false;
+          firewall.enable = false;
+        };
+
+        systemd.network = {
+          enable = true;
+          networks = {
+            "01-eth1" = {
+              name = "eth1";
+              networkConfig = {
+                DHCP = true;
+              };
+              dhcpV6Config = {
+                DUIDType = "uuid";
+                DUIDRawData = "30:0e:49:fb:08:9f:44:d1:9d:47:a7:9c:9e:56:68:9a";
+              };
+            };
+          };
+        };
+      };
+  };
+  testScript =
+    { ... }:
+    ''
+      import shlex
+
+      router.start()
+      router.wait_for_unit("postgresql-setup.service")
+      router.succeed("kea-admin db-init pgsql -u kea -p kea -n kea")
+
+      router.systemctl("reset-failed kea-dhcp6-server.service")
+      router.systemctl("restart kea-dhcp6-server.service")
+      router.wait_for_unit("kea-dhcp6-server.service")
+
+      reservation = r"""
+      "reservation": {
+        "subnet-id": 1,
+        "duid": "00:04:30:0e:49:fb:08:9f:44:d1:9d:47:a7:9c:9e:56:68:9a",
+        "ip-addresses": ["fc00:c0de::cafe"]
+      }
+      """
+      router.succeed(f"kea-shell --service dhcp6 reservation-add <<< {shlex.quote(reservation)} | jq -e 'all(.[], .result == 0)'")
+
+      client.start()
+      client.systemctl("start systemd-networkd-wait-online.service")
+      client.wait_for_unit("systemd-networkd-wait-online.service")
+      client.wait_until_succeeds("ping -c 5 fc00:c0de::1")
+      router.wait_until_succeeds("ping -c 5 fc00:c0de::cafe")
+      router.log(router.execute("curl 127.0.0.1:9547")[1])
+      # Reservations don't count against this value, so check if it is still 0
+      router.succeed("curl --no-buffer 127.0.0.1:9547 | grep -qE '^kea_dhcp6_na_assigned_total.*0.0$'")
+    '';
+}

--- a/nixos/tests/kea/dhcp6-postgres.nix
+++ b/nixos/tests/kea/dhcp6-postgres.nix
@@ -1,0 +1,208 @@
+# This test verifies DHCPv6 interaction between a client and a router.
+# The DHCPv6 server uses a PostgreSQL database, where a reservation is
+# made through the control socket.
+# We then verify whether client and router can ping each other.
+
+{
+  pkgs,
+  lib,
+  ...
+}:
+{
+  meta.maintainers = with lib.maintainers; [ wfdewith ];
+
+  name = "dhcp6-postgres";
+
+  containers = {
+    router =
+      { config, pkgs, ... }:
+      {
+        virtualisation.interfaces.eth1 = {
+          vlan = 1;
+          assignIP = false;
+        };
+
+        networking = {
+          useDHCP = false;
+          firewall.enable = false;
+        };
+
+        services.resolved.enable = false;
+        systemd.network = {
+          enable = true;
+          networks = {
+            "01-eth1" = {
+              name = "eth1";
+              networkConfig = {
+                Address = "fc00:c0de::1/64";
+                IPv6SendRA = true;
+              };
+              ipv6Prefixes = [
+                {
+                  Prefix = "fc00:c0de::/64";
+                  AddressAutoconfiguration = false;
+                }
+              ];
+              ipv6SendRAConfig.Managed = true;
+            };
+          };
+        };
+
+        services.postgresql = {
+          enable = true;
+          settings = {
+            password_encryption = "md5";
+          };
+          initialScript = pkgs.writeText "init-kea-db" ''
+            CREATE ROLE kea WITH LOGIN PASSWORD 'kea';
+            CREATE DATABASE kea OWNER kea;
+          '';
+        };
+
+        services.kea.dhcp6 = {
+          enable = true;
+          extraArgs = [ "-X" ];
+          settings = {
+            valid-lifetime = 3600;
+            renew-timer = 900;
+            rebind-timer = 1800;
+
+            hooks-libraries = [
+              { library = "libdhcp_pgsql.so"; }
+              { library = "libdhcp_host_cmds.so"; }
+            ];
+
+            lease-database = {
+              type = "postgresql";
+              name = "kea";
+              user = "kea";
+              password = "kea";
+              host = "localhost";
+            };
+
+            hosts-databases = [
+              {
+                type = "postgresql";
+                name = "kea";
+                user = "kea";
+                password = "kea";
+                host = "localhost";
+              }
+            ];
+
+            control-sockets = [
+              {
+                socket-type = "unix";
+                socket-name = "/run/kea/dhcp6.sock";
+              }
+              {
+                socket-type = "http";
+                socket-address = "127.0.0.1";
+                socket-port = 8000;
+              }
+            ];
+
+            interfaces-config = {
+              interfaces = [
+                "eth1"
+              ];
+            };
+
+            subnet6 = [
+              {
+                id = 1;
+                subnet = "fc00:c0de::/64";
+                interface = "eth1";
+                pools = [
+                  {
+                    pool = "fc00:c0de::dead - fc00:c0de::dead";
+                  }
+                ];
+              }
+            ];
+          };
+        };
+
+        services.prometheus.exporters.kea = {
+          enable = true;
+          targets = [
+            "/run/kea/dhcp6.sock"
+          ];
+        };
+
+        environment.systemPackages = with pkgs; [ jq ];
+      };
+
+    client =
+      { config, pkgs, ... }:
+      {
+        virtualisation.interfaces.eth1 = {
+          vlan = 1;
+          assignIP = false;
+        };
+
+        services.resolved.enable = false;
+        systemd.services.systemd-networkd.environment.SYSTEMD_LOG_LEVEL = "debug";
+        networking = {
+          useDHCP = false;
+          firewall.enable = false;
+        };
+
+        systemd.network = {
+          enable = true;
+          networks = {
+            "01-eth1" = {
+              name = "eth1";
+              networkConfig = {
+                DHCP = true;
+              };
+              dhcpV6Config = {
+                DUIDType = "uuid";
+                DUIDRawData = "30:0e:49:fb:08:9f:44:d1:9d:47:a7:9c:9e:56:68:9a";
+              };
+            };
+          };
+        };
+      };
+  };
+  testScript =
+    # python
+    ''
+      import shlex
+
+      router.start()
+      router.systemctl("stop kea-dhcp6-server.service")
+      router.systemctl("stop prometheus-kea-exporter.service")
+
+      with subtest("PostgreSQL initialization"):
+        router.wait_for_unit("postgresql-setup.service")
+        router.succeed("kea-admin db-init pgsql -u kea -p kea -n kea")
+
+      with subtest("DHCPv6 reservation"):
+        router.systemctl("start kea-dhcp6-server.service")
+        router.wait_until_succeeds("kea-shell version-get")
+
+        reservation = r"""
+        "reservation": {
+          "subnet-id": 1,
+          "duid": "00:04:30:0e:49:fb:08:9f:44:d1:9d:47:a7:9c:9e:56:68:9a",
+          "ip-addresses": ["fc00:c0de::cafe"]
+        }
+        """
+        router.succeed(f"kea-shell reservation-add <<< {shlex.quote(reservation)} | jq -e 'all(.[], .result == 0)'")
+
+      with subtest("DHCPv6"):
+        client.start()
+        client.systemctl("start systemd-networkd-wait-online.service")
+        client.wait_for_unit("systemd-networkd-wait-online.service")
+        client.wait_until_succeeds("ping -c 5 fc00:c0de::1")
+        router.wait_until_succeeds("ping -c 5 fc00:c0de::cafe")
+
+      with subtest("Prometheus Exporter"):
+        router.systemctl("start prometheus-kea-exporter.service")
+        router.wait_for_open_port(9547)
+        router.log(router.execute("curl 127.0.0.1:9547")[1])
+        # Reservations don't count against this value, so check if it is still 0
+        router.succeed("curl --no-buffer 127.0.0.1:9547 | grep -qE '^kea_dhcp6_na_assigned_total.*0.0$'")
+    '';
+}

--- a/pkgs/by-name/ke/kea/package.nix
+++ b/pkgs/by-name/ke/kea/package.nix
@@ -56,7 +56,6 @@ stdenv.mkDerivation (finalAttrs: {
   outputs = [
     "out"
     "doc"
-    "python"
     "db"
   ];
 
@@ -112,9 +111,6 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   postFixup = ''
-    mkdir -p $python/lib
-    mv $out/lib/python* $python/lib/
-
     mkdir -p $db/bin $db/share/kea
     mv $out/bin/kea-admin $db/bin/
     mv $out/share/kea/scripts $db/share/kea/

--- a/pkgs/by-name/ke/kea/package.nix
+++ b/pkgs/by-name/ke/kea/package.nix
@@ -6,6 +6,7 @@
   # build time
   bison,
   flex,
+  makeBinaryWrapper,
   meson,
   ninja,
   pkg-config,
@@ -20,12 +21,18 @@
   krb5,
   withMysql ? stdenv.buildPlatform.system == stdenv.hostPlatform.system,
   libmysqlclient,
+  mariadb,
   withPostgresql ? stdenv.buildPlatform.system == stdenv.hostPlatform.system,
   libpq,
+  postgresql,
 
   # tests
   nixosTests,
 }:
+
+let
+  keaAdminUtils = (lib.optional withMysql mariadb) ++ (lib.optional withPostgresql postgresql);
+in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "kea";
@@ -50,6 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
     "out"
     "doc"
     "python"
+    "db"
   ];
 
   mesonFlags = [
@@ -72,6 +80,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     bison
     flex
+    makeBinaryWrapper
     meson
     ninja
     pkg-config
@@ -105,6 +114,17 @@ stdenv.mkDerivation (finalAttrs: {
   postFixup = ''
     mkdir -p $python/lib
     mv $out/lib/python* $python/lib/
+
+    mkdir -p $db/bin $db/share/kea
+    mv $out/bin/kea-admin $db/bin/
+    mv $out/share/kea/scripts $db/share/kea/
+
+    find $db -type f -exec sed -i 's,${placeholder "out"},${placeholder "db"},g' {} \+
+
+    ${lib.optionalString (keaAdminUtils != [ ]) ''
+      wrapProgramBinary $db/bin/kea-admin \
+          --suffix PATH : ${lib.makeBinPath keaAdminUtils}
+    ''}
   '';
 
   passthru.tests = {

--- a/pkgs/by-name/ke/kea/package.nix
+++ b/pkgs/by-name/ke/kea/package.nix
@@ -6,6 +6,7 @@
   # build time
   bison,
   flex,
+  makeBinaryWrapper,
   meson,
   ninja,
   pkg-config,
@@ -20,14 +21,20 @@
   krb5,
   withMysql ? stdenv.buildPlatform.system == stdenv.hostPlatform.system,
   libmysqlclient,
+  mariadb,
   withPostgresql ? stdenv.buildPlatform.system == stdenv.hostPlatform.system,
   libpq,
+  postgresql,
 
   # tests
   nixosTests,
   testers,
   kea,
 }:
+
+let
+  keaAdminUtils = (lib.optional withMysql mariadb) ++ (lib.optional withPostgresql postgresql);
+in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "kea";
@@ -52,6 +59,7 @@ stdenv.mkDerivation (finalAttrs: {
     "out"
     "doc"
     "python"
+    "db"
   ];
 
   mesonFlags = [
@@ -76,6 +84,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     bison
     flex
+    makeBinaryWrapper
     meson
     ninja
     pkg-config
@@ -104,6 +113,19 @@ stdenv.mkDerivation (finalAttrs: {
 
   postBuild = ''
     ninja doc
+  '';
+
+  postFixup = ''
+    mkdir -p $db/bin $db/share/kea
+    mv $out/bin/kea-admin $db/bin/
+    mv $out/share/kea/scripts $db/share/kea/
+
+    find $db -type f -exec sed -i 's,${placeholder "out"},${placeholder "db"},g' {} \+
+
+    ${lib.optionalString (keaAdminUtils != [ ]) ''
+      wrapProgramBinary $db/bin/kea-admin \
+          --suffix PATH : ${lib.makeBinPath keaAdminUtils}
+    ''}
   '';
 
   passthru.tests = {


### PR DESCRIPTION
`kea-admin` uses the `psql` and `mysql` CLI utilities to initialize the Kea database. In some circumstances, the main Kea binaries actually call this tool directly to initialize the database ([code](https://github.com/isc-projects/kea/blob/212031ac1478c9cd80f5cc49d7d568bc257716c5/src/lib/pgsql/pgsql_connection.cc#L213-L246)). That last part tripped me up when I tried to deploy Kea.

I'm not entirely happy about this change because the MySQL closure is pretty large and it is _technically_ not needed if you set up the database correctly beforehand, but it does save a bit of debugging when you run into this problem.

Do we want to add a NixOS test for the database interactions?

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
