### PR TITLE
pipeweaver: init at 0.1.6

### DIFF
--- a/pkgs/by-name/pi/pipeweaver/package.nix
+++ b/pkgs/by-name/pi/pipeweaver/package.nix
@@ -1,0 +1,99 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  rustPlatform,
+  pkg-config,
+  pipewire,
+  nix-update-script,
+}:
+let
+  pname = "pipeweaver";
+  version = "0-unstable-2026-01-18";
+
+  src = fetchFromGitHub {
+    owner = "pipeweaver";
+    repo = "pipeweaver";
+    rev = "fae4e1190f339c80ec881fee16d2c200cec25643";
+    hash = "sha256-YppeAyayvQCfyYbKULlJW5KlSiWvWkokQhuprTxqqho=";
+  };
+
+  web = buildNpmPackage {
+    inherit version src;
+    pname = "pipeweaver-web";
+
+    npmDepsHash = "sha256-lq/ZVHYNpBUbKZnUbrC+QmpXt1SlLRkyGqhBX+ubeoA=";
+
+    sourceRoot = "${src.name}/web";
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out
+      cp -r dist/* $out/
+      runHook postInstall
+    '';
+  };
+in
+rustPlatform.buildRustPackage (finalAttrs: {
+  inherit pname version src;
+
+  cargoHash = "sha256-QDzMis5NlKc0DvXET56clHQOvlAXrEC69FgG4poQwA0=";
+
+  nativeBuildInputs = [
+    pkg-config
+    rustPlatform.bindgenHook
+  ];
+
+  buildInputs = [
+    pipewire
+  ];
+
+  # Prevent build.rs from running to prevent impure git and npm calls.
+  postPatch = ''
+    rm daemon/build.rs
+    substituteInPlace daemon/Cargo.toml --replace-fail 'build = "build.rs"' ""
+  '';
+  # Provide GIT_HASH that build.rs would have set
+  env = {
+    GIT_HASH = src.rev;
+  };
+
+  preBuild = ''
+    mkdir -p daemon/web-content
+    cp -r ${web}/* daemon/web-content/
+  '';
+
+  postInstall = ''
+    mkdir -p $out/share/applications
+    cp ${src}/daemon/resources/desktop/pipeweaver.desktop $out/share/applications/
+    substituteInPlace $out/share/applications/pipeweaver.desktop \
+      --replace-fail '/usr/bin/pipeweaver-daemon' "$out/bin/pipeweaver-daemon"
+
+    mkdir -p $out/share/icons/hicolor/48x48/apps
+    mkdir -p $out/share/icons/hicolor/128x128/apps
+    cp ${src}/daemon/resources/icons/pipeweaver.png $out/share/icons/hicolor/48x48/apps/
+    cp ${src}/daemon/resources/icons/pipeweaver-large.png $out/share/icons/hicolor/128x128/apps/pipeweaver.png
+  '';
+
+  passthru = {
+    inherit web;
+
+    updateScript = nix-update-script {
+      extraArgs = [
+        "--subpackage"
+        "web"
+
+        "--version=branch"
+      ];
+    };
+  };
+
+  meta = {
+    description = "Manage streaming audio on Linux through PipeWire with virtual channels, mixing, and routing";
+    homepage = "https://github.com/pipeweaver/pipeweaver";
+    license = lib.licenses.mit;
+    mainProgram = "pipeweaver-daemon";
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ bridgesense ];
+  };
+})

--- a/pkgs/by-name/pi/pipeweaver/package.nix
+++ b/pkgs/by-name/pi/pipeweaver/package.nix
@@ -1,0 +1,126 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  rustPlatform,
+  pkg-config,
+  pipewire,
+  nix-update-script,
+  stdenv,
+}:
+
+rustPlatform.buildRustPackage (
+  finalAttrs:
+  let
+    web = buildNpmPackage {
+      pname = "${finalAttrs.pname}-web";
+      inherit (finalAttrs) version src;
+
+      sourceRoot = "${finalAttrs.src.name}/web";
+
+      npmDepsHash = "sha256-ZX/3H/VdRdWC2j+mPA/0rZflDhslqTN1mqA9vvQRQG0=";
+
+      installPhase = ''
+        runHook preInstall
+        cp -r dist $out
+        runHook postInstall
+      '';
+    };
+  in
+  {
+    pname = "pipeweaver";
+    version = "0.1.6";
+
+    __structuredAttrs = true;
+
+    src = fetchFromGitHub {
+      owner = "pipeweaver";
+      repo = "pipeweaver";
+      tag = "v${finalAttrs.version}";
+      hash = "sha256-wf3gxCLT5vOz+5+CpfmkX0stKoAOpQ6KIoW6xBNV1xk=";
+    };
+
+    cargoHash = "sha256-Jv0fF6keg2NcUnCJhCId7rwPVZK1/Q9+otQNjp54RCI=";
+
+    nativeBuildInputs = [
+      pkg-config
+      rustPlatform.bindgenHook
+    ];
+
+    buildInputs = [
+      pipewire
+    ];
+
+    cargoBuildFlags = [
+      "--workspace"
+      "--exclude"
+      "pipeweaver-app"
+      "--all-features"
+    ];
+
+    cargoTestFlags = [
+      "--workspace"
+      "--exclude"
+      "pipeweaver-app"
+      "--all-features"
+    ];
+
+    postPatch = ''
+      # Prevent daemon/build.rs from running to prevent impure git and npm calls.
+      rm daemon/build.rs
+      substituteInPlace daemon/Cargo.toml --replace-fail 'build = "build.rs"' ""
+
+      mkdir -p daemon/web-content
+      cp -r ${web}/* daemon/web-content/
+    '';
+
+    # Provide GIT_HASH that build.rs would have set
+    env.GIT_HASH = finalAttrs.src.tag;
+
+    installPhase = ''
+      runHook preInstall
+
+      releaseDir=target/${stdenv.hostPlatform.rust.cargoShortTarget}/release
+
+      install -Dm755 $releaseDir/pipeweaver-daemon -t $out/bin
+      install -Dm755 $releaseDir/pipeweaver-client -t $out/bin
+
+      install -Dm644 daemon/resources/icons/pipeweaver.png \
+        $out/share/icons/hicolor/48x48/apps/pipeweaver.png
+      install -Dm644 daemon/resources/icons/pipeweaver.svg \
+        $out/share/icons/hicolor/scalable/apps/pipeweaver.svg
+      install -Dm644 daemon/resources/icons/pipeweaver-large.png \
+        $out/share/pixmaps/pipeweaver.png
+      install -Dm644 daemon/resources/desktop/pipeweaver.desktop \
+        $out/share/applications/pipeweaver.desktop
+
+      substituteInPlace $out/share/applications/pipeweaver.desktop \
+        --replace-fail "Path=/usr/bin" "Path=$out/bin" \
+        --replace-fail "Exec=/usr/bin/pipeweaver-daemon" "Exec=$out/bin/pipeweaver-daemon"
+
+      install -Dm644 README.md $out/share/doc/pipeweaver/README.md
+      install -Dm644 LICENSE $out/share/licenses/pipeweaver/LICENSE
+
+      runHook postInstall
+    '';
+
+    passthru = {
+      inherit web;
+      updateScript = nix-update-script {
+        extraArgs = [
+          "--subpackage"
+          "web"
+        ];
+      };
+    };
+
+    meta = {
+      description = "Manage streaming audio on Linux through PipeWire with virtual channels, mixing, and routing";
+      homepage = "https://github.com/pipeweaver/pipeweaver";
+      license = lib.licenses.mit;
+      mainProgram = "pipeweaver-daemon";
+      platforms = lib.platforms.linux;
+      maintainers = with lib.maintainers; [ saadndm ];
+    };
+  }
+)


### PR DESCRIPTION
Adds [PipeWeaver](https://github.com/pipeweaver/pipeweaver), an audio management and routing tool for Linux built on top of PipeWire, designed specifically with streaming and broadcasting in mind.

It can be configured via API or a web page in the browser, and it allows for the creation of virtual audio sources, attaching physical audio sources, managing volumes (including matrix mixing), 'complex' mute arrangements, and routing to physical and virtual outputs.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
