### PR TITLE
apparmor-parser: enable `strictDeps`

### DIFF
--- a/pkgs/by-name/ap/apparmor-parser/package.nix
+++ b/pkgs/by-name/ap/apparmor-parser/package.nix
@@ -10,6 +10,7 @@
   # apparmor deps
   libapparmor,
   apparmor-bin-utils,
+  runtimeShellPackage,
 
   # testing
   perl,
@@ -39,7 +40,10 @@ stdenv.mkDerivation (finalAttrs: {
     which
   ];
 
-  buildInputs = [ libapparmor ];
+  buildInputs = [
+    libapparmor
+    runtimeShellPackage
+  ];
 
   makeFlags = [
     "LANGS="
@@ -64,11 +68,13 @@ stdenv.mkDerivation (finalAttrs: {
   postCheck = "popd";
 
   doCheck = stdenv.hostPlatform == stdenv.buildPlatform;
-  checkInputs = [
+  nativeCheckInputs = [
     bashInteractive
     perl
     python3
   ];
+
+  strictDeps = true;
 
   meta = libapparmor.meta // {
     description = "Mandatory access control system - core library";


### PR DESCRIPTION
motivated by https://github.com/NixOS/nixpkgs/issues/178468

bash, perl and python are all shebangs used by the test scripts hence they're moved to `nativeCheckInputs` so that they can be on PATH.

runtimeShellPackage is added to `buildInputs` to fix the shebang in $out/lib/apparmor/rc.apparmor.function. prior to this, its `#!/bin/sh` shebang was being patched via the bash from `checkInputs`. that's flimsy as it relies on `doCheck == true` (which is false e.g. when cross compiling). instead, provide a shell in `buildInputs` to ensure patching of `#!/bin/sh` in runtime scripts.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
