### PR TITLE
prek: 0.2.20 -> 0.2.30

### DIFF
--- a/pkgs/by-name/pr/prek/package.nix
+++ b/pkgs/by-name/pr/prek/package.nix
@@ -5,21 +5,22 @@
   git,
   uv,
   python312,
+  versionCheckHook,
   nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "prek";
-  version = "0.2.20";
+  version = "0.2.30";
 
   src = fetchFromGitHub {
     owner = "j178";
     repo = "prek";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-AZyYjgUd2dGnBUHwo/cPagFE8IJmzsgMLwebTypLAgE=";
+    hash = "sha256-IqFUJNFs7a/M9IUNEwW40EZTAh+6a5Ov37xg5c9iwRc=";
   };
 
-  cargoHash = "sha256-a1yBu4MuyR0veBSQAUdaE/9rB04i6RVJ/NdWNmpRzmM=";
+  cargoHash = "sha256-KOpQ3P9cmcWYT3bPKtKpzHPagX4b9hH0EiWGpt98NnE=";
 
   nativeCheckInputs = [
     git
@@ -45,7 +46,13 @@ rustPlatform.buildRustPackage (finalAttrs: {
   useNextest = true;
 
   # some python tests use uv, which in turn needs python
-  UV_PYTHON = "${python312}/bin/python";
+  env = {
+    UV_PYTHON = "${python312}/bin/python";
+    UV_NO_MANAGED_PYTHON = true;
+    UV_SYSTEM_PYTHON = true;
+  };
+
+  cargoTestFlags = [ "--no-fail-fast" ];
 
   checkFlags = map (t: "--skip ${t}") [
     # these tests require internet access
@@ -67,6 +74,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "rust::remote_hooks"
     "rust::remote_hooks_with_lib_deps"
     "unsupported::unsupported_language"
+    "remote_hook_non_workspace"
     # "meta_hooks"
     "reuse_env"
     "docker::docker"
@@ -145,7 +153,29 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "run_in_non_git_repo"
     # depends on locale
     "init_nonexistent_repo"
+    # https://github.com/astral-sh/uv/issues/8635
+    "alternate_config_file"
+    "basic_discovery"
+    "color"
+    "cookiecutter_template_directories_are_skipped"
+    "empty_entry"
+    "git_dir_respected"
+    "git_env_vars_not_leaked_to_pip_install"
+    "gitignore_respected"
+    "invalid_entry"
+    "local_python_hook"
+    "orphan_projects"
+    "run_with_selectors"
+    "run_with_stdin_closed"
+    "show_diff_on_failure"
+    "submodule_discovery"
+    "workspace_install_hooks"
+    # We don't have git info; we run versionCheckHook instead
+    "version_info"
   ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/pr/prek/package.nix
+++ b/pkgs/by-name/pr/prek/package.nix
@@ -153,7 +153,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/j178/prek";
     description = "Better `pre-commit`, re-engineered in Rust ";
     mainProgram = "prek";
-    changelog = "https://github.com/j178/prek/releases/tag/${finalAttrs.src.tag}";
+    changelog = "https://github.com/j178/prek/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = [ lib.licenses.mit ];
     maintainers = [ lib.maintainers.knl ];
   };


### PR DESCRIPTION
- **prek: use changelog in meta.changelog, not GitHub release**
- **prek: 0.2.20 -> 0.2.30**
  Changelog: https://github.com/j178/prek/blob/v0.2.30/CHANGELOG.md

Closes: #480609

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
