### PR TITLE
nixos/php-fpm: socket activate all units

### DIFF
--- a/nixos/tests/anuko-time-tracker.nix
+++ b/nixos/tests/anuko-time-tracker.nix
@@ -11,7 +11,6 @@
   };
   testScript = ''
     start_all()
-    machine.wait_for_unit("phpfpm-anuko-time-tracker")
     machine.wait_for_open_port(80);
     machine.wait_until_succeeds("curl -s --fail -L http://localhost/time.php | grep 'Anuko Time Tracker'")
   '';

--- a/nixos/tests/bookstack.nix
+++ b/nixos/tests/bookstack.nix
@@ -44,7 +44,6 @@ in
   };
 
   testScript = ''
-    bookstackMysql.wait_for_unit("phpfpm-bookstack.service")
     bookstackMysql.wait_for_unit("nginx.service")
     bookstackMysql.wait_for_unit("mysql.service")
     bookstackMysql.succeed("curl -fvvv -Ls http://localhost/ | grep 'Log In'")

--- a/nixos/tests/castopod.nix
+++ b/nixos/tests/castopod.nix
@@ -233,8 +233,6 @@
 
   testScript = ''
     start_all()
-    castopod.wait_for_unit("castopod-setup.service")
-    castopod.wait_for_file("/run/phpfpm/castopod.sock")
     castopod.wait_for_unit("nginx.service")
     castopod.wait_for_open_port(80)
     castopod.wait_until_succeeds("curl -sS -f http://castopod.example.com")

--- a/nixos/tests/cloudlog.nix
+++ b/nixos/tests/cloudlog.nix
@@ -9,7 +9,6 @@
   };
   testScript = ''
     start_all()
-    machine.wait_for_unit("phpfpm-cloudlog")
     machine.wait_for_open_port(80);
     machine.wait_until_succeeds("curl -s -L --fail http://localhost | grep 'Login - Cloudlog'")
   '';

--- a/nixos/tests/davis.nix
+++ b/nixos/tests/davis.nix
@@ -55,10 +55,7 @@
   testScript = ''
     start_all()
 
-    machine1.wait_for_unit("postgresql.target")
-    machine1.wait_for_unit("davis-env-setup.service")
-    machine1.wait_for_unit("davis-db-migrate.service")
-    machine1.wait_for_unit("phpfpm-davis.service")
+    machine1.wait_for_unit("nginx.service")
 
     with subtest("welcome screen loads"):
         machine1.succeed(
@@ -76,8 +73,8 @@
         machine1.succeed(
           "[[ $(grep -i 'location: ' headers | cut -d: -f2- | xargs echo) == /dashboard* ]]"
         )
-    machine2.wait_for_unit("davis-env-setup.service")
-    machine2.wait_for_unit("davis-db-migrate.service")
+
+    machine2.systemctl("start phpfpm-davis.service")
     machine2.wait_for_unit("phpfpm-davis.service")
     r = machine2.succeed(
         "find /var/lib/davis/var/log"

--- a/nixos/tests/dokuwiki.nix
+++ b/nixos/tests/dokuwiki.nix
@@ -126,8 +126,6 @@ in
 
     for machine in (dokuwiki_nginx, dokuwiki_caddy):
       for site_name in site_names:
-        machine.wait_for_unit(f"phpfpm-dokuwiki-{site_name}")
-
         machine.succeed("curl -sSfL http://site1.local/ | grep 'DokuWiki'")
         machine.fail("curl -sSfL 'http://site1.local/doku.php?do=login' | grep 'Login'")
 

--- a/nixos/tests/dolibarr.nix
+++ b/nixos/tests/dolibarr.nix
@@ -50,10 +50,6 @@
         def handle_endtag(self, tag): pass
         def handle_data(self, data): pass
 
-      # wait for app
-      for machine in (nginx_mysql, h2o_postgresql):
-        machine.wait_for_unit("phpfpm-dolibarr.service")
-
       # wait for web servers
       nginx_mysql.wait_for_unit("nginx.service")
       nginx_mysql.wait_for_open_port(80)

--- a/nixos/tests/drupal.nix
+++ b/nixos/tests/drupal.nix
@@ -69,8 +69,6 @@ in
 
     for machine in (${lib.concatStringsSep ", " (builtins.attrNames nodes)}):
         for site_name in site_names:
-            machine.wait_for_unit(f"phpfpm-drupal-{site_name}")
-
             with subtest("website returns welcome screen"):
                 assert "Choose language" in machine.succeed(f"curl -k -L {site_name}")
 

--- a/nixos/tests/engelsystem.nix
+++ b/nixos/tests/engelsystem.nix
@@ -25,7 +25,7 @@
 
   testScript = ''
     engelsystem.start()
-    engelsystem.wait_for_unit("phpfpm-engelsystem.service")
+    engelsystem.wait_for_unit("nginx.service")
     engelsystem.wait_until_succeeds("curl engelsystem/login -sS -f")
     engelsystem.succeed(
         "curl engelsystem/login -sS -f -c cookie | xmllint -html -xmlout - >login"

--- a/nixos/tests/firefly-iii-data-importer.nix
+++ b/nixos/tests/firefly-iii-data-importer.nix
@@ -20,7 +20,6 @@
     };
 
   testScript = ''
-    dataImporter.wait_for_unit("phpfpm-firefly-iii-data-importer.service")
     dataImporter.wait_for_unit("nginx.service")
     dataImporter.succeed("curl -fvvv -Ls http://localhost/token | grep 'Firefly III Data Import Tool'")
   '';

--- a/nixos/tests/firefly-iii.nix
+++ b/nixos/tests/firefly-iii.nix
@@ -101,17 +101,14 @@ in
     };
 
   testScript = ''
-    fireflySqlite.wait_for_unit("phpfpm-firefly-iii.service")
     fireflySqlite.wait_for_unit("nginx.service")
     fireflySqlite.succeed("curl -fvvv -Ls http://localhost/ | grep 'Firefly III'")
     fireflySqlite.succeed("curl -fvvv -Ls http://localhost/v1/js/app.js")
     fireflySqlite.succeed("systemctl start firefly-iii-cron.service")
-    fireflyPostgresql.wait_for_unit("phpfpm-firefly-iii.service")
     fireflyPostgresql.wait_for_unit("nginx.service")
     fireflyPostgresql.wait_for_unit("postgresql.target")
     fireflyPostgresql.succeed("curl -fvvv -Ls http://localhost/ | grep 'Firefly III'")
     fireflyPostgresql.succeed("systemctl start firefly-iii-cron.service")
-    fireflyMysql.wait_for_unit("phpfpm-firefly-iii.service")
     fireflyMysql.wait_for_unit("nginx.service")
     fireflyMysql.wait_for_unit("mysql.service")
     fireflyMysql.succeed("curl -fvvv -Ls http://localhost/ | grep 'Firefly III'")

--- a/nixos/tests/jirafeau.nix
+++ b/nixos/tests/jirafeau.nix
@@ -14,7 +14,6 @@
 
   testScript = ''
     machine.start()
-    machine.wait_for_unit("phpfpm-jirafeau.service")
     machine.wait_for_unit("nginx.service")
     machine.wait_for_open_port(80)
     machine.succeed("curl -sSfL http://localhost/ | grep 'Jirafeau'")

--- a/nixos/tests/kimai.nix
+++ b/nixos/tests/kimai.nix
@@ -13,7 +13,6 @@
     };
 
   testScript = ''
-    machine.wait_for_unit("phpfpm-kimai-localhost.service")
     machine.wait_for_unit("nginx.service")
     machine.wait_for_open_port(80)
     machine.succeed("curl -v --location --fail http://localhost/")

--- a/nixos/tests/limesurvey.nix
+++ b/nixos/tests/limesurvey.nix
@@ -35,7 +35,6 @@
 
       start_all()
 
-      machine.wait_for_unit("phpfpm-limesurvey.service")
       machine.wait_for_unit("httpd.service")
       machine.wait_for_open_port(80)
       test()

--- a/nixos/tests/matomo.nix
+++ b/nixos/tests/matomo.nix
@@ -22,7 +22,6 @@
   testScript = ''
     start_all()
     machine.wait_for_unit("mysql.service")
-    machine.wait_for_unit("phpfpm-matomo.service")
     machine.wait_for_unit("nginx.service")
 
     with subtest("matomo.js reachable via HTTP"):

--- a/nixos/tests/mediawiki.nix
+++ b/nixos/tests/mediawiki.nix
@@ -33,7 +33,7 @@ in
     testScript = ''
       start_all()
 
-      machine.wait_for_unit("phpfpm-mediawiki.service")
+      machine.wait_for_unit("httpd.service")
 
       page = machine.succeed("curl -fL http://localhost/")
       assert "MediaWiki has been installed" in page
@@ -48,7 +48,7 @@ in
     testScript = ''
       start_all()
 
-      machine.wait_for_unit("phpfpm-mediawiki.service")
+      machine.wait_for_unit("httpd.service")
 
       page = machine.succeed("curl -fL http://localhost/")
       assert "MediaWiki has been installed" in page
@@ -64,7 +64,6 @@ in
       { nodes, ... }:
       ''
         start_all()
-        machine.wait_for_unit("phpfpm-mediawiki.service")
         env = (
           "SCRIPT_NAME=/index.php",
           "SCRIPT_FILENAME=${nodes.machine.services.mediawiki.finalPackage}/share/mediawiki/index.php",
@@ -85,7 +84,6 @@ in
     testScript = ''
       start_all()
 
-      machine.wait_for_unit("phpfpm-mediawiki.service")
       machine.wait_for_unit("nginx.service")
 
       page = machine.succeed("curl -fL http://localhost/")

--- a/nixos/tests/moodle.nix
+++ b/nixos/tests/moodle.nix
@@ -18,7 +18,7 @@
 
   testScript = ''
     start_all()
-    machine.wait_for_unit("phpfpm-moodle.service", timeout=1800)
+    machine.wait_for_unit("httpd.service", timeout=1800)
     machine.wait_until_succeeds("curl http://localhost/ | grep 'You are not logged in'")
   '';
 }

--- a/nixos/tests/php/fpm.nix
+++ b/nixos/tests/php/fpm.nix
@@ -50,7 +50,6 @@
     { ... }:
     ''
       machine.wait_for_unit("nginx.service")
-      machine.wait_for_unit("phpfpm-foobar.socket")
 
       # Check so we get an evaluated PHP back
       response = machine.succeed("curl -fvvv -s http://127.0.0.1:80/")

--- a/nixos/tests/php/fpm.nix
+++ b/nixos/tests/php/fpm.nix
@@ -50,7 +50,7 @@
     { ... }:
     ''
       machine.wait_for_unit("nginx.service")
-      machine.wait_for_unit("phpfpm-foobar.service")
+      machine.wait_for_unit("phpfpm-foobar.socket")
 
       # Check so we get an evaluated PHP back
       response = machine.succeed("curl -fvvv -s http://127.0.0.1:80/")

--- a/nixos/tests/privatebin.nix
+++ b/nixos/tests/privatebin.nix
@@ -14,7 +14,6 @@
     };
 
   testScript = ''
-    dataImporter.wait_for_unit("phpfpm-privatebin.service")
     dataImporter.wait_for_unit("nginx.service")
     dataImporter.succeed("curl -fvvv -Ls http://localhost/ | grep 'PrivateBin'")
   '';

--- a/nixos/tests/prometheus-exporters.nix
+++ b/nixos/tests/prometheus-exporters.nix
@@ -1287,9 +1287,12 @@ let
           };
         };
         exporterTest = ''
-          wait_for_unit("phpfpm-php-fpm-exporter.service")
           wait_for_unit("prometheus-php-fpm-exporter.service")
-          succeed("curl -sSf http://localhost:9253/metrics | grep 'phpfpm_up{.*} 1'")
+          succeed("curl -sSf http://localhost:9253/metrics | grep 'phpfpm_up{.*} 0'")
+
+          systemctl("start phpfpm-php-fpm-exporter.service")
+          wait_for_unit("phpfpm-php-fpm-exporter.service")
+          wait_until_succeeds("curl -sSf http://localhost:9253/metrics | grep 'phpfpm_up{.*} 1'")
         '';
       };
 
@@ -1632,7 +1635,7 @@ let
       {
         exporterConfig = {
           enable = true;
-          metrics-file = "${pkgs.writeText "test.json" ''{}''}";
+          metrics-file = "${pkgs.writeText "test.json" "{}"}";
         };
         exporterTest = ''
           wait_for_unit("prometheus-shelly-exporter.service")

--- a/nixos/tests/roundcube.nix
+++ b/nixos/tests/roundcube.nix
@@ -31,7 +31,6 @@
   testScript = ''
     roundcube.start
     roundcube.wait_for_unit("postgresql.target")
-    roundcube.wait_for_unit("phpfpm-roundcube.service")
     roundcube.wait_for_unit("nginx.service")
     roundcube.succeed("curl -sSfL http://roundcube/ | grep 'Keep me logged in'")
   '';

--- a/nixos/tests/web-apps/grav.nix
+++ b/nixos/tests/web-apps/grav.nix
@@ -12,7 +12,6 @@
 
   testScript = ''
     start_all()
-    machine.wait_for_unit("phpfpm-grav.service")
     machine.wait_for_open_port(80)
 
     # The first request to a fresh install should result in a redirect to the

--- a/nixos/tests/web-apps/kanboard.nix
+++ b/nixos/tests/web-apps/kanboard.nix
@@ -15,7 +15,6 @@
   testScript = ''
     start_all()
     machine.wait_for_unit("nginx.service")
-    machine.wait_for_unit("phpfpm-kanboard.service")
     machine.wait_for_open_port(80)
 
     machine.succeed("curl -k --fail http://localhost", timeout=10)

--- a/nixos/tests/web-apps/movim/ejabberd-h2o.nix
+++ b/nixos/tests/web-apps/movim/ejabberd-h2o.nix
@@ -243,7 +243,6 @@ in
     ''
       ejabberdctl = "su ejabberd -s $(which ejabberdctl) "
 
-      server.wait_for_unit("phpfpm-movim.service")
       server.wait_for_unit("h2o.service")
       server.wait_for_open_port(${toString movim.port})
       server.wait_for_open_port(80)

--- a/nixos/tests/web-apps/movim/prosody-nginx.nix
+++ b/nixos/tests/web-apps/movim/prosody-nginx.nix
@@ -85,7 +85,6 @@ in
 
   testScript = # python
     ''
-      server.wait_for_unit("phpfpm-movim.service")
       server.wait_for_unit("nginx.service")
       server.wait_for_open_port(${toString movim.port})
       server.wait_for_open_port(80)

--- a/nixos/tests/web-apps/pixelfed/standard.nix
+++ b/nixos/tests/web-apps/pixelfed/standard.nix
@@ -23,8 +23,6 @@
   };
 
   testScript = ''
-    # Wait for Pixelfed PHP pool
-    server.wait_for_unit("phpfpm-pixelfed.service")
     # Wait for NGINX
     server.wait_for_unit("nginx.service")
     # Wait for HTTP port

--- a/nixos/tests/web-apps/rss-bridge/caddy.nix
+++ b/nixos/tests/web-apps/rss-bridge/caddy.nix
@@ -17,7 +17,6 @@ import ../../make-test-python.nix (
 
     testScript = ''
       machine.wait_for_unit("caddy.service")
-      machine.wait_for_unit("phpfpm-rss-bridge.service")
       machine.wait_for_open_port(80)
 
       # check for successful feed download

--- a/nixos/tests/web-apps/rss-bridge/nginx.nix
+++ b/nixos/tests/web-apps/rss-bridge/nginx.nix
@@ -16,7 +16,6 @@ import ../../make-test-python.nix (
 
     testScript = ''
       machine.wait_for_unit("nginx.service")
-      machine.wait_for_unit("phpfpm-rss-bridge.service")
       machine.wait_for_open_port(80)
 
       # check for successful feed download

--- a/nixos/tests/wordpress.nix
+++ b/nixos/tests/wordpress.nix
@@ -106,8 +106,6 @@ rec {
 
     for machine in (${lib.concatStringsSep ", " (builtins.attrNames nodes)}):
         for site_name in site_names:
-            machine.wait_for_unit(f"phpfpm-wordpress-{site_name}")
-
             with subtest("website returns welcome screen"):
                 assert "Welcome to the famous" in machine.succeed(f"curl -k -L {site_name}")
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR creates systemd socket units for all phpfpm instances, and relaxes the waiting constraints of various nixos tests to rely on only the reverse proxy. This change can let systemd buffer incoming traffic while restarting php-fpm units, as well as opening the door for sandboxing php-applications that don't do network requests themself into separate networking namespaces (e.g. with `PrivateNetwork=true`).

I also removed the dependency on `phpfpm.target` for `multi-user.target`, so the units can be started as needed.

<details>
<summary>Status of affected NixOS tests</summary>

- [X] `.#nixosTests.anuko-time-tracker`
- [X] `.#nixosTests.bookstack`
- [X] `.#nixosTests.castopod`
- [X] `.#nixosTests.cloudlog`
- [X] `.#nixosTests.davis`
- [X] `.#nixosTests.dokuwiki`
- [ ] `.#nixosTests.dolibarr` (broken on master)
- [X] `.#nixosTests.drupal`
- [X] `.#nixosTests.engelsystem`
- [X] `.#nixosTests.firefly-iii`
- [X] `.#nixosTests.firefly-iii-data-importer`
- [X] `.#nixosTests.grav`
- [X] `.#nixosTests.jirafeau`
- [X] `.#nixosTests.kanboard`
- [ ] `.#nixosTests.kimai` (broken on master)
- [X] `.#nixosTests.limesurvey`
- [X] `.#nixosTests.matomo`
- [X] `.#nixosTests.mediawiki.mysql`
- [X] `.#nixosTests.mediawiki.nginx`
- [X] `.#nixosTests.mediawiki.nohttpd`
- [ ] `.#nixosTests.mediawiki.postgresql` (broken on master)
- [X] `.#nixosTests.moodle`
- [X] `.#nixosTests.movim.ejabberd-h2o`
- [X] `.#nixosTests.movim.prosody-nginx`
- [X] `.#nixosTests.pixelfed.standard`
- [X] `.#nixosTests.privatebin`
- [X] `.#nixosTests.prometheus-exporters.php-fpm`
- [X] `.#nixosTests.roundcube`
- [X] `.#nixosTests.rss-bridge.caddy`
- [X] `.#nixosTests.rss-bridge.nginx`
- [X] `.#nixosTests.wordpress`

</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
