### PR TITLE
lib.filesystem.listFilesRecursiveCond: init

### DIFF
--- a/lib/filesystem.nix
+++ b/lib/filesystem.nix
@@ -7,7 +7,10 @@
 # Tested in lib/tests/filesystem.sh
 let
   inherit (builtins)
+    attrNames
+    concatMap
     pathExists
+    readDir
     toString
     ;
 
@@ -17,9 +20,7 @@ let
     packagesFromDirectoryRecursive
     ;
 
-  inherit (lib.strings)
-    hasSuffix
-    ;
+  inherit (lib.strings) hasSuffix;
 in
 
 {
@@ -240,6 +241,68 @@ in
         ) (builtins.readDir dir));
     in
     dir: lib.flatten (internalFunc dir);
+
+  /**
+    Lists files conditionally from a directory tree.
+
+    Given a directory and some condition, return a flattened list of all files that matched the condition.
+
+    # Inputs
+
+    `dir`
+
+    : The path to recursively list files from
+
+    `condition`
+
+    : The condition is a function that receives the filename as argument and returns a boolean.
+
+    # Type
+
+    ```
+    listFilesRecursiveCond :: Path -> (String -> Bool) -> [ Path ]
+    ```
+
+    # Examples
+    :::{.example}
+    ## `lib.filesystem.listFilesRecursiveCond` usage example
+
+    ```nix
+    listFilesRecursiveCond ./modules (filename: true)
+    => [./modules/foo.nix ./modules/nested/_bar.nix ./modules/nested/baz.json]
+
+    listFilesRecursiveCond ./modules (lib.hasSuffix ".nix")
+    => [./modules/foo.nix ./modules/nested/_bar.nix]
+
+    listFilesRecursiveCond ./modules (filename: lib.hasSuffix ".nix" filename && !lib.hasPrefix "_" filename)
+    => [./modules/foo.nix]
+    ```
+
+    :::
+  */
+  listFilesRecursiveCond =
+    dir: condition:
+    let
+      internalFunc =
+        folder:
+        let
+          contents = readDir folder;
+        in
+        concatMap (
+          filename:
+          let
+            subpath = folder + "/${filename}";
+            type = contents.${filename};
+          in
+          if type == "regular" && condition filename then
+            [ subpath ]
+          else if type == "directory" then
+            internalFunc subpath
+          else
+            [ ]
+        ) (attrNames contents);
+    in
+    internalFunc dir;
 
   /**
     Transform a directory tree containing package files suitable for


### PR DESCRIPTION
There's several community functions/libraries for "automatic" imports (like [import-tree](https://github.com/vic/import-tree)). However, I've found that these end up unnecessarily wrapping `lib.fileset`, and generally being unoptimized. We can account for most usecases with a simple `condition` function that's called on every regular file found. 

The entire logic only requires three builtins (readDir, concatMap, and attrNames). I use a trick I learned from @adisbladis, where rather than using `mapAttrsToList`, which maps each attribute to a new value, then takes that value, we instead map over the _names_, access the old value with `attrset.${name}`, and return the new value. This prevents us from needing to allocate duplicate attribute names, that we end up ignoring with `attrValues` anyways. We also use `concatMap` while recursing, rather than running a `flatten` at the very end. 

In a future PR, I'd like to land some of these performance improvements to the normal `listFilesRecursive`, and compare that to [this version](https://github.com/NixOS/nixpkgs/pull/449744#issuecomment-3383857304) by philip to see what's faster.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
