### PR TITLE
nixos/tandoor-recipes: update MEDIA_ROOT remediation docs

### DIFF
--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -65,11 +65,16 @@
   "module-services-keycloak-unix-socket": [
     "index.html#module-services-keycloak-unix-socket"
   ],
-  "module-services-tandoor-recipes-migrating-media-option-1": [
+  "module-services-tandoor-recipes-migrating-media-option-move": [
+    "index.html#module-services-tandoor-recipes-migrating-media-option-move",
     "index.html#module-services-tandoor-recipes-migrating-media-option-1"
   ],
-  "module-services-tandoor-recipes-migrating-media-option-2": [
+  "module-services-tandoor-recipes-migrating-media-option-postgresql": [
+    "index.html#module-services-tandoor-recipes-migrating-media-option-postgresql",
     "index.html#module-services-tandoor-recipes-migrating-media-option-2"
+  ],
+  "module-services-tandoor-recipes-migrating-media-option-disallow-access": [
+    "index.html#module-services-tandoor-recipes-migrating-media-option-disallow-access"
   ],
   "sec-override-nixos-test": [
     "index.html#sec-override-nixos-test"

--- a/nixos/modules/services/misc/tandoor-recipes.md
+++ b/nixos/modules/services/misc/tandoor-recipes.md
@@ -1,19 +1,53 @@
 # Tandoor Recipes {#module-services-tandoor-recipes}
 
-## Dealing with `MEDIA_ROOT` for installations prior 26.05 {#module-services-tandoor-recipes-migrating-media}
+## Remediating insecure `MEDIA_ROOT` for installations prior to 26.05 {#module-services-tandoor-recipes-migrating-media}
 
-See https://github.com/NixOS/nixpkgs/issues/338339 for some background.
+Tandoor Recipes installations initialized with `system.stateVersion < 26.05`
+may suffer from a security vulnerability. To remediate this issue, apply one of
+the recommendations below.
 
-### Option 1: Migrate media to new `MEDIA_ROOT` {#module-services-tandoor-recipes-migrating-media-option-1}
+See [NixOS/nixpkgs#338339](https://github.com/NixOS/nixpkgs/issues/338339) and
+[GHSA-g8w3-p77x-mmxh](https://github.com/NixOS/nixpkgs/security/advisories/GHSA-g8w3-p77x-mmxh)
+for some background.
+
+### Recommended: Move `MEDIA_ROOT` into a subdirectory {#module-services-tandoor-recipes-migrating-media-option-move}
+
+The issue is only present when `MEDIA_ROOT` is the same as the data directory. Moving it into a subdirectory of `/var/lib/tandoor-recipes` remediates this and any similar issues in the future.
 
 1. Stop the currently running service: `systemctl stop tandoor-recipes.service`
 2. Create a media folder. NixOS `26.05` creates the media path at `/var/lib/tandoor-recipes/media` by default, but you may choose any other path as well. `mkdir -p /var/lib/tandoor-recipes/media`
 3. Move existing media to the new path: `mv /var/lib/tandoor-recipes/{files,recipes} /var/lib/tandoor-recipes/media`
 4. Set `services.tandoor-recipes.extraConfig.MEDIA_ROOT = "/var/lib/tandoor-recipes/media";` in your NixOS configuration (not needed if `system.stateVersion >= 26.05`).
-5. Rebuild and switch!
+5. If not using `GUNICORN_MEDIA`, update your reverse proxy / web server configuration accordingly.
+6. Rebuild and switch!
 
 These changes can be reverted by moving the files back into the state directory.
 
-### Option 2: Keep existing directory (may be insecure) {#module-services-tandoor-recipes-migrating-media-option-2}
+### Not recommended: Switch to PostgreSQL {#module-services-tandoor-recipes-migrating-media-option-postgresql}
 
-To keep the existing directory, set `services.tandoor-recipes.extraConfig.MEDIA_ROOT = "/var/lib/tandoor-recipes";`.
+When using an external database like PostgreSQL (the only other option available in Tandoor Recipes) this issue does not manifest.
+
+A simple PostgreSQL configuration can be enabled using the option
+[`services.tandoor-recipes.database.createLocally`](https://search.nixos.org/options?channel=unstable&show=services.tandoor-recipes.database.createLocally).
+
+Note that this will require migrating the existing database to PostgreSQL. Refer to the [upstream documentation](https://docs.tandoor.dev/system/migration_sqlite-postgres/) for this procedure. It is important to delete or move the `db.sqlite3` file out of the media path, after this has been done.
+
+More information on configuring PostgreSQL can be found in the [upstream documentation](https://docs.tandoor.dev/system/configuration/#database).
+
+Set the following option to ignore the evaluation warnings once `db.sqlite3` has been deleted.
+
+```nix
+{
+  services.tandoor-recipes.extraConfig.MEDIA_ROOT = "/var/lib/tandoor-recipes";
+}
+```
+
+As future releases of Tandoor Recipes could add additional files to the data
+directory, this is not a future-proof solution.
+
+### Not recommended: Disallow access to `db.sqlite3` {#module-services-tandoor-recipes-migrating-media-option-disallow-access}
+
+When using a web server like nginx, access to this file can be disabled.
+
+As future releases of Tandoor Recipes could add additional files to the data
+directory, this is not a future-proof solution.


### PR DESCRIPTION
In preparation for the upcoming GHSA, update the remediation docs for
Tandoor Recipes.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
