### PR TITLE
kube-prompt: adopt modern best practices

### DIFF
--- a/pkgs/by-name/ku/kube-prompt/package.nix
+++ b/pkgs/by-name/ku/kube-prompt/package.nix
@@ -2,26 +2,38 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
+  nix-update-script,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "kube-prompt";
   version = "1.0.11";
 
   src = fetchFromGitHub {
     owner = "c-bata";
     repo = "kube-prompt";
-    rev = "v${version}";
-    sha256 = "sha256-9OWsITbC7YO51QzsRwDWvojU54DiuGJhkSGwmesEj9w=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-9OWsITbC7YO51QzsRwDWvojU54DiuGJhkSGwmesEj9w=";
   };
 
   vendorHash = "sha256-wou5inOX8vadEBCIBccwSRjtzf0GH1abwNdUu4JBvyM=";
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  # kube-prompt doesn't support --version and requires kubernetes config
+  doInstallCheck = false;
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Interactive kubernetes client featuring auto-complete";
     mainProgram = "kube-prompt";
     license = lib.licenses.mit;
     homepage = "https://github.com/c-bata/kube-prompt";
+    changelog = "https://github.com/c-bata/kube-prompt/releases/tag/v${finalAttrs.version}";
     maintainers = with lib.maintainers; [ vdemeester ];
   };
-}
+})


### PR DESCRIPTION
Updates kube-prompt to follow current nixpkgs best practices. This brings the package definition up to date with current nixpkgs standards and makes future maintenance easier through automated update scripts.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc