### PR TITLE
emacs: withEmacsPlus, patches for darwin

### DIFF
--- a/pkgs/applications/editors/emacs/default.nix
+++ b/pkgs/applications/editors/emacs/default.nix
@@ -1,4 +1,8 @@
-{ lib, pkgs }:
+{
+  callPackage,
+  lib,
+  pkgs,
+}:
 
 lib.makeScope pkgs.newScope (
   self:
@@ -9,13 +13,7 @@ lib.makeScope pkgs.newScope (
     };
   in
   {
-    sources = import ./sources.nix {
-      inherit lib;
-      inherit (pkgs)
-        fetchFromGitHub
-        fetchzip
-        ;
-    };
+    sources = callPackage ./sources.nix { };
 
     emacs30 = callPackage (self.sources.emacs30) inheritedArgs;
 
@@ -37,5 +35,7 @@ lib.makeScope pkgs.newScope (
         srcRepo = true;
       }
     );
+
+    emacs30-plus = callPackage (self.sources.emacs30-plus) inheritedArgs;
   }
 )

--- a/pkgs/applications/editors/emacs/make-emacs.nix
+++ b/pkgs/applications/editors/emacs/make-emacs.nix
@@ -19,7 +19,6 @@
   dbus,
   emacsPackagesFor,
   fetchpatch,
-  fetchFromGitHub,
   gettext,
   giflib,
   glib-networking,
@@ -74,8 +73,6 @@
   withCairo ? withX,
   withCsrc ? true,
   withDbus ? stdenv.hostPlatform.isLinux,
-  # https://github.com/d12frosted/homebrew-emacs-plus
-  withEmacsPlus ? false,
   # https://github.com/emacs-mirror/emacs/blob/emacs-30.2/etc/NEWS#L52-L56
   withGcMarkTrace ? false,
   withGTK3 ? withPgtk && !noGui,
@@ -128,7 +125,6 @@ assert (withGTK3 && !withNS && variant != "macport") -> withX || withPgtk;
 assert noGui -> !(withX || withGTK3 || withNS || variant == "macport");
 assert withAcl -> stdenv.hostPlatform.isLinux;
 assert withAlsaLib -> stdenv.hostPlatform.isLinux;
-assert withEmacsPlus -> (stdenv.hostPlatform.isDarwin && variant != "macport");
 assert withGpm -> stdenv.hostPlatform.isLinux;
 assert withImageMagick -> (withX || withNS);
 assert withNS -> stdenv.hostPlatform.isDarwin && !(withX || variant == "macport");
@@ -144,12 +140,6 @@ let
   ++ lib.optionals (stdenv.cc ? cc.lib.libgcc) [
     "${lib.getLib stdenv.cc.cc.lib.libgcc}/lib"
   ];
-  emacsPlus = fetchFromGitHub {
-    owner = "d12frosted";
-    repo = "homebrew-emacs-plus";
-    rev = "ffd7b5d2be09476a5c790ae2723de3a3e049401a";
-    hash = "sha256-82jRHHGCD0GLCBrvo1R3F5MEfA+G4ia9gMn4dy8h1Ec=";
-  };
 
   withWebkitgtk = withXwidgets && stdenv.hostPlatform.isLinux;
 in
@@ -171,16 +161,6 @@ stdenv.mkDerivation (finalAttrs: {
   inherit version;
 
   inherit src;
-
-  prePatch =
-    let
-      emacsPlusPatches = "${emacsPlus}/patches/emacs-${lib.versions.major finalAttrs.version}";
-    in
-    lib.optionalString withEmacsPlus ''
-      for f in ${emacsPlusPatches}/*; do
-        appendToVar patches "$f"
-      done
-    '';
 
   patches =
     patches fetchpatch

--- a/pkgs/applications/editors/emacs/sources.nix
+++ b/pkgs/applications/editors/emacs/sources.nix
@@ -1,4 +1,5 @@
 {
+  applyPatches,
   lib,
   fetchFromGitHub,
   fetchzip,
@@ -24,13 +25,14 @@ let
         ;
 
       src =
+        let
+          mainline = fetchzip {
+            url = "mirror://gnu/emacs/${rev}.tar.xz";
+            inherit hash;
+          };
+        in
         {
-          "mainline" = (
-            fetchzip {
-              url = "mirror://gnu/emacs/${rev}.tar.xz";
-              inherit hash;
-            }
-          );
+          inherit mainline;
           "macport" = (
             fetchFromGitHub {
               owner = "jdtsmith";
@@ -38,6 +40,32 @@ let
               inherit rev hash;
             }
           );
+          "plus" = applyPatches {
+            src = mainline;
+            patches =
+              let
+                emacsPlus = fetchFromGitHub {
+                  owner = "d12frosted";
+                  repo = "homebrew-emacs-plus";
+                  rev = "19b50cd8dfb967b0c56dd5c73092ad2d72a795f1";
+                  hash = "sha256-NVngI/bJdXAFbo4ROELBKdk8PFThklxTXbLXBTIQMcg=";
+                };
+                majorVersion = lib.versions.major version;
+                fileNames =
+                  {
+                    "30" = [
+                      "fix-macos-tahoe-scrolling.patch"
+                      "fix-window-role.patch"
+                      "round-undecorated-frame.patch"
+                      "system-appearance.patch"
+                      "treesit-compatibility.patch"
+                    ];
+                  }
+                  .${majorVersion} or (throw "No emacs-plus patches registered for ${majorVersion}");
+                dir = "${emacsPlus}/patches/emacs-${majorVersion}";
+              in
+              map (name: "${dir}/${name}") fileNames;
+          };
         }
         .${variant};
 
@@ -46,11 +74,12 @@ let
           {
             "mainline" = "https://www.gnu.org/software/emacs/";
             "macport" = "https://github.com/jdtsmith/emacs-mac";
+            "plus" = "https://github.com/d12frosted/homebrew-emacs-plus";
           }
           .${variant};
         description =
           "Extensible, customizable GNU text editor"
-          + lib.optionalString (variant == "macport") " - macport variant";
+          + lib.optionalString (variant != "mainline") " - ${variant} variant";
         longDescription = ''
           GNU Emacs is an extensible, customizable text editor—and more. At its core
           is an interpreter for Emacs Lisp, a dialect of the Lisp programming
@@ -66,21 +95,38 @@ let
           interface, calendar, and more. Many of these extensions are distributed
           with GNU Emacs; others are available separately.
         ''
-        + lib.optionalString (variant == "macport") ''
+        + (
+          {
+            "macport" = ''
 
-          This release initially was built from Mitsuharu Yamamoto's patched source code
-          tailored for macOS. Moved to a fork of the latter starting with emacs v30 as the
-          original project seems to be currently dormant.
-        '';
+              This release initially was built from Mitsuharu Yamamoto's patched source code
+              tailored for macOS. Moved to a fork of the latter starting with emacs v30 as the
+              original project seems to be currently dormant.
+            '';
+            "plus" = ''
+
+              This is stock upstream Emacs, plus the patches from the
+              homebrew-emacs-plus project.  It offers a wide range of extra
+              functionality over regular Emacs package. Emacs+ intent is to give
+              the most of ‘plus’ stuff by default, leaving only controversial
+              options as opt-in.
+            '';
+          }
+          .${variant} or ""
+        );
         changelog =
           {
-            "mainline" = "https://www.gnu.org/savannah-checkouts/gnu/emacs/news/NEWS.${version}";
             "macport" = "https://github.com/jdtsmith/emacs-mac/blob/${rev}/NEWS-mac";
+            "mainline" = "https://www.gnu.org/savannah-checkouts/gnu/emacs/news/NEWS.${version}";
+            "plus" = "https://github.com/d12frosted/homebrew-emacs-plus/blob/master/NEWS.org";
           }
           .${variant};
         license = lib.licenses.gpl3Plus;
         maintainers =
           {
+            "macport" = with lib.maintainers; [
+              kfiz
+            ];
             "mainline" = with lib.maintainers; [
               AndersonTorres
               adisbladis
@@ -88,24 +134,23 @@ let
               lovek323
               panchoh
             ];
-            "macport" = with lib.maintainers; [
-              kfiz
+            "plus" = with lib.maintainers; [
+              hraban
             ];
           }
           .${variant};
         platforms =
           {
-            "mainline" = lib.platforms.all;
             "macport" = lib.platforms.darwin;
+            "mainline" = lib.platforms.all;
+            "plus" = lib.platforms.darwin;
           }
           .${variant};
         mainProgram = "emacs";
       }
       // meta;
     };
-in
-{
-  emacs30 = import ./make-emacs.nix (mkArgs {
+  mainlineArgs = {
     pname = "emacs";
     version = "30.2";
     variant = "mainline";
@@ -117,7 +162,10 @@ in
         path = ./inhibit-lexical-cookie-warning-67916-30.patch;
       })
     ];
-  });
+  };
+in
+{
+  emacs30 = import ./make-emacs.nix (mkArgs mainlineArgs);
 
   emacs30-macport = import ./make-emacs.nix (mkArgs {
     pname = "emacs-mac";
@@ -126,4 +174,14 @@ in
     rev = "emacs-mac-30.2";
     hash = "sha256-i/W2Xa6Vk1+T1fs6fa4wJVMLLB6BK8QAPcdmPrU8NwM=";
   });
+
+  # emacs-plus is mainline + some patches
+  emacs30-plus = import ./make-emacs.nix (
+    mkArgs (
+      mainlineArgs
+      // {
+        variant = "plus";
+      }
+    )
+  );
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10059,9 +10059,11 @@ with pkgs;
     emacs30-pgtk
 
     emacs30-macport
+    emacs30-plus
     ;
 
   emacs-macport = emacs30-macport;
+  emacs-plus = emacs30-plus;
   emacs = emacs30;
   emacs-gtk = emacs30-gtk3;
   emacs-nox = emacs30-nox;


### PR DESCRIPTION
Light-weight patchset for various versions of emacs to make it more darwin native. See https://github.com/d12frosted/homebrew-emacs-plus

I'm using this locally, thought I'd contribute it to nixpkgs. What do y'all think? Does it fit?

I searched the pull request history for something similar but oculdn't find anything.

Context: homebrew-emacs-plus is an emacs "distribution" which is a very light weight set of patches on stock emacs, to give it access to some more native macos apis. Using homebrew you'd have to install a full separate tap and separate binary, like macport (I think?), but in reality it's just a few patches which you can apply to the original emacs derivation directly.

Features include:
- hook for light/dark theme switch
- rounded corners
- smooth, pixel resolution resizing
- no titlebar

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
