### PR TITLE
vibe-kanban: init at 0.0.155

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5292,6 +5292,11 @@
     githubId = 6487079;
     name = "Dane Rieber";
   };
+  conao3 = {
+    github = "conao3";
+    githubId = 4703128;
+    name = "Naoya Yamashita";
+  };
   conduktorbot = {
     email = "automation@conduktor.io";
     github = "conduktorbot";

--- a/pkgs/by-name/vi/vibe-kanban/package.nix
+++ b/pkgs/by-name/vi/vibe-kanban/package.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  rustPlatform,
+  nodejs,
+  pnpm,
+  fetchPnpmDeps,
+  pnpmConfigHook,
+  makeWrapper,
+  pkg-config,
+  sqlite,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "vibe-kanban";
+  version = "0.0.155";
+
+  src = fetchFromGitHub {
+    owner = "BloopAI";
+    repo = "vibe-kanban";
+    tag = "v${version}-20260117094247";
+    hash = "sha256-5t/mEeeddqygOT7+s+FZ2R08gKsrcbYoxv/1G9bC/XE=";
+  };
+
+  cargoHash = "sha256-RmIjC+URRPnOFncWVTp0nmSf+lfhsQ9dz/4AGeujAnQ=";
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit pname version src;
+    hash = "sha256-dbOKNE4Q1Z4VjbbrNoShi+/8FdGg4r4a12GkEEH7URw=";
+    fetcherVersion = 3;
+  };
+
+  nativeBuildInputs = [
+    nodejs
+    pnpm
+    pnpmConfigHook
+    makeWrapper
+    pkg-config
+    rustPlatform.bindgenHook
+  ];
+
+  buildInputs = [
+    sqlite
+  ];
+
+  doCheck = false;
+
+  preBuild = ''
+    pushd frontend
+    pnpm build
+    popd
+  '';
+
+  postInstall = ''
+    mv $out/bin/server $out/bin/vibe-kanban
+    wrapProgram $out/bin/vibe-kanban
+  '';
+
+  meta = {
+    description = "Get 10X more out of Claude Code, Gemini CLI, Codex, Amp and other coding agents";
+    homepage = "https://vibekanban.com";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ conao3 ];
+    mainProgram = "vibe-kanban";
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION

Vibe Kanban is a task management tool for AI coding agents (Claude Code, Gemini CLI, Codex, Amp).
It provides task tracking, parallel/sequential execution, centralized MCP configuration, and remote project access via SSH.

Homepage: https://vibekanban.com

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

nix-review

```
$ nix run 'nixpkgs#nixpkgs-review' -- rev HEAD
$ git -c fetch.prune=false fetch --no-tags --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0
remote: Enumerating objects: 243, done.
remote: Counting objects: 100% (145/145), done.
remote: Compressing objects: 100% (55/55), done.
remote: Total 243 (delta 110), reused 103 (delta 89), pack-reused 98 (from 2)
Receiving objects: 100% (243/243), 668.07 KiB | 7.11 MiB/s, done.
Resolving deltas: 100% (129/129), completed with 60 local objects.
From https://github.com/NixOS/nixpkgs
 * [new branch]                master     -> refs/nixpkgs-review/0
$ git worktree add /home/conao/.cache/nixpkgs-review/rev-d08cc89f40d5a8d54597644a079ed1c9d87ff4cf/nixpkgs 4f43a6ca7863c5508a0c45cac54948ad49699ffd
Preparing worktree (detached HEAD 4f43a6ca7863)
Updating files: 100% (50736/50736), done.
HEAD is now at 4f43a6ca7863 yaziPlugins.jjui: init at 0-unstable-2026-01-17 (#481008)
Local evaluation for computing rebuilds
$ nix-env --extra-experimental-features no-url-literals --option system x86_64-linux -f <nixpkgs> --nix-path nixpkgs=/home/conao/.cache/nixpkgs-review/rev-d08cc89f40d5a8d54597644a079ed1c9d87ff4cf/nixpkgs nixpkgs-overlays=/tmp/tmpdabx907_ -qaP --xml --out-path --show-trace --no-allow-import-from-derivation
$ git merge --no-commit --no-ff d08cc89f40d5a8d54597644a079ed1c9d87ff4cf
Automatic merge went well; stopped before committing as requested
$ nix-env --extra-experimental-features no-url-literals --option system x86_64-linux -f <nixpkgs> --nix-path nixpkgs=/home/conao/.cache/nixpkgs-review/rev-d08cc89f40d5a8d54597644a079ed1c9d87ff4cf/nixpkgs nixpkgs-overlays=/tmp/tmpdabx907_ -qaP --xml --out-path --show-trace --no-allow-import-from-derivation --meta
--------- Impacted packages on 'x86_64-linux' ---------
1 package added:
vibe-kanban (init at 0.0.155)

$ nom build --file /nix/store/d61z39b7bh0mbqqfsd0nwd7hchfblka6-nixpkgs-review-3.6.0/lib/python3.13/site-packages/nixpkgs_review/nix/review-shell.nix --nix-path 'nixpkgs=/home/conao/.cache/nixpkgs-review/rev-d08cc89f40d5a8d54597644a079ed1c9d87ff4cf/nixpkgs nixpkgs-overlays=/tmp/tmpdabx907_' --extra-experimental-features 'nix-command no-url-literals' --no-link --keep-going --no-allow-import-from-derivation --option build-use-sandbox relaxed --argstr local-system x86_64-linux --argstr nixpkgs-path /home/conao/.cache/nixpkgs-review/rev-d08cc89f40d5a8d5459764┏━ Dependency Graph:
┃ ✔ review-shell 
┣━━━ Builds         
┗━ ∑ ⏵ 0 │ ✔ 1 │ ⏸ 0 │ Finished at 23:40:14 after 1s
--------- Report for 'x86_64-linux' ---------
1 package built:
vibe-kanban

Logs can be found under:
/home/conao/.cache/nixpkgs-review/rev-d08cc89f40d5a8d54597644a079ed1c9d87ff4cf/logs

$ /etc/profiles/per-user/conao/bin/nom-shell --argstr local-system x86_64-linux --argstr nixpkgs-path /home/conao/.cache/nixpkgs-review/rev-d08cc89f40d5a8d54597644a079ed1c9d87ff4cf/nixpkgs --argstr nixpkgs-config-path /tmp/tmp2_k4rpip.nix --argstr attrs-path /home/conao/.cache/nixpkgs-review/rev-d08cc89f40d5a8d54597644a079ed1c9d87ff4cf/attrs.nix --nix-path 'nixpkgs=/home/conao/.cache/nixpkgs-review/rev-d08cc89f40d5a8d54597644a079ed1c9d87ff4cf/nixpkgs nixpkgs-overlays=/tmp/tmpdabx907_' /nix/store/d61z39b7bh0mbqqfsd0nwd7hchfblka6-nixpkgs-review-3.6.0/lib/python3.13/site-packages/nixpkgs_review/nix/review-shell.nix
```

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
