### PR TITLE
python314Packages.aioswitcher: disable failing test on Python 3.14

### DIFF
--- a/pkgs/development/python-modules/aioswitcher/default.nix
+++ b/pkgs/development/python-modules/aioswitcher/default.nix
@@ -16,7 +16,7 @@
   time-machine,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "aioswitcher";
   version = "6.0.3";
   pyproject = true;
@@ -24,7 +24,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "TomerFi";
     repo = "aioswitcher";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-6wBeAbBiuAZW9kHq/bKC0FMJxkLxM6RZN7RLwbF1ig4=";
   };
 
@@ -66,7 +66,7 @@ buildPythonPackage rec {
     "test_minutes_to_hexadecimal_seconds_with_a_negative_value_should_throw_an_error"
     "test_current_timestamp_to_hexadecimal_with_errornous_value_should_throw_an_error"
   ]
-  ++ lib.optionals (pythonAtLeast "3.12") [
+  ++ lib.optionals (pythonAtLeast "3.14") [
     # AssertionError: Expected <hour must be in 0..23, not -1> to be equal
     "test_seconds_to_iso_time_with_a_nagative_value_should_throw_an_error"
   ];
@@ -76,8 +76,8 @@ buildPythonPackage rec {
   meta = {
     description = "Python module to interact with Switcher water heater";
     homepage = "https://github.com/TomerFi/aioswitcher";
-    changelog = "https://github.com/TomerFi/aioswitcher/releases/tag/${src.tag}";
+    changelog = "https://github.com/TomerFi/aioswitcher/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ fab ];
   };
-}
+})

--- a/pkgs/development/python-modules/aioswitcher/default.nix
+++ b/pkgs/development/python-modules/aioswitcher/default.nix
@@ -62,9 +62,13 @@ buildPythonPackage rec {
     "test_schedule_parser_with_a_non_recurring_enabled_schedule_data"
   ]
   ++ lib.optionals (pythonAtLeast "3.12") [
-    # ssertionError: Expected <'I' format requires 0 <= number <= 4294967295> to be equal to <argument out of range>, but was not.
+    # AssertionError: Expected <'I' format requires 0 <= number <= 4294967295> to be equal to <argument out of range>, but was not.
     "test_minutes_to_hexadecimal_seconds_with_a_negative_value_should_throw_an_error"
     "test_current_timestamp_to_hexadecimal_with_errornous_value_should_throw_an_error"
+  ]
+  ++ lib.optionals (pythonAtLeast "3.12") [
+    # AssertionError: Expected <hour must be in 0..23, not -1> to be equal
+    "test_seconds_to_iso_time_with_a_nagative_value_should_throw_an_error"
   ];
 
   pythonImportsCheck = [ "aioswitcher" ];


### PR DESCRIPTION
Related #475732

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
