### PR TITLE
(Part 1) various: replace `systemd.services.<name>.{script,preStart}` with `ExecStart{,Pre}`

### DIFF
--- a/nixos/modules/security/soteria.nix
+++ b/nixos/modules/security/soteria.nix
@@ -36,8 +36,8 @@ in
       wants = [ "graphical-session.target" ];
       after = [ "graphical-session.target" ];
 
-      script = lib.getExe cfg.package;
       serviceConfig = {
+        ExecStart = lib.getExe cfg.package;
         Type = "simple";
         Restart = "on-failure";
         RestartSec = 1;

--- a/nixos/modules/services/blockchain/ethereum/geth.nix
+++ b/nixos/modules/services/blockchain/ethereum/geth.nix
@@ -206,6 +206,43 @@ in
           after = [ "network.target" ];
 
           serviceConfig = {
+            ExecStart =
+              let
+                args = lib.cli.toCommandLineShellGNU { } {
+                  inherit (cfg)
+                    syncmode
+                    gcmode
+                    port
+                    maxpeers
+                    ;
+                  nousb = true;
+                  ipcdisable = true;
+                  datadir = dataDir;
+                  ${cfg.network} = true;
+
+                  http = cfg.http.enable;
+                  "http.addr" = if cfg.http.enable then cfg.http.address else null;
+                  "http.port" = if cfg.http.enable then cfg.http.port else null;
+                  "http.api" = if cfg.http.apis != null then lib.concatStringsSep "," cfg.http.apis else null;
+
+                  ws = cfg.websocket.enable;
+                  "ws.addr" = if cfg.websocket.enable then cfg.websocket.address else null;
+                  "ws.port" = if cfg.websocket.enable then cfg.websocket.port else null;
+                  "ws.api" = if cfg.websocket.apis != null then lib.concatStringsSep "," cfg.websocket.apis else null;
+
+                  metrics = cfg.metrics.enable;
+                  "metrics.addr" = if cfg.metrics.enable then cfg.metrics.address else null;
+                  "metrics.port" = if cfg.metrics.enable then cfg.metrics.port else null;
+
+                  "authrpc.addr" = cfg.authrpc.address;
+                  "authrpc.port" = cfg.authrpc.port;
+                  "authrpc.vhosts" = lib.concatStringsSep "," cfg.authrpc.vhosts;
+                  "authrpc.jwtsecret" =
+                    if cfg.authrpc.jwtsecret != "" then cfg.authrpc.jwtsecret else "${dataDir}/geth/jwtsecret";
+                };
+              in
+              "${lib.getExe cfg.package} ${args} ${lib.escapeShellArgs cfg.extraArgs}";
+
             DynamicUser = true;
             Restart = "always";
             StateDirectory = stateDir;
@@ -217,37 +254,6 @@ in
             PrivateDevices = "true";
             MemoryDenyWriteExecute = "true";
           };
-
-          script = ''
-            ${cfg.package}/bin/geth \
-              --nousb \
-              --ipcdisable \
-              ${lib.optionalString (cfg.network != null) ''--${cfg.network}''} \
-              --syncmode ${cfg.syncmode} \
-              --gcmode ${cfg.gcmode} \
-              --port ${toString cfg.port} \
-              --maxpeers ${toString cfg.maxpeers} \
-              ${lib.optionalString cfg.http.enable ''--http --http.addr ${cfg.http.address} --http.port ${toString cfg.http.port}''} \
-              ${
-                lib.optionalString (cfg.http.apis != null) ''--http.api ${lib.concatStringsSep "," cfg.http.apis}''
-              } \
-              ${lib.optionalString cfg.websocket.enable ''--ws --ws.addr ${cfg.websocket.address} --ws.port ${toString cfg.websocket.port}''} \
-              ${
-                lib.optionalString (
-                  cfg.websocket.apis != null
-                ) ''--ws.api ${lib.concatStringsSep "," cfg.websocket.apis}''
-              } \
-              ${lib.optionalString cfg.metrics.enable ''--metrics --metrics.addr ${cfg.metrics.address} --metrics.port ${toString cfg.metrics.port}''} \
-              --authrpc.addr ${cfg.authrpc.address} --authrpc.port ${toString cfg.authrpc.port} --authrpc.vhosts ${lib.concatStringsSep "," cfg.authrpc.vhosts} \
-              ${
-                if (cfg.authrpc.jwtsecret != "") then
-                  ''--authrpc.jwtsecret ${cfg.authrpc.jwtsecret}''
-                else
-                  ''--authrpc.jwtsecret ${dataDir}/geth/jwtsecret''
-              } \
-              ${lib.escapeShellArgs cfg.extraArgs} \
-              --datadir ${dataDir}
-          '';
         }
       ))
     ) eachGeth;

--- a/nixos/modules/services/computing/boinc/client.nix
+++ b/nixos/modules/services/computing/boinc/client.nix
@@ -99,10 +99,8 @@ in
       description = "BOINC Client";
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
-      script = ''
-        exec ${fhsEnvExecutable} --dir ${cfg.dataDir} ${allowRemoteGuiRpcFlag}
-      '';
       serviceConfig = {
+        ExecStart = "${fhsEnvExecutable} --dir ${cfg.dataDir} ${allowRemoteGuiRpcFlag}";
         User = "boinc";
         Nice = 10;
       };

--- a/nixos/modules/services/hardware/pommed.nix
+++ b/nixos/modules/services/hardware/pommed.nix
@@ -51,7 +51,7 @@ in
     systemd.services.pommed = {
       description = "Pommed Apple Hotkeys Daemon";
       wantedBy = [ "multi-user.target" ];
-      script = "${pkgs.pommed_light}/bin/pommed -f";
+      serviceConfig.ExecStart = "${lib.getExe pkgs.pommed_light} -f";
     };
   };
 }

--- a/nixos/modules/services/home-automation/zigbee2mqtt.nix
+++ b/nixos/modules/services/home-automation/zigbee2mqtt.nix
@@ -79,6 +79,7 @@ in
       after = [ "network.target" ];
       environment.ZIGBEE2MQTT_DATA = cfg.dataDir;
       serviceConfig = {
+        ExecStartPre = "${lib.getExe' pkgs.coreutils "cp"} --no-preserve=mode ${configFile} '${cfg.dataDir}/configuration.yaml'";
         ExecStart = "${cfg.package}/bin/zigbee2mqtt";
         User = "zigbee2mqtt";
         Group = "zigbee2mqtt";
@@ -130,9 +131,6 @@ in
         ];
         UMask = "0077";
       };
-      preStart = ''
-        cp --no-preserve=mode ${configFile} "${cfg.dataDir}/configuration.yaml"
-      '';
     };
 
     users.users.zigbee2mqtt = {

--- a/nixos/modules/services/logging/heartbeat.nix
+++ b/nixos/modules/services/logging/heartbeat.nix
@@ -67,12 +67,10 @@ in
     systemd.services.heartbeat = {
       description = "heartbeat log shipper";
       wantedBy = [ "multi-user.target" ];
-      preStart = ''
-        mkdir -p "${cfg.stateDir}"/{data,logs}
-      '';
       serviceConfig = {
         User = "nobody";
         AmbientCapabilities = "cap_net_raw";
+        ExecStartPre = "${lib.getExe' pkgs.coreutils "mkdir"} -p '${cfg.stateDir}'/data '${cfg.stateDir}'/logs";
         ExecStart = "${cfg.package}/bin/heartbeat -c \"${heartbeatYml}\" -path.data \"${cfg.stateDir}/data\" -path.logs \"${cfg.stateDir}/logs\"";
       };
     };

--- a/nixos/modules/services/logging/journalbeat.nix
+++ b/nixos/modules/services/logging/journalbeat.nix
@@ -71,12 +71,12 @@ in
       wantedBy = [ "multi-user.target" ];
       wants = [ "elasticsearch.service" ];
       after = [ "elasticsearch.service" ];
-      preStart = ''
-        mkdir -p ${cfg.stateDir}/data
-        mkdir -p ${cfg.stateDir}/logs
-      '';
       serviceConfig = {
         StateDirectory = cfg.stateDir;
+        ExecStartPre = [
+          "${lib.getExe' pkgs.coreutils "mkdir"} -p ${cfg.stateDir}/data"
+          "${lib.getExe' pkgs.coreutils "mkdir"} -p ${cfg.stateDir}/logs"
+        ];
         ExecStart = ''
           ${cfg.package}/bin/journalbeat \
             -c ${journalbeatYml} \

--- a/nixos/modules/services/logging/journaldriver.nix
+++ b/nixos/modules/services/logging/journaldriver.nix
@@ -91,12 +91,12 @@ in
   config = mkIf cfg.enable {
     systemd.services.journaldriver = {
       description = "Stackdriver Logging journal forwarder";
-      script = "${pkgs.journaldriver}/bin/journaldriver";
       wants = [ "network-online.target" ];
       after = [ "network-online.target" ];
       wantedBy = [ "multi-user.target" ];
 
       serviceConfig = {
+        ExecStart = lib.getExe pkgs.journaldriver;
         Restart = "always";
         DynamicUser = true;
 

--- a/nixos/modules/services/logging/promtail.nix
+++ b/nixos/modules/services/logging/promtail.nix
@@ -66,14 +66,11 @@ in
       wantedBy = [ "multi-user.target" ];
       stopIfChanged = false;
 
-      preStart = ''
-        ${lib.getExe pkgs.promtail} -config.file=${configFile} -check-syntax
-      '';
-
       serviceConfig = {
         Restart = "on-failure";
         TimeoutStopSec = 10;
 
+        ExecStartPre = "${lib.getExe pkgs.promtail} -config.file=${configFile} -check-syntax";
         ExecStart = "${pkgs.promtail}/bin/promtail -config.file=${configFile} ${escapeShellArgs cfg.extraFlags}";
 
         ProtectSystem = "strict";

--- a/nixos/modules/services/logging/syslog-ng.nix
+++ b/nixos/modules/services/logging/syslog-ng.nix
@@ -79,7 +79,6 @@ in
   config = lib.mkIf cfg.enable {
     systemd.services.syslog-ng = {
       description = "syslog-ng daemon";
-      preStart = "mkdir -p /{var,run}/syslog-ng";
       wantedBy = [ "multi-user.target" ];
       after = [ "multi-user.target" ]; # makes sure hostname etc is set
       serviceConfig = {
@@ -87,6 +86,7 @@ in
         PIDFile = pidFile;
         StandardOutput = "null";
         Restart = "on-failure";
+        ExecStartPre = "${lib.getExe' pkgs.coreutils "mkdir"} -p /var/syslog-ng /run/syslog-ng";
         ExecStart = "${cfg.package}/sbin/syslog-ng ${lib.concatStringsSep " " syslogngOptions}";
         ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
       };

--- a/nixos/modules/services/mail/cyrus-imap.nix
+++ b/nixos/modules/services/mail/cyrus-imap.nix
@@ -342,6 +342,7 @@ in
         User = if (cfg.user == null) then "cyrus" else cfg.user;
         Group = if (cfg.group == null) then "cyrus" else cfg.group;
         Type = "simple";
+        ExecStartPre = "${lib.getExe' pkgs.coreutils "mkdir"} -p '${cfg.imapdSettings.configdirectory}/socket' '${cfg.tmpDBDir}' /run/cyrus/proc /run/cyrus/lock";
         ExecStart = "${cyrus-imapdPkg}/libexec/master -l $LISTENQUEUE -C /etc/imapd.conf -M /etc/cyrus.conf -p /run/cyrus/master.pid -D";
         Restart = "on-failure";
         RestartSec = "1s";
@@ -367,9 +368,6 @@ in
         RestrictNamespaces = true;
         RestrictRealtime = true;
       };
-      preStart = ''
-        mkdir -p '${cfg.imapdSettings.configdirectory}/socket' '${cfg.tmpDBDir}' /run/cyrus/proc /run/cyrus/lock
-      '';
     };
     environment.systemPackages = [ cyrus-imapdPkg ];
   };

--- a/nixos/modules/services/mail/dkimproxy-out.nix
+++ b/nixos/modules/services/mail/dkimproxy-out.nix
@@ -109,10 +109,8 @@ in
             chown -R dkimproxy-out:dkimproxy-out "${keydir}"
           fi
         '';
-        script = ''
-          exec ${pkgs.dkimproxy}/bin/dkimproxy.out --conf_file=${configfile}
-        '';
         serviceConfig = {
+          ExecStart = "${pkgs.dkimproxy}/bin/dkimproxy.out --conf_file=${configfile}";
           User = "dkimproxy-out";
           PermissionsStartOnly = true;
         };

--- a/nixos/modules/services/mail/nullmailer.nix
+++ b/nixos/modules/services/mail/nullmailer.nix
@@ -245,13 +245,13 @@
         wantedBy = [ "multi-user.target" ];
         after = [ "network.target" ];
 
-        preStart = ''
-          rm -f /var/spool/nullmailer/trigger && mkfifo -m 660 /var/spool/nullmailer/trigger
-        '';
-
         serviceConfig = {
           User = cfg.user;
           Group = cfg.group;
+          ExecStartPre = [
+            "${lib.getExe' pkgs.coreutils "rm"} -f /var/spool/nullmailer/trigger"
+            "${lib.getExe' pkgs.coreutils "mkfifo"} -m 660 /var/spool/nullmailer/trigger"
+          ];
           ExecStart = "${pkgs.nullmailer}/bin/nullmailer-send";
           Restart = "always";
         };

--- a/nixos/modules/services/mail/postgrey.nix
+++ b/nixos/modules/services/mail/postgrey.nix
@@ -210,13 +210,13 @@ in
         description = "Postfix Greylisting Service";
         wantedBy = [ "multi-user.target" ];
         before = [ "postfix.service" ];
-        preStart = ''
-          mkdir -p /var/postgrey
-          chown postgrey:postgrey /var/postgrey
-          chmod 0770 /var/postgrey
-        '';
         serviceConfig = {
           Type = "simple";
+          ExecStartPre = [
+            "${lib.getExe' pkgs.coreutils "mkdir"} -p /var/postgrey"
+            "${lib.getExe' pkgs.coreutils "chown"} postgrey:postgrey /var/postgrey"
+            "${lib.getExe' pkgs.coreutils "chmod"} 0770 /var/postgrey"
+          ];
           ExecStart = ''
             ${pkgs.postgrey}/bin/postgrey \
                       ${bind-flag} \

--- a/nixos/modules/services/mail/stalwart-mail.nix
+++ b/nixos/modules/services/mail/stalwart-mail.nix
@@ -162,16 +162,6 @@ in
           "network.target"
         ];
 
-        preStart =
-          if useLegacyStorage then
-            ''
-              mkdir -p ${cfg.dataDir}/data/blobs
-            ''
-          else
-            ''
-              mkdir -p ${cfg.dataDir}/db
-            '';
-
         serviceConfig = {
           # Upstream service config
           Type = "simple";
@@ -182,6 +172,15 @@ in
           RestartSec = 5;
           SyslogIdentifier = "stalwart-mail";
 
+          ExecStartPre =
+            if useLegacyStorage then
+              ''
+                ${lib.getExe' pkgs.coreutils "mkdir"} -p ${cfg.dataDir}/data/blobs
+              ''
+            else
+              ''
+                ${lib.getExe' pkgs.coreutils "mkdir"} -p ${cfg.dataDir}/db
+              '';
           ExecStart = [
             ""
             "${lib.getExe cfg.package} --config=${configFile}"

--- a/nixos/modules/services/misc/autofs.nix
+++ b/nixos/modules/services/misc/autofs.nix
@@ -88,14 +88,11 @@ in
       wants = [ "network-online.target" ];
       wantedBy = [ "multi-user.target" ];
 
-      preStart = ''
-        # There should be only one autofs service managed by systemd, so this should be safe.
-        rm -f /tmp/autofs-running
-      '';
-
       serviceConfig = {
         Type = "forking";
         PIDFile = "/run/autofs.pid";
+        # There should be only one autofs service managed by systemd, so this should be safe.
+        ExecStartPre = "${lib.getExe' pkgs.coreutils "rm"} -f /tmp/autofs-running";
         ExecStart = "${pkgs.autofs5}/bin/automount ${lib.optionalString cfg.debug "-d"} -p /run/autofs.pid -t ${toString cfg.timeout} ${autoMaster}";
         ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
       };

--- a/nixos/modules/services/misc/dictd.nix
+++ b/nixos/modules/services/misc/dictd.nix
@@ -78,7 +78,7 @@ in
         # with code 143 instead of exiting with code 0.
         serviceConfig.SuccessExitStatus = [ 143 ];
         serviceConfig.Type = "forking";
-        script = "${pkgs.dict}/sbin/dictd -s -c ${dictdb}/share/dictd/dictd.conf --locale en_US.UTF-8";
+        serviceConfig.ExecStart = "${pkgs.dict}/sbin/dictd -s -c ${dictdb}/share/dictd/dictd.conf --locale en_US.UTF-8";
       };
     };
 }

--- a/nixos/modules/services/misc/docker-registry.nix
+++ b/nixos/modules/services/misc/docker-registry.nix
@@ -143,11 +143,9 @@ in
       description = "Docker Container Registry";
       wantedBy = [ "multi-user.target" ];
       after = [ "network.target" ];
-      script = ''
-        ${cfg.package}/bin/registry serve ${configFile}
-      '';
 
       serviceConfig = {
+        ExecStart = "${lib.getExe cfg.package} serve ${configFile}";
         User = "docker-registry";
         WorkingDirectory = cfg.storagePath;
         AmbientCapabilities = lib.mkIf (cfg.port < 1024) "cap_net_bind_service";

--- a/nixos/modules/services/misc/errbot.nix
+++ b/nixos/modules/services/misc/errbot.nix
@@ -100,13 +100,13 @@ in
         {
           after = [ "network-online.target" ];
           wantedBy = [ "multi-user.target" ];
-          preStart = ''
-            mkdir -p ${dataDir}
-            chown -R errbot:errbot ${dataDir}
-          '';
           serviceConfig = {
             User = "errbot";
             Restart = "on-failure";
+            ExecStartPre = [
+              "${lib.getExe' pkgs.coreutils "mkdir"} -p ${dataDir}"
+              "${lib.getExe' pkgs.coreutils "chown"} -R errbot:errbot ${dataDir}"
+            ];
             ExecStart = "${pkgs.errbot}/bin/errbot -c ${mkConfigDir instanceCfg dataDir}/config.py";
             PermissionsStartOnly = true;
           };


### PR DESCRIPTION
This is a partial revert of 39e9380

This PR goes over a few nixos modules where `script`/`preStart` was easily replacable with `ExecStart`/`ExecStartPre`.
This gets rid of unnecessary bash wrappers, and lets you see the command being run directly when running `systemctl cat <name>.service`.

It also makes some of the services usable with the bashless profile.

Since this is more or less a manual treewide, this is a single PR in a set of PRs that has been split into reviewable chunks.

<details>
<summary>NixOS test coverage</summary>

Modules with the checkbox checked have tests.

- [ ] autofs
- [ ] boinc
- [X] cyrus-imap
- [X] dictd
- [ ] dkimproxy-out
- [ ] docker-registry (Broken on main, but works via gitlab)
- [ ] errbot
- [ ] heartbeat
- [X] geth
- [X] journalbeat (via elk)
- [ ] journaldriver
- [ ] nullmailer (#452850)
- [ ] pommed
- [ ] postgrey
- [ ] promtail
- [ ] soteria
- [X] stalwart-mail
- [ ] syslog-ng
- [X] zigbee2mqtt

`NIXPKGS_ALLOW_UNFREE=1 nix build .#nixosTests.cyrus-imap .#nixosTests.dictd .#nixosTests.gitlab.gitlab .#nixosTests.geth .#nixosTests.elk.unfree.ELK-7 .#nixosTests.stalwart-mail .#nixosTests.zigbee2mqtt --impure -L`

</details>


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
