### PR TITLE
shortcircuit-XT: init at unstable-2026-05-15

### DIFF
--- a/pkgs/by-name/sh/shortcircuit-xt/package.nix
+++ b/pkgs/by-name/sh/shortcircuit-xt/package.nix
@@ -1,0 +1,142 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  fetchurl,
+  runCommand,
+  cmake,
+  pkg-config,
+  alsa-lib,
+  fontconfig,
+  freetype,
+  git,
+  gtkmm3,
+  libjack2,
+  libx11,
+  libxcursor,
+  libxext,
+  libxinerama,
+  libxrandr,
+
+  buildVST3 ? true,
+  buildStandalone ? true,
+}:
+let
+
+  # Required version, base URL and expected location specified in cmake/CPM.cmake
+  cpmDownloadVersion = "0.40.2";
+  cpmSrc = fetchurl {
+    url = "https://github.com/cpm-cmake/CPM.cmake/releases/download/v${cpmDownloadVersion}/CPM.cmake";
+    hash = "sha256-yM3DLAOBZTjOInge1ylk3IZLKjSjENO3EEgSpcotg10=";
+  };
+  cpmSourceCache = runCommand "cpm-source-cache" { } ''
+    mkdir -p $out/cpm
+    ln -s ${cpmSrc} $out/cpm/CPM_${cpmDownloadVersion}.cmake
+  '';
+  vst3sdk = fetchFromGitHub {
+    owner = "robbert-vdh";
+    repo = "vst3sdk";
+    tag = "v3.7.7_build_19-patched";
+    fetchSubmodules = true;
+    hash = "sha256-LsPHPoAL21XOKmF1Wl/tvLJGzjaCLjaDAcUtDvXdXSU=";
+  };
+  rtaudioSrc = fetchFromGitHub {
+    owner = "thestk";
+    repo = "rtaudio";
+    tag = "6.0.1";
+    hash = "sha256-Acsxbnl+V+Y4mKC1gD11n0m03E96HMK+oEY/YV7rlIY=";
+  };
+
+  rtmidiSrc = fetchFromGitHub {
+    owner = "thestk";
+    repo = "rtmidi";
+    tag = "6.0.0";
+    hash = "sha256-QuUeFx8rPpe0+exB3chT6dUceDa/7ygVy+cQYykq7e0=";
+  };
+
+  toCMakeBoolean = v: if v then "ON" else "OFF";
+in
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "shortcircuit-xt";
+  version = "unstable-2026-05-15";
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "surge-synthesizer";
+    repo = "shortcircuit-xt";
+    rev = "68bca1b930137d0878d8a57203678b6df7835a77";
+    fetchSubmodules = true;
+    hash = "sha256-P2G3uQZN07WbnwfuwApPtnquRpfIMQVQ2zw8m41WJRg=";
+  };
+
+  NIX_CFLAGS_COMPILE = "-Wno-error=format-security";
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    git
+  ];
+
+  buildInputs = [
+    alsa-lib
+    fontconfig
+    freetype
+    gtkmm3
+    libjack2
+    libx11
+    libxcursor
+    libxext
+    libxinerama
+    libxrandr
+  ];
+
+  enableParallelBuilding = true;
+
+  # GCC 15 / libstdc++ 15: keyboard.h uses std::clamp without including
+  # <algorithm>, which is no longer pulled in transitively.
+  # Reported upstream; drop once a release includes the include.
+  postPatch = ''
+    sed -i '/^#include <cassert>/a #include <algorithm>' \
+      src/scxt-core/engine/keyboard.h
+  '';
+
+  cmakeFlags = [
+    (lib.cmakeFeature "CPM_SOURCE_CACHE" "${cpmSourceCache}")
+    (lib.cmakeBool "CPM_LOCAL_PACKAGES_ONLY" true)
+    (lib.cmakeFeature "VST3_SDK_ROOT" "${vst3sdk}")
+    (lib.cmakeFeature "RTAUDIO_SDK_ROOT" "${rtaudioSrc}")
+    (lib.cmakeFeature "RTMIDI_SDK_ROOT" "${rtmidiSrc}")
+    (lib.cmakeFeature "GIT_COMMIT_HASH" finalAttrs.src.rev)
+    (lib.cmakeFeature "GIT_COMMIT_DATE" "2026-05-15")
+
+    (lib.cmakeFeature "SCXT_BUILD_STANDALONE" "${toCMakeBoolean buildStandalone}")
+    (lib.cmakeFeature "SCXT_BUILD_VST3" "${toCMakeBoolean buildVST3}")
+  ];
+
+  # JUCE dlopen's these at runtime, crashes without them
+  NIX_LDFLAGS = (
+    toString [
+      "-lX11"
+      "-lXext"
+      "-lXcursor"
+      "-lXinerama"
+      "-lXrandr"
+    ]
+  );
+
+  preConfigure = ''
+    unset SOURCE_DATE_EPOCH
+  '';
+
+  meta = {
+    description = "Will be a sampler when its done!";
+    homepage = "https://github.com/surge-synthesizer/shortcircuit-xt";
+    license = lib.licenses.gpl3;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with lib.maintainers; [
+      magnetophon
+    ];
+  };
+})


### PR DESCRIPTION
The WIP sampler by the surge team:
https://github.com/surge-synthesizer/shortcircuit-xt

Draft for now, until they release version 1.0.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
