### PR TITLE
nu-lint: init at 0.1.1

### DIFF
--- a/pkgs/by-name/nu/nu-lint/package.nix
+++ b/pkgs/by-name/nu/nu-lint/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  fetchFromGitea,
+  rustPlatform,
+  nix-update-script,
+  versionCheckHook,
+  stdenvNoCC,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "nu-lint";
+  version = "0.1.1";
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "wvhulle";
+    repo = "nu-lint";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-RU+Jy0AMesQpvndjF29IlJb2gpV76lm0Fz0Fk/i6RYU=";
+  };
+
+  cargoHash = "sha256-NbjeOtvvJhk/27Jg/jthdSZ09n/j37J2Y+yAIiVUia4=";
+
+  nativeBuildInputs = lib.optionals stdenvNoCC.hostPlatform.isDarwin [
+    # Avoids "couldn't find any valid shared libraries matching: ['libclang.dylib']" error on darwin in sandbox mode.
+    rustPlatform.bindgenHook
+  ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  # NOTE: Disabled for version 0.1.1 outputs "0.1.0" when run `nu-lint --version` is run
+  doInstallCheck = false;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Linter for the Nu shell scripting language";
+    homepage = "https://codeberg.org/wvhulle/nu-lint";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kpbaks ];
+    platforms = lib.platforms.all;
+    mainProgram = "nu-lint";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Init package [nu-lint](https://codeberg.org/wvhulle/nu-lint)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
