### PR TITLE
services/prometheus-varnish-exporter: Adapt to changes in Varnish 7.

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/exporters/varnish.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/varnish.nix
@@ -57,8 +57,7 @@ in
     };
     instance = mkOption {
       type = types.nullOr types.str;
-      default = config.services.varnish.stateDir;
-      defaultText = lib.literalExpression "config.services.varnish.stateDir";
+      default = "/var/run/varnishd";
       description = ''
         varnishstat -n value.
       '';


### PR DESCRIPTION
The system Varnish service is no longer instanced by hostname or configurable. We will default to the same hardcoded path which that service uses. Nothing will change for anybody who was setting this value already; this only affects people who wanted the default behavior.

If you have some curious hybrid setup which requires this exporter to attach to Varnish 6, and this *wasn't* broken for you before because you spliced nixpkgs commits somehow, then you will have to override the default by setting `services.prometheus.exporters.varnish.instance` to the correct directory. On one hand, I apologize for inconvenience; on the other hand, surely this is the least weird part of such a setup!

I've indicated that this should go into the release notes. Probably the release manager will want to roll this up into a wider Varnish update.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
