### PR TITLE
nixos/drupal: add support for custom pnames

### DIFF
--- a/nixos/modules/services/web-apps/drupal.nix
+++ b/nixos/modules/services/web-apps/drupal.nix
@@ -51,10 +51,10 @@ let
       '';
 
       postInstall = ''
-        ln -s ${cfg.filesDir} $out/share/php/drupal/sites/default/files
-        ln -s ${cfg.stateDir}/sites/default/settings.php $out/share/php/drupal/sites/default/settings.php
-        ln -s ${cfg.modulesDir} $out/share/php/drupal/modules
-        ln -s ${cfg.themesDir} $out/share/php/drupal/themes
+        ln -s ${cfg.filesDir} $out/share/php/${cfg.package.pname}/sites/default/files
+        ln -s ${cfg.stateDir}/sites/default/settings.php $out/share/php/${cfg.package.pname}/sites/default/settings.php
+        ln -s ${cfg.modulesDir} $out/share/php/${cfg.package.pname}/modules
+        ln -s ${cfg.themesDir} $out/share/php/${cfg.package.pname}/themes
       '';
     });
 
@@ -387,7 +387,7 @@ in
 
                 if [ ! -d "${cfg.stateDir}/sites" ]; then
                   echo "Preparing sites directory..."
-                  cp -r "${cfg.package}/share/php/drupal/sites" "${cfg.stateDir}"
+                  cp -r "${cfg.package}/share/php/${cfg.package.pname}/sites" "${cfg.stateDir}"
                 fi
 
                 if [ ! -d "${cfg.filesDir}" ]; then
@@ -397,7 +397,7 @@ in
                 fi
 
                 settings_file="${cfg.stateDir}/sites/default/settings.php"
-                default_settings="${cfg.package}/share/php/drupal/sites/default/default.settings.php"
+                default_settings="${cfg.package}/share/php/${cfg.package.pname}/sites/default/default.settings.php"
 
                 if [ ! -f "$settings_file" ]; then
                   echo "Preparing settings.php for ${hostName}..."
@@ -434,7 +434,7 @@ in
         enable = true;
         virtualHosts = mapAttrs (hostName: cfg: {
           serverName = mkDefault hostName;
-          root = "${pkg hostName cfg}/share/php/drupal";
+          root = "${pkg hostName cfg}/share/php/${cfg.package.pname}";
           extraConfig = ''
             index index.php;
           '';
@@ -535,7 +535,7 @@ in
           hostName: cfg:
           (nameValuePair hostName {
             extraConfig = ''
-              root * ${pkg hostName cfg}/share/php/drupal
+              root * ${pkg hostName cfg}/share/php/${cfg.package.pname}
               file_server
 
               encode zstd gzip


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR fixes a bug and enables users to define their own Drupal package with a custom `pname` attribute. In particular, it updates some path names of the derivation that results from `buildComposerProject2`.

When using `buildComposerProject2`, the package gets built at `$out/share/php/<pname>` where `<pname>` is the project's `pname` attribute. The changes here allow that name to be dynamic, without breaking the standard nixpkgs build.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
