### PR TITLE
beets-filetote: 1.3.5 -> 1.3.6, migrate to uv-build

### DIFF
--- a/pkgs/development/python-modules/beets-filetote/default.nix
+++ b/pkgs/development/python-modules/beets-filetote/default.nix
@@ -13,27 +13,38 @@
   pytestCheckHook,
   beets-audible,
   mediafile,
-  pytest,
   reflink,
   toml,
   typeguard,
   writableTmpDirAsHomeHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "beets-filetote";
-  version = "1.1.1";
+  version = "1.3.4";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "gtronset";
     repo = "beets-filetote";
-    tag = "v${version}";
-    hash = "sha256-NsYBsP60SiCfQ63C4WMkshyreFqOSmx3LP5Gwq6ECF0=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-6pMKhsnUG25jbTKWbGiA0tp5QKAHwxPE3/4iVJz3SYk=";
   };
+
+  patches = [
+    # Fix test imports: add the source tree's beetsplug/ to beetsplug.__path__
+    # so relative imports resolve when loading filetote via importlib.
+    ./fix-test-imports.patch
+  ];
 
   postPatch = ''
     substituteInPlace pyproject.toml --replace-fail "poetry-core<2.0.0" "poetry-core"
+
+    # Replace beetsplug/__init__.py with a namespace package extend_path.
+    # The upstream __init__.py turns beetsplug into a regular package, which
+    # shadows the beets namespace package and breaks all other beets plugins.
+    echo 'from pkgutil import extend_path; __path__ = extend_path(__path__, __name__)' \
+      > beetsplug/__init__.py
   '';
 
   build-system = [
@@ -61,26 +72,16 @@ buildPythonPackage rec {
     writableTmpDirAsHomeHook
   ];
 
-  pytestFlags = [
-    # This is the same as:
-    #   -r fEs
+  pytestFlagsArray = [
     "-rfEs"
-  ];
-
-  disabledTestPaths = [
-    "tests/test_cli_operation.py"
-    "tests/test_pruning.py"
-    "tests/test_version.py"
   ];
 
   meta = {
     description = "Beets plugin to move non-music files during the import process";
     homepage = "https://github.com/gtronset/beets-filetote";
-    changelog = "https://github.com/gtronset/beets-filetote/blob/${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/gtronset/beets-filetote/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     maintainers = with lib.maintainers; [ dansbandit ];
     license = lib.licenses.mit;
     inherit (beets-minimal.meta) platforms;
-    # https://github.com/gtronset/beets-filetote/issues/211
-    broken = true;
   };
-}
+})

--- a/pkgs/development/python-modules/beets-filetote/default.nix
+++ b/pkgs/development/python-modules/beets-filetote/default.nix
@@ -1,20 +1,21 @@
 {
   lib,
   fetchFromGitHub,
-  fetchpatch2,
   buildPythonPackage,
 
   # build-system
-  poetry-core,
+  uv-build,
 
   # nativeBuildInputs
   beets-minimal,
 
+  # dependencies
+  mediafile,
+
   # tests
   pytestCheckHook,
   beets-audible,
-  mediafile,
-  pytest,
+  pytest-xdist,
   reflink,
   toml,
   typeguard,
@@ -23,31 +24,24 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "beets-filetote";
-  version = "1.3.5";
+  version = "1.3.6";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "gtronset";
     repo = "beets-filetote";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-qMHjcBrXkVG7U5a1E0yRwNgmg7XinRnK3gnV7jAZLTk=";
+    hash = "sha256-ZrF9Z3Eaem8ZzNJgQoW45MvsNOCoLsd7l/yLQ2pldR0=";
   };
-  # needed to keep beetsplug a namespace package, othwise other plugins will not be found
-  # can be removed with next version
-  patches = [
-    (fetchpatch2 {
-      url = "https://github.com/gtronset/beets-filetote/commit/762cf0c4b60b8f6b38cf39b027de4241f12cef37.patch?full_index=1";
-      hash = "sha256-c7qIECcqwoV4ZOaA/8JYsM6Aym34peWPh7ZLWUxIYSI=";
-      excludes = [ "CHANGELOG.md" ];
-    })
-  ];
 
   postPatch = ''
-    substituteInPlace pyproject.toml --replace-fail "poetry-core<2.0.0" "poetry-core"
+    # nixpkgs ships uv-build 0.10.0; relax the upstream build backend bound.
+    substituteInPlace pyproject.toml \
+      --replace-fail "uv_build>=0.11.21,<0.12" "uv_build"
   '';
 
   build-system = [
-    poetry-core
+    uv-build
   ];
 
   nativeBuildInputs = [
@@ -56,15 +50,12 @@ buildPythonPackage (finalAttrs: {
 
   dependencies = [
     mediafile
-    reflink
-    toml
-    typeguard
   ];
 
   nativeCheckInputs = [
     pytestCheckHook
     beets-audible
-    mediafile
+    pytest-xdist
     reflink
     toml
     typeguard
@@ -72,8 +63,6 @@ buildPythonPackage (finalAttrs: {
   ];
 
   pytestFlags = [
-    # This is the same as:
-    #   -r fEs
     "-rfEs"
   ];
 

--- a/pkgs/development/python-modules/beets-filetote/fix-test-imports.patch
+++ b/pkgs/development/python-modules/beets-filetote/fix-test-imports.patch
@@ -1,0 +1,15 @@
+--- a/tests/helper.py
++++ b/tests/helper.py
+@@ -111,6 +111,12 @@ def _load_module_from_path(module_name: str, module_path: str) -> types.ModuleTy
+ 
+     module = importlib.util.module_from_spec(spec)
+     sys.modules[module_name] = module
++    # Ensure the source tree's beetsplug/ is on beetsplug.__path__ so that
++    # relative imports (from .filetote_dataclasses) resolve correctly.
++    if module_name.startswith("beetsplug."):
++        _src_bp = str(Path(__file__).resolve().parent.parent / "beetsplug")
++        if _src_bp not in beetsplug.__path__:
++            beetsplug.__path__.insert(0, _src_bp)
+     spec.loader.exec_module(module)
+     return module
+ 


### PR DESCRIPTION
Update beets-filetote from 1.3.5 to 1.3.6 and migrate to the new upstream `uv_build` build backend.

> Note: master already landed an equivalent 1.3.5 update (finalAttrs, unbroken, `pytestFlags`, namespace fix via `fetchpatch2`). This PR is now effectively a `1.3.5 -> 1.3.6` bump that removes the temporary patch.

### Changes

- **Version bump**: 1.3.5 → 1.3.6
- **Migrate build-system** from `poetry-core` to `uv-build` (upstream switched to the `uv_build` backend). A `postPatch` relaxes the upstream `uv_build>=0.11.21,<0.12` bound since nixpkgs ships uv-build 0.10.0.
- **Drop the namespace-package patch** (`fetchpatch2`): 1.3.6 ships a proper PEP 420 namespace package (no `beetsplug/__init__.py`), so other beets plugins are no longer shadowed without patching.
- **Dependency cleanup**: move `reflink`/`toml`/`typeguard` out of runtime `dependencies` (they are dev/test only upstream) and add `pytest-xdist` to the test inputs.

For a changelog, see the upstream release: [v1.3.6](https://github.com/gtronset/beets-filetote/releases/tag/v1.3.6).

All tests pass: `178 passed, 1 skipped` (skip is reflink-unsupported platform).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
