### PR TITLE
kreuzberg: init at 4.0.0rc21

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -20427,6 +20427,12 @@
     githubId = 20529;
     name = "Andreas Pelme";
   };
+  pelpieter = {
+    name = "Pieter Pel";
+    email = "pelpieter@gmail.com";
+    github = "pelpieter";
+    githubId = 25645555;
+  };
   penalty1083 = {
     email = "penalty1083@outlook.com";
     github = "penalty1083";

--- a/pkgs/development/python-modules/kreuzberg/default.nix
+++ b/pkgs/development/python-modules/kreuzberg/default.nix
@@ -1,0 +1,124 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  cargo,
+  rustc,
+  cmake,
+  buildPythonPackage,
+  nix-update-script,
+  pdfium-binaries,
+  python,
+}:
+
+let
+  version = "4.0.0rc21";
+
+  src = fetchFromGitHub {
+    owner = "kreuzberg-dev";
+    repo = "kreuzberg";
+    rev = "v4.0.0-rc.21";
+    hash = "sha256-H2NiAK0/UY4CK3hpiRSe+J9EpXFqupyVHeDQrYHAK9s=";
+  };
+
+in
+buildPythonPackage rec {
+  pname = "kreuzberg";
+  inherit version src;
+  pyproject = true;
+  sourceRoot = "${src.name}/packages/python";
+
+  # Point vendoring at the workspace root so Cargo.lock is found.
+  cargoRoot = ".";
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit src cargoRoot;
+    hash = "sha256-XFOoNyCJgb6u2X8le2043gmsMS0Rsf+g+QdCnLaRpXM=";
+  };
+
+  postPatch = ''
+    cp ../../Cargo.lock Cargo.lock
+
+    if [ -e ../../.cargo/config.toml ]; then
+      substituteInPlace ../../.cargo/config.toml \
+        --replace "build-std = [\"panic_abort\", \"std\"]" "" \
+        --replace "[unstable]" ""
+    fi
+
+    substituteInPlace ../../crates/kreuzberg-ffi/build.rs \
+      --replace 'std::fs::write("kreuzberg-ffi.pc"' 'std::fs::write(&format!("{}/kreuzberg-ffi.pc", std::env::var("OUT_DIR").unwrap())' \
+      --replace 'std::fs::write("kreuzberg-ffi-install.pc"' 'std::fs::write(&format!("{}/kreuzberg-ffi-install.pc", std::env::var("OUT_DIR").unwrap())'
+  '';
+
+  dontUseCmakeConfigure = true;
+
+  nativeBuildInputs = [
+    cargo
+    rustc
+    cmake
+    rustPlatform.cargoSetupHook
+    rustPlatform.maturinBuildHook
+  ];
+
+  buildInputs = [
+    pdfium-binaries
+  ];
+
+  env = {
+    KREUZBERG_PDFIUM_PREBUILT = pdfium-binaries;
+    CARGO_TARGET_DIR = "target";
+  };
+
+  # Build the Rust CLI and embed it in the wheel so the console script works.
+  preBuild = ''
+    cargo build -p kreuzberg-cli --release --features all --locked --offline
+
+    if [ -n "''${CARGO_TARGET_DIR-}" ]; then
+      target_dir=''${CARGO_TARGET_DIR}
+    else
+      target_dir=target
+    fi
+
+    cli_path=$(find "''${target_dir}" -type f \( -name kreuzberg -o -name kreuzberg-cli \) | head -n1)
+    if [ -z "''${cli_path}" ]; then
+      echo "kreuzberg CLI binary was not produced during build" >&2
+      exit 1
+    fi
+
+    cli_name=$(basename "''${cli_path}")
+    install -Dm755 "''${cli_path}" "kreuzberg/''${cli_name}"
+    if [ "''${cli_name}" != "kreuzberg-cli" ]; then
+      ln -sf "''${cli_name}" kreuzberg/kreuzberg-cli
+    fi
+  '';
+
+  postInstall = ''
+    for name in kreuzberg-cli kreuzberg; do
+      if [ -e "$out/${python.sitePackages}/kreuzberg/$name" ]; then
+        install -Dm755 "$out/${python.sitePackages}/kreuzberg/$name" "$out/bin/$name"
+      fi
+    done
+  '';
+
+  pythonCheckInterpreter = python;
+  pythonImportsCheck = [ "kreuzberg" ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "4\.0\.0rc.*"
+    ];
+  };
+
+  meta = {
+    description = "High-performance document intelligence library for Python with Rust core";
+    homepage = "https://github.com/kreuzberg-dev/kreuzberg";
+    changelog = "https://kreuzberg.dev/CHANGELOG/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ pelpieter ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-darwin"
+    ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8167,6 +8167,8 @@ self: super: with self; {
 
   krb5 = callPackage ../development/python-modules/krb5 { krb5-c = pkgs.krb5; };
 
+  kreuzberg = callPackage ../development/python-modules/kreuzberg { };
+
   krfzf-py = callPackage ../development/python-modules/krfzf-py { };
 
   kserve = callPackage ../development/python-modules/kserve { };


### PR DESCRIPTION
## Summary

This PR adds a new Python package `kreuzberg` (version 4.0.0-rc21) to nixpkgs. Kreuzberg is a high-performance document intelligence library with a Rust core that provides document processing capabilities.

### Key Changes:
- Adds `kreuzberg` Python package at `pkgs/development/python-modules/kreuzberg/default.nix`
- Registers the package in `pkgs/top-level/python-packages.nix`
- Adds maintainer entry `pelpieter` to `maintainers/maintainer-list.nix`

The package builds Rust binaries from source and embeds the kreuzberg CLI in the Python wheel, avoiding prebuilt binary dependencies for PDFium. The build process includes:
- Cargo vendoring for Rust dependencies
- Maturin hook for Python/Rust integration
- Custom post-build step to include the CLI binary in the package
- Support for x86_64-linux and aarch64-darwin platforms

---

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] Package tests at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR.
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test