### PR TITLE
concessio: 0.1.10 -> 0.2.1

### DIFF
--- a/pkgs/by-name/co/concessio/package.nix
+++ b/pkgs/by-name/co/concessio/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  blueprint-compiler,
   desktop-file-utils,
   fetchFromGitHub,
   gjs,
@@ -17,18 +18,19 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "concessio";
-  version = "0.1.10";
+  version = "0.2.1";
 
   src = fetchFromGitHub {
     owner = "ronniedroid";
     repo = "concessio";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-GDiwpErxz6GiYajcRBOnX0RO1jeaSmpLLxqEsB3nJLA=";
+    hash = "sha256-vPHL46mZj6idIv9VXY73jrcA2GEpPdG5hn0ZzAZjo6A=";
   };
 
   strictDeps = true;
 
   nativeBuildInputs = [
+    blueprint-compiler
     desktop-file-utils
     gjs
     glib # For `glib-compile-schema`


### PR DESCRIPTION
Diff: https://github.com/ronniedroid/concessio/compare/v0.1.10...v0.2.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
