### PR TITLE
freetube: 0.23.12-unstable-2026-01-15 -> 0.23.13

### DIFF
--- a/pkgs/by-name/fr/freetube/package.nix
+++ b/pkgs/by-name/fr/freetube/package.nix
@@ -20,14 +20,13 @@ let
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "freetube";
-  version = "0.23.12-unstable-2026-01-15";
+  version = "0.23.13";
 
   src = fetchFromGitHub {
     owner = "FreeTubeApp";
     repo = "FreeTube";
-    # tag = "v${finalAttrs.version}-beta";
-    rev = "e110a4b603e0f5f275d210aea005698a0d4b26ad";
-    hash = "sha256-kq6twf7ce2987iHtwikPzolzzbxr1xcoirqUGpPG4V8=";
+    tag = "v${finalAttrs.version}-beta";
+    hash = "sha256-vnqrl/2hxL0RQbLHkgRntyTRSWmhMM7hOi31r4pKCgs=";
   };
 
   # Darwin requires writable Electron dist
@@ -50,7 +49,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   yarnOfflineCache = fetchYarnDeps {
     yarnLock = "${finalAttrs.src}/yarn.lock";
-    hash = "sha256-E6D2Uo06MAcnOKy00e5JoLdKQOeGVr7y7Lu6rZ1F82M=";
+    hash = "sha256-sM9CkDnATSEUf/uuUyT4JuRmjzwa1WzIyNYEw69MPtU=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/fr/freetube/patch-build-script.patch
+++ b/pkgs/by-name/fr/freetube/patch-build-script.patch
@@ -1,13 +1,13 @@
-diff --git a/_scripts/ebuilder.config.mjs b/_scripts/ebuilder.config.mjs
-index 55e72b227..d218f5ac4 100644
---- a/_scripts/ebuilder.config.mjs
-+++ b/_scripts/ebuilder.config.mjs
-@@ -2,6 +2,8 @@ import packageDetails from '../package.json' with { type: 'json' }
+diff --git a/_scripts/ebuilder.config.js b/_scripts/ebuilder.config.js
+index 14d0d9df1..c5fc569c8 100644
+--- a/_scripts/ebuilder.config.js
++++ b/_scripts/ebuilder.config.js
+@@ -1,6 +1,8 @@
+ const { name, productName } = require('../package.json')
  
- /** @type {import('electron-builder').Configuration} */
- export default {
+ const config = {
 +  electronVersion: "@electron-version@",
 +  electronDist: "electron-dist",
-   appId: `io.freetubeapp.${packageDetails.name}`,
+   appId: `io.freetubeapp.${name}`,
    copyright: 'Copyleft © 2020-2025 freetubeapp@protonmail.com',
    // asar: false,


### PR DESCRIPTION
Changelog: https://github.com/FreeTubeApp/FreeTube/releases/tag/v0.23.13-beta

Had to change the patch again. Can someone please review by trying to build? I think I saw an error but freetube seems to work fine, so I opened the PR anyway.

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
