### PR TITLE
[25.11] siyuan: 3.4.0 -> 3.5.4-dev2, fixes CVE-2026-23645

### DIFF
--- a/pkgs/by-name/si/siyuan/package.nix
+++ b/pkgs/by-name/si/siyuan/package.nix
@@ -35,20 +35,20 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "siyuan";
-  version = "3.4.0";
+  version = "3.4.1";
 
   src = fetchFromGitHub {
     owner = "siyuan-note";
     repo = "siyuan";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-jeAT/4MlvCxLrwsk3LhVs/mVaBRR4NhSecsYkQSY6wM=";
+    hash = "sha256-BplxcFV8h0V+eyk2knCpwPCxUo9PdoIHp4mDXXo/HyE=";
   };
 
   kernel = buildGoModule {
     name = "${finalAttrs.pname}-${finalAttrs.version}-kernel";
     inherit (finalAttrs) src;
     sourceRoot = "${finalAttrs.src.name}/kernel";
-    vendorHash = "sha256-9GMlwqvU3LqzTc/HWQXFZM9RgGCk2V6OAXNoWIjzL4I=";
+    vendorHash = "sha256-v2I8+1K+Yz+DR2QsJ+1SaKLh3aEIBaR3aXRfwDMNvVs=";
 
     patches = [
       (replaceVars ./set-pandoc-path.patch {

--- a/pkgs/by-name/si/siyuan/package.nix
+++ b/pkgs/by-name/si/siyuan/package.nix
@@ -35,20 +35,20 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "siyuan";
-  version = "3.5.0";
+  version = "3.5.1";
 
   src = fetchFromGitHub {
     owner = "siyuan-note";
     repo = "siyuan";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-h7oYlxz9Loh4HiZDeQdWV9ycWfCaNNifgFLo1d5zOJk=";
+    hash = "sha256-7fKvSK3gatEdIHAZuOzL6LdzLz4k97G+ZKpQh39yhbs=";
   };
 
   kernel = buildGoModule {
     name = "${finalAttrs.pname}-${finalAttrs.version}-kernel";
     inherit (finalAttrs) src;
     sourceRoot = "${finalAttrs.src.name}/kernel";
-    vendorHash = "sha256-Q6Bpcgav9ClM+d723jYmuunybEP5iHt9nF5ssQ1kokQ=";
+    vendorHash = "sha256-SqPegOTdjd8HrnXNIRUMAbDhKKrFR+xWZUuqblrZ10c=";
 
     patches = [
       (replaceVars ./set-pandoc-path.patch {

--- a/pkgs/by-name/si/siyuan/package.nix
+++ b/pkgs/by-name/si/siyuan/package.nix
@@ -35,20 +35,20 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "siyuan";
-  version = "3.4.1";
+  version = "3.4.2";
 
   src = fetchFromGitHub {
     owner = "siyuan-note";
     repo = "siyuan";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-BplxcFV8h0V+eyk2knCpwPCxUo9PdoIHp4mDXXo/HyE=";
+    hash = "sha256-INwbp6gGqrmOtrM5d/8iEv1nlTUDSuo9AVN0EwNhW9Y=";
   };
 
   kernel = buildGoModule {
     name = "${finalAttrs.pname}-${finalAttrs.version}-kernel";
     inherit (finalAttrs) src;
     sourceRoot = "${finalAttrs.src.name}/kernel";
-    vendorHash = "sha256-v2I8+1K+Yz+DR2QsJ+1SaKLh3aEIBaR3aXRfwDMNvVs=";
+    vendorHash = "sha256-kt5fnkF/bxpeY9d86zKr9VlShvLy1gtaICfA0PGVGKI=";
 
     patches = [
       (replaceVars ./set-pandoc-path.patch {

--- a/pkgs/by-name/si/siyuan/package.nix
+++ b/pkgs/by-name/si/siyuan/package.nix
@@ -35,20 +35,20 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "siyuan";
-  version = "3.5.3";
+  version = "3.5.4-dev2";
 
   src = fetchFromGitHub {
     owner = "siyuan-note";
     repo = "siyuan";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-YAd7XVJLs66CAhb5ro8o5GrT5AhVpp/RHOpl1XkBBHU=";
+    hash = "sha256-D3vpbtGNeDP+PZIOUGYufZo0ZTq9/eZsesizNuvAHdE=";
   };
 
   kernel = buildGoModule {
     name = "${finalAttrs.pname}-${finalAttrs.version}-kernel";
     inherit (finalAttrs) src;
     sourceRoot = "${finalAttrs.src.name}/kernel";
-    vendorHash = "sha256-2O8gk6Y6odlMldUfanPf5MIiczfd5lH/yMX0IbIEVvc=";
+    vendorHash = "sha256-/VLI51s3CQSzaLhiO673chXgqDml2l0zVXGFvhiVbAs=";
 
     patches = [
       (replaceVars ./set-pandoc-path.patch {

--- a/pkgs/by-name/si/siyuan/package.nix
+++ b/pkgs/by-name/si/siyuan/package.nix
@@ -35,20 +35,20 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "siyuan";
-  version = "3.5.1";
+  version = "3.5.2";
 
   src = fetchFromGitHub {
     owner = "siyuan-note";
     repo = "siyuan";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-7fKvSK3gatEdIHAZuOzL6LdzLz4k97G+ZKpQh39yhbs=";
+    hash = "sha256-Rimb2OfohjTfaqVCZcoGDxpEfXvyp2CLqwqOjqAJjJg=";
   };
 
   kernel = buildGoModule {
     name = "${finalAttrs.pname}-${finalAttrs.version}-kernel";
     inherit (finalAttrs) src;
     sourceRoot = "${finalAttrs.src.name}/kernel";
-    vendorHash = "sha256-SqPegOTdjd8HrnXNIRUMAbDhKKrFR+xWZUuqblrZ10c=";
+    vendorHash = "sha256-PNFIWH6IL/Zj/eK/5M8ACICOeQi4WEBIh1aY4eyfkn4=";
 
     patches = [
       (replaceVars ./set-pandoc-path.patch {
@@ -99,7 +99,7 @@ stdenv.mkDerivation (finalAttrs: {
       ;
     pnpm = pnpm_9;
     fetcherVersion = 1;
-    hash = "sha256-bteZZ9sgYLLvOPSVbqm9E0Hb5x1UdWMu8DtpQHGjbPU=";
+    hash = "sha256-JTfCU5kWR2tvVNFT+PAzqKe8tUk4+uwwVgo85VOntck=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/app";

--- a/pkgs/by-name/si/siyuan/package.nix
+++ b/pkgs/by-name/si/siyuan/package.nix
@@ -35,20 +35,20 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "siyuan";
-  version = "3.4.2";
+  version = "3.5.0";
 
   src = fetchFromGitHub {
     owner = "siyuan-note";
     repo = "siyuan";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-INwbp6gGqrmOtrM5d/8iEv1nlTUDSuo9AVN0EwNhW9Y=";
+    hash = "sha256-h7oYlxz9Loh4HiZDeQdWV9ycWfCaNNifgFLo1d5zOJk=";
   };
 
   kernel = buildGoModule {
     name = "${finalAttrs.pname}-${finalAttrs.version}-kernel";
     inherit (finalAttrs) src;
     sourceRoot = "${finalAttrs.src.name}/kernel";
-    vendorHash = "sha256-kt5fnkF/bxpeY9d86zKr9VlShvLy1gtaICfA0PGVGKI=";
+    vendorHash = "sha256-Q6Bpcgav9ClM+d723jYmuunybEP5iHt9nF5ssQ1kokQ=";
 
     patches = [
       (replaceVars ./set-pandoc-path.patch {

--- a/pkgs/by-name/si/siyuan/package.nix
+++ b/pkgs/by-name/si/siyuan/package.nix
@@ -35,20 +35,20 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "siyuan";
-  version = "3.5.2";
+  version = "3.5.3";
 
   src = fetchFromGitHub {
     owner = "siyuan-note";
     repo = "siyuan";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-Rimb2OfohjTfaqVCZcoGDxpEfXvyp2CLqwqOjqAJjJg=";
+    hash = "sha256-YAd7XVJLs66CAhb5ro8o5GrT5AhVpp/RHOpl1XkBBHU=";
   };
 
   kernel = buildGoModule {
     name = "${finalAttrs.pname}-${finalAttrs.version}-kernel";
     inherit (finalAttrs) src;
     sourceRoot = "${finalAttrs.src.name}/kernel";
-    vendorHash = "sha256-PNFIWH6IL/Zj/eK/5M8ACICOeQi4WEBIh1aY4eyfkn4=";
+    vendorHash = "sha256-2O8gk6Y6odlMldUfanPf5MIiczfd5lH/yMX0IbIEVvc=";
 
     patches = [
       (replaceVars ./set-pandoc-path.patch {
@@ -99,7 +99,7 @@ stdenv.mkDerivation (finalAttrs: {
       ;
     pnpm = pnpm_9;
     fetcherVersion = 1;
-    hash = "sha256-JTfCU5kWR2tvVNFT+PAzqKe8tUk4+uwwVgo85VOntck=";
+    hash = "sha256-/h8tHSJGsqjFXp/qpxOqoHmsEiuRXvIWBLRalTdXVi4=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/app";


### PR DESCRIPTION
Fixes #481069

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
