### PR TITLE
unpoller: add support for api key

### DIFF
--- a/nixos/modules/services/monitoring/unpoller.nix
+++ b/nixos/modules/services/monitoring/unpoller.nix
@@ -208,6 +208,16 @@ in
             '';
             apply = v: "file://${v}";
           };
+          api_key = lib.mkOption {
+            type = lib.types.path;
+            default = pkgs.writeText "unpoller-unifi-default.api_key" "unifi";
+            defaultText = lib.literalExpression "unpoller-unifi-default.api_key";
+            description = ''
+              Path of a file containing the API Key for authentication.
+              This file needs to be readable by the unifi-poller user.
+            '';
+            apply = v: "file://${v}";
+          };
           url = lib.mkOption {
             type = lib.types.str;
             default = "https://unifi:8443";


### PR DESCRIPTION
Adds unpoller config field for api key which was added in https://github.com/unpoller/unpoller/pull/791

https://github.com/unpoller/unpoller/blob/f47b463384df7ce2790eb777fadf3c37417bb305/examples/up.conf.example#L146-L148

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
