### PR TITLE
haskellPackages: fix some pkgsCross.ucrt64 packages

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2367,6 +2367,13 @@ with haskellLib;
     pkgs.stdenv.hostPlatform.isPower64 && pkgs.stdenv.hostPlatform.isBigEndian
   ) super.crypton-x509-validation;
 
+  crypton-x509-system = overrideCabal (drv: {
+    # Case sensitive when doing cross-compilation to windows
+    postPatch = drv.postPatch or "" + ''
+      substituteInPlace crypton-x509-system.cabal --replace-fail "Crypt32" "crypt32"
+    '';
+  }) super.crypton-x509-system;
+
   # Likely fallout from the crypton issues
   # exception: HandshakeFailed (Error_Protocol "bad PubKeyALG_Ed448 signature for ecdhparams" DecryptError)
   tls = dontCheckIf (

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -494,15 +494,20 @@ with haskellLib;
   jpeg-turbo = dontCheck super.jpeg-turbo;
   JuicyPixels-jpeg-turbo = dontCheck super.JuicyPixels-jpeg-turbo;
 
-  # Fixes compilation for basement on i686
-  # https://github.com/haskell-foundation/foundation/pull/573
   basement = appendPatches [
+    # Fixes compilation for basement on i686
+    # https://github.com/haskell-foundation/foundation/pull/573
     (fetchpatch {
       name = "basement-i686-ghc-9.4.patch";
       url = "https://github.com/haskell-foundation/foundation/pull/573/commits/38be2c93acb6f459d24ed6c626981c35ccf44095.patch";
       sha256 = "17kz8glfim29vyhj8idw8bdh3id5sl9zaq18zzih3schfvyjppj7";
       stripLen = 1;
     })
+
+    # Fixes compilation on windows
+    # Repo is archived, package is abandoned: https://github.com/haskell-foundation/foundation
+    ./patches/basement-add-cast.patch
+
   ] super.basement;
 
   # Fixes compilation of memory with GHC >= 9.4 on 32bit platforms

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -274,7 +274,7 @@ with haskellLib;
       "vector-tests-O2"
     ];
     # inspection-testing doesn't work on all archs & ABIs
-    doCheck = !self.inspection-testing.meta.broken;
+    doCheck = super.vector.doCheck && !self.inspection-testing.meta.broken;
   }) super.vector;
 
   # https://github.com/lspitzner/data-tree-print/issues/4

--- a/pkgs/development/haskell-modules/configuration-windows.nix
+++ b/pkgs/development/haskell-modules/configuration-windows.nix
@@ -8,6 +8,8 @@ with haskellLib;
 
 (self: super: {
   # cabal2nix doesn't properly add dependencies conditional on os(windows)
+  unix-time = addBuildDepends [ pkgs.windows.pthreads ] super.unix-time;
+
   network = lib.pipe super.network [
     (addBuildDepends [ self.temporary ])
 

--- a/pkgs/development/haskell-modules/configuration-windows.nix
+++ b/pkgs/development/haskell-modules/configuration-windows.nix
@@ -42,11 +42,4 @@ with haskellLib;
     splitmix
     temporary
     ;
-
-  # https://github.com/fpco/streaming-commons/pull/84
-  streaming-commons = appendPatch (fetchpatch {
-    name = "fix-headers-case.patch";
-    url = "https://github.com/fpco/streaming-commons/commit/6da611f63e9e862523ce6ee53262ddbc9681ae24.patch";
-    sha256 = "sha256-giEQqXZfoiAvtCFohdgOoYna2Tnu5aSYAOUH8YVldi0=";
-  }) super.streaming-commons;
 })

--- a/pkgs/development/haskell-modules/configuration-windows.nix
+++ b/pkgs/development/haskell-modules/configuration-windows.nix
@@ -8,6 +8,8 @@ with haskellLib;
 
 (self: super: {
   # cabal2nix doesn't properly add dependencies conditional on os(windows)
+  http-client = addBuildDepends [ self.safe ] super.http-client;
+
   unix-time = addBuildDepends [ pkgs.windows.pthreads ] super.unix-time;
 
   network = lib.pipe super.network [

--- a/pkgs/development/haskell-modules/patches/basement-add-cast.patch
+++ b/pkgs/development/haskell-modules/patches/basement-add-cast.patch
@@ -1,0 +1,13 @@
+diff --git a/Basement/Terminal/Size.hsc b/Basement/Terminal/Size.hsc
+index 62c315e..4bfe0ad 100644
+--- a/Basement/Terminal/Size.hsc
++++ b/Basement/Terminal/Size.hsc
+@@ -121,7 +121,7 @@ instance Storable ConsoleScreenBufferInfo where
+         #{poke CONSOLE_SCREEN_BUFFER_INFO, dwMaximumWindowSize} ptr m
+     
+ invalidHandleValue :: IntPtr
+-invalidHandleValue = #{const INVALID_HANDLE_VALUE}
++invalidHandleValue = IntPtr $ #{const (long long int)INVALID_HANDLE_VALUE}
+ 
+ stdOutputHandle :: CULong
+ stdOutputHandle = #{const STD_OUTPUT_HANDLE}


### PR DESCRIPTION
```
nix-build -E 'with (import ./. {}).haskellPackages; [ streaming-commons vector unix-time basement http-client crypton-x509-system ]'
```
```
nix-build -E 'with (import ./. {}).pkgsCross.ucrt64.haskell.packages.ghc912; [ streaming-commons vector unix-time basement http-client crypton-x509-system ]'
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
