### PR TITLE
[Backport release-25.11] rke2: update all packages

### DIFF
--- a/pkgs/applications/networking/cluster/rke2/1_31/versions.nix
+++ b/pkgs/applications/networking/cluster/rke2/1_31/versions.nix
@@ -8,5 +8,6 @@
   pauseVersion = "3.6";
   ccmVersion = "v1.31.14-0.20251010190929-c49b201b7cf5-build20251017";
   dockerizedVersion = "v1.31.14-rke2r1";
+  helmJobVersion = "";
   imagesVersions = with builtins; fromJSON (readFile ./images-versions.json);
 }

--- a/pkgs/applications/networking/cluster/rke2/1_32/images-versions.json
+++ b/pkgs/applications/networking/cluster/rke2/1_32/images-versions.json
@@ -1,138 +1,138 @@
 {
   "images-calico-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.10%2Brke2r1/rke2-images-calico.linux-amd64.tar.gz",
-    "sha256": "5d833bca6808595318f80bf687a5556ed0db7ad55d399a7e1f159f91f58c3399"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-calico.linux-amd64.tar.gz",
+    "sha256": "3c30438a4eddeb831db2ac5f52f447b8848815c2fd0aa86d05764603689d39c6"
   },
   "images-calico-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.10%2Brke2r1/rke2-images-calico.linux-amd64.tar.zst",
-    "sha256": "68bbc30990d83a8a7280555f9ce633462582de888c03c7d5f6627b0052527d6b"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-calico.linux-amd64.tar.zst",
+    "sha256": "33c00385b8c3cec3ee5c1eff6f165284b4bf63ee53b1cbbe707fe3317706a7d2"
   },
   "images-calico-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.10%2Brke2r1/rke2-images-calico.linux-arm64.tar.gz",
-    "sha256": "083e270c4370a420499c94924041cf8aa84e730ed29718bb8f91075a421f329c"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-calico.linux-arm64.tar.gz",
+    "sha256": "0aa89b6a25f0d8ddcd32e7c1931d190d805cb79870a80593d8aa5ec797fc9f79"
   },
   "images-calico-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.10%2Brke2r1/rke2-images-calico.linux-arm64.tar.zst",
-    "sha256": "7ba9e0774559b091a9d6b3587fb39e2c106078f2e412bbdadf6b2b1986060e6f"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-calico.linux-arm64.tar.zst",
+    "sha256": "e5c760962303fd6296842737be355cde7ee066f464ea550b55f1f6ba7dd95f2c"
   },
   "images-canal-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.10%2Brke2r1/rke2-images-canal.linux-amd64.tar.gz",
-    "sha256": "51ffc6c9b718b0d5d12b034b69dab0c2394f38131d16aaf0c3f16cd68bab071a"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-canal.linux-amd64.tar.gz",
+    "sha256": "a1a2f2fd90d92bbfdf0a77b77c4295e119e542021204a728cc42f618ab798622"
   },
   "images-canal-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.10%2Brke2r1/rke2-images-canal.linux-amd64.tar.zst",
-    "sha256": "d96d183a2265eaf6d6c9a7787cbb9a191d690130542de45b67389c390fcccada"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-canal.linux-amd64.tar.zst",
+    "sha256": "a2b72764ab8f5e72169812ce875bbc861e1c2e341b167bef7d5e980b78dd9f6b"
   },
   "images-canal-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.10%2Brke2r1/rke2-images-canal.linux-arm64.tar.gz",
-    "sha256": "2321bf1b453615ba8a50254fb02f260e96bb1a725c1cddee848ef44a0a88a527"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-canal.linux-arm64.tar.gz",
+    "sha256": "a7163212bea884f76a6a2e3b62be7bf8086460f9149d9f2e5693edeaf0d7ad93"
   },
   "images-canal-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.10%2Brke2r1/rke2-images-canal.linux-arm64.tar.zst",
-    "sha256": "a0285e10bd977b93218231511b3ebbc8913d848c2b77bed73ecaa72a06e7a94a"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-canal.linux-arm64.tar.zst",
+    "sha256": "3780c1220874f41028ba8f0a49209b090fb2947da23bff53bdc0953ed6e4db9e"
   },
   "images-cilium-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.10%2Brke2r1/rke2-images-cilium.linux-amd64.tar.gz",
-    "sha256": "d89bb5e9b608e4f949375ccecd2685f7317dcea24f39ee2657769e8d65aa02ae"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-cilium.linux-amd64.tar.gz",
+    "sha256": "38dbc7f386c4fce06aa7a2c6051b4176113e1ff93f2da4beae66853e8ae582b1"
   },
   "images-cilium-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.10%2Brke2r1/rke2-images-cilium.linux-amd64.tar.zst",
-    "sha256": "997ddd67ba6636a139bd635c594e71e16b6c3a06a3e2e6f5260abd9500831fd6"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-cilium.linux-amd64.tar.zst",
+    "sha256": "75bd972ec8e3266ae01b4968b224a118e374b01c830def92a20dfcbf29cb20e8"
   },
   "images-cilium-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.10%2Brke2r1/rke2-images-cilium.linux-arm64.tar.gz",
-    "sha256": "1777e1e63b9087e157541acfcc03db9ed9ccf96ffd48850eb850c03653629a60"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-cilium.linux-arm64.tar.gz",
+    "sha256": "48d46a224df1ffe173b432b69f08249e98da31209de613b2ec06eb4476e8f4ff"
   },
   "images-cilium-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.10%2Brke2r1/rke2-images-cilium.linux-arm64.tar.zst",
-    "sha256": "fa3c6e9bc5a36fca572f777e37d43f53d632240a0807206ff88411c6e05e39c8"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-cilium.linux-arm64.tar.zst",
+    "sha256": "f71fb6f5e2b650958baff8133c61a1ad43c04ab7d222334cf54839de735e2897"
   },
   "images-core-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.10%2Brke2r1/rke2-images-core.linux-amd64.tar.gz",
-    "sha256": "771fbd5957d04cb58038bea2f76f83c34c2040083ab544318f0cfda76f4066f7"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-core.linux-amd64.tar.gz",
+    "sha256": "375f0bf18da30f2f76aca8bbb065dda9ac75caca76a4704424c800917e351b42"
   },
   "images-core-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.10%2Brke2r1/rke2-images-core.linux-amd64.tar.zst",
-    "sha256": "3b0ef04fa3f5384892b3d9cd4e7f92d1b4de2ee6cd962104e40ddacd9e221fd4"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-core.linux-amd64.tar.zst",
+    "sha256": "c651e89aabdf77f4c90af42fd337b522691190600272f26059b8f1b48ac2f68c"
   },
   "images-core-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.10%2Brke2r1/rke2-images-core.linux-arm64.tar.gz",
-    "sha256": "30558605dcae858acdb9206e5b60bd1df84053b35d48ee6ef3bb6d4cd416375b"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-core.linux-arm64.tar.gz",
+    "sha256": "0161796116bab9afcfee91e9116b10516634254ec0771a08178761443eac2147"
   },
   "images-core-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.10%2Brke2r1/rke2-images-core.linux-arm64.tar.zst",
-    "sha256": "ff9bc0790e2dbaf4ff4514cb387b61f0659149e9ff9b345dae2604be39eb1d7f"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-core.linux-arm64.tar.zst",
+    "sha256": "53648ffc5b03c0aae262734bbe4c684a62a33a89fad4e8183957e57af4b5d65f"
   },
   "images-flannel-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.10%2Brke2r1/rke2-images-flannel.linux-amd64.tar.gz",
-    "sha256": "978b366bffae9e2b9aae3746832123f9063c029b6c0100413ff759a998aec357"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-flannel.linux-amd64.tar.gz",
+    "sha256": "7683ea5abbf25b1af3a1fc6c1967fb65a05f2d927d1fe8b37fe3f30990c99907"
   },
   "images-flannel-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.10%2Brke2r1/rke2-images-flannel.linux-amd64.tar.zst",
-    "sha256": "1e3d3e7ed0c815233a2d90eff6d828483575fe120070632a03dfdad313e38209"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-flannel.linux-amd64.tar.zst",
+    "sha256": "99be4dff6a72d45c14ec4c7e2142a52eaac7e79e901d260b7b2a85c9463524f1"
   },
   "images-flannel-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.10%2Brke2r1/rke2-images-flannel.linux-arm64.tar.gz",
-    "sha256": "fe48db6c1e28526c2963a6d104ed6dc51200dfdedad79dd7dae6796808539e86"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-flannel.linux-arm64.tar.gz",
+    "sha256": "2157b8db3e36a598d266f475f359e78ea8f13ce759e865992fd52728de7f727e"
   },
   "images-flannel-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.10%2Brke2r1/rke2-images-flannel.linux-arm64.tar.zst",
-    "sha256": "3779149f30cdadf1102080e4b4766be922cd31abc58489fe5f69bb54fb98b4dc"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-flannel.linux-arm64.tar.zst",
+    "sha256": "4413a6ec9305fb811eb99973f0b609ba4412b5a7ae6384146f7be647c8726851"
   },
   "images-harvester-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.10%2Brke2r1/rke2-images-harvester.linux-amd64.tar.gz",
-    "sha256": "8d4d35d196c0661ee52bfa29583042e388613ea13fd52928b3cfae9d7581fc36"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-harvester.linux-amd64.tar.gz",
+    "sha256": "5edf9c8e8b76e9ffd8accf30ab8d8e4d3edaf0aaf80d325c5cb7c0d319230f35"
   },
   "images-harvester-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.10%2Brke2r1/rke2-images-harvester.linux-amd64.tar.zst",
-    "sha256": "7118609bc2158dfd0552cb581735a57f1ed270752125f6e7a543dbaac77dbbce"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-harvester.linux-amd64.tar.zst",
+    "sha256": "1ed7217d8e08947f03f96b482e095274d70a491286a8ffc58dfedad43958bcb8"
   },
   "images-harvester-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.10%2Brke2r1/rke2-images-harvester.linux-arm64.tar.gz",
-    "sha256": "58caa6f91d1cd6ae8fcd7b3033599c88a3d37544298a13322aacb10c2c9e1fa6"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-harvester.linux-arm64.tar.gz",
+    "sha256": "31e926524431667425d7f2120a25aca48ff4ae912e471a117a5d76c178002083"
   },
   "images-harvester-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.10%2Brke2r1/rke2-images-harvester.linux-arm64.tar.zst",
-    "sha256": "8420e153021708aa947adb2a39e751227a9f2aacced5c782f8ba22333c46e553"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-harvester.linux-arm64.tar.zst",
+    "sha256": "e93b68f4123ae02bb62142468add0be45d98ed2667333421f26102ef01e06048"
   },
   "images-multus-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.10%2Brke2r1/rke2-images-multus.linux-amd64.tar.gz",
-    "sha256": "b41e8cee051759e1626b2998419da06e91a713063fb55c2a26dd7fdc7b34973a"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-multus.linux-amd64.tar.gz",
+    "sha256": "e642b17c843780f9961864a6a7ef6f5031a05c255cac62f7109a95870ecc46e7"
   },
   "images-multus-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.10%2Brke2r1/rke2-images-multus.linux-amd64.tar.zst",
-    "sha256": "2908a31ef4d1d43940fc49279c5845a9536c1fdc5bb0e7a831f2e0bf4e6e8977"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-multus.linux-amd64.tar.zst",
+    "sha256": "7997ccf45051611f8c2ba6f0ac4ae59636aeec3e227fe2c31bd678a57396c813"
   },
   "images-multus-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.10%2Brke2r1/rke2-images-multus.linux-arm64.tar.gz",
-    "sha256": "9c7bdca941237c3cb8a18f606f6b62a890cf2b59650d4fb594f0c8b6f665103d"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-multus.linux-arm64.tar.gz",
+    "sha256": "0483706f7871c1965a0de7c63a011462aadf8f97f5a9fd28c5c16d914a0ca627"
   },
   "images-multus-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.10%2Brke2r1/rke2-images-multus.linux-arm64.tar.zst",
-    "sha256": "b7837f58c46abbdd9a0fdd810ad7fc660593ed38623342287aba6759e21583b5"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-multus.linux-arm64.tar.zst",
+    "sha256": "0a46e0ce765a01099eba369ff311a12fe2537ebaa32fdbe11248f47e6fe625b4"
   },
   "images-traefik-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.10%2Brke2r1/rke2-images-traefik.linux-amd64.tar.gz",
-    "sha256": "cbcf55b5e40d15557a316178363620d8d7bf8d858f73bed6081de82de127d51d"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-traefik.linux-amd64.tar.gz",
+    "sha256": "d58271f93c27bad3651b084357025ee5232044ef10c24f9e72c3f70a8fd5112c"
   },
   "images-traefik-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.10%2Brke2r1/rke2-images-traefik.linux-amd64.tar.zst",
-    "sha256": "ec1f4bf39d610276118048b0e8230e3d7079dbdcf2dd00ad7469c317b052d857"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-traefik.linux-amd64.tar.zst",
+    "sha256": "c5170ab51f07f90da4972e6cda7186a042913a10064792529c3c292cd1c5b723"
   },
   "images-traefik-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.10%2Brke2r1/rke2-images-traefik.linux-arm64.tar.gz",
-    "sha256": "04a242d8aebc07acf39758d5d93163ebf1efbeaf439f1e4f8e70775039a001fd"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-traefik.linux-arm64.tar.gz",
+    "sha256": "266398b100bd47ca86bb6ccd2edd0163f7606032a36780407dbb553c50705ea3"
   },
   "images-traefik-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.10%2Brke2r1/rke2-images-traefik.linux-arm64.tar.zst",
-    "sha256": "62d3dabf8f62c7a98fed3aecbd88adf7ed8858a059bd1a4d2a31c175f119b6e5"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-traefik.linux-arm64.tar.zst",
+    "sha256": "1aedcb967b4203a54e247d90e3dfd054cd5de55281c0d9e4a6c7bbea45e0cd7e"
   },
   "images-vsphere-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.10%2Brke2r1/rke2-images-vsphere.linux-amd64.tar.gz",
-    "sha256": "75ecd15d83aea5e9068fae44a8f1a0b272afec8a3155f117e3b0d4da3e0a9277"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-vsphere.linux-amd64.tar.gz",
+    "sha256": "90e37c8c8cbff0e23dee712821fd6d09302fe1064f8b87d53fae6e26800322c6"
   },
   "images-vsphere-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.10%2Brke2r1/rke2-images-vsphere.linux-amd64.tar.zst",
-    "sha256": "d1a5f823829f1045948f5523b6156329610ed74c0f990f42ff8823a4988ffde8"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-vsphere.linux-amd64.tar.zst",
+    "sha256": "341ec63cde711b4aa55f22e59d2238230ae703c70f67e74347755f5909c00b7b"
   }
 }

--- a/pkgs/applications/networking/cluster/rke2/1_32/versions.nix
+++ b/pkgs/applications/networking/cluster/rke2/1_32/versions.nix
@@ -1,13 +1,13 @@
 {
-  rke2Version = "1.32.10+rke2r1";
-  rke2Commit = "7a87b5095b6e5c8e73bb1524082a5d644dd5e46b";
-  rke2TarballHash = "sha256-GDh7n5xAkeqbE2RDzj905fAf+ip8EU2pcpPPjWKQ3AQ=";
-  rke2VendorHash = "sha256-Hy10UPKyEU3enEitRchbLJILqzFa++7HlFkxth5pBag=";
-  k8sImageTag = "v1.32.10-rke2r1-build20251112";
-  etcdVersion = "v3.5.21-k3s1-build20251017";
+  rke2Version = "1.32.11+rke2r1";
+  rke2Commit = "836ebdc75f3d96bbeed0373e1fee7de24d3798f7";
+  rke2TarballHash = "sha256-AErhQfpUyINPLNaCeXxl67EehB8aKrQUDWZKrFlrG4E=";
+  rke2VendorHash = "sha256-yiyMD4VPM592nwbKGEo380FX/B2NytKcw6ly2JSYx7E=";
+  k8sImageTag = "v1.32.11-rke2r1-build20251216";
+  etcdVersion = "v3.5.25-k3s1-build20251210";
   pauseVersion = "3.6";
-  ccmVersion = "v1.32.10-0.20251010190908-d439f1a03318-build20251017";
-  dockerizedVersion = "v1.32.10-rke2r1";
-  helmJobVersion = "";
+  ccmVersion = "v1.32.11-0.20251210094421-ded016535487-build20251210";
+  dockerizedVersion = "v1.32.11-rke2r1";
+  helmJobVersion = "v0.9.12-build20251215";
   imagesVersions = with builtins; fromJSON (readFile ./images-versions.json);
 }

--- a/pkgs/applications/networking/cluster/rke2/1_32/versions.nix
+++ b/pkgs/applications/networking/cluster/rke2/1_32/versions.nix
@@ -8,5 +8,6 @@
   pauseVersion = "3.6";
   ccmVersion = "v1.32.10-0.20251010190908-d439f1a03318-build20251017";
   dockerizedVersion = "v1.32.10-rke2r1";
+  helmJobVersion = "";
   imagesVersions = with builtins; fromJSON (readFile ./images-versions.json);
 }

--- a/pkgs/applications/networking/cluster/rke2/1_33/images-versions.json
+++ b/pkgs/applications/networking/cluster/rke2/1_33/images-versions.json
@@ -1,138 +1,138 @@
 {
   "images-calico-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.6%2Brke2r1/rke2-images-calico.linux-amd64.tar.gz",
-    "sha256": "09c368f17a10e74dafc68188a5548011e7605398d36331699554073668c0e1f8"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-calico.linux-amd64.tar.gz",
+    "sha256": "8ffd0de3ae47590d6891b21c95a4bf718ba26b00acc72c3502e5b7a98cfeaebf"
   },
   "images-calico-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.6%2Brke2r1/rke2-images-calico.linux-amd64.tar.zst",
-    "sha256": "70aa654347b671a3674e9bdf4f027423f441f35bd352a62302cbcae0ac6a9709"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-calico.linux-amd64.tar.zst",
+    "sha256": "a3edff8cee5b147c736c11c2e074a8501ae82b5aca14d9149a04b14714312570"
   },
   "images-calico-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.6%2Brke2r1/rke2-images-calico.linux-arm64.tar.gz",
-    "sha256": "e1bf14ab9ee37d236d5d81d298ae305f52d4b704326cb34b328c993a05110561"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-calico.linux-arm64.tar.gz",
+    "sha256": "d3e40d0c99a37419764bbd5be541fa1cc5469f8127aeb3297ab8f203194c916c"
   },
   "images-calico-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.6%2Brke2r1/rke2-images-calico.linux-arm64.tar.zst",
-    "sha256": "bc8b6bb30393380f9b9d115166a7f6c6424a9f75087bc6cce50788d4a85561d2"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-calico.linux-arm64.tar.zst",
+    "sha256": "d48b4a1d17c8befc174344dab58e5bda6a018d703ffc0cf17bddcfa94c538512"
   },
   "images-canal-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.6%2Brke2r1/rke2-images-canal.linux-amd64.tar.gz",
-    "sha256": "9bdd4622e92b0e77d6d42b17e920697024cd5429a67268af1cb69a2034aed8b3"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-canal.linux-amd64.tar.gz",
+    "sha256": "b779c59e5d18bd237eaa1664dd469943bbc98231fb471b3dea13c990c5d0c86b"
   },
   "images-canal-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.6%2Brke2r1/rke2-images-canal.linux-amd64.tar.zst",
-    "sha256": "02d7fbfa8cf6e77f5aa98191f7698bd222244f749ec6b79a7d5cf7c62c86f66a"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-canal.linux-amd64.tar.zst",
+    "sha256": "f113b95fd2835db27570dc5525a5e8b86918b379a67aca12f6d547f5a3aaed23"
   },
   "images-canal-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.6%2Brke2r1/rke2-images-canal.linux-arm64.tar.gz",
-    "sha256": "e28f38bce6f1ce6230f5ed6d7ad69397832d7cd7dc705b6221be2d152aa2ca6b"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-canal.linux-arm64.tar.gz",
+    "sha256": "507a46b8b160eb85c5d0833342bdc61a769bbcc7e5e0ee9ba4b90563b565e2a5"
   },
   "images-canal-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.6%2Brke2r1/rke2-images-canal.linux-arm64.tar.zst",
-    "sha256": "715c828e08936153f6cad0730474637c64e8c36e686ae2200fc14cc1bd9b040c"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-canal.linux-arm64.tar.zst",
+    "sha256": "9b542b33488d580223e161ba8d9bb11736eabddd3ed029d7a4a095d42b6e7122"
   },
   "images-cilium-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.6%2Brke2r1/rke2-images-cilium.linux-amd64.tar.gz",
-    "sha256": "8051ec537f5a7cda0a069a4016e5cafcc5edc004543766767ff3fbec5fbbf12b"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-cilium.linux-amd64.tar.gz",
+    "sha256": "e11afea5475d8c87d078f6847b41167b682d2b59dcd717b50f57912a43544f7c"
   },
   "images-cilium-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.6%2Brke2r1/rke2-images-cilium.linux-amd64.tar.zst",
-    "sha256": "b933b21227faf6a55cb5535d3f010285b13fe54625b7890a083393f9a6b90ed5"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-cilium.linux-amd64.tar.zst",
+    "sha256": "dd8a2be05ec194783058d3656a07a6b68b0ff7361fd4bc071cb2c61eee9d7803"
   },
   "images-cilium-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.6%2Brke2r1/rke2-images-cilium.linux-arm64.tar.gz",
-    "sha256": "ebfd5842d93451073438a44c6cf56285141005260c201f151aa09bf1b4a27c81"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-cilium.linux-arm64.tar.gz",
+    "sha256": "7f3c01c545d101ca7b05efbb1d629433f914ad29e99d8d825372027f73b3a628"
   },
   "images-cilium-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.6%2Brke2r1/rke2-images-cilium.linux-arm64.tar.zst",
-    "sha256": "4c4106746308370e57ee239a63308111eac17b2cfd6b31f07c49d8a97055ae53"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-cilium.linux-arm64.tar.zst",
+    "sha256": "f708c5275cb2a6ac390dcdeba1521da03b10e8812dcd4eef0a72bc7478f50aa7"
   },
   "images-core-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.6%2Brke2r1/rke2-images-core.linux-amd64.tar.gz",
-    "sha256": "b8322b16df2ad433fda09cb78249ad938b495a769bae5e27b914bb2542c13f42"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-core.linux-amd64.tar.gz",
+    "sha256": "c46fb5f1e71f33d30b3fdfad9bdb9cf45ed56172e99aa197db76e429e9c798b6"
   },
   "images-core-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.6%2Brke2r1/rke2-images-core.linux-amd64.tar.zst",
-    "sha256": "eb01422cbf955d11fe74eb746fff891579d2db62666e788dc82244d7991fbcd1"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-core.linux-amd64.tar.zst",
+    "sha256": "4d45c42f2a676a69db2cfe61a661d07897dcaf6286e6edd7e0a0a13c4107f1ae"
   },
   "images-core-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.6%2Brke2r1/rke2-images-core.linux-arm64.tar.gz",
-    "sha256": "3f5d7021b071f63fa0ca4084367c36b0886c1e59626b30fbbc434065b047c80a"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-core.linux-arm64.tar.gz",
+    "sha256": "7312ad66a5ab852abc3365258520ac12ad1682e4d899ebe27c0852524eb7b8e0"
   },
   "images-core-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.6%2Brke2r1/rke2-images-core.linux-arm64.tar.zst",
-    "sha256": "e26daf41fc76f6b5f9e2285a459276a6302af9b72fa85edc73d76d7daff2b114"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-core.linux-arm64.tar.zst",
+    "sha256": "2e428e080ae979e7a253b1f8a8e0d9d045bbf37e3429a1e0cda7bfd816f9e5f8"
   },
   "images-flannel-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.6%2Brke2r1/rke2-images-flannel.linux-amd64.tar.gz",
-    "sha256": "5e48442961327b025a309e7e9e0beeac3547de034fc267b22d74660b91c363b6"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-flannel.linux-amd64.tar.gz",
+    "sha256": "c42c70de2a03e024b2a215cf572c2043ad387e647b7f9c79f11f6c8f16169673"
   },
   "images-flannel-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.6%2Brke2r1/rke2-images-flannel.linux-amd64.tar.zst",
-    "sha256": "8d5317988078acc47163e7c5774b767c1b26e7f43ba919fdacde05232d589a8a"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-flannel.linux-amd64.tar.zst",
+    "sha256": "93136f61caf9b45dea0ab1d76473ebb880c56df404417d7706bab5677ce60ebb"
   },
   "images-flannel-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.6%2Brke2r1/rke2-images-flannel.linux-arm64.tar.gz",
-    "sha256": "67c0713d617f1840c722747d802b5a5a47a58d7d6ed5d32f822965a546589bd8"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-flannel.linux-arm64.tar.gz",
+    "sha256": "4f32b6f1b4bd502c9622e79143e1f0bb1a5f57277bd496e0534415507094a57b"
   },
   "images-flannel-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.6%2Brke2r1/rke2-images-flannel.linux-arm64.tar.zst",
-    "sha256": "aac6c722f7d07c41eaf80deb1bf8719cb93963fb9d713335fe8c0aef22d65d63"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-flannel.linux-arm64.tar.zst",
+    "sha256": "46d14c3531e0fd14483fe148ebec5e14b14c28bf1049f258d06511051b167873"
   },
   "images-harvester-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.6%2Brke2r1/rke2-images-harvester.linux-amd64.tar.gz",
-    "sha256": "5eb3e5ab6b0676d7197da756b46f94c7c9eb096d4d79b332eb74016f40136cb5"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-harvester.linux-amd64.tar.gz",
+    "sha256": "40829aff7709374b9d2d6b5cade000eb3f5dbcc91247364832cae8e1770b9749"
   },
   "images-harvester-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.6%2Brke2r1/rke2-images-harvester.linux-amd64.tar.zst",
-    "sha256": "f52fc26611fa766ad6781d295717199d81f0a21c2108bd333902bb5887689e89"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-harvester.linux-amd64.tar.zst",
+    "sha256": "fa712c7061cf6cc84c65e2d6aa86e4e98e862c17413d228677eedff2e32b500c"
   },
   "images-harvester-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.6%2Brke2r1/rke2-images-harvester.linux-arm64.tar.gz",
-    "sha256": "612030145cc28528aebf773795deae0c2dfc83eddaf9b90179db978e6fa66330"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-harvester.linux-arm64.tar.gz",
+    "sha256": "ac5ee84a05b4d9a8082ed58e3691305137f50dcd3de54a503905bd5943f5ada0"
   },
   "images-harvester-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.6%2Brke2r1/rke2-images-harvester.linux-arm64.tar.zst",
-    "sha256": "83501275b07b2632abbde646b07675bdf509dafdff90490f35af4d6cb402cd68"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-harvester.linux-arm64.tar.zst",
+    "sha256": "94a72b07d0cb69dd2406f52cf6b6d87be2aae2291d76370ded49f7f47197b631"
   },
   "images-multus-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.6%2Brke2r1/rke2-images-multus.linux-amd64.tar.gz",
-    "sha256": "734f2833d156092afd85b0106779ae842745d71e4e226120d2450d9ad894127b"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-multus.linux-amd64.tar.gz",
+    "sha256": "b2f5875d3d9702b8778d609134a99cdbff720ea41ef7b490a0af2460e2e3ca8f"
   },
   "images-multus-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.6%2Brke2r1/rke2-images-multus.linux-amd64.tar.zst",
-    "sha256": "5da8147e6330b3b60723734afb5a2cc70a67c6282edf730f6bd3c1f2d89958e5"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-multus.linux-amd64.tar.zst",
+    "sha256": "69ed710c8a64668d9fd59f1fa30601d26051389819753dcb27f46fc12192a884"
   },
   "images-multus-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.6%2Brke2r1/rke2-images-multus.linux-arm64.tar.gz",
-    "sha256": "bd6e3efc21b83431ba3d49a8ecf514320046ce9ba5b35de6241ffb549883d2c7"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-multus.linux-arm64.tar.gz",
+    "sha256": "8917010380e3c2501af3b6cfc497b0d226aecf9a290b1a84090d62c549716564"
   },
   "images-multus-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.6%2Brke2r1/rke2-images-multus.linux-arm64.tar.zst",
-    "sha256": "74c60dfa064c4ab636a15378d082338fe245875648c4fc2522905f81b9b56154"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-multus.linux-arm64.tar.zst",
+    "sha256": "8c6164f34bff5253874fa7d5c18da79c5d2849bd874cf75eb6200bce79e4e342"
   },
   "images-traefik-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.6%2Brke2r1/rke2-images-traefik.linux-amd64.tar.gz",
-    "sha256": "9c03f6d933412f3c084e2cccfcae0bd2f2da5833fdc9bab1d5a38224afcb6013"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-traefik.linux-amd64.tar.gz",
+    "sha256": "3af0e0aae8de0558602b278216f92d85bc976d1d44028900067b4e164b987f19"
   },
   "images-traefik-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.6%2Brke2r1/rke2-images-traefik.linux-amd64.tar.zst",
-    "sha256": "fdff38dee1bdba17f047c1d7575d8ee30ca4da36e54c856829bdc019d74f17fe"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-traefik.linux-amd64.tar.zst",
+    "sha256": "2bdec4a29e5660aeeb7789a12b48e0c92d1abb3d3533c779e1eb3a1859868895"
   },
   "images-traefik-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.6%2Brke2r1/rke2-images-traefik.linux-arm64.tar.gz",
-    "sha256": "b990c68a76480620275a55f0db199aed84a2415add3575cae4ac116197ad4481"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-traefik.linux-arm64.tar.gz",
+    "sha256": "d3c0a38066a85ee63d8363ed26ca511a2c94267ef48334e45d1abb756fc3d562"
   },
   "images-traefik-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.6%2Brke2r1/rke2-images-traefik.linux-arm64.tar.zst",
-    "sha256": "a1e35cc62a5c9c16b5d9df99ec3a467bcf7cdb22c778435baa784ffcb13baf8f"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-traefik.linux-arm64.tar.zst",
+    "sha256": "02187f5f06231bb50c8ac0cd908669e7a7bd5c611f633eb119f8bc8458a5f24c"
   },
   "images-vsphere-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.6%2Brke2r1/rke2-images-vsphere.linux-amd64.tar.gz",
-    "sha256": "b73d6cd9caef5bc6617106def9af18c7bd6a56a68b87eb0bf3c107eb62a7b011"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-vsphere.linux-amd64.tar.gz",
+    "sha256": "b492c8863e82f6223c8a8ff27d316d51c8931778921a16cab9b6861915ed7c45"
   },
   "images-vsphere-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.6%2Brke2r1/rke2-images-vsphere.linux-amd64.tar.zst",
-    "sha256": "c9162d55c1129e83c1af956c6a0b9173857f0b2bccda889955b490df90578223"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-vsphere.linux-amd64.tar.zst",
+    "sha256": "547cb03a489f2762e2d6de5693d91a17780113d88d3b6881fc4b182e864e7adb"
   }
 }

--- a/pkgs/applications/networking/cluster/rke2/1_33/versions.nix
+++ b/pkgs/applications/networking/cluster/rke2/1_33/versions.nix
@@ -8,5 +8,6 @@
   pauseVersion = "3.6";
   ccmVersion = "v1.33.6-0.20251010190850-d6b5244412d1-build20251017";
   dockerizedVersion = "v1.33.6-rke2r1";
+  helmJobVersion = "";
   imagesVersions = with builtins; fromJSON (readFile ./images-versions.json);
 }

--- a/pkgs/applications/networking/cluster/rke2/1_33/versions.nix
+++ b/pkgs/applications/networking/cluster/rke2/1_33/versions.nix
@@ -1,13 +1,13 @@
 {
-  rke2Version = "1.33.6+rke2r1";
-  rke2Commit = "2c2298232b55a94bd16b059f893c76a950811489";
-  rke2TarballHash = "sha256-K58K5jqOtabjyG1MIfvnaMo4pePgWaAd9SQ5BCNo3nw=";
-  rke2VendorHash = "sha256-taNWaULzVE3d4MhHvet3JFH3Mb4m/8no+DzIhqAjyVw=";
-  k8sImageTag = "v1.33.6-rke2r1-build20251112";
-  etcdVersion = "v3.5.21-k3s1-build20251017";
+  rke2Version = "1.33.7+rke2r1";
+  rke2Commit = "b0a4ec8463abd1e23e41f213fdb54ad8006c693b";
+  rke2TarballHash = "sha256-Dkr+rDsC3L9LSGuu6hBLuyWqWJLrpEi/p35wzP7P0uw=";
+  rke2VendorHash = "sha256-ybxWnzKjpH3sYeFIqUZyvV1KXB5zxpjMAzN6oC6MOXo=";
+  k8sImageTag = "v1.33.7-rke2r1-build20251210";
+  etcdVersion = "v3.5.25-k3s1-build20251210";
   pauseVersion = "3.6";
-  ccmVersion = "v1.33.6-0.20251010190850-d6b5244412d1-build20251017";
-  dockerizedVersion = "v1.33.6-rke2r1";
-  helmJobVersion = "";
+  ccmVersion = "v1.33.7-0.20251210094413-291666bcc1a4-build20251210";
+  dockerizedVersion = "v1.33.7-rke2r1";
+  helmJobVersion = "v0.9.12-build20251215";
   imagesVersions = with builtins; fromJSON (readFile ./images-versions.json);
 }

--- a/pkgs/applications/networking/cluster/rke2/1_34/images-versions.json
+++ b/pkgs/applications/networking/cluster/rke2/1_34/images-versions.json
@@ -1,138 +1,138 @@
 {
   "images-calico-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.2%2Brke2r1/rke2-images-calico.linux-amd64.tar.gz",
-    "sha256": "46f81e8114ddb829352d83ae3c45fc533659d474dbd19aeaf05971321885b9ad"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-calico.linux-amd64.tar.gz",
+    "sha256": "b85571d4e77831c90e5ab9169890177b472bb471ca4538335594109659239f32"
   },
   "images-calico-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.2%2Brke2r1/rke2-images-calico.linux-amd64.tar.zst",
-    "sha256": "2da3ed0859fa19b86deb78f39f7d4eea40b5322475d367bf95c2ca7ab3e5876c"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-calico.linux-amd64.tar.zst",
+    "sha256": "94721c4576ea11ac7a53077f7b3b83e0da06d83bbe4ab7bf696085eee8d79bdf"
   },
   "images-calico-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.2%2Brke2r1/rke2-images-calico.linux-arm64.tar.gz",
-    "sha256": "7166499d6aa70d2e08c2088db2edd7ac6be61dafbfcb7279767faad1608b4b06"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-calico.linux-arm64.tar.gz",
+    "sha256": "d5ea81e1b784d6631faf6c2dad980c2ab119a9d6bee3766e174c4ddd6afbd7d7"
   },
   "images-calico-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.2%2Brke2r1/rke2-images-calico.linux-arm64.tar.zst",
-    "sha256": "858ab93a661a028d09f389f3b67cfc323dddb488976dd0a7fc6a98be352b09e4"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-calico.linux-arm64.tar.zst",
+    "sha256": "1e6fac46a83442055666c2ab2aecbbbb8d8491c723fe6f587bd4af53423f5e23"
   },
   "images-canal-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.2%2Brke2r1/rke2-images-canal.linux-amd64.tar.gz",
-    "sha256": "7d336b65888212130ccdd572343ebd806d1332b061ea210204c32d98c5e1c790"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-canal.linux-amd64.tar.gz",
+    "sha256": "17d5b245b9ed022c4eb806c0a974be672b87dd5d21491dcac17ba2fc6cf7b105"
   },
   "images-canal-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.2%2Brke2r1/rke2-images-canal.linux-amd64.tar.zst",
-    "sha256": "c3e220b89fa78ea6522aaf8155d0c3d3b75521932cb412ffc776572e1731eefd"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-canal.linux-amd64.tar.zst",
+    "sha256": "20a8491b6a1c5ede6db6b2f8eb9c6dd2bccb1014193f50273b794d466f96b671"
   },
   "images-canal-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.2%2Brke2r1/rke2-images-canal.linux-arm64.tar.gz",
-    "sha256": "231c685f1412a67631aca0dac648e0484a23d219318eb110ee4f2b857dd734c4"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-canal.linux-arm64.tar.gz",
+    "sha256": "172691f696af33bec02fa560eb490fac5bba90ff206c3fe76f33ac48b3d89235"
   },
   "images-canal-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.2%2Brke2r1/rke2-images-canal.linux-arm64.tar.zst",
-    "sha256": "05449ac08f395ca1df496d37d50cb2531b1dea73074e0eed4d46680d59c723e8"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-canal.linux-arm64.tar.zst",
+    "sha256": "c6b4f18d5512159a783d8980b266eae0697e2eb9c9b6a87e845d8155ac3d10a7"
   },
   "images-cilium-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.2%2Brke2r1/rke2-images-cilium.linux-amd64.tar.gz",
-    "sha256": "181714ca655d22b4eb2bfe76f87ec94e86dde2e7b1d8770b9497ea4c987d81cd"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-cilium.linux-amd64.tar.gz",
+    "sha256": "d0b3351896b2475d86b3db55a176300b13e5c29f7ce253895871181de6c554d5"
   },
   "images-cilium-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.2%2Brke2r1/rke2-images-cilium.linux-amd64.tar.zst",
-    "sha256": "bd32f93fe2abe41f404789382daaeedf30e609fe681bb8320e2ea1a3e6ea821a"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-cilium.linux-amd64.tar.zst",
+    "sha256": "5eb9e750ccb966a5f65b294df586cadaa7988b84585c06538ba7e26a5e04ea31"
   },
   "images-cilium-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.2%2Brke2r1/rke2-images-cilium.linux-arm64.tar.gz",
-    "sha256": "7638a5cef90a4d978b458e6e01604b902e90900dcc56c98e0693555baf7810b3"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-cilium.linux-arm64.tar.gz",
+    "sha256": "473c179e121fa372118d8acf6d4042dcfbd78aa4180bde8f32a3686f6e67da0c"
   },
   "images-cilium-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.2%2Brke2r1/rke2-images-cilium.linux-arm64.tar.zst",
-    "sha256": "30fd832859920a01768c951dde0e91261a543c3cf59448324b96ec543532a7a6"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-cilium.linux-arm64.tar.zst",
+    "sha256": "9d60605d51e9adeae650731b1fcb06681140fe7ddff76178c3437f8bfc5876e8"
   },
   "images-core-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.2%2Brke2r1/rke2-images-core.linux-amd64.tar.gz",
-    "sha256": "429f4447439d293cf07ca50cedb64e2611c113ce0019abad82485198b57a2fbb"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-core.linux-amd64.tar.gz",
+    "sha256": "cd62de26e53ff647b542782a539b2f5b4fadd9e34e8c84071fb1ac744b353af5"
   },
   "images-core-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.2%2Brke2r1/rke2-images-core.linux-amd64.tar.zst",
-    "sha256": "a60e746be8075a67f2ded0e2beff192346fb0779f3e9896a86b20c3bb0a1ec36"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-core.linux-amd64.tar.zst",
+    "sha256": "c19d06dcafbadd08bc46199a7f22d43ce70848191c242d3642313f17b4fe186f"
   },
   "images-core-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.2%2Brke2r1/rke2-images-core.linux-arm64.tar.gz",
-    "sha256": "e1814a7f7f0f10c029e35fa3b49b9ede1039d60e47dfb1c17d7a730c4f7937c1"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-core.linux-arm64.tar.gz",
+    "sha256": "ed1650ffed4882821a833aaa86247038d386ab36a753726926de2346f228f240"
   },
   "images-core-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.2%2Brke2r1/rke2-images-core.linux-arm64.tar.zst",
-    "sha256": "83410a65484d691c280ee9fc29928dae53890b4623a2ffc2482b12c646fb56a9"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-core.linux-arm64.tar.zst",
+    "sha256": "9df49d0786965a359e3ab70208e65632e7962befb46175e217d5b35e5a556f4b"
   },
   "images-flannel-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.2%2Brke2r1/rke2-images-flannel.linux-amd64.tar.gz",
-    "sha256": "45767364848ceaa3824d9767dc269d2c042d4c73861d02100dc68d5e423ebd9f"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-flannel.linux-amd64.tar.gz",
+    "sha256": "5642c999542e0e09b5b304f363b4612bc7e1d18ea209787c65015728a61d64f7"
   },
   "images-flannel-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.2%2Brke2r1/rke2-images-flannel.linux-amd64.tar.zst",
-    "sha256": "cc77078e84b41ddf77c2eb7cb03e7e3fb6f70e07ada84daf2fdd553093aaa9b3"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-flannel.linux-amd64.tar.zst",
+    "sha256": "e87d546dcbe16384fe163bf8d52cd41b36a106a6202ac0bf308e91085cc02c00"
   },
   "images-flannel-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.2%2Brke2r1/rke2-images-flannel.linux-arm64.tar.gz",
-    "sha256": "350c22c1980745d86f639376f4567d1da65488288cd1b85d0957c52bec8b2a4f"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-flannel.linux-arm64.tar.gz",
+    "sha256": "6ff5df889ac61275f876c090476768cb0fde8d675300ac17ffa1bcab19c419a6"
   },
   "images-flannel-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.2%2Brke2r1/rke2-images-flannel.linux-arm64.tar.zst",
-    "sha256": "056ff1ed67c6fa75dd9653cb98d785349dbbcd7c4f47ca0847b9ec890f2e0afd"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-flannel.linux-arm64.tar.zst",
+    "sha256": "9f33d2b63ae6c59e91e534a9f9908966116b3fec4880c3a13b522d3bbbddf207"
   },
   "images-harvester-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.2%2Brke2r1/rke2-images-harvester.linux-amd64.tar.gz",
-    "sha256": "a876cfe3af3fa2630489e836729948257deb1056c0ad11083cd9ccd516f48ed0"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-harvester.linux-amd64.tar.gz",
+    "sha256": "a27f7c2ca33466cbf99d79648d30aa6b9cd8813bda40abf78f48315f7b038d2d"
   },
   "images-harvester-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.2%2Brke2r1/rke2-images-harvester.linux-amd64.tar.zst",
-    "sha256": "8447aaa2c45b753fd37b9ea3e49deaa0e90d207c7b53d4cb53dd3ab83f7e25fa"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-harvester.linux-amd64.tar.zst",
+    "sha256": "8b83f60edc527b368bc412a1f2773387d8691f4e17b3a176cf2f648af9b4989b"
   },
   "images-harvester-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.2%2Brke2r1/rke2-images-harvester.linux-arm64.tar.gz",
-    "sha256": "5f957df8553c5c2678342e8138ef30f81483be94e1399c0f0c8de4e7cc9c0fda"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-harvester.linux-arm64.tar.gz",
+    "sha256": "abe89abd5e5b09a00469e256cfcb0e4bd1b72f5ac01d8efecfef2c623c705454"
   },
   "images-harvester-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.2%2Brke2r1/rke2-images-harvester.linux-arm64.tar.zst",
-    "sha256": "639db539e8e95ae6ff25f4af54b47144784975a06ec0091c52dc48606b79dad1"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-harvester.linux-arm64.tar.zst",
+    "sha256": "cf1ff411e9acd0a78994e4d2fa52b63fc03ae30e59ecebf24609a65988fe877c"
   },
   "images-multus-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.2%2Brke2r1/rke2-images-multus.linux-amd64.tar.gz",
-    "sha256": "61f03dbac2a3911d558d0dbdf685966d26982f799e837256cd7f9d353a00dd2b"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-multus.linux-amd64.tar.gz",
+    "sha256": "4472b330de3725c0135740da2c59e954c1f2cd3904b6bb22b2c764a2333c4a9a"
   },
   "images-multus-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.2%2Brke2r1/rke2-images-multus.linux-amd64.tar.zst",
-    "sha256": "8e2cf0a062b8b704f612ced0751e288278f63632d9444141036da933d847ebcf"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-multus.linux-amd64.tar.zst",
+    "sha256": "aadd39289a95d0658cf8373aa896608d6ac62c654ed66f4edf1ff7f8e6a75881"
   },
   "images-multus-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.2%2Brke2r1/rke2-images-multus.linux-arm64.tar.gz",
-    "sha256": "a67e9317749743a30313bca5c919aa7300b83513eb330535669b411beb8b6220"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-multus.linux-arm64.tar.gz",
+    "sha256": "b4447f161a0c86adea6050f298644fa42ef9b6eb0f315cd64d22b62ad20b3780"
   },
   "images-multus-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.2%2Brke2r1/rke2-images-multus.linux-arm64.tar.zst",
-    "sha256": "611231207174f2c90dc767296d39b3da6c81acdb6809add4bb0e9ecf32c3eecf"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-multus.linux-arm64.tar.zst",
+    "sha256": "f1b91676d2517fa30afc36d077aef5568db8dcedfffce5f2081d35f6468620b2"
   },
   "images-traefik-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.2%2Brke2r1/rke2-images-traefik.linux-amd64.tar.gz",
-    "sha256": "6d0d198443f3102a0160179d57645d98888ad5da4a22e7e3cde78d1661c0e0b3"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-traefik.linux-amd64.tar.gz",
+    "sha256": "52b6fdc13ba7ada02a1bf4a9e6044e2f1b53a864d53edeb1908f82a41e442c25"
   },
   "images-traefik-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.2%2Brke2r1/rke2-images-traefik.linux-amd64.tar.zst",
-    "sha256": "55e06739983ea113870d5e161797ad7fc9a045adb7424c6112b6fc7ef77f4613"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-traefik.linux-amd64.tar.zst",
+    "sha256": "8c07f6491263873efbdf40795cf733a3a3da349e4bfc9d5edc59c50504347ebd"
   },
   "images-traefik-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.2%2Brke2r1/rke2-images-traefik.linux-arm64.tar.gz",
-    "sha256": "34b8bd724ed79f471b5cd0f739cbaf6d6e7907fd2ea0f7fd9836fbe4c9d85d1c"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-traefik.linux-arm64.tar.gz",
+    "sha256": "21d052162e50021c9d0efae0ad1c22e490dec2ac70d8d36dfe2975ab0d0105e3"
   },
   "images-traefik-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.2%2Brke2r1/rke2-images-traefik.linux-arm64.tar.zst",
-    "sha256": "5a58a01484e0f1e1e5752cb303bf1127897a252ac3b38c67f29e087d5178364c"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-traefik.linux-arm64.tar.zst",
+    "sha256": "25a2c696e2ff8cfa508bf8cf7efdfe897018783dba92ff92c8aebcfcd1f2fb08"
   },
   "images-vsphere-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.2%2Brke2r1/rke2-images-vsphere.linux-amd64.tar.gz",
-    "sha256": "887fc456a3092fa085081432a24600cbffa5118d0a04573e24c8dc040311d49b"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-vsphere.linux-amd64.tar.gz",
+    "sha256": "9d37cc1e535d65a8f2d53ff35f35f3a0d0a09d5aa1fea474f47dc60900741e42"
   },
   "images-vsphere-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.2%2Brke2r1/rke2-images-vsphere.linux-amd64.tar.zst",
-    "sha256": "1f159abf894d00e9aab001efc6ea7cef34ba8ce9a4c2e9ce4f1162860c57d25d"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-vsphere.linux-amd64.tar.zst",
+    "sha256": "325587c90dbb2bbaf7aa5c2a42910b6110927031dc031535db779486c36e969d"
   }
 }

--- a/pkgs/applications/networking/cluster/rke2/1_34/versions.nix
+++ b/pkgs/applications/networking/cluster/rke2/1_34/versions.nix
@@ -8,5 +8,6 @@
   pauseVersion = "3.6";
   ccmVersion = "v1.34.2-0.20251010190833-cf0d35a732d1-build20251017";
   dockerizedVersion = "v1.34.2-rke2r1";
+  helmJobVersion = "";
   imagesVersions = with builtins; fromJSON (readFile ./images-versions.json);
 }

--- a/pkgs/applications/networking/cluster/rke2/1_34/versions.nix
+++ b/pkgs/applications/networking/cluster/rke2/1_34/versions.nix
@@ -1,13 +1,13 @@
 {
-  rke2Version = "1.34.2+rke2r1";
-  rke2Commit = "5e3fff8134a5269977762be64197d0cb9b26b48c";
-  rke2TarballHash = "sha256-qd8oD51x2tiIRLWWA5rWUVp/stBB2ebe8dFIB5XuZME=";
-  rke2VendorHash = "sha256-0qsCo/9kttOaFqOwfNfwxaG9z+EAdk15Dde3Gw5tK98=";
-  k8sImageTag = "v1.34.2-rke2r1-build20251112";
-  etcdVersion = "v3.6.5-k3s1-build20251017";
+  rke2Version = "1.34.3+rke2r1";
+  rke2Commit = "1b103f296ab20fac6b32951c9efe59d28a5ed79f";
+  rke2TarballHash = "sha256-94wB6Dt06/evdQcW1K8blNBHwNR3ZGCZPLJyeyMbYAM=";
+  rke2VendorHash = "sha256-hVEIhaF5gabDKWX2VCTyKQa0cZktO9w+l2JtSNQIkg8=";
+  k8sImageTag = "v1.34.3-rke2r1-build20251210";
+  etcdVersion = "v3.6.6-k3s1-build20251210";
   pauseVersion = "3.6";
-  ccmVersion = "v1.34.2-0.20251010190833-cf0d35a732d1-build20251017";
-  dockerizedVersion = "v1.34.2-rke2r1";
-  helmJobVersion = "";
+  ccmVersion = "v1.34.3-0.20251210094406-1ff6ebef7028-build20251210";
+  dockerizedVersion = "v1.34.3-rke2r1";
+  helmJobVersion = "v0.9.12-build20251215";
   imagesVersions = with builtins; fromJSON (readFile ./images-versions.json);
 }

--- a/pkgs/applications/networking/cluster/rke2/builder.nix
+++ b/pkgs/applications/networking/cluster/rke2/builder.nix
@@ -10,6 +10,7 @@ lib:
   pauseVersion,
   ccmVersion,
   dockerizedVersion,
+  helmJobVersion,
   imagesVersions,
 }:
 
@@ -76,20 +77,27 @@ buildGoModule (finalAttrs: {
   # Passing boringcrypto to GOEXPERIMENT variable to build with goboring library
   GOEXPERIMENT = "boringcrypto";
 
-  # See: https://github.com/rancher/rke2/blob/e7f87c6dd56fdd76a7dab58900aeea8946b2c008/scripts/build-binary#L27-L38
-  ldflags = [
-    "-w"
-    "-X github.com/k3s-io/k3s/pkg/version.GitCommit=${lib.substring 0 6 rke2Commit}"
-    "-X github.com/k3s-io/k3s/pkg/version.Program=${finalAttrs.pname}"
-    "-X github.com/k3s-io/k3s/pkg/version.Version=v${finalAttrs.version}"
-    "-X github.com/k3s-io/k3s/pkg/version.UpstreamGolang=go${go.version}"
-    "-X github.com/rancher/rke2/pkg/images.DefaultRegistry=docker.io"
-    "-X github.com/rancher/rke2/pkg/images.DefaultEtcdImage=rancher/hardened-etcd:${etcdVersion}"
-    "-X github.com/rancher/rke2/pkg/images.DefaultKubernetesImage=rancher/hardened-kubernetes:${k8sImageTag}"
-    "-X github.com/rancher/rke2/pkg/images.DefaultPauseImage=rancher/mirrored-pause:${pauseVersion}"
-    "-X github.com/rancher/rke2/pkg/images.DefaultRuntimeImage=rancher/rke2-runtime:${dockerizedVersion}"
-    "-X github.com/rancher/rke2/pkg/images.DefaultCloudControllerManagerImage=rancher/rke2-cloud-provider:${ccmVersion}"
-  ];
+  # https://github.com/rancher/rke2/blob/104ddbf3de65ab5490aedff36df2332d503d90fe/scripts/build-binary#L27-L39
+  ldflags =
+    let
+      K3S_PKG = "github.com/k3s-io/k3s";
+      HELMCTR_PKG = "github.com/k3s-io/helm-controller";
+      RKE2_PKG = "github.com/rancher/rke2";
+    in
+    [
+      "-w"
+      "-X ${K3S_PKG}/pkg/version.GitCommit=${lib.substring 0 6 rke2Commit}"
+      "-X ${K3S_PKG}/pkg/version.Program=${finalAttrs.pname}"
+      "-X ${K3S_PKG}/pkg/version.Version=v${finalAttrs.version}"
+      "-X ${K3S_PKG}/pkg/version.UpstreamGolang=go${go.version}"
+      "-X ${HELMCTR_PKG}/pkg/controllers/chart.DefaultJobImage=rancher/klipper-helm:${helmJobVersion}"
+      "-X ${RKE2_PKG}/pkg/images.DefaultRegistry=docker.io"
+      "-X ${RKE2_PKG}/pkg/images.DefaultEtcdImage=rancher/hardened-etcd:${etcdVersion}"
+      "-X ${RKE2_PKG}/pkg/images.DefaultKubernetesImage=rancher/hardened-kubernetes:${k8sImageTag}"
+      "-X ${RKE2_PKG}/pkg/images.DefaultPauseImage=rancher/mirrored-pause:${pauseVersion}"
+      "-X ${RKE2_PKG}/pkg/images.DefaultRuntimeImage=rancher/rke2-runtime:${dockerizedVersion}"
+      "-X ${RKE2_PKG}/pkg/images.DefaultCloudControllerManagerImage=rancher/rke2-cloud-provider:${ccmVersion}"
+    ];
 
   tags = [
     "no_cri_dockerd"

--- a/pkgs/applications/networking/cluster/rke2/default.nix
+++ b/pkgs/applications/networking/cluster/rke2/default.nix
@@ -16,6 +16,8 @@ rec {
       }
     ) extraArgs).overrideAttrs
       {
+        # limited functionality due to missing version data
+        meta.broken = true;
         meta.knownVulnerabilities = [ "rke2_1_31 has reached end-of-life on 2025-11-11" ];
       };
 

--- a/pkgs/applications/networking/cluster/rke2/update-script.sh
+++ b/pkgs/applications/networking/cluster/rke2/update-script.sh
@@ -71,6 +71,7 @@ cat << EOF > "${WORKDIR}/1_${MINOR_VERSION}/versions.nix"
   pauseVersion = "${PAUSE_VERSION}";
   ccmVersion = "${CCM_VERSION}";
   dockerizedVersion = "${DOCKERIZED_VERSION}";
+  helmJobVersion = "${KLIPPERHELM_VERSION}";
   imagesVersions = with builtins; fromJSON (readFile ./images-versions.json);
 }
 EOF


### PR DESCRIPTION
Manual backport of #478739, supersedes #479301 since `rke2_1_31` needs the new `helmJobVersion` attr to eval properly. It builds but still fails tests with the updated builder just like `k3s_1_31` (#477410) so I marked it as broken, but all other tests passed.

cc @rorosen @zimbatm @stefan-bordei

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
