### PR TITLE
cups-zj-58: fix build

### DIFF
--- a/pkgs/by-name/cu/cups-zj-58/package.nix
+++ b/pkgs/by-name/cu/cups-zj-58/package.nix
@@ -30,6 +30,8 @@ stdenv.mkDerivation {
     --replace-fail "cmake_minimum_required ( VERSION 3.0 )" "cmake_minimum_required ( VERSION 3.10 )"
   '';
 
+  env.NIX_CFLAGS_COMPILE = "-Wno-error=incompatible-pointer-types";
+
   installPhase = ''
     install -D ppd/zj80.ppd $out/share/cups/model/zjiang/zj80.ppd
     install -D ppd/zj58.ppd $out/share/cups/model/zjiang/zj58.ppd


### PR DESCRIPTION
exclude incompatible-pointer-types by setting env.NIX_CFLAGS_COMPILE


## Things done



- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `result/lib/cups/filter/rastertozj`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
