### PR TITLE
python3Packages.lxml: fix cross-compilation

### DIFF
--- a/pkgs/development/python-modules/lxml/default.nix
+++ b/pkgs/development/python-modules/lxml/default.nix
@@ -7,6 +7,7 @@
   # build-system
   cython,
   setuptools,
+  pkg-config,
 
   # native dependencies
   libxml2,
@@ -40,8 +41,7 @@ buildPythonPackage rec {
 
   # required for build time dependency check
   nativeBuildInputs = [
-    libxml2.dev
-    libxslt.dev
+    pkg-config
   ];
 
   buildInputs = [


### PR DESCRIPTION
Rather than relying on lxml's build system to find its dependencies by path, use the pkg-config hook.  This makes cross-compilation work, as otherwise the build will attempt to link build platform libs while making host platform outputs.

## Things done

Built on powerpc64le-linux for powerpc64le-linux and armv7l-linux hosts.