### PR TITLE
ttl: init at 0.13.0

### DIFF
--- a/pkgs/by-name/tt/ttl/package.nix
+++ b/pkgs/by-name/tt/ttl/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  installShellFiles,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "ttl";
+  version = "0.13.0";
+
+  src = fetchFromGitHub {
+    owner = "lance0";
+    repo = "ttl";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-cHiAIWUewdUwV9PO1He2V/+FML8XSVJOlyp+J+tdB24=";
+  };
+
+  cargoHash = "sha256-6TehH3p9ikt1lx7p2Y2jM/21gASk8Taqoe/2bBfFs94=";
+
+  nativeBuildInputs = [
+    installShellFiles
+    versionCheckHook
+  ];
+  doInstallCheck = true;
+
+  postInstall = ''
+    installShellCompletion --cmd ttl \
+      --bash <($out/bin/ttl --completions bash) \
+      --fish <($out/bin/ttl --completions fish) \
+      --zsh <($out/bin/ttl --completions zsh)
+  '';
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Modern traceroute/mtr-style TUI";
+    longDescription = ''
+      ttl provides a live traceroute interface that can trace multiple targets,
+      detect ECMP paths, run PMTUD, export JSON/CSV reports, and optionally
+      enrich hop data with DNS, ASN, geolocation, and PeeringDB information.
+    '';
+    mainProgram = "ttl";
+    homepage = "https://github.com/lance0/ttl";
+    changelog = "https://github.com/lance0/ttl/releases/tag/v${finalAttrs.version}";
+    maintainers = with lib.maintainers; [ vincentbernat ];
+    license = with lib.licenses; [
+      asl20
+      mit
+    ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
ttl is a better mtr with a real-time TUI, per-hop stats.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
