### PR TITLE
gns3-gui: use overrideScope for pyqt5 websockets override

### DIFF
--- a/pkgs/applications/networking/gns3/gui.nix
+++ b/pkgs/applications/networking/gns3/gui.nix
@@ -14,7 +14,14 @@
   wrapQtAppsHook,
 }:
 
-python3Packages.buildPythonApplication rec {
+let
+  pythonPackages = python3Packages.overrideScope (
+    final: prev: {
+      pyqt5 = prev.pyqt5.override { withWebSockets = true; };
+    }
+  );
+in
+pythonPackages.buildPythonApplication rec {
   pname = "gns3-gui";
   inherit version;
   format = "setuptools";
@@ -28,20 +35,20 @@ python3Packages.buildPythonApplication rec {
 
   nativeBuildInputs = [ wrapQtAppsHook ];
 
-  build-system = with python3Packages; [ setuptools ];
+  build-system = with pythonPackages; [ setuptools ];
 
   propagatedBuildInputs = [ qt5.qtwayland ];
 
   dependencies =
-    with python3Packages;
+    with pythonPackages;
     [
       distro
       jsonschema
       psutil
+      pyqt5
       sentry-sdk
       setuptools
       sip
-      (pyqt5.override { withWebSockets = true; })
       truststore
     ]
     ++ lib.optionals (pythonOlder "3.9") [
@@ -56,7 +63,7 @@ python3Packages.buildPythonApplication rec {
 
   doCheck = true;
 
-  checkInputs = with python3Packages; [ pytestCheckHook ];
+  checkInputs = with pythonPackages; [ pytestCheckHook ];
 
   preCheck = ''
     export HOME=$(mktemp -d)


### PR DESCRIPTION
See https://github.com/NixOS/nixpkgs/pull/481332#discussion_r2702610733

Will also open another PR to upgrade the package, migrate to pkgs/by-name and use `pyproject = true`


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
