### PR TITLE
[release-25.11] deno: fix CVE-2026-22863

### DIFF
--- a/pkgs/by-name/de/deno/package.nix
+++ b/pkgs/by-name/de/deno/package.nix
@@ -53,6 +53,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
     ./patches/0002-tests-replace-hardcoded-paths.patch
     ./patches/0003-tests-linux-no-chown.patch
     ./patches/0004-tests-darwin-fixes.patch
+    # CVE-2026-22863: prevent cipher operations after finalize
+    # https://github.com/denoland/deno/security/advisories/GHSA-5379-f5hf-w38v
+    ./patches/0005-fix-ext-node-prevent-cipher-operations-after-finalize.patch
   ];
   postPatch = ''
     # Use patched nixpkgs libffi in order to fix https://github.com/libffi/libffi/pull/857

--- a/pkgs/by-name/de/deno/patches/0005-fix-ext-node-prevent-cipher-operations-after-finalize.patch
+++ b/pkgs/by-name/de/deno/patches/0005-fix-ext-node-prevent-cipher-operations-after-finalize.patch
@@ -1,0 +1,193 @@
+From 446c4c8d36b9b9d3a8eccbb1486ac6e644aed930 Mon Sep 17 00:00:00 2001
+From: Divy <dj.srivastava23@gmail.com>
+Date: Tue, 9 Dec 2025 16:03:37 +0530
+Subject: [PATCH] fix(ext/node): prevent cipher operations after finalize
+ (#31533)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Throw a state error for operations if the cipher is already finalized.
+
+(cherry picked from commit 0bc213b15b819597d935be6cb04cec03659d146b)
+Signed-off-by: Jörg Thalheim <joerg@thalheim.io>
+---
+ ext/node/polyfills/internal/crypto/cipher.ts | 25 ++++++++
+ tests/unit_node/crypto/crypto_cipher_test.ts | 63 ++++++++++++++++++++
+ 2 files changed, 88 insertions(+)
+
+diff --git a/ext/node/polyfills/internal/crypto/cipher.ts b/ext/node/polyfills/internal/crypto/cipher.ts
+index d4c790706..ac2a32118 100644
+--- a/ext/node/polyfills/internal/crypto/cipher.ts
++++ b/ext/node/polyfills/internal/crypto/cipher.ts
+@@ -184,6 +184,8 @@ export class Cipheriv extends Transform implements Cipher {
+ 
+   #autoPadding = true;
+ 
++  #finalized = false;
++
+   constructor(
+     cipher: string,
+     key: CipherKey,
+@@ -213,12 +215,17 @@ export class Cipheriv extends Transform implements Cipher {
+   }
+ 
+   final(encoding: string = getDefaultEncoding()): Buffer | string {
++    if (this.#finalized) {
++      throw new ERR_CRYPTO_INVALID_STATE("final");
++    }
++
+     this.#lazyInitDecoder(encoding);
+ 
+     const buf = new FastBuffer(16);
+     if (this.#cache.cache.byteLength == 0) {
+       const maybeTag = op_node_cipheriv_take(this.#context);
+       if (maybeTag) this.#authTag = Buffer.from(maybeTag);
++      this.#finalized = true;
+       return encoding === "buffer" ? Buffer.from([]) : "";
+     }
+ 
+@@ -233,9 +240,11 @@ export class Cipheriv extends Transform implements Cipher {
+     );
+     if (maybeTag) {
+       this.#authTag = Buffer.from(maybeTag);
++      this.#finalized = true;
+       return encoding === "buffer" ? Buffer.from([]) : "";
+     }
+ 
++    this.#finalized = true;
+     if (encoding !== "buffer") {
+       return this.#decoder!.end(buf);
+     }
+@@ -270,6 +279,10 @@ export class Cipheriv extends Transform implements Cipher {
+     inputEncoding?: Encoding,
+     outputEncoding: Encoding = getDefaultEncoding(),
+   ): Buffer | string {
++    if (this.#finalized) {
++      throw new ERR_CRYPTO_INVALID_STATE("update");
++    }
++
+     // TODO(kt3k): throw ERR_INVALID_ARG_TYPE if data is not string, Buffer, or ArrayBufferView
+     let buf = data;
+     if (typeof data === "string") {
+@@ -391,6 +404,8 @@ export class Decipheriv extends Transform implements Cipher {
+ 
+   #authTag?: BinaryLike;
+ 
++  #finalized = false;
++
+   constructor(
+     cipher: string,
+     key: CipherKey,
+@@ -427,6 +442,10 @@ export class Decipheriv extends Transform implements Cipher {
+   }
+ 
+   final(encoding: string = getDefaultEncoding()): Buffer | string {
++    if (this.#finalized) {
++      throw new ERR_CRYPTO_INVALID_STATE("final");
++    }
++
+     this.#lazyInitDecoder(encoding);
+ 
+     let buf = new FastBuffer(16);
+@@ -439,6 +458,7 @@ export class Decipheriv extends Transform implements Cipher {
+     );
+ 
+     if (!this.#needsBlockCache || this.#cache.cache.byteLength === 0) {
++      this.#finalized = true;
+       return encoding === "buffer" ? Buffer.from([]) : "";
+     }
+     if (this.#cache.cache.byteLength != 16) {
+@@ -446,6 +466,7 @@ export class Decipheriv extends Transform implements Cipher {
+     }
+ 
+     buf = buf.subarray(0, 16 - buf.at(-1)); // Padded in Pkcs7 mode
++    this.#finalized = true;
+     if (encoding !== "buffer") {
+       return this.#decoder!.end(buf);
+     }
+@@ -480,6 +501,10 @@ export class Decipheriv extends Transform implements Cipher {
+     inputEncoding?: Encoding,
+     outputEncoding: Encoding = getDefaultEncoding(),
+   ): Buffer | string {
++    if (this.#finalized) {
++      throw new ERR_CRYPTO_INVALID_STATE("update");
++    }
++
+     // TODO(kt3k): throw ERR_INVALID_ARG_TYPE if data is not string, Buffer, or ArrayBufferView
+     let buf = data;
+     if (typeof data === "string") {
+diff --git a/tests/unit_node/crypto/crypto_cipher_test.ts b/tests/unit_node/crypto/crypto_cipher_test.ts
+index 4d96a11d8..a15032dea 100644
+--- a/tests/unit_node/crypto/crypto_cipher_test.ts
++++ b/tests/unit_node/crypto/crypto_cipher_test.ts
+@@ -569,3 +569,66 @@ Deno.test({
+     assertEquals(decryptedText, text);
+   },
+ });
++
++
++Deno.test({
++  name: "createCipheriv - cipher lockdown after final()",
++  fn() {
++    const key = crypto.randomBytes(32);
++    const iv = crypto.randomBytes(16);
++    const cipher = crypto.createCipheriv("aes-256-cbc", key, iv);
++
++    // Call final() to lock down the cipher
++    cipher.final();
++
++    assertThrows(
++      () => {
++        cipher.update("test data");
++      },
++      Error,
++      "Invalid state for operation update",
++    );
++
++    assertThrows(
++      () => {
++        cipher.final();
++      },
++      Error,
++      "Invalid state for operation final",
++    );
++  },
++});
++
++Deno.test({
++  name: "createDecipheriv - decipher lockdown after final()",
++  fn() {
++    const key = crypto.randomBytes(32);
++    const iv = crypto.randomBytes(16);
++
++    const cipher = crypto.createCipheriv("aes-256-cbc", key, iv);
++    const encrypted = Buffer.concat([
++      cipher.update("test data"),
++      cipher.final(),
++    ]);
++
++    const decipher = crypto.createDecipheriv("aes-256-cbc", key, iv);
++    decipher.update(encrypted);
++    decipher.final();
++
++    assertThrows(
++      () => {
++        decipher.update(encrypted);
++      },
++      Error,
++      "Invalid state for operation update",
++    );
++
++    assertThrows(
++      () => {
++        decipher.final();
++      },
++      Error,
++      "Invalid state for operation final",
++    );
++  },
++});
+-- 
+2.52.0
+


### PR DESCRIPTION
Backport upstream fix to prevent cipher operations after finalize. This fixes a vulnerability where node:crypto doesn't finalize cipher, allowing infinite encryptions which could enable brute forcing attacks.

Upstream fix: https://github.com/denoland/deno/pull/31533
Security advisory: https://github.com/denoland/deno/security/advisories/GHSA-5379-f5hf-w38v

nixpkgs stable has deno 2.6.x, which also comes with this patch.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
