### PR TITLE
wireshark: 4.6.2 -> 4.6.3

### DIFF
--- a/pkgs/applications/networking/sniffers/wireshark/default.nix
+++ b/pkgs/applications/networking/sniffers/wireshark/default.nix
@@ -58,7 +58,7 @@ assert withQt -> qt6 != null;
 
 stdenv.mkDerivation rec {
   pname = "wireshark-${if withQt then "qt" else "cli"}";
-  version = "4.6.2";
+  version = "4.6.3";
 
   outputs = [
     "out"
@@ -69,7 +69,7 @@ stdenv.mkDerivation rec {
     repo = "wireshark";
     owner = "wireshark";
     rev = "v${version}";
-    hash = "sha256-fojQ0D7v6xSDltpL3Y6iIzLj6pRZU/0U0ww+sVaWDZ8=";
+    hash = "sha256-DthYkAW6UYnsDLQf2h3jgJB8RZoasjREWV1NTtZv7PQ=";
   };
 
   patches = [


### PR DESCRIPTION
Fixes:
https://www.wireshark.org/security/wnpa-sec-2026-01.html
https://www.wireshark.org/security/wnpa-sec-2026-02.html
https://www.wireshark.org/security/wnpa-sec-2026-03.html
https://www.wireshark.org/security/wnpa-sec-2026-04.html

Changes:
https://www.wireshark.org/docs/relnotes/wireshark-4.6.3.html


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test


## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 481020`
Commit: `4a15db1fb5408cca5a3b25f45d34ee88b2e28ec3`

---
### `aarch64-linux`
<details>
  <summary>:x: 4 packages failed to build:</summary>
  <ul>
    <li>python314Packages.dissect-cobaltstrike</li>
    <li>python314Packages.dissect-cobaltstrike.dist</li>
    <li>python314Packages.pyshark</li>
    <li>python314Packages.pyshark.dist</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 26 packages built:</summary>
  <ul>
    <li>compactor</li>
    <li>dbmonster</li>
    <li>ghost</li>
    <li>ghost.dist</li>
    <li>hfinger</li>
    <li>hfinger.dist</li>
    <li>ostinato</li>
    <li>python313Packages.dissect-cobaltstrike</li>
    <li>python313Packages.dissect-cobaltstrike.dist</li>
    <li>python313Packages.manuf</li>
    <li>python313Packages.manuf.dist</li>
    <li>python313Packages.pex-entysec</li>
    <li>python313Packages.pex-entysec.dist</li>
    <li>python313Packages.pyshark</li>
    <li>python313Packages.pyshark.dist</li>
    <li>python314Packages.manuf</li>
    <li>python314Packages.manuf.dist</li>
    <li>python314Packages.pex-entysec</li>
    <li>python314Packages.pex-entysec.dist</li>
    <li>termshark</li>
    <li>tshark (wireshark-cli)</li>
    <li>tshark.dev (wireshark-cli.dev)</li>
    <li>wifite2</li>
    <li>wifite2.dist</li>
    <li>wireshark (wireshark-qt)</li>
    <li>wireshark.dev (wireshark-qt.dev)</li>
  </ul>
</details>

---
<details>
<summary>Error logs: `aarch64-linux`</summary>
<details>
<summary>python314Packages.pyshark</summary>
<pre>ERROR ../tests/test_basic_parsing.py::test_layers[True] - RuntimeError: There is no current event loop in thread &#x27;MainThread&#x27;.
ERROR ../tests/test_basic_parsing.py::test_layers[False] - RuntimeError: There is no current event loop in thread &#x27;MainThread&#x27;.
ERROR ../tests/test_basic_parsing.py::test_ethernet[True] - RuntimeError: There is no current event loop in thread &#x27;MainThread&#x27;.
ERROR ../tests/test_basic_parsing.py::test_ethernet[False] - RuntimeError: There is no current event loop in thread &#x27;MainThread&#x27;.
ERROR ../tests/test_basic_parsing.py::test_icmp[True] - RuntimeError: There is no current event loop in thread &#x27;MainThread&#x27;.
ERROR ../tests/test_basic_parsing.py::test_icmp[False] - RuntimeError: There is no current event loop in thread &#x27;MainThread&#x27;.
ERROR ../tests/test_cap_operations.py::test_packet_callback_called_for_each_packet - RuntimeError: There is no current event loop in thread &#x27;MainThread&#x27;.
ERROR ../tests/test_cap_operations.py::test_apply_on_packet_stops_on_timeout - RuntimeError: There is no current event loop in thread &#x27;MainThread&#x27;.
ERROR ../tests/test_cap_operations.py::test_lazy_loading_of_packets_on_getitem - RuntimeError: There is no current event loop in thread &#x27;MainThread&#x27;.
ERROR ../tests/test_cap_operations.py::test_lazy_loading_of_packet_does_not_recreate_packets - RuntimeError: There is no current event loop in thread &#x27;MainThread&#x27;.
ERROR ../tests/test_cap_operations.py::test_filling_cap_in_increments - RuntimeError: There is no current event loop in thread &#x27;MainThread&#x27;.
ERROR ../tests/test_cap_operations.py::test_iterate_empty_psml_capture - RuntimeError: There is no current event loop in thread &#x27;MainThread&#x27;.
ERROR ../tests/test_packet_operations.py::test_can_access_layer[&lt;lambda&gt;0] - RuntimeError: There is no current event loop in thread &#x27;MainThread&#x27;.
ERROR ../tests/test_packet_operations.py::test_can_access_layer[&lt;lambda&gt;1] - RuntimeError: There is no current event loop in thread &#x27;MainThread&#x27;.
ERROR ../tests/test_packet_operations.py::test_can_access_layer[&lt;lambda&gt;2] - RuntimeError: There is no current event loop in thread &#x27;MainThread&#x27;.
ERROR ../tests/test_packet_operations.py::test_can_access_layer[&lt;lambda&gt;3] - RuntimeError: There is no current event loop in thread &#x27;MainThread&#x27;.
ERROR ../tests/test_packet_operations.py::test_packet_contains_layer - RuntimeError: There is no current event loop in thread &#x27;MainThread&#x27;.
ERROR ../tests/test_packet_operations.py::test_raw_mode - RuntimeError: There is no current event loop in thread &#x27;MainThread&#x27;.
ERROR ../tests/test_packet_operations.py::test_frame_info_access - RuntimeError: There is no current event loop in thread &#x27;MainThread&#x27;.
====== 6 failed, 36 passed, 1 deselected, 37 warnings, 30 errors in 3.79s ======</pre>
</details>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
