### PR TITLE
[Backport release-25.11] cloudflare-warp: add darwin support, 2025.9.558 -> 2025.10.186.0

### DIFF
--- a/pkgs/by-name/cl/cloudflare-warp/package.nix
+++ b/pkgs/by-name/cl/cloudflare-warp/package.nix
@@ -20,19 +20,29 @@
   jq,
   ripgrep,
   common-updater-scripts,
+  xar,
+  cpio,
   headless ? false,
 }:
 
 let
-  version = "2025.9.558";
+  version = "2025.10.186.0";
   sources = {
     x86_64-linux = fetchurl {
-      url = "https://pkg.cloudflareclient.com/pool/noble/main/c/cloudflare-warp/cloudflare-warp_${version}.0_amd64.deb";
-      hash = "sha256-eYPy8YnP/vvYmvvjvF6Y0gSzdglsvoPW6CJ5npjrtpo=";
+      url = "https://pkg.cloudflareclient.com/pool/noble/main/c/cloudflare-warp/cloudflare-warp_${version}_amd64.deb";
+      hash = "sha256-l+csDSBXRAFb2075ciCAlE0bS5F48mAIK/Bv1r3Q8GE=";
     };
     aarch64-linux = fetchurl {
-      url = "https://pkg.cloudflareclient.com/pool/noble/main/c/cloudflare-warp/cloudflare-warp_${version}.0_arm64.deb";
-      hash = "sha256-K8XENo+9n3ChmQ33wAg/KiVHjNOKOXp6UQM2fpntgkE=";
+      url = "https://pkg.cloudflareclient.com/pool/noble/main/c/cloudflare-warp/cloudflare-warp_${version}_arm64.deb";
+      hash = "sha256-S6CfWYzcv+1Djj+TX+lrP5eG7oIpM0JrqtSw/UDD9ko=";
+    };
+    x86_64-darwin = fetchurl {
+      url = "https://downloads.cloudflareclient.com/v1/download/macos/version/${version}";
+      hash = "sha256-nnoOXPSpOJRyNdCC0/YAoBK8SwB+++qVwgZplrjNi2U=";
+    };
+    aarch64-darwin = fetchurl {
+      url = "https://downloads.cloudflareclient.com/v1/download/macos/version/${version}";
+      hash = "sha256-nnoOXPSpOJRyNdCC0/YAoBK8SwB+++qVwgZplrjNi2U=";
     };
   };
 in
@@ -46,26 +56,34 @@ stdenv.mkDerivation (finalAttrs: {
       or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
 
   nativeBuildInputs = [
+    makeWrapper
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    xar
+    cpio
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
     dpkg
     autoPatchelfHook
     versionCheckHook
-    makeWrapper
   ]
-  ++ lib.optionals (!headless) [
+  ++ lib.optionals (!headless && stdenv.hostPlatform.isLinux) [
     copyDesktopItems
     desktop-file-utils
   ];
 
-  buildInputs = [
-    dbus
-    libpcap
-    openssl
-    nss
-    (lib.getLib stdenv.cc.cc)
-  ]
-  ++ lib.optionals (!headless) [
-    gtk3
-  ];
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux (
+    [
+      dbus
+      libpcap
+      openssl
+      nss
+      (lib.getLib stdenv.cc.cc)
+    ]
+    ++ lib.optionals (!headless) [
+      gtk3
+    ]
+  );
 
   desktopItems = lib.optionals (!headless) [
     (makeDesktopItem {
@@ -88,49 +106,79 @@ stdenv.mkDerivation (finalAttrs: {
     "libpcap.so.0.8"
   ];
 
-  installPhase = ''
-    runHook preInstall
+  unpackPhase = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    runHook preUnpack
 
-    mv usr $out
-    mv bin $out
-    mv etc $out
-    patchelf --replace-needed libpcap.so.0.8 ${libpcap}/lib/libpcap.so $out/bin/warp-dex
-    mv lib/systemd/system $out/lib/systemd/
-    substituteInPlace $out/lib/systemd/system/warp-svc.service \
-      --replace-fail "ExecStart=" "ExecStart=$out"
-    ${lib.optionalString (!headless) ''
-      substituteInPlace $out/lib/systemd/user/warp-taskbar.service \
-        --replace-fail "ExecStart=" "ExecStart=$out" \
-        --replace-fail "BindsTo=" "PartOf="
+    xar -xf $src
+    zcat < Cloudflare_WARP_${version}.pkg/Payload | cpio -i
 
-      cat >>$out/lib/systemd/user/warp-taskbar.service <<EOF
-
-      [Service]
-      BindReadOnlyPaths=$out:/usr:
-      EOF
-    ''}
-    ${lib.optionalString headless ''
-      # For headless version, remove GUI components
-      rm $out/bin/warp-taskbar
-      rm -r $out/lib/systemd/user
-      rm -r $out/etc
-      rm -r $out/share/applications
-      rm -r $out/share/icons
-      rm -r $out/share/warp
-    ''}
-
-    runHook postInstall
+    runHook postUnpack
   '';
 
-  postInstall = ''
+  installPhase =
+    if stdenv.hostPlatform.isDarwin then
+      ''
+        runHook preInstall
+
+        mkdir -p $out/Applications $out/bin
+
+        cp -R "Cloudflare WARP.app" $out/Applications/
+
+        for tool in warp-cli warp-dex warp-diag; do
+          ln -s "$out/Applications/Cloudflare WARP.app/Contents/Resources/$tool" "$out/bin/$tool"
+        done
+
+        runHook postInstall
+      ''
+    else
+      ''
+        runHook preInstall
+
+        mv usr $out
+        mv bin $out
+        mv etc $out
+        patchelf --replace-needed libpcap.so.0.8 ${libpcap}/lib/libpcap.so $out/bin/warp-dex
+        mv lib/systemd/system $out/lib/systemd/
+        substituteInPlace $out/lib/systemd/system/warp-svc.service \
+          --replace-fail "ExecStart=" "ExecStart=$out"
+        ${lib.optionalString (!headless) ''
+          substituteInPlace $out/lib/systemd/user/warp-taskbar.service \
+            --replace-fail "ExecStart=" "ExecStart=$out" \
+            --replace-fail "BindsTo=" "PartOf="
+
+          cat >>$out/lib/systemd/user/warp-taskbar.service <<EOF
+
+          [Service]
+          BindReadOnlyPaths=$out:/usr:
+          EOF
+        ''}
+        ${lib.optionalString headless ''
+          # For headless version, remove GUI components
+          rm $out/bin/warp-taskbar
+          rm -r $out/lib/systemd/user
+          rm -r $out/etc
+          rm -r $out/share/applications
+          rm -r $out/share/icons
+          rm -r $out/share/warp
+        ''}
+
+        runHook postInstall
+      '';
+
+  postInstall = lib.optionalString stdenv.hostPlatform.isLinux ''
     wrapProgram $out/bin/warp-svc --prefix PATH : ${lib.makeBinPath [ nftables ]}
     ${lib.optionalString (!headless) ''
       wrapProgram $out/bin/warp-cli --prefix PATH : ${lib.makeBinPath [ desktop-file-utils ]}
     ''}
   '';
 
-  doInstallCheck = true;
+  doInstallCheck = stdenv.hostPlatform.isLinux;
   versionCheckProgramArg = "--version";
+
+  # The Sparkle.framework in the upstream macOS package contains a broken symlink
+  # (XPCServices -> Versions/Current/XPCServices) where the target doesn't exist.
+  # This is present in the official installed app and doesn't affect functionality.
+  dontCheckForBrokenSymlinks = stdenv.hostPlatform.isDarwin;
 
   passthru = {
     inherit sources;
@@ -152,7 +200,7 @@ stdenv.mkDerivation (finalAttrs: {
             -H 'X-GitHub-Api-Version: 2022-11-28' \
             'https://api.github.com/repos/cloudflare/cloudflare-docs/git/trees/production?recursive=true' |
             jq -r '[.tree[].path | select(startswith("src/content/warp-releases/linux/ga/"))] | max_by(split("/")[-1] | split(".") | map(tonumber?))' |
-            rg '([^/]+)\.0\.yaml\b' --only-matching --replace '$1'
+            rg '([^/]+)\.yaml\b' --only-matching --replace '$1'
         )"
 
         for platform in ${lib.escapeShellArgs finalAttrs.meta.platforms}; do
@@ -163,7 +211,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   meta = {
-    changelog = "https://github.com/cloudflare/cloudflare-docs/blob/production/src/content/warp-releases/linux/ga/${finalAttrs.version}.0.yaml";
+    changelog = "https://github.com/cloudflare/cloudflare-docs/blob/production/src/content/warp-releases/linux/ga/${finalAttrs.version}.yaml";
     description =
       "Replaces the connection between your device and the Internet with a modern, optimized, protocol"
       + lib.optionalString headless " (headless version)";
@@ -173,10 +221,13 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "warp-cli";
     maintainers = with lib.maintainers; [
       marcusramberg
+      anish
     ];
     platforms = [
       "x86_64-linux"
       "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
     ];
   };
 })


### PR DESCRIPTION
Backport of https://github.com/NixOS/nixpkgs/pull/481432

(cherry picked from commit 33bff8b6c55dccfca8ed474d1bfbc458589dc8c1)

I also made an accompanying PR https://github.com/nix-darwin/nix-darwin/pull/1684 that allows the GUI in addition to the CLI. It needed a launchd daemon to be running for the GUI to communicate with.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
