### PR TITLE
[staging-next] rocmPackages.llvm.{llvm,compiler-rt-libc}: fix build on current staging-next

### DIFF
--- a/pkgs/development/rocm-modules/llvm/default.nix
+++ b/pkgs/development/rocm-modules/llvm/default.nix
@@ -436,6 +436,14 @@ overrideLlvmPackagesRocm (s: {
       isGNU = false;
     };
   compiler-rt-libc = s.prev.compiler-rt-libc.overrideAttrs (old: {
+    patches = old.patches ++ [
+      # fix build with glibc >= 2.42
+      (fetchpatch {
+        url = "https://github.com/llvm/llvm-project/commit/59978b21ad9c65276ee8e14f26759691b8a65763.patch";
+        hash = "sha256-ys5SMLfO3Ay9nCX9GV5yRCQ6pLsseFu/ZY6Xd6OL4p0=";
+        relative = "compiler-rt";
+      })
+    ];
     meta = old.meta // llvmMeta;
   });
   compiler-rt = s.final.compiler-rt-libc;

--- a/pkgs/development/rocm-modules/llvm/default.nix
+++ b/pkgs/development/rocm-modules/llvm/default.nix
@@ -285,13 +285,6 @@ overrideLlvmPackagesRocm (s: {
       # TODO: consider reapplying "Don't include aliases in RegisterClassInfo::IgnoreCSRForAllocOrder"
       # it was reverted as it's a pessimization for non-GPU archs, but this compiler
       # is used mostly for amdgpu
-
-      # fix build w/ glibc-2.42
-      (fetchpatch {
-        url = "https://github.com/llvm/llvm-project/commit/6ee49080e4bb43efe7ede10bed15935853bbd434.patch";
-        hash = "sha256-DHEhTC3IWjWksMTD4RqsPQBTKKJOJcNCt16xsEe0QZs=";
-        relative = "llvm";
-      })
     ];
     dontStrip = profilableStdenv;
     hardeningDisable = [ "all" ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
