### PR TITLE
maintainers: drop rembo10

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22159,11 +22159,6 @@
     githubId = 43930;
     name = "Ricky Elrod";
   };
-  rembo10 = {
-    github = "rembo10";
-    githubId = 801525;
-    name = "rembo10";
-  };
   remcoschrijver = {
     email = "info@writerit.nl";
     matrix = "@remcoschrijver:tchncs.de";

--- a/pkgs/by-name/he/headphones/package.nix
+++ b/pkgs/by-name/he/headphones/package.nix
@@ -39,7 +39,7 @@ python3.pkgs.buildPythonApplication rec {
     description = "Automatic music downloader for SABnzbd";
     license = lib.licenses.gpl3Plus;
     homepage = "https://github.com/rembo10/headphones";
-    maintainers = with lib.maintainers; [ rembo10 ];
+    maintainers = [ ];
     mainProgram = "headphones";
   };
 }

--- a/pkgs/by-name/si/sickgear/package.nix
+++ b/pkgs/by-name/si/sickgear/package.nix
@@ -52,6 +52,6 @@ stdenv.mkDerivation rec {
     mainProgram = "sickgear";
     license = lib.licenses.gpl3;
     homepage = "https://github.com/SickGear/SickGear";
-    maintainers = with lib.maintainers; [ rembo10 ];
+    maintainers = [ ];
   };
 }


### PR DESCRIPTION
## Reasons

- Last commented in [May 2024](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Arembo10)
- Hasn't created any PRs / Issues since [July 2025](https://github.com/NixOS/nixpkgs/issues?q=author%3Arembo10)
- About 52 [unanswered](https://github.com/NixOS/nixpkgs/issues?q=involves%3Arembo10%20-commenter%3Arembo10%20-author%3Arembo10%20-reviewed-by%3Arembo10) PRs / Issues

See [lossing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs. You still seem to be active on GitHub so if you still plan to maintain packages actively in `nixpkgs`, let me know so I can close the PR :)
## Packages 

Those packages only have them as their maintainer and would need at least one new maintainer.

- [ ] headphones
- [ ] sickgear