### PR TITLE
nixos/librechat: add meilisearch support

### DIFF
--- a/nixos/modules/services/search/meilisearch.nix
+++ b/nixos/modules/services/search/meilisearch.nix
@@ -121,6 +121,9 @@ in
         Path to file which contains the master key.
         By doing so, all routes will be protected and will require a key to be accessed.
         If no master key is provided, all routes can be accessed without requiring any key.
+
+        You can generate a master key by running `openssl rand -base64 36`.
+        Alternatively, you can start Meilisearch without a master key and use the pre-generated key from the service's logs that can be obtained by `journalctl -u meilisearch | grep -- --master-key`.
       '';
       default = null;
       type = lib.types.nullOr lib.types.path;

--- a/nixos/tests/librechat.nix
+++ b/nixos/tests/librechat.nix
@@ -17,6 +17,7 @@
       credsIvFile = pkgs.writeText "librechat-creds-iv" "7c09a571f65ac793611685cc9ab1dbe7";
       jwtSecret = pkgs.writeText "librechat-jwt-secret" "29c4dc7f7de15306accf5eddb4cb8a70eb233d9fba4301f8f47f14c8c047ac81";
       jwtRefreshSecret = pkgs.writeText "librechat-jwt-refresh-secret" "f2c1685561f2f570b3e7955df267b5c602ee099f14dc5caa0dacc320580ea180";
+      meilisearchMasterKeyFile = pkgs.writeText "meilisearch-master-key" "xHkP3Bzcf98fw7FiSCR82g5ULLGrXc4frK1qkEfN8St/3kJZ";
     in
     {
       services.librechat = {
@@ -32,13 +33,19 @@
           JWT_REFRESH_SECRET = jwtRefreshSecret;
         };
         enableLocalDB = true;
+        meilisearch.enable = true;
       };
+
+      services.meilisearch.masterKeyFile = meilisearchMasterKeyFile;
     };
 
   testScript = ''
     machine.start()
 
     machine.succeed("grep -qF 'ALLOW_REGISTRATION=true' /etc/systemd/system/librechat.service")
+    machine.succeed("grep -qF 'SEARCH=true' /etc/systemd/system/librechat.service")
+    machine.succeed("grep -qF 'MEILI_HOST=http://localhost:7700' /etc/systemd/system/librechat.service")
+    machine.succeed("grep -qG 'MEILI_MASTER_KEY_FILE:/nix/store/.*meilisearch-master-key' /etc/systemd/system/librechat.service")
 
     machine.wait_for_unit("librechat.service")
     machine.wait_for_open_port(3080)


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This is a follow up for https://github.com/NixOS/nixpkgs/pull/462287#pullrequestreview-3571061443.

The implementation mostly follows https://www.librechat.ai/docs/configuration/meilisearch with these differences:
- instead of the user having to start meilisearch, copy the master key, and restart meilisearch, the user is advised to generate one with openssl which sounds simpler
- the guide recommend disabling meilisearch analytics, from the description of the NixOS module, this is already disabled

Tested this on our server, searching chats works like a charm :)

(I'd like to do RAG next, so file uploads could work, but I haven't really checked what services it really needs and how well is the current nixpkgs support for them.)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
