### PR TITLE
contour: 0.6.1.7494 -> 0.6.2.8008

### DIFF
--- a/pkgs/by-name/co/contour/package.nix
+++ b/pkgs/by-name/co/contour/package.nix
@@ -5,6 +5,7 @@
   cmake,
   pkg-config,
   boxed-cpp,
+  cairo,
   freetype,
   fontconfig,
   libunicode,
@@ -28,13 +29,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "contour";
-  version = "0.6.1.7494";
+  version = "0.6.2.8008";
 
   src = fetchFromGitHub {
     owner = "contour-terminal";
     repo = "contour";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-jgasZhdcJ+UF3VIl8HLcxBayvbA/dkaOG8UtANRgeP4=";
+    hash = "sha256-xbJxV1q7+ddhnH0jDYzqVHwARCD0EyVh3POFRkl4d1Q=";
   };
 
   patches = lib.optionals stdenv.hostPlatform.isDarwin [
@@ -59,6 +60,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     boxed-cpp
+    cairo
     fontconfig
     freetype
     libunicode
@@ -78,8 +80,6 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     darwin.libutil
   ];
-
-  cmakeFlags = [ "-DCONTOUR_QT_VERSION=6" ];
 
   postInstall = ''
     mkdir -p $out/nix-support $terminfo/share

--- a/pkgs/by-name/li/libunicode/package.nix
+++ b/pkgs/by-name/li/libunicode/package.nix
@@ -7,26 +7,27 @@
   catch2_3,
   fmt,
   python3,
+  simdImplementation ? "none", # see https://github.com/contour-terminal/libunicode/blob/v0.7.0/CMakeLists.txt#L53 for options
 }:
 
 let
-  ucd-version = "16.0.0";
+  ucd-version = "17.0.0";
 
   ucd-src = fetchzip {
     url = "https://www.unicode.org/Public/${ucd-version}/ucd/UCD.zip";
-    hash = "sha256-GgEYjOLrxxfTAQsc2bpi7ShoAr3up8z7GXXpe+txFuw";
+    hash = "sha256-k2OFy8xPvn+Bboyr1EsmZNeVDOglvk2kSZ+H17YaX60=";
     stripRoot = false;
   };
 in
 stdenv.mkDerivation (final: {
   pname = "libunicode";
-  version = "0.6.0";
+  version = "0.7.0";
 
   src = fetchFromGitHub {
     owner = "contour-terminal";
     repo = "libunicode";
-    rev = "v${final.version}";
-    hash = "sha256-zX33aTQ7Wgl8MABu+o6nA2HWrfXD4zQ9b3NDB+T2saI";
+    tag = "v${final.version}";
+    hash = "sha256-J8qawT1oiUO9xTVEMQvsY0K2NtIfkUq9PoCbFt6wqek=";
   };
 
   # Fix: set_target_properties Can not find target to add properties to: Catch2, et al.
@@ -41,7 +42,10 @@ stdenv.mkDerivation (final: {
     fmt
   ];
 
-  cmakeFlags = [ "-DLIBUNICODE_UCD_DIR=${ucd-src}" ];
+  cmakeFlags = [
+    (lib.cmakeFeature "LIBUNICODE_SIMD_IMPLEMENTATION" simdImplementation)
+    (lib.cmakeFeature "LIBUNICODE_UCD_DIR" "${ucd-src}")
+  ];
 
   meta = {
     description = "Modern C++20 Unicode library";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
