### PR TITLE
python3Packages.distributed: 2025.12.0 -> 2026.1.1

### DIFF
--- a/pkgs/development/python-modules/distributed/default.nix
+++ b/pkgs/development/python-modules/distributed/default.nix
@@ -27,14 +27,14 @@
 
 buildPythonPackage rec {
   pname = "distributed";
-  version = "2025.12.0";
+  version = "2026.1.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "dask";
     repo = "distributed";
     tag = version;
-    hash = "sha256-srFYbAdlnxpxhSVFqd1geOBoD7bbpLNSlAUWNtefokM=";
+    hash = "sha256-xriIsrdFNSHAO9SmdowXK9uPW06ziz9uGie3PkYncqo=";
   };
 
   build-system = [


### PR DESCRIPTION
Fixes CVE-2026-23528 / https://github.com/dask/distributed/security/advisories/GHSA-c336-7962-wfj2
Fixes #481316

Changes:
https://docs.dask.org/en/stable/changelog.html#v2026-1-1


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 481343`
Commit: `79d77cf667d3a9b89c1d4df41111d7b649106aab`

---
### `x86_64-linux`
<details>
  <summary>:x: 18 packages failed to build:</summary>
  <ul>
    <li>python313Packages.odc-geo</li>
    <li>python313Packages.odc-geo.dist</li>
    <li>python313Packages.odc-loader</li>
    <li>python313Packages.odc-loader.dist</li>
    <li>python313Packages.odc-stac</li>
    <li>python313Packages.odc-stac.dist</li>
    <li>python314Packages.coiled</li>
    <li>python314Packages.coiled.dist</li>
    <li>python314Packages.eliot</li>
    <li>python314Packages.eliot.dist</li>
    <li>python314Packages.odc-geo</li>
    <li>python314Packages.odc-geo.dist</li>
    <li>python314Packages.odc-loader</li>
    <li>python314Packages.odc-loader.dist</li>
    <li>python314Packages.odc-stac</li>
    <li>python314Packages.odc-stac.dist</li>
    <li>python314Packages.streamz</li>
    <li>python314Packages.streamz.dist</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 49 packages built:</summary>
  <ul>
    <li>eliot-tree</li>
    <li>eliot-tree.dist</li>
    <li>python313Packages.coiled</li>
    <li>python313Packages.coiled.dist</li>
    <li>python313Packages.dask-gateway</li>
    <li>python313Packages.dask-gateway.dist</li>
    <li>python313Packages.dask-glm</li>
    <li>python313Packages.dask-glm.dist</li>
    <li>python313Packages.dask-jobqueue</li>
    <li>python313Packages.dask-jobqueue.dist</li>
    <li>python313Packages.dask-ml</li>
    <li>python313Packages.dask-ml.dist</li>
    <li>python313Packages.dask-mpi</li>
    <li>python313Packages.dask-mpi.dist</li>
    <li>python313Packages.dask-yarn</li>
    <li>python313Packages.dask-yarn.dist</li>
    <li>python313Packages.distributed</li>
    <li>python313Packages.distributed.dist</li>
    <li>python313Packages.eliot</li>
    <li>python313Packages.eliot.dist</li>
    <li>python313Packages.streamz</li>
    <li>python313Packages.streamz.dist</li>
    <li>python313Packages.stumpy</li>
    <li>python313Packages.stumpy.dist</li>
    <li>python313Packages.tsfresh</li>
    <li>python313Packages.tsfresh.dist</li>
    <li>python314Packages.dask-gateway</li>
    <li>python314Packages.dask-gateway.dist</li>
    <li>python314Packages.dask-glm</li>
    <li>python314Packages.dask-glm.dist</li>
    <li>python314Packages.dask-jobqueue</li>
    <li>python314Packages.dask-jobqueue.dist</li>
    <li>python314Packages.dask-ml</li>
    <li>python314Packages.dask-ml.dist</li>
    <li>python314Packages.dask-mpi</li>
    <li>python314Packages.dask-mpi.dist</li>
    <li>python314Packages.dask-yarn</li>
    <li>python314Packages.dask-yarn.dist</li>
    <li>python314Packages.distributed</li>
    <li>python314Packages.distributed.dist</li>
    <li>python314Packages.stumpy</li>
    <li>python314Packages.stumpy.dist</li>
    <li>python314Packages.tsfresh</li>
    <li>python314Packages.tsfresh.dist</li>
    <li>tahoe-lafs</li>
    <li>tahoe-lafs.dist</li>
    <li>tahoe-lafs.doc</li>
    <li>tahoe-lafs.info</li>
    <li>tahoe-lafs.man</li>
  </ul>
</details>

---
<details>
<summary>Error logs: `x86_64-linux`</summary>
<details>
<summary>python313Packages.odc-geo</summary>
<pre>E        +    where &lt;Geographic 2D CRS: EPSG:4326&gt;\nName: WGS 84\nAxis Info [ellipsoidal]:\n- Lat[north]: Geodetic latitude (degree)\n- Lon[ea...-180.0, -90.0, 180.0, 90.0)\nDatum: World Geodetic System 1984 ensemble\n- Ellipsoid: WGS 84\n- Prime Meridian: Greenwich\n = CRS(&#x27;GEOGCRS[&quot;WGS 84&quot;,ENSEMBLE[&quot;World Geodetic System 1984 ensemble&quot;,MEMBER[&quot;World Geodetic System 1984 (Transit)&quot;],ME...2925199433]],USAGE[SCOPE[&quot;Horizontal component of 3D system.&quot;],AREA[&quot;World.&quot;],BBOX[-90,-180,90,180]],ID[&quot;EPSG&quot;,4326]]&#x27;).proj
E        +      where CRS(&#x27;GEOGCRS[&quot;WGS 84&quot;,ENSEMBLE[&quot;World Geodetic System 1984 ensemble&quot;,MEMBER[&quot;World Geodetic System 1984 (Transit)&quot;],ME...2925199433]],USAGE[SCOPE[&quot;Horizontal component of 3D system.&quot;],AREA[&quot;World.&quot;],BBOX[-90,-180,90,180]],ID[&quot;EPSG&quot;,4326]]&#x27;) = GeoBox((8, 11), Affine(566047.0585719852, 0.0, -1698141.1757159554,\n       0.0, -566047.0585719852, 2264188.234287941)...925199433]],USAGE[SCOPE[&quot;Horizontal component of 3D system.&quot;],AREA[&quot;World.&quot;],BBOX[-90,-180,90,180]],ID[&quot;EPSG&quot;,4326]]&#x27;)).crs
E        +        where GeoBox((8, 11), Affine(566047.0585719852, 0.0, -1698141.1757159554,\n       0.0, -566047.0585719852, 2264188.234287941)...925199433]],USAGE[SCOPE[&quot;Horizontal component of 3D system.&quot;],AREA[&quot;World.&quot;],BBOX[-90,-180,90,180]],ID[&quot;EPSG&quot;,4326]]&#x27;)) = &lt;odc.geo._xr_interop.ODCExtensionDs object at 0x7fff500fb950&gt;.geobox
E        +          where &lt;odc.geo._xr_interop.ODCExtensionDs object at 0x7fff500fb950&gt; = &lt;xarray.Dataset&gt; Size: 540B\nDimensions:      (time: 1, y: 8, x: 11, dim_0: 3)\nCoordinates:\n  * time         (time) dat...     (time, y, x) uint16 176B dask.array&lt;chunksize=(1, 4, 4), meta=np.ndarray&gt;\n    c            (dim_0) int64 24B 2 3 4.odc

tests/test_xr_interop.py:499: AssertionError
=============================== warnings summary ===============================
tests/test_geom.py::test_gen_test_image_xy
  /build/source/odc/geo/testutils.py:122: RuntimeWarning: invalid value encountered in cast
    return a.astype(ii.dtype)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================== short test summary info ============================
FAILED tests/test_xr_interop.py::test_xr_reproject[None-None] - assert None is not None
FAILED tests/test_xr_interop.py::test_xr_reproject[None-xx_time1] - assert None is not None
FAILED tests/test_xr_interop.py::test_xr_reproject[xx_chunks1-None] - assert None is not None
FAILED tests/test_xr_interop.py::test_xr_reproject[xx_chunks1-xx_time1] - assert None is not None
FAILED tests/test_xr_interop.py::test_xr_reproject[xx_chunks2-None] - assert None is not None
FAILED tests/test_xr_interop.py::test_xr_reproject[xx_chunks2-xx_time1] - assert None is not None
= 6 failed, 667 passed, 11 skipped, 79 deselected, 1 xfailed, 1 warning in 12.99s =</pre>
</details>
<details>
<summary>python314Packages.eliot</summary>
<pre>    add_destination(messages.append)

eliot/tests/test_validation.py::EndToEndValidationTests::test_correctFromMessageType
  /build/source/eliot/tests/test_validation.py:888: DeprecationWarning: MessageType.__call__() is deprecated since 1.11.0, use MessageType.log() instead.
    msg = self.MESSAGE().bind(key=123)

eliot/tests/test_validation.py::EndToEndValidationTests::test_incorrectFromMessageType
  /build/source/eliot/tests/test_validation.py:898: DeprecationWarning: MessageType.__call__() is deprecated since 1.11.0, use MessageType.log() instead.
    msg = self.MESSAGE().bind(key=&quot;123&quot;)

eliot/tests/test_validation.py::EndToEndValidationTests::test_omitLoggerFromActionType
  /build/source/eliot/tests/test_validation.py:917: DeprecationWarning: add_destination is deprecated since 1.1.0. Use add_destinations instead.
    add_destination(messages.append)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================== short test summary info ============================
FAILED eliot/tests/test_coroutines.py::CoroutineTests::test_await_inherits_coroutine_contexts - RuntimeError: There is no current event loop in thread &#x27;MainThread&#x27;.
FAILED eliot/tests/test_coroutines.py::CoroutineTests::test_interleaved_coroutines - RuntimeError: There is no current event loop in thread &#x27;MainThread&#x27;.
FAILED eliot/tests/test_coroutines.py::CoroutineTests::test_multiple_coroutines_contexts - RuntimeError: There is no current event loop in thread &#x27;MainThread&#x27;.
========== 3 failed, 473 passed, 26 skipped, 4776 warnings in 50.86s ===========</pre>
</details>
<details>
<summary>python314Packages.odc-geo</summary>
<pre>E        +    where &lt;Geographic 2D CRS: EPSG:4326&gt;\nName: WGS 84\nAxis Info [ellipsoidal]:\n- Lat[north]: Geodetic latitude (degree)\n- Lon[ea...-180.0, -90.0, 180.0, 90.0)\nDatum: World Geodetic System 1984 ensemble\n- Ellipsoid: WGS 84\n- Prime Meridian: Greenwich\n = CRS(&#x27;GEOGCRS[&quot;WGS 84&quot;,ENSEMBLE[&quot;World Geodetic System 1984 ensemble&quot;,MEMBER[&quot;World Geodetic System 1984 (Transit)&quot;],ME...2925199433]],USAGE[SCOPE[&quot;Horizontal component of 3D system.&quot;],AREA[&quot;World.&quot;],BBOX[-90,-180,90,180]],ID[&quot;EPSG&quot;,4326]]&#x27;).proj
E        +      where CRS(&#x27;GEOGCRS[&quot;WGS 84&quot;,ENSEMBLE[&quot;World Geodetic System 1984 ensemble&quot;,MEMBER[&quot;World Geodetic System 1984 (Transit)&quot;],ME...2925199433]],USAGE[SCOPE[&quot;Horizontal component of 3D system.&quot;],AREA[&quot;World.&quot;],BBOX[-90,-180,90,180]],ID[&quot;EPSG&quot;,4326]]&#x27;) = GeoBox((8, 11), Affine(566047.0585719852, 0.0, -1698141.1757159554,\n       0.0, -566047.0585719852, 2264188.234287941)...925199433]],USAGE[SCOPE[&quot;Horizontal component of 3D system.&quot;],AREA[&quot;World.&quot;],BBOX[-90,-180,90,180]],ID[&quot;EPSG&quot;,4326]]&#x27;)).crs
E        +        where GeoBox((8, 11), Affine(566047.0585719852, 0.0, -1698141.1757159554,\n       0.0, -566047.0585719852, 2264188.234287941)...925199433]],USAGE[SCOPE[&quot;Horizontal component of 3D system.&quot;],AREA[&quot;World.&quot;],BBOX[-90,-180,90,180]],ID[&quot;EPSG&quot;,4326]]&#x27;)) = &lt;odc.geo._xr_interop.ODCExtensionDs object at 0x7fff42560b30&gt;.geobox
E        +          where &lt;odc.geo._xr_interop.ODCExtensionDs object at 0x7fff42560b30&gt; = &lt;xarray.Dataset&gt; Size: 540B\nDimensions:      (time: 1, y: 8, x: 11, dim_0: 3)\nCoordinates:\n  * time         (time) dat...     (time, y, x) uint16 176B dask.array&lt;chunksize=(1, 4, 4), meta=np.ndarray&gt;\n    c            (dim_0) int64 24B 2 3 4.odc

tests/test_xr_interop.py:499: AssertionError
=============================== warnings summary ===============================
tests/test_geom.py::test_gen_test_image_xy
  /build/source/odc/geo/testutils.py:122: RuntimeWarning: invalid value encountered in cast
    return a.astype(ii.dtype)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================== short test summary info ============================
FAILED tests/test_xr_interop.py::test_xr_reproject[None-None] - assert None is not None
FAILED tests/test_xr_interop.py::test_xr_reproject[None-xx_time1] - assert None is not None
FAILED tests/test_xr_interop.py::test_xr_reproject[xx_chunks1-None] - assert None is not None
FAILED tests/test_xr_interop.py::test_xr_reproject[xx_chunks1-xx_time1] - assert None is not None
FAILED tests/test_xr_interop.py::test_xr_reproject[xx_chunks2-None] - assert None is not None
FAILED tests/test_xr_interop.py::test_xr_reproject[xx_chunks2-xx_time1] - assert None is not None
= 6 failed, 667 passed, 11 skipped, 79 deselected, 1 xfailed, 1 warning in 13.57s =</pre>
</details>
<details>
<summary>python314Packages.streamz</summary>
<pre>ERROR streamz/dataframe/tests/test_dataframes.py::test_cumulative_aggregations[dask-&lt;lambda&gt;0-cummax] - AttributeError: &#x27;OrderedSet&#x27; object has no attribute &#x27;copy&#x27;
ERROR streamz/dataframe/tests/test_dataframes.py::test_cumulative_aggregations[dask-&lt;lambda&gt;0-cumprod] - AttributeError: &#x27;OrderedSet&#x27; object has no attribute &#x27;copy&#x27;
ERROR streamz/dataframe/tests/test_dataframes.py::test_cumulative_aggregations[dask-&lt;lambda&gt;0-cummin] - AttributeError: &#x27;OrderedSet&#x27; object has no attribute &#x27;copy&#x27;
ERROR streamz/dataframe/tests/test_dataframes.py::test_cumulative_aggregations[dask-&lt;lambda&gt;1-cumsum] - AttributeError: &#x27;OrderedSet&#x27; object has no attribute &#x27;copy&#x27;
ERROR streamz/dataframe/tests/test_dataframes.py::test_cumulative_aggregations[dask-&lt;lambda&gt;1-cummax] - AttributeError: &#x27;OrderedSet&#x27; object has no attribute &#x27;copy&#x27;
ERROR streamz/dataframe/tests/test_dataframes.py::test_cumulative_aggregations[dask-&lt;lambda&gt;1-cumprod] - AttributeError: &#x27;OrderedSet&#x27; object has no attribute &#x27;copy&#x27;
ERROR streamz/dataframe/tests/test_dataframes.py::test_cumulative_aggregations[dask-&lt;lambda&gt;1-cummin] - AttributeError: &#x27;OrderedSet&#x27; object has no attribute &#x27;copy&#x27;
ERROR streamz/dataframe/tests/test_dataframes.py::test_tail[dask] - AttributeError: &#x27;OrderedSet&#x27; object has no attribute &#x27;copy&#x27;
ERROR streamz/dataframe/tests/test_dataframes.py::test_dataframes[dask] - AttributeError: &#x27;OrderedSet&#x27; object has no attribute &#x27;copy&#x27;
ERROR streamz/dataframe/tests/test_dataframes.py::test_groupby_aggregate_updating[dask] - AttributeError: &#x27;OrderedSet&#x27; object has no attribute &#x27;copy&#x27;
ERROR streamz/dataframe/tests/test_dataframes.py::test_window_sum[dask] - AttributeError: &#x27;OrderedSet&#x27; object has no attribute &#x27;copy&#x27;
ERROR streamz/dataframe/tests/test_dataframes.py::test_window_sum_dataframe[dask] - AttributeError: &#x27;OrderedSet&#x27; object has no attribute &#x27;copy&#x27;
ERROR streamz/dataframe/tests/test_dataframes.py::test_windowing_value_empty_intermediate_index[dask] - AttributeError: &#x27;OrderedSet&#x27; object has no attribute &#x27;copy&#x27;
ERROR streamz/dataframe/tests/test_dataframes.py::test_groupby_aggregate_with_start_state[dask] - AttributeError: &#x27;OrderedSet&#x27; object has no attribute &#x27;copy&#x27;
ERROR streamz/dataframe/tests/test_dataframes.py::test_reductions_with_start_state[dask] - AttributeError: &#x27;OrderedSet&#x27; object has no attribute &#x27;copy&#x27;
ERROR streamz/dataframe/tests/test_dataframes.py::test_rolling_aggs_with_start_state[dask] - AttributeError: &#x27;OrderedSet&#x27; object has no attribute &#x27;copy&#x27;
ERROR streamz/dataframe/tests/test_dataframes.py::test_window_aggs_with_start_state[dask] - AttributeError: &#x27;OrderedSet&#x27; object has no attribute &#x27;copy&#x27;
ERROR streamz/dataframe/tests/test_dataframes.py::test_windowed_groupby_aggs_with_start_state[dask] - AttributeError: &#x27;OrderedSet&#x27; object has no attribute &#x27;copy&#x27;
ERROR streamz/dataframe/tests/test_dataframes.py::test_dir[dask] - AttributeError: &#x27;OrderedSet&#x27; object has no attribute &#x27;copy&#x27;
= 836 failed, 41 passed, 441 skipped, 14 deselected, 104 xfailed, 135 warnings, 137 errors in 75.98s (0:01:15) =</pre>
</details>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
