### PR TITLE
python3Packages.setproctitle: disable crashing tests on Darwin

### DIFF
--- a/pkgs/development/python-modules/setproctitle/default.nix
+++ b/pkgs/development/python-modules/setproctitle/default.nix
@@ -27,8 +27,13 @@ buildPythonPackage rec {
     procps
   ];
 
-  # Setting the process title fails on macOS in the Nix builder environment (regardless of sandboxing)
-  disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [ "test_setproctitle_darwin" ];
+  disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [
+    # Setting the process title fails on macOS in the Nix builder environment (regardless of sandboxing)
+    "test_setproctitle_darwin"
+    # *** multi-threaded process forked ***; crashed on child side of fork pre-exec. fork without exec is unsafe.
+    "test_fork_segfault"
+    "test_thread_fork_segfault"
+  ];
 
   pythonImportsCheck = [ "setproctitle" ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
