### PR TITLE
signal-desktop: force 90 days expiration

### DIFF
--- a/pkgs/by-name/si/signal-desktop/force-90-days-expiration.patch
+++ b/pkgs/by-name/si/signal-desktop/force-90-days-expiration.patch
@@ -1,0 +1,28 @@
+diff --git a/ts/scripts/get-expire-time.node.ts b/ts/scripts/get-expire-time.node.ts
+index 7938f74d3..9d427977d 100644
+--- a/ts/scripts/get-expire-time.node.ts
++++ b/ts/scripts/get-expire-time.node.ts
+@@ -18,7 +18,7 @@ const buildCreation = unixTimestamp * 1000;
+ 
+ // NB: Build expirations are also determined via users' auto-update settings; see
+ // getExpirationTimestamp
+-const validDuration = isNotUpdatable(version) ? DAY * 30 : DAY * 90;
++const validDuration = DAY * 90;
+ const buildExpiration = buildCreation + validDuration;
+ 
+ const localProductionPath = join(
+diff --git a/ts/util/buildExpiration.std.ts b/ts/util/buildExpiration.std.ts
+index 530443ec7..26cb03d7c 100644
+--- a/ts/util/buildExpiration.std.ts
++++ b/ts/util/buildExpiration.std.ts
+@@ -70,9 +70,7 @@ export function hasBuildExpired({
+     return true;
+   }
+ 
+-  const safeExpirationMs = autoDownloadUpdate
+-    ? NINETY_ONE_DAYS
+-    : THIRTY_ONE_DAYS;
++  const safeExpirationMs = NINETY_ONE_DAYS;
+ 
+   const buildExpirationDuration = buildExpirationTimestamp - now;
+   const tooFarIntoFuture = buildExpirationDuration > safeExpirationMs;

--- a/pkgs/by-name/si/signal-desktop/package.nix
+++ b/pkgs/by-name/si/signal-desktop/package.nix
@@ -111,7 +111,10 @@ stdenv.mkDerivation (finalAttrs: {
   ];
   buildInputs = (lib.optional (!withAppleEmojis) noto-fonts-color-emoji-png);
 
-  patches = lib.optional (!withAppleEmojis) (
+  patches = [
+    ./force-90-days-expiration.patch
+  ]
+  ++ lib.optional (!withAppleEmojis) (
     replaceVars ./replace-apple-emoji-with-noto-emoji.patch {
       noto-emoji-pngs = "${noto-fonts-color-emoji-png}/share/noto-fonts-color-emoji-png";
     }


### PR DESCRIPTION
This should prevent issues like <https://github.com/NixOS/nixpkgs/issues/481074> in the future.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
