### PR TITLE
diun: init at 4.31.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -24916,6 +24916,12 @@
     github = "spectre256";
     githubId = 72505298;
   };
+  Sped0n = {
+    name = "Ryan Wen";
+    email = "hi@sped0n.com";
+    github = "Sped0n";
+    githubId = 197479310;
+  };
   spencerjanssen = {
     email = "spencerjanssen@gmail.com";
     matrix = "@sjanssen:matrix.org";

--- a/pkgs/by-name/di/diun/package.nix
+++ b/pkgs/by-name/di/diun/package.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+  versionCheckHook,
+}:
+buildGoModule (finalAttrs: {
+  pname = "diun";
+  version = "4.31.0";
+
+  src = fetchFromGitHub {
+    owner = "crazy-max";
+    repo = "diun";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-H05yZSH2rUrwM+ZR/PDCxXmrDkZ/Gd4RrpywGk5eW2A=";
+  };
+  vendorHash = null;
+
+  # upstream disable CGO in release build
+  # https://github.com/crazy-max/diun/blob/76c0fe99212adc58d6a3433bbcde1ffa9fb879c4/Dockerfile#L11
+  env.CGO_ENABLED = false;
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X"
+    "main.version=${finalAttrs.version}"
+  ];
+
+  checkFlags =
+    let
+      # these tests require a network connection
+      skippedTests = [
+        "TestTags"
+        "TestTagsWithDigest"
+        "TestCompareDigest"
+        "TestManifest"
+        "TestManifestMultiUpdatedPlatform"
+        "TestManifestMultiNotUpdatedPlatform"
+        "TestManifestVariant"
+        "TestManifestTaggedDigest"
+        "TestManifestTaggedDigestUnknownTag"
+      ];
+    in
+    [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
+
+  postInstall = ''
+    mv $out/bin/cmd $out/bin/diun
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "CLI application to receive notifications when a Docker image is updated on a Docker registry";
+    homepage = "https://crazymax.dev/diun";
+    changelog = "https://crazymax.dev/diun/changelog";
+    license = lib.licenses.mit;
+    mainProgram = "diun";
+    maintainers = with lib.maintainers; [ Sped0n ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
adds diun, a CLI application written in Go to receive notifications when a Docker image is updated on a Docker registry.

homepage: https://github.com/crazy-max/diun

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
