### PR TITLE
which: fix musl build

### DIFF
--- a/pkgs/by-name/wh/which/gcc15-musl.patch
+++ b/pkgs/by-name/wh/which/gcc15-musl.patch
@@ -1,0 +1,44 @@
+Patch-Source: https://lists.gnu.org/archive/html/which-bugs/2025-03/msg00000.html
+---
+From 16a1647fc26953fab659de5f55d4c0defdfb894f Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Sat, 22 Mar 2025 17:56:19 -0700
+Subject: [PATCH] getopt: Fix signature of getenv function
+
+This happens on musl systems using GCC 15
+
+../which-2.21/getopt.h:106:12: error: conflicting types for 'getopt'; have 
+'int(void)'
+  106 | extern int getopt ();
+      |            ^~~~~~
+---
+ getopt.c | 2 +-
+ getopt.h | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/getopt.c b/getopt.c
+index 9ac2ed6..7e14270 100644
+--- a/getopt.c
++++ b/getopt.c
+@@ -205,7 +205,7 @@ static char *posixly_correct;
+ /* Avoid depending on library functions or files
+    whose names are inconsistent.  */
+ 
+-char *getenv();
++char *getenv(const char*);
+ 
+ static char *my_index(str, chr) const char *str;
+ int chr;
+diff --git a/getopt.h b/getopt.h
+index f080053..635fc46 100644
+--- a/getopt.h
++++ b/getopt.h
+@@ -102,7 +102,7 @@ struct option {
+    errors, only prototype getopt for the GNU C library.  */
+ extern int getopt(int argc, char *const *argv, const char *shortopts);
+ #else  /* not __GNU_LIBRARY__ */
+-extern int getopt();
++extern int getopt(int, char * const [], const char *);
+ #endif /* __GNU_LIBRARY__ */
+ extern int getopt_long(int argc, char *const *argv, const char *shortopts, const struct option *longopts, int *longind);
+ extern int getopt_long_only(int argc, char *const *argv, const char *shortopts, const struct option *longopts,

--- a/pkgs/by-name/wh/which/package.nix
+++ b/pkgs/by-name/wh/which/package.nix
@@ -14,6 +14,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-osVYIm/E2eTOMxvS/Tw/F/lVEV0sAORHYYpO+ZeKKnM=";
   };
 
+  patches = [
+    ./gcc15-musl.patch
+  ];
+
   strictDeps = true;
   enableParallelBuilding = true;
 


### PR DESCRIPTION
fixes `nix-build -A pkgsMusl.which`.

the patch was submitted upstream here:
<https://lists.gnu.org/archive/html/which-bugs/2025-03/msg00000.html>

where it's been adopted by musl-based distros like Alpine: <https://gitlab.alpinelinux.org/alpine/aports/-/blob/0a023cc7baaee9adeddd8559897bf6583c3bdc0e/main/which/gcc15.patch>

the patch is carried in-repo because `which` is an input to `bash`, so conveniences like `fetchpatch` aren't generally available here.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
