### PR TITLE
gwq: init at 0.0.11

### DIFF
--- a/pkgs/by-name/gw/gwq/package.nix
+++ b/pkgs/by-name/gw/gwq/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  gitMinimal,
+  installShellFiles,
+  testers,
+  writableTmpDirAsHomeHook,
+  gwq,
+}:
+
+buildGoModule rec {
+  pname = "gwq";
+  version = "0.0.11";
+
+  src = fetchFromGitHub {
+    owner = "d-kuro";
+    repo = "gwq";
+    tag = "v${version}";
+    hash = "sha256-T9G/sbI7P2I2yXNdX95SIr7Mzx87Z5oaqZmb6Y3Fooc=";
+  };
+
+  vendorHash = "sha256-c1vq9yETUYfY2BoXSEmRZj/Ceetu0NkIoVCM3wYy5iY=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X=github.com/d-kuro/gwq/cmd.version=${version}"
+  ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  nativeCheckInputs = [
+    gitMinimal
+    writableTmpDirAsHomeHook
+  ];
+
+  postInstall = ''
+    installShellCompletion --cmd gwq \
+      --bash <($out/bin/gwq completion bash) \
+      --fish <($out/bin/gwq completion fish) \
+      --zsh <($out/bin/gwq completion zsh)
+  '';
+
+  passthru.tests.version = testers.testVersion {
+    package = gwq;
+  };
+
+  meta = {
+    description = "Git worktree manager with fuzzy finder";
+    homepage = "https://github.com/d-kuro/gwq";
+    changelog = "https://github.com/d-kuro/gwq/releases/tag/v${version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ ryoppippi ];
+    mainProgram = "gwq";
+  };
+}


### PR DESCRIPTION
[gwq](https://github.com/d-kuro/gwq) is a CLI tool for managing Git worktrees with a fuzzy finder interface. It enables working on multiple branches simultaneously from the same repository in separate directories.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test