### PR TITLE
auto-editor: 29.6.1 -> 29.6.2

### DIFF
--- a/pkgs/by-name/au/auto-editor/package.nix
+++ b/pkgs/by-name/au/auto-editor/package.nix
@@ -10,6 +10,7 @@
   withVpx ? true,
   withSvtAv1 ? true,
   withCuda ? false,
+  withVpl ? stdenv.hostPlatform.isLinux,
 
   ffmpeg-full,
   yt-dlp,
@@ -29,13 +30,13 @@
 
 buildNimPackage rec {
   pname = "auto-editor";
-  version = "29.6.1";
+  version = "29.7.0";
 
   src = fetchFromGitHub {
     owner = "WyattBlue";
     repo = "auto-editor";
     tag = version;
-    hash = "sha256-7/ey7nZdy1SnGdW5LjX7dtxyqqvrTuIvtJXMXYVYB6k=";
+    hash = "sha256-R1GnvFjC/nq/gIiX6rUxP7qR3IfpGfc4Ci28AIk4CfQ=";
   };
 
   lockFile = ./lock.json;
@@ -51,14 +52,15 @@ buildNimPackage rec {
   ++ lib.optionals withWhisper [ whisper-cpp ]
   ++ lib.optionals withVpx [ libvpx ]
   ++ lib.optionals withSvtAv1 [ svt-av1 ]
-  ++ lib.optionals stdenv.hostPlatform.isLinux [ libvpl ];
+  ++ lib.optionals withVpl [ libvpl ];
 
   nimFlags =
     lib.optionals withHEVC [ "-d:enable_hevc" ]
     ++ lib.optionals withWhisper [ "-d:enable_whisper" ]
     ++ lib.optionals withVpx [ "-d:enable_vpx" ]
     ++ lib.optionals withSvtAv1 [ "-d:enable_svtav1" ]
-    ++ lib.optionals withCuda [ "-d:enable_cuda" ];
+    ++ lib.optionals withCuda [ "-d:enable_cuda" ]
+    ++ lib.optionals withVpl [ "-d:enable_vpl" ];
 
   postPatch = ''
     substituteInPlace src/log.nim \


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
