### PR TITLE
hyprvoice: init at version 0.1.13

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17035,6 +17035,12 @@
     github = "metalmatze";
     githubId = 872251;
   };
+  metehanyurtseven = {
+    email = "metehan.yurtseven@icloud.com";
+    name = "Metehan Yurtseven";
+    github = "MetehanYurtseven";
+    githubId = 11601179;
+  };
   mevatron = {
     email = "mevatron@gmail.com";
     name = "mevatron";

--- a/pkgs/by-name/hy/hyprvoice/package.nix
+++ b/pkgs/by-name/hy/hyprvoice/package.nix
@@ -10,7 +10,7 @@
   wtype,
   ydotool,
   libnotify,
-  withWhisper ? true,
+  whisperPkg ? whisper-cpp,
 }:
 buildGoModule (finalAttrs: {
   pname = "hyprvoice";
@@ -54,7 +54,7 @@ buildGoModule (finalAttrs: {
             ydotool
             libnotify
           ]
-          ++ lib.optionals withWhisper [ whisper-cpp ]
+          ++ lib.optionals (whisperPkg != null) [ whisperPkg ]
         )
       }
   '';

--- a/pkgs/by-name/hy/hyprvoice/package.nix
+++ b/pkgs/by-name/hy/hyprvoice/package.nix
@@ -1,0 +1,75 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+  makeWrapper,
+  whisper-cpp,
+  pipewire,
+  wl-clipboard,
+  wtype,
+  ydotool,
+  libnotify,
+  withWhisper ? true,
+}:
+buildGoModule (finalAttrs: {
+  pname = "hyprvoice";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "LeonardoTrapani";
+    repo = "hyprvoice";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-geIjm5vChQwO44eSw8E9Tp8d4QkL3IGIdI7Xvpz9Eu8=";
+  };
+
+  vendorHash = "sha256-b1IsFlhj+xTQT/4PzL97YjVjjS7TQtcIsbeK3dLOxR4=";
+
+  env.CI = "true";
+
+  nativeCheckInputs = [
+    wl-clipboard
+    wtype
+    ydotool
+  ];
+
+  nativeBuildInputs = [
+    installShellFiles
+    makeWrapper
+  ];
+
+  postInstall = ''
+    installShellCompletion --cmd hyprvoice \
+      --bash <($out/bin/hyprvoice completion bash) \
+      --zsh <($out/bin/hyprvoice completion zsh) \
+      --fish <($out/bin/hyprvoice completion fish)
+
+    wrapProgram $out/bin/hyprvoice \
+      --prefix PATH : ${
+        lib.makeBinPath (
+          [
+            pipewire
+            wl-clipboard
+            wtype
+            ydotool
+            libnotify
+          ]
+          ++ lib.optionals withWhisper [ whisper-cpp ]
+        )
+      }
+  '';
+
+  meta = {
+    description = "Voice-powered typing for Hyprland/Wayland";
+    longDescription = ''
+      Press a toggle key, speak, and get instant text input.
+      Built natively for Wayland/Hyprland - no X11 hacks or workarounds,
+      just clean integration with modern Linux desktops.
+    '';
+    homepage = "https://github.com/LeonardoTrapani/hyprvoice";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    mainProgram = "hyprvoice";
+    maintainers = with lib.maintainers; [ metehanyurtseven ];
+  };
+})


### PR DESCRIPTION
This PR adds `hyprvoice`, a voice-powered typing tool for Hyprland/Wayland environments
**Package homepage**: https://github.com/LeonardoTrapani/hyprvoice

I have been using this package extensively in [my personal NixOS setup](https://github.com/MetehanYurtseven/nixos) and can confirm it works reliably.

This also adds myself as a new maintainer to the maintainer list.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
