### PR TITLE
llm-ls: use system oniguruma

### DIFF
--- a/pkgs/by-name/ll/llm-ls/package.nix
+++ b/pkgs/by-name/ll/llm-ls/package.nix
@@ -4,24 +4,26 @@
   fetchFromGitHub,
   fetchpatch,
   pkg-config,
+  oniguruma,
   versionCheckHook,
   nix-update-script,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "llm-ls";
   version = "0.5.3";
 
   src = fetchFromGitHub {
     owner = "huggingface";
     repo = "llm-ls";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-ICMM2kqrHFlKt2/jmE4gum1Eb32afTJkT3IRoqcjJJ8=";
   };
 
   cargoPatches = [
     # https://github.com/huggingface/llm-ls/pull/102
     ./fix-time-compilation-failure.patch
+
     (fetchpatch {
       name = "fix-version.patch";
       url = "https://github.com/huggingface/llm-ls/commit/479401f3a5173f2917a888c8068f84e29b7dceed.patch?full_index=1";
@@ -29,11 +31,17 @@ rustPlatform.buildRustPackage rec {
     })
   ];
 
+  env.RUSTONIG_SYSTEM_LIBONIG = true;
+
   cargoHash = "sha256-qiYspv2KcvzxVshVpAMlSqFDqbbiutpLyWMz+QSIVmQ=";
 
   buildAndTestSubdir = "crates/llm-ls";
 
   nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    oniguruma
+  ];
 
   nativeInstallCheckInputs = [
     versionCheckHook
@@ -47,10 +55,10 @@ rustPlatform.buildRustPackage rec {
   meta = {
     description = "LSP server leveraging LLMs for code completion (and more?)";
     homepage = "https://github.com/huggingface/llm-ls";
-    changelog = "https://github.com/huggingface/llm-ls/releases/tag/${version}";
+    changelog = "https://github.com/huggingface/llm-ls/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ jfvillablanca ];
     platforms = lib.platforms.all;
     mainProgram = "llm-ls";
   };
-}
+})


### PR DESCRIPTION
## Things done

Fix build failure by updating the `onig_sys` crate.
The version shipped by this package fails to build with GCC 15:
```
oniguruma/src/regparse.c: In function 'onig_st_init_strend_table_with_size':
oniguruma/src/regparse.c:588:5: error: initialization of 'int (*)(void)' from incompatible pointer type 'int (*)(st_str_end_key *, st_str_end_key *)' [-Wincompatible-pointer-types]
  588 |     str_end_cmp,
      |     ^~~~~~~~~~~
```

Tracking: https://github.com/NixOS/nixpkgs/issues/475479

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
