### PR TITLE
homebox: better test and tmpdir resolution

### DIFF
--- a/nixos/tests/homebox.nix
+++ b/nixos/tests/homebox.nix
@@ -14,6 +14,8 @@ in
           services.homebox = {
             enable = true;
             settings.HBOX_WEB_PORT = port;
+            settings.HBOX_OPTIONS_ALLOW_REGISTRATION = "true";
+            settings.HBOX_LOG_LEVEL = "trace";
           };
         };
 
@@ -25,6 +27,7 @@ in
     in
     self;
   testScript = ''
+    import json
     def test_homebox(node):
       node.wait_for_unit("homebox.service")
       node.wait_for_open_port(${port})
@@ -32,6 +35,29 @@ in
       node.succeed("curl --fail -X GET 'http://localhost:${port}/'")
       out = node.succeed("curl --fail 'http://localhost:${port}/api/v1/status'")
       assert '"health":true' in out
+      node.succeed("curl --request POST --fail 'http://localhost:${port}/api/v1/users/register' \
+        --data '{\"email\":\"a@b.c\",\"name\":\"test\",\"password\":\"password\"}' \
+      ")
+      login = node.succeed("curl --request POST --fail 'http://localhost:${port}/api/v1/users/login' \
+        --data-urlencode 'password=password' \
+        --data-urlencode 'username=a@b.c' \
+      ")
+      login_data = json.loads(login)
+      token = login_data["token"]
+      locations = node.succeed(f"curl --request GET --fail 'http://localhost:${port}/api/v1/locations' \
+        --header 'Authorization: {token}' \
+      ")
+      location_id = json.loads(locations)[0]["id"]
+      item = node.succeed(f"curl --request POST --fail 'http://localhost:${port}/api/v1/items' \
+        --header 'Authorization: {token}' \
+        --data '{{\"name\":\"testitem\",\"locationID\":\"{location_id}\"}}' \
+      ")
+      item_id = json.loads(item)["id"]
+      node.succeed(f"curl --request POST --fail 'http://localhost:${port}/api/v1/items/{item_id}/attachments' \
+        --header 'Authorization: {token}' \
+        --form 'file=test;type=text/plain;filename=test.txt' \
+        --form name=test.txt \
+      ")
 
     test_homebox(simple)
     simple.send_monitor_command("quit")


### PR DESCRIPTION
Basically follow up to #479022.

I think using the fileblob url option is the better way instead of moving `$TMPDIR`.

Also added a test to ensure attachment creation works.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
