### PR TITLE
snapmixer: init at 2.3.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -26981,6 +26981,12 @@
     githubId = 207457;
     name = "Matthieu Chevrier";
   };
+  tremby = {
+    email = "bart@tremby.net";
+    github = "tremby";
+    githubId = 199635;
+    name = "Bart Nagel";
+  };
   trepetti = {
     email = "trepetti@cs.columbia.edu";
     github = "trepetti";

--- a/pkgs/by-name/sn/snapmixer/package.nix
+++ b/pkgs/by-name/sn/snapmixer/package.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "snapmixer";
+  version = "2.3.3";
+
+  src = fetchFromGitHub {
+    owner = "tremby";
+    repo = "snapmixer";
+    rev = "v${version}";
+    hash = "sha256-xykkYt2WC4mIEynk3wbl+Z7zc2549k/uaTKdeZF9mkQ=";
+  };
+
+  cargoHash = "sha256-5jjp6huS3JN49PhlYiCMsQOh3nAVZ90OmaDpuWkv83U=";
+
+  meta = with lib; {
+    description = "Text-mode volume mixer for Snapcast";
+    homepage = "https://github.com/tremby/snapmixer";
+    license = licenses.mit;
+    maintainers = with maintainers; [ tremby ];
+    mainProgram = "snapmixer";
+  };
+}


### PR DESCRIPTION
I'm adding `snapmixer` (https://github.com/tremby/snapmixer), which is a text-mode volume control for [Snapcast](https://github.com/snapcast/snapcast), the multi-room audio system.

I'm the author. It's a brand new rewrite in rust of my old version (which was written in Nodejs).

I'm not aware of any other program which does the same thing either in text mode on as a desktop application.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux -- I tried building and that worked, but I've nowhere to try running it
  - [ ] x86_64-darwin -- ought to work but no Darwin equipment
  - [ ] aarch64-darwin -- ought to work but no Darwin equipment
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
