### PR TITLE
ld64: fix zippered binaries

### DIFF
--- a/pkgs/by-name/ld/ld64/package.nix
+++ b/pkgs/by-name/ld/ld64/package.nix
@@ -73,6 +73,10 @@ stdenv.mkDerivation (finalAttrs: {
     ./patches/0016-Add-dyldinfo-to-the-ld64-build.patch
     ./patches/0017-Fix-dyldinfo-build.patch
     ./patches/0018-Use-STL-containers-instead-of-LLVM-containers.patch
+
+    # Fix zippered versions on macOS 26+. Part of upstream ld64-956.6. Remove on next version bump.
+    # https://github.com/apple-oss-distributions/ld64/commit/1a4389663d65d6630e4b3e31ace2a86b6183b452
+    ./patches/0019-Fix-zippered-versions-macos-26.patch
   ];
 
   prePatch = ''

--- a/pkgs/by-name/ld/ld64/patches/0019-Fix-zippered-versions-macos-26.patch
+++ b/pkgs/by-name/ld/ld64/patches/0019-Fix-zippered-versions-macos-26.patch
@@ -1,0 +1,13 @@
+diff --git a/src/ld/Options.cpp b/src/ld/Options.cpp
+--- a/src/ld/Options.cpp
++++ b/src/ld/Options.cpp
+@@ -4882,7 +4885,8 @@ void Options::reconfigureDefaults()
+ 		uint32_t iOSMacOSMajorVersion = (iOSMacVersion >> 16) & 0xFFFF;
+ 
+ 		// macOS 11 -> iOSMac 14, and so on
+-		uint32_t newMajorVersion = macOSMajorVersion + 3;
++		uint32_t newMajorVersion = macOSMajorVersion < 26 ? macOSMajorVersion + 3 : macOSMajorVersion;
++		// rdar://154107557 (ld64 fix handling of zippered versions for macOS 26+)
+ 		if ( newMajorVersion > iOSMacOSMajorVersion ) {
+ 			uint32_t newVersion = newMajorVersion << 16;
+ 			std::string oldVersionString = getVersionString32(iOSMacVersion);


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This should fix the x86_64-darwin build of llvmPackages_20.compiler-rt.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
