### PR TITLE
music-assistant: 2.7.3 -> 2.7.5, python3Packages.aiosendspin: 1.2.0 -> 2.1.0, python3Packages.py-opensonic: 7.0.4 -> 8.1.1

### DIFF
--- a/pkgs/by-name/mu/music-assistant/package.nix
+++ b/pkgs/by-name/mu/music-assistant/package.nix
@@ -47,14 +47,14 @@ assert
 
 python.pkgs.buildPythonApplication rec {
   pname = "music-assistant";
-  version = "2.7.3";
+  version = "2.7.5";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "music-assistant";
     repo = "server";
     tag = version;
-    hash = "sha256-6D3B88wjfVHvNhNrTDOu77eAkherOqdBVafUhht7okA=";
+    hash = "sha256-iWdOGdmPJO7Pjdn8UjuSOhWnRGBFjmARFsuHmP6IP58=";
   };
 
   patches = [

--- a/pkgs/by-name/mu/music-assistant/providers.nix
+++ b/pkgs/by-name/mu/music-assistant/providers.nix
@@ -1,7 +1,7 @@
 # Do not edit manually, run ./update-providers.py
 
 {
-  version = "2.7.3";
+  version = "2.7.5";
   providers = {
     airplay = ps: [
     ];
@@ -134,6 +134,7 @@
     sendspin =
       ps: with ps; [
         aiosendspin
+        av
       ];
     siriusxm = ps: [
     ]; # missing sxm

--- a/pkgs/development/python-modules/aiosendspin/default.nix
+++ b/pkgs/development/python-modules/aiosendspin/default.nix
@@ -30,6 +30,12 @@ buildPythonPackage rec {
     hash = "sha256-3vTEfXeFqouPswRKST/9U7yg9ah7J9m2KAMoxaBZNR0=";
   };
 
+  # https://github.com/Sendspin/aiosendspin/blob/1.2.0/pyproject.toml#L7
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail 'version = "0.0.0"' 'version = "${version}"'
+  '';
+
   build-system = [
     setuptools
   ];

--- a/pkgs/development/python-modules/aiosendspin/default.nix
+++ b/pkgs/development/python-modules/aiosendspin/default.nix
@@ -20,14 +20,14 @@
 
 buildPythonPackage rec {
   pname = "aiosendspin";
-  version = "1.2.0";
+  version = "2.1.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Sendspin";
     repo = "aiosendspin";
     tag = version;
-    hash = "sha256-3vTEfXeFqouPswRKST/9U7yg9ah7J9m2KAMoxaBZNR0=";
+    hash = "sha256-9VhNtfXH2r/cGkscz51PIK2/66pPOGv0S0IpO0wFvO4=";
   };
 
   # https://github.com/Sendspin/aiosendspin/blob/1.2.0/pyproject.toml#L7

--- a/pkgs/development/python-modules/py-opensonic/default.nix
+++ b/pkgs/development/python-modules/py-opensonic/default.nix
@@ -3,25 +3,27 @@
   buildPythonPackage,
   fetchFromGitHub,
   setuptools,
+  aiohttp,
   mashumaro,
   requests,
 }:
 
 buildPythonPackage rec {
   pname = "py-opensonic";
-  version = "7.0.4";
+  version = "8.1.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "khers";
     repo = "py-opensonic";
     tag = "v${version}";
-    hash = "sha256-5wsisIfYW+0uh0khUzt9wKFxBf/ZXVsKpNF/Dcrj2wI=";
+    hash = "sha256-/P/7ytA0YHuJZEq7KQosPBQM2vo6VAss1G8pTIEswJA=";
   };
 
   build-system = [ setuptools ];
 
   dependencies = [
+    aiohttp
     mashumaro
     requests
   ];


### PR DESCRIPTION
https://github.com/music-assistant/server/releases/tag/2.7.4

https://github.com/music-assistant/server/releases/tag/2.7.5

security label because of https://github.com/music-assistant/server/pull/2916

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
