### PR TITLE
kimai: (re-)enable Composer plugins and asset install; fix running Kimai, 2.44.0 -> 2.46.0

### DIFF
--- a/pkgs/by-name/ki/kimai/package.nix
+++ b/pkgs/by-name/ki/kimai/package.nix
@@ -40,6 +40,7 @@ php.buildComposerProject2 (finalAttrs: {
 
   vendorHash = "sha256-3/LT5HjCpnO3Sz+NshrSMTujtYka0FMyT56qmiEi2t4=";
 
+  composerNoPlugins = false;
   postInstall = ''
     # Make available the console utility, as Kimai doesn't list this in
     # composer.json.
@@ -48,7 +49,7 @@ php.buildComposerProject2 (finalAttrs: {
 
     # Install bundled assets. This is normally done in the `composer install`
     # post-install script, but it's being skipped.
-    # (cd "$out"/share/php/kimai && php ./bin/console assets:install)
+    (cd "$out"/share/php/kimai && php ./bin/console assets:install)
   '';
 
   passthru.tests = {

--- a/pkgs/by-name/ki/kimai/package.nix
+++ b/pkgs/by-name/ki/kimai/package.nix
@@ -7,13 +7,13 @@
 
 php.buildComposerProject2 (finalAttrs: {
   pname = "kimai";
-  version = "2.44.0";
+  version = "2.46.0";
 
   src = fetchFromGitHub {
     owner = "kimai";
     repo = "kimai";
     tag = finalAttrs.version;
-    hash = "sha256-Y2nLM4OK5FsX4e1o0mar5PizwLsqcFdnq4NISp936gE=";
+    hash = "sha256-sZjDl3nQ4i5KVnM2fLVvaQxMlE225q7EBkgFmTn+ugc=";
   };
 
   php = php.buildEnv {
@@ -38,7 +38,7 @@ php.buildComposerProject2 (finalAttrs: {
     '';
   };
 
-  vendorHash = "sha256-3/LT5HjCpnO3Sz+NshrSMTujtYka0FMyT56qmiEi2t4=";
+  vendorHash = "sha256-FJaWNlzOIm4hJexgKI8fEmRvBfaa8nxxkg8zJeCz3SU=";
 
   composerNoPlugins = false;
   postInstall = ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
`composerNoPlugins = false` allow plugin from Symphony, Kimai's
dependency, to create `autoload_runtime.php`. Meanwhile, asset install
step in `postInstall` script copies certain static assets to its final
position.

Both were disabled as part of PR 459254 [^1].

[^1]: https://github.com/NixOS/nixpkgs/pull/459254 ("build-support/php:
        improve PHP builder stability")

While we're at it, update Kimai from 2.44.0 -> 2.46.0. Changelog: https://github.com/kimai/kimai/releases/tag/2.45.0 https://github.com/kimai/kimai/releases/tag/2.46.0

This PR supersedes #476774.

Fixes #481730 for NixOS unstable.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
