### PR TITLE
stock-tui: init at 0.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18696,6 +18696,12 @@
     githubId = 10180857;
     name = "Anmol Sethi";
   };
+  ni5arga = {
+    email = "hello@ni5arga.com";
+    github = "ni5arga";
+    githubId = 45588772;
+    name = "Nisarga Adhikary";
+  };
   nialov = {
     email = "nikolasovaskainen@gmail.com";
     github = "nialov";

--- a/pkgs/by-name/st/stock-tui/package.nix
+++ b/pkgs/by-name/st/stock-tui/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "stock-tui";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "ni5arga";
+    repo = "stock-tui";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-5k24fBG0ZBr2JhVf30IGjLky087j203hZGEvtSzwUqQ=";
+  };
+
+  subPackages = [ "cmd/stock-tui" ];
+
+  vendorHash = "sha256-Use54AVRMZ9xYx8tQpcRN3th+MufuER3lCJ+JVPpYRU=";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Terminal-based stock and cryptocurrency price tracker";
+    homepage = "https://github.com/ni5arga/stock-tui";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ni5arga ];
+    mainProgram = "stock-tui";
+  };
+})


### PR DESCRIPTION
adds stock-tui, a terminal-based stock and crypto price tracker written in go.

homepage: https://github.com/ni5arga/stock-tui

also adds @ni5arga as a maintainer for the package.

## Things done


- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
