### PR TITLE
linyaps: 1.10.0 -> 1.11.0

### DIFF
--- a/pkgs/by-name/li/linyaps/package.nix
+++ b/pkgs/by-name/li/linyaps/package.nix
@@ -1,6 +1,5 @@
 {
   fetchFromGitHub,
-  fetchpatch,
   lib,
   stdenv,
   cmake,
@@ -10,10 +9,11 @@
   linyaps-box,
   cli11,
   curl,
+  elfutils,
   gpgme,
   gtest,
   libarchive,
-  libelf,
+  libcap,
   libsodium,
   libsysprof-capture,
   nlohmann_json,
@@ -24,7 +24,6 @@
   uncrustify,
   xz,
   yaml-cpp,
-  replaceVars,
   bash,
   binutils,
   coreutils,
@@ -39,13 +38,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "linyaps";
-  version = "1.10.0";
+  version = "1.11.0";
 
   src = fetchFromGitHub {
     owner = "OpenAtom-Linyaps";
     repo = finalAttrs.pname;
     tag = finalAttrs.version;
-    hash = "sha256-C5rP6r3V+hxTjM+kmXjS4MnuL6P5wxSVP9nNmlQbcB8=";
+    hash = "sha256-qPHDAwEQVnHLWGioEfgz11ZWhlEBJynap3a0hgfL050=";
   };
 
   patches = [
@@ -53,6 +52,9 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   postPatch = ''
+    substituteInPlace apps/ll-cli/src/main.cpp \
+      --replace-fail "ociRuntimeCLI, { BINDIR }" "ociRuntimeCLI, { \"${lib.getBin linyaps-box}/bin\" }"
+
     substituteInPlace apps/ll-init/CMakeLists.txt \
       --replace-fail "target_link_options(\''${LL_INIT_TARGET} PRIVATE -static -static-libgcc" \
                      "target_link_options(\''${LL_INIT_TARGET} PRIVATE -static -static-libgcc -L${stdenv.cc.libc.static}/lib"
@@ -68,10 +70,11 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     cli11
     curl
+    elfutils
     gpgme
     gtest
     libarchive
-    libelf
+    libcap
     libsodium
     libsysprof-capture
     nlohmann_json
@@ -90,6 +93,10 @@ stdenv.mkDerivation (finalAttrs: {
     copyDesktopItems
     pkg-config
     qt6Packages.wrapQtAppsHook
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "CPM_LOCAL_PACKAGES_ONLY" true)
   ];
 
   postInstall = ''


### PR DESCRIPTION
Use elfutils instead of libelf, for [ELF_C_READ_MMAP](https://man.archlinux.org/man/elf_begin.3.en#ELF_C_READ_MMAP) appeared in the code.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
