### PR TITLE
(Part 2) various: replace `systemd.services.<name>.{script,preStart}` with `ExecStart{,Pre}`

### DIFF
--- a/nixos/modules/services/misc/paperless.nix
+++ b/nixos/modules/services/misc/paperless.nix
@@ -703,6 +703,9 @@ in
           serviceConfig = {
             User = cfg.user;
             WorkingDirectory = cfg.dataDir;
+            ExecStart = "${manage}/bin/paperless-manage document_exporter ${cfg.exporter.directory} ${
+              lib.cli.toCommandLineShellGNU { } cfg.exporter.settings
+            }";
           };
           unitConfig =
             let
@@ -721,13 +724,7 @@ in
               OnFailure = services;
               OnSuccess = services;
             };
-          enableStrictShellChecks = true;
           path = [ manage ];
-          script = ''
-            paperless-manage document_exporter ${cfg.exporter.directory} ${
-              lib.cli.toCommandLineShellGNU { } cfg.exporter.settings
-            }
-          '';
         };
       })
     ]

--- a/nixos/modules/services/misc/svnserve.nix
+++ b/nixos/modules/services/misc/svnserve.nix
@@ -40,8 +40,8 @@ in
     systemd.services.svnserve = {
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
-      preStart = "mkdir -p ${cfg.svnBaseDir}";
-      script = "${pkgs.subversion.out}/bin/svnserve -r ${cfg.svnBaseDir} -d --foreground --pid-file=/run/svnserve.pid";
+      serviceConfig.ExecStartPre = "${lib.getExe' pkgs.coreutils "mkdir"} -p ${cfg.svnBaseDir}";
+      serviceConfig.ExecStart = "${pkgs.subversion.out}/bin/svnserve -r ${cfg.svnBaseDir} -d --foreground --pid-file=/run/svnserve.pid";
     };
   };
 }

--- a/nixos/modules/services/misc/tandoor-recipes.nix
+++ b/nixos/modules/services/misc/tandoor-recipes.nix
@@ -129,6 +129,12 @@ in
       after = lib.optional cfg.database.createLocally "postgresql.target";
 
       serviceConfig = {
+        ExecStartPre = [
+          "${lib.getExe' pkgs.coreutils "ln"} -sf ${manage} tandoor-recipes-manage"
+
+          # Let django migrate the DB as needed
+          "${lib.getExe pkg} migrate"
+        ];
         ExecStart = ''
           ${pkg.python.pkgs.gunicorn}/bin/gunicorn recipes.wsgi
         '';
@@ -184,13 +190,6 @@ in
       };
 
       wantedBy = [ "multi-user.target" ];
-
-      preStart = ''
-        ln -sf ${manage} tandoor-recipes-manage
-
-        # Let django migrate the DB as needed
-        ${pkg}/bin/tandoor-recipes migrate
-      '';
 
       environment = env // {
         PYTHONPATH = "${pkg.python.pkgs.makePythonPath pkg.propagatedBuildInputs}:${pkg}/lib/tandoor-recipes";

--- a/nixos/modules/services/monitoring/prometheus/exporters/pgbouncer.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/pgbouncer.nix
@@ -139,9 +139,9 @@ in
 
   serviceOpts = {
     after = [ "pgbouncer.service" ];
-    script = concatStringsSep " " (
+    serviceConfig.ExecStart = concatStringsSep " " (
       [
-        "exec -- ${escapeShellArg (getExe cfg.package)}"
+        "${escapeShellArg (getExe cfg.package)}"
         "--web.listen-address ${cfg.listenAddress}:${toString cfg.port}"
       ]
       ++ optionals (cfg.connectionString != null) [

--- a/nixos/modules/services/networking/freeradius.nix
+++ b/nixos/modules/services/networking/freeradius.nix
@@ -13,11 +13,9 @@ let
     wantedBy = [ "multi-user.target" ];
     after = [ "network.target" ];
     wants = [ "network.target" ];
-    preStart = ''
-      ${cfg.package}/bin/radiusd -C -d ${cfg.configDir} -l stdout
-    '';
 
     serviceConfig = {
+      ExecStartPre = "${cfg.package}/bin/radiusd -C -d ${cfg.configDir} -l stdout";
       ExecStart =
         "${cfg.package}/bin/radiusd -f -d ${cfg.configDir} -l stdout" + lib.optionalString cfg.debug " -xx";
       ExecReload = [

--- a/nixos/modules/services/networking/ircd-hybrid/default.nix
+++ b/nixos/modules/services/networking/ircd-hybrid/default.nix
@@ -152,7 +152,7 @@ in
       wants = [ "network-online.target" ];
       after = [ "network-online.target" ];
       wantedBy = [ "multi-user.target" ];
-      script = "${ircdService}/bin/control start";
+      serviceConfig.ExecStart = "${ircdService}/bin/control start";
     };
   };
 }

--- a/nixos/modules/services/networking/nghttpx/default.nix
+++ b/nixos/modules/services/networking/nghttpx/default.nix
@@ -112,11 +112,9 @@ in
       nghttpx = {
         wantedBy = [ "multi-user.target" ];
         after = [ "network.target" ];
-        script = ''
-          ${pkgs.nghttp2}/bin/nghttpx --conf=${configurationFile}
-        '';
 
         serviceConfig = {
+          ExecStart = "${pkgs.nghttp2}/bin/nghttpx --conf=${configurationFile}";
           Restart = "on-failure";
           RestartSec = 60;
         };

--- a/nixos/modules/services/networking/nm-file-secret-agent.nix
+++ b/nixos/modules/services/networking/nm-file-secret-agent.nix
@@ -131,7 +131,7 @@ in
       after = [ "NetworkManager.service" ];
       wantedBy = [ "multi-user.target" ];
       restartTriggers = [ nmFileSecretAgentConfigFile ];
-      script = "${lib.getExe cfg.ensureProfiles.secrets.package} --conf ${nmFileSecretAgentConfigFile}";
+      serviceConfig.ExecStart = "${lib.getExe cfg.ensureProfiles.secrets.package} --conf ${nmFileSecretAgentConfigFile}";
     };
   };
 }

--- a/nixos/modules/services/networking/oidentd.nix
+++ b/nixos/modules/services/networking/oidentd.nix
@@ -32,7 +32,7 @@ with lib;
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
       serviceConfig.Type = "forking";
-      script = "${pkgs.oidentd}/sbin/oidentd -u oidentd -g nogroup";
+      serviceConfig.ExecStart = "${lib.getExe pkgs.oidentd} -u oidentd -g nogroup";
     };
 
     users.users.oidentd = {

--- a/nixos/modules/services/networking/ostinato.nix
+++ b/nixos/modules/services/networking/ostinato.nix
@@ -108,9 +108,7 @@ in
     systemd.services.drone = {
       description = "Ostinato agent-controller";
       wantedBy = [ "multi-user.target" ];
-      script = ''
-        ${pkg}/bin/drone ${toString cfg.port} ${configFile}
-      '';
+      serviceConfig.ExecStart = "${pkg}/bin/drone ${toString cfg.port} ${configFile}";
     };
 
   };

--- a/nixos/modules/services/networking/pangolin.nix
+++ b/nixos/modules/services/networking/pangolin.nix
@@ -265,11 +265,6 @@ in
           requires = [ "network.target" ];
           after = [ "network.target" ];
 
-          preStart = ''
-            mkdir -p ${cfg.dataDir}/config
-            cp -f ${cfgFile} ${cfg.dataDir}/config/config.yml
-          '';
-
           serviceConfig = {
             User = "pangolin";
             Group = "fossorial";
@@ -340,6 +335,11 @@ in
               "~@setuid:EPERM"
               "~@swap:EPERM"
               "~@timer:EPERM"
+            ];
+
+            ExecStartPre = [
+              "${lib.getExe' pkgs.coreutils "mkdir"} -p ${cfg.dataDir}/config"
+              "${lib.getExe' pkgs.coreutils "cp"} -f ${cfgFile} ${cfg.dataDir}/config/config.yml"
             ];
             ExecStart = lib.getExe cfg.package;
           };

--- a/nixos/modules/services/networking/pdnsd.nix
+++ b/nixos/modules/services/networking/pdnsd.nix
@@ -80,13 +80,13 @@ in
     systemd.services.pdnsd = {
       wantedBy = [ "multi-user.target" ];
       after = [ "network.target" ];
-      preStart = ''
-        mkdir -p "${cfg.cacheDir}"
-        touch "${cfg.cacheDir}/pdnsd.cache"
-        chown -R ${pdnsdUser}:${pdnsdGroup} "${cfg.cacheDir}"
-      '';
       description = "pdnsd";
       serviceConfig = {
+        ExecStartPre = [
+          "${lib.getExe' pkgs.coreutils "mkdir"} -p '${cfg.cacheDir}'"
+          "${lib.getExe' pkgs.coreutils "touch"} '${cfg.cacheDir}/pdnsd.cache'"
+          "${lib.getExe' pkgs.coreutils "chown"} -R ${pdnsdUser}:${pdnsdGroup} '${cfg.cacheDir}'"
+        ];
         ExecStart = "${pdnsd}/bin/pdnsd -c ${pdnsdConf}";
       };
     };

--- a/nixos/modules/services/networking/redsocks.nix
+++ b/nixos/modules/services/networking/redsocks.nix
@@ -276,7 +276,7 @@ in
         description = "Redsocks";
         after = [ "network.target" ];
         wantedBy = [ "multi-user.target" ];
-        script = "${pkgs.redsocks}/bin/redsocks -c ${configfile}";
+        serviceConfig.ExecStart = "${lib.getExe pkgs.redsocks} -c ${configfile}";
       };
 
       networking.firewall.extraCommands = iptables;

--- a/nixos/modules/services/networking/smokeping.nix
+++ b/nixos/modules/services/networking/smokeping.nix
@@ -337,12 +337,12 @@ in
       serviceConfig = {
         User = cfg.user;
         Restart = "on-failure";
+        ExecStartPre = [
+          "${cfg.package}/bin/smokeping --check --config=${configPath}"
+          "${cfg.package}/bin/smokeping --static --config=${configPath}"
+        ];
         ExecStart = "${cfg.package}/bin/smokeping --config=/etc/smokeping.conf --nodaemon";
       };
-      preStart = ''
-        ${cfg.package}/bin/smokeping --check --config=${configPath}
-        ${cfg.package}/bin/smokeping --static --config=${configPath}
-      '';
     };
 
     systemd.tmpfiles.rules = [

--- a/nixos/modules/services/networking/supybot.nix
+++ b/nixos/modules/services/networking/supybot.nix
@@ -104,14 +104,12 @@ in
       documentation = [ "https://limnoria.readthedocs.io/" ];
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
-      preStart = ''
-        # This needs to be created afresh every time
-        rm -f '${cfg.stateDir}/supybot.cfg.bak'
-      '';
 
       startLimitIntervalSec = 5 * 60; # 5 min
       startLimitBurst = 1;
       serviceConfig = {
+        # This needs to be created afresh every time
+        ExecStartPre = "${lib.getExe' pkgs.coreutils "rm"} -f '${cfg.stateDir}/supybot.cfg.bak'";
         ExecStart = "${pyEnv}/bin/supybot ${cfg.stateDir}/supybot.cfg";
         PIDFile = "/run/supybot.pid";
         User = "supybot";

--- a/nixos/modules/services/networking/tailscale.nix
+++ b/nixos/modules/services/networking/tailscale.nix
@@ -243,10 +243,8 @@ in
       wantedBy = [ "multi-user.target" ];
       serviceConfig = {
         Type = "oneshot";
+        ExecStart = "${lib.getExe cfg.package} set ${escapeShellArgs cfg.extraSetFlags}";
       };
-      script = ''
-        ${lib.getExe cfg.package} set ${escapeShellArgs cfg.extraSetFlags}
-      '';
     };
 
     boot.kernel.sysctl = mkIf (cfg.useRoutingFeatures == "server" || cfg.useRoutingFeatures == "both") {

--- a/nixos/modules/services/networking/thelounge.nix
+++ b/nixos/modules/services/networking/thelounge.nix
@@ -114,11 +114,11 @@ in
       wantedBy = [ "multi-user.target" ];
       after = [ "network-online.target" ];
       wants = [ "network-online.target" ];
-      preStart = "ln -sf ${pkgs.writeText "config.js" configJsData} ${dataDir}/config.js";
       environment.THELOUNGE_PACKAGES = mkIf (cfg.plugins != [ ]) "${plugins}";
       serviceConfig = {
         User = "thelounge";
         StateDirectory = baseNameOf dataDir;
+        ExecStartPre = "${lib.getExe' pkgs.coreutils "ln"} -sf ${pkgs.writeText "config.js" configJsData} ${dataDir}/config.js";
         ExecStart = "${getExe cfg.package} start";
       };
     };

--- a/nixos/tests/paperless.nix
+++ b/nixos/tests/paperless.nix
@@ -119,9 +119,9 @@
           assert "1 timers listed." in timers, "incorrect number of timers"
 
           # Double check that our attrset option override works as expected
-          cmdline = node.succeed("grep 'paperless-manage' $(systemctl cat paperless-exporter | grep ExecStart | cut -f 2 -d=)")
+          cmdline = node.succeed("systemctl cat paperless-exporter | grep ExecStart | grep 'paperless-manage' | cut -f 2 -d=")
           print(f"Exporter command line {cmdline!r}")
-          assert cmdline.strip() == "paperless-manage document_exporter /var/lib/paperless/export --compare-checksums --delete --no-progress-bar --no-thumbnail", "Unexpected exporter command line"
+          assert cmdline.strip().endswith("paperless-manage document_exporter /var/lib/paperless/export --compare-checksums --delete --no-progress-bar --no-thumbnail"), "Unexpected exporter command line"
 
     test_paperless(simple)
     simple.send_monitor_command("quit")


### PR DESCRIPTION
This is a partial revert of 39e9380

This PR goes over a few nixos modules where `script`/`preStart` was easily replacable with `ExecStart`/`ExecStartPre`.
This gets rid of unnecessary bash wrappers, and lets you see the command being run directly when running `systemctl cat <name>.service`.

It also makes some of the services usable with the bashless profile.

Since this is more or less a manual treewide, this is a single PR in a set of PRs that has been split into reviewable chunks.

Part 1: #481637

<details>
<summary>NixOS test coverage</summary>

Modules with the checkbox checked have tests.

- [ ] freeradius
- [ ] ircd-hybrid
- [X] nghttpx
- [ ] nm-file-secret-agent
- [ ] oidentd (#456126)
- [ ] ostinato
- [X] pangolin
- [X] paperless
- [ ] pdnsd
- [X] prometheus-exporters.pgbouncer
- [ ] redsocks
- [X] smokeping
- [ ] supybot
- [X] svnserve
- [X] tailscale (via `headscale`)
- [X] tandoor-recipes
- [X] thelounge

`nix build .#nixosTests.paperless .#nixosTests.svnserve .#nixosTests.tandoor-recipes .#nixosTests.tandoor-recipes-media .#nixosTests.tandoor-recipes-script-name .#nixosTests.prometheus-exporters.pgbouncer .#nixosTests.nghttpx .#nixosTests.pangolin .#nixosTests.smokeping .#nixosTests.headscale .#nixosTests.thelounge -L`

</details>


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
