### PR TITLE
stdenv: handle null replaceStdenv as identity

### DIFF
--- a/pkgs/stdenv/custom/default.nix
+++ b/pkgs/stdenv/custom/default.nix
@@ -31,7 +31,10 @@ bootStages
     stdenv =
       assert vanillaPackages.stdenv.hostPlatform == localSystem;
       assert vanillaPackages.stdenv.targetPlatform == localSystem;
-      config.replaceStdenv { pkgs = vanillaPackages; };
+      let
+        fn = config.replaceStdenv or null;
+      in
+      if fn == null then vanillaPackages.stdenv else fn { pkgs = vanillaPackages; };
   })
 
 ]


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

replaceStdenv is defined as nullOr (functionTo package) with null as default,
but custom stdenv stage unconditionally applied it as a function.

```nix
       … in the left operand of the update (//) operator
         at «github:NixOS/nixpkgs/e4bae1bd10c9c57b2cf517953ab70060a828ee6f?narHash=sha256-Kell/SpJYVkHWMvnhqJz/8DqQg2b6PguxVWOuadbHCc%3D»/pkgs/stdenv/booter.nix:100:18:
           99|       args' = args // {
          100|         stdenv = args.stdenv // {
             |                  ^
          101|           # For debugging

       … while evaluating the attribute 'stdenv'
         at «github:NixOS/nixpkgs/e4bae1bd10c9c57b2cf517953ab70060a828ee6f?narHash=sha256-Kell/SpJYVkHWMvnhqJz/8DqQg2b6PguxVWOuadbHCc%3D»/pkgs/stdenv/custom/default.nix:31:5:
           30|     inherit config overlays;
           31|     stdenv =
             |     ^
           32|       assert vanillaPackages.stdenv.hostPlatform == localSystem;

       error: attempt to call something which is not a function but null: null
       at «github:NixOS/nixpkgs/e4bae1bd10c9c57b2cf517953ab70060a828ee6f?narHash=sha256-Kell/SpJYVkHWMvnhqJz/8DqQg2b6PguxVWOuadbHCc%3D»/pkgs/stdenv/custom/default.nix:34:7:
           33|       assert vanillaPackages.stdenv.targetPlatform == localSystem;
           34|       config.replaceStdenv { pkgs = vanillaPackages; };
             |       ^
           35|   })
Error: Process completed with exit code 1.

```

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
