### PR TITLE
vja: init at 4.10.1

### DIFF
--- a/pkgs/by-name/vj/vja/package.nix
+++ b/pkgs/by-name/vj/vja/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  python3,
+  fetchFromGitLab,
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "vja";
+  version = "4.10.1";
+  pyproject = true;
+
+  src = fetchFromGitLab {
+    owner = "ce72";
+    repo = "vja";
+    tag = version;
+    hash = "sha256-J2GX0t7hPLqqI2n8H0kDboGfpRff3+lHM3026fTX5rs=";
+  };
+
+  build-system = [
+    python3.pkgs.setuptools
+    python3.pkgs.wheel
+  ];
+
+  dependencies = with python3.pkgs; [
+    click
+    click-aliases
+    parsedatetime
+    python-dateutil
+    requests
+  ];
+
+  pythonImportsCheck = [
+    "vja"
+  ];
+
+  meta = {
+    description = "Command line interface for Vikunja";
+    homepage = "https://gitlab.com/ce72/vja";
+    changelog = "https://gitlab.com/ce72/vja/-/blob/${src.tag}/CHANGELOG.md";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "vja";
+    maintainers = with lib.maintainers; [ iv-nn ];
+  };
+}


### PR DESCRIPTION
Add [vja](https://gitlab.com/ce72/vja) a CLI client for Vikunja

A command line interface for Vikunja > [The todo app to organize your life](https://vikunja.io/).
Manage your tasks and projects directly from the terminal with simple commands.
It provides a command line interface for adding, viewing and editing todo tasks on a Vikunja Server.
The goal is to support a command line based task workflow ~ similar to taskwarrior.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
