### PR TITLE
gh-workon: init at 0-unstable-2025-02-14

### DIFF
--- a/pkgs/by-name/gh/gh-workon/package.nix
+++ b/pkgs/by-name/gh/gh-workon/package.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+
+  bash,
+  gh,
+  git,
+  fzf,
+  gnused,
+  gawk,
+
+  makeWrapper,
+  nix-update-script,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "gh-workon";
+  version = "0-unstable-2025-02-14";
+
+  src = fetchFromGitHub {
+    owner = "chmouel";
+    repo = "gh-workon";
+    rev = "5018894c7a0c9b433db16cd69ad9a46cf46ba80e";
+    hash = "sha256-rFfyR44IgL1DerFbzVPSHk1fltDbln2Fh2QQTTashac=";
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  buildInputs = [ bash ];
+
+  strictDeps = true;
+
+  runtimeDeps = [
+    gh
+    git
+    fzf
+    gnused
+    gawk
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    install -D -m755 "gh-workon" "$out/bin/gh-workon"
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    wrapProgram "$out/bin/gh-workon" \
+      --prefix PATH : "${lib.makeBinPath finalAttrs.runtimeDeps}"
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "GitHub CLI extension to create git branches and worktrees from GitHub issues";
+    homepage = "https://github.com/chmouel/gh-workon";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      vdemeester
+      chmouel
+    ];
+    mainProgram = "gh-workon";
+    inherit (gh.meta) platforms;
+  };
+})


### PR DESCRIPTION
This PR adds `gh-workon`, a GitHub CLI extension that allows creating git branches from GitHub issues.

`gh-workon` is a shell-based gh extension that provides an interactive FZF-based selector to choose from GitHub issues and automatically create a corresponding git branch while assigning the issue to yourself.

**Features:**
- Interactive issue selection with FZF
- Automatic branch creation from issue
- Auto-assignment of selected issue
- Dependencies: gh, git, fzf, gnused, gawk

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc