### PR TITLE
heaptrack: enable rustc-demangle

### DIFF
--- a/pkgs/by-name/he/heaptrack/package.nix
+++ b/pkgs/by-name/he/heaptrack/package.nix
@@ -11,6 +11,7 @@
   sparsehash,
   zstd,
   kdePackages,
+  rustc-demangle,
 }:
 
 stdenv.mkDerivation {
@@ -38,6 +39,7 @@ stdenv.mkDerivation {
     libunwind
     sparsehash
     zstd
+    rustc-demangle
   ]
   ++ (with kdePackages; [
     qtbase
@@ -52,6 +54,11 @@ stdenv.mkDerivation {
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     elfutils
   ];
+
+  postPatch = ''
+    substituteInPlace src/interpret/demangler.cpp \
+      --replace-fail "librustc_demangle.so" "${rustc-demangle}/lib/librustc_demangle.so"
+  '';
 
   postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
     makeWrapper \


### PR DESCRIPTION
Hi,
Rust is [switching to their own symbol mangling convention (V0)](https://blog.rust-lang.org/2025/11/20/switching-to-v0-mangling-on-nightly/) which requires dynamically loading the `rustc-demangle` library in heaptrack.

The heaptrack CMake setup doesn't have a way to link demanglers, but adjusting the dlopen path is reasonably simple.

NB: Demangling happens during the initial heaptrack invocation so this only applies to newly recorded profiles.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
