### PR TITLE
(Part 3) various: replace `systemd.services.<name>.{script,preStart}` with `ExecStart{,Pre}`

### DIFF
--- a/nixos/modules/services/networking/tinydns.nix
+++ b/nixos/modules/services/networking/tinydns.nix
@@ -58,10 +58,11 @@ with lib;
         ln -sf ${pkgs.writeText "tinydns-data" config.services.tinydns.data} data
         tinydns-data
       '';
-      script = ''
-        cd /var/lib/tinydns
-        exec ./run
-      '';
+      serviceConfig = {
+        StateDirectory = "tinydns";
+        WorkingDirectory = "/var/lib/tinydns";
+        ExecStart = "/var/lib/tinydns/run";
+      };
     };
   };
 }

--- a/nixos/modules/services/networking/toxvpn.nix
+++ b/nixos/modules/services/networking/toxvpn.nix
@@ -43,20 +43,19 @@ with lib;
       wantedBy = [ "multi-user.target" ];
       after = [ "network.target" ];
 
-      preStart = ''
-        mkdir -p /run/toxvpn || true
-        chown toxvpn /run/toxvpn
-      '';
-
-      path = [ pkgs.toxvpn ];
-
-      script = ''
-        exec toxvpn -i ${config.services.toxvpn.localip} -l /run/toxvpn/control -u toxvpn -p ${toString config.services.toxvpn.port} ${
-          lib.concatMapStringsSep " " (x: "-a ${x}") config.services.toxvpn.auto_add_peers
-        }
-      '';
-
       serviceConfig = {
+        ExecStart =
+          let
+            args = lib.cli.toCommandLineShellGNU { } {
+              i = config.services.toxvpn.localip;
+              l = "/run/toxvpn/control";
+              u = "toxvpn";
+              p = config.services.toxvpn.port;
+              a = config.services.toxvpn.auto_add_peers;
+            };
+          in
+          "${lib.getExe pkgs.toxvpn} ${args}";
+        RuntimeDirectory = "toxvpn";
         KillMode = "process";
         Restart = "on-success";
         Type = "notify";

--- a/nixos/modules/services/networking/twingate.nix
+++ b/nixos/modules/services/networking/twingate.nix
@@ -17,7 +17,7 @@ in
   config = lib.mkIf cfg.enable {
     systemd.packages = [ cfg.package ];
     systemd.services.twingate = {
-      preStart = "cp -r --update=none ${cfg.package}/etc/twingate/. /etc/twingate/";
+      serviceConfig.ExecStartPre = "${lib.getExe' pkgs.coreutils "cp"} -r --update=none ${cfg.package}/etc/twingate/. /etc/twingate/";
       wantedBy = [ "multi-user.target" ];
     };
 

--- a/nixos/modules/services/networking/xinetd.nix
+++ b/nixos/modules/services/networking/xinetd.nix
@@ -143,8 +143,7 @@ in
       description = "xinetd server";
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
-      path = [ pkgs.xinetd ];
-      script = "exec xinetd -syslog daemon -dontfork -stayalive -f ${configFile}";
+      serviceConfig.ExecStart = "${lib.getExe pkgs.xinetd} -syslog daemon -dontfork -stayalive -f ${configFile}";
     };
   };
 }

--- a/nixos/modules/services/networking/xray.nix
+++ b/nixos/modules/services/networking/xray.nix
@@ -93,10 +93,8 @@ with lib;
         description = "xray Daemon";
         after = [ "network.target" ];
         wantedBy = [ "multi-user.target" ];
-        script = ''
-          exec "${cfg.package}/bin/xray" -config "$CREDENTIALS_DIRECTORY/config.json"
-        '';
         serviceConfig = {
+          ExecStart = "${cfg.package}/bin/xray -config \"\${CREDENTIALS_DIRECTORY}\"/config.json";
           DynamicUser = true;
           LoadCredential = "config.json:${settingsFile}";
           CapabilityBoundingSet = "CAP_NET_ADMIN CAP_NET_BIND_SERVICE";

--- a/nixos/modules/services/networking/zerobin.nix
+++ b/nixos/modules/services/networking/zerobin.nix
@@ -91,14 +91,14 @@ in
       enable = true;
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
+      serviceConfig.ExecStartPre = [
+        "${lib.getExe' pkgs.coreutils "mkdir"} -p ${cfg.dataDir}"
+        "${lib.getExe' pkgs.coreutils "chown"} ${cfg.user} ${cfg.dataDir}"
+      ];
       serviceConfig.ExecStart = "${pkgs.zerobin}/bin/zerobin ${cfg.listenAddress} ${toString cfg.listenPort} false ${cfg.user} ${cfg.group} ${zerobin_config}";
       serviceConfig.PrivateTmp = "yes";
       serviceConfig.User = cfg.user;
       serviceConfig.Group = cfg.group;
-      preStart = ''
-        mkdir -p ${cfg.dataDir}
-        chown ${cfg.user} ${cfg.dataDir}
-      '';
     };
   };
 }

--- a/nixos/modules/services/security/authelia.nix
+++ b/nixos/modules/services/security/authelia.nix
@@ -375,10 +375,10 @@ in
             })
             // instance.environmentVariables;
 
-          preStart = "${execCommand} ${configArg} validate-config";
           serviceConfig = {
             User = instance.user;
             Group = instance.group;
+            ExecStartPre = "${execCommand} ${configArg} validate-config";
             ExecStart = "${execCommand} ${configArg}";
             Restart = "always";
             RestartSec = "5s";

--- a/nixos/modules/services/security/authelia.nix
+++ b/nixos/modules/services/security/authelia.nix
@@ -389,10 +389,10 @@ in
           // lib.mapAttrs (_: v: "%d/${v}") nonNullEnvSecretsMap
           // instance.environmentVariables;
 
-          preStart = "${execCommand} ${configArg} validate-config";
           serviceConfig = {
             User = instance.user;
             Group = instance.group;
+            ExecStartPre = "${execCommand} ${configArg} validate-config";
             ExecStart = "${execCommand} ${configArg}";
             Restart = "always";
             RestartSec = "5s";

--- a/nixos/modules/services/security/certmgr.nix
+++ b/nixos/modules/services/security/certmgr.nix
@@ -34,11 +34,6 @@ let
         [ spec ]
     ) (lib.attrValues cfg.specs)
   );
-
-  preStart = ''
-    ${lib.concatStringsSep " \\\n" ([ "mkdir -p" ] ++ map lib.escapeShellArg specPaths)}
-    ${cfg.package}/bin/certmgr -f ${certmgrYaml} check
-  '';
 in
 {
   options.services.certmgr = {
@@ -215,11 +210,14 @@ in
       wants = [ "network-online.target" ];
       after = [ "network-online.target" ];
       wantedBy = [ "multi-user.target" ];
-      inherit preStart;
 
       serviceConfig = {
         Restart = "always";
         RestartSec = "10s";
+        ExecStartPre = [
+          "${lib.getExe' pkgs.coreutils "mkdir"} -p ${lib.escapeShellArgs specPaths}"
+          "${lib.getExe cfg.package} -f ${certmgrYaml} check"
+        ];
         ExecStart = "${cfg.package}/bin/certmgr -f ${certmgrYaml}";
       };
     };

--- a/nixos/modules/services/security/hologram-agent.nix
+++ b/nixos/modules/services/security/hologram-agent.nix
@@ -55,10 +55,8 @@ in
         "network-link-dummy0.service"
         "network-addresses-dummy0.service"
       ];
-      preStart = ''
-        /run/current-system/sw/bin/rm -fv /run/hologram.sock
-      '';
       serviceConfig = {
+        ExecStartPre = "/run/current-system/sw/bin/rm -fv /run/hologram.sock";
         ExecStart = "${pkgs.hologram}/bin/hologram-agent -debug -conf ${cfgFile} -port ${cfg.httpPort}";
       };
     };

--- a/nixos/modules/services/web-apps/bluemap.nix
+++ b/nixos/modules/services/web-apps/bluemap.nix
@@ -298,10 +298,8 @@ in
         Type = "oneshot";
         Group = "nginx";
         UMask = "026";
+        ExecStart = "${lib.getExe pkgs.bluemap} -c ${configFolder} -gs -r";
       };
-      script = ''
-        ${lib.getExe pkgs.bluemap} -c ${configFolder} -gs -r
-      '';
     };
 
     systemd.timers."render-bluemap-maps" = lib.mkIf cfg.enableRender {

--- a/nixos/modules/services/web-apps/cloudlog.nix
+++ b/nixos/modules/services/web-apps/cloudlog.nix
@@ -383,37 +383,44 @@ in
         cloudlog-upload-lotw = {
           description = "Upload QSOs to LoTW if certs have been provided";
           enable = cfg.upload-lotw.enable;
-          script = "${pkgs.curl}/bin/curl -s ${cfg.baseUrl}/lotw/lotw_upload";
+          serviceConfig.ExecStart = "${lib.getExe pkgs.curl} -s ${cfg.baseUrl}/lotw/lotw_upload";
+          serviceConfig.Type = "oneshot";
         };
         cloudlog-update-lotw-users = {
           description = "Update LOTW Users Database";
           enable = cfg.update-lotw-users.enable;
-          script = "${pkgs.curl}/bin/curl -s ${cfg.baseUrl}/lotw/load_users";
+          serviceConfig.ExecStart = "${lib.getExe pkgs.curl} -s ${cfg.baseUrl}/lotw/load_users";
+          serviceConfig.Type = "oneshot";
         };
         cloudlog-update-dok = {
           description = "Update DOK File for autocomplete";
           enable = cfg.update-dok.enable;
-          script = "${pkgs.curl}/bin/curl -s ${cfg.baseUrl}/update/update_dok";
+          serviceConfig.ExecStart = "${lib.getExe pkgs.curl} -s ${cfg.baseUrl}/update/update_dok";
+          serviceConfig.Type = "oneshot";
         };
         cloudlog-update-clublog-scp = {
           description = "Update Clublog SCP Database File";
           enable = cfg.update-clublog-scp.enable;
-          script = "${pkgs.curl}/bin/curl -s ${cfg.baseUrl}/update/update_clublog_scp";
+          serviceConfig.ExecStart = "${lib.getExe pkgs.curl} -s ${cfg.baseUrl}/update/update_clublog_scp";
+          serviceConfig.Type = "oneshot";
         };
         cloudlog-update-wwff = {
           description = "Update WWFF File for autocomplete";
           enable = cfg.update-wwff.enable;
-          script = "${pkgs.curl}/bin/curl -s ${cfg.baseUrl}/update/update_wwff";
+          serviceConfig.ExecStart = "${lib.getExe pkgs.curl} -s ${cfg.baseUrl}/update/update_wwff";
+          serviceConfig.Type = "oneshot";
         };
         cloudlog-upload-qrz = {
           description = "Upload QSOs to QRZ Logbook";
           enable = cfg.upload-qrz.enable;
-          script = "${pkgs.curl}/bin/curl -s ${cfg.baseUrl}/qrz/upload";
+          serviceConfig.ExecStart = "${lib.getExe pkgs.curl} -s ${cfg.baseUrl}/qrz/upload";
+          serviceConfig.Type = "oneshot";
         };
         cloudlog-update-sota = {
           description = "Update SOTA File for autocomplete";
           enable = cfg.update-sota.enable;
-          script = "${pkgs.curl}/bin/curl -s ${cfg.baseUrl}/update/update_sota";
+          serviceConfig.ExecStart = "${lib.getExe pkgs.curl} -s ${cfg.baseUrl}/update/update_sota";
+          serviceConfig.Type = "oneshot";
         };
       };
       timers = {

--- a/nixos/modules/services/web-apps/cloudlog.nix
+++ b/nixos/modules/services/web-apps/cloudlog.nix
@@ -380,37 +380,44 @@ in
         cloudlog-upload-lotw = {
           description = "Upload QSOs to LoTW if certs have been provided";
           enable = cfg.upload-lotw.enable;
-          script = "${pkgs.curl}/bin/curl -s ${cfg.baseUrl}/lotw/lotw_upload";
+          serviceConfig.ExecStart = "${lib.getExe pkgs.curl} -s ${cfg.baseUrl}/lotw/lotw_upload";
+          serviceConfig.Type = "oneshot";
         };
         cloudlog-update-lotw-users = {
           description = "Update LOTW Users Database";
           enable = cfg.update-lotw-users.enable;
-          script = "${pkgs.curl}/bin/curl -s ${cfg.baseUrl}/lotw/load_users";
+          serviceConfig.ExecStart = "${lib.getExe pkgs.curl} -s ${cfg.baseUrl}/lotw/load_users";
+          serviceConfig.Type = "oneshot";
         };
         cloudlog-update-dok = {
           description = "Update DOK File for autocomplete";
           enable = cfg.update-dok.enable;
-          script = "${pkgs.curl}/bin/curl -s ${cfg.baseUrl}/update/update_dok";
+          serviceConfig.ExecStart = "${lib.getExe pkgs.curl} -s ${cfg.baseUrl}/update/update_dok";
+          serviceConfig.Type = "oneshot";
         };
         cloudlog-update-clublog-scp = {
           description = "Update Clublog SCP Database File";
           enable = cfg.update-clublog-scp.enable;
-          script = "${pkgs.curl}/bin/curl -s ${cfg.baseUrl}/update/update_clublog_scp";
+          serviceConfig.ExecStart = "${lib.getExe pkgs.curl} -s ${cfg.baseUrl}/update/update_clublog_scp";
+          serviceConfig.Type = "oneshot";
         };
         cloudlog-update-wwff = {
           description = "Update WWFF File for autocomplete";
           enable = cfg.update-wwff.enable;
-          script = "${pkgs.curl}/bin/curl -s ${cfg.baseUrl}/update/update_wwff";
+          serviceConfig.ExecStart = "${lib.getExe pkgs.curl} -s ${cfg.baseUrl}/update/update_wwff";
+          serviceConfig.Type = "oneshot";
         };
         cloudlog-upload-qrz = {
           description = "Upload QSOs to QRZ Logbook";
           enable = cfg.upload-qrz.enable;
-          script = "${pkgs.curl}/bin/curl -s ${cfg.baseUrl}/qrz/upload";
+          serviceConfig.ExecStart = "${lib.getExe pkgs.curl} -s ${cfg.baseUrl}/qrz/upload";
+          serviceConfig.Type = "oneshot";
         };
         cloudlog-update-sota = {
           description = "Update SOTA File for autocomplete";
           enable = cfg.update-sota.enable;
-          script = "${pkgs.curl}/bin/curl -s ${cfg.baseUrl}/update/update_sota";
+          serviceConfig.ExecStart = "${lib.getExe pkgs.curl} -s ${cfg.baseUrl}/update/update_sota";
+          serviceConfig.Type = "oneshot";
         };
       };
       timers = {

--- a/nixos/modules/services/web-apps/galene.nix
+++ b/nixos/modules/services/web-apps/galene.nix
@@ -133,19 +133,16 @@ in
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
 
-      preStart = ''
-        ${optionalString (cfg.insecure != true && cfg.certFile != null && cfg.keyFile != null) ''
-          install -m 700 -o '${cfg.user}' -g '${cfg.group}' ${cfg.certFile} ${cfg.dataDir}/cert.pem
-          install -m 700 -o '${cfg.user}' -g '${cfg.group}' ${cfg.keyFile} ${cfg.dataDir}/key.pem
-        ''}
-      '';
-
       serviceConfig = mkMerge [
         {
           Type = "simple";
           User = cfg.user;
           Group = cfg.group;
           WorkingDirectory = cfg.stateDir;
+          ExecStartPre = lib.mkIf (cfg.insecure != true && cfg.certFile != null && cfg.keyFile != null) [
+            "${lib.getExe' pkgs.coreutils "install"} -m 700 -o '${cfg.user}' -g '${cfg.group}' ${cfg.certFile} ${cfg.dataDir}/cert.pem"
+            "${lib.getExe' pkgs.coreutils "install"} -m 700 -o '${cfg.user}' -g '${cfg.group}' ${cfg.keyFile} ${cfg.dataDir}/key.pem"
+          ];
           ExecStart = ''
             ${cfg.package}/bin/galene \
             ${optionalString (cfg.insecure) "-insecure"} \

--- a/nixos/modules/services/web-apps/glitchtip.nix
+++ b/nixos/modules/services/web-apps/glitchtip.nix
@@ -236,11 +236,8 @@ in
         glitchtip = commonService // {
           description = "GlitchTip";
 
-          preStart = ''
-            ${lib.getExe pkg} migrate
-          '';
-
           serviceConfig = commonServiceConfig // {
+            ExecStartPre = "${lib.getExe pkg} migrate";
             ExecStart = ''
               ${lib.getExe python.pkgs.gunicorn} \
                 --bind=${cfg.listenAddress}:${toString cfg.port} \

--- a/nixos/modules/services/web-apps/glitchtip.nix
+++ b/nixos/modules/services/web-apps/glitchtip.nix
@@ -280,13 +280,12 @@ in
           bindsTo = [ "glitchtip-worker.service" ];
           before = [ "glitchtip-worker.service" ];
 
-          preStart = ''
-            ${lib.getExe pkg} migrate
-            ${lib.getExe pkg} createcachetable
-            ${lib.getExe pkg} maintain_partitions
-          '';
-
           serviceConfig = commonServiceConfig // {
+            ExecStartPre = [
+              "${lib.getExe pkg} migrate"
+              "${lib.getExe pkg} createcachetable"
+              "${lib.getExe pkg} maintain_partitions"
+            ];
             ExecStart = ''
               ${lib.getExe python.pkgs.granian} \
                 --interface ${if cfg.settings.GLITCHTIP_ENABLE_MCP then "asgi" else "asginl"} \

--- a/nixos/modules/services/web-apps/healthchecks.nix
+++ b/nixos/modules/services/web-apps/healthchecks.nix
@@ -237,14 +237,13 @@ in
           wantedBy = [ "healthchecks.target" ];
           after = [ "healthchecks-migration.service" ];
 
-          preStart = ''
-            ${pkg}/opt/healthchecks/manage.py collectstatic --no-input
-            ${pkg}/opt/healthchecks/manage.py remove_stale_contenttypes --no-input
-          ''
-          + lib.optionalString (cfg.settings.DEBUG != "True") "${pkg}/opt/healthchecks/manage.py compress";
-
           serviceConfig = commonConfig // {
             Restart = "always";
+            ExecStartPre = [
+              "${pkg}/opt/healthchecks/manage.py collectstatic --no-input"
+              "${pkg}/opt/healthchecks/manage.py remove_stale_contenttypes --no-input"
+            ]
+            ++ lib.optionals (cfg.settings.DEBUG != "True") [ "${pkg}/opt/healthchecks/manage.py compress" ];
             ExecStart = ''
               ${pkgs.python3Packages.gunicorn}/bin/gunicorn hc.wsgi \
                 --bind ${cfg.listenAddress}:${toString cfg.port} \

--- a/nixos/modules/services/web-apps/mediagoblin.nix
+++ b/nixos/modules/services/web-apps/mediagoblin.nix
@@ -310,19 +310,6 @@ in
       in
       {
         mediagoblin-celeryd = lib.recursiveUpdate serviceDefaults {
-          # we cannot change DEFAULT.data_dir inside mediagoblin.ini because of an annoying bug
-          # https://todo.sr.ht/~mediagoblin/mediagoblin/57
-          preStart = ''
-            cp --remove-destination ${
-              pkgs.writeText "mediagoblin.ini" (
-                lib.generators.toINI { } (lib.filterAttrsRecursive (n: v: n != "plugins") cfg.settings)
-                + "\n"
-                + lib.generators.toINI { mkKeyValue = mkSubSectionKeyValue 2; } {
-                  inherit (cfg.settings.mediagoblin) plugins;
-                }
-              )
-            } /var/lib/mediagoblin/mediagoblin.ini
-          '';
           serviceConfig = {
             Environment = [
               "CELERY_CONFIG_MODULE=mediagoblin.init.celery.from_celery"
@@ -331,6 +318,19 @@ in
               "MEDIAGOBLIN_CONFIG=/var/lib/mediagoblin/mediagoblin.ini"
               "PASTE_CONFIG=${pasteConfig}"
             ];
+            # we cannot change DEFAULT.data_dir inside mediagoblin.ini because of an annoying bug
+            # https://todo.sr.ht/~mediagoblin/mediagoblin/57
+            ExecStartPre = ''
+              ${lib.getExe' pkgs.coreutils "cp"} --remove-destination ${
+                pkgs.writeText "mediagoblin.ini" (
+                  lib.generators.toINI { } (lib.filterAttrsRecursive (n: v: n != "plugins") cfg.settings)
+                  + "\n"
+                  + lib.generators.toINI { mkKeyValue = mkSubSectionKeyValue 2; } {
+                    inherit (cfg.settings.mediagoblin) plugins;
+                  }
+                )
+              } /var/lib/mediagoblin/mediagoblin.ini
+            '';
             ExecStart = "${lib.getExe' finalPackage "celery"} worker --loglevel=INFO";
           };
           unitConfig.Description = "MediaGoblin Celery";
@@ -345,15 +345,15 @@ in
             "mediagoblin-celeryd.service"
             "postgresql.target"
           ];
-          preStart = ''
-            cp --remove-destination ${pasteConfig} /var/lib/mediagoblin/paste.ini
-            ${lib.getExe' finalPackage "gmg"} dbupdate
-          '';
           serviceConfig = {
             Environment = [
               "CELERY_ALWAYS_EAGER=false"
               "GI_TYPELIB_PATH=${GI_TYPELIB_PATH}"
               "GST_PLUGIN_PATH=${GST_PLUGIN_PATH}"
+            ];
+            ExecStartPre = [
+              "${lib.getExe' pkgs.coreutils "cp"} --remove-destination ${pasteConfig} /var/lib/mediagoblin/paste.ini"
+              "${lib.getExe' finalPackage "gmg"} dbupdate"
             ];
             ExecStart = "${lib.getExe' finalPackage "paster"} serve /var/lib/mediagoblin/paste.ini";
           };

--- a/nixos/modules/services/web-apps/miniflux.nix
+++ b/nixos/modules/services/web-apps/miniflux.nix
@@ -18,14 +18,6 @@ let
   cfg = config.services.miniflux;
 
   boolToInt = b: if b then 1 else 0;
-
-  pgbin = "${config.services.postgresql.package}/bin";
-  # The hstore extension is no longer needed as of v2.2.14
-  # and would prevent Miniflux from starting.
-  preStart = pkgs.writeScript "miniflux-pre-start" ''
-    #!${pkgs.runtimeShell}
-    ${pgbin}/psql "miniflux" -c "DROP EXTENSION IF EXISTS hstore"
-  '';
 in
 
 {
@@ -143,7 +135,9 @@ in
       serviceConfig = {
         Type = "oneshot";
         User = config.services.postgresql.superUser;
-        ExecStart = preStart;
+        # The hstore extension is no longer needed as of v2.2.14
+        # and would prevent Miniflux from starting.
+        ExecStart = ''${config.services.postgresql.package}/bin/psql "miniflux" -c "DROP EXTENSION IF EXISTS hstore"'';
       };
     };
 

--- a/nixos/modules/services/web-apps/miniflux.nix
+++ b/nixos/modules/services/web-apps/miniflux.nix
@@ -17,14 +17,6 @@ let
   cfg = config.services.miniflux;
 
   boolToInt = b: if b then 1 else 0;
-
-  pgbin = "${config.services.postgresql.package}/bin";
-  # The hstore extension is no longer needed as of v2.2.14
-  # and would prevent Miniflux from starting.
-  preStart = pkgs.writeScript "miniflux-pre-start" ''
-    #!${pkgs.runtimeShell}
-    ${pgbin}/psql "miniflux" -c "DROP EXTENSION IF EXISTS hstore"
-  '';
 in
 
 {
@@ -142,7 +134,9 @@ in
       serviceConfig = {
         Type = "oneshot";
         User = config.services.postgresql.superUser;
-        ExecStart = preStart;
+        # The hstore extension is no longer needed as of v2.2.14
+        # and would prevent Miniflux from starting.
+        ExecStart = ''${config.services.postgresql.package}/bin/psql "miniflux" -c "DROP EXTENSION IF EXISTS hstore"'';
       };
     };
 

--- a/nixos/modules/services/web-apps/nexus.nix
+++ b/nixos/modules/services/web-apps/nexus.nix
@@ -142,9 +142,8 @@ in
         fi
       '';
 
-      script = "${cfg.package}/bin/nexus run";
-
       serviceConfig = {
+        ExecStart = "${cfg.package}/bin/nexus run";
         User = cfg.user;
         Group = cfg.group;
         PrivateTmp = true;

--- a/nixos/modules/services/web-apps/part-db.nix
+++ b/nixos/modules/services/web-apps/part-db.nix
@@ -203,6 +203,7 @@ in
           requires = [ "postgresql.target" ];
           wantedBy = [ "multi-user.target" ];
           serviceConfig = {
+            ExecStart = "${lib.getExe cfg.phpPackage} ${lib.getExe' cfg.package "console"} doctrine:migrations:migrate --no-interaction";
             Type = "oneshot";
             RemainAfterExit = true;
             User = "part-db";
@@ -210,10 +211,6 @@ in
           restartTriggers = [
             cfg.package
           ];
-          script = ''
-            set -euo pipefail
-            ${lib.getExe cfg.phpPackage} ${lib.getExe' cfg.package "console"} doctrine:migrations:migrate --no-interaction
-          '';
         };
 
         phpfpm-part-db = {

--- a/nixos/modules/services/web-apps/part-db.nix
+++ b/nixos/modules/services/web-apps/part-db.nix
@@ -257,6 +257,7 @@ in
           ];
           wantedBy = [ "multi-user.target" ];
           serviceConfig = {
+            ExecStart = "${lib.getExe cfg.phpPackage} ${lib.getExe' cfg.package "console"} doctrine:migrations:migrate --no-interaction";
             Type = "oneshot";
             RemainAfterExit = true;
             User = "part-db";
@@ -264,10 +265,6 @@ in
           restartTriggers = [
             cfg.package
           ];
-          script = ''
-            set -euo pipefail
-            ${lib.getExe cfg.phpPackage} ${lib.getExe' cfg.package "console"} doctrine:migrations:migrate --no-interaction
-          '';
         };
 
         phpfpm-part-db = {

--- a/nixos/modules/services/web-apps/peering-manager.nix
+++ b/nixos/modules/services/web-apps/peering-manager.nix
@@ -307,11 +307,8 @@ in
           ]
           ++ lib.optionals (cfg.environmentFile != null) [ "peering-manager-config.service" ];
 
-          preStart = ''
-            ${pkg}/bin/peering-manager remove_stale_contenttypes --no-input
-          '';
-
           serviceConfig = {
+            ExecStartPre = "${pkg}/bin/peering-manager remove_stale_contenttypes --no-input";
             ExecStart = ''
               ${pkg.python.pkgs.gunicorn}/bin/gunicorn peering_manager.wsgi \
                 --bind ${cfg.listenAddress}:${toString cfg.port} \

--- a/nixos/modules/services/web-apps/silverbullet.nix
+++ b/nixos/modules/services/web-apps/silverbullet.nix
@@ -95,7 +95,6 @@ in
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
 
-      preStart = lib.mkIf (!lib.hasPrefix "/var/lib/" cfg.spaceDir) "mkdir -p '${cfg.spaceDir}'";
       serviceConfig = {
         Type = "simple";
         User = "${cfg.user}";
@@ -104,6 +103,9 @@ in
         StateDirectory = lib.mkIf (lib.hasPrefix "/var/lib/" cfg.spaceDir) (
           lib.last (lib.splitString "/" cfg.spaceDir)
         );
+        ExecStartPre = lib.mkIf (
+          !lib.hasPrefix "/var/lib/" cfg.spaceDir
+        ) "${lib.getExe' pkgs.coreutils "mkdir"} -p '${cfg.spaceDir}'";
         ExecStart =
           "${lib.getExe cfg.package} --port ${toString cfg.listenPort} --hostname '${cfg.listenAddress}' '${cfg.spaceDir}' "
           + lib.concatStringsSep " " cfg.extraArgs;

--- a/nixos/modules/services/web-apps/wakapi.nix
+++ b/nixos/modules/services/web-apps/wakapi.nix
@@ -143,10 +143,6 @@ in
       ++ optional (cfg.database.dialect == "postgres") "postgresql.target";
       wantedBy = [ "multi-user.target" ];
 
-      script = ''
-        exec ${getExe cfg.package} -config ${settingsFile}
-      '';
-
       serviceConfig = {
         Environment = mkMerge [
           (mkIf (cfg.passwordSalt != null) "WAKAPI_PASSWORD_SALT=${cfg.passwordSalt}")
@@ -156,6 +152,8 @@ in
         EnvironmentFile =
           (lib.optional (cfg.passwordSaltFile != null) cfg.passwordSaltFile)
           ++ (lib.optional (cfg.smtpPasswordFile != null) cfg.smtpPasswordFile);
+
+        ExecStart = "${getExe cfg.package} -config ${settingsFile}";
 
         User = config.users.users.wakapi.name;
         Group = config.users.users.wakapi.group;

--- a/nixos/modules/services/web-apps/wakapi.nix
+++ b/nixos/modules/services/web-apps/wakapi.nix
@@ -144,12 +144,10 @@ in
       ++ optional (cfg.database.dialect == "postgres") "postgresql.target";
       wantedBy = [ "multi-user.target" ];
 
-      script = ''
-        exec ${getExe cfg.package} -config ${settingsFile}
-      '';
-
       serviceConfig = {
         EnvironmentFile = cfg.environmentFiles;
+
+        ExecStart = "${getExe cfg.package} -config ${settingsFile}";
 
         User = config.users.users.wakapi.name;
         Group = config.users.users.wakapi.group;

--- a/nixos/modules/services/web-servers/h2o/default.nix
+++ b/nixos/modules/services/web-servers/h2o/default.nix
@@ -443,6 +443,7 @@ in
       ++ map (certName: "acme-${certName}.service") acmeCertNames.all;
 
       serviceConfig = {
+        ExecStartPre = "${h2oExe} --mode 'test'";
         ExecStart = "${h2oExe} --mode 'master'";
         ExecReload = [
           "${h2oExe} --mode 'test'"
@@ -483,8 +484,6 @@ in
         AmbientCapabilities = [ "CAP_NET_BIND_SERVICE" ];
         CapabilitiesBoundingSet = [ "CAP_NET_BIND_SERVICE" ];
       };
-
-      preStart = "${h2oExe} --mode 'test'";
     };
 
     # This service waits for all certificates to be available before reloading

--- a/nixos/modules/services/web-servers/jboss/default.nix
+++ b/nixos/modules/services/web-servers/jboss/default.nix
@@ -93,7 +93,7 @@ in
   config = mkIf config.services.jboss.enable {
     systemd.services.jboss = {
       description = "JBoss server";
-      script = "${jbossService}/bin/control start";
+      serviceConfig.ExecStart = "${jbossService}/bin/control start";
       wantedBy = [ "multi-user.target" ];
     };
   };


### PR DESCRIPTION
This is a partial revert of 39e9380

This PR goes over a few nixos modules where `script`/`preStart` was easily replacable with `ExecStart`/`ExecStartPre`.
This gets rid of unnecessary bash wrappers, and lets you see the command being run directly when running `systemctl cat <name>.service`.

It also makes some of the services usable with the bashless profile.

Since this is more or less a manual treewide, this is a single PR in a set of PRs that has been split into reviewable chunks.

Part 1: #481637
Part 2: #481638

<details>
<summary>NixOS test coverage</summary>

Modules with the checkbox checked have tests.

- [X] authelia
- [ ] bluemap
- [X] certmgr
- [X] cloudlog
- [X] galene
- [X] glitchtip
- [X] h2o
- [X] healthchecks
- [ ] hologram-agent
- [ ] jboss
- [ ] mediagoblin
- [X] miniflux
- [X] misskey
- [X] nexus
- [X] part-db
- [X] peering-manager
- [X] silverbullet
- [X] tinydns
- [ ] toxvpn
- [X] twingate
- [X] wakapi
- [ ] xinetd
- [ ] xray
- [ ] zerobin

`NIXPKGS_ALLOW_UNFREE=1 NIXPKGS_ALLOW_INSECURE=1 nix build .#nixosTests.authelia .#nixosTests.certmgr.command .#nixosTests.certmgr.systemd .#nixosTests.cloudlog .#nixosTests.galene.basic .#nixosTests.galene.file-transfer .#nixosTests.glitchtip .#nixosTests.h2o.basic .#nixosTests.h2o.mruby .#nixosTests.h2o.tls-recommendations .#nixosTests.healthchecks .#nixosTests.miniflux .#nixosTests.misskey .#nixosTests.nexus .#nixosTests.nexus .#nixosTests.part-db .#nixosTests.peering-manager .#nixosTests.silverbullet .#nixosTests.tinydns .#nixosTests.twingate .#nixosTests.wakapi -L --impure`

</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
