### PR TITLE
chess-tui: 2.0.0 -> 2.3.0

### DIFF
--- a/pkgs/by-name/ch/chess-tui/package.nix
+++ b/pkgs/by-name/ch/chess-tui/package.nix
@@ -1,32 +1,45 @@
 {
+  stdenv,
   lib,
   fetchFromGitHub,
   rustPlatform,
   openssl,
   pkg-config,
+  alsa-lib,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "chess-tui";
-  version = "2.0.0";
+  version = "2.3.0";
 
   src = fetchFromGitHub {
     owner = "thomas-mauran";
     repo = "chess-tui";
     tag = finalAttrs.version;
-    hash = "sha256-SIQoi/pnbS1TyX6iA8azo0nVfsCQd6ntn9VZCz/Zkgw=";
+    hash = "sha256-g+rKib+ZoBa2ssYKgS0tg0xngurY1z3DbBZZEn/LJU4=";
   };
 
-  cargoHash = "sha256-aWj8ruu/Y/VCgvhAkWVfDDztmVzHsZix88JUAOYttmg=";
+  cargoHash = "sha256-Brj+9AS0ZR/b188jkJa84WRHk0HtiKpMlyMUSLmzBfA=";
 
   checkFlags = [
     # assertion failed: result.is_ok()
     "--skip=tests::test_config_create"
   ];
 
-  buildInputs = [ openssl ];
+  buildInputs = [
+    openssl
+  ]
+  # alsa-lib is required for the alsa-sys. alsa-lib does not compile on darwin
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ alsa-lib ]
+  # bindgenHook is required for coreaudio-sys on darwin
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [ rustPlatform.bindgenHook ];
+
   nativeBuildInputs = [ pkg-config ];
+
   PKG_CONFIG_PATH = "${openssl.dev}/lib/pkgconfig";
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Chess TUI implementation in rust";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/thomas-mauran/chess-tui/releases/tag/2.3.0

Closes https://github.com/NixOS/nixpkgs/issues/481223

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
