### PR TITLE
alfred,batctl,linuxPackages.batman_adv: 2025.4 -> 2025.5

### DIFF
--- a/pkgs/os-specific/linux/batman-adv/version.nix
+++ b/pkgs/os-specific/linux/batman-adv/version.nix
@@ -1,14 +1,14 @@
 {
-  version = "2025.4";
+  version = "2025.5";
 
   # To get these, run:
   #
   # ```
-  # for tool in alfred batctl batman-adv; do nix-prefetch-url https://downloads.open-mesh.org/batman/releases/batman-adv-2025.4/$tool-2025.4.tar.gz --type sha256 | xargs nix --extra-experimental-features nix-command hash convert --hash-algo sha256 --to sri; done
+  # for tool in alfred batctl batman-adv; do nix-prefetch-url https://downloads.open-mesh.org/batman/releases/batman-adv-2025.5/$tool-2025.5.tar.gz --type sha256 | xargs nix --extra-experimental-features nix-command hash convert --hash-algo sha256 --to sri; done
   # ```
   sha256 = {
-    alfred = "sha256-g3VHVHjtHNQTnJAAF1p9FAfujdkZoLfJ2/fRUJWIBIU=";
-    batctl = "sha256-Vmqk/XQ1Xo1d0r0hwl6YzAaOd/0I4Z+AuOK17d58jmU=";
-    batman-adv = "sha256-YkkKj4tYwC6Bkhbz6WMkmYRkXT5GAVagQ7c/xT4k+G0=";
+    alfred = "sha256-dcEsHDw5zbIkb2H8pdTZ9h4kD+KCcSn6t6A97vhV/+g=";
+    batctl = "sha256-HgvNSfku7aDXa8aDVirfNmAk4u5MGZ+kAgNva5PLsUc=";
+    batman-adv = "sha256-GtvoI5kelxjjB/N2bqlkBf4fKEwZvLmMZi16H6oyTDU=";
   };
 }


### PR DESCRIPTION
Changes:

- batman-adv
  - support latest kernels (5.10 - 6.19)
  - coding style cleanups and refactoring

Source: https://www.open-mesh.org/news/125

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
