### PR TITLE
charles: fix desktop icons and mime integration

### DIFF
--- a/pkgs/applications/networking/charles/default.nix
+++ b/pkgs/applications/networking/charles/default.nix
@@ -31,7 +31,7 @@ let
         desktopName = "Charles";
         exec = "charles %F";
         genericName = "Web Debugging Proxy";
-        icon = "charles-proxy";
+        icon = "charles-proxy" + lib.optionalString (lib.versionAtLeast version "5.0") "5";
         mimeTypes = [
           "application/x-charles-savedsession"
           "application/x-charles-savedsession+xml"
@@ -73,8 +73,24 @@ let
         mkdir -p $out/share/applications
         ln -s ${desktopItem}/share/applications/* $out/share/applications/
 
-        mkdir -p $out/share/icons
-        cp -r icon $out/share/icons/hicolor
+        ${
+          if lib.versionOlder version "4.0" then
+            ''
+              for size in 16 32 48 64 128 256 512; do
+                install -Dm644 icon/charles_icon$size.png $out/share/icons/hicolor/''${size}x''${size}/apps/charles-proxy.png
+              done
+              install -Dm644 icon/charles_icon.svg $out/share/icons/hicolor/scalable/apps/charles-proxy.svg
+            ''
+          else
+            ''
+              mkdir -p $out/share/icons
+              cp -r icon $out/share/icons/hicolor
+              if [ -d "etc/mime" ]; then
+                mkdir -p $out/share/mime/packages
+                cp etc/mime/*.xml $out/share/mime/packages/
+              fi
+            ''
+        }
 
         runHook postInstall
       '';


### PR DESCRIPTION
This addresses icon and mimetype issues for different versions:

- For Charles 5+:
  - Update desktop entry to use 'charles-proxy5'.
  - Install the upstream provided shared-mime-info XML. This correctly
    maps mime types to the upstream icon names (e.g. charles-proxy5-har).
- For Charles 4: Install the upstream provided shared-mime-info XML.
- For Charles 3: Fix icon installation paths (upstream tarball has
  non-standard layout). No mime icons are available for this version.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
