### PR TITLE
romdirfs: switch to finalAttrs and modernize fetcher

### DIFF
--- a/pkgs/by-name/ro/romdirfs/package.nix
+++ b/pkgs/by-name/ro/romdirfs/package.nix
@@ -7,15 +7,15 @@
   fuse,
 }:
 
-gccStdenv.mkDerivation rec {
+gccStdenv.mkDerivation (finalAttrs: {
   pname = "romdirfs";
   version = "1.2";
 
   src = fetchFromGitHub {
     owner = "mlafeldt";
     repo = "romdirfs";
-    rev = "v${version}";
-    sha256 = "1jbsmpklrycz5q86qmzvbz4iz2g5fvd7p9nca160aw2izwpws0g7";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-5wHNL/9RcAVMUMyme9p25YkfyV/7V2wQLp/5TOetesk=";
   };
 
   nativeBuildInputs = [
@@ -37,4 +37,4 @@ gccStdenv.mkDerivation rec {
     maintainers = [ ];
     mainProgram = "romdirfs";
   };
-}
+})


### PR DESCRIPTION
This pull request updates the packaging of `romdirfs` in Nixpkgs to use a more modern and maintainable derivation style. The main changes involve switching to the lambda-style argument for `mkDerivation` and updating how source fetching is handled.

Packaging modernization:

* Refactored `romdirfs` package to use the lambda-style argument for `gccStdenv.mkDerivation`, improving maintainability and consistency with current Nixpkgs best practices. 

Source fetching improvements:

* Updated the `src` attribute to use the `tag` and `hash` arguments instead of `rev` and `sha256`, aligning with the latest Nix conventions and improving clarity.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
