### PR TITLE
python3Packages.shiny: 1.5.0 -> 1.5.1

### DIFF
--- a/pkgs/development/python-modules/shiny/default.nix
+++ b/pkgs/development/python-modules/shiny/default.nix
@@ -48,14 +48,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "shiny";
-  version = "1.5.0";
+  version = "1.5.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "posit-dev";
     repo = "py-shiny";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-zRKfSY0rE+jzwYUcrRTIFW3OVmavhMDbAQEpry46zCI=";
+    hash = "sha256-8iqnm1SQ4h0GuwqKDzL6qEdbw0gJ2a5Aqg5WJgbaKBI=";
   };
 
   build-system = [
@@ -127,6 +127,15 @@ buildPythonPackage (finalAttrs: {
     "test_theme_from_brand_base_case_compiles"
     # ValueError: A tokenizer is required to impose `token_limits` on messages
     "test_chat_message_trimming"
+
+    # Snapshot tests fail with AssertionError
+    "test_toast_header_icon_renders_in_header"
+    "test_toast_header_icon_with_status_and_title"
+    "test_toast_icon_renders_in_body_with_header"
+    "test_toast_icon_renders_in_body_without_header"
+    "test_toast_icon_works_with_closable_button_in_body"
+    "test_toast_with_both_header_icon_and_body_icon"
+    "test_toast_with_custom_tag_header"
   ];
 
   __darwinAllowLocalNetworking = true;


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/posit-dev/py-shiny/compare/v1.5.0...v1.5.1
Changelog: https://github.com/posit-dev/py-shiny/blob/v1.5.1/CHANGELOG.md

cc @Sigmanificient

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test