### PR TITLE
kdePackages.kguiaddons: fix kdeconnect clipboard crash

### DIFF
--- a/pkgs/kde/generated/sources/frameworks.json
+++ b/pkgs/kde/generated/sources/frameworks.json
@@ -145,9 +145,9 @@
     "hash": "sha256-My4749CsKuyOeGQZweh1obM66EuKraMoNjnezMb/1Ng="
   },
   "kguiaddons": {
-    "version": "6.22.0",
-    "url": "mirror://kde/stable/frameworks/6.22/kguiaddons-6.22.0.tar.xz",
-    "hash": "sha256-t2Urzr6/yMH9ook8Gu/0E2xYbud//G5YnjY08OVTnu8="
+    "version": "6.22.1",
+    "url": "mirror://kde/stable/frameworks/6.22/kguiaddons-6.22.1.tar.xz",
+    "hash": "sha256-o/WWMtdY753x2uPqQ8it9GFT+aN+Awk48TX6n5gW1bk="
   },
   "kholidays": {
     "version": "6.22.0",


### PR DESCRIPTION
bump kguiaddons to fix a crash when kdeconnect messes around with the clipboard.

## Things done

I have verified that kdeconnect is no longer crashing.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
