### PR TITLE
rathole: 0.5.0-unstable-2024-06-06 -> 0.5.0-unstable-2025-07-29

### DIFF
--- a/pkgs/by-name/ra/rathole/package.nix
+++ b/pkgs/by-name/ra/rathole/package.nix
@@ -11,12 +11,12 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "rathole";
-  version = "0.5.0-unstable-2024-06-06";
+  version = "0.5.0-unstable-2025-07-29";
 
   src = fetchFromGitHub {
-    owner = "rapiz1";
+    owner = "rathole-org";
     repo = "rathole";
-    rev = "be14d124a22e298d12d92e56ef4fec0e51517998";
+    rev = "5a9dd6d939744859af322aeff7fd60f7483a68bc";
     hash = "sha256-C0/G4JOZ4pTAvcKZhRHsGvlLlwAyWBQ0rMScLvaLSuA=";
   };
 
@@ -67,7 +67,7 @@ rustPlatform.buildRustPackage rec {
 
   meta = {
     description = "Reverse proxy for NAT traversal";
-    homepage = "https://github.com/rapiz1/rathole";
+    homepage = "https://github.com/rathole-org/rathole";
     license = lib.licenses.asl20;
     mainProgram = "rathole";
     maintainers = with lib.maintainers; [


### PR DESCRIPTION
I updated the source of rathole, as it was moved to its own org. While doing so, I also bumped it to the latest commit in the master release. The diff to the last version released is here: https://github.com/rathole-org/rathole/compare/be14d124a22e298d12d92e56ef4fec0e51517998...5a9dd6d939744859af322aeff7fd60f7483a68bc

This is my first nixpkgs PR, I hope I did everything correct, please let me know if I did something wrong!

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
