### PR TITLE
dbmate: 2.28.0 -> 2.29.3; fixes, adopt

### DIFF
--- a/pkgs/by-name/db/dbmate/package.nix
+++ b/pkgs/by-name/db/dbmate/package.nix
@@ -6,18 +6,18 @@
 
 buildGoModule rec {
   pname = "dbmate";
-  version = "2.28.0";
+  version = "2.29.3";
 
   src = fetchFromGitHub {
     owner = "amacneil";
     repo = "dbmate";
     tag = "v${version}";
-    hash = "sha256-DQTeLqlZmzfTQoJBTFTX8x3iplkmrl1cplDQQcCGCZM=";
+    hash = "sha256-H/HBDM2uBRrlgetU2S9ZS1c6//Le+DlrYlnnJpTs3XM=";
   };
 
-  vendorHash = "sha256-Js0hiRt6l3ur7+pfeYa35C17gr77NHvapaSrgF9cP8c=";
 
   doCheck = false;
+  vendorHash = "sha256-wfcVb8fqnpT8smKuL6SPANAK86tLXglhQPZCA4G8P9E=";
 
   meta = {
     description = "Database migration tool";

--- a/pkgs/by-name/db/dbmate/package.nix
+++ b/pkgs/by-name/db/dbmate/package.nix
@@ -35,5 +35,8 @@ buildGoModule (finalAttrs: {
     homepage = "https://github.com/amacneil/dbmate";
     changelog = "https://github.com/amacneil/dbmate/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      sarahec
+    ];
   };
 })

--- a/pkgs/by-name/db/dbmate/package.nix
+++ b/pkgs/by-name/db/dbmate/package.nix
@@ -2,6 +2,7 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
+  nix-update-script,
 
   # testing
   sqlite,
@@ -25,6 +26,8 @@ buildGoModule (finalAttrs: {
   nativeCheckInputs = [
     sqlite
   ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Database migration tool";

--- a/pkgs/by-name/db/dbmate/package.nix
+++ b/pkgs/by-name/db/dbmate/package.nix
@@ -7,14 +7,14 @@
   sqlite,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "dbmate";
   version = "2.29.3";
 
   src = fetchFromGitHub {
     owner = "amacneil";
     repo = "dbmate";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-H/HBDM2uBRrlgetU2S9ZS1c6//Le+DlrYlnnJpTs3XM=";
   };
 
@@ -30,7 +30,7 @@ buildGoModule rec {
     description = "Database migration tool";
     mainProgram = "dbmate";
     homepage = "https://github.com/amacneil/dbmate";
-    changelog = "https://github.com/amacneil/dbmate/releases/tag/v${version}";
+    changelog = "https://github.com/amacneil/dbmate/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
   };
-}
+})

--- a/pkgs/by-name/db/dbmate/package.nix
+++ b/pkgs/by-name/db/dbmate/package.nix
@@ -2,6 +2,9 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
+
+  # testing
+  sqlite,
 }:
 
 buildGoModule rec {
@@ -15,9 +18,13 @@ buildGoModule rec {
     hash = "sha256-H/HBDM2uBRrlgetU2S9ZS1c6//Le+DlrYlnnJpTs3XM=";
   };
 
-
-  doCheck = false;
   vendorHash = "sha256-wfcVb8fqnpT8smKuL6SPANAK86tLXglhQPZCA4G8P9E=";
+
+  tags = [ "fts5" ];
+
+  nativeCheckInputs = [
+    sqlite
+  ];
 
   meta = {
     description = "Database migration tool";


### PR DESCRIPTION
1. Version bump [diff](https://github.com/amacneil/dbmate/compare/v2.28.0...v2.29.3)
2. Enabled `doCheck`
4. Migrate to `finalAttrs`
5. Added `passthru.updateScript`
6. Added self as maintainer

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
