### PR TITLE
python3Packages: export MPLBACKEND to Agg to fix matplotlib tests on darwin

### DIFF
--- a/pkgs/development/python-modules/dscribe/default.nix
+++ b/pkgs/development/python-modules/dscribe/default.nix
@@ -53,10 +53,15 @@ buildPythonPackage rec {
     "dscribe.ext"
   ];
 
-  # Prevents python from loading dscribe from the current working directory instead of using $out
-  preCheck = ''
-    rm -rf dscribe
-  '';
+  preCheck =
+    # Prevents python from loading dscribe from the current working directory instead of using $out
+    ''
+      rm -rf dscribe
+    ''
+    # Prevents 'Fatal Python error: Aborted' on darwin during checkPhase
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      export MPLBACKEND="Agg"
+    '';
 
   nativeCheckInputs = [
     pytestCheckHook
@@ -72,12 +77,7 @@ buildPythonPackage rec {
       [
         # AssertionError on a numerical test
         "test_cell_list"
-      ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    # Fatal Python error: Aborted
-    # matplotlib/backend_bases.py", line 2654 in create_with_canvas
-    "test_examples"
-  ];
+      ];
 
   # Broken due to use of missing _get_constraints attr in ase >= 3.26.0
   # https://github.com/SINGROUP/dscribe/issues/160

--- a/pkgs/development/python-modules/niaarm/default.nix
+++ b/pkgs/development/python-modules/niaarm/default.nix
@@ -52,15 +52,14 @@ buildPythonPackage rec {
   ]
   ++ lib.optionals (pythonOlder "3.11") [ tomli ];
 
+  env = lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+    # Prevents 'Fatal Python error: Aborted' on darwin during checkPhase
+    MPLBACKEND = "Agg";
+  };
+
   disabledTests = [
     # Test requires extra nltk data dependency
     "test_text_mining"
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    # Fatal Python error: Aborted
-    # matplotlib/backend_bases.py", line 2654 in create_with_canvas
-    "test_hill_slopes"
-    "test_two_key_plot"
   ];
 
   nativeCheckInputs = [ pytestCheckHook ];

--- a/pkgs/development/python-modules/nifty8/default.nix
+++ b/pkgs/development/python-modules/nifty8/default.nix
@@ -70,20 +70,14 @@ buildPythonPackage rec {
     openssh
   ];
 
-  disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [
-    # Fatal Python error: Aborted
-    # matplotlib/backend_bases.py", line 2654 in create_with_canvas
-    "test_optimize_kl_domain_expansion"
-    "test_plot_priorsamples"
+  # Prevents 'Fatal Python error: Aborted' on darwin during checkPhase
+  preCheck = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    export MPLBACKEND="Agg"
+  '';
 
+  disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [
     # [XPASS(strict)] np.vdot inaccurate for single precision
     "test_vdot"
-  ];
-
-  disabledTestPaths = lib.optionals stdenv.hostPlatform.isDarwin [
-    # Fatal Python error: Aborted
-    # matplotlib/backend_bases.py", line 2654 in create_with_canvas
-    "test/test_plot.py"
   ];
 
   __darwinAllowLocalNetworking = true;

--- a/pkgs/development/python-modules/optuna/default.nix
+++ b/pkgs/development/python-modules/optuna/default.nix
@@ -84,10 +84,15 @@ buildPythonPackage rec {
     ];
   };
 
-  # grpc tests are racy
-  preCheck = ''
-    sed -i '/"grpc",/d' optuna/testing/storages.py
-  '';
+  preCheck =
+    # grpc tests are racy
+    ''
+      sed -i '/"grpc",/d' optuna/testing/storages.py
+    ''
+    # Prevents 'Fatal Python error: Aborted' on darwin during checkPhase
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      export MPLBACKEND="Agg"
+    '';
 
   nativeCheckInputs = [
     addBinToPathHook
@@ -117,24 +122,6 @@ buildPythonPackage rec {
     "test_plot_intermediate_values"
     "test_plot_rank"
     "test_plot_terminator_improvement"
-
-    # Fatal Python error: Aborted
-    # matplotlib/backend_bases.py", line 2654 in create_with_canvas
-    "test_edf_plot_no_trials"
-    "test_get_timeline_plot"
-    "test_plot_contour"
-    "test_plot_contour_customized_target_name"
-    "test_plot_edf_with_multiple_studies"
-    "test_plot_edf_with_target"
-    "test_plot_parallel_coordinate"
-    "test_plot_parallel_coordinate_customized_target_name"
-    "test_plot_param_importances"
-    "test_plot_param_importances_customized_target_name"
-    "test_plot_param_importances_multiobjective_all_objectives_displayed"
-    "test_plot_slice"
-    "test_plot_slice_customized_target_name"
-    "test_target_is_none_and_study_is_multi_obj"
-    "test_visualizations_with_single_objectives"
   ];
 
   disabledTestPaths = lib.optionals stdenv.hostPlatform.isDarwin [

--- a/pkgs/development/python-modules/pymatgen/default.nix
+++ b/pkgs/development/python-modules/pymatgen/default.nix
@@ -133,6 +133,10 @@ buildPythonPackage rec {
     # ensure tests can find these
     ''
       export PMG_TEST_FILES_DIR="$(realpath ./tests/files)"
+    ''
+    # Prevents 'Fatal Python error: Aborted' on darwin during checkPhase
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      export MPLBACKEND="Agg"
     '';
 
   disabledTests = [
@@ -147,25 +151,6 @@ buildPythonPackage rec {
     "test_mean_field"
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    # Fatal Python error: Aborted
-    # matplotlib/backend_bases.py", line 2654 in create_with_canvas
-    # https://github.com/materialsproject/pymatgen/issues/4452
-    "test_angle"
-    "test_as_dict_from_dict"
-    "test_attributes"
-    "test_basic"
-    "test_core_state_eigen"
-    "test_eos_func"
-    "test_get_info_cohps_to_neighbors"
-    "test_get_plot"
-    "test_get_point_group_operations"
-    "test_matplotlib_plots"
-    "test_ph_plot_w_gruneisen"
-    "test_plot"
-    "test_proj_bandstructure_plot"
-    "test_structure"
-    "test_structure_environments"
-
     # attempt to insert nil object from objects[1]
     "test_timer_10_2_7"
     "test_timer"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- **python3Packages.niaarm: fix matplotlib tests on darwin**
- **python3Packages.pymatgen: fix matplotlib tests on darwin**
- **python3Packages.nifty8: fix matplotlib tests on darwin**
- **python3Packages.optuna: fix matplotlib tests on darwin**
- **python3Packages.dscribe: fix matplotlib tests on darwin**

---

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
