### PR TITLE
gopkgs: adopt modern best practices

### DIFF
--- a/pkgs/by-name/go/gopkgs/package.nix
+++ b/pkgs/by-name/go/gopkgs/package.nix
@@ -2,16 +2,17 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
+  nix-update-script,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "gopkgs";
   version = "2.1.2";
 
   src = fetchFromGitHub {
-    rev = "v${version}";
     owner = "uudashr";
     repo = "gopkgs";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-ll5fhwzzCNL0UtMLNSGOY6Yyy0EqI8OZ1iqWad4KU8k=";
   };
 
@@ -19,13 +20,24 @@ buildGoModule rec {
 
   subPackages = [ "cmd/gopkgs" ];
 
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
   doCheck = false;
+
+  # gopkgs doesn't support --version
+  doInstallCheck = false;
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Tool to get list available Go packages";
     mainProgram = "gopkgs";
     homepage = "https://github.com/uudashr/gopkgs";
+    changelog = "https://github.com/uudashr/gopkgs/releases/tag/v${finalAttrs.version}";
     maintainers = with lib.maintainers; [ vdemeester ];
     license = lib.licenses.mit;
   };
-}
+})


### PR DESCRIPTION
Updates gopkgs to follow current nixpkgs best practices. This brings the package definition up to date with current nixpkgs standards and makes future maintenance easier through automated update scripts.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc