### PR TITLE
yaziPlugins.jjui: init at 0-unstable-2026-01-17

### DIFF
--- a/pkgs/by-name/ya/yazi/plugins/jjui/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/jjui/default.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkYaziPlugin,
+}:
+mkYaziPlugin {
+  pname = "jjui.yazi";
+  version = "0-unstable-2026-01-17";
+
+  src = fetchFromGitHub {
+    owner = "Adda0";
+    repo = "jjui.yazi";
+    rev = "a41b2e17a4d256bc06868079efb375716e07cd28";
+    hash = "sha256-r2XWSu0voQmQj6jI2Jh17FiNwbvQcEwM6LNDqX7qCOQ=";
+  };
+
+  meta = {
+    description = "jjui plugin for yazi";
+    homepage = "https://github.com/Adda0/jjui.yazi";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ adda ];
+  };
+}


### PR DESCRIPTION
This PR adds a `yazi` plugin for running `jjui` when inside a repository with jujutsu enabled. [Plugin page](https://github.com/Adda0/jjui.yazi).
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
 