### PR TITLE
packages-config.nix: move custom filter of attrsets into top-level

### DIFF
--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -2217,6 +2217,49 @@ rec {
   dontRecurseIntoAttrs = attrs: attrs // { recurseForDerivations = false; };
 
   /**
+    Make CI and Hydra consider the contents of the resulting attribute set
+    when looking for what to build, find, etc.
+
+    In comparison to `rerecurseIntoAttrs` this does affect user-facing Nix tools.
+
+    This function only affects a single attribute set;
+    it does not apply itself recursively for nested attribute sets.
+    # Inputs
+
+    `attrs`
+
+    : An attribute set to scan for derivations.
+
+    # Type
+
+    ```
+    recurseIntoAttrsRelease :: AttrSet -> AttrSet
+    ```
+
+    # Examples
+    :::{.example}
+    ## `lib.attrsets.recurseIntoAttrsRelease` usage example
+
+    ```nix
+    { pkgs ? import <nixpkgs> {} }:
+    {
+      myTools = pkgs.lib.recurseIntoAttrsRelease {
+        inherit (pkgs) hello figlet;
+      };
+    }
+    ```
+
+    :::
+  */
+  recurseIntoAttrsRelease =
+    attrs:
+    attrs
+    // {
+      recurseForDerivations = false;
+      recurseForRelease = true;
+    };
+
+  /**
     `unionOfDisjoint x y` is equal to `x // y`, but accessing attributes present
     in both `x` and `y` will throw an error.  This operator is commutative, unlike `//`.
 

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -225,6 +225,7 @@ let
         chooseDevOutputs
         recurseIntoAttrs
         dontRecurseIntoAttrs
+        recurseIntoAttrsRelease
         cartesianProduct
         mapCartesianProduct
         updateManyAttrsByPath

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -114,7 +114,8 @@ with pkgs;
     You should not evaluate entire Nixpkgs without measures to handle failing packages.
   '';
 
-  tests = recurseIntoAttrs (callPackages ../test { });
+  # Tests should be build by Hydra, but not show up in search
+  tests = lib.recurseIntoAttrsRelease (callPackages ../test { });
 
   defaultPkgConfigPackages =
     # We don't want nix-env -q to enter this, because all of these are aliases.

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9570,7 +9570,12 @@ with pkgs;
   };
 
   mdadm = mdadm4;
-  minimal-bootstrap = recurseIntoAttrs (
+
+  # minimal-bootstrap packages aren't used for anything but bootstrapping our
+  # stdenv. They should not be used for any other purpose and therefore not
+  # show up in search results or repository tracking services that consume our
+  # packages.json https://github.com/NixOS/nixpkgs/issues/244966
+  minimal-bootstrap = lib.recurseIntoAttrsRelease (
     import ../os-specific/linux/minimal-bootstrap {
       inherit (stdenv) buildPlatform hostPlatform;
       inherit lib config;

--- a/pkgs/top-level/packages-config.nix
+++ b/pkgs/top-level/packages-config.nix
@@ -19,11 +19,5 @@
       # emacsPackages is an alias for emacs.pkgs
       # Re-introduce emacsPackages here so that emacs.pkgs can be searched.
       emacsPackages = emacs.pkgs;
-
-      # minimal-bootstrap packages aren't used for anything but bootstrapping our
-      # stdenv. They should not be used for any other purpose and therefore not
-      # show up in search results or repository tracking services that consume our
-      # packages.json https://github.com/NixOS/nixpkgs/issues/244966
-      minimal-bootstrap = { };
     };
 }

--- a/pkgs/top-level/packages-config.nix
+++ b/pkgs/top-level/packages-config.nix
@@ -25,8 +25,5 @@
       # show up in search results or repository tracking services that consume our
       # packages.json https://github.com/NixOS/nixpkgs/issues/244966
       minimal-bootstrap = { };
-
-      # This makes it so that tests are not appering on search.nixos.org
-      tests = { };
     };
 }


### PR DESCRIPTION
This adds a function to set an attrset to be only evaled by CI and Hydra but not by other tooling like the generation of our `package.json`, `nix-env` and `search.nixos.org`.

This also applies this function to the 2 attrs set that were filtered out in `packages-config.nix`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
​