### PR TITLE
nixos/resolved: resurrect extraConfig as a deprecated option

### DIFF
--- a/nixos/modules/system/boot/resolved.nix
+++ b/nixos/modules/system/boot/resolved.nix
@@ -78,8 +78,9 @@ in
       [ "services" "resolved" "settings" "Resolve" "DNSOverTLS" ]
     )
     {
-      warnings = optional (cfg.extraConfig != "")
-        "services.resolved.extraConfig is deprecated; use services.resolved.settings.Resolve";
+      warnings = optional (
+        cfg.extraConfig != ""
+      ) "services.resolved.extraConfig is deprecated; use services.resolved.settings.Resolve";
     }
   ];
 

--- a/nixos/modules/system/boot/resolved.nix
+++ b/nixos/modules/system/boot/resolved.nix
@@ -77,11 +77,6 @@ in
       [ "services" "resolved" "dnsovertls" ]
       [ "services" "resolved" "settings" "Resolve" "DNSOverTLS" ]
     )
-    {
-      warnings = optional (
-        cfg.extraConfig != ""
-      ) "services.resolved.extraConfig is deprecated; use services.resolved.settings.Resolve";
-    }
   ];
 
   options = {
@@ -169,6 +164,10 @@ in
           message = "Using host resolv.conf is not supported with systemd-resolved";
         }
       ];
+
+      warnings = optional (
+        cfg.extraConfig != ""
+      ) "services.resolved.extraConfig is deprecated; use services.resolved.settings.Resolve";
 
       users.users.systemd-resolve.group = "systemd-resolve";
 


### PR DESCRIPTION
Keep supporting `services.resolved.extraConfig`, but add a deprecation warning, instead of removing the option.

This is quite important when sharing config between stable and unstable systems.

We might also think about backporting `settings` to stable, in order to allow for smoother upgrades.

Should this be added to the changelog? https://github.com/NixOS/nixpkgs/pull/416720 didn't do so for the removal ...

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
