### PR TITLE
psc: init at 0.3.2

### DIFF
--- a/nixos/tests/bpf.nix
+++ b/nixos/tests/bpf.nix
@@ -1,16 +1,40 @@
-{ lib, ... }:
+{ lib, pkgs, ... }:
 {
   name = "bpf";
   meta.maintainers = with lib.maintainers; [ martinetd ];
 
   nodes.machine =
-    { pkgs, ... }:
+    { pkgs, config, ... }:
     {
       programs.bcc.enable = true;
-      environment.systemPackages = with pkgs; [ bpftrace ];
+      environment.systemPackages = with pkgs; [
+        bpftrace
+        config.boot.kernelPackages.psc
+      ];
+
+      # Simple TCP server for testing psc socket visibility
+      systemd.services.tcp-test-server = {
+        description = "Simple TCP test server for psc testing";
+        wantedBy = [ "multi-user.target" ];
+        script = ''
+          ${pkgs.python3}/bin/python3 -c "
+          import socket
+          s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+          s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+          s.bind(('127.0.0.1', 9999))
+          s.listen(1)
+          print('Listening on port 9999', flush=True)
+          while True:
+              conn, addr = s.accept()
+              conn.close()
+          "
+        '';
+      };
     };
 
   testScript = ''
+    machine.wait_for_unit("multi-user.target")
+
     ## bcc
     # syscount -d 1 stops 1s after probe started so is good for that
     print(machine.succeed("syscount -d 1"))
@@ -43,5 +67,70 @@
     # glibc includes
     print(machine.succeed("bpftrace -e '#include <errno.h>\n"
         "BEGIN { printf(\"ok %d\\n\", EINVAL); exit(); }'"))
+
+    ## psc - eBPF-powered process scanner
+    with subtest("psc basic functionality"):
+        # Show version
+        print(machine.succeed("psc version"))
+
+        # List available fields and presets
+        output = machine.succeed("psc fields")
+        print(output)
+        assert "process.pid" in output, "psc fields should list process.pid"
+        assert "socket" in output.lower(), "psc fields should list socket fields"
+
+        # Basic process listing - should show systemd (PID 1)
+        output = machine.succeed("psc --no-color")
+        print(output)
+        assert "systemd" in output, "psc should show systemd process"
+
+    with subtest("psc tree view"):
+        # Tree view shows process hierarchy
+        output = machine.succeed("psc --tree --no-color")
+        print(output)
+        assert "systemd" in output, "psc tree should show systemd"
+
+    with subtest("psc socket output"):
+        # Wait for our test server to be listening
+        machine.wait_for_unit("tcp-test-server.service")
+        machine.wait_for_open_port(9999)
+
+        # Show sockets - should see our test server
+        output = machine.succeed("psc -o sockets --no-color")
+        print("=== psc -o sockets output ===")
+        print(output)
+        # The socket output shows processes with their sockets
+        # Our python server should appear with port 9999
+        assert "python" in output.lower(), "psc -o sockets should show python process"
+
+        # Network preset (compact socket view)
+        output = machine.succeed("psc -o network --no-color")
+        print("=== psc -o network output ===")
+        print(output)
+
+    with subtest("psc file output"):
+        # Show open files
+        output = machine.succeed("psc -o files --no-color")
+        print("=== psc -o files output ===")
+        print(output)
+
+    with subtest("psc CEL filtering"):
+        # Filter for systemd process by name
+        output = machine.succeed("psc 'process.name == \"systemd\"' --no-color")
+        print("=== CEL filter for systemd ===")
+        print(output)
+        assert "systemd" in output, "CEL filter should find systemd"
+
+        # Filter for our test server using contains
+        output = machine.succeed("psc 'process.name.contains(\"python\")' --no-color")
+        print("=== CEL filter for python ===")
+        print(output)
+        assert "python" in output, "CEL filter should find python process"
+
+        # Filter by PID 1
+        output = machine.succeed("psc 'process.pid == 1' --no-color")
+        print("=== CEL filter for PID 1 ===")
+        print(output)
+        assert "systemd" in output, "CEL filter for PID 1 should show systemd"
   '';
 }

--- a/pkgs/by-name/bp/bpf2go/package.nix
+++ b/pkgs/by-name/bp/bpf2go/package.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  clang,
+  llvmPackages,
+}:
+
+buildGoModule rec {
+  pname = "bpf2go";
+  version = "0.20.0";
+
+  src = fetchFromGitHub {
+    owner = "cilium";
+    repo = "ebpf";
+    rev = "v${version}";
+    hash = "sha256-rb2fkVF5/fQLzil+Ns8VeeC785kFWLWrDt92VNcMWk0=";
+  };
+
+  vendorHash = "sha256-PEkr+uL/hO2fKYGt+IgRghWFH75mv54uyhi0D3JPhAc=";
+
+  subPackages = [ "cmd/bpf2go" ];
+
+  # Tests require clang and llvm-strip; run via passthru.tests instead
+  doCheck = false;
+
+  passthru.tests.bpf2go = buildGoModule {
+    pname = "bpf2go-tests";
+    inherit version src vendorHash;
+
+    subPackages = [ "cmd/bpf2go" ];
+
+    nativeCheckInputs = [
+      clang
+      llvmPackages.bintools
+    ];
+
+    # eBPF targets don't support -fzero-call-used-regs
+    hardeningDisable = [ "zerocallusedregs" ];
+
+    doCheck = true;
+
+    # TestRun cross-compiles for multiple architectures and needs network access
+    checkFlags = [ "-skip=^TestRun$" ];
+
+    # Don't install anything, just run tests
+    installPhase = "touch $out";
+  };
+
+  meta = {
+    description = "Generate Go bindings for eBPF programs";
+    homepage = "https://github.com/cilium/ebpf";
+    changelog = "https://github.com/cilium/ebpf/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ];
+    mainProgram = "bpf2go";
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/by-name/bp/bpf2go/package.nix
+++ b/pkgs/by-name/bp/bpf2go/package.nix
@@ -52,7 +52,7 @@ buildGoModule rec {
     homepage = "https://github.com/cilium/ebpf";
     changelog = "https://github.com/cilium/ebpf/releases/tag/v${version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ ];
+    maintainers = with lib.maintainers; [ philiptaron ];
     mainProgram = "bpf2go";
     platforms = lib.platforms.linux;
   };

--- a/pkgs/os-specific/linux/psc/default.nix
+++ b/pkgs/os-specific/linux/psc/default.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  kernel,
+  bpftools,
+  bpf2go,
+  clang,
+  libbpf,
+  nixosTests,
+}:
+
+buildGoModule rec {
+  pname = "psc";
+  version = "0.3.2";
+
+  src = fetchFromGitHub {
+    owner = "loresuso";
+    repo = "psc";
+    rev = "v${version}";
+    hash = "sha256-D0Jy+2e7BjxZe3vFl0iR4a1fo/YOA1FfTyEusKjDraw=";
+  };
+
+  vendorHash = "sha256-fUdbCgek1msYm+VUj8DZQE/jnwlQ8jAz712h5RhJuy0=";
+
+  nativeBuildInputs = [
+    clang
+    bpftools
+    bpf2go
+  ];
+
+  # eBPF compilation doesn't support -fzero-call-used-regs
+  hardeningDisable = [ "zerocallusedregs" ];
+
+  postPatch = ''
+    # Generate vmlinux.h from kernel BTF
+    bpftool btf dump file ${kernel.dev}/vmlinux format c > bpf/vmlinux.h
+  '';
+
+  preBuild = ''
+    # Generate eBPF Go bindings using bpf2go
+    bpf2go -go-package main -cc clang -no-strip -target bpfel \
+      -cflags "-O2 -g -Wall -I${libbpf}/include" tasks bpf/tasks.c
+    bpf2go -go-package main -cc clang -no-strip -target bpfel \
+      -cflags "-O2 -g -Wall -I${libbpf}/include" files bpf/files.c
+  '';
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X=github.com/loresuso/psc/cmd.Version=${version}"
+    "-X=github.com/loresuso/psc/cmd.Commit=${src.rev}"
+    "-X=github.com/loresuso/psc/cmd.BuildDate=1970-01-01T00:00:00Z"
+  ];
+
+  passthru.tests = {
+    inherit (nixosTests) bpf;
+  };
+
+  meta = {
+    description = "The ps utility, with an eBPF twist and container context";
+    homepage = "https://github.com/loresuso/psc";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ philiptaron ];
+    mainProgram = "psc";
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/os-specific/linux/psc/default.nix
+++ b/pkgs/os-specific/linux/psc/default.nix
@@ -54,7 +54,7 @@ buildGoModule rec {
   ];
 
   passthru.tests = {
-    inherit (nixosTests) bpf;
+    inherit (nixosTests) bpf docker podman;
   };
 
   meta = {

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -500,6 +500,8 @@ in
 
         ply = callPackage ../os-specific/linux/ply { };
 
+        psc = callPackage ../os-specific/linux/psc { };
+
         r8125 = callPackage ../os-specific/linux/r8125 { };
 
         r8168 = callPackage ../os-specific/linux/r8168 { };


### PR DESCRIPTION
`psc` (`ps` container) is a fast process scanner that uses eBPF iterators and Google CEL to query system state with precision and full container context.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test