### PR TITLE
swgp-go: init at 1.8.0-0-unstable-2026-01-18

### DIFF
--- a/pkgs/by-name/sw/swgp-go/package.nix
+++ b/pkgs/by-name/sw/swgp-go/package.nix
@@ -1,0 +1,44 @@
+{
+  buildGoModule,
+  lib,
+  fetchFromGitHub,
+  # doubles the binary size
+  withPprof ? false,
+}:
+
+buildGoModule {
+  pname = "swgp-go";
+  version = "1.8.0-0-unstable-2026-01-18";
+
+  src = fetchFromGitHub {
+    owner = "database64128";
+    repo = "swgp-go";
+    rev = "e8ed210b0a016c450ba371ee43041f2f53444841";
+    hash = "sha256-LDYNQwc6vdVkI0bqD96p64D25fz0aGclFDc8SqvCdJQ=";
+  };
+
+  vendorHash = "sha256-Ghv5FwSPQSUFQ1t2zWTXpFggCA4/qrQmnVYkYBF8AQ4=";
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  tags = lib.optionals (!withPprof) [
+    "swgpgo_nopprof"
+  ];
+
+  # Tests try to do DNS lookups
+  doCheck = false;
+
+  meta = {
+    description = "Simple WireGuard proxy with minimal overhead for WireGuard traffic";
+    homepage = "https://github.com/database64128/swgp-go";
+    license = lib.licenses.agpl3Plus;
+    maintainers = with lib.maintainers; [
+      flokli
+      rvdp
+    ];
+    mainProgram = "swgp-go";
+  };
+}


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
