### PR TITLE
wowup-cf: 2.20.0 -> 2.22.0

### DIFF
--- a/pkgs/by-name/wo/wowup-cf/package.nix
+++ b/pkgs/by-name/wo/wowup-cf/package.nix
@@ -5,12 +5,12 @@
 }:
 
 let
-  version = "2.20.0";
+  version = "2.22.0";
   pname = "wowup-cf";
 
   src = fetchurl {
     url = "https://github.com/WowUp/WowUp.CF/releases/download/v${version}/WowUp-CF-${version}.AppImage";
-    hash = "sha256-Fu0FqeWJip0cXSifu1QDktu73SsxGpkEU3cuYbFghxc=";
+    hash = "sha256-X5gDnj4YBZRBwJEeb8sVMNoGmWUI9iVdWOmsA20bWig=";
   };
 
   appimageContents = appimageTools.extractType1 { inherit pname version src; };


### PR DESCRIPTION
2.20.0 doesn't work for TBC anniversary version of wow.

2.22.0 adds support for TBC anniversary.

## Changelog
* [2.22.0](https://github.com/WowUp/WowUp.CF/releases/tag/v2.22.0)
  * TBC Anniversary support.
  * Electron upgrades.
* [2.21.0-beta.3](https://github.com/WowUp/WowUp.CF/releases/tag/v2.21.0-beta.3)
  * More MoP Updates
* [2.21.0-beta.2](https://github.com/WowUp/WowUp.CF/releases/tag/v2.21.0-beta.2)
  * MoP Updates
  
 Can't find a 2.21.0-beta.1, or a full 2.21 release

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

Builds:
<img width="615" height="106" alt="image" src="https://github.com/user-attachments/assets/014ea760-d0b5-434b-90ce-788bf8989d54" />

Detects TBC anniversary:
<img width="800" height="436" alt="image" src="https://github.com/user-attachments/assets/f603e443-5a05-4767-8b8e-d3a5fd62f42a" />

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
