### PR TITLE
vampire: 5.0.0 -> 5.0.1

### DIFF
--- a/pkgs/by-name/is/isabelle/package.nix
+++ b/pkgs/by-name/is/isabelle/package.nix
@@ -50,7 +50,8 @@ let
 
   # Isabelle uses a branch of vampire that is not in the normal release line
   # that adds support for higher order goals
-  vampire' = (vampire.override { stdenv = gcc14Stdenv; }).overrideAttrs (_: {
+  vampireStdenv = if stdenv.hostPlatform.isLinux then gcc14Stdenv else stdenv;
+  vampire' = (vampire.override { stdenv = vampireStdenv; }).overrideAttrs (_: {
     pname = "vampire-for-isabelle";
     version = "4.8";
 
@@ -61,7 +62,16 @@ let
       hash = "sha256-CmppaGa4M9tkE1b25cY1LSPFygJy5yV4kpHKbPqvcVE=";
     };
 
-    cmakeFlags = [ (lib.cmakeFeature "CMAKE_BUILD_HOL" "On") ];
+    patches = [ ./vampire-add-install-directive.patch ];
+
+    postInstall = ''
+      mv $out/bin/vampire_rel $out/bin/vampire
+    '';
+
+    cmakeFlags = [
+      (lib.cmakeFeature "CMAKE_BUILD_HOL" "On")
+      (lib.cmakeFeature "CMAKE_DISABLE_FIND_PACKAGE_Z3" "On")
+    ];
   });
 
   sha1 = stdenv.mkDerivation {

--- a/pkgs/by-name/is/isabelle/vampire-add-install-directive.patch
+++ b/pkgs/by-name/is/isabelle/vampire-add-install-directive.patch
@@ -1,0 +1,11 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -997,6 +997,8 @@ set_target_properties(vampire PROPERTIES
+   )
+ configure_file(version.cpp.in version.cpp)
+ 
++install(TARGETS vampire)
++
+ if(CMAKE_BUILD_TYPE STREQUAL Release AND IPO)
+   message(STATUS "compiling Vampire with IPO: this might take a while")
+   set_property(TARGET obj PROPERTY INTERPROCEDURAL_OPTIMIZATION true)

--- a/pkgs/by-name/va/vampire/package.nix
+++ b/pkgs/by-name/va/vampire/package.nix
@@ -19,13 +19,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "vampire";
-  version = "5.0.0";
+  version = "5.0.1";
 
   src = fetchFromGitHub {
     owner = "vprover";
     repo = "vampire";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-jRzVh1KirWi9GpOkzSGoIBUExDN1rV0b3AGwa6gWb3I=";
+    hash = "sha256-Ka9HmicIf7b5VN9nbiCW604ZZrGpJuP57RPTzOnwJbU=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/by-name/va/vampire/package.nix
+++ b/pkgs/by-name/va/vampire/package.nix
@@ -42,20 +42,6 @@ stdenv.mkDerivation (finalAttrs: {
     rm -rf z3
   '';
 
-  installPhase = ''
-    runHook preInstall
-
-    # some versions place the binary at ./ while others at bin/
-    if test -n "$(find . -maxdepth 1 -name 'vampire*' -print -quit)"
-    then
-      install -m0755 -D vampire* $out/bin/vampire
-    else
-      install -m0755 -D bin/vampire* $out/bin/vampire
-    fi
-
-    runHook postInstall
-  '';
-
   meta = {
     homepage = "https://vprover.github.io/";
     description = "Vampire Theorem Prover";


### PR DESCRIPTION
Bump the version, remove the unneeded installPhase and fix the isabelle build with the changes

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
