### PR TITLE
nixos/tandoor-recipes: fix NixOS version in test comments

### DIFF
--- a/nixos/tests/tandoor-recipes-media.nix
+++ b/nixos/tests/tandoor-recipes-media.nix
@@ -66,7 +66,7 @@
       machine.succeed(f"curl --head {db_path} | grep \"HTTP/1.1 404 Not Found\"")
 
 
-      # Switch to NixOS 24.11 to check if the setup still functions the same
+      # Switch to NixOS 25.11 to check if the setup still functions the same
       # as before.
       stop_and_rm()
       machine.succeed("${oldVersion}/bin/switch-to-configuration test")
@@ -77,7 +77,7 @@
       machine.succeed(f"curl --head {db_path} | grep \"HTTP/1.1 200 OK\"")
 
 
-      # Switch to NixOS 24.11 with the MEDIA_ROOT already set to
+      # Switch to NixOS 25.11 with the MEDIA_ROOT already set to
       # /var/lib/tandoor-recipes/media.
       stop_and_rm()
       machine.succeed("${oldVersionOverrideMedia}/bin/switch-to-configuration test")


### PR DESCRIPTION
Ref https://github.com/NixOS/nixpkgs/pull/481140#pullrequestreview-3675804478

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
