### PR TITLE
ringboard: 0.13.2-unstable-2025-12-19 -> 0.14.0-unstable-2026-01-19

### DIFF
--- a/pkgs/by-name/ri/ringboard/package.nix
+++ b/pkgs/by-name/ri/ringboard/package.nix
@@ -10,6 +10,7 @@
   makeWrapper,
   displayServer ? "x11",
   nixosTests,
+  nix-update-script,
 }:
 
 assert lib.assertOneOf "displayServer" displayServer [
@@ -22,16 +23,16 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   # release version needs nightly, so we use a custom tree, see:
   # https://github.com/SUPERCILEX/clipboard-history/issues/22#issuecomment-3676256971
-  version = "0.13.2-unstable-2025-12-19";
+  version = "0.14.0-unstable-2026-01-19";
 
   src = fetchFromGitHub {
     owner = "SUPERCILEX";
     repo = "clipboard-history";
-    rev = "08a2a2a77fa38240dfc6a33adabb3a473ce6bcfd";
-    hash = "sha256-iG/pk6xizCv2sUqTA44nb4AnbaOuDsIONuUfJuOWnc8=";
+    rev = "cb2e94add2388a68a8f015b77f9b082b1658b3b7";
+    hash = "sha256-r2632XJ/2Er1TuHCDNm6uItvdhqJ87i9p+h9M2MwKwk=";
   };
 
-  cargoHash = "sha256-LuWUf37X/Z0xCbAQmaMY8lle7gGZWoz2bgYhe/uRonU=";
+  cargoHash = "sha256-c5Zdvz2xHsGh4VnOED2JiitNWwNTSkygaMFHPPLANqw=";
 
   nativeBuildInputs = [
     makeWrapper
@@ -97,11 +98,15 @@ rustPlatform.buildRustPackage (finalAttrs: {
     sed -i "s|Icon=ringboard|Icon=$out/share/icons/hicolor/1024x1024/ringboard.jpeg|g" $out/share/applications/ringboard-egui.desktop
   '';
 
-  passthru.tests.nixos = nixosTests.ringboard;
+  passthru = {
+    tests.nixos = nixosTests.ringboard;
+    updateScript = nix-update-script { extraArgs = [ "--version=branch=stable" ]; };
+  };
 
   meta = {
     description = "Fast, efficient, and composable clipboard manager for Linux";
     homepage = "https://github.com/SUPERCILEX/clipboard-history";
+    changelog = "https://github.com/SUPERCILEX/clipboard-history/releases/tag/${finalAttrs.version}";
     license = lib.licenses.asl20;
     platforms = lib.platforms.linux;
     maintainers = [ lib.maintainers.magnetophon ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
