### PR TITLE
pkgsStrict: init

### DIFF
--- a/pkgs/top-level/variants.nix
+++ b/pkgs/top-level/variants.nix
@@ -183,4 +183,10 @@ self: super: {
     ]
     ++ overlays;
   };
+
+  pkgsStrict = nixpkgsFun {
+    config = super.config // {
+      strictDepsByDefault = true;
+    };
+  };
 }


### PR DESCRIPTION
enabling top-level access to this config supports the effort to enable `strictDeps` by default:
<https://github.com/NixOS/nixpkgs/issues/178468>

PRs to support musl, static, and cross compiled builds benefit from simple instructions the reviewer can observe improvements, e.g.:

- "fixes build for `pkgsMusl.hello`"
- "fixes `nix-build -A pkgsStatic.hello`"
- "fixes `pkgsCross.aarch64-multiplatform.hello`"

now strictDeps-related changes can benefit from this same idiom:

- "fixes build for `pkgsStrict.hello`"


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
