### PR TITLE
argononed: unstable-2022-03-25 -> 0.4.1-unstable-2025-12-26

### DIFF
--- a/pkgs/by-name/ar/argononed/fix-hardcoded-reboot-poweroff-paths.patch
+++ b/pkgs/by-name/ar/argononed/fix-hardcoded-reboot-poweroff-paths.patch
@@ -5,14 +5,14 @@
              log_message(LOG_DEBUG, "EXEC REBOOT");
              sync();
 -            system("/sbin/reboot");
-+            system("/run/current-system/sw/bin/reboot");
++            system("reboot");
          }
          if (count >= 39 && count <= 41)
          {
              log_message(LOG_DEBUG, "EXEC SHUTDOWN");
              sync();
 -            system("/sbin/poweroff");
-+            system("/run/current-system/sw/bin/poweroff");
++            system("poweroff");
          }
      } else {
          log_message(LOG_INFO + LOG_BOLD,"Daemon Ready");

--- a/pkgs/by-name/ar/argononed/fix-hardcoded-reboot-poweroff-paths.patch
+++ b/pkgs/by-name/ar/argononed/fix-hardcoded-reboot-poweroff-paths.patch
@@ -1,18 +1,18 @@
 --- a/src/argononed.c
 +++ b/src/argononed.c
-@@ -783,13 +783,13 @@
-     {
-         log_message(LOG_DEBUG, "EXEC REBOOT");
-         sync();
--        system("/sbin/reboot");
-+        system("/run/current-system/sw/bin/reboot");
-     }
-     if (count >= 39 && count <= 41)
-     {
-         log_message(LOG_DEBUG, "EXEC SHUTDOWN");
-         sync();
--        system("/sbin/poweroff");
-+        system("/run/current-system/sw/bin/poweroff");
-     }
- #else
-     log_message(LOG_INFO,"Daemon Ready");
+@@ -665,13 +665,13 @@
+         {
+             log_message(LOG_DEBUG, "EXEC REBOOT");
+             sync();
+-            system("/sbin/reboot");
++            system("/run/current-system/sw/bin/reboot");
+         }
+         if (count >= 39 && count <= 41)
+         {
+             log_message(LOG_DEBUG, "EXEC SHUTDOWN");
+             sync();
+-            system("/sbin/poweroff");
++            system("/run/current-system/sw/bin/poweroff");
+         }
+     } else {
+         log_message(LOG_INFO + LOG_BOLD,"Daemon Ready");

--- a/pkgs/by-name/ar/argononed/package.nix
+++ b/pkgs/by-name/ar/argononed/package.nix
@@ -5,16 +5,15 @@
   dtc,
   installShellFiles,
 }:
-
 stdenv.mkDerivation {
   pname = "argononed";
-  version = "unstable-2022-03-26";
+  version = "0.4.1-unstable-2025-12-26";
 
   src = fetchFromGitLab {
     owner = "DarkElvenAngel";
     repo = "argononed";
-    rev = "97c4fa07fc2c09ffc3bd86e0f6319d50fa639578";
-    hash = "sha256-5/xUYbprRiwD+FN8V2cUpHxnTbBkEsFG2wfsEXrCrgQ=";
+    rev = "34d70b3bb1b2a8ba4b146ba7d9962dd0d925e67e";
+    hash = "sha256-f7YGoky4C5P/Iyez3kuLEKU/yWKZ4Dh6Cy//PAKMYuU=";
   };
 
   patches = [ ./fix-hardcoded-reboot-poweroff-paths.patch ];


### PR DESCRIPTION
~~Argononed does not compile with gcc 15, so I've pinned it to 14.~~
Changes in gcc 15 breaks argononed compilation. Upstream has been updated to fix this.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
