### PR TITLE
chromium: fix unsubstituted placeholders in `.desktop`

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/browser.nix
+++ b/pkgs/applications/networking/browsers/chromium/browser.nix
@@ -62,19 +62,20 @@ mkChromiumDerivation (base: rec {
       $out/share/applications/chromium-browser.desktop
 
     substituteInPlace $out/share/applications/chromium-browser.desktop \
-      --replace "@@MENUNAME@@" "Chromium" \
-      --replace "@@PACKAGE@@" "chromium" \
-      --replace "Exec=/usr/bin/@@USR_BIN_SYMLINK_NAME@@" "Exec=chromium"
-
-    # Append more mime types to the end
-    sed -i '/^MimeType=/ s,$,x-scheme-handler/webcal;x-scheme-handler/mailto;x-scheme-handler/about;x-scheme-handler/unknown,' \
-      $out/share/applications/chromium-browser.desktop
+      --replace-fail "@@MENUNAME@@" "Chromium" \
+      --replace-fail "@@PACKAGE@@" "chromium" \
+      --replace-fail "/usr/bin/@@USR_BIN_SYMLINK_NAME@@" "chromium" \
+      --replace-fail "@@URI_SCHEME@@" "x-scheme-handler/chromium;" \
+      --replace-fail "@@EXTRA_DESKTOP_ENTRIES@@" ""
 
     # See https://github.com/NixOS/nixpkgs/issues/12433
-    sed -i \
-      -e '/\[Desktop Entry\]/a\' \
-      -e 'StartupWMClass=chromium-browser' \
-      $out/share/applications/chromium-browser.desktop
+    substituteInPlace $out/share/applications/chromium-browser.desktop \
+      --replace-fail "[Desktop Entry]" "[Desktop Entry]''\nStartupWMClass=chromium-browser"
+
+    if grep -F '@@' $out/share/applications/chromium-browser.desktop ; then
+      echo "error: chromium-browser.desktop contains unsubstituted placeholders" >&2
+      exit 1
+    fi
   '';
 
   passthru = { inherit sandboxExecutableName; };


### PR DESCRIPTION
Closes #481248.

Fix unsubstituted placeholders in `.desktop` like `@@EXTRA_DESKTOP_ENTRIES@@` and `@@URI_SCHEME@@` and add a simple check to prevent this from happening again.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
