### PR TITLE
freerdp: 3.20.0 -> 3.20.2

### DIFF
--- a/pkgs/by-name/fr/freerdp/package.nix
+++ b/pkgs/by-name/fr/freerdp/package.nix
@@ -70,13 +70,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "freerdp";
-  version = "3.20.0";
+  version = "3.20.2";
 
   src = fetchFromGitHub {
     owner = "FreeRDP";
     repo = "FreeRDP";
     rev = finalAttrs.version;
-    hash = "sha256-/v6M3r0qELpKvDmM8p3SnOmstyqfYNzyS7gw6HBOSd0=";
+    hash = "sha256-IcEWlNh0AI3Vkqf2FzQYOIq64J6iWJxWlUfYkcBpGUU=";
   };
 
   postPatch = ''


### PR DESCRIPTION
Fixes:
* CVE-2026-22851
* CVE-2026-22852
* CVE-2026-22853
* CVE-2026-22854
* CVE-2026-22855
* CVE-2026-22856
* CVE-2026-22857
* CVE-2026-22858
* CVE-2026-22859

Fixes #481006
Fixes #481005

Changes:
https://www.freerdp.com/2026/01/14/3_20_1-release
https://www.freerdp.com/2026/01/14/3_20_2-release


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test


## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 481013`
Commit: `5f5f4c6a7c9dfdff26f1c237224aa1ad6e8e2380`

---
### `aarch64-linux`
<details>
  <summary>:x: 3 packages failed to build:</summary>
  <ul>
    <li>brutespray</li>
    <li>medusa</li>
    <li>medusa.man</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 25 packages built:</summary>
  <ul>
    <li>budgie-control-center</li>
    <li>budgie-control-center.debug</li>
    <li>crowbar</li>
    <li>crowbar.dist</li>
    <li>freerdp</li>
    <li>gnome-connections</li>
    <li>gnome-control-center</li>
    <li>gnome-control-center.debug</li>
    <li>gnome-remote-desktop</li>
    <li>gtk-frdp</li>
    <li>kdePackages.krdc</li>
    <li>kdePackages.krdc.debug</li>
    <li>kdePackages.krdc.dev</li>
    <li>kdePackages.krdc.devtools</li>
    <li>kdePackages.krdp</li>
    <li>kdePackages.krdp.debug</li>
    <li>kdePackages.krdp.dev</li>
    <li>kdePackages.krdp.devtools</li>
    <li>phosh</li>
    <li>phosh-mobile-settings</li>
    <li>remmina</li>
    <li>weston</li>
    <li>x11docker</li>
    <li>xwayland-run</li>
    <li>xwayland-run.man</li>
  </ul>
</details>

---
<details>
<summary>Error logs: `aarch64-linux`</summary>
<details>
<summary>medusa</summary>
<pre>  442 |   pResponseCallback = response_callback;
      |                     ^
ssh.c:398:6: note: &#x27;response_callback&#x27; declared here
  398 | void response_callback(const char* name, int name_len, const char* instruction, int instruction_len, int num_prompts, const LIBSSH2_USERAUTH_KBDINT_PROMPT* prompts, LIBSSH2_USERAUTH_KBDINT_RESPONSE* responses, void **abstract)
      |      ^~~~~~~~~~~~~~~~~
ssh.c:495:11: error: passing argument 4 of &#x27;libssh2_userauth_keyboard_interactive_ex&#x27; from incompatible pointer type [8;;https://gcc.gnu.org/onlinedocs/gcc-15.2.0/gcc/Warning-Options.html#index-Wincompatible-pointer-types-Wincompatible-pointer-types8;;]
  495 |       if (libssh2_userauth_keyboard_interactive(session, szLogin, pResponseCallback) )
      |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |           |
      |           void (*)(void)
/nix/store/6j229civb2i7421ckla3zns5h77z14cd-libssh2-1.11.1-dev/include/libssh2.h:798:42: note: expected &#x27;void (*)(const char *, int,  const char *, int,  int,  const LIBSSH2_USERAUTH_KBDINT_PROMPT *, LIBSSH2_USERAUTH_KBDINT_RESPONSE *, void **)&#x27; but argument is of type &#x27;void (*)(void)&#x27;
  798 |                                          LIBSSH2_USERAUTH_KBDINT_RESPONSE_FUNC
      |                                          ^
make[3]: *** [Makefile:781: ssh.o] Error 1
make[3]: Leaving directory &#x27;/build/source/src/modsrc&#x27;
make[2]: *** [Makefile:418: all-recursive] Error 1
make[2]: Leaving directory &#x27;/build/source/src&#x27;
make[1]: *** [Makefile:446: all-recursive] Error 1
make[1]: Leaving directory &#x27;/build/source&#x27;
make: *** [Makefile:344: all] Error 2</pre>
</details>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
