### PR TITLE
programmer-calculator: switch to finalAttrs and modernize hash

### DIFF
--- a/pkgs/by-name/pr/programmer-calculator/package.nix
+++ b/pkgs/by-name/pr/programmer-calculator/package.nix
@@ -5,7 +5,7 @@
   ncurses,
 }:
 
-gccStdenv.mkDerivation rec {
+gccStdenv.mkDerivation (finalAttrs: {
   pname = "programmer-calculator";
   version = "3.0-unstable-2025-11-06";
 
@@ -13,7 +13,7 @@ gccStdenv.mkDerivation rec {
     owner = "alt-romes";
     repo = "programmer-calculator";
     rev = "153272c50b2491ddf25dfbfcf228a08a3b3ace69";
-    sha256 = "sha256-24OYG3tVxcc/1i9HRrzW/jPY41KnKkugLziWnG1wQIw=";
+    hash = "sha256-24OYG3tVxcc/1i9HRrzW/jPY41KnKkugLziWnG1wQIw=";
   };
 
   buildInputs = [ ncurses ];
@@ -32,9 +32,9 @@ gccStdenv.mkDerivation rec {
       representations, sizes, and overall close to the bits
     '';
     homepage = "https://alt-romes.github.io/programmer-calculator";
-    changelog = "https://github.com/alt-romes/programmer-calculator/releases/tag/v${lib.versions.majorMinor version}";
+    changelog = "https://github.com/alt-romes/programmer-calculator/releases/tag/v${lib.versions.majorMinor finalAttrs.version}";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ cjab ];
     platforms = lib.platforms.all;
   };
-}
+})


### PR DESCRIPTION
This pull request makes minor improvements to the `programmer-calculator` package definition, mainly updating the derivation style and correcting attribute usage for better compatibility and maintainability.

Packaging improvements:

* Refactored the derivation to use the lambda-style `mkDerivation (finalAttrs: { ... })` instead of the older `rec` style, aligning with modern Nix packaging conventions.
* Updated the `changelog` attribute to reference `finalAttrs.version` instead of `version`, ensuring correct version interpolation after attribute finalization.
* Renamed the `sha256` attribute to `hash` in the `fetchFromGitHub` call, following updated Nix conventions.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
