### PR TITLE
{workflows/eval,ci/github-script}: check for mass and NixOS test rebuilds targeting master/release-* branches

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -168,6 +168,7 @@ jobs:
     needs: [eval]
     if: ${{ !cancelled() && !failure() }}
     permissions:
+      pull-requests: write
       statuses: write
     timeout-minutes: 5
     steps:
@@ -253,6 +254,17 @@ jobs:
               state: 'success',
               description,
               target_url
+            })
+      - name: Request changes if PR is against an inappropriate branch
+        if: ${{ github.event_name == 'pull_request_target' }}
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            require('./nixpkgs/trusted/ci/github-script/check-target-branch.js')({
+              github,
+              context,
+              core,
+              dry: context.eventName == 'pull_request',
             })
 
   # Creates a matrix of Eval performance for various versions and systems.

--- a/.github/workflows/merge-group.yml
+++ b/.github/workflows/merge-group.yml
@@ -84,6 +84,7 @@ jobs:
     # even though they are unused when working with the merge queue.
     permissions:
       # compare
+      pull-requests: write
       statuses: write
     secrets:
       CACHIX_AUTH_TOKEN_GHA: ${{ secrets.CACHIX_AUTH_TOKEN_GHA }}

--- a/.github/workflows/pull-request-target.yml
+++ b/.github/workflows/pull-request-target.yml
@@ -81,6 +81,7 @@ jobs:
     uses: ./.github/workflows/eval.yml
     permissions:
       # compare
+      pull-requests: write
       statuses: write
     with:
       artifact-prefix: ${{ inputs.artifact-prefix }}

--- a/ci/github-script/check-target-branch.js
+++ b/ci/github-script/check-target-branch.js
@@ -1,0 +1,135 @@
+/// @ts-check
+
+// TODO: should this be combined with the branch checks in prepare.js?
+// They do seem quite similar, but this needs to run after eval,
+// and prepare.js obviously doesn't.
+
+const { classify, split } = require('../supportedBranches.js')
+const { readFile } = require('node:fs/promises')
+const { postReview } = require('./reviews.js')
+
+/**
+ * @param {{
+ *  github: InstanceType<import('@actions/github/lib/utils').GitHub>,
+ *  context: import('@actions/github/lib/context').Context
+ *  core: import('@actions/core')
+ *  dry: boolean
+ * }} CheckTargetBranchProps
+ */
+async function checkTargetBranch({ github, context, core, dry }) {
+  const changed = JSON.parse(
+    await readFile('comparison/changed-paths.json', 'utf-8'),
+  )
+  const pull_number = context.payload.pull_request?.number
+  if (!pull_number) {
+    core.warning(
+      'Skipping checkTargetBranch: no pull_request number (is this being run as part of a merge group?)',
+    )
+    return
+  }
+  const prInfo = (
+    await github.rest.pulls.get({
+      ...context.repo,
+      pull_number,
+    })
+  ).data
+  const base = prInfo.base.ref
+  const head = prInfo.head.ref
+  const baseClassification = classify(base)
+  const headClassification = classify(head)
+
+  // Don't run on, e.g., staging-nixos to master merges.
+  if (headClassification.type.includes('development')) {
+    core.info(
+      `Skipping checkTargetBranch: PR is from a development branch (${head})`,
+    )
+    return
+  }
+  // Don't run on PRs against staging branches, wip branches, haskell-updates, etc.
+  if (!baseClassification.type.includes('primary')) {
+    core.info(
+      `Skipping checkTargetBranch: PR is against a non-primary base branch (${base})`,
+    )
+    return
+  }
+
+  const maxRebuildCount = Math.max(
+    ...Object.values(changed.rebuildCountByKernel),
+  )
+  const rebuildsAllTests =
+    changed.attrdiff.changed.includes('nixosTests.simple') ?? false
+  core.info(
+    `checkTargetBranch: PR causes ${maxRebuildCount} rebuilds and ${rebuildsAllTests ? 'does' : 'does not'} rebuild all NixOS tests.`,
+  )
+
+  if (maxRebuildCount >= 1000) {
+    const desiredBranch =
+      base === 'master' ? 'staging' : `staging-${split(base).version}`
+    const body = [
+      `The PR's base branch is set to \`${base}\`, but this PR causes ${maxRebuildCount} rebuilds.`,
+      'It is therefore considered a mass rebuild.',
+      `Please [change the base branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-base-branch-of-a-pull-request) to [the right base branch for your changes](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#branch-conventions) (probably \`${desiredBranch}\`).`,
+    ].join('\n')
+
+    await postReview({
+      github,
+      context,
+      core,
+      dry,
+      body,
+      event: 'REQUEST_CHANGES',
+    })
+
+    throw new Error('This PR is against the wrong branch.')
+  } else if (rebuildsAllTests) {
+    let branchText
+    if (base === 'master' && maxRebuildCount >= 500) {
+      branchText = '(probably either `staging-nixos` or `staging`)'
+    } else if (base === 'master') {
+      branchText = '(probably `staging-nixos`)'
+    } else {
+      branchText = `(probably \`staging-${split(base).version}\`)`
+    }
+    const body = [
+      `The PR's base branch is set to \`${base}\`, but this PR rebuilds all NixOS tests.`,
+      base === 'master' && maxRebuildCount >= 500
+        ? `Since this PR also causes ${maxRebuildCount} rebuilds, it may also be considered a mass rebuild.`
+        : '',
+      `Please [change the base branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-base-branch-of-a-pull-request) to [the right base branch for your changes](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#branch-conventions) ${branchText}.`,
+    ].join('\n')
+
+    await postReview({
+      github,
+      context,
+      core,
+      dry,
+      body,
+      event: 'REQUEST_CHANGES',
+    })
+
+    throw new Error('This PR is against the wrong branch.')
+  } else if (maxRebuildCount >= 500) {
+    const stagingBranch =
+      base === 'master' ? 'staging' : `staging-${split(base).version}`
+    const body = [
+      `The PR's base branch is set to \`${base}\`, and this PR causes ${maxRebuildCount} rebuilds.`,
+      `Please consider whether this PR causes a mass rebuild according to [our conventions](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#branch-conventions).`,
+      `If it does cause a mass rebuild, please [change the base branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-base-branch-of-a-pull-request) to [the right base branch for your changes](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#branch-conventions) (probably \`${stagingBranch}\`).`,
+      `If it does not cause a mass rebuild, this message can be ignored.`,
+    ].join('\n')
+
+    await postReview({
+      github,
+      context,
+      core,
+      dry,
+      body,
+      event: 'COMMENT',
+    })
+  } else {
+    // Any existing reviews were dismissed by commits.js
+    core.info('checkTargetBranch: this PR is against an appropriate branch.')
+  }
+}
+
+module.exports = checkTargetBranch

--- a/ci/github-script/reviews.js
+++ b/ci/github-script/reviews.js
@@ -1,3 +1,16 @@
+const eventToState = {
+  COMMENT: 'COMMENTED',
+  REQUEST_CHANGES: 'CHANGES_REQUESTED',
+}
+
+/**
+ * @param {{
+ *  github: InstanceType<import('@actions/github/lib/utils').GitHub>,
+ *  context: import('@actions/github/lib/context').Context
+ *  core: import('@actions/core')
+ *  dry: boolean
+ * }} CheckTargetBranchProps
+ */
 async function dismissReviews({ github, context, dry }) {
   const pull_number = context.payload.pull_request.number
 
@@ -36,7 +49,14 @@ async function dismissReviews({ github, context, dry }) {
   )
 }
 
-async function postReview({ github, context, core, dry, body }) {
+async function postReview({
+  github,
+  context,
+  core,
+  dry,
+  body,
+  event = 'REQUEST_CHANGES',
+}) {
   const pull_number = context.payload.pull_request.number
 
   const pendingReview = (
@@ -49,7 +69,7 @@ async function postReview({ github, context, core, dry, body }) {
       review.user?.login === 'github-actions[bot]' &&
       // If a review is still pending, we can just update this instead
       // of posting a new one.
-      review.state === 'CHANGES_REQUESTED',
+      review.state === eventToState[event],
   )
 
   if (dry) {
@@ -69,7 +89,7 @@ async function postReview({ github, context, core, dry, body }) {
       await github.rest.pulls.createReview({
         ...context.repo,
         pull_number,
-        event: 'REQUEST_CHANGES',
+        event,
         body,
       })
     }

--- a/ci/github-script/reviews.js
+++ b/ci/github-script/reviews.js
@@ -19,13 +19,13 @@ async function dismissReviews({ github, context, dry }) {
             ...context.repo,
             pull_number,
             review_id: review.id,
-            message: 'All good now, thank you!',
+            message: 'Review dismissed automatically',
           })
         }
         await github.graphql(
           `mutation($node_id:ID!) {
             minimizeComment(input: {
-              classifier: RESOLVED,
+              classifier: OUTDATED,
               subjectId: $node_id
             })
             { clientMutationId }
@@ -49,10 +49,7 @@ async function postReview({ github, context, core, dry, body }) {
       review.user?.login === 'github-actions[bot]' &&
       // If a review is still pending, we can just update this instead
       // of posting a new one.
-      (review.state === 'CHANGES_REQUESTED' ||
-        // No need to post a new review, if an older one with the exact
-        // same content had already been dismissed.
-        review.body === body),
+      review.state === 'CHANGES_REQUESTED',
   )
 
   if (dry) {

--- a/ci/github-script/run
+++ b/ci/github-script/run
@@ -105,4 +105,15 @@ program
     await run(checkCommitMessages, owner, repo, pr, options)
   })
 
+program
+  .command('check-target-branch')
+  .description('Check that the PR is made against the correct branch')
+  .argument('<owner>', 'Owner of the GitHub repository to run on (Example: NixOS)')
+  .argument('<repo>', 'Name of the GitHub repository to run on (Example: nixpkgs)')
+  .argument('<pr>', 'Number of the Pull Request to run on')
+  .action(async (owner, repo, pr, options) => {
+    const checkCommitMessages = (await import('./check-target-branch.js')).default
+    await run(checkCommitMessages, owner, repo, pr, options)
+  })
+
 await program.parse()

--- a/ci/supportedBranches.js
+++ b/ci/supportedBranches.js
@@ -44,7 +44,7 @@ function classify(branch) {
   }
 }
 
-module.exports = { classify }
+module.exports = { classify, split }
 
 // If called directly via CLI, runs the following tests:
 if (!module.parent) {


### PR DESCRIPTION
Per discussion in infra matrix channel.

### Commits
- **ci/supportedBranches: export split()**
  Needed for check-target-branch
- **ci/github-script/reviews: rework dismissal/non-posting logic**
  Dismissals are done automatically by commits.js, even for reviews from
  check-target-branches.js. This is not desirable.

  The solution is
  (1) do not decline to post a review because it was already dismissed
      (because it may have not been dismissed by a human, and circumstances may
      have changed), and
  (2) reword the auto-dismissal message to not imply that whatever
      problems were present are fixed.
- **ci/github-script/reviews: allow leaving review comments**
- **{workflows/eval,ci/github-script}: check for mass rebuilds targeting master/release-\* branches**
  Check if a PR was made against the wrong branch based on rebuild amount.

### Screenshots

<img width="687" height="190" alt="Screenshot 2026-01-18 210101" src="https://github.com/user-attachments/assets/a0502283-6117-42db-8995-3cd2a2254388" />
 
<img width="690" height="188" alt="Screenshot 2026-01-18 210117" src="https://github.com/user-attachments/assets/bc915321-f401-49b8-9298-11ddc3375860" />

<img width="696" height="205" alt="Screenshot 2026-01-18 210131" src="https://github.com/user-attachments/assets/1e79b022-146e-4209-8cb2-1ac3b135e9b0" />

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested on my [i-can't-believe-it's-not-a-fork](https://github.com/mdaniels5757/unconnected-nixpkgs).
    - mdaniels5757/unconnected-nixpkgs#25
    - mdaniels5757/unconnected-nixpkgs#26
    - mdaniels5757/unconnected-nixpkgs#28
    - mdaniels5757/unconnected-nixpkgs#29
    - mdaniels5757/unconnected-nixpkgs#30
    - mdaniels5757/unconnected-nixpkgs#31
    - mdaniels5757/unconnected-nixpkgs#32
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
