### PR TITLE
yafetch: migrate to pkgs/by-name

### DIFF
--- a/pkgs/by-name/ya/yafetch/package.nix
+++ b/pkgs/by-name/ya/yafetch/package.nix
@@ -1,18 +1,18 @@
 {
   lib,
-  stdenv,
+  clangStdenv,
   fetchFromGitHub,
 }:
 
-stdenv.mkDerivation rec {
+clangStdenv.mkDerivation (finalAttrs: {
   pname = "yafetch";
   version = "unstable-2022-04-20";
 
   src = fetchFromGitHub {
     owner = "kira64xyz";
-    repo = pname;
+    repo = "yafetch";
     rev = "a118cfc13f0b475db7c266105c10138d838788b8";
-    sha256 = "bSJlerfbJG6h5dDwWQKHnVLH6DEuvuUyqaRuJ7jvOsA=";
+    hash = "sha256-bSJlerfbJG6h5dDwWQKHnVLH6DEuvuUyqaRuJ7jvOsA=";
   };
 
   # Use the provided NixOS logo automatically
@@ -34,4 +34,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.linux;
     mainProgram = "yafetch";
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1111,10 +1111,6 @@ with pkgs;
     wine = wineWowPackages.yabridge;
   };
 
-  yafetch = callPackage ../tools/misc/yafetch {
-    stdenv = clangStdenv;
-  };
-
   ### APPLICATIONS/VERSION-MANAGEMENT
 
   # The full-featured Git.


### PR DESCRIPTION
This pull request reorganizes the packaging of `yafetch` and updates its build configuration to use `clangStdenv` directly in the package definition. The changes improve maintainability by moving the package to a new location and simplifying its invocation in the top-level package list.

**Package reorganization and build configuration:**

* Moved the `yafetch` package from `pkgs/tools/misc/yafetch/default.nix` to `pkgs/by-name/ya/yafetch/package.nix`, reflecting a more organized package structure.
* Updated the build to use `clangStdenv.mkDerivation` directly in the package definition, removing the need to override `stdenv` in the top-level package list. 

* Removed the explicit override of `stdenv` for `yafetch` in `pkgs/top-level/all-packages.nix`, as the package now specifies its own build environment.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
