### PR TITLE
{,python313Packages.}dtschema: 2025.08 -> 2025.12, modernize, enable tests

### DIFF
--- a/pkgs/by-name/dt/dt-schema/package.nix
+++ b/pkgs/by-name/dt/dt-schema/package.nix
@@ -1,26 +1,5 @@
 {
-  python3,
+  python3Packages,
 }:
 
-let
-  python = python3.override {
-    self = python;
-    packageOverrides = self: super: {
-      # see https://github.com/devicetree-org/dt-schema/issues/108
-      jsonschema = super.jsonschema.overridePythonAttrs (old: rec {
-        version = "4.17.3";
-
-        src = old.src.override {
-          inherit version;
-          hash = "sha256-D4ZEN6uLYHa6ZwdFPvj5imoNUSqA6T+KvbZ29zfstg0=";
-        };
-
-        propagatedBuildInputs = with self; [
-          attrs
-          pyrsistent
-        ];
-      });
-    };
-  };
-in
-python.pkgs.toPythonApplication python.pkgs.dtschema
+python3Packages.toPythonApplication python3Packages.dtschema

--- a/pkgs/development/python-modules/dtschema/default.nix
+++ b/pkgs/development/python-modules/dtschema/default.nix
@@ -12,14 +12,14 @@
 
 buildPythonPackage rec {
   pname = "dtschema";
-  version = "2025.08";
+  version = "2025.12";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "devicetree-org";
     repo = "dt-schema";
     tag = "v${version}";
-    sha256 = "sha256-SW2WAVB7ZSgKRjIyFdMqe8tRIuM97ZVBg4d0BJC6SBI=";
+    sha256 = "sha256-DCkZDI0/W/4IkMzaa769vKJxlSMWoEsLIdlyChYd+Mk=";
   };
 
   nativeBuildInputs = [ setuptools-scm ];
@@ -46,13 +46,7 @@ buildPythonPackage rec {
     ];
     maintainers = with lib.maintainers; [ sorki ];
 
-    broken = (
-      # Library not loaded: @rpath/libfdt.1.dylib
-      stdenv.hostPlatform.isDarwin
-      ||
-
-        # see https://github.com/devicetree-org/dt-schema/issues/108
-        lib.versionAtLeast jsonschema.version "4.18"
-    );
+    # Library not loaded: @rpath/libfdt.1.dylib
+    broken = stdenv.hostPlatform.isDarwin;
   };
 }

--- a/pkgs/development/python-modules/dtschema/default.nix
+++ b/pkgs/development/python-modules/dtschema/default.nix
@@ -12,7 +12,7 @@
   dtc,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "dtschema";
   version = "2025.12";
   pyproject = true;
@@ -20,13 +20,13 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "devicetree-org";
     repo = "dt-schema";
-    tag = "v${version}";
-    sha256 = "sha256-DCkZDI0/W/4IkMzaa769vKJxlSMWoEsLIdlyChYd+Mk=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-DCkZDI0/W/4IkMzaa769vKJxlSMWoEsLIdlyChYd+Mk=";
   };
 
-  nativeBuildInputs = [ setuptools-scm ];
+  build-system = [ setuptools-scm ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     jsonschema
     rfc3987
     ruamel-yaml
@@ -45,7 +45,7 @@ buildPythonPackage rec {
   meta = {
     description = "Tooling for devicetree validation using YAML and jsonschema";
     homepage = "https://github.com/devicetree-org/dt-schema/";
-    changelog = "https://github.com/devicetree-org/dt-schema/releases/tag/v${version}";
+    changelog = "https://github.com/devicetree-org/dt-schema/releases/tag/v${finalAttrs.version}";
     license = with lib.licenses; [
       bsd2 # or
       gpl2Only
@@ -55,4 +55,4 @@ buildPythonPackage rec {
     # Library not loaded: @rpath/libfdt.1.dylib
     broken = stdenv.hostPlatform.isDarwin;
   };
-}
+})

--- a/pkgs/development/python-modules/dtschema/default.nix
+++ b/pkgs/development/python-modules/dtschema/default.nix
@@ -8,6 +8,8 @@
   ruamel-yaml,
   setuptools-scm,
   libfdt,
+  pytestCheckHook,
+  dtc,
 }:
 
 buildPythonPackage rec {
@@ -31,10 +33,14 @@ buildPythonPackage rec {
     libfdt
   ];
 
-  # Module has no tests
-  doCheck = false;
-
   pythonImportsCheck = [ "dtschema" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    dtc
+  ];
+
+  enabledTestPaths = [ "test/test-dt-validate.py" ];
 
   meta = {
     description = "Tooling for devicetree validation using YAML and jsonschema";


### PR DESCRIPTION
- found this package using a `python3.override` while looking at #481065, and turned out it was no longer necessary because the issue was fixed upstream, and a new version was available (`2025.12`):
  - https://github.com/devicetree-org/dt-schema/issues/109 

Applied a few other changes:
- modernize the derivation to latest nixpkgs convention (`rec` -> `finalAttrs`, `build-system`/`dependencies`, `python.pkgs` -> `python3Packages`)
- enable tests (there was a test suite after all)
- remove broken on `lib.versionAtLeast jsonschema.version "4.18"` (i cannot test darwin)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
