### PR TITLE
haskellPackages.ghcup: deprecate

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1631,6 +1631,10 @@ with haskellLib;
     '';
   }) (addExtraLibrary self.QuickCheck super.Chart-tests);
 
+  # 2026-01-17: too strict bounds on QuickCheck < 2.15
+  # https://github.com/hasufell/lzma-static/pull/15
+  xz = doJailbreak super.xz;
+
   # This breaks because of version bounds, but compiles and runs fine.
   # Last commit is 5 years ago, so we likely won't get upstream fixed soon.
   # https://bitbucket.org/rvlm/hakyll-contrib-hyphenation/src/master/

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1635,6 +1635,11 @@ with haskellLib;
   # https://github.com/hasufell/lzma-static/pull/15
   xz = doJailbreak super.xz;
 
+  ghcup =
+    lib.throwIf pkgs.config.allowAliases
+      "ghcup cannot be used to install the haskell tool chain on NixOS because there is no compatible bindist. Please install ghc etc. via Nix. On non-NixOS systems you can use the ghcup shell installer"
+      super.ghcup;
+
   # This breaks because of version bounds, but compiles and runs fine.
   # Last commit is 5 years ago, so we likely won't get upstream fixed soon.
   # https://bitbucket.org/rvlm/hakyll-contrib-hyphenation/src/master/

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -7326,7 +7326,6 @@ broken-packages:
   - xslt # failure in job https://hydra.nixos.org/build/233225636 at 2023-09-02
   - xtea # failure in job https://hydra.nixos.org/build/282175333 at 2024-12-23
   - xxhash # failure in job https://hydra.nixos.org/build/233240335 at 2023-09-02
-  - xz # failure in job https://hydra.nixos.org/build/307523211 at 2025-09-19
   - y0l0bot # failure in job https://hydra.nixos.org/build/233212722 at 2023-09-02
   - yabi-muno # failure in job https://hydra.nixos.org/build/233246871 at 2023-09-02
   - yackage # failure in job https://hydra.nixos.org/build/233213393 at 2023-09-02

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
@@ -1992,7 +1992,6 @@ dont-distribute-packages:
  - knit-haskell
  - koji-install
  - koji-tool
- - koji-tool_1_3_1
  - korfu
  - ks-test
  - kubernetes-client
@@ -3411,6 +3410,7 @@ dont-distribute-packages:
  - sydtest-amqp
  - sydtest-webdriver-screenshot
  - sydtest-webdriver-yesod
+ - sydtest-webdriver-yesod_0_0_1_0
  - sylvia
  - symantic-atom
  - symantic-http-demo


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- `xz`, was a dependency of `ghcup`
  - Bound `QuickCheck < 2.15` was too strict

Relevant issues and PRs have been opened upstream; see commit messages and comments for more details. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux (wsl)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [X] Package update: when the change is major or breaking. *Package is being deprecated.*
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [X] Module update: when the change is significant. *Package is being deprecated.*
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

`nixpkgs-review` output:

```
================================================================================
PR #481229: haskellPackages.ghcup: jailbreak
================================================================================
Author: Ai-Ya-Ya
Branch: Ai-Ya-Ya:fix-ghcup -> NixOS:haskell-updates
State: open
Status: Draft

Description:
----------------------------------------
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- `ghcup`
  - Bound `brick < 2.8` was too strict, and is already bumped to `< 2.11` upstream
  - Bound `vty ^>= 6.2` is equivalent to `<= 6.3`, but the `vty` bounds were written in such a way that `doJailbreak` didn't jailbreak it. So, manual appending of the bounds up to `^>= 6.4` (which is what `nixpkgs-25.11` has)
- `xz`, was a dependency of `ghcup`
  - Bound `QuickCheck < 2.15` was too strict

Relevant issues and PRs have been opened upstream; see commit messages and comments for more details. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platfor

... (truncated)
----------------------------------------

Files changed (4 files):
  - pkgs/development/haskell-modules/configuration-common.nix
  - pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
  - pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
  - pkgs/development/haskell-modules/hackage-packages.nix
================================================================================

-> Fetching eval results from GitHub actions
-> Successfully fetched rebuilds: no local evaluation needed
$ git -c fetch.prune=false fetch --no-tags --force https://github.com/NixOS/nixpkgs 6546203f291efcbb5cb384f8162be4970327b4bd:refs/nixpkgs-review/0
$ git worktree add /home/<username>/.cache/nixpkgs-review/pr-481229-3/nixpkgs 6546203f291efcbb5cb384f8162be4970327b4bd

$ nix build --file /nix/store/ihslwbxj0y8jv0730zn2qna5vjn90pl3-nixpkgs-review-3.5.1/lib/python3.13/site-packages/nixpkgs_review/nix/review-shell.nix --nix-path 'nixpkgs=/home/<username>/.cache/nixpkgs-review/pr-481229-3/nixpkgs nixpkgs-overlays=/tmp/tmppsozwnpi' --extra-experimental-features 'nix-command no-url-literals' --no-link --keep-going --no-allow-import-from-derivation --option build-use-sandbox relaxed --argstr local-system x86_64-linux --argstr nixpkgs-path /home/<username>/.cache/nixpkgs-review/pr-481229-3/nixpkgs --argstr nixpkgs-config-path /tmp/tmp8wt578ek.nix --argstr attrs-path /home/<username>/.cache/nixpkgs-review/pr-481229-3/attrs.nix

Link to currently reviewing PR:
https://github.com/NixOS/nixpkgs/pull/481229
--------- Report for 'x86_64-linux' ---------
4 packages built:
haskell.package-list haskellPackages.ghcup haskellPackages.xz haskellPackages.xz.doc

Logs can be found under:
/home/<username>/.cache/nixpkgs-review/pr-481229-3/logs


$ /nix/store/n5s95aq6my065mxv8nywdp24afqmk48q-nix-2.31.2/bin/nix-shell --argstr local-system x86_64-linux --argstr nixpkgs-path /home/<username>/.cache/nixpkgs-review/pr-481229-3/nixpkgs --argstr nixpkgs-config-path /tmp/tmp8wt578ek.nix --argstr attrs-path /home/<username>/.cache/nixpkgs-review/pr-481229-3/attrs.nix --nix-path 'nixpkgs=/home/<username>/.cache/nixpkgs-review/pr-481229-3/nixpkgs nixpkgs-overlays=/tmp/tmppsozwnpi' /nix/store/ihslwbxj0y8jv0730zn2qna5vjn90pl3-nixpkgs-review-3.5.1/lib/python3.13/site-packages/nixpkgs_review/nix/review-shell.nix
$ git worktree remove -f /home/<username>/.cache/nixpkgs-review/pr-481229-3/nixpkgs
```

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
