### PR TITLE
buildPerlPackage: remove explicit `src` argument

### DIFF
--- a/pkgs/development/perl-modules/generic/default.nix
+++ b/pkgs/development/perl-modules/generic/default.nix
@@ -12,7 +12,6 @@
     "out"
     "devdoc"
   ],
-  src ? null,
 
   # enabling or disabling does nothing for perl packages so set it explicitly
   # to false to not change hashes when enableParallelBuildingByDefault is enabled
@@ -64,7 +63,6 @@ lib.throwIf (attrs ? name)
 
           inherit
             outputs
-            src
             doCheck
             checkTarget
             enableParallelBuilding


### PR DESCRIPTION
This goal of this change is to make nix-update-script work out of the box with packages built using `buildPerlPackage`.

Explicitly setting `src` in the `stdenv.mkDerivation` call currently causes `builtins.unsafeGetAttrPos "src" <package>` to point to `pkgs/development/perl-modules/generic/default.nix` for packages built using `buildPerlPackage`. If the result of this expression is not `null`, nix-update [will try to update `src` of `<package>` in that file](https://github.com/Mic92/nix-update/blob/8227513ecf2f9ca657951fac3a6935410107eb90/nix_update/eval.nix#L99), which will fail for obvious reasons.

A good example of this happening is with the pgformatter package. Removing the explicit `inherit src` allows `builtins.unsafeGetAttrPos "src" <package>` to point to the file where `<package>.src` is actually defined, fixing nix-update runs for affected packages.

Git history doesn't provide any indication as to why this argument was introduced in the first place, so I hope it's fine to remove it. The only difference in evaluation will be for calls to `buildPerlPackage` without `src`: In these cases, `src` will be unset instead of `null`.

Ideally, of course, this change will result in zero rebuilds. (Update: It does.)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
