### PR TITLE
openloco: 25.11 → 25.12

### DIFF
--- a/pkgs/games/openloco/default.nix
+++ b/pkgs/games/openloco/default.nix
@@ -22,26 +22,31 @@ let
   };
 
   openloco-objects = fetchurl {
-    url = "https://github.com/OpenLoco/OpenGraphics/releases/download/v0.1.5/objects.zip";
-    sha256 = "fe8943fabad8eb07cebab5354589abd7e798a705f7993bb4d9dab2122b4fe96e";
+    url = "https://github.com/OpenLoco/OpenGraphics/releases/download/v0.1.6/objects.zip";
+    sha256 = "4cea1ab77131650b5475b489445ce65c275b3a23b921456afda4d9c5c83e580c";
   };
 
 in
 stdenv.mkDerivation rec {
   pname = "openloco";
-  version = "25.11";
+  version = "25.12";
 
   src = fetchFromGitHub {
     owner = "OpenLoco";
     repo = "OpenLoco";
     tag = "v${version}";
-    hash = "sha256-ohHTa5ow6wiq0GajqLcOwL9mnjocw+Od93SEaxCR2C0=";
+    hash = "sha256-kne9G+GKbfDJDAI4DDxWFQKK7zp2FhX/rL2ws7iqXKE=";
   };
 
   postPatch = ''
-    # the upstream build process determines the version tag from git; since we
-    # are not using a git checkout, we patch it manually
-    sed -i '/#define OPENLOCO_NAME "OpenLoco"/a#define OPENLOCO_VERSION_TAG "${version}"' src/OpenLoco/src/Version.cpp
+    # the upstream build process determines the version tag, branch
+    # and commit hash from git; since we are not using a git checkout,
+    # we patch it manually
+    sed -i '/#define OPENLOCO_NAME "OpenLoco"/a\
+    #define OPENLOCO_VERSION_TAG "${version}"\
+    #define OPENLOCO_BRANCH "master"\
+    #define OPENLOCO_COMMIT_SHA1_SHORT "b79ace0"'\
+      src/Version/include/OpenLoco/Version.hpp
 
     # prefetch sfl header sources
     grep -q 'GIT_TAG \+${sfl-src.tag}' thirdparty/CMakeLists.txt


### PR DESCRIPTION
openloco: 25.11 → 25.12

https://openloco.io/news/2025/12/openloco-v25.12.html


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
