### PR TITLE
treewide: remove superfluous pythonOlder "3.8"

### DIFF
--- a/pkgs/by-name/de/deface/package.nix
+++ b/pkgs/by-name/de/deface/package.nix
@@ -11,8 +11,6 @@ python3.pkgs.buildPythonApplication rec {
   version = "1.5.0";
   pyproject = true;
 
-  disabled = python3.pythonOlder "3.8";
-
   src = fetchFromGitHub {
     owner = "ORB-HD";
     repo = "deface";

--- a/pkgs/by-name/dt/dt-schema/package.nix
+++ b/pkgs/by-name/dt/dt-schema/package.nix
@@ -1,5 +1,4 @@
 {
-  lib,
   python3,
 }:
 
@@ -16,22 +15,10 @@ let
           hash = "sha256-D4ZEN6uLYHa6ZwdFPvj5imoNUSqA6T+KvbZ29zfstg0=";
         };
 
-        propagatedBuildInputs =
-          with self;
-          (
-            [
-              attrs
-              pyrsistent
-            ]
-            ++ lib.optionals (pythonOlder "3.8") [
-              importlib-metadata
-              typing-extensions
-            ]
-            ++ lib.optionals (pythonOlder "3.9") [
-              importlib-resources
-              pkgutil-resolve-name
-            ]
-          );
+        propagatedBuildInputs = with self; [
+          attrs
+          pyrsistent
+        ];
       });
     };
   };

--- a/pkgs/by-name/go/gogdl/package.nix
+++ b/pkgs/by-name/go/gogdl/package.nix
@@ -18,8 +18,6 @@ python3Packages.buildPythonApplication rec {
     hash = "sha256-pK6JeTJeBq9qVfflNSYs3s4HuD0Kz6k9DDUVHL81FV0=";
   };
 
-  disabled = python3Packages.pythonOlder "3.8";
-
   propagatedBuildInputs = with python3Packages; [
     setuptools
     requests

--- a/pkgs/by-name/im/imgp/package.nix
+++ b/pkgs/by-name/im/imgp/package.nix
@@ -8,7 +8,6 @@ python3Packages.buildPythonApplication rec {
   pname = "imgp";
   version = "2.9";
   pyproject = true;
-  disabled = python3Packages.pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "jarun";

--- a/pkgs/by-name/le/legendary-gl/package.nix
+++ b/pkgs/by-name/le/legendary-gl/package.nix
@@ -26,8 +26,6 @@ python3Packages.buildPythonApplication {
     filelock
   ];
 
-  disabled = python3Packages.pythonOlder "3.8";
-
   # no tests
   doCheck = false;
 

--- a/pkgs/by-name/ma/mapproxy/package.nix
+++ b/pkgs/by-name/ma/mapproxy/package.nix
@@ -9,7 +9,6 @@ python3Packages.buildPythonApplication rec {
   pname = "mapproxy";
   version = "5.1.1";
   pyproject = true;
-  disabled = python3Packages.pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "mapproxy";

--- a/pkgs/by-name/pd/pdm/package.nix
+++ b/pkgs/by-name/pd/pdm/package.nix
@@ -33,8 +33,6 @@ python.pkgs.buildPythonApplication rec {
   version = "2.26.2";
   pyproject = true;
 
-  disabled = python.pkgs.pythonOlder "3.8";
-
   src = fetchFromGitHub {
     owner = "pdm-project";
     repo = "pdm";

--- a/pkgs/by-name/pg/pg_activity/package.nix
+++ b/pkgs/by-name/pg/pg_activity/package.nix
@@ -8,7 +8,6 @@ python3Packages.buildPythonApplication rec {
   pname = "pg_activity";
   version = "3.6.1";
   pyproject = true;
-  disabled = python3Packages.pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "dalibo";

--- a/pkgs/by-name/po/portablemc/package.nix
+++ b/pkgs/by-name/po/portablemc/package.nix
@@ -50,8 +50,6 @@ python3Packages.buildPythonApplication rec {
   version = "4.4.1";
   pyproject = true;
 
-  disabled = python3Packages.pythonOlder "3.8";
-
   src = fetchFromGitHub {
     owner = "mindstorm38";
     repo = "portablemc";

--- a/pkgs/by-name/ra/rapid-photo-downloader/package.nix
+++ b/pkgs/by-name/ra/rapid-photo-downloader/package.nix
@@ -36,35 +36,32 @@ python3Packages.buildPythonApplication rec {
     setuptools
   ];
 
-  dependencies =
-    with python3Packages;
-    [
-      ifuse
-      libimobiledevice
-      # Python dependencies
-      pyqt5
-      pygobject3
-      gphoto2
-      pyzmq
-      tornado
-      psutil
-      pyxdg
-      arrow
-      python-dateutil
-      easygui
-      babel
-      colour
-      pillow
-      pymediainfo
-      sortedcontainers
-      requests
-      colorlog
-      pyprind
-      setuptools
-      show-in-file-manager
-      tenacity
-    ]
-    ++ lib.optional (pythonOlder "3.8") importlib-metadata;
+  dependencies = with python3Packages; [
+    ifuse
+    libimobiledevice
+    # Python dependencies
+    pyqt5
+    pygobject3
+    gphoto2
+    pyzmq
+    tornado
+    psutil
+    pyxdg
+    arrow
+    python-dateutil
+    easygui
+    babel
+    colour
+    pillow
+    pymediainfo
+    sortedcontainers
+    requests
+    colorlog
+    pyprind
+    setuptools
+    show-in-file-manager
+    tenacity
+  ];
 
   postPatch = ''
     # Drop broken version specifier

--- a/pkgs/by-name/sq/sqlfluff/package.nix
+++ b/pkgs/by-name/sq/sqlfluff/package.nix
@@ -22,31 +22,25 @@ python3Packages.buildPythonApplication rec {
   pythonRelaxDeps = [
     "click"
   ];
-  dependencies =
-    with python3Packages;
-    [
-      appdirs
-      cached-property
-      chardet
-      click
-      colorama
-      configparser
-      diff-cover
-      jinja2
-      oyaml
-      pathspec
-      platformdirs
-      pytest
-      regex
-      tblib
-      toml
-      tqdm
-      typing-extensions
-    ]
-    ++ lib.optionals (pythonOlder "3.8") [
-      backports.cached-property
-      importlib_metadata
-    ];
+  dependencies = with python3Packages; [
+    appdirs
+    cached-property
+    chardet
+    click
+    colorama
+    configparser
+    diff-cover
+    jinja2
+    oyaml
+    pathspec
+    platformdirs
+    pytest
+    regex
+    tblib
+    toml
+    tqdm
+    typing-extensions
+  ];
 
   nativeCheckInputs = with python3Packages; [
     hypothesis

--- a/pkgs/by-name/st/stac-validator/package.nix
+++ b/pkgs/by-name/st/stac-validator/package.nix
@@ -8,7 +8,6 @@ python3Packages.buildPythonPackage rec {
   pname = "stac-validator";
   version = "3.10.2";
   pyproject = true;
-  disabled = python3Packages.pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "stac-utils";

--- a/pkgs/development/python-modules/accupy/default.nix
+++ b/pkgs/development/python-modules/accupy/default.nix
@@ -3,14 +3,12 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
-  pythonOlder,
   setuptools,
   mpmath,
   numpy,
   pybind11,
   pyfma,
   eigen,
-  importlib-metadata,
   pytestCheckHook,
   matplotlib,
   dufte,
@@ -40,8 +38,7 @@ buildPythonPackage rec {
     mpmath
     numpy
     pyfma
-  ]
-  ++ lib.optional (pythonOlder "3.8") importlib-metadata;
+  ];
 
   nativeCheckInputs = [
     perfplot

--- a/pkgs/development/python-modules/aiosmtpd/default.nix
+++ b/pkgs/development/python-modules/aiosmtpd/default.nix
@@ -8,7 +8,6 @@
   pytestCheckHook,
   pythonOlder,
   setuptools,
-  typing-extensions,
 
   # for passthru.tests
   django,
@@ -32,8 +31,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     atpublic
     attrs
-  ]
-  ++ lib.optionals (pythonOlder "3.8") [ typing-extensions ];
+  ];
 
   nativeCheckInputs = [
     pytest-mock

--- a/pkgs/development/python-modules/amaranth/default.nix
+++ b/pkgs/development/python-modules/amaranth/default.nix
@@ -1,14 +1,11 @@
 {
   lib,
   buildPythonPackage,
-  pythonOlder,
   fetchFromGitHub,
   pdm-backend,
   jschon,
   pyvcd,
   jinja2,
-  importlib-resources,
-  importlib-metadata,
   git,
 
   # for tests
@@ -43,9 +40,7 @@ buildPythonPackage rec {
     jschon
     jinja2
     pyvcd
-  ]
-  ++ lib.optional (pythonOlder "3.9") importlib-resources
-  ++ lib.optional (pythonOlder "3.8") importlib-metadata;
+  ];
 
   nativeCheckInputs = [
     pytestCheckHook

--- a/pkgs/development/python-modules/anywidget/default.nix
+++ b/pkgs/development/python-modules/anywidget/default.nix
@@ -4,10 +4,8 @@
   fetchPypi,
   pytestCheckHook,
   writableTmpDirAsHomeHook,
-  pythonOlder,
   hatch-jupyter-builder,
   hatchling,
-  importlib-metadata,
   ipykernel,
   ipywidgets,
   psygnal,
@@ -43,8 +41,7 @@ buildPythonPackage rec {
     ipywidgets
     psygnal
     typing-extensions
-  ]
-  ++ lib.optional (pythonOlder "3.8") importlib-metadata;
+  ];
 
   nativeCheckInputs = [
     pytestCheckHook

--- a/pkgs/development/python-modules/automate-home/default.nix
+++ b/pkgs/development/python-modules/automate-home/default.nix
@@ -8,7 +8,6 @@
   hiredis,
   pytestCheckHook,
   pythonAtLeast,
-  pythonOlder,
   pytz,
   pyyaml,
   setuptools,
@@ -20,7 +19,7 @@ buildPythonPackage rec {
   pyproject = true;
 
   # Typing issue
-  disabled = pythonOlder "3.8" || pythonAtLeast "3.12";
+  disabled = pythonAtLeast "3.12";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/avro/default.nix
+++ b/pkgs/development/python-modules/avro/default.nix
@@ -1,10 +1,8 @@
 {
   lib,
   buildPythonPackage,
-  pythonOlder,
   setuptools,
   fetchPypi,
-  typing-extensions,
   pytest7CheckHook,
 }:
 
@@ -19,8 +17,6 @@ buildPythonPackage rec {
   };
 
   build-system = [ setuptools ];
-
-  dependencies = lib.optionals (pythonOlder "3.8") [ typing-extensions ];
 
   nativeCheckInputs = [ pytest7CheckHook ];
 

--- a/pkgs/development/python-modules/aws-xray-sdk/default.nix
+++ b/pkgs/development/python-modules/aws-xray-sdk/default.nix
@@ -7,13 +7,11 @@
   django,
   fetchFromGitHub,
   httpx,
-  importlib-metadata,
   jsonpickle,
   pymysql,
   pytest-asyncio_0,
   pynamodb,
   pytestCheckHook,
-  pythonOlder,
   requests,
   setuptools,
   sqlalchemy,
@@ -40,8 +38,7 @@ buildPythonPackage rec {
     jsonpickle
     requests
     wrapt
-  ]
-  ++ lib.optionals (pythonOlder "3.8") [ importlib-metadata ];
+  ];
 
   nativeCheckInputs = [
     aiohttp

--- a/pkgs/development/python-modules/azure-mgmt-appcontainers/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-appcontainers/default.nix
@@ -2,12 +2,10 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  pythonOlder,
   azure-common,
   azure-mgmt-core,
   isodate,
   setuptools,
-  typing-extensions,
 }:
 
 buildPythonPackage rec {
@@ -28,8 +26,7 @@ buildPythonPackage rec {
     azure-common
     azure-mgmt-core
     isodate
-  ]
-  ++ lib.optionals (pythonOlder "3.8") [ typing-extensions ];
+  ];
 
   # no tests included
   doCheck = false;

--- a/pkgs/development/python-modules/azure-mgmt-batchai/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-batchai/default.nix
@@ -5,8 +5,6 @@
   azure-common,
   azure-mgmt-core,
   isodate,
-  pythonOlder,
-  typing-extensions,
 }:
 
 buildPythonPackage rec {
@@ -24,8 +22,7 @@ buildPythonPackage rec {
     isodate
     azure-common
     azure-mgmt-core
-  ]
-  ++ lib.optionals (pythonOlder "3.8") [ typing-extensions ];
+  ];
 
   pythonNamespaces = [ "azure.mgmt" ];
 

--- a/pkgs/development/python-modules/azure-mgmt-maps/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-maps/default.nix
@@ -5,8 +5,6 @@
   buildPythonPackage,
   fetchPypi,
   isodate,
-  pythonOlder,
-  typing-extensions,
   msrest,
 }:
 
@@ -25,8 +23,7 @@ buildPythonPackage rec {
     azure-common
     azure-mgmt-core
     msrest
-  ]
-  ++ lib.optionals (pythonOlder "3.8") [ typing-extensions ];
+  ];
 
   pythonNamespaces = [ "azure.mgmt" ];
 

--- a/pkgs/development/python-modules/azure-mgmt-redis/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-redis/default.nix
@@ -5,8 +5,6 @@
   buildPythonPackage,
   fetchPypi,
   isodate,
-  pythonOlder,
-  typing-extensions,
 }:
 
 buildPythonPackage rec {
@@ -24,8 +22,7 @@ buildPythonPackage rec {
     isodate
     azure-common
     azure-mgmt-core
-  ]
-  ++ lib.optionals (pythonOlder "3.8") [ typing-extensions ];
+  ];
 
   # Module has no tests
   doCheck = false;

--- a/pkgs/development/python-modules/azure-mgmt-reservations/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-reservations/default.nix
@@ -6,8 +6,6 @@
   msrest,
   azure-common,
   azure-mgmt-core,
-  typing-extensions,
-  pythonOlder,
 }:
 
 buildPythonPackage rec {
@@ -27,8 +25,7 @@ buildPythonPackage rec {
     msrest
     azure-common
     azure-mgmt-core
-  ]
-  ++ lib.optionals (pythonOlder "3.8") [ typing-extensions ];
+  ];
 
   # has no tests
   doCheck = false;

--- a/pkgs/development/python-modules/backports-entry-points-selectable/default.nix
+++ b/pkgs/development/python-modules/backports-entry-points-selectable/default.nix
@@ -2,9 +2,7 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  pythonOlder,
   setuptools-scm,
-  importlib-metadata,
 }:
 
 buildPythonPackage rec {
@@ -19,8 +17,6 @@ buildPythonPackage rec {
   };
 
   nativeBuildInputs = [ setuptools-scm ];
-
-  propagatedBuildInputs = lib.optionals (pythonOlder "3.8") [ importlib-metadata ];
 
   # no tests
   doCheck = false;

--- a/pkgs/development/python-modules/backports-strenum/default.nix
+++ b/pkgs/development/python-modules/backports-strenum/default.nix
@@ -5,7 +5,6 @@
   poetry-core,
   pytestCheckHook,
   pythonAtLeast,
-  pythonOlder,
 }:
 
 buildPythonPackage rec {
@@ -13,7 +12,7 @@ buildPythonPackage rec {
   version = "1.3.1";
   pyproject = true;
 
-  disabled = pythonOlder "3.8" || pythonAtLeast "3.11";
+  disabled = pythonAtLeast "3.11";
 
   src = fetchFromGitHub {
     owner = "clbarnes";

--- a/pkgs/development/python-modules/catalogue/default.nix
+++ b/pkgs/development/python-modules/catalogue/default.nix
@@ -3,10 +3,7 @@
   buildPythonPackage,
   fetchPypi,
   pytestCheckHook,
-  pythonOlder,
   setuptools,
-  typing-extensions,
-  zipp,
 }:
 
 buildPythonPackage rec {
@@ -20,11 +17,6 @@ buildPythonPackage rec {
   };
 
   nativeBuildInputs = [ setuptools ];
-
-  propagatedBuildInputs = lib.optionals (pythonOlder "3.8") [
-    typing-extensions
-    zipp
-  ];
 
   nativeCheckInputs = [ pytestCheckHook ];
 

--- a/pkgs/development/python-modules/cli-ui/default.nix
+++ b/pkgs/development/python-modules/cli-ui/default.nix
@@ -2,7 +2,6 @@
   lib,
   fetchFromGitHub,
   pytestCheckHook,
-  pythonOlder,
   poetry-core,
   colorama,
   tabulate,
@@ -13,8 +12,6 @@ buildPythonPackage rec {
   pname = "cli-ui";
   version = "0.19.0";
   pyproject = true;
-
-  disabled = pythonOlder "3.8.1";
 
   src = fetchFromGitHub {
     owner = "your-tools";

--- a/pkgs/development/python-modules/django-configurations/default.nix
+++ b/pkgs/development/python-modules/django-configurations/default.nix
@@ -7,9 +7,7 @@
   django,
   django-cache-url,
   fetchPypi,
-  importlib-metadata,
   mock,
-  pythonOlder,
   setuptools-scm,
 }:
 
@@ -25,7 +23,7 @@ buildPythonPackage rec {
 
   buildInputs = [ setuptools-scm ];
 
-  propagatedBuildInputs = [ django ] ++ lib.optionals (pythonOlder "3.8") [ importlib-metadata ];
+  propagatedBuildInputs = [ django ];
 
   nativeCheckInputs = [
     mock

--- a/pkgs/development/python-modules/django/4.nix
+++ b/pkgs/development/python-modules/django/4.nix
@@ -5,7 +5,6 @@
   fetchFromGitHub,
   fetchpatch,
   pythonAtLeast,
-  pythonOlder,
   replaceVars,
 
   # build
@@ -48,7 +47,7 @@ buildPythonPackage rec {
   version = "4.2.27";
   pyproject = true;
 
-  disabled = pythonOlder "3.8" || pythonAtLeast "3.13";
+  disabled = pythonAtLeast "3.13";
 
   src = fetchFromGitHub {
     owner = "django";

--- a/pkgs/development/python-modules/dufte/default.nix
+++ b/pkgs/development/python-modules/dufte/default.nix
@@ -2,8 +2,6 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  pythonOlder,
-  importlib-metadata,
   matplotlib,
   numpy,
   pytestCheckHook,
@@ -27,8 +25,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     matplotlib
     numpy
-  ]
-  ++ lib.optionals (pythonOlder "3.8") [ importlib-metadata ];
+  ];
 
   preCheck = ''
     export HOME=$(mktemp -d)

--- a/pkgs/development/python-modules/evaluate/default.nix
+++ b/pkgs/development/python-modules/evaluate/default.nix
@@ -2,12 +2,10 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  pythonOlder,
   datasets,
   dill,
   fsspec,
   huggingface-hub,
-  importlib-metadata,
   multiprocess,
   numpy,
   packaging,
@@ -44,8 +42,7 @@ buildPythonPackage rec {
     fsspec
     huggingface-hub
     packaging
-  ]
-  ++ lib.optionals (pythonOlder "3.8") [ importlib-metadata ];
+  ];
 
   # most tests require internet access.
   doCheck = false;

--- a/pkgs/development/python-modules/exdown/default.nix
+++ b/pkgs/development/python-modules/exdown/default.nix
@@ -3,9 +3,7 @@
   buildPythonPackage,
   isPy27,
   fetchPypi,
-  pythonOlder,
   setuptools,
-  importlib-metadata,
   pytestCheckHook,
 }:
 
@@ -23,8 +21,6 @@ buildPythonPackage rec {
   };
 
   nativeBuildInputs = [ setuptools ];
-
-  propagatedBuildInputs = lib.optionals (pythonOlder "3.8") [ importlib-metadata ];
 
   nativeCheckInputs = [ pytestCheckHook ];
 

--- a/pkgs/development/python-modules/fake-useragent/default.nix
+++ b/pkgs/development/python-modules/fake-useragent/default.nix
@@ -2,7 +2,6 @@
   lib,
   fetchFromGitHub,
   buildPythonPackage,
-  importlib-metadata,
   importlib-resources,
   setuptools,
   pythonOlder,
@@ -27,9 +26,7 @@ buildPythonPackage rec {
 
   build-system = [ setuptools ];
 
-  dependencies =
-    lib.optionals (pythonOlder "3.10") [ importlib-resources ]
-    ++ lib.optionals (pythonOlder "3.8") [ importlib-metadata ];
+  dependencies = lib.optionals (pythonOlder "3.10") [ importlib-resources ];
 
   nativeCheckInputs = [ pytestCheckHook ];
 

--- a/pkgs/development/python-modules/ffmpy/default.nix
+++ b/pkgs/development/python-modules/ffmpy/default.nix
@@ -3,8 +3,6 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
-  fetchpatch2,
-  pythonOlder,
   uv-build,
   pytestCheckHook,
   go,
@@ -15,8 +13,6 @@ buildPythonPackage rec {
   pname = "ffmpy";
   version = "0.6.2";
   pyproject = true;
-
-  disabled = pythonOlder "3.8.1";
 
   src = fetchFromGitHub {
     owner = "Ch00k";

--- a/pkgs/development/python-modules/flask-mongoengine/default.nix
+++ b/pkgs/development/python-modules/flask-mongoengine/default.nix
@@ -7,10 +7,8 @@
   flask-wtf,
   markupsafe,
   mongoengine,
-  pythonOlder,
   setuptools,
   setuptools-scm,
-  typing-extensions,
   wtforms,
 }:
 
@@ -38,8 +36,7 @@ buildPythonPackage rec {
     flask
     flask-wtf
     mongoengine
-  ]
-  ++ lib.optionals (pythonOlder "3.8") [ typing-extensions ];
+  ];
 
   optional-dependencies = {
     wtf = [

--- a/pkgs/development/python-modules/gentools/default.nix
+++ b/pkgs/development/python-modules/gentools/default.nix
@@ -2,10 +2,8 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  importlib-metadata,
   poetry-core,
   pytestCheckHook,
-  pythonOlder,
 }:
 
 buildPythonPackage rec {
@@ -21,8 +19,6 @@ buildPythonPackage rec {
   };
 
   nativeBuildInputs = [ poetry-core ];
-
-  propagatedBuildInputs = lib.optionals (pythonOlder "3.8") [ importlib-metadata ];
 
   nativeCheckInputs = [ pytestCheckHook ];
 

--- a/pkgs/development/python-modules/gptcache/default.nix
+++ b/pkgs/development/python-modules/gptcache/default.nix
@@ -4,7 +4,6 @@
   fetchFromGitHub,
   cachetools,
   numpy,
-  pythonOlder,
   redis,
   redis-om,
   requests,
@@ -14,8 +13,6 @@ buildPythonPackage rec {
   pname = "gptcache";
   version = "0.1.44";
   format = "setuptools";
-
-  disabled = pythonOlder "3.8.1";
 
   src = fetchFromGitHub {
     owner = "zilliztech";

--- a/pkgs/development/python-modules/graphql-relay/default.nix
+++ b/pkgs/development/python-modules/graphql-relay/default.nix
@@ -3,14 +3,11 @@
   buildPythonPackage,
   fetchPypi,
 
-  pythonOlder,
-
   # build
   poetry-core,
 
   # runtime
   graphql-core,
-  typing-extensions,
 
   # tests
   pytest-asyncio,
@@ -41,7 +38,7 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [ poetry-core ];
 
-  propagatedBuildInputs = [ graphql-core ] ++ lib.optionals (pythonOlder "3.8") [ typing-extensions ];
+  propagatedBuildInputs = [ graphql-core ];
 
   nativeCheckInputs = [
     pytest-asyncio

--- a/pkgs/development/python-modules/h5py/default.nix
+++ b/pkgs/development/python-modules/h5py/default.nix
@@ -2,7 +2,6 @@
   lib,
   fetchPypi,
   buildPythonPackage,
-  pythonOlder,
   setuptools,
   numpy,
   hdf5,
@@ -12,7 +11,6 @@
   openssh,
   pytestCheckHook,
   pytest-mpi,
-  cached-property,
 }:
 
 assert hdf5.mpiSupport -> mpi4py != null && hdf5.mpi == mpi4py.mpi;
@@ -71,8 +69,7 @@ buildPythonPackage rec {
   ++ lib.optionals mpiSupport [
     mpi4py
     openssh
-  ]
-  ++ lib.optionals (pythonOlder "3.8") [ cached-property ];
+  ];
 
   nativeCheckInputs = [
     pytestCheckHook

--- a/pkgs/development/python-modules/hatch-fancy-pypi-readme/default.nix
+++ b/pkgs/development/python-modules/hatch-fancy-pypi-readme/default.nix
@@ -7,7 +7,6 @@
   build,
   hatchling,
   tomli,
-  typing-extensions,
 }:
 
 buildPythonPackage rec {
@@ -26,8 +25,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     hatchling
   ]
-  ++ lib.optionals (pythonOlder "3.11") [ tomli ]
-  ++ lib.optionals (pythonOlder "3.8") [ typing-extensions ];
+  ++ lib.optionals (pythonOlder "3.11") [ tomli ];
 
   nativeCheckInputs = [
     build

--- a/pkgs/development/python-modules/importlib-metadata/default.nix
+++ b/pkgs/development/python-modules/importlib-metadata/default.nix
@@ -2,10 +2,8 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  pythonOlder,
   setuptools,
   setuptools-scm,
-  typing-extensions,
   toml,
   zipp,
 
@@ -32,8 +30,7 @@ buildPythonPackage rec {
   dependencies = [
     toml
     zipp
-  ]
-  ++ lib.optionals (pythonOlder "3.8") [ typing-extensions ];
+  ];
 
   # Cyclic dependencies due to pyflakefs
   doCheck = false;

--- a/pkgs/development/python-modules/ipykernel/tests.nix
+++ b/pkgs/development/python-modules/ipykernel/tests.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   buildPythonPackage,
-  pythonOlder,
   flaky,
   ipykernel,
   ipyparallel,
@@ -45,29 +44,15 @@ buildPythonPackage {
     # traitlets.config.configurable.MultipleInstanceError: An incompatible siblin...
     "test_install_kernelspec"
   ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin (
-    [
-      # see https://github.com/NixOS/nixpkgs/issues/76197
-      "test_subprocess_print"
-      "test_subprocess_error"
-      "test_ipython_start_kernel_no_userns"
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # see https://github.com/NixOS/nixpkgs/issues/76197
+    "test_subprocess_print"
+    "test_subprocess_error"
+    "test_ipython_start_kernel_no_userns"
 
-      # https://github.com/ipython/ipykernel/issues/506
-      "test_unc_paths"
-    ]
-    ++ lib.optionals (pythonOlder "3.8") [
-      # flaky test https://github.com/ipython/ipykernel/issues/485
-      "test_shutdown"
-
-      # test regression https://github.com/ipython/ipykernel/issues/486
-      "test_sys_path_profile_dir"
-      "test_save_history"
-      "test_help_output"
-      "test_write_kernel_spec"
-      "test_ipython_start_kernel_userns"
-      "ZMQDisplayPublisherTests"
-    ]
-  );
+    # https://github.com/ipython/ipykernel/issues/506
+    "test_unc_paths"
+  ];
 
   # Some of the tests use localhost networking.
   __darwinAllowLocalNetworking = true;

--- a/pkgs/development/python-modules/line-profiler/default.nix
+++ b/pkgs/development/python-modules/line-profiler/default.nix
@@ -7,7 +7,6 @@
   ipython,
   scikit-build,
   cmake,
-  pythonOlder,
   pytestCheckHook,
   ubelt,
 }:
@@ -17,7 +16,7 @@ buildPythonPackage rec {
   version = "5.0.0";
   format = "setuptools";
 
-  disabled = pythonOlder "3.8" || isPyPy;
+  disabled = isPyPy;
 
   src = fetchPypi {
     pname = "line_profiler";

--- a/pkgs/development/python-modules/logilab/common.nix
+++ b/pkgs/development/python-modules/logilab/common.nix
@@ -2,11 +2,9 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  importlib-metadata,
   mypy-extensions,
   pytestCheckHook,
   pythonAtLeast,
-  pythonOlder,
   pytz,
   setuptools,
   typing-extensions,
@@ -33,8 +31,7 @@ buildPythonPackage rec {
     setuptools
     mypy-extensions
     typing-extensions
-  ]
-  ++ lib.optionals (pythonOlder "3.8") [ importlib-metadata ];
+  ];
 
   nativeCheckInputs = [
     pytestCheckHook

--- a/pkgs/development/python-modules/mailmanclient/default.nix
+++ b/pkgs/development/python-modules/mailmanclient/default.nix
@@ -2,9 +2,7 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  pythonOlder,
   requests,
-  typing-extensions,
 }:
 
 buildPythonPackage rec {
@@ -17,7 +15,7 @@ buildPythonPackage rec {
     hash = "sha256-Y1gcYEyn6sAhSJwVqsygaklY63b2ZXTG+rBerGVN2Fc=";
   };
 
-  propagatedBuildInputs = [ requests ] ++ lib.optionals (pythonOlder "3.8") [ typing-extensions ];
+  propagatedBuildInputs = [ requests ];
 
   # Tests require a running Mailman instance
   doCheck = false;

--- a/pkgs/development/python-modules/markups/default.nix
+++ b/pkgs/development/python-modules/markups/default.nix
@@ -3,12 +3,10 @@
   buildPythonPackage,
   docutils,
   fetchFromGitHub,
-  importlib-metadata,
   markdown,
   pygments,
   pytestCheckHook,
   python-markdown-math,
-  pythonOlder,
   pyyaml,
   setuptools,
   textile,
@@ -35,8 +33,7 @@ buildPythonPackage rec {
     python-markdown-math
     pyyaml
     textile
-  ]
-  ++ lib.optionals (pythonOlder "3.8") [ importlib-metadata ];
+  ];
 
   nativeCheckInputs = [ pytestCheckHook ];
 

--- a/pkgs/development/python-modules/netcdf4/default.nix
+++ b/pkgs/development/python-modules/netcdf4/default.nix
@@ -13,7 +13,6 @@
   numpy,
   oldest-supported-numpy,
   python,
-  pythonOlder,
   setuptools-scm,
   stdenv,
   wheel,
@@ -30,7 +29,7 @@ buildPythonPackage {
   inherit version;
   pyproject = true;
 
-  disabled = isPyPy || pythonOlder "3.8";
+  disabled = isPyPy;
 
   src = fetchFromGitHub {
     owner = "Unidata";

--- a/pkgs/development/python-modules/ormar/default.nix
+++ b/pkgs/development/python-modules/ormar/default.nix
@@ -10,7 +10,6 @@
   fastapi,
   fetchFromGitHub,
   httpx,
-  importlib-metadata,
   mysqlclient,
   nest-asyncio,
   orjson,
@@ -20,9 +19,7 @@
   pymysql,
   pytest-asyncio,
   pytestCheckHook,
-  pythonOlder,
   sqlalchemy,
-  typing-extensions,
 }:
 
 buildPythonPackage rec {
@@ -53,10 +50,6 @@ buildPythonPackage rec {
     pydantic
     sqlalchemy
     psycopg2
-  ]
-  ++ lib.optionals (pythonOlder "3.8") [
-    typing-extensions
-    importlib-metadata
   ];
 
   optional-dependencies = {

--- a/pkgs/development/python-modules/pep517/default.nix
+++ b/pkgs/development/python-modules/pep517/default.nix
@@ -4,9 +4,6 @@
   fetchPypi,
   flit-core,
   tomli,
-  pythonOlder,
-  importlib-metadata,
-  zipp,
   pytestCheckHook,
   setuptools,
   testpath,
@@ -28,10 +25,6 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     tomli
-  ]
-  ++ lib.optionals (pythonOlder "3.8") [
-    importlib-metadata
-    zipp
   ];
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/pg8000/default.nix
+++ b/pkgs/development/python-modules/pg8000/default.nix
@@ -2,10 +2,8 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  importlib-metadata,
   passlib,
   python-dateutil,
-  pythonOlder,
   scramp,
   hatchling,
   versioningit,
@@ -30,8 +28,7 @@ buildPythonPackage rec {
     passlib
     python-dateutil
     scramp
-  ]
-  ++ lib.optionals (pythonOlder "3.8") [ importlib-metadata ];
+  ];
 
   # Tests require a running PostgreSQL instance
   doCheck = false;

--- a/pkgs/development/python-modules/pipdate/default.nix
+++ b/pkgs/development/python-modules/pipdate/default.nix
@@ -3,9 +3,7 @@
   appdirs,
   buildPythonPackage,
   fetchPypi,
-  importlib-metadata,
   packaging,
-  pythonOlder,
   requests,
   rich,
   setuptools,
@@ -30,8 +28,7 @@ buildPythonPackage rec {
     requests
     rich
     setuptools
-  ]
-  ++ lib.optionals (pythonOlder "3.8") [ importlib-metadata ];
+  ];
 
   # Tests require network access and pythonImportsCheck requires configuration file
   doCheck = false;

--- a/pkgs/development/python-modules/pony/default.nix
+++ b/pkgs/development/python-modules/pony/default.nix
@@ -4,7 +4,6 @@
   fetchFromGitHub,
   pytestCheckHook,
   pythonAtLeast,
-  pythonOlder,
   setuptools,
 }:
 
@@ -13,7 +12,7 @@ buildPythonPackage rec {
   version = "0.7.19";
   pyproject = true;
 
-  disabled = pythonOlder "3.8" || pythonAtLeast "3.13";
+  disabled = pythonAtLeast "3.13";
 
   src = fetchFromGitHub {
     owner = "ponyorm";

--- a/pkgs/development/python-modules/pyfma/default.nix
+++ b/pkgs/development/python-modules/pyfma/default.nix
@@ -3,11 +3,9 @@
   buildPythonPackage,
   fetchFromGitHub,
   fetchpatch,
-  importlib-metadata,
   numpy,
   pybind11,
   pytestCheckHook,
-  pythonOlder,
   setuptools,
 }:
 
@@ -35,7 +33,7 @@ buildPythonPackage rec {
 
   buildInputs = [ pybind11 ];
 
-  dependencies = [ numpy ] ++ lib.optionals (pythonOlder "3.8") [ importlib-metadata ];
+  dependencies = [ numpy ];
 
   nativeCheckInputs = [ pytestCheckHook ];
 

--- a/pkgs/development/python-modules/pytest-isort/default.nix
+++ b/pkgs/development/python-modules/pytest-isort/default.nix
@@ -2,12 +2,10 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  importlib-metadata,
   isort,
   poetry-core,
   pytest,
   pytestCheckHook,
-  pythonOlder,
 }:
 
 buildPythonPackage rec {
@@ -26,7 +24,7 @@ buildPythonPackage rec {
 
   buildInputs = [ pytest ];
 
-  propagatedBuildInputs = [ isort ] ++ lib.optionals (pythonOlder "3.8") [ importlib-metadata ];
+  propagatedBuildInputs = [ isort ];
 
   nativeCheckInputs = [ pytestCheckHook ];
 

--- a/pkgs/development/python-modules/python-miio/default.nix
+++ b/pkgs/development/python-modules/python-miio/default.nix
@@ -11,14 +11,12 @@
   defusedxml,
   fetchPypi,
   fetchpatch,
-  importlib-metadata,
   micloud,
   netifaces,
   poetry-core,
   pytest-asyncio,
   pytest-mock,
   pytestCheckHook,
-  pythonOlder,
   pytz,
   pyyaml,
   tqdm,
@@ -67,8 +65,7 @@ buildPythonPackage rec {
     pyyaml
     tqdm
     zeroconf
-  ]
-  ++ lib.optionals (pythonOlder "3.8") [ importlib-metadata ];
+  ];
 
   nativeCheckInputs = [
     pytest-asyncio

--- a/pkgs/development/python-modules/python-rabbitair/default.nix
+++ b/pkgs/development/python-modules/python-rabbitair/default.nix
@@ -5,9 +5,7 @@
   fetchFromGitHub,
   pytest-asyncio,
   pytestCheckHook,
-  pythonOlder,
   setuptools,
-  typing-extensions,
   zeroconf,
 }:
 
@@ -28,8 +26,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     cryptography
     zeroconf
-  ]
-  ++ lib.optionals (pythonOlder "3.8") [ typing-extensions ];
+  ];
 
   nativeCheckInputs = [
     pytest-asyncio

--- a/pkgs/development/python-modules/pythonfinder/default.nix
+++ b/pkgs/development/python-modules/pythonfinder/default.nix
@@ -1,14 +1,12 @@
 {
   lib,
   buildPythonPackage,
-  cached-property,
   click,
   fetchFromGitHub,
   packaging,
   pytest-cov-stub,
   pytest-timeout,
   pytestCheckHook,
-  pythonOlder,
   setuptools,
 }:
 
@@ -26,7 +24,7 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [ setuptools ];
 
-  propagatedBuildInputs = [ packaging ] ++ lib.optionals (pythonOlder "3.8") [ cached-property ];
+  propagatedBuildInputs = [ packaging ];
 
   optional-dependencies = {
     cli = [ click ];

--- a/pkgs/development/python-modules/pyvo/default.nix
+++ b/pkgs/development/python-modules/pyvo/default.nix
@@ -4,7 +4,6 @@
   fetchPypi,
   astropy,
   pillow,
-  pythonOlder,
   pytestCheckHook,
   pytest-astropy,
   requests,
@@ -17,8 +16,6 @@ buildPythonPackage rec {
   pname = "pyvo";
   version = "1.8";
   pyproject = true;
-
-  disabled = pythonOlder "3.8"; # according to setup.cfg
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/quandl/default.nix
+++ b/pkgs/development/python-modules/quandl/default.nix
@@ -5,7 +5,6 @@
   faker,
   fetchPypi,
   httpretty,
-  importlib-metadata,
   inflection,
   jsondate,
   mock,
@@ -15,7 +14,6 @@
   parameterized,
   pytestCheckHook,
   python-dateutil,
-  pythonOlder,
   requests,
   six,
 }:
@@ -41,8 +39,7 @@ buildPythonPackage rec {
     python-dateutil
     six
     more-itertools
-  ]
-  ++ lib.optionals (pythonOlder "3.8") [ importlib-metadata ];
+  ];
 
   nativeCheckInputs = [
     factory-boy

--- a/pkgs/development/python-modules/signedjson/default.nix
+++ b/pkgs/development/python-modules/signedjson/default.nix
@@ -3,12 +3,9 @@
   buildPythonPackage,
   canonicaljson,
   fetchPypi,
-  importlib-metadata,
   pynacl,
   pytestCheckHook,
-  pythonOlder,
   setuptools-scm,
-  typing-extensions,
   unpaddedbase64,
 }:
 
@@ -28,10 +25,6 @@ buildPythonPackage rec {
     canonicaljson
     unpaddedbase64
     pynacl
-  ]
-  ++ lib.optionals (pythonOlder "3.8") [
-    importlib-metadata
-    typing-extensions
   ];
 
   nativeCheckInputs = [ pytestCheckHook ];

--- a/pkgs/development/python-modules/sphinxcontrib-spelling/default.nix
+++ b/pkgs/development/python-modules/sphinxcontrib-spelling/default.nix
@@ -2,8 +2,6 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  pythonOlder,
-  importlib-metadata,
   sphinx,
   pyenchant,
   setuptools,
@@ -32,8 +30,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     sphinx
     pyenchant
-  ]
-  ++ lib.optionals (pythonOlder "3.8") [ importlib-metadata ];
+  ];
 
   # No tests included
   doCheck = false;

--- a/pkgs/development/python-modules/statmake/default.nix
+++ b/pkgs/development/python-modules/statmake/default.nix
@@ -7,7 +7,6 @@
   fetchFromGitHub,
   fonttools,
   fs,
-  importlib-metadata,
   poetry-core,
   pytestCheckHook,
   pythonOlder,
@@ -43,8 +42,7 @@ buildPythonPackage rec {
     # required by fonttools[ufo]
     fs
   ]
-  ++ lib.optionals (pythonOlder "3.11") [ exceptiongroup ]
-  ++ lib.optionals (pythonOlder "3.8") [ importlib-metadata ];
+  ++ lib.optionals (pythonOlder "3.11") [ exceptiongroup ];
 
   nativeCheckInputs = [
     pytestCheckHook

--- a/pkgs/development/python-modules/troposphere/default.nix
+++ b/pkgs/development/python-modules/troposphere/default.nix
@@ -4,8 +4,6 @@
   buildPythonPackage,
   cfn-flip,
   fetchFromGitHub,
-  pythonOlder,
-  typing-extensions,
   unittestCheckHook,
 }:
 
@@ -21,7 +19,7 @@ buildPythonPackage rec {
     hash = "sha256-s7eb8W/QjD+lNmq3bPhCP3tH8VV/xNf3cE2dGzWAgFk=";
   };
 
-  propagatedBuildInputs = [ cfn-flip ] ++ lib.optionals (pythonOlder "3.8") [ typing-extensions ];
+  propagatedBuildInputs = [ cfn-flip ];
 
   nativeCheckInputs = [
     awacs

--- a/pkgs/servers/mautrix-telegram/default.nix
+++ b/pkgs/servers/mautrix-telegram/default.nix
@@ -26,7 +26,6 @@ in
 python.pkgs.buildPythonPackage rec {
   pname = "mautrix-telegram";
   version = "0.15.3";
-  disabled = python.pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "mautrix";


### PR DESCRIPTION
Tracking: https://github.com/NixOS/nixpkgs/issues/312288

Previous: https://github.com/NixOS/nixpkgs/pull/479981


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
