### PR TITLE
[25.11] nixos/tandoor-recipes: fix database leak when serving media

### DIFF
--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -38,11 +38,16 @@
   "module-boot-plymouth-tpm2-totp-quick-start-enable": [
     "index.html#module-boot-plymouth-tpm2-totp-quick-start-enable"
   ],
-  "module-services-tandoor-recipes-migrating-media-option-1": [
+  "module-services-tandoor-recipes-migrating-media-option-move": [
+    "index.html#module-services-tandoor-recipes-migrating-media-option-move",
     "index.html#module-services-tandoor-recipes-migrating-media-option-1"
   ],
-  "module-services-tandoor-recipes-migrating-media-option-2": [
+  "module-services-tandoor-recipes-migrating-media-option-postgresql": [
+    "index.html#module-services-tandoor-recipes-migrating-media-option-postgresql",
     "index.html#module-services-tandoor-recipes-migrating-media-option-2"
+  ],
+  "module-services-tandoor-recipes-migrating-media-option-disallow-access": [
+    "index.html#module-services-tandoor-recipes-migrating-media-option-disallow-access"
   ],
   "sec-override-nixos-test": [
     "index.html#sec-override-nixos-test"

--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -38,6 +38,12 @@
   "module-boot-plymouth-tpm2-totp-quick-start-enable": [
     "index.html#module-boot-plymouth-tpm2-totp-quick-start-enable"
   ],
+  "module-services-tandoor-recipes-migrating-media-option-1": [
+    "index.html#module-services-tandoor-recipes-migrating-media-option-1"
+  ],
+  "module-services-tandoor-recipes-migrating-media-option-2": [
+    "index.html#module-services-tandoor-recipes-migrating-media-option-2"
+  ],
   "sec-override-nixos-test": [
     "index.html#sec-override-nixos-test"
   ],
@@ -1106,6 +1112,12 @@
   ],
   "module-services-samba-configuring-file-share": [
     "index.html#module-services-samba-configuring-file-share"
+  ],
+  "module-services-tandoor-recipes": [
+    "index.html#module-services-tandoor-recipes"
+  ],
+  "module-services-tandoor-recipes-migrating-media": [
+    "index.html#module-services-tandoor-recipes-migrating-media"
   ],
   "module-services-litestream": [
     "index.html#module-services-litestream"

--- a/nixos/modules/services/misc/tandoor-recipes.md
+++ b/nixos/modules/services/misc/tandoor-recipes.md
@@ -1,0 +1,19 @@
+# Tandoor Recipes {#module-services-tandoor-recipes}
+
+## Dealing with `MEDIA_ROOT` for installations prior 26.05 {#module-services-tandoor-recipes-migrating-media}
+
+See https://github.com/NixOS/nixpkgs/issues/338339 for some background.
+
+### Option 1: Migrate media to new `MEDIA_ROOT` {#module-services-tandoor-recipes-migrating-media-option-1}
+
+1. Stop the currently running service: `systemctl stop tandoor-recipes.service`
+2. Create a media folder. NixOS `26.05` creates the media path at `/var/lib/tandoor-recipes/media` by default, but you may choose any other path as well. `mkdir -p /var/lib/tandoor-recipes/media`
+3. Move existing media to the new path: `mv /var/lib/tandoor-recipes/{files,recipes} /var/lib/tandoor-recipes/media`
+4. Set `services.tandoor-recipes.extraConfig.MEDIA_ROOT = "/var/lib/tandoor-recipes/media";` in your NixOS configuration (not needed if `system.stateVersion >= 26.05`).
+5. Rebuild and switch!
+
+These changes can be reverted by moving the files back into the state directory.
+
+### Option 2: Keep existing directory (may be insecure) {#module-services-tandoor-recipes-migrating-media-option-2}
+
+To keep the existing directory, set `services.tandoor-recipes.extraConfig.MEDIA_ROOT = "/var/lib/tandoor-recipes";`.

--- a/nixos/modules/services/misc/tandoor-recipes.md
+++ b/nixos/modules/services/misc/tandoor-recipes.md
@@ -1,19 +1,53 @@
 # Tandoor Recipes {#module-services-tandoor-recipes}
 
-## Dealing with `MEDIA_ROOT` for installations prior 26.05 {#module-services-tandoor-recipes-migrating-media}
+## Remediating insecure `MEDIA_ROOT` for installations prior to 26.05 {#module-services-tandoor-recipes-migrating-media}
 
-See https://github.com/NixOS/nixpkgs/issues/338339 for some background.
+Tandoor Recipes installations initialized with `system.stateVersion < 26.05`
+may suffer from a security vulnerability. To remediate this issue, apply one of
+the recommendations below.
 
-### Option 1: Migrate media to new `MEDIA_ROOT` {#module-services-tandoor-recipes-migrating-media-option-1}
+See [NixOS/nixpkgs#338339](https://github.com/NixOS/nixpkgs/issues/338339) and
+[GHSA-g8w3-p77x-mmxh](https://github.com/NixOS/nixpkgs/security/advisories/GHSA-g8w3-p77x-mmxh)
+for some background.
+
+### Recommended: Move `MEDIA_ROOT` into a subdirectory {#module-services-tandoor-recipes-migrating-media-option-move}
+
+The issue is only present when `MEDIA_ROOT` is the same as the data directory. Moving it into a subdirectory of `/var/lib/tandoor-recipes` remediates this and any similar issues in the future.
 
 1. Stop the currently running service: `systemctl stop tandoor-recipes.service`
 2. Create a media folder. NixOS `26.05` creates the media path at `/var/lib/tandoor-recipes/media` by default, but you may choose any other path as well. `mkdir -p /var/lib/tandoor-recipes/media`
 3. Move existing media to the new path: `mv /var/lib/tandoor-recipes/{files,recipes} /var/lib/tandoor-recipes/media`
 4. Set `services.tandoor-recipes.extraConfig.MEDIA_ROOT = "/var/lib/tandoor-recipes/media";` in your NixOS configuration (not needed if `system.stateVersion >= 26.05`).
-5. Rebuild and switch!
+5. If not using `GUNICORN_MEDIA`, update your reverse proxy / web server configuration accordingly.
+6. Rebuild and switch!
 
 These changes can be reverted by moving the files back into the state directory.
 
-### Option 2: Keep existing directory (may be insecure) {#module-services-tandoor-recipes-migrating-media-option-2}
+### Not recommended: Switch to PostgreSQL {#module-services-tandoor-recipes-migrating-media-option-postgresql}
 
-To keep the existing directory, set `services.tandoor-recipes.extraConfig.MEDIA_ROOT = "/var/lib/tandoor-recipes";`.
+When using an external database like PostgreSQL (the only other option available in Tandoor Recipes) this issue does not manifest.
+
+A simple PostgreSQL configuration can be enabled using the option
+[`services.tandoor-recipes.database.createLocally`](https://search.nixos.org/options?channel=unstable&show=services.tandoor-recipes.database.createLocally).
+
+Note that this will require migrating the existing database to PostgreSQL. Refer to the [upstream documentation](https://docs.tandoor.dev/system/migration_sqlite-postgres/) for this procedure. It is important to delete or move the `db.sqlite3` file out of the media path, after this has been done.
+
+More information on configuring PostgreSQL can be found in the [upstream documentation](https://docs.tandoor.dev/system/configuration/#database).
+
+Set the following option to ignore the evaluation warnings once `db.sqlite3` has been deleted.
+
+```nix
+{
+  services.tandoor-recipes.extraConfig.MEDIA_ROOT = "/var/lib/tandoor-recipes";
+}
+```
+
+As future releases of Tandoor Recipes could add additional files to the data
+directory, this is not a future-proof solution.
+
+### Not recommended: Disallow access to `db.sqlite3` {#module-services-tandoor-recipes-migrating-media-option-disallow-access}
+
+When using a web server like nginx, access to this file can be disabled.
+
+As future releases of Tandoor Recipes could add additional files to the data
+directory, this is not a future-proof solution.

--- a/nixos/modules/services/misc/tandoor-recipes.nix
+++ b/nixos/modules/services/misc/tandoor-recipes.nix
@@ -7,13 +7,15 @@
 let
   cfg = config.services.tandoor-recipes;
   pkg = cfg.package;
+  stateDir = "/var/lib/tandoor-recipes";
+  useNewMediaRoot = lib.versionAtLeast config.system.stateVersion "26.05";
 
   # SECRET_KEY through an env file
   env = {
     GUNICORN_CMD_ARGS = "--bind=${cfg.address}:${toString cfg.port}";
     DEBUG = "0";
     DEBUG_TOOLBAR = "0";
-    MEDIA_ROOT = "/var/lib/tandoor-recipes";
+    MEDIA_ROOT = "${stateDir}${lib.optionalString useNewMediaRoot "/media"}";
   }
   // lib.optionalAttrs (config.time.timeZone != null) {
     TZ = config.time.timeZone;
@@ -26,12 +28,15 @@ let
     # UID is a read-only shell variable
     eval "$(${config.systemd.package}/bin/systemctl show -pUID,GID,MainPID tandoor-recipes.service | tr '[:upper:]' '[:lower:]')"
     exec ${pkgs.util-linux}/bin/nsenter \
-      -t $mainpid -m -S $uid -G $gid --wdns=${env.MEDIA_ROOT} \
+      -t $mainpid -m -S $uid -G $gid --wdns=${stateDir} \
       ${pkg}/bin/tandoor-recipes "$@"
   '';
 in
 {
-  meta.maintainers = with lib.maintainers; [ jvanbruegge ];
+  meta = {
+    maintainers = with lib.maintainers; [ jvanbruegge ];
+    doc = ./tandoor-recipes.md;
+  };
 
   options.services.tandoor-recipes = {
     enable = lib.mkOption {
@@ -101,6 +106,10 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    warnings = lib.mkIf (!useNewMediaRoot && !(cfg.extraConfig ? MEDIA_ROOT)) [
+      "`services.tandoor-recipes.extraConfig.MEDIA_ROOT` is unset. This is considered insecure for `system.stateVersion` < 26.05. See https://nixos.org/manual/nixos/stable/#module-services-tandoor-recipes-migrating-media for migration instructions."
+    ];
+
     users.users = lib.mkIf (cfg.user == "tandoor_recipes") {
       tandoor_recipes = {
         inherit (cfg) group;
@@ -126,8 +135,11 @@ in
 
         User = cfg.user;
         Group = cfg.group;
-        StateDirectory = "tandoor-recipes";
-        WorkingDirectory = env.MEDIA_ROOT;
+        StateDirectory = [
+          "tandoor-recipes"
+        ]
+        ++ lib.optional (env.MEDIA_ROOT == "/var/lib/tandoor-recipes/media") "tandoor-recipes/media";
+        WorkingDirectory = stateDir;
         RuntimeDirectory = "tandoor-recipes";
 
         BindReadOnlyPaths = [

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1551,6 +1551,7 @@ in
   szurubooru = handleTest ./szurubooru.nix { };
   taler = handleTest ./taler { };
   tandoor-recipes = runTest ./tandoor-recipes.nix;
+  tandoor-recipes-media = runTest ./tandoor-recipes-media.nix;
   tandoor-recipes-script-name = runTest ./tandoor-recipes-script-name.nix;
   tang = runTest ./tang.nix;
   taskchampion-sync-server = runTest ./taskchampion-sync-server.nix;

--- a/nixos/tests/tandoor-recipes-media.nix
+++ b/nixos/tests/tandoor-recipes-media.nix
@@ -1,0 +1,91 @@
+{ ... }:
+{
+  name = "tandoor-recipes-media";
+
+  nodes.machine = {
+    services.tandoor-recipes = {
+      enable = true;
+      # This setting is not recommended, but it's an easy way serve the media
+      # folder in this test.
+      extraConfig = {
+        GUNICORN_MEDIA = true;
+      };
+    };
+
+    specialisation.oldVersion.configuration = {
+      system.stateVersion = "25.11";
+      services.tandoor-recipes = {
+        enable = true;
+        extraConfig = {
+          GUNICORN_MEDIA = true;
+          # Explicitly set insecure value (skips warning)
+          MEDIA_ROOT = "/var/lib/tandoor-recipes";
+        };
+      };
+    };
+
+    specialisation.oldVersionOverrideMedia.configuration = {
+      system.stateVersion = "25.11";
+      services.tandoor-recipes = {
+        enable = true;
+        extraConfig = {
+          GUNICORN_MEDIA = true;
+          MEDIA_ROOT = "/var/lib/tandoor-recipes/media";
+        };
+      };
+    };
+  };
+
+  testScript =
+    { nodes, ... }:
+    let
+      specBase = "${nodes.machine.system.build.toplevel}/specialisation";
+      oldVersion = "${specBase}/oldVersion";
+      oldVersionOverrideMedia = "${specBase}/oldVersionOverrideMedia";
+    in
+    # python
+    ''
+      def wait_for_tandoor():
+        machine.wait_for_unit("tandoor-recipes.service")
+        machine.wait_for_open_port(8080)
+
+
+      def stop_and_rm():
+        machine.systemctl("stop tandoor-recipes")
+        machine.succeed("rm -r /var/lib/tandoor-recipes")
+
+
+      db_path = "http://localhost:8080/media/db.sqlite3"
+
+
+      # The media folder shouldn't contain the database. Subsequently it
+      # should **not** get served, resulting in a 404. Previously the
+      # database was located in the media folder. Therefore serving the media
+      # folder would expose the database. See #338339.
+      wait_for_tandoor()
+      machine.succeed(f"curl --head {db_path} | grep \"HTTP/1.1 404 Not Found\"")
+
+
+      # Switch to NixOS 24.11 to check if the setup still functions the same
+      # as before.
+      stop_and_rm()
+      machine.succeed("${oldVersion}/bin/switch-to-configuration test")
+
+      # With the old setup the media folder should contain the database.
+      # Subsequently it should get served, resulting in a 200.
+      wait_for_tandoor()
+      machine.succeed(f"curl --head {db_path} | grep \"HTTP/1.1 200 OK\"")
+
+
+      # Switch to NixOS 24.11 with the MEDIA_ROOT already set to
+      # /var/lib/tandoor-recipes/media.
+      stop_and_rm()
+      machine.succeed("${oldVersionOverrideMedia}/bin/switch-to-configuration test")
+
+      # With MEDIA_ROOT being set to /var/lib/tandoor-recipes/media the media
+      # folder shouldn't contain the database. Subsequently it should **not**
+      # get served, resulting in a 404.
+      wait_for_tandoor()
+      machine.succeed(f"curl --head {db_path} | grep \"HTTP/1.1 404 Not Found\"")
+    '';
+}

--- a/nixos/tests/tandoor-recipes-media.nix
+++ b/nixos/tests/tandoor-recipes-media.nix
@@ -66,7 +66,7 @@
       machine.succeed(f"curl --head {db_path} | grep \"HTTP/1.1 404 Not Found\"")
 
 
-      # Switch to NixOS 24.11 to check if the setup still functions the same
+      # Switch to NixOS 25.11 to check if the setup still functions the same
       # as before.
       stop_and_rm()
       machine.succeed("${oldVersion}/bin/switch-to-configuration test")
@@ -77,7 +77,7 @@
       machine.succeed(f"curl --head {db_path} | grep \"HTTP/1.1 200 OK\"")
 
 
-      # Switch to NixOS 24.11 with the MEDIA_ROOT already set to
+      # Switch to NixOS 25.11 with the MEDIA_ROOT already set to
       # /var/lib/tandoor-recipes/media.
       stop_and_rm()
       machine.succeed("${oldVersionOverrideMedia}/bin/switch-to-configuration test")

--- a/pkgs/by-name/ta/tandoor-recipes/package.nix
+++ b/pkgs/by-name/ta/tandoor-recipes/package.nix
@@ -166,7 +166,7 @@ python.pkgs.buildPythonPackage {
     updateScript = ./update.sh;
 
     tests = {
-      inherit (nixosTests) tandoor-recipes tandoor-recipes-script-name;
+      inherit (nixosTests) tandoor-recipes tandoor-recipes-script-name tandoor-recipes-media;
     };
   };
 


### PR DESCRIPTION
Backport of https://github.com/NixOS/nixpkgs/pull/427845 and https://github.com/NixOS/nixpkgs/pull/481134
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
