### PR TITLE
various: switch to finalAttrs pattern #1

### DIFF
--- a/pkgs/by-name/ab/abaddon/package.nix
+++ b/pkgs/by-name/ab/abaddon/package.nix
@@ -21,14 +21,14 @@
   sqlite,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "abaddon";
   version = "0.2.2";
 
   src = fetchFromGitHub {
     owner = "uowuo";
     repo = "abaddon";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-48lR1rIWMwLaTv+nIdqmQ3mHOayrC1P5OQuUb+URYh0=";
     fetchSubmodules = true;
   };
@@ -74,11 +74,11 @@ stdenv.mkDerivation rec {
 
   desktopItems = [
     (makeDesktopItem {
-      name = pname;
-      exec = pname;
+      name = "abaddon";
+      exec = "abaddon";
       desktopName = "Abaddon";
-      genericName = meta.description;
-      startupWMClass = pname;
+      genericName = "Discord client reimplementation, written in C++";
+      startupWMClass = "abaddon";
       categories = [
         "Network"
         "InstantMessaging"
@@ -95,4 +95,4 @@ stdenv.mkDerivation rec {
     maintainers = [ ];
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/ab/abaddon/package.nix
+++ b/pkgs/by-name/ab/abaddon/package.nix
@@ -21,14 +21,14 @@
   sqlite,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "abaddon";
   version = "0.2.4";
 
   src = fetchFromGitHub {
     owner = "uowuo";
     repo = "abaddon";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-fSNXMbyYmUOA4x911/an02fhhhWe6a4xlLVb2DIqIOE=";
     fetchSubmodules = true;
   };
@@ -74,11 +74,11 @@ stdenv.mkDerivation rec {
 
   desktopItems = [
     (makeDesktopItem {
-      name = pname;
-      exec = pname;
+      name = finalAttrs.pname;
+      exec = finalAttrs.pname;
       desktopName = "Abaddon";
-      genericName = meta.description;
-      startupWMClass = pname;
+      genericName = "Discord client reimplementation, written in C++";
+      startupWMClass = "abaddon";
       categories = [
         "Network"
         "InstantMessaging"
@@ -95,4 +95,4 @@ stdenv.mkDerivation rec {
     maintainers = with lib.maintainers; [ choco98 ];
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/ac/acpilight/package.nix
+++ b/pkgs/by-name/ac/acpilight/package.nix
@@ -7,13 +7,13 @@
   udevCheckHook,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "acpilight";
   version = "1.2";
 
   src = fetchgit {
     url = "https://gitlab.com/wavexx/acpilight.git";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     sha256 = "1r0r3nx6x6vkpal6vci0zaa1n9dfacypldf6k8fxg7919vzxdn1w";
   };
 
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
     substituteInPlace Makefile --replace udevadm true
   '';
 
-  buildInputs = [ pyenv ];
+  buildInputs = [ finalAttrs.pyenv ];
 
   makeFlags = [ "DESTDIR=$(out) prefix=" ];
 
@@ -45,4 +45,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.linux;
     mainProgram = "xbacklight";
   };
-}
+})

--- a/pkgs/by-name/ac/acpilight/package.nix
+++ b/pkgs/by-name/ac/acpilight/package.nix
@@ -7,13 +7,13 @@
   udevCheckHook,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "acpilight";
   version = "1.2";
 
   src = fetchgit {
     url = "https://gitlab.com/wavexx/acpilight.git";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     sha256 = "1r0r3nx6x6vkpal6vci0zaa1n9dfacypldf6k8fxg7919vzxdn1w";
   };
 
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
     substituteInPlace Makefile --replace-fail udevadm true
   '';
 
-  buildInputs = [ pyenv ];
+  buildInputs = [ finalAttrs.pyenv ];
 
   makeFlags = [ "DESTDIR=$(out) prefix=" ];
 
@@ -45,4 +45,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.linux;
     mainProgram = "xbacklight";
   };
-}
+})

--- a/pkgs/by-name/ad/adr-tools/package.nix
+++ b/pkgs/by-name/ad/adr-tools/package.nix
@@ -20,14 +20,14 @@
   runCommand,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "adr-tools";
   version = "3.0.0";
 
   src = fetchFromGitHub {
     owner = "npryce";
     repo = "adr-tools";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-JEwLn+SY6XcaQ9VhN8ARQaZc1zolgAJKfIqPggzV+sU=";
   };
 
@@ -112,4 +112,4 @@ stdenv.mkDerivation rec {
     mainProgram = "adr";
     platforms = lib.platforms.all;
   };
-}
+})


### PR DESCRIPTION
This pull request refactors multiple Nix package definitions to use the `finalAttrs` argument in `stdenv.mkDerivation` instead of the previous `rec` form. This change improves consistency and future-proofs the codebase for upcoming Nixpkgs conventions. Additionally, all references to package attributes such as `version`, `src`, and related fields are updated to reference `finalAttrs`. Some desktop item definitions are also clarified for explicitness.

Key changes by theme:

**Refactor to `finalAttrs` and attribute usage:**
- All affected package files now use `stdenv.mkDerivation (finalAttrs: { ... })` instead of `stdenv.mkDerivation rec { ... }`. 

- All references to attributes such as `version`, `src`, and related fields inside the derivation are now accessed via `finalAttrs`, e.g., `${finalAttrs.version}` instead of `${version}`. 

**Desktop item and metadata improvements:**
- In `abaddon`, desktop item fields are now set explicitly to string literals rather than referencing variables, providing clearer intent and reducing ambiguity.

**Consistency and cleanup:**
- All files now end the derivation with `})` instead of `}` to match the new argument style.

These changes are largely mechanical but important for long-term maintainability and compatibility with evolving Nixpkgs best practices.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
