### PR TITLE
gosmee: migrate to finalAttrs pattern and add best practices

### DIFF
--- a/pkgs/by-name/go/gosmee/package.nix
+++ b/pkgs/by-name/go/gosmee/package.nix
@@ -4,24 +4,27 @@
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
+  versionCheckHook,
+  nix-update-script,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "gosmee";
   version = "0.28.3";
 
   src = fetchFromGitHub {
     owner = "chmouel";
     repo = "gosmee";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-97Z/q0cOX4zPGYaeAKqxm3sb7WfJ1fpUcMhuqHsPG1c=";
   };
+
   vendorHash = null;
 
   nativeBuildInputs = [ installShellFiles ];
 
   postPatch = ''
-    printf ${version} > gosmee/templates/version
+    printf ${finalAttrs.version} > gosmee/templates/version
   '';
 
   postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
@@ -31,13 +34,20 @@ buildGoModule rec {
       --zsh <($out/bin/gosmee completion zsh)
   '';
 
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
   meta = {
     description = "Command line server and client for webhooks deliveries (and https://smee.io)";
     homepage = "https://github.com/chmouel/gosmee";
+    changelog = "https://github.com/chmouel/gosmee/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       vdemeester
       chmouel
     ];
+    mainProgram = "gosmee";
   };
-}
+})


### PR DESCRIPTION
This PR migrates the gosmee package to modern nixpkgs best practices, following the pattern established by lazyworktree and other recent packages.

Migrates from `buildGoModule rec` to the `finalAttrs` pattern, adds `versionCheckHook` for post-install verification, includes `nix-update-script` for automated updates, and enhances metadata with changelog URL and mainProgram. All version references now use `finalAttrs.version` for consistency.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests` (versionCheckHook added).
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test