### PR TITLE
pypy3Packages.matplotlib: fix failing dependencies

### DIFF
--- a/pkgs/development/python-modules/brotlicffi/default.nix
+++ b/pkgs/development/python-modules/brotlicffi/default.nix
@@ -3,9 +3,11 @@
   fetchFromGitHub,
   buildPythonPackage,
   cffi,
+  isPyPy,
   # overridden as pkgs.brotli
   brotli,
   setuptools,
+  pycparser,
   pytestCheckHook,
   hypothesis,
 }:
@@ -28,7 +30,7 @@ buildPythonPackage rec {
 
   propagatedNativeBuildInputs = [ cffi ];
 
-  dependencies = [ cffi ];
+  dependencies = [ cffi ] ++ lib.optional isPyPy pycparser;
 
   preBuild = ''
     export USE_SHARED_BROTLI=1

--- a/pkgs/development/python-modules/hypothesis/default.nix
+++ b/pkgs/development/python-modules/hypothesis/default.nix
@@ -136,6 +136,10 @@ buildPythonPackage rec {
     "test_resolving_standard_reversible_as_generic"
     "test_resolving_standard_sequence_as_generic"
     "test_specialised_collection_types"
+  ]
+  ++ lib.optionals isPyPy [
+    # hypothesis.errors.Unsatisfiable: Could not find any examples from datetimes(min_value=datetime.datetime(2003, 1, 1, 0, 0), max_value=datetime.datetime(2005, 12, 31, 23, 59, 59, 999999)) that satisfied lambda x: x.month == 2 and x.day == 29
+    "test_bordering_on_a_leap_year"
   ];
 
   pythonImportsCheck = [ "hypothesis" ];

--- a/pkgs/development/python-modules/matplotlib/default.nix
+++ b/pkgs/development/python-modules/matplotlib/default.nix
@@ -93,18 +93,23 @@ buildPythonPackage rec {
   # installed under the same path which is not true in Nix.
   # With the following patch we just hard-code these paths into the install
   # script.
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace-fail "meson-python>=0.13.1,<0.17.0" meson-python
+  postPatch =
+    lib.optionalString isPyPy ''
+      substituteInPlace tools/generate_matplotlibrc.py \
+        --replace-fail "/usr/bin/env python3" "/usr/bin/env pypy3"
+    ''
+    + ''
+      substituteInPlace pyproject.toml \
+        --replace-fail "meson-python>=0.13.1,<0.17.0" meson-python
 
-    patchShebangs tools
-  ''
-  + lib.optionalString (stdenv.hostPlatform.isLinux && interactive) ''
-    # fix paths to libraries in dlopen calls (headless detection)
-    substituteInPlace src/_c_internal_utils.cpp \
-      --replace-fail libX11.so.6 ${libX11}/lib/libX11.so.6 \
-      --replace-fail libwayland-client.so.0 ${wayland}/lib/libwayland-client.so.0
-  '';
+      patchShebangs tools
+    ''
+    + lib.optionalString (stdenv.hostPlatform.isLinux && interactive) ''
+      # fix paths to libraries in dlopen calls (headless detection)
+      substituteInPlace src/_c_internal_utils.cpp \
+        --replace-fail libX11.so.6 ${libX11}/lib/libX11.so.6 \
+        --replace-fail libwayland-client.so.0 ${wayland}/lib/libwayland-client.so.0
+    '';
 
   nativeBuildInputs = [ pkg-config ] ++ lib.optionals enableGtk3 [ gobject-introspection ];
 

--- a/pkgs/development/python-modules/virtualenv/default.nix
+++ b/pkgs/development/python-modules/virtualenv/default.nix
@@ -10,6 +10,7 @@
   hatch-vcs,
   hatchling,
   platformdirs,
+  pytest-freezer,
   pytest-mock,
   pytestCheckHook,
   time-machine,
@@ -43,6 +44,7 @@ buildPythonPackage rec {
     pytest-mock
     pytestCheckHook
   ]
+  ++ lib.optionals isPyPy [ pytest-freezer ]
   ++ lib.optionals (!isPyPy) [ time-machine ];
 
   disabledTestPaths = [


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
