### PR TITLE
steam-art-manager: init at 3.12.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -588,6 +588,11 @@
       { fingerprint = "CE85 54F7 B9BC AC0D D648  5661 AB5F C04C 3C94 443F"; }
     ];
   };
+  adam-tj = {
+    github = "adam-tj";
+    githubId = 9314405;
+    name = "Adam Tjörnhammar";
+  };
   adam248 = {
     email = "adamjbutler091@gmail.com";
     github = "adam248";
@@ -611,11 +616,6 @@
     github = "adamtulinius";
     githubId = 749381;
     name = "Adam Tulinius";
-  };
-  adam-tj = {
-    github = "adam-tj";
-    githubId = "9314405";
-    name = "Adam Tjörnhammar";
   };
   adda = {
     email = "chocholaty.david@protonmail.com";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -612,6 +612,11 @@
     githubId = 749381;
     name = "Adam Tulinius";
   };
+  adam-tj = {
+    github = "adam-tj";
+    githubId = "9314405";
+    name = "Adam Tjörnhammar";
+  };
   adda = {
     email = "chocholaty.david@protonmail.com";
     matrix = "@adda0:matrix.org";

--- a/pkgs/by-name/st/steam-art-manager/package.nix
+++ b/pkgs/by-name/st/steam-art-manager/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  fetchurl,
+  appimageTools,
+}:
+
+let
+  pname = "steam-art-manager";
+  version = "3.12.1";
+  src = fetchurl {
+    url = "https://github.com/Tormak9970/Steam-Art-Manager/releases/download/v${version}/steam-art-manager.AppImage";
+    hash = "sha256-eH2Adl0+i+8I7+hPUyCGHzrm7xW34D7MdVex5Yi7pfI=";
+  };
+  appimageContents = appimageTools.extract { inherit pname version src; };
+in
+appimageTools.wrapType2 {
+  inherit pname version src;
+
+  extraInstallCommands = ''
+    install -m 444 -D "${appimageContents}/usr/share/applications/Steam Art Manager.desktop" $out/share/applications/steam-art-manager.desktop
+    install -m 444 -D "${appimageContents}/Steam Art Manager.png" $out/share/icons/hicolor/512x512/apps/steam-art-manager.png
+    substituteInPlace $out/share/applications/steam-art-manager.desktop \
+      --replace 'Exec=AppRun' 'Exec=${pname}' \
+      --replace 'Icon=Steam Art Manager' 'Icon=steam-art-manager'
+  '';
+
+  meta = with lib; {
+    description = "A tool to manage and change Steam library artwork";
+    homepage = "https://github.com/Tormak9970/Steam-Art-Manager";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ adam-tj ];
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "steam-art-manager";
+  };
+}


### PR DESCRIPTION

Allows easy customisation of the artwork in one's Steam library. https://github.com/Tormak9970/Steam-Art-Manager


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
