### PR TITLE
home-assistant: 2026.1.1 -> 2026.1.2

### DIFF
--- a/pkgs/development/python-modules/aiomealie/default.nix
+++ b/pkgs/development/python-modules/aiomealie/default.nix
@@ -17,14 +17,14 @@
 
 buildPythonPackage rec {
   pname = "aiomealie";
-  version = "1.1.1";
+  version = "1.2.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "joostlek";
     repo = "python-mealie";
     tag = "v${version}";
-    hash = "sha256-qiLynV/nJkejUVyS3p12bcAR3+Oj+XKp7Z/zVpxb84I=";
+    hash = "sha256-Q+8EZHZqbv5IEqhwCKhRPgr1Cfs/zVhLiwFgCZnNcW4=";
   };
 
   build-system = [ poetry-core ];

--- a/pkgs/development/python-modules/aiomealie/default.nix
+++ b/pkgs/development/python-modules/aiomealie/default.nix
@@ -15,7 +15,7 @@
   yarl,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "aiomealie";
   version = "1.2.0";
   pyproject = true;
@@ -23,7 +23,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "joostlek";
     repo = "python-mealie";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-Q+8EZHZqbv5IEqhwCKhRPgr1Cfs/zVhLiwFgCZnNcW4=";
   };
 
@@ -50,8 +50,8 @@ buildPythonPackage rec {
   meta = {
     description = "Module to interact with Mealie";
     homepage = "https://github.com/joostlek/python-mealie";
-    changelog = "https://github.com/joostlek/python-mealie/releases/tag/${src.tag}";
+    changelog = "https://github.com/joostlek/python-mealie/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
   };
-}
+})

--- a/pkgs/development/python-modules/knx-frontend/default.nix
+++ b/pkgs/development/python-modules/knx-frontend/default.nix
@@ -7,14 +7,14 @@
 
 buildPythonPackage rec {
   pname = "knx-frontend";
-  version = "2025.12.30.151231";
+  version = "2026.1.15.112308";
   pyproject = true;
 
   # TODO: source build, uses yarn.lock
   src = fetchPypi {
     pname = "knx_frontend";
     inherit version;
-    hash = "sha256-3KRufDLB1p+k2pmY9Mivvd2DmxWCZHZSIPhUZImKZIY=";
+    hash = "sha256-Q+9BUS0A/e0hIBq8J2hRZi/L7LKhf7vSEIFkPI0RMj0=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/pymicro-vad/default.nix
+++ b/pkgs/development/python-modules/pymicro-vad/default.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  pybind11,
+  setuptools,
+
+  # tests
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "pymicro-vad";
+  version = "1.0.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "rhasspy";
+    repo = "pymicro-vad";
+    tag = version;
+    hash = "sha256-yKy/oD6nl2qZW64+aAHZRAEFextCXT6RpMfPThB8DXE=";
+  };
+
+  build-system = [
+    pybind11
+    setuptools
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "pymicro_vad" ];
+
+  meta = {
+    changelog = "https://github.com/rhasspy/pymicro-vad/releases/tag/${version}";
+    description = "Self-contained voice activity detector";
+    homepage = "https://github.com/rhasspy/pymicro-vad";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ hexa ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "2026.1.1";
+  version = "2026.1.2";
   components = {
     "3_day_blinds" =
       ps: with ps; [
@@ -33,8 +33,8 @@
         home-assistant-intents
         ifaddr
         mutagen
+        pymicro-vad
         pyserial
-        pysilero-vad
         pyspeex-noise
         zeroconf
       ];
@@ -157,8 +157,8 @@
         home-assistant-intents
         ifaddr
         mutagen
+        pymicro-vad
         pyserial
-        pysilero-vad
         pyspeex-noise
         zeroconf
       ];
@@ -298,7 +298,7 @@
         hassil
         home-assistant-intents
         mutagen
-        pysilero-vad
+        pymicro-vad
         pyspeex-noise
       ];
     "anwb_energie" =
@@ -386,8 +386,8 @@
         home-assistant-intents
         ifaddr
         mutagen
+        pymicro-vad
         pyserial
-        pysilero-vad
         pyspeex-noise
         zeroconf
       ];
@@ -428,7 +428,7 @@
         hassil
         home-assistant-intents
         mutagen
-        pysilero-vad
+        pymicro-vad
         pyspeex-noise
       ];
     "assist_satellite" =
@@ -437,7 +437,7 @@
         hassil
         home-assistant-intents
         mutagen
-        pysilero-vad
+        pymicro-vad
         pyspeex-noise
       ];
     "asuswrt" =
@@ -469,7 +469,7 @@
         hassil
         home-assistant-intents
         mutagen
-        pysilero-vad
+        pymicro-vad
         pyspeex-noise
         python-matter-server
         pyturbojpeg
@@ -658,8 +658,8 @@
         home-assistant-intents
         ifaddr
         mutagen
+        pymicro-vad
         pyserial
-        pysilero-vad
         pyspeex-noise
         zeroconf
       ];
@@ -705,8 +705,8 @@
         home-assistant-intents
         ifaddr
         mutagen
+        pymicro-vad
         pyserial
-        pysilero-vad
         pyspeex-noise
         zeroconf
       ];
@@ -731,8 +731,8 @@
         home-assistant-intents
         ifaddr
         mutagen
+        pymicro-vad
         pyserial
-        pysilero-vad
         pyspeex-noise
         zeroconf
       ];
@@ -832,8 +832,8 @@
         home-assistant-intents
         ifaddr
         mutagen
+        pymicro-vad
         pyserial
-        pysilero-vad
         pyspeex-noise
         zeroconf
       ];
@@ -889,7 +889,7 @@
         plexauth
         plexwebsocket
         pychromecast
-        pysilero-vad
+        pymicro-vad
         pyspeex-noise
         python-matter-server
         pyturbojpeg
@@ -952,7 +952,7 @@
         hassil
         home-assistant-intents
         mutagen
-        pysilero-vad
+        pymicro-vad
         pyspeex-noise
         python-matter-server
         pyturbojpeg
@@ -1153,9 +1153,9 @@
         numpy
         pillow
         psutil-home-assistant
+        pymicro-vad
         pynacl
         pyserial
-        pysilero-vad
         pyspeex-noise
         python-matter-server
         pyturbojpeg
@@ -1313,8 +1313,8 @@
         ifaddr
         mutagen
         py-dormakaba-dkey
+        pymicro-vad
         pyserial
-        pysilero-vad
         pyspeex-noise
         zeroconf
       ];
@@ -1605,8 +1605,8 @@
         home-assistant-intents
         ifaddr
         mutagen
+        pymicro-vad
         pyserial
-        pysilero-vad
         pyspeex-noise
         zeroconf
       ];
@@ -1636,8 +1636,8 @@
         home-assistant-intents
         ifaddr
         mutagen
+        pymicro-vad
         pyserial
-        pysilero-vad
         pyspeex-noise
         zeroconf
       ];
@@ -1675,8 +1675,8 @@
         home-assistant-intents
         ifaddr
         mutagen
+        pymicro-vad
         pyserial
-        pysilero-vad
         pyspeex-noise
         zeroconf
       ];
@@ -1824,8 +1824,8 @@
         home-assistant-intents
         ifaddr
         mutagen
+        pymicro-vad
         pyserial
-        pysilero-vad
         pyspeex-noise
         zeroconf
       ];
@@ -2013,8 +2013,8 @@
         home-assistant-intents
         ifaddr
         mutagen
+        pymicro-vad
         pyserial
-        pysilero-vad
         pyspeex-noise
         zeroconf
       ];
@@ -2153,7 +2153,7 @@
         hassil
         home-assistant-intents
         mutagen
-        pysilero-vad
+        pymicro-vad
         pyspeex-noise
       ];
     "google_mail" =
@@ -2217,8 +2217,8 @@
         home-assistant-intents
         ifaddr
         mutagen
+        pymicro-vad
         pyserial
-        pysilero-vad
         pyspeex-noise
         zeroconf
       ];
@@ -2478,9 +2478,9 @@
         home-assistant-intents
         ifaddr
         mutagen
+        pymicro-vad
         pyroute2
         pyserial
-        pysilero-vad
         pyspeex-noise
         python-otbr-api
         zeroconf
@@ -2551,8 +2551,8 @@
         hueble
         ifaddr
         mutagen
+        pymicro-vad
         pyserial
-        pysilero-vad
         pyspeex-noise
         zeroconf
       ];
@@ -2597,8 +2597,8 @@
         home-assistant-intents
         ifaddr
         mutagen
+        pymicro-vad
         pyserial
-        pysilero-vad
         pyspeex-noise
         zeroconf
       ];
@@ -2653,8 +2653,8 @@
         ibeacon-ble
         ifaddr
         mutagen
+        pymicro-vad
         pyserial
-        pysilero-vad
         pyspeex-noise
         zeroconf
       ];
@@ -2684,8 +2684,8 @@
         idasen-ha
         ifaddr
         mutagen
+        pymicro-vad
         pyserial
-        pysilero-vad
         pyspeex-noise
         zeroconf
       ];
@@ -2763,8 +2763,8 @@
         ifaddr
         mutagen
         py-improv-ble-client
+        pymicro-vad
         pyserial
-        pysilero-vad
         pyspeex-noise
         zeroconf
       ];
@@ -2808,8 +2808,8 @@
         ifaddr
         inkbird-ble
         mutagen
+        pymicro-vad
         pyserial
-        pysilero-vad
         pyspeex-noise
         zeroconf
       ];
@@ -2922,9 +2922,9 @@
         home-assistant-intents
         ifaddr
         mutagen
+        pymicro-vad
         pynecil
         pyserial
-        pysilero-vad
         pyspeex-noise
         zeroconf
       ];
@@ -3052,8 +3052,8 @@
         ifaddr
         kegtron-ble
         mutagen
+        pymicro-vad
         pyserial
-        pysilero-vad
         pyspeex-noise
         zeroconf
       ];
@@ -3086,9 +3086,9 @@
         home-assistant-intents
         ifaddr
         mutagen
+        pymicro-vad
         pymicrobot
         pyserial
-        pysilero-vad
         pyspeex-noise
         zeroconf
       ];
@@ -3166,8 +3166,8 @@
         ifaddr
         mutagen
         pykulersky
+        pymicro-vad
         pyserial
-        pysilero-vad
         pyspeex-noise
         zeroconf
       ];
@@ -3208,8 +3208,8 @@
         ifaddr
         mutagen
         pylamarzocco
+        pymicro-vad
         pyserial
-        pysilero-vad
         pyspeex-noise
         zeroconf
       ];
@@ -3269,8 +3269,8 @@
         ifaddr
         ld2410-ble
         mutagen
+        pymicro-vad
         pyserial
-        pysilero-vad
         pyspeex-noise
         zeroconf
       ];
@@ -3296,8 +3296,8 @@
         ifaddr
         leaone-ble
         mutagen
+        pymicro-vad
         pyserial
-        pysilero-vad
         pyspeex-noise
         zeroconf
       ];
@@ -3323,8 +3323,8 @@
         ifaddr
         led-ble
         mutagen
+        pymicro-vad
         pyserial
-        pysilero-vad
         pyspeex-noise
         zeroconf
       ];
@@ -3481,7 +3481,7 @@
         home-assistant-intents
         loqedapi
         mutagen
-        pysilero-vad
+        pymicro-vad
         pyspeex-noise
         python-matter-server
         pyturbojpeg
@@ -3621,8 +3621,8 @@
         ifaddr
         medcom-ble
         mutagen
+        pymicro-vad
         pyserial
-        pysilero-vad
         pyspeex-noise
         zeroconf
       ];
@@ -3673,8 +3673,8 @@
         ifaddr
         melnor-bluetooth
         mutagen
+        pymicro-vad
         pyserial
-        pysilero-vad
         pyspeex-noise
         zeroconf
       ];
@@ -3795,8 +3795,8 @@
         ifaddr
         moat-ble
         mutagen
+        pymicro-vad
         pyserial
-        pysilero-vad
         pyspeex-noise
         zeroconf
       ];
@@ -3810,8 +3810,8 @@
         home-assistant-intents
         mutagen
         pillow
+        pymicro-vad
         pynacl
-        pysilero-vad
         pyspeex-noise
         python-matter-server
         pyturbojpeg
@@ -3882,8 +3882,8 @@
         ifaddr
         mopeka-iot-ble
         mutagen
+        pymicro-vad
         pyserial
-        pysilero-vad
         pyspeex-noise
         zeroconf
       ];
@@ -3914,8 +3914,8 @@
         ifaddr
         motionblindsble
         mutagen
+        pymicro-vad
         pyserial
-        pysilero-vad
         pyspeex-noise
         zeroconf
       ];
@@ -4056,7 +4056,7 @@
         home-assistant-intents
         mutagen
         pyatmo
-        pysilero-vad
+        pymicro-vad
         pyspeex-noise
         python-matter-server
         pyturbojpeg
@@ -4270,7 +4270,7 @@
         home-assistant-intents
         mutagen
         ollama
-        pysilero-vad
+        pymicro-vad
         pyspeex-noise
       ];
     "ombi" =
@@ -4301,7 +4301,7 @@
         home-assistant-intents
         mutagen
         onedrive-personal-sdk
-        pysilero-vad
+        pymicro-vad
         pyspeex-noise
         python-matter-server
         pyturbojpeg
@@ -4333,7 +4333,7 @@
         home-assistant-intents
         mutagen
         openai
-        pysilero-vad
+        pymicro-vad
         pyspeex-noise
         python-open-router
       ];
@@ -4344,7 +4344,7 @@
         home-assistant-intents
         mutagen
         openai
-        pysilero-vad
+        pymicro-vad
         pyspeex-noise
       ];
     "openalpr_cloud" =
@@ -4434,8 +4434,8 @@
         ifaddr
         mutagen
         oralb-ble
+        pymicro-vad
         pyserial
-        pysilero-vad
         pyspeex-noise
         zeroconf
       ];
@@ -4494,7 +4494,7 @@
         hassil
         home-assistant-intents
         mutagen
-        pysilero-vad
+        pymicro-vad
         pyspeex-noise
         python-matter-server
         python-overseerr
@@ -4515,8 +4515,8 @@
         home-assistant-intents
         mutagen
         paho-mqtt
+        pymicro-vad
         pynacl
-        pysilero-vad
         pyspeex-noise
         python-matter-server
         pyturbojpeg
@@ -4639,8 +4639,8 @@
         hassil
         home-assistant-intents
         mutagen
+        pymicro-vad
         pyplaato
-        pysilero-vad
         pyspeex-noise
         python-matter-server
         pyturbojpeg
@@ -4722,8 +4722,8 @@
         home-assistant-intents
         ifaddr
         mutagen
+        pymicro-vad
         pyserial
-        pysilero-vad
         pyspeex-noise
         zeroconf
       ];
@@ -4748,9 +4748,9 @@
         home-assistant-intents
         ifaddr
         mutagen
+        pymicro-vad
         pyprobeplus
         pyserial
-        pysilero-vad
         pyspeex-noise
         zeroconf
       ];
@@ -4885,8 +4885,8 @@
         home-assistant-intents
         ifaddr
         mutagen
+        pymicro-vad
         pyserial
-        pysilero-vad
         pyspeex-noise
         qingping-ble
         zeroconf
@@ -4938,7 +4938,7 @@
         hassil
         home-assistant-intents
         mutagen
-        pysilero-vad
+        pymicro-vad
         pyspeex-noise
         python-matter-server
         pyturbojpeg
@@ -5005,8 +5005,8 @@
         home-assistant-intents
         ifaddr
         mutagen
+        pymicro-vad
         pyserial
-        pysilero-vad
         pyspeex-noise
         rapt-ble
         zeroconf
@@ -5047,7 +5047,7 @@
         home-assistant-frontend
         home-assistant-intents
         mutagen
-        pysilero-vad
+        pymicro-vad
         pyspeex-noise
         python-matter-server
         pyturbojpeg
@@ -5251,8 +5251,8 @@
         home-assistant-intents
         ifaddr
         mutagen
+        pymicro-vad
         pyserial
-        pysilero-vad
         pyspeex-noise
         ruuvitag-ble
         zeroconf
@@ -5378,8 +5378,8 @@
         home-assistant-intents
         ifaddr
         mutagen
+        pymicro-vad
         pyserial
-        pysilero-vad
         pyspeex-noise
         sensirion-ble
         zeroconf
@@ -5414,8 +5414,8 @@
         home-assistant-intents
         ifaddr
         mutagen
+        pymicro-vad
         pyserial
-        pysilero-vad
         pyspeex-noise
         sensorpro-ble
         zeroconf
@@ -5441,8 +5441,8 @@
         home-assistant-intents
         ifaddr
         mutagen
+        pymicro-vad
         pyserial
-        pysilero-vad
         pyspeex-noise
         sensorpush-ble
         zeroconf
@@ -5702,8 +5702,8 @@
         home-assistant-intents
         ifaddr
         mutagen
+        pymicro-vad
         pyserial
-        pysilero-vad
         pysnooz
         pyspeex-noise
         zeroconf
@@ -5944,8 +5944,8 @@
         home-assistant-intents
         ifaddr
         mutagen
+        pymicro-vad
         pyserial
-        pysilero-vad
         pyspeex-noise
         pyswitchbot
         zeroconf
@@ -6139,8 +6139,8 @@
         home-assistant-intents
         ifaddr
         mutagen
+        pymicro-vad
         pyserial
-        pysilero-vad
         pyspeex-noise
         thermobeacon-ble
         zeroconf
@@ -6169,8 +6169,8 @@
         home-assistant-intents
         ifaddr
         mutagen
+        pymicro-vad
         pyserial
-        pysilero-vad
         pyspeex-noise
         thermopro-ble
         zeroconf
@@ -6236,8 +6236,8 @@
         home-assistant-intents
         ifaddr
         mutagen
+        pymicro-vad
         pyserial
-        pysilero-vad
         pyspeex-noise
         tilt-ble
         zeroconf
@@ -6302,7 +6302,7 @@
         hassil
         home-assistant-intents
         mutagen
-        pysilero-vad
+        pymicro-vad
         pyspeex-noise
         python-matter-server
         pyturbojpeg
@@ -6630,8 +6630,8 @@
         home-assistant-intents
         ifaddr
         mutagen
+        pymicro-vad
         pyserial
-        pysilero-vad
         pyspeex-noise
         zeroconf
       ]; # missing inputs: victron-ble-ha-parser
@@ -6673,7 +6673,7 @@
         home-assistant-intents
         ifaddr
         mutagen
-        pysilero-vad
+        pymicro-vad
         pyspeex-noise
         voip-utils
       ];
@@ -6731,7 +6731,7 @@
         hassil
         home-assistant-intents
         mutagen
-        pysilero-vad
+        pymicro-vad
         pyspeex-noise
         python-matter-server
         pyturbojpeg
@@ -6822,7 +6822,7 @@
         hassil
         home-assistant-intents
         mutagen
-        pysilero-vad
+        pymicro-vad
         pyspeex-noise
         python-matter-server
         pyturbojpeg
@@ -6872,7 +6872,7 @@
         hassil
         home-assistant-intents
         mutagen
-        pysilero-vad
+        pymicro-vad
         pyspeex-noise
         wyoming
       ];
@@ -6916,8 +6916,8 @@
         home-assistant-intents
         ifaddr
         mutagen
+        pymicro-vad
         pyserial
-        pysilero-vad
         pyspeex-noise
         xiaomi-ble
         zeroconf
@@ -6950,7 +6950,7 @@
         hassil
         home-assistant-intents
         mutagen
-        pysilero-vad
+        pymicro-vad
         pyspeex-noise
         python-matter-server
         pyturbojpeg
@@ -6983,8 +6983,8 @@
         home-assistant-intents
         ifaddr
         mutagen
+        pymicro-vad
         pyserial
-        pysilero-vad
         pyspeex-noise
         yalexs-ble
         zeroconf

--- a/pkgs/servers/home-assistant/custom-lovelace-modules/atomic-calendar-revive/package.nix
+++ b/pkgs/servers/home-assistant/custom-lovelace-modules/atomic-calendar-revive/package.nix
@@ -1,35 +1,49 @@
 {
   lib,
   stdenv,
-  fetchYarnDeps,
   fetchFromGitHub,
-  yarnBuildHook,
-  yarnConfigHook,
+  fetchPnpmDeps,
   nodejs,
+  pnpm_9,
+  pnpmConfigHook,
   nix-update-script,
 }:
 
+let
+  pnpm = pnpm_9;
+in
+
 stdenv.mkDerivation (finalAttrs: {
   pname = "atomic-calendar-revive";
-  version = "10.0.0";
+  version = "10.2.0";
 
   src = fetchFromGitHub {
     owner = "totaldebug";
     repo = "atomic-calendar-revive";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-TaxvxAUcewQH0IMJ0/VjW4+T6squ1tuZIFGn3PE3jhU=";
+    hash = "sha256-cqtXhBSFuEuh8IH/6S0qZN3+SrdCt0WXrBJlBcDUujY=";
   };
 
-  offlineCache = fetchYarnDeps {
-    inherit (finalAttrs) src;
-    hash = "sha256-d3lk3mwgaWMPFl/EDUWH/tUlAC7OfhNycOLbi1GzkfM=";
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    inherit pnpm;
+    fetcherVersion = 3;
+    hash = "sha256-fhi1ysI2ygMfPTSiu40tt713fA/dy7r28Xyk0HxSvXE=";
   };
 
   nativeBuildInputs = [
-    yarnConfigHook
-    yarnBuildHook
+    pnpmConfigHook
+    pnpm
     nodejs
   ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    pnpm run build
+
+    runHook postBuild
+  '';
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -293,7 +293,7 @@ let
   extraBuildInputs = extraPackages python.pkgs;
 
   # Don't forget to run update-component-packages.py after updating
-  hassVersion = "2026.1.1";
+  hassVersion = "2026.1.2";
 
 in
 python.pkgs.buildPythonApplication rec {
@@ -314,13 +314,13 @@ python.pkgs.buildPythonApplication rec {
     owner = "home-assistant";
     repo = "core";
     tag = version;
-    hash = "sha256-l2/mi/WfZ3PbuB7LEhpWkubsY1xMyUjeolxPDHYEXWU=";
+    hash = "sha256-+H+ujcJ7uYLNFfm05V7FBdogGGUSkC1b6PaWJ5Zu24k=";
   };
 
   # Secondary source is pypi sdist for translations
   sdist = fetchPypi {
     inherit pname version;
-    hash = "sha256-Ll1wwcdkH/A2N8M1ZuE1RvjNFRu6ipEyuy4Th34s/Uo=";
+    hash = "sha256-uWcSCmarOtfYIVYPz8wAgO8tx15MJcEP1Wv3h8YT0xI=";
   };
 
   build-system = with python.pkgs; [

--- a/pkgs/servers/home-assistant/frontend.nix
+++ b/pkgs/servers/home-assistant/frontend.nix
@@ -8,7 +8,7 @@ buildPythonPackage rec {
   # the frontend version corresponding to a specific home-assistant version can be found here
   # https://github.com/home-assistant/home-assistant/blob/master/homeassistant/components/frontend/manifest.json
   pname = "home-assistant-frontend";
-  version = "20260107.1";
+  version = "20260107.2";
   format = "wheel";
 
   src = fetchPypi {
@@ -17,7 +17,7 @@ buildPythonPackage rec {
     pname = "home_assistant_frontend";
     dist = "py3";
     python = "py3";
-    hash = "sha256-P/7ZKtNwZZN7klPNISxOjfsdbk2KzFzGbTM5H44we7I=";
+    hash = "sha256-NPgtoNS4HgCBhRfHHJ835I5IvOCAggCnR81ieH/ItI0=";
   };
 
   # there is nothing to strip in this package

--- a/pkgs/servers/home-assistant/pytest-homeassistant-custom-component.nix
+++ b/pkgs/servers/home-assistant/pytest-homeassistant-custom-component.nix
@@ -18,7 +18,7 @@
 
 buildPythonPackage rec {
   pname = "pytest-homeassistant-custom-component";
-  version = "0.13.306";
+  version = "0.13.307";
   pyproject = true;
 
   disabled = pythonOlder "3.13";
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     owner = "MatthewFlamm";
     repo = "pytest-homeassistant-custom-component";
     tag = version;
-    hash = "sha256-RcUI15/+0nu453mcrRzMo2VvJAn3Up336LiuJygJaM0=";
+    hash = "sha256-E3kZEwyEmUxeRzwXQgI769mikyL1FkazmZXQFaknvlA=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/servers/home-assistant/stubs.nix
+++ b/pkgs/servers/home-assistant/stubs.nix
@@ -10,7 +10,7 @@
 
 buildPythonPackage rec {
   pname = "homeassistant-stubs";
-  version = "2026.1.1";
+  version = "2026.1.2";
   pyproject = true;
 
   disabled = python.version != home-assistant.python.version;
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     owner = "KapJI";
     repo = "homeassistant-stubs";
     tag = version;
-    hash = "sha256-owl8Twq1FtRtWm9QZlhx/ZgsaOVaPX3W+oxiP0ZCPQg=";
+    hash = "sha256-f1decOoOyavabUC2KnScB+bnuernkyKMnKwnilViuRQ=";
   };
 
   build-system = [

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -351,7 +351,6 @@ mapAliases {
   pylit = throw "'pylit' has been removed as it was broken and unmaintained upstream"; # Added 2025-11-29
   pymc3 = throw "'pymc3' has been renamed to/replaced by 'pymc'"; # Converted to throw 2025-10-29
   pymelcloud = throw "'pymelcloud' has been renamed to/replaced by 'python-melcloud'"; # Converted to throw 2025-10-29
-  pymicro-vad = throw "'pymicro-vad' was removed because Home Assistant switched to 'pysilero-vad'"; # added 2026-01-08
   PyMVGLive = throw "'PyMVGLive' has been renamed to/replaced by 'pymvglive'"; # Converted to throw 2025-10-29
   pymyq = throw "'pymyq' has been renamed to/replaced by 'python-myq'"; # Converted to throw 2025-10-29
   pyobject = throw "'pyobject' has been removed because it was only supporting python 2"; # Added 2026-01-24

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13943,6 +13943,8 @@ self: super: with self; {
 
   pymfy = callPackage ../development/python-modules/pymfy { };
 
+  pymicro-vad = callPackage ../development/python-modules/pymicro-vad { };
+
   pymicrobot = callPackage ../development/python-modules/pymicrobot { };
 
   pymiele = callPackage ../development/python-modules/pymiele { };


### PR DESCRIPTION
https://github.com/home-assistant/core/releases/tag/2026.1.2

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
