### PR TITLE
ghidra: add ghidralib

### DIFF
--- a/pkgs/tools/security/ghidra/extensions.nix
+++ b/pkgs/tools/security/ghidra/extensions.nix
@@ -13,6 +13,8 @@ lib.makeScope newScope (self: {
 
   findcrypt = self.callPackage ./extensions/findcrypt { };
 
+  ghidralib = self.callPackage ./extensions/ghidralib { };
+
   ghidra-delinker-extension = self.callPackage ./extensions/ghidra-delinker-extension {
     inherit ghidra;
   };

--- a/pkgs/tools/security/ghidra/extensions/ghidralib/default.nix
+++ b/pkgs/tools/security/ghidra/extensions/ghidralib/default.nix
@@ -1,0 +1,26 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildGhidraScripts,
+}:
+buildGhidraScripts {
+  pname = "GhidraLib";
+  version = "0.2.0-unstable-2025-10-31";
+
+  src = fetchFromGitHub {
+    owner = "msm-code";
+    repo = "ghidralib";
+    rev = "f3e33e444b4a8682c240c87f8754542e2e338731";
+    hash = "sha256-Dz7CWHkszHq5HT/S9cBGOfkoamnf9T1l2IbaAZXEGf0=";
+  };
+
+  meta = {
+    description = "A Pythonic Ghidra standard library";
+    homepage = "https://github.com/msm-code/ghidralib";
+    maintainers = with lib.maintainers; [
+      BonusPlay
+      msm
+    ];
+    license = lib.licenses.asl20;
+  };
+}


### PR DESCRIPTION
This PR adds ghidralib, very useful scripting library for ghidra.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
