### PR TITLE
cupp: init at 0-unstable-2025-12-26

### DIFF
--- a/pkgs/by-name/cu/cupp/package.nix
+++ b/pkgs/by-name/cu/cupp/package.nix
@@ -1,0 +1,43 @@
+{
+  fetchFromGitHub,
+  lib,
+  python3,
+  stdenvNoCC,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "cupp";
+  version = "0-unstable-2025-12-26";
+
+  src = fetchFromGitHub {
+    owner = "mebus";
+    repo = "cupp";
+    rev = "616a7b0c01b9cec51954df86a2a538dffcba3834";
+    hash = "sha256-s2yxQwth5CsPU0D10OpoKSCj0Q71ybWj13Rwu+75Xws=";
+  };
+
+  postPatch = ''
+    substituteInPlace cupp.py \
+      --replace-fail /usr/bin/python3 ${lib.getExe python3} \
+      --replace-fail cupp.cfg ${placeholder "out"}/lib/cupp.cfg
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D cupp.py $out/bin/${finalAttrs.meta.mainProgram}
+    install -Dm644 cupp.cfg --target-directory=$out/lib
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Common User Passwords Profiler";
+    homepage = "https://github.com/mebus/cupp";
+    changelog = "https://github.com/mebus/cupp/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ yiyu ];
+    mainProgram = "cupp";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
