### PR TITLE
akku: pin Guile 3.0.10

### DIFF
--- a/pkgs/tools/package-management/akku/akku.nix
+++ b/pkgs/tools/package-management/akku/akku.nix
@@ -1,14 +1,26 @@
 {
   lib,
   stdenv,
+  fetchurl,
   fetchFromGitLab,
   autoreconfHook,
   pkg-config,
   git,
-  guile,
+  guile_3_0,
   curl,
   nix-update-script,
 }:
+let
+  # Akku currently breaks starting with Guile 3.0.11.
+  # So we pin Guile 3.0.10 for now.
+  # https://hydra.nixos.org/build/319214800/nixlog/1/tail
+  guile_3_0_10 = guile_3_0.overrideAttrs {
+    src = fetchurl {
+      url = "mirror://gnu/guile/guile-3.0.10.tar.xz";
+      sha256 = "sha256-vXFoUX/VJjM0RtT3q4FlJ5JWNAlPvTcyLhfiuNjnY4g=";
+    };
+  };
+in
 stdenv.mkDerivation rec {
   pname = "akku";
   version = "1.1.0-unstable-2025-11-08";
@@ -27,7 +39,7 @@ stdenv.mkDerivation rec {
 
   # akku calls curl commands
   buildInputs = [
-    guile
+    guile_3_0_10
     curl
     git
   ];


### PR DESCRIPTION
This prevents a breakage with the upcoming Guile 3.0.11.

cc @konst-aa


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
