### PR TITLE
goconvey: adopt modern best practices

### DIFF
--- a/pkgs/by-name/go/goconvey/package.nix
+++ b/pkgs/by-name/go/goconvey/package.nix
@@ -5,9 +5,10 @@
   # 'vendor/golang.org/x/tools/internal/tokeninternal/tokeninternal.go:64:9: invalid array length -delta * delta (constant -256 of type int64)'
   # Wait for upstream to update their vendored dependencies before unpinning.
   buildGo124Module,
+  nix-update-script,
 }:
 
-buildGo124Module {
+buildGo124Module (finalAttrs: {
   pname = "goconvey";
   version = "1.8.1-unstable-2024-03-06";
 
@@ -31,11 +32,17 @@ buildGo124Module {
     "-short"
   ];
 
+  # goconvey doesn't support --version flag
+  doInstallCheck = false;
+
+  passthru.updateScript = nix-update-script { };
+
   meta = {
     description = "Go testing in the browser. Integrates with `go test`. Write behavioral tests in Go";
     mainProgram = "goconvey";
     homepage = "https://github.com/smartystreets/goconvey";
+    changelog = "https://github.com/smartystreets/goconvey/blob/${finalAttrs.src.rev}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ vdemeester ];
   };
-}
+})


### PR DESCRIPTION
Updates goconvey to follow current nixpkgs best practices. This brings the package definition up to date with current nixpkgs standards and makes future maintenance easier through automated update scripts.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc