### PR TITLE
cgt-calc: 1.13.0 -> 1.14.0

### DIFF
--- a/pkgs/by-name/cg/cgt-calc/package.nix
+++ b/pkgs/by-name/cg/cgt-calc/package.nix
@@ -1,21 +1,34 @@
 {
   lib,
   fetchFromGitHub,
+  fetchpatch,
   python3Packages,
   withTeXLive ? true,
   texliveSmall,
 }:
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "cgt-calc";
-  version = "1.13.0";
+  version = "1.14.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "KapJI";
     repo = "capital-gains-calculator";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-y/Y05wG89nccXyxfjqazyPJhd8dOkfwRJre+Rzx97Hw=";
+    hash = "sha256-6iOlDNlpfCrbRCxEJsRYw6zqOehv/buVN+iU6J6CtIk=";
   };
+
+  patches = [
+    # https://github.com/KapJI/capital-gains-calculator/pull/715
+    (fetchpatch {
+      url = "https://github.com/KapJI/capital-gains-calculator/commit/ec7155c1256b876d5906a3885656489e9fdd798c.patch";
+      hash = "sha256-pfGHSKuDRF0T1hP7kpRC285limd1voqLXcXCP7mAD3s=";
+    })
+  ];
+
+  pythonRelaxDeps = [
+    "defusedxml"
+  ];
 
   build-system = with python3Packages; [
     poetry-core
@@ -26,6 +39,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     jinja2
     pandas
     requests
+    pyrate-limiter
     types-requests
     yfinance
   ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

changelog: https://github.com/KapJI/capital-gains-calculator/releases/tag/v1.14.0

notes:
- loosen defusedxml dep
- 1.14 added a dependency on requests-ratelimiter, but that is broken in
     nixpkgs as it depends on pyrate-limiter 2, but nixpkgs is on 3.9:
      - https://github.com/JWCook/requests-ratelimiter/issues/78
      - https://github.com/NixOS/nixpkgs/pull/437746#issuecomment-3232365968
- I have an upstream patch to switch cgt-calc to natively use pyrate-limiter 3.9, which I had to backport to 1.14: https://github.com/KapJI/capital-gains-calculator/pull/715

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
