### PR TITLE
nodejs: make `nodejs_*` depend on `nodejs-slim_*`

### DIFF
--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -140,6 +140,8 @@
 
 - `services.openssh.settings.AcceptEnv` now explicitly defined as an option that takes a list of strings, to facilitate option merging. Setting it to a string value is no longer supported.
 
+- `nodejs-slim` has a `npm` output, and `nodejs` no longer has a `libv8` output.
+
 - All Xfce packages have been moved to top level (e.g. if you previously added `pkgs.xfce.xfce4-whiskermenu-plugin` to `environment.systemPackages`, you will need to change it to `pkgs.xfce4-whiskermenu-plugin`). The `xfce` scope will be removed in NixOS 26.11.
 
 - `vimPlugins.nvim-treesitter` has been updated to `main` branch, which is a full and incompatible rewrite. If you can't or don't want to update, you should use `vimPlugins.nvim-treesitter-legacy`.

--- a/pkgs/by-name/th/thelounge/package.nix
+++ b/pkgs/by-name/th/thelounge/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   fetchYarnDeps,
   nodejs,
+  nodejs-slim,
   yarn,
   fixup-yarn-lock,
   python3,
@@ -84,7 +85,7 @@ stdenv.mkDerivation (finalAttrs: {
     rm -rf node_modules/sqlite3/build-tmp-napi-v6/{Release/obj.target,node_sqlite3.target.mk}
   '';
 
-  disallowedReferences = [ nodejs.src ];
+  disallowedReferences = [ nodejs-slim.src ];
 
   dontNpmPrune = true;
 

--- a/pkgs/by-name/x2/x2t/package.nix
+++ b/pkgs/by-name/x2/x2t/package.nix
@@ -16,6 +16,7 @@
   jdk,
   lib,
   nodejs_22,
+  nodejs-slim_22,
   openssl,
   pkg-config,
   python3,
@@ -704,7 +705,7 @@ let
       qmakeFlags
       ++ icuQmakeFlags
       ++ [
-        # c++1z for nodejs_22.libv8 (20 seems to produce errors around 'is_void_v' there)
+        # c++1z for nodejs-slim_22.libv8 (20 seems to produce errors around 'is_void_v' there)
         # c++ 20 for nodejs_23.libv8
         "CONFIG+=c++2a"
         # v8_base.h will set nMaxVirtualMemory to 4000000000/5000000000
@@ -735,8 +736,8 @@ let
       echo "== v8 =="
       mkdir -p Common/3dParty/v8_89/v8/out.gn/linux_64
       # using nodejs_22 here is a workaround for https://github.com/NixOS/nixpkgs/issues/477805
-      ln -s ${nodejs_22.libv8}/lib Common/3dParty/v8_89/v8/out.gn/linux_64/obj
-      tar xf ${nodejs_22.libv8.src} --one-top-level=/tmp/xxxxx
+      ln -s ${nodejs-slim_22.libv8}/lib Common/3dParty/v8_89/v8/out.gn/linux_64/obj
+      tar xf ${nodejs-slim_22.libv8.src} --one-top-level=/tmp/xxxxx
       for i in /tmp/xxxxx/*/deps/v8/*; do
         cp -r $i Common/3dParty/v8_89/v8/
       done

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -958,7 +958,7 @@ let
       rustc
     ];
     vdiffr = [ pkgs.libpng.dev ];
-    V8 = [ pkgs.nodejs_22.libv8 ]; # when unpinning the version, don't forget about the other usages later
+    V8 = [ pkgs.nodejs-slim_22.libv8 ]; # when unpinning the version, don't forget about the other usages later
     xactonomial = with pkgs; [
       cargo
       rustc
@@ -2515,8 +2515,8 @@ let
 
       preConfigure = ''
         # when unpinning the version, don't forget about the other usage earlier
-        export INCLUDE_DIR=${pkgs.nodejs_22.libv8}/include
-        export LIB_DIR=${pkgs.nodejs_22.libv8}/lib
+        export INCLUDE_DIR=${pkgs.nodejs-slim_22.libv8}/include
+        export LIB_DIR=${pkgs.nodejs-slim_22.libv8}/lib
         patchShebangs configure
       '';
 

--- a/pkgs/development/ruby-modules/gem-config/default.nix
+++ b/pkgs/development/ruby-modules/gem-config/default.nix
@@ -31,7 +31,7 @@
   which,
   libiconv,
   libpq,
-  nodejs,
+  nodejs-slim,
   clang,
   sqlite,
   zlib,
@@ -338,7 +338,7 @@ in
 
   mini_racer = attrs: {
     buildFlags = [
-      "--with-v8-dir=\"${nodejs.libv8}\""
+      "--with-v8-dir=\"${nodejs-slim.libv8}\""
     ];
     dontBuild = false;
     postPatch = ''
@@ -699,7 +699,7 @@ in
   };
 
   execjs = attrs: {
-    propagatedBuildInputs = [ nodejs.libv8 ];
+    propagatedBuildInputs = [ nodejs-slim.libv8 ];
   };
 
   libxml-ruby = attrs: {

--- a/pkgs/development/web/nodejs/nodejs.nix
+++ b/pkgs/development/web/nodejs/nodejs.nix
@@ -57,7 +57,6 @@
 }:
 
 {
-  enableNpm ? true,
   version,
   sha256,
   patches ? [ ],
@@ -68,7 +67,7 @@ let
   majorVersion = lib.versions.major version;
   minorVersion = lib.versions.minor version;
 
-  pname = if enableNpm then "nodejs" else "nodejs-slim";
+  pname = "nodejs-slim";
 
   canExecute = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
   emulator = stdenv.hostPlatform.emulator buildPackages;
@@ -274,6 +273,7 @@ let
       outputs = [
         "out"
         "libv8"
+        "npm"
       ]
       ++ lib.optionals (stdenv.hostPlatform == stdenv.buildPlatform) [ "dev" ];
       setOutputFlags = false;
@@ -299,7 +299,6 @@ let
         "--emulator=${emulator}"
       ]
       ++ lib.optionals (lib.versionOlder version "19") [ "--without-dtrace" ]
-      ++ lib.optionals (!enableNpm) [ "--without-npm" ]
       ++ lib.concatMap (name: [
         "--shared-${name}"
         "--shared-${name}-libpath=${lib.getLib sharedLibDeps.${name}}/lib"
@@ -352,12 +351,17 @@ let
 
       inherit patches;
 
-      postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
+      postPatch = ''
+        substituteInPlace tools/install.py \
+          --replace-fail '  npm_files(options, action)' "  oip=options.install_path;options.install_path='$npm';npm_files(options, action);options.install_path=oip"
+      ''
+      + lib.optionalString stdenv.hostPlatform.isDarwin ''
         substituteInPlace test/parallel/test-macos-app-sandbox.js \
           --subst-var-by codesign '${darwin.sigtool}/bin/codesign'
       '';
 
       __darwinAllowLocalNetworking = true; # for tests
+      __structuredAttrs = true; # for outputChecks
 
       doCheck = canExecute;
 
@@ -498,6 +502,27 @@ let
         }"
       ];
 
+      outputChecks = {
+        out = {
+          disallowedReferences = [
+            "npm"
+            "libv8"
+          ];
+        };
+        libv8 = {
+          disallowedReferences = [
+            "out"
+            "npm"
+          ];
+        };
+        npm = {
+          disallowedReferences = [
+            "out"
+            "libv8"
+          ];
+        };
+      };
+
       sandboxProfile = ''
         (allow file-read*
           (literal "/Library/Keychains/System.keychain")
@@ -542,17 +567,9 @@ let
             installShellCompletion node.bash
           ''}
 
-          ${lib.optionalString enableNpm ''
-            mkdir -p $out/share/bash-completion/completions
-            ln -s $out/lib/node_modules/npm/lib/utils/completion.sh \
-              $out/share/bash-completion/completions/npm
-            for dir in "$out/lib/node_modules/npm/man/"*; do
-              mkdir -p $out/share/man/$(basename "$dir")
-              for page in "$dir"/*; do
-                ln -rs $page $out/share/man/$(basename "$dir")
-              done
-            done
-          ''}
+          mkdir -p $npm/share/bash-completion/completions
+          ln -s $npm/lib/node_modules/npm/lib/utils/completion.sh \
+            $npm/share/bash-completion/completions/npm
 
           # install the missing headers for node-gyp
           # TODO: use propagatedBuildInputs instead of copying headers.
@@ -590,6 +607,15 @@ let
         + lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
           cp -r $out/include $dev/include
         '';
+
+      postFixup = ''
+        for dir in "$npm/lib/node_modules/npm/man/"*; do
+          mkdir -p $npm/share/man/$(basename "$dir")
+          for page in "$dir"/*; do
+            ln -rs $page $npm/share/man/$(basename "$dir")
+          done
+        done
+      '';
 
       passthru.tests = {
         version = testers.testVersion {

--- a/pkgs/development/web/nodejs/v20.nix
+++ b/pkgs/development/web/nodejs/v20.nix
@@ -5,7 +5,6 @@
   fetchpatch2,
   openssl,
   python3,
-  enableNpm ? true,
 }:
 
 let
@@ -35,7 +34,6 @@ let
   ];
 in
 buildNodejs {
-  inherit enableNpm;
   version = "20.20.0";
   sha256 = "5294d9d2915620e819e6892fd7e545b98d650bad36dae54e6527eaac482add98";
   patches = [

--- a/pkgs/development/web/nodejs/v22.nix
+++ b/pkgs/development/web/nodejs/v22.nix
@@ -6,7 +6,6 @@
   fetchpatch2,
   openssl,
   python3,
-  enableNpm ? true,
 }:
 
 let
@@ -22,7 +21,6 @@ let
       [ ];
 in
 buildNodejs {
-  inherit enableNpm;
   version = "22.22.0";
   sha256 = "4c138012bb5352f49822a8f3e6d1db71e00639d0c36d5b6756f91e4c6f30b683";
   patches =

--- a/pkgs/development/web/nodejs/v24.nix
+++ b/pkgs/development/web/nodejs/v24.nix
@@ -6,7 +6,6 @@
   fetchpatch2,
   openssl,
   python3,
-  enableNpm ? true,
 }:
 
 let
@@ -24,7 +23,6 @@ let
       [ ];
 in
 buildNodejs {
-  inherit enableNpm;
   version = "24.13.0";
   sha256 = "320fe909cbb347dcf516201e4964ef177b8138df9a7f810d0d54950481b3158b";
   patches =

--- a/pkgs/development/web/nodejs/v25.nix
+++ b/pkgs/development/web/nodejs/v25.nix
@@ -6,7 +6,6 @@
   fetchpatch2,
   openssl,
   python3,
-  enableNpm ? true,
 }:
 
 let
@@ -24,7 +23,6 @@ let
       [ ];
 in
 buildNodejs {
-  inherit enableNpm;
   version = "25.6.0";
   sha256 = "9db6848c802b1981c0faeb71a5b8cc79913f82a747f7f1d50260c6d2f781ef7e";
   patches =

--- a/pkgs/servers/sql/postgresql/ext/plv8/package.nix
+++ b/pkgs/servers/sql/postgresql/ext/plv8/package.nix
@@ -1,7 +1,7 @@
 {
   fetchFromGitHub,
   lib,
-  nodejs_20,
+  nodejs-slim_20,
   perl,
   postgresql,
   postgresqlBuildExtension,
@@ -13,7 +13,7 @@
 }:
 
 let
-  libv8 = nodejs_20.libv8;
+  libv8 = nodejs-slim_20.libv8;
 in
 postgresqlBuildExtension (finalAttrs: {
   pname = "plv8";

--- a/pkgs/servers/web-apps/discourse/default.nix
+++ b/pkgs/servers/web-apps/discourse/default.nix
@@ -43,7 +43,7 @@
   fetchPnpmDeps,
   pnpmConfigHook,
   svgo,
-  nodejs_22,
+  nodejs-slim_22,
   jq,
   moreutils,
   terser,
@@ -72,7 +72,7 @@ let
     gnutar
     git
     brotli
-    nodejs_22
+    nodejs-slim_22
 
     # Misc required system utils
     which
@@ -193,9 +193,9 @@ let
             cd ../..
 
             mkdir -p vendor/v8/${stdenv.hostPlatform.system}/libv8/obj/
-            ln -s "${nodejs_22.libv8}/lib/libv8.a" vendor/v8/${stdenv.hostPlatform.system}/libv8/obj/libv8_monolith.a
+            ln -s "${nodejs-slim_22.libv8}/lib/libv8.a" vendor/v8/${stdenv.hostPlatform.system}/libv8/obj/libv8_monolith.a
 
-            ln -s ${nodejs_22.libv8}/include vendor/v8/include
+            ln -s ${nodejs-slim_22.libv8}/include vendor/v8/include
 
             mkdir -p ext/libv8-node
             echo '--- !ruby/object:Libv8::Node::Location::Vendor {}' >ext/libv8-node/.location.yml
@@ -318,7 +318,7 @@ let
       terser
       jq
       moreutils
-      nodejs_22
+      nodejs-slim_22
       pnpmConfigHook
       pnpm_9
     ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2872,20 +2872,48 @@ with pkgs;
   nodejs = nodejs_24;
   nodejs-slim = nodejs-slim_24;
 
-  nodejs_20 = callPackage ../development/web/nodejs/v20.nix { };
-  nodejs-slim_20 = callPackage ../development/web/nodejs/v20.nix { enableNpm = false; };
-  corepack_20 = callPackage ../development/web/nodejs/corepack.nix { nodejs = nodejs_20; };
+  nodejs-slim_20 = callPackage ../development/web/nodejs/v20.nix { };
+  nodejs_20 = symlinkJoin {
+    pname = "nodejs";
+    inherit (nodejs-slim_20) version passthru meta;
+    paths = [
+      nodejs-slim_20
+      nodejs-slim_20.npm
+    ];
+  };
+  corepack_20 = callPackage ../development/web/nodejs/corepack.nix { nodejs = nodejs-slim_20; };
 
-  nodejs_22 = callPackage ../development/web/nodejs/v22.nix { };
-  nodejs-slim_22 = callPackage ../development/web/nodejs/v22.nix { enableNpm = false; };
-  corepack_22 = callPackage ../development/web/nodejs/corepack.nix { nodejs = nodejs_22; };
+  nodejs-slim_22 = callPackage ../development/web/nodejs/v22.nix { };
+  nodejs_22 = symlinkJoin {
+    pname = "nodejs";
+    inherit (nodejs-slim_22) version passthru meta;
+    paths = [
+      nodejs-slim_22
+      nodejs-slim_22.npm
+    ];
+  };
+  corepack_22 = callPackage ../development/web/nodejs/corepack.nix { nodejs = nodejs-slim_22; };
 
-  nodejs_24 = callPackage ../development/web/nodejs/v24.nix { };
-  nodejs-slim_24 = callPackage ../development/web/nodejs/v24.nix { enableNpm = false; };
-  corepack_24 = callPackage ../development/web/nodejs/corepack.nix { nodejs = nodejs_24; };
+  nodejs-slim_24 = callPackage ../development/web/nodejs/v24.nix { };
+  nodejs_24 = symlinkJoin {
+    pname = "nodejs";
+    inherit (nodejs-slim_24) version passthru meta;
+    paths = [
+      nodejs-slim_24
+      nodejs-slim_24.npm
+    ];
+  };
+  corepack_24 = callPackage ../development/web/nodejs/corepack.nix { nodejs = nodejs-slim_24; };
 
-  nodejs_25 = callPackage ../development/web/nodejs/v25.nix { };
-  nodejs-slim_25 = callPackage ../development/web/nodejs/v25.nix { enableNpm = false; };
+  nodejs-slim_25 = callPackage ../development/web/nodejs/v25.nix { };
+  nodejs_25 = symlinkJoin {
+    pname = "nodejs";
+    inherit (nodejs-slim_25) version passthru meta;
+    paths = [
+      nodejs-slim_25
+      nodejs-slim_25.npm
+    ];
+  };
 
   # Update this when adding the newest nodejs major version!
   nodejs_latest = nodejs_25;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Having nodejs-slim and nodejs building the same software twice is a waste of resources. Opening as draft as the patches need to be ported to the new package.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
