### PR TITLE
akonadi: set MYSQLD_EXECUTABLE in extraCmakeFlags for mysql backend

### DIFF
--- a/pkgs/kde/gear/akonadi/default.nix
+++ b/pkgs/kde/gear/akonadi/default.nix
@@ -31,6 +31,7 @@ mkKdeDerivation {
   ]
   ++ lib.optionals (backend == "mysql") [
     "-DMYSQLD_SCRIPTS_PATH=${lib.getBin mariadb}/bin"
+    "-DMYSQLD_EXECUTABLE=${lib.getBin mariadb}/bin/mariadbd"
   ]
   ++ lib.optionals (backend == "postgres") [
     "-DPOSTGRES_PATH=${lib.getBin libpq}/bin"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

For the "mysql" backend, the current akonadi package code causes the creation of the config file "~/.config/akonadi/akonadiserverrc" with the configuration:

`ServerPath=/nix/store/drgq0947sv8x8a1wfpr9rhp8qq4sikp6-mariadb-server-11.4.8/bin/mariadb`

But this is incorrect as akonadi expects the mariadbd daemon here. This causes akonadi apps to crash.

The fix is to add the MYSQLD_EXECUTABLE variable in akonadi's [CMakeLists.txt](https://github.com/KDE/akonadi/blob/v25.12.1/CMakeLists.txt) pointing to the mariadbd daemon.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
