### PR TITLE
fence: init at 0.1.32

### DIFF
--- a/pkgs/by-name/fe/fence/package.nix
+++ b/pkgs/by-name/fe/fence/package.nix
@@ -1,0 +1,78 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+  stdenv,
+  # linux dependencies
+  makeWrapper,
+  bubblewrap,
+  socat,
+  bpftrace,
+  installShellFiles,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "fence";
+  version = "0.1.32";
+
+  src = fetchFromGitHub {
+    owner = "Use-Tusk";
+    repo = "fence";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-D+mAwmeOGSuKqO72atjvlhg2ez4MXtrjlnHEXPX34jI=";
+  };
+
+  vendorHash = "sha256-8v6B39TCwzu6DgFr1nuaGBEQ9s06rbBCENiGUIVw9Rk=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X=main.version=${finalAttrs.version}"
+    "-X=main.buildTime=1970-01-01T00:00:00Z"
+    "-X=main.gitCommit=${finalAttrs.src.rev}"
+  ];
+
+  nativeBuildInputs = [
+    installShellFiles
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ makeWrapper ];
+
+  # Tests want to create sandbox profiles on darwin.
+  # Nested sandboxes are unsupported by seatbelt, which means we cannot execute the tests inside the nix build sandbox.
+  doCheck = stdenv.hostPlatform.isLinux;
+
+  nativeCheckInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    bubblewrap
+    socat
+    bpftrace
+  ];
+
+  postInstall =
+    lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+      installShellCompletion --cmd ${finalAttrs.meta.mainProgram} \
+        --bash <($out/bin/${finalAttrs.meta.mainProgram} completion bash) \
+        --fish <($out/bin/${finalAttrs.meta.mainProgram} completion fish) \
+        --zsh <($out/bin/${finalAttrs.meta.mainProgram} completion zsh)
+    ''
+    + lib.optionalString stdenv.hostPlatform.isLinux ''
+      wrapProgram $out/bin/${finalAttrs.meta.mainProgram} \
+        --suffix PATH : ${
+          lib.makeBinPath [
+            bubblewrap
+            socat
+            bpftrace
+          ]
+        }
+    '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Lightweight, container-free sandbox for running commands with network and filesystem restrictions";
+    homepage = "https://github.com/Use-Tusk/fence";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ dwt ];
+    mainProgram = "fence";
+  };
+})


### PR DESCRIPTION
## Things done

Small code review and local tests of sandboxing utility on darwin.

Some problems:
I can't get the test suite to execute at all in the nix build sandbox on darwin, and get errors on linux. I suspect that on darwin you cannot have nested seatbelt sandboxes, but I couldn't find definitive proof of that.

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
