### PR TITLE
spirv-tools: Enable & run tests

### DIFF
--- a/pkgs/by-name/sp/spirv-tools/package.nix
+++ b/pkgs/by-name/sp/spirv-tools/package.nix
@@ -2,11 +2,23 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  abseil-cpp,
   cmake,
+  ctestCheckHook,
+  gtest,
   python3,
+  re2,
   spirv-headers,
 }:
 
+let
+  effcee-src = fetchFromGitHub {
+    owner = "google";
+    repo = "effcee";
+    rev = "ae38e040cbb7e83efa8bfbb4967e5b8c8c89b55a";
+    hash = "sha256-Ub5cyr6Wi+rbZ/Fs7JVilo9mhsj/SSS/hkqzQboXPCM=";
+  };
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "spirv-tools";
   version = "1.4.341.0";
@@ -27,6 +39,11 @@ stdenv.mkDerivation (finalAttrs: {
   # description
   ++ lib.optional stdenv.hostPlatform.isStatic ./no-shared-libs.patch;
 
+  # Can't pass this location via flags
+  postPatch = lib.optionalString finalAttrs.finalPackage.doCheck ''
+    ln -vs ${effcee-src} external/effcee
+  '';
+
   outputs = [
     "out"
     "lib"
@@ -38,11 +55,30 @@ stdenv.mkDerivation (finalAttrs: {
     python3
   ];
 
+  nativeCheckInputs = [
+    ctestCheckHook
+  ];
+
   cmakeFlags = [
     "-DSPIRV-Headers_SOURCE_DIR=${spirv-headers}"
     # Avoid blanket -Werror to evade build failures on less
     # tested compilers.
     "-DSPIRV_WERROR=OFF"
+    (lib.cmakeBool "SPIRV_SKIP_TESTS" (!finalAttrs.finalPackage.doCheck))
+  ]
+  ++ lib.optionals finalAttrs.finalPackage.doCheck [
+    (lib.cmakeFeature "absl_SOURCE_DIR" "${abseil-cpp.src}")
+    (lib.cmakeFeature "GMOCK_DIR" "${gtest.src}")
+    (lib.cmakeFeature "RE2_SOURCE_DIR" "${re2.src}")
+  ];
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  disabledTests = lib.optionals (!stdenv.hostPlatform.isLittleEndian) [
+    # TODO Report.
+    # TODO Submit patch to make these tests report the actual strings, instead of just if they match, to better show the issue.
+    # Looks similar to issues in glslang: strings are reversed in 4-byte chunks
+    "spirv-tools-test_spirv_unit_test_tools_objdump"
   ];
 
   meta = {

--- a/pkgs/by-name/sp/spirv-tools/package.nix
+++ b/pkgs/by-name/sp/spirv-tools/package.nix
@@ -2,11 +2,23 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  abseil-cpp,
   cmake,
+  ctestCheckHook,
+  gtest,
   python3,
+  re2,
   spirv-headers,
 }:
 
+let
+  effcee-src = fetchFromGitHub {
+    owner = "google";
+    repo = "effcee";
+    rev = "910ed15722d5d05c9d71ecf36c1a22243cb79b02";
+    hash = "sha256-l6MbPrPHqpeov4QSO/rmIuPcFqnlLJ5kTusNqZM5mFM=";
+  };
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "spirv-tools";
   version = "1.4.357.0";
@@ -27,6 +39,11 @@ stdenv.mkDerivation (finalAttrs: {
   # description
   ++ lib.optional stdenv.hostPlatform.isStatic ./no-shared-libs.patch;
 
+  # Can't pass this location via flags
+  postPatch = lib.optionalString finalAttrs.finalPackage.doCheck ''
+    ln -vs ${effcee-src} external/effcee
+  '';
+
   outputs = [
     "out"
     "lib"
@@ -38,11 +55,28 @@ stdenv.mkDerivation (finalAttrs: {
     python3
   ];
 
+  nativeCheckInputs = [
+    ctestCheckHook
+  ];
+
   cmakeFlags = [
     "-DSPIRV-Headers_SOURCE_DIR=${spirv-headers}"
     # Avoid blanket -Werror to evade build failures on less
     # tested compilers.
     "-DSPIRV_WERROR=OFF"
+    (lib.cmakeBool "SPIRV_SKIP_TESTS" (!finalAttrs.finalPackage.doCheck))
+  ]
+  ++ lib.optionals finalAttrs.finalPackage.doCheck [
+    (lib.cmakeFeature "absl_SOURCE_DIR" "${abseil-cpp.src}")
+    (lib.cmakeFeature "GMOCK_DIR" "${gtest.src}")
+    (lib.cmakeFeature "RE2_SOURCE_DIR" "${re2.src}")
+  ];
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  disabledTests = lib.optionals (!stdenv.hostPlatform.isLittleEndian) [
+    # Likely fixed by https://github.com/KhronosGroup/SPIRV-Tools/pull/5302
+    "spirv-tools-test_spirv_unit_test_tools_objdump"
   ];
 
   meta = {


### PR DESCRIPTION
Similar to #479398, but for SPIRV-Tools.

Project lacks support for building against system-installed gtest etc, so this isn't *great*. Don't have the spoons to implement & submit that rn.

Most of `spirv-tools-test_spirv_unit_test_tools_objdump` fails on non-LE. I'd expect that to get fixed by the long-standing PR https://github.com/KhronosGroup/SPIRV-Tools/pull/5302:

```
/build/source/test/tools/objdump/extract_source_test.cpp:223: Failure
Expected equality of these values:
  resStr.c_str()
    Which is: "diovmoc etup}{)("
  "void compute(){}"
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] powerpc64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
