### PR TITLE
pam_fde_boot_pw: init at 0.1

### DIFF
--- a/pkgs/by-name/pa/pam_fde_boot_pw/package.nix
+++ b/pkgs/by-name/pa/pam_fde_boot_pw/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  stdenv,
+  fetchFromSourcehut,
+  meson,
+  ninja,
+  pkg-config,
+  pam,
+  keyutils,
+}:
+
+stdenv.mkDerivation {
+  pname = "pam_fde_boot_pw";
+  version = "0-unstable-2025-02-14";
+
+  src = fetchFromSourcehut {
+    owner = "~kennylevinsen";
+    repo = "pam_fde_boot_pw";
+    rev = "49bf498fd8d13f73e4a24221818a8a5d2af20088";
+    hash = "sha256-dS9ufryg3xfxgUzJKDgrvMZP2qaYH+WJQFw1ogl1isc=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    pam
+    keyutils
+  ];
+
+  mesonFlags = [
+    (lib.mesonOption "pam-mod-dir" "${placeholder "out"}/lib/security")
+  ];
+
+  meta = {
+    description = "PAM module for leveraging disk encryption password in the PAM session";
+    longDescription = ''
+      pam_fde_boot_pw transfers a password from the kernel keyring (for example,
+      the passphrase used to unlock an encrypted disk) into the PAM session.
+      This enables user-space keyrings, such as gnome-keyring, to be
+      automatically unlocked.
+    '';
+    homepage = "https://git.sr.ht/~kennylevinsen/pam_fde_boot_pw";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ ivanbrennan ];
+  };
+}


### PR DESCRIPTION
Add [pam_fde_boot_pw](https://git.sr.ht/~kennylevinsen/pam_fde_boot_pw), a PAM module that transfers a password from the kernel keyring (for example, the passphrase used to unlock an encrypted disk) into the PAM session. This enables user-space keyrings, such as gnome-keyring, to be automatically unlocked.

Unlike pam_systemd_loadkey, which operates in the authentication phase via an auth rule, pam_fde_boot_pw integrates into the session phase via a session rule. This makes it effective for greetd auto-login setups, where the authentication stack is skipped entirely.

An example configuration could contain:
```nix
# Enable a systemd-based initrd so the LUKS passphrase entered at boot
# is stored in the kernel keyring.
boot.initrd.systemd.enable = true;

# Configure the login PAM stack to unlock the user’s default GNOME
# keyring when a password is available.
security.pam.services.login.enableGnomeKeyring = true;

# Configure greetd's PAM stack to:
#  - delegate most operations to login's PAM stack
#  - transfer the LUKS passphrase into the PAM session during auto-login
#  - inject the passphrase for use by gnome-keyring
security.pam.services.greetd.text = ''
  auth      substack      login
  account   include       login
  password  substack      login
  session   optional      ${pkgs.pam_fde_boot_pw}/lib/security/pam_fde_boot_pw.so inject_for=gkr
  session   include       login
'';

services.greetd = {
  enable = true;
  settings = {
    # Automatically start a user session on boot.
    initial_session = {
      command = "sway";
      user = "john";
    };

    # Start a greeter after the initial session exits.
    default_session = {
      command = "${pkgs.cage}/bin/cage -s -d -- gtkgreet";
    };
  };
};
```

I have been using pam_fde_boot_pw successfully in my own nixos config, as demonstrated [here](
https://codeberg.org/ivanbrennan/nixos-config/commit/d8a77d947838a6e9c5ef117ddf97fb68c577112a).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc