### PR TITLE
libwacom: add bin output

### DIFF
--- a/pkgs/by-name/li/libwacom/package.nix
+++ b/pkgs/by-name/li/libwacom/package.nix
@@ -20,6 +20,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.17.0";
 
   outputs = [
+    "bin"
     "out"
     "dev"
   ];


### PR DESCRIPTION
PR #372392 added runtime dependencies on the libevdev and pyudev python packages, which are necessary to run several scripts contained in the libwacom project. Since the project used a split derivation containing `"out"` and `"dev"` outputs, this change introduced python3 to the closure of libwacom and all dependent packages. It seems #407391 was made to address the same issue, but has become stale.

By adding an additional `"bin"` output, the scripts will be contained only in the `libwacom-bin` and `libwacom-out` closures. The `libwacom` derivation does not depend on python.

```
$ nix-store -qR $(nix-build -A libwacom.out)
/nix/store/6h39qxzrm4i1fhl538knvyjapcdyasfx-xgcc-15.2.0-libgcc
/nix/store/hlcdbvwjlzjd2x86fxghzj1gpzplccqw-libunistring-1.4.1
/nix/store/kywwgk85nl83mpf10av3bvm2khdlq5ib-libidn2-2.3.8
/nix/store/j193mfi0f921y0kfs8vjc1znnr45ispv-glibc-2.40-66
/nix/store/1z031fwbsc8jhmm7i39r6z6m1xn7rbza-libffi-3.5.2
/nix/store/5qzr2w5n5gcgh8gp3mi8sdfh6ryypfqj-libxcrypt-4.5.2
/nix/store/jggxi5a991sx5si6sv47y0l2y1nqlh0g-pcre2-10.46
/nix/store/9862zy8hnb7xhygn1dbs9i316ldvbjyx-libselinux-3.8.1
/nix/store/c2qsgf2832zi4n29gfkqgkjpvmbmxam6-zlib-1.3.1
/nix/store/xbydf9b2lx6jziwi6z85g0bny5331dim-util-linux-minimal-2.41.2-lib
/nix/store/f7rcazhd826xlcz43il4vafv28888cgj-glib-2.86.3
/nix/store/dj62xc7d90axna889yzxd4r192vib8gj-util-linux-minimal-2.41.2-login
/nix/store/mm6518pcn7aggvsqzlag9awqacd88lm9-libcap-2.77-lib
/nix/store/n234iswy40dzhd7aw6ak0wfrbyjpvbw4-systemd-minimal-libs-258.2
/nix/store/n5zsk9wihymdwi7zss8d8my2m3njz1mp-libgudev-238
/nix/store/w3vy3bpndpj0b6ja5bgc7ll3kf5mv0qd-libevdev-1.13.4
/nix/store/cwdn4md7x08y7hjvlhz508zhnaxxsf1p-libwacom-2.17.0
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc


Closes: https://github.com/NixOS/nixpkgs/pull/407391