### PR TITLE
nixos/influxdb: rename default config section: cluster -> coordinator; nixos/tests/influxdb: add timeouts to ensure quick fail

### DIFF
--- a/nixos/modules/services/databases/influxdb.nix
+++ b/nixos/modules/services/databases/influxdb.nix
@@ -69,8 +69,7 @@ in
                 wal-partition-flush-delay = "2s";
               };
 
-              cluster = mkAllOptionDefault {
-                shard-writer-timeout = "5s";
+              coordinator = mkAllOptionDefault {
                 write-timeout = "5s";
               };
 
@@ -156,6 +155,13 @@ in
   ###### implementation
 
   config = lib.mkIf config.services.influxdb.enable {
+
+    assertions = [
+      {
+        assertion = !(cfg.settings ? cluster);
+        message = "services.influxdb.settings.cluster was renamed to services.influxdb.settings.coordinator";
+      }
+    ];
 
     systemd.tmpfiles.rules = [
       "d '${cfg.dataDir}' 0770 ${cfg.user} ${cfg.group} - -"

--- a/nixos/tests/influxdb.nix
+++ b/nixos/tests/influxdb.nix
@@ -18,20 +18,20 @@
 
     start_all()
 
-    one.wait_for_unit("influxdb.service")
+    one.wait_for_unit("influxdb.service", timeout=30)
 
     # create database
     one.succeed(
-        "curl -XPOST http://localhost:8086/query --data-urlencode 'q=CREATE DATABASE test'"
+        "curl --max-time 15 -XPOST http://localhost:8086/query --data-urlencode 'q=CREATE DATABASE test'"
     )
 
     # write some points and run simple query
     out = one.succeed(
-        "curl -XPOST 'http://localhost:8086/write?db=test' --data-binary 'cpu_load_short,host=server01,region=us-west value=0.64 1434055562000000000'"
+        "curl --max-time 15 -XPOST 'http://localhost:8086/write?db=test' --data-binary 'cpu_load_short,host=server01,region=us-west value=0.64 1434055562000000000'"
     )
 
     qv = "SELECT value FROM cpu_load_short WHERE region='us-west'"
-    cmd = f'curl -GET "http://localhost:8086/query?db=test" --data-urlencode {shlex.quote("q="+ qv)}'
+    cmd = f'curl --max-time 15 -GET "http://localhost:8086/query?db=test" --data-urlencode {shlex.quote("q="+ qv)}'
     out = one.succeed(cmd)
 
     assert "2015-06-11T20:46:02Z" in out


### PR DESCRIPTION
Influxdb currently gives the following warning on every start:

```
deprecated config option [cluster] replaced with [coordinator]; [cluster] will not be supported in a future release
```

Fix this by renaming the cluster section accordingly.

Removed the `shard-writer-timeout` setting. It seems to have been a thing in [v0.9](https://archive.docs.influxdata.com/influxdb/v0.9/administration/config/#shard-writer-timeout-5s) but has been missing in the manual from [v1.0](https://archive.docs.influxdata.com/influxdb/v1.0/administration/config/) (like the cluster section as a whole).

The current docs for the coordinator section can be found [here](https://docs.influxdata.com/influxdb/v1/administration/config/#coordinator).

Added an assertion because influxdb won't start if both sections are present. An automatic rename with a warning would be nicer but i think that isn't easily done with a freeform settings option and it probably won't affect that many users (if any) so it's probably acceptable to do it this way.

I've also adjusted the timeout settings of the test because i noticed that the `one.wait_for_unit("influxdb.service")` could take quite a while if influxdb didn't start (in my case due to testing what happens if both sections are present).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
