### PR TITLE
Revert "emacsPackages.elpaca: 0-unstable-2025-02-16 -> 0-unstable-202…

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/elpaca/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/elpaca/default.nix
@@ -6,63 +6,24 @@
   lib,
 }:
 
-melpaBuild rec {
+melpaBuild {
   pname = "elpaca";
-  version = "0-unstable-2025-11-06";
+  version = "0-unstable-2025-02-16";
 
   src = fetchFromGitHub {
     owner = "progfolio";
     repo = "elpaca";
-    rev = "b5ef5f19ac1224853234c9acdac0ec9ea1c440a1";
-    hash = "sha256-EZ9emYTweRZzMKxZu9nbAaGgE2tInaL7KCKvJ5TaD0g=";
+    rev = "07b3a653e2411f4d4b5902af1c9b3f159e07bec5";
+    hash = "sha256-+YJX2BJxH3D5u7YC/yJskZu0F4Nlat3ZROe+RCZGq9w=";
   };
 
   nativeBuildInputs = [ git ];
 
-  # Moves extensions into the source root directory to install them.
-  # Disables warnings related to being used with package.el and not matching the installer
-  # Points the elpaca-repos-directory to the installed package in the nix store
-  postPatch =
-    let
-      siteVersion = lib.concatStrings (lib.drop 2 (lib.splitVersion version));
-    in
-    ''
-      mv extensions/* .
-      substituteInPlace elpaca.el \
-        --replace-fail "lwarn '(elpaca installer)" \
-                       "ignore '(elpaca installer)" \
-        --replace-fail "warn \"Package.el" \
-                       "ignore \"Package.el" \
-        --replace-fail "(expand-file-name \"elpaca/\" elpaca-repos-directory)" \
-                       "\"${placeholder "out"}/share/emacs/site-lisp/elpa/elpaca-${siteVersion}.0\""
-    '';
-
   passthru.updateScript = unstableGitUpdater { };
 
   meta = {
-    description = "Elisp package manager and replacement for package.el";
-    longDescription = ''
-      Elpaca is an elisp package manager. It allows users to find,
-      install, update, and remove third-party packages for Emacs. It
-      is a replacement for the built-in Emacs package manager,
-      package.el.
-
-      Elpaca:
-       - Installs packages asynchronously, in parallel for fast, non-blocking installations.
-       - Includes a flexible UI for finding and operating on packages.
-       - Downloads packages from their sources for convenient elisp development.
-       - Supports thousands of elisp packages out of the box (MELPA, NonGNU/GNU ELPA, Org/org-contrib).
-       - Makes it easy for users to create their own ELPAs.
-
-      Elpaca has been adapted for Emacs managed via Nix. To activate
-      Elpaca, this snippet can be used within your init.el:
-
-      ```elisp
-      (add-hook 'after-init-hook #'elpaca-process-queues)
-      (elpaca-use-package-mode) ;; Optional, for use-package support
-      ```
-    '';
     homepage = "https://github.com/progfolio/elpaca";
+    description = "Elisp package manager";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [
       abhisheksingh0x558


### PR DESCRIPTION
…5-11-06"

This reverts commit 515ed78687e9919b518097117e4066a06eb47d4c.

This patch is not complete, see reviews[1] after it was merged and a follow-up PR[2] by the same author.

Revert it since the original author's GitHub account was deleted. This patch can be re-applied in the future if someone else wants to push it over the finish line.

[1]: https://github.com/NixOS/nixpkgs/pull/470901
[2]: https://github.com/NixOS/nixpkgs/pull/477267


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
