### PR TITLE
ocamlPackages.stdcompat: 19 -> 21.1

### DIFF
--- a/pkgs/development/ocaml-modules/pyml/default.nix
+++ b/pkgs/development/ocaml-modules/pyml/default.nix
@@ -18,6 +18,10 @@ buildDunePackage rec {
     hash = "sha256-WPtmj9EEs7P72OXWJg1syIrbLuh7u4V4W4nyozXmSa0=";
   };
 
+  patches = [
+    ./remove-stdcompat.patch
+  ];
+
   buildInputs = [
     utop
   ];

--- a/pkgs/development/ocaml-modules/pyml/remove-stdcompat.patch
+++ b/pkgs/development/ocaml-modules/pyml/remove-stdcompat.patch
@@ -1,0 +1,11 @@
+diff --git a/pyml_stubs.c b/pyml_stubs.c
+index 40e3481..e7826f1 100644
+--- a/pyml_stubs.c
++++ b/pyml_stubs.c
+@@ -11,7 +11,6 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <errno.h>
+-#include <stdcompat.h>
+ #include <assert.h>
+ #include "pyml_stubs.h"

--- a/pkgs/development/ocaml-modules/stdcompat/default.nix
+++ b/pkgs/development/ocaml-modules/stdcompat/default.nix
@@ -7,22 +7,22 @@
 
 buildDunePackage rec {
   pname = "stdcompat";
-  version = "19";
+  version = "21.1";
 
-  minimalOCamlVersion = "4.06";
+  minimalOCamlVersion = "4.11";
 
   src = fetchurl {
-    url = "https://github.com/thierry-martinez/stdcompat/releases/download/v${version}/stdcompat-${version}.tar.gz";
-    sha256 = "sha256-DKQGd4nnIN6SPls6hcA/2Jvc7ivYNpeMU6rYsVc1ClU=";
+    url = "https://github.com/ocamllibs/stdcompat/archive/refs/tags/${version}.tar.gz";
+    sha256 = "sha256-RSJ9AgUEmt23QZCk60ETIXmkJhG7knQe+s8wNxxIHm4=";
   };
 
   # Otherwise ./configure script will run and create files conflicting with dune.
   dontConfigure = true;
 
   meta = {
-    homepage = "https://github.com/thierry-martinez/stdcompat";
+    homepage = "https://github.com/ocamllibs/stdcompat";
     license = lib.licenses.bsd2;
     maintainers = [ lib.maintainers.vbgl ];
-    broken = lib.versionAtLeast ocaml.version "5.2";
+    broken = lib.versionAtLeast ocaml.version "5.4";
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Upgrading stdcompat to support the version of ocaml that we're using in nixpkgs.

New upstream repo: thierry-martinez/stdcompat redirects to ocamllibs/stdcompat.

This change breaks pyml, since stdcompat.h is no longer present. Also adding a patch to remove the import, all dependent packages build successfully.

Also updating the source hash on pyml, since the upstream appears to have changed it again. Looks like we're still waiting on a response at https://github.com/ocamllibs/pyml/issues/112, so just bumping the hash again for now.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
