### PR TITLE
haskellPackages: allow configuring gmp when cross compiling

### DIFF
--- a/pkgs/development/compilers/ghc/common-hadrian.nix
+++ b/pkgs/development/compilers/ghc/common-hadrian.nix
@@ -50,8 +50,9 @@
   # If enabled, GHC will be built with the GPL-free but slightly slower native
   # bignum backend instead of the faster but GPLed gmp backend.
   enableNativeBignum ?
-    !(lib.meta.availableOn stdenv.hostPlatform gmp && lib.meta.availableOn stdenv.targetPlatform gmp)
-    || stdenv.targetPlatform.isGhcjs,
+    stdenv.targetPlatform.isGhcjs
+    || !(lib.meta.availableOn stdenv.hostPlatform gmp)
+    || !(lib.meta.availableOn stdenv.targetPlatform gmp),
   gmp,
 
   # If enabled, use -fPIC when compiling static libs.
@@ -668,7 +669,7 @@ stdenv.mkDerivation (
       "--with-ffi-includes=${targetLibs.libffi.dev}/include"
       "--with-ffi-libraries=${targetLibs.libffi.out}/lib"
     ]
-    ++ lib.optionals (targetPlatform == hostPlatform && !enableNativeBignum) [
+    ++ lib.optionals (!enableNativeBignum) [
       "--with-gmp-includes=${targetLibs.gmp.dev}/include"
       "--with-gmp-libraries=${targetLibs.gmp.out}/lib"
     ]


### PR DESCRIPTION
Fixed
```
$ nix-build -A pkgsStatic.haskell.packages.ghc910.th-orphans 
/nix/store/5y2qffwjsidcdpvs2jk8y4g2afl7kzcx-th-orphans-static-x86_64-unknown-linux-musl-0.13.16

$ nix-build -A pkgsCross.aarch64-multiplatform.pkgsStatic.haskell.packages.ghc910.th-orphans
/nix/store/n89y2gf1skypdigmprh0ph0jwda8bvni-th-orphans-static-aarch64-unknown-linux-musl-0.13.16
```

Triggers rebuild for
```
$ nix-build -A pkgsCross.aarch64-multiplatform.haskell.packages.ghc910.th-orphans
/nix/store/c4m6srj4nn12n70lwqc6jlg3af8i35wc-th-orphans-aarch64-unknown-linux-gnu-0.13.16
```

Not sure why `pkgsCross.aarch64-multiplatform` worked before as this is needed for integer-gmp flavour in https://github.com/NixOS/nixpkgs/pull/479902 as I would expect.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
