### PR TITLE
mautrix-gmessages: 25.11 -> 26.05

### DIFF
--- a/pkgs/by-name/ma/mautrix-gmessages/package.nix
+++ b/pkgs/by-name/ma/mautrix-gmessages/package.nix
@@ -16,17 +16,17 @@
 
 buildGoModule rec {
   pname = "mautrix-gmessages";
-  version = "25.11";
-  tag = "v0.2511.0";
+  version = "26.01";
+  tag = "v0.2601.0";
 
   src = fetchFromGitHub {
     owner = "mautrix";
     repo = "gmessages";
     inherit tag;
-    hash = "sha256-WmZ2eRKRckZtYMsI7r0b+atLSYA5e3N4ifeSEI2Rvu8=";
+    hash = "sha256-TtSGZfk7o4D7eizOVpWouVXCnU42LseuixFEpvxJ8N0=";
   };
 
-  vendorHash = "sha256-HVM9W4gOZFs9BDT1wFzDXkhDklCDtKUyNdYxPWkGZ3w=";
+  vendorHash = "sha256-bgb5s3BaFMnrFFVwchg9r+mRjfs1fWkM47PFbDF3BQI=";
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/ma/mautrix-gmessages/package.nix
+++ b/pkgs/by-name/ma/mautrix-gmessages/package.nix
@@ -16,17 +16,17 @@
 
 buildGoModule rec {
   pname = "mautrix-gmessages";
-  version = "26.01";
-  tag = "v0.2601.0";
+  version = "26.02";
+  tag = "v0.2602.0";
 
   src = fetchFromGitHub {
     owner = "mautrix";
     repo = "gmessages";
     inherit tag;
-    hash = "sha256-TtSGZfk7o4D7eizOVpWouVXCnU42LseuixFEpvxJ8N0=";
+    hash = "sha256-FMEPXeSGpktAosSsYIm1sCP6YNCPUt5iEFHVlvv62us=";
   };
 
-  vendorHash = "sha256-bgb5s3BaFMnrFFVwchg9r+mRjfs1fWkM47PFbDF3BQI=";
+  vendorHash = "sha256-hIi0XgsdBFUXufeXmWavxmMsGUsnGTAkQG5eZcMNNLA=";
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/ma/mautrix-gmessages/package.nix
+++ b/pkgs/by-name/ma/mautrix-gmessages/package.nix
@@ -38,7 +38,7 @@ buildGoModule rec {
   buildInputs = lib.optional (!withGoolm) olm;
   tags = lib.optional withGoolm "goolm";
 
-  doCheck = false;
+  doCheck = true;
 
   passthru = {
     updateScript = nix-update-script { };

--- a/pkgs/by-name/ma/mautrix-gmessages/package.nix
+++ b/pkgs/by-name/ma/mautrix-gmessages/package.nix
@@ -16,17 +16,17 @@
 
 buildGoModule rec {
   pname = "mautrix-gmessages";
-  version = "26.02";
-  tag = "v0.2602.0";
+  version = "26.04";
+  tag = "v0.2604.0";
 
   src = fetchFromGitHub {
     owner = "mautrix";
     repo = "gmessages";
     inherit tag;
-    hash = "sha256-FMEPXeSGpktAosSsYIm1sCP6YNCPUt5iEFHVlvv62us=";
+    hash = "sha256-NeGtg0KZVNeRvemuOXqKU1ozTu2DhFHxzWduEs5+zos=";
   };
 
-  vendorHash = "sha256-hIi0XgsdBFUXufeXmWavxmMsGUsnGTAkQG5eZcMNNLA=";
+  vendorHash = "sha256-At9VWLn6gD2MxT0df9LEGE7Kpy7ksrfd3+XL9YRfWHQ=";
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/ma/mautrix-gmessages/package.nix
+++ b/pkgs/by-name/ma/mautrix-gmessages/package.nix
@@ -16,17 +16,17 @@
 
 buildGoModule rec {
   pname = "mautrix-gmessages";
-  version = "26.04";
-  tag = "v0.2604.0";
+  version = "26.05";
+  tag = "v0.2605.0";
 
   src = fetchFromGitHub {
     owner = "mautrix";
     repo = "gmessages";
     inherit tag;
-    hash = "sha256-NeGtg0KZVNeRvemuOXqKU1ozTu2DhFHxzWduEs5+zos=";
+    hash = "sha256-ScsjUmQZsB86hT+EqIoI4V3KX3T1sV9C4/3ytcLV8O0=";
   };
 
-  vendorHash = "sha256-At9VWLn6gD2MxT0df9LEGE7Kpy7ksrfd3+XL9YRfWHQ=";
+  vendorHash = "sha256-rEcPW/egdx2AhXWqpjpaXbIjbmU9fShOKSv4fUZiX0w=";
 
   ldflags = [
     "-s"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://mau.fi/blog/2026-01-mautrix-release/
https://github.com/mautrix/gmessages/releases/v0.2601.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
