### PR TITLE
ii: migrate to by-name

### DIFF
--- a/pkgs/by-name/ii/ii/package.nix
+++ b/pkgs/by-name/ii/ii/package.nix
@@ -1,16 +1,16 @@
 {
   lib,
-  stdenv,
+  gccStdenv,
   fetchurl,
 }:
 
-stdenv.mkDerivation rec {
+gccStdenv.mkDerivation (finalAttrs: {
   pname = "ii";
   version = "2.0";
 
   src = fetchurl {
-    url = "https://dl.suckless.org/tools/${pname}-${version}.tar.gz";
-    sha256 = "sha256-T2evzSCMB5ObiKrb8hSXpwKtCgf5tabOhh+fOf/lQls=";
+    url = "https://dl.suckless.org/tools/ii-${finalAttrs.version}.tar.gz";
+    hash = "sha256-T2evzSCMB5ObiKrb8hSXpwKtCgf5tabOhh+fOf/lQls=";
   };
 
   makeFlags = [ "CC:=$(CC)" ];
@@ -24,4 +24,4 @@ stdenv.mkDerivation rec {
     mainProgram = "ii";
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10783,10 +10783,6 @@ with pkgs;
 
   wmfocus = callPackage ../applications/window-managers/i3/wmfocus.nix { };
 
-  ii = callPackage ../applications/networking/irc/ii {
-    stdenv = gccStdenv;
-  };
-
   ikiwiki = callPackage ../applications/misc/ikiwiki {
     inherit
       (perlPackages.override {


### PR DESCRIPTION
This pull request reorganizes and updates the packaging of the `ii` IRC client. The main change is moving the package definition to a new location under `pkgs/by-name`, modernizing its packaging style, and removing its explicit inclusion from `all-packages.nix`.

**Package reorganization and modernization:**

* Moved the `ii` package definition from `pkgs/applications/networking/irc/ii/default.nix` to `pkgs/by-name/ii/ii/package.nix`, updating the derivation to use `gccStdenv.mkDerivation` with the new lambda-style argument structure and modernizing attribute names (e.g., `sha256` to `hash`).

**Top-level package set cleanup:**

* Removed the explicit `ii` package entry from `pkgs/top-level/all-packages.nix`, as it will now be picked up automatically in the new structure.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
