### PR TITLE
python313Packages.google-cloud-spanner: 3.58.0 -> 3.63.0

### DIFF
--- a/pkgs/development/python-modules/google-cloud-spanner/default.nix
+++ b/pkgs/development/python-modules/google-cloud-spanner/default.nix
@@ -13,6 +13,7 @@
   google-cloud-testutils,
   grpc-google-iam-v1,
   grpc-interceptor,
+  opentelemetry-resourcedetector-gcp,
   proto-plus,
   protobuf,
   sqlparse,
@@ -31,16 +32,16 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "google-cloud-spanner";
-  version = "3.58.0";
+  version = "3.63.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "googleapis";
     repo = "python-spanner";
-    tag = "v${version}";
-    hash = "sha256-bIagQjQv+oatIo8mkA8t5wP9igMnorkiudgyWkVnJcg=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-QWBl7X/cKGds617IrHKaIteOnqgwB83jgfi8j/ESUws=";
   };
 
   build-system = [ setuptools ];
@@ -51,6 +52,7 @@ buildPythonPackage rec {
     google-cloud-core
     grpc-google-iam-v1
     grpc-interceptor
+    opentelemetry-resourcedetector-gcp
     proto-plus
     protobuf
     sqlparse
@@ -79,7 +81,7 @@ buildPythonPackage rec {
     pytest-asyncio
     pytestCheckHook
   ]
-  ++ lib.concatAttrValues optional-dependencies;
+  ++ lib.concatAttrValues finalAttrs.passthru.optional-dependencies;
 
   preCheck = ''
     # prevent google directory from shadowing google imports
@@ -97,6 +99,9 @@ buildPythonPackage rec {
     "test_snapshot_read_concurrent"
     # Flaky, can retry too quickly and fail
     "test_retry_helper"
+    # Flaky, system speed sensitive
+    "test_transaction_for_concurrent_statement_should_begin_one_transaction_with_query"
+    "test_transaction_for_concurrent_statement_should_begin_one_transaction_with_read"
   ];
 
   disabledTestPaths = [
@@ -130,8 +135,8 @@ buildPythonPackage rec {
   meta = {
     description = "Cloud Spanner API client library";
     homepage = "https://github.com/googleapis/python-spanner";
-    changelog = "https://github.com/googleapis/python-spanner/blob/${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/googleapis/python-spanner/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.asl20;
     maintainers = [ lib.maintainers.sarahec ];
   };
-}
+})

--- a/pkgs/development/python-modules/opentelemetry-resourcedetector-gcp/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-resourcedetector-gcp/default.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  opentelemetry-api,
+  opentelemetry-sdk,
+  requests,
+  typing-extensions,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "opentelemetry-resourcedetector-gcp";
+  version = "1.11.0a0";
+  pyproject = true;
+
+  # Use PyPi instead of GitHub because the GitHub tags are inaccurate
+  # (GitHub tags lack the alpha suffix)
+  src = fetchPypi {
+    pname = "opentelemetry_resourcedetector_gcp";
+    inherit (finalAttrs) version;
+    hash = "sha256-kVodb9FdrKnu3T/FKw9wU3UFTy7xQOLnprTMqVpHzbE=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    opentelemetry-api
+    opentelemetry-sdk
+    requests
+    typing-extensions
+  ];
+
+  pythonImportsCheck = [
+    "opentelemetry.resourcedetector.gcp_resource_detector"
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  disabledTestPaths = [
+    # These require a 4-year-old syrupy version
+    "tests/test_mapping.py"
+    "tests/test_gcp_resource_detector.py"
+  ];
+
+  meta = {
+    description = "Google Cloud resource detector for OpenTelemetry";
+    homepage = "https://pypi.org/project/opentelemetry-resourcedetector-gcp";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      sarahec
+    ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11676,6 +11676,10 @@ self: super: with self; {
 
   opentelemetry-proto = callPackage ../development/python-modules/opentelemetry-proto { };
 
+  opentelemetry-resourcedetector-gcp =
+    callPackage ../development/python-modules/opentelemetry-resourcedetector-gcp
+      { };
+
   opentelemetry-sdk = callPackage ../development/python-modules/opentelemetry-sdk { };
 
   opentelemetry-semantic-conventions =


### PR DESCRIPTION
Includes `python3Packages.opentelemetry-resourcedetector-gcp: init at 1.11.0a0`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
