### PR TITLE
fakeroot: 1.37.1.2 → 1.37.2

### DIFF
--- a/pkgs/by-name/fa/fakeroot/package.nix
+++ b/pkgs/by-name/fa/fakeroot/package.nix
@@ -14,7 +14,7 @@
 }:
 
 stdenv.mkDerivation (finalAttrs: {
-  version = "1.37.1.2";
+  version = "1.37.2";
   pname = "fakeroot";
 
   src = fetchFromGitLab {
@@ -22,30 +22,12 @@ stdenv.mkDerivation (finalAttrs: {
     repo = "fakeroot";
     rev = "upstream/${finalAttrs.version}";
     domain = "salsa.debian.org";
-    hash = "sha256-2ihdvYRnv2wpZrEikP4hCdshY8Eqarqnw3s9HPb+xKU=";
+    hash = "sha256-TU/9oltd+2wYums8EEDUhaIVzwPeQvW13laCrJqb5A4=";
   };
 
-  patches =
-    lib.optionals stdenv.hostPlatform.isLinux [
-      ./einval.patch
-
-      # patches needed for musl libc, borrowed from alpine packaging.
-      # it is applied regardless of the environment to prevent patchrot
-      (fetchpatch {
-        name = "fakeroot-no64.patch";
-        url = "https://git.alpinelinux.org/aports/plain/main/fakeroot/fakeroot-no64.patch?id=f68c541324ad07cc5b7f5228501b5f2ce4b36158";
-        sha256 = "sha256-NCDaB4nK71gvz8iQxlfaQTazsG0SBUQ/RAnN+FqwKkY=";
-      })
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      # patch needed to fix execution on macos
-      # TODO: remove when the next release comes out: https://salsa.debian.org/clint/fakeroot/-/merge_requests/34
-      (fetchpatch {
-        name = "fakeroot-fix-macos.patch";
-        url = "https://salsa.debian.org/clint/fakeroot/-/merge_requests/34.diff";
-        hash = "sha256-D5f1bXUaN2YMD/NTx/WIrqDBx/qNHpfLRcPhbdHYLl8=";
-      })
-    ];
+  patches = lib.optionals stdenv.hostPlatform.isLinux [
+    ./einval.patch
+  ];
 
   nativeBuildInputs = [
     autoreconfHook


### PR DESCRIPTION
The Alpine & macOS patches are included in this release.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
