### PR TITLE
blocky: build time config checking, finalAttrs, add kuflierl as maintainer

### DIFF
--- a/nixos/modules/services/networking/blocky.nix
+++ b/nixos/modules/services/networking/blocky.nix
@@ -16,6 +16,10 @@ in
 
     package = lib.mkPackageOption pkgs "blocky" { };
 
+    enableConfigCheck = lib.mkEnableOption "checking the config during build time" // {
+      default = true;
+    };
+
     settings = lib.mkOption {
       type = format.type;
       default = { };
@@ -80,6 +84,14 @@ in
         ];
       };
     };
+    system.checks = lib.mkIf cfg.enableConfigCheck [
+      (pkgs.runCommand "check-blocky-config" { } ''
+        ${lib.getExe cfg.package} --config ${configFile} validate && touch $out
+      '')
+    ];
   };
-  meta.maintainers = with lib.maintainers; [ paepcke ];
+  meta.maintainers = with lib.maintainers; [
+    paepcke
+    kuflierl
+  ];
 }

--- a/nixos/tests/blocky.nix
+++ b/nixos/tests/blocky.nix
@@ -15,15 +15,17 @@
                 "printer.lan" = "192.168.178.3,2001:0db8:85a3:08d3:1319:8a2e:0370:7344";
               };
             };
-            upstream = {
+            upstreams.groups = {
               default = [
                 "8.8.8.8"
                 "1.1.1.1"
               ];
             };
-            port = 53;
-            httpPort = 5000;
-            logLevel = "info";
+            ports = {
+              dns = 53;
+              http = 5000;
+            };
+            log.level = "info";
           };
         };
       };

--- a/pkgs/by-name/bl/blocky/package.nix
+++ b/pkgs/by-name/bl/blocky/package.nix
@@ -5,14 +5,14 @@
   nixosTests,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "blocky";
   version = "0.28.2";
 
   src = fetchFromGitHub {
     owner = "0xERR0R";
     repo = "blocky";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-GLVyPb2Qyn1jnRz+e74dFzL/AMloKqSe1BUUAGTquWA=";
   };
 
@@ -25,7 +25,7 @@ buildGoModule rec {
   ldflags = [
     "-s"
     "-w"
-    "-X github.com/0xERR0R/blocky/util.Version=${version}"
+    "-X github.com/0xERR0R/blocky/util.Version=${finalAttrs.version}"
   ];
 
   passthru.tests = { inherit (nixosTests) blocky; };
@@ -35,7 +35,10 @@ buildGoModule rec {
     homepage = "https://0xerr0r.github.io/blocky";
     changelog = "https://github.com/0xERR0R/blocky/releases";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ ratsclub ];
+    maintainers = with lib.maintainers; [
+      ratsclub
+      kuflierl
+    ];
     mainProgram = "blocky";
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
