### PR TITLE
selfci: init at 0-unstable-2026-01-17

### DIFF
--- a/pkgs/by-name/se/selfci/Cargo.toml.patch
+++ b/pkgs/by-name/se/selfci/Cargo.toml.patch
@@ -1,0 +1,13 @@
+diff --git a/Cargo.toml b/Cargo.toml
+index 8f7a1e2..e2062c4 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -10,7 +10,7 @@ readme = "README.md"
+ keywords = ["ci"]
+ categories = ["development-tools"]
+ authors = ["dpc <dpc@dpc.pw>"]
+-rust-version = "1.92"
++rust-version = "1.91"
+ 
+ [[bin]]
+ name = "selfci"

--- a/pkgs/by-name/se/selfci/package.nix
+++ b/pkgs/by-name/se/selfci/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  fetchgit,
+  nix-update-script,
+  rustPlatform,
+  git,
+  makeWrapper,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "selfci";
+  version = "0-unstable-2026-01-17";
+
+  src = fetchgit {
+    url = "https://radicle.dpc.pw/z2tDzYbAXxTQEKTGFVwiJPajkbeDU.git";
+    rev = "83e693dada851ce0da32713869d3da02c52ed257";
+    hash = "sha256-f0BfHvIQnhhiPie3a+9MeEGzZ+/KcgrbKBneu8Jo+xs=";
+  };
+
+  cargoHash = "sha256-Z3f35HIZiNeKeDNFPUVkFvL2OpMWzqRvxOL5/hUEzJw=";
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  patches = [
+    ./Cargo.toml.patch
+  ];
+
+  doCheck = false;
+
+  postInstall = ''
+    wrapProgram "$out"/bin/selfci \
+    --prefix PATH : ${lib.makeBinPath [ git ]}
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Minimalistic local-first Unix-philosophy-abiding CI";
+    homepage = "https://app.radicle.xyz/nodes/radicle.dpc.pw/rad%3Az2tDzYbAXxTQEKTGFVwiJPajkbeDU";
+    license = lib.licenses.mpl20;
+    maintainers = with lib.maintainers; [
+      dvn0
+    ];
+    mainProgram = "selfci";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Git is not a hard dependency but some primary functionality will be broken without it.
Four tests fail, so tests are disabled. Did not spend much time investigating.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
