### PR TITLE
lurk: fix aarch64 build

### DIFF
--- a/pkgs/by-name/lu/lurk/package.nix
+++ b/pkgs/by-name/lu/lurk/package.nix
@@ -3,6 +3,7 @@
   rustPlatform,
   fetchFromGitHub,
   fetchpatch,
+  versionCheckHook,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -30,6 +31,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
     substituteInPlace src/lib.rs \
       --replace-fail '/usr/bin/ls' 'ls'
   '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgramArg = "--version";
 
   meta = {
     changelog = "https://github.com/jakwai01/lurk/releases/tag/v${finalAttrs.version}";

--- a/pkgs/by-name/lu/lurk/package.nix
+++ b/pkgs/by-name/lu/lurk/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   fetchpatch,
   versionCheckHook,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -37,6 +38,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
     versionCheckHook
   ];
   versionCheckProgramArg = "--version";
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     changelog = "https://github.com/jakwai01/lurk/releases/tag/v${finalAttrs.version}";

--- a/pkgs/by-name/lu/lurk/package.nix
+++ b/pkgs/by-name/lu/lurk/package.nix
@@ -2,6 +2,7 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
+  fetchpatch,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -14,6 +15,14 @@ rustPlatform.buildRustPackage (finalAttrs: {
     tag = "v${finalAttrs.version}";
     hash = "sha256-Sng+mMMKDuI1aSgusJDRFMT5iKNUlp9arp9ruRn0bb0=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "fix-aarch64-build.patch";
+      url = "https://github.com/JakWai01/lurk/commit/132e6557ddeafbdb1bb1d4d1411099f0d7df7a51.patch?full_index=1";
+      hash = "sha256-B5rNLipnFFWxIhTm+eCacJkw38D7stQ27WIHzgj7Vy0=";
+    })
+  ];
 
   cargoHash = "sha256-Cmlhhda35FmNg/OvfMRPHBLPRXF5bs0ebBYT7KfierA=";
 


### PR DESCRIPTION
Fixes https://hydra.nixos.org/build/318504397.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
