### PR TITLE
Use AWS CLI v2

### DIFF
--- a/pkgs/build-support/fetchs3/default.nix
+++ b/pkgs/build-support/fetchs3/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   runCommand,
-  awscli,
+  awscli2,
 }:
 lib.fetchers.withNormalizedHash { } (
   {
@@ -33,7 +33,7 @@ lib.fetchers.withNormalizedHash { } (
   runCommand name
     (
       {
-        nativeBuildInputs = [ awscli ];
+        nativeBuildInputs = [ awscli2 ];
 
         inherit outputHash outputHashAlgo;
         outputHashMode = if recursiveHash then "recursive" else "flat";

--- a/pkgs/by-name/gi/git-remote-codecommit/package.nix
+++ b/pkgs/by-name/gi/git-remote-codecommit/package.nix
@@ -2,7 +2,7 @@
   lib,
   fetchFromGitHub,
   python3Packages,
-  awscli,
+  awscli2,
 }:
 
 python3Packages.buildPythonApplication rec {
@@ -30,7 +30,7 @@ python3Packages.buildPythonApplication rec {
   dependencies = with python3Packages; [ botocore ];
 
   nativeCheckInputs = [
-    awscli
+    awscli2
   ]
   ++ (with python3Packages; [
     pytestCheckHook

--- a/pkgs/by-name/ic/iceshelf/package.nix
+++ b/pkgs/by-name/ic/iceshelf/package.nix
@@ -3,39 +3,47 @@
   fetchFromGitHub,
   git,
   awscli,
-  python3,
+  python3Packages,
+  unstableGitUpdater,
 }:
 
-python3.pkgs.buildPythonApplication {
+python3Packages.buildPythonApplication {
   pname = "iceshelf";
-  version = "0-unstable-2019-07-03";
-
+  version = "0-unstable-2025-06-29";
   pyproject = false;
 
   src = fetchFromGitHub {
     owner = "mrworf";
     repo = "iceshelf";
-    rev = "26768dde3fc54fa412e523eb8f8552e866b4853b";
-    sha256 = "08rcbd14vn7312rmk2hyvdzvhibri31c4r5lzdrwb1n1y9q761qm";
+    rev = "5380c49e3f7f3df04b61a494b2d94db2f2c65e25";
+    sha256 = "hiJZX6HG6a9kUr8R7DdkPBcuH3tmVJthWXrPtCaVayU=";
   };
 
   propagatedBuildInputs = [
-    git
     awscli
-    python3.pkgs.python-gnupg
+    git
+  ];
+
+  dependencies = with python3Packages; [
+    python-gnupg
   ];
 
   installPhase = ''
-    mkdir -p $out/bin $out/share/doc/iceshelf $out/${python3.sitePackages}
+    mkdir -p $out/bin $out/share/doc/iceshelf $out/${python3Packages.python.sitePackages}
     cp -v iceshelf iceshelf-restore $out/bin
     cp -v iceshelf.sample.conf $out/share/doc/iceshelf/
-    cp -rv modules $out/${python3.sitePackages}
+    cp -rv modules $out/${python3Packages.python.sitePackages}
   '';
+
+  passthru = {
+    updateScript = unstableGitUpdater { };
+  };
 
   meta = {
     description = "Simple tool to allow storage of signed, encrypted, incremental backups using Amazon's Glacier storage";
     license = lib.licenses.lgpl2;
     homepage = "https://github.com/mrworf/iceshelf";
     maintainers = with lib.maintainers; [ mmahut ];
+    mainProgram = "iceshelf";
   };
 }

--- a/pkgs/development/python-modules/smart-open/default.nix
+++ b/pkgs/development/python-modules/smart-open/default.nix
@@ -2,7 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  awscli,
+  awscli2,
   azure-common,
   azure-core,
   azure-storage-blob,
@@ -58,7 +58,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "smart_open" ];
 
   nativeCheckInputs = [
-    awscli
+    awscli2
     moto
     numpy
     pytest-cov-stub


### PR DESCRIPTION
See https://github.com/NixOS/nixpkgs/pull/481436#issuecomment-3765778594

AWS CLI v1 is deprecated: AWS plans to stop maintaining it on July 15, 2026 (see https://github.com/aws/aws-cli/issues/9994) and the v1 package is not actively maintained in nixpkgs since v2 is the recommended replacement (v2 is available since 2020, 5 years ago).

* Migrate git-remote-codecommit, smart-open, fetchs3 from awscli (v1) to awscli2
* Upgrade iceshelf from 0-unstable-2019-07-03 to 0-unstable-2025-06-29

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
