### PR TITLE
krew: adopt modern best practices

### DIFF
--- a/pkgs/by-name/kr/krew/package.nix
+++ b/pkgs/by-name/kr/krew/package.nix
@@ -4,17 +4,18 @@
   fetchFromGitHub,
   makeWrapper,
   gitMinimal,
+  nix-update-script,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "krew";
   version = "0.4.5";
 
   src = fetchFromGitHub {
     owner = "kubernetes-sigs";
     repo = "krew";
-    rev = "v${version}";
-    sha256 = "sha256-3GoC2HEp9XJe853/JYvX9kAAcFf7XxglVEeU9oQ/5Ms=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-3GoC2HEp9XJe853/JYvX9kAAcFf7XxglVEeU9oQ/5Ms=";
   };
 
   vendorHash = "sha256-r4Dywm0+YxWWD59oaKodkldE2uq8hlt9MwOMYDaj6Gc=";
@@ -23,16 +24,27 @@ buildGoModule rec {
 
   nativeBuildInputs = [ makeWrapper ];
 
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
   postFixup = ''
     wrapProgram $out/bin/krew \
       --prefix PATH : ${lib.makeBinPath [ gitMinimal ]}
   '';
 
+  # krew doesn't support --version and requires kubectl
+  doInstallCheck = false;
+
+  passthru.updateScript = nix-update-script { };
+
   meta = {
     description = "Package manager for kubectl plugins";
     mainProgram = "krew";
     homepage = "https://github.com/kubernetes-sigs/krew";
+    changelog = "https://github.com/kubernetes-sigs/krew/releases/tag/v${finalAttrs.version}";
     maintainers = with lib.maintainers; [ vdemeester ];
     license = lib.licenses.asl20;
   };
-}
+})


### PR DESCRIPTION
Updates krew to follow current nixpkgs best practices. This brings the package definition up to date with current nixpkgs standards and makes future maintenance easier through automated update scripts.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc