### PR TITLE
muscle: switch to finalAttrs and fix sourceRoot

### DIFF
--- a/pkgs/by-name/mu/muscle/package.nix
+++ b/pkgs/by-name/mu/muscle/package.nix
@@ -4,18 +4,18 @@
   fetchFromGitHub,
 }:
 
-gccStdenv.mkDerivation rec {
+gccStdenv.mkDerivation (finalAttrs: {
   pname = "muscle";
   version = "5.1.0";
 
   src = fetchFromGitHub {
     owner = "rcedgar";
     repo = "muscle";
-    rev = version;
+    tag = finalAttrs.version;
     hash = "sha256-NpnJziZXga/T5OavUt3nQ5np8kJ9CFcSmwyg4m6IJsk=";
   };
 
-  sourceRoot = "${src.name}/src";
+  sourceRoot = "${finalAttrs.src.name}/src";
 
   patches = [
     ./muscle-darwin-g++.patch
@@ -38,4 +38,4 @@ gccStdenv.mkDerivation rec {
       unode
     ];
   };
-}
+})


### PR DESCRIPTION
This pull request updates the `muscle` package definition in `package.nix` to use the newer function argument style and makes minor improvements for consistency and correctness.

**Refactoring and modernization:**

* Refactored `gccStdenv.mkDerivation` usage to accept a lambda with `finalAttrs` instead of using `rec`, improving compatibility with newer Nixpkgs conventions. 

**Minor improvements:**

* Replaced `rev = version;` with `tag = finalAttrs.version;` in the `fetchFromGitHub` call for clarity and correctness.
* Updated attribute references from `src` and `version` to `finalAttrs.src` and `finalAttrs.version` for consistency within the lambda.
* Changed `sourceRoot` to use `finalAttrs.src.name` for accuracy in source path resolution.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
