### PR TITLE
php85: init at 8.5.2

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1240,6 +1240,10 @@ in
     inherit runTest;
     php = pkgs.php84;
   };
+  php85 = import ./php/default.nix {
+    inherit runTest;
+    php = pkgs.php85;
+  };
   phylactery = runTest ./web-apps/phylactery.nix;
   pict-rs = runTest ./pict-rs.nix;
   pihole-ftl = import ./pihole-ftl { inherit runTest; };

--- a/pkgs/development/interpreters/php/8.5.nix
+++ b/pkgs/development/interpreters/php/8.5.nix
@@ -1,0 +1,57 @@
+{ callPackage, ... }@_args:
+
+let
+  base = callPackage ./generic.nix (
+    _args
+    // {
+      version = "8.5.2";
+      hash = "sha256-9+/ezMOoELGJIGkjBlNrmaO6hmENvQeVopbPd9P7OgY=";
+    }
+  );
+in
+base.withExtensions (
+  { all, ... }:
+  with all;
+  [
+    bcmath
+    calendar
+    curl
+    ctype
+    dom
+    exif
+    fileinfo
+    filter
+    ftp
+    gd
+    gettext
+    gmp
+    iconv
+    intl
+    ldap
+    mbstring
+    mysqli
+    mysqlnd
+    openssl
+    pcntl
+    pdo
+    pdo_mysql
+    pdo_odbc
+    pdo_pgsql
+    pdo_sqlite
+    pgsql
+    posix
+    readline
+    session
+    simplexml
+    sockets
+    soap
+    sodium
+    sysvsem
+    sqlite3
+    tokenizer
+    xmlreader
+    xmlwriter
+    zip
+    zlib
+  ]
+)

--- a/pkgs/development/interpreters/php/generic.nix
+++ b/pkgs/development/interpreters/php/generic.nix
@@ -346,6 +346,10 @@ let
 
             substituteInPlace $dev/bin/phpize \
               --replace-fail "$out/lib" "$dev/lib"
+          ''
+          + lib.optionalString (lib.versionAtLeast version "8.5") ''
+            # PHP 8.5+ has lexbor built into core; dom needs its headers.
+            cp -r ext/lexbor/lexbor $dev/include/php/ext/lexbor/
           '';
 
           src = if phpSrc == null then defaultPhpSrc else phpSrc;

--- a/pkgs/development/php-packages/grpc/default.nix
+++ b/pkgs/development/php-packages/grpc/default.nix
@@ -3,6 +3,7 @@
   pkg-config,
   lib,
   grpc,
+  php,
 }:
 
 buildPecl {
@@ -26,5 +27,6 @@ buildPecl {
     homepage = "https://github.com/grpc/grpc/tree/master/src/php/ext/grpc";
     license = lib.licenses.asl20;
     teams = [ lib.teams.php ];
+    broken = lib.versionAtLeast php.version "8.5";
   };
 }

--- a/pkgs/development/php-packages/igbinary/default.nix
+++ b/pkgs/development/php-packages/igbinary/default.nix
@@ -1,5 +1,8 @@
-{ buildPecl, lib }:
-
+{
+  buildPecl,
+  lib,
+  php,
+}:
 buildPecl {
   pname = "igbinary";
   version = "3.2.14";
@@ -17,5 +20,6 @@ buildPecl {
     homepage = "https://github.com/igbinary/igbinary/";
     license = lib.licenses.bsd3;
     teams = [ lib.teams.php ];
+    broken = lib.versionAtLeast php.version "8.5";
   };
 }

--- a/pkgs/development/php-packages/ioncube-loader/default.nix
+++ b/pkgs/development/php-packages/ioncube-loader/default.nix
@@ -49,6 +49,7 @@ stdenv.mkDerivation {
     sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
     license = lib.licenses.unfree;
     maintainers = with lib.maintainers; [ neverbehave ];
+    broken = lib.versionAtLeast php.version "8.5";
     platforms = [
       "x86_64-linux"
       "aarch64-linux"

--- a/pkgs/development/php-packages/memcache/default.nix
+++ b/pkgs/development/php-packages/memcache/default.nix
@@ -31,5 +31,6 @@ buildPecl rec {
     homepage = "https://github.com/websupport-sk/pecl-memcache";
     maintainers = [ lib.maintainers.krzaczek ];
     teams = [ lib.teams.php ];
+    broken = lib.versionAtLeast php.version "8.5";
   };
 }

--- a/pkgs/development/php-packages/openswoole/default.nix
+++ b/pkgs/development/php-packages/openswoole/default.nix
@@ -35,6 +35,6 @@ buildPecl {
       You can use the sync or async, Coroutine API to write whole applications or create thousands of light weight Coroutines within one Linux process.
     '';
     teams = [ lib.teams.php ];
-    broken = lib.versionOlder php.version "8.2";
+    broken = lib.versionOlder php.version "8.2" || lib.versionAtLeast php.version "8.5";
   };
 }

--- a/pkgs/development/php-packages/pdo_sqlsrv/default.nix
+++ b/pkgs/development/php-packages/pdo_sqlsrv/default.nix
@@ -22,5 +22,6 @@ buildPecl {
     license = lib.licenses.mit;
     homepage = "https://github.com/Microsoft/msphpsql";
     teams = [ lib.teams.php ];
+    broken = lib.versionAtLeast php.version "8.5";
   };
 }

--- a/pkgs/development/php-packages/phalcon/default.nix
+++ b/pkgs/development/php-packages/phalcon/default.nix
@@ -38,5 +38,6 @@ buildPecl rec {
     homepage = "https://phalcon.io";
     maintainers = [ lib.maintainers.krzaczek ];
     teams = [ lib.teams.php ];
+    broken = lib.versionAtLeast php.version "8.5";
   };
 }

--- a/pkgs/development/php-packages/rrd/default.nix
+++ b/pkgs/development/php-packages/rrd/default.nix
@@ -3,6 +3,7 @@
   lib,
   pkg-config,
   rrdtool,
+  fetchpatch,
 }:
 
 buildPecl {
@@ -17,6 +18,14 @@ buildPecl {
 
   nativeBuildInputs = [
     pkg-config
+  ];
+
+  patches = [
+    # PHP 8.5 compatibility patch
+    (fetchpatch {
+      url = "https://github.com/php/pecl-processing-rrd/pull/4/commits/dd4856dc89499a0141b1710e791f0e1096c7b244.patch";
+      hash = "sha256-ES+cMhMBUubFB5TpTZzzKKfEK2cY737z7zCuNy4XF8Y=";
+    })
   ];
 
   # Fix GCC 14 build.

--- a/pkgs/development/php-packages/swoole/default.nix
+++ b/pkgs/development/php-packages/swoole/default.nix
@@ -33,5 +33,6 @@ buildPecl {
     homepage = "https://www.swoole.com";
     license = lib.licenses.asl20;
     teams = [ lib.teams.php ];
+    broken = lib.versionAtLeast php.version "8.5";
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5476,6 +5476,16 @@ with pkgs;
   phpExtensions = recurseIntoAttrs php.extensions;
   phpPackages = recurseIntoAttrs php.packages;
 
+  # Import PHP85 interpreter, extensions and packages
+  php85 = callPackage ../development/interpreters/php/8.5.nix {
+    stdenv = if stdenv.cc.isClang then llvmPackages.stdenv else stdenv;
+    pcre2 = pcre2.override {
+      withJitSealloc = false; # See https://bugs.php.net/bug.php?id=78927 and https://bugs.php.net/bug.php?id=78630
+    };
+  };
+  php85Extensions = recurseIntoAttrs php85.extensions;
+  php85Packages = recurseIntoAttrs php85.packages;
+
   # Import PHP84 interpreter, extensions and packages
   php84 = callPackage ../development/interpreters/php/8.4.nix {
     stdenv = if stdenv.cc.isClang then llvmPackages.stdenv else stdenv;

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -447,6 +447,10 @@ lib.makeScope pkgs.newScope (
               configureFlags = [
                 "--enable-dom"
               ];
+              # PHP 8.5+ has lexbor built into core; dom needs its headers.
+              env = lib.optionalAttrs (lib.versionAtLeast php.version "8.5") {
+                NIX_CFLAGS_COMPILE = "-I${php.unwrapped.dev}/include/php/ext/lexbor";
+              };
             }
             {
               name = "enchant";
@@ -572,28 +576,6 @@ lib.makeScope pkgs.newScope (
                      | Copyright (c) The PHP Group                                          |
                 '')
               ];
-            }
-            {
-              name = "opcache";
-              buildInputs = [
-                pcre2
-              ]
-              ++ lib.optional (
-                !stdenv.hostPlatform.isDarwin && lib.meta.availableOn stdenv.hostPlatform valgrind
-              ) valgrind.dev;
-              configureFlags = lib.optional php.ztsSupport "--disable-opcache-jit";
-              zendExtension = true;
-              postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
-                # Tests are flaky on darwin
-                rm ext/opcache/tests/blacklist.phpt
-                rm ext/opcache/tests/bug66338.phpt
-                rm ext/opcache/tests/bug78106.phpt
-                rm ext/opcache/tests/issue0115.phpt
-                rm ext/opcache/tests/issue0149.phpt
-                rm ext/opcache/tests/revalidate_path_01.phpt
-              '';
-              # Tests launch the builtin webserver.
-              __darwinAllowLocalNetworking = true;
             }
             {
               name = "openssl";
@@ -828,6 +810,30 @@ lib.makeScope pkgs.newScope (
                 "--with-imap-ssl"
                 "--with-kerberos"
               ];
+            }
+          ]
+          ++ lib.optionals (lib.versionOlder php.version "8.5") [
+            {
+              name = "opcache";
+              buildInputs = [
+                pcre2
+              ]
+              ++ lib.optional (
+                !stdenv.hostPlatform.isDarwin && lib.meta.availableOn stdenv.hostPlatform valgrind
+              ) valgrind.dev;
+              configureFlags = lib.optional php.ztsSupport "--disable-opcache-jit";
+              zendExtension = true;
+              postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
+                # Tests are flaky on darwin
+                rm ext/opcache/tests/blacklist.phpt
+                rm ext/opcache/tests/bug66338.phpt
+                rm ext/opcache/tests/bug78106.phpt
+                rm ext/opcache/tests/issue0115.phpt
+                rm ext/opcache/tests/issue0149.phpt
+                rm ext/opcache/tests/revalidate_path_01.phpt
+              '';
+              # Tests launch the builtin webserver.
+              __darwinAllowLocalNetworking = true;
             }
           ];
 


### PR DESCRIPTION
Supersedes https://github.com/NixOS/nixpkgs/pull/422308

Notes:
opcache is now built-in. I run a test using `var_dump(function_exists('opcache_get_status'));`

uri extension works. Tested using:

```
$uri = Uri\Rfc3986\Uri::parse('https://example.com/path?query=value#fragment');  
var_dump($uri->getScheme());
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
