### PR TITLE
(Part 4) various: replace `systemd.services.<name>.{script,preStart}` with `ExecStart{,Pre}`

### DIFF
--- a/nixos/modules/services/misc/bcg.nix
+++ b/nixos/modules/services/misc/bcg.nix
@@ -162,14 +162,12 @@ in
         ]
         ++ lib.optional config.services.mosquitto.enable "mosquitto.service";
         after = [ "network-online.target" ];
-        preStart = lib.mkIf envConfig ''
-          umask 077
-          ${pkgs.envsubst}/bin/envsubst -i "${configFile}" -o "${finalConfig}"
-        '';
         serviceConfig = {
           EnvironmentFile = cfg.environmentFiles;
+          ExecStartPre = lib.mkIf envConfig "${pkgs.envsubst}/bin/envsubst -i '${configFile}' -o \"${finalConfig}\"";
           ExecStart = "${cfg.package}/bin/bcg -c ${finalConfig} -v ${cfg.verbose}";
           RuntimeDirectory = "bcg";
+          RuntimeDirectoryMode = "0700";
         };
       };
   };

--- a/nixos/modules/services/misc/turn-rs.nix
+++ b/nixos/modules/services/misc/turn-rs.nix
@@ -68,16 +68,14 @@ in
       enable = true;
       wantedBy = [ "multi-user.target" ];
       description = "Turn-rs Server Daemon";
-      preStart =
-        let
-          configFile = format.generate "turn-rs-config.toml" cfg.settings;
-        in
-        ''
-          ${lib.getExe pkgs.envsubst} -i "${configFile}" -o /run/turn-rs/config.toml
-        '';
       serviceConfig = {
         RuntimeDirectory = "turn-rs";
         EnvironmentFile = lib.optional (cfg.secretFile != null) cfg.secretFile;
+        ExecStartPre =
+          let
+            configFile = format.generate "turn-rs-config.toml" cfg.settings;
+          in
+          "${lib.getExe pkgs.envsubst} -i '${configFile}' -o /run/turn-rs/config.toml";
         ExecStart = "${lib.getExe cfg.package} --config=/run/turn-rs/config.toml";
         DynamicUser = true;
       };

--- a/nixos/modules/services/monitoring/prometheus/exporters/junos-czerwonk.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/junos-czerwonk.nix
@@ -68,12 +68,8 @@ in
       DynamicUser = false;
       EnvironmentFile = mkIf (cfg.environmentFile != null) [ cfg.environmentFile ];
       RuntimeDirectory = "prometheus-junos-czerwonk-exporter";
-      ExecStartPre = [
-        "${pkgs.writeShellScript "subst-secrets-junos-czerwonk-exporter" ''
-          umask 0077
-          ${pkgs.envsubst}/bin/envsubst -i ${configFile} -o ''${RUNTIME_DIRECTORY}/junos-exporter.json
-        ''}"
-      ];
+      RuntimeDirectoryMode = "0700";
+      ExecStartPre = "${pkgs.envsubst}/bin/envsubst -i ${configFile} -o \"\${RUNTIME_DIRECTORY}\"/junos-exporter.json";
       ExecStart = ''
         ${pkgs.prometheus-junos-czerwonk-exporter}/bin/junos_exporter \
           -web.listen-address ${cfg.listenAddress}:${toString cfg.port} \

--- a/nixos/modules/services/monitoring/prometheus/exporters/mail.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/mail.nix
@@ -199,17 +199,15 @@ in
       DynamicUser = false;
       EnvironmentFile = mkIf (cfg.environmentFile != null) [ cfg.environmentFile ];
       RuntimeDirectory = "prometheus-mail-exporter";
+      RuntimeDirectoryMode = "0700";
       ExecStartPre = [
-        "${pkgs.writeShellScript "subst-secrets-mail-exporter" ''
-          umask 0077
-          ${pkgs.envsubst}/bin/envsubst -i ${configFile} -o ''${RUNTIME_DIRECTORY}/mail-exporter.json
-        ''}"
+        "'${pkgs.envsubst}/bin/envsubst' -i '${configFile}' -o \"\${RUNTIME_DIRECTORY}/mail-exporter.json\""
       ];
       ExecStart = ''
-        ${pkgs.prometheus-mail-exporter}/bin/mailexporter \
-          --web.listen-address ${cfg.listenAddress}:${toString cfg.port} \
-          --web.telemetry-path ${cfg.telemetryPath} \
-          --config.file ''${RUNTIME_DIRECTORY}/mail-exporter.json \
+        '${pkgs.prometheus-mail-exporter}/bin/mailexporter' \
+          --web.listen-address '${cfg.listenAddress}:${toString cfg.port}' \
+          --web.telemetry-path '${cfg.telemetryPath}' \
+          --config.file "''${RUNTIME_DIRECTORY}/mail-exporter.json" \
           ${concatStringsSep " \\\n  " cfg.extraFlags}
       '';
     };

--- a/nixos/modules/services/monitoring/prometheus/sachet.nix
+++ b/nixos/modules/services/monitoring/prometheus/sachet.nix
@@ -70,13 +70,12 @@ in
         "network.target"
         "network-online.target"
       ];
-      script = ''
-        ${pkgs.envsubst}/bin/envsubst -i "${configFile}" > /tmp/sachet.yaml
-        exec ${pkgs.prometheus-sachet}/bin/sachet -config /tmp/sachet.yaml -listen-address ${cfg.address}:${toString cfg.port}
-      '';
 
       serviceConfig = {
         Restart = "always";
+
+        ExecStartPre = "${pkgs.envsubst}/bin/envsubst -i '${configFile}' -o /tmp/sachet.yaml";
+        ExecStart = "${pkgs.prometheus-sachet}/bin/sachet -config /tmp/sachet.yaml -listen-address ${cfg.address}:${toString cfg.port}";
 
         ProtectSystem = "strict";
         ProtectHome = true;

--- a/nixos/modules/services/monitoring/telegraf.nix
+++ b/nixos/modules/services/monitoring/telegraf.nix
@@ -72,15 +72,13 @@ in
           ++ lib.optional (config.services.telegraf.extraConfig.inputs ? ping) pkgs.iputils;
         serviceConfig = {
           EnvironmentFile = config.services.telegraf.environmentFiles;
-          ExecStartPre = lib.optional (config.services.telegraf.environmentFiles != [ ]) (
-            pkgs.writeShellScript "pre-start" ''
-              umask 077
-              ${pkgs.envsubst}/bin/envsubst -i "${configFile}" > /var/run/telegraf/config.toml
-            ''
-          );
+          ExecStartPre = lib.optional (
+            config.services.telegraf.environmentFiles != [ ]
+          ) "${pkgs.envsubst}/bin/envsubst -i '${configFile}' -o /var/run/telegraf/config.toml";
           ExecStart = "${cfg.package}/bin/telegraf -config ${finalConfigFile}";
           ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
           RuntimeDirectory = "telegraf";
+          RuntimeDirectoryMode = "0700";
           User = "telegraf";
           Group = "telegraf";
           Restart = "on-failure";

--- a/nixos/modules/services/networking/ghostunnel.nix
+++ b/nixos/modules/services/networking/ghostunnel.nix
@@ -190,32 +190,33 @@ let
               ++ optional (config.cert != null) "cert:${config.cert}"
               ++ optional (config.key != null) "key:${config.key}"
               ++ optional (config.cacert != null) "cacert:${config.cacert}";
+
+            ExecStart = concatStringsSep " " (
+              [
+                "${mainCfg.package}/bin/ghostunnel"
+                # ghostunnel's landlock rules don't like reading the CA certs from /etc
+                # because they are links to /nix/store, which isn't part of its rules
+                "--disable-landlock"
+              ]
+              ++ optional (config.keystore != null) "--keystore=\"\${CREDENTIALS_DIRECTORY}\"/keystore"
+              ++ optional (config.cert != null) "--cert=\"\${CREDENTIALS_DIRECTORY}\"/cert"
+              ++ optional (config.key != null) "--key=\"\${CREDENTIALS_DIRECTORY}\"/key"
+              ++ optional (config.cacert != null) "--cacert=\"\${CREDENTIALS_DIRECTORY}\"/cacert"
+              ++ [
+                "server"
+                "--listen ${config.listen}"
+                "--target ${config.target}"
+              ]
+              ++ optional config.allowAll "--allow-all"
+              ++ map (v: "--allow-cn=${escapeShellArg v}") config.allowCN
+              ++ map (v: "--allow-ou=${escapeShellArg v}") config.allowOU
+              ++ map (v: "--allow-dns=${escapeShellArg v}") config.allowDNS
+              ++ map (v: "--allow-uri=${escapeShellArg v}") config.allowURI
+              ++ optional config.disableAuthentication "--disable-authentication"
+              ++ optional config.unsafeTarget "--unsafe-target"
+              ++ [ config.extraArguments ]
+            );
           };
-          script = concatStringsSep " " (
-            [
-              "${mainCfg.package}/bin/ghostunnel"
-              # ghostunnel's landlock rules don't like reading the CA certs from /etc
-              # because they are links to /nix/store, which isn't part of its rules
-              "--disable-landlock"
-            ]
-            ++ optional (config.keystore != null) "--keystore=$CREDENTIALS_DIRECTORY/keystore"
-            ++ optional (config.cert != null) "--cert=$CREDENTIALS_DIRECTORY/cert"
-            ++ optional (config.key != null) "--key=$CREDENTIALS_DIRECTORY/key"
-            ++ optional (config.cacert != null) "--cacert=$CREDENTIALS_DIRECTORY/cacert"
-            ++ [
-              "server"
-              "--listen ${config.listen}"
-              "--target ${config.target}"
-            ]
-            ++ optional config.allowAll "--allow-all"
-            ++ map (v: "--allow-cn=${escapeShellArg v}") config.allowCN
-            ++ map (v: "--allow-ou=${escapeShellArg v}") config.allowOU
-            ++ map (v: "--allow-dns=${escapeShellArg v}") config.allowDNS
-            ++ map (v: "--allow-uri=${escapeShellArg v}") config.allowURI
-            ++ optional config.disableAuthentication "--disable-authentication"
-            ++ optional config.unsafeTarget "--unsafe-target"
-            ++ [ config.extraArguments ]
-          );
         };
       };
     };

--- a/nixos/modules/services/networking/keepalived/default.nix
+++ b/nixos/modules/services/networking/keepalived/default.nix
@@ -379,13 +379,11 @@ in
           PIDFile = pidFile;
           KillMode = "process";
           RuntimeDirectory = "keepalived";
+          RuntimeDirectoryMode = "0700";
           EnvironmentFile = lib.optional (cfg.secretFile != null) cfg.secretFile;
-          ExecStartPre = lib.optional (cfg.secretFile != null) (
-            pkgs.writeShellScript "keepalived-pre-start" ''
-              umask 077
-              ${pkgs.envsubst}/bin/envsubst -i "${keepalivedConf}" > ${finalConfigFile}
-            ''
-          );
+          ExecStartPre = lib.optional (
+            cfg.secretFile != null
+          ) "${pkgs.envsubst}/bin/envsubst -i '${keepalivedConf}' -o '${finalConfigFile}'";
           ExecStart =
             "${lib.getExe cfg.package}"
             + " -f ${finalConfigFile}"

--- a/nixos/modules/services/networking/powerdns.nix
+++ b/nixos/modules/services/networking/powerdns.nix
@@ -59,12 +59,10 @@ in
 
       serviceConfig = {
         EnvironmentFile = lib.optional (cfg.secretFile != null) cfg.secretFile;
-        ExecStartPre = lib.optional (cfg.secretFile != null) (
-          pkgs.writeShellScript "pdns-pre-start" ''
-            umask 077
-            ${pkgs.envsubst}/bin/envsubst -i "${configDir}/pdns.conf" > ${finalConfigDir}/pdns.conf
-          ''
-        );
+        RuntimeDirectoryMode = "0700";
+        ExecStartPre = lib.optional (
+          cfg.secretFile != null
+        ) "${pkgs.envsubst}/bin/envsubst -i '${configDir}/pdns.conf' -o '${finalConfigDir}/pdns.conf'";
         ExecStart = [
           ""
           "${pkgs.pdns}/bin/pdns_server --config-dir=${finalConfigDir} --guardian=no --daemon=no --disable-syslog --log-timestamp=no --write-pid=no"

--- a/nixos/modules/services/networking/prosody.nix
+++ b/nixos/modules/services/networking/prosody.nix
@@ -1001,11 +1001,6 @@ in
       wants = [ "network-online.target" ];
       wantedBy = [ "multi-user.target" ];
       restartTriggers = [ config.environment.etc."prosody/prosody.cfg.lua".source ];
-      preStart = ''
-        ${pkgs.envsubst}/bin/envsubst -i ${
-          config.environment.etc."prosody/prosody.cfg.lua".source
-        } -o /run/prosody/prosody.cfg.lua
-      '';
       serviceConfig = mkMerge [
         {
           User = cfg.user;
@@ -1014,6 +1009,7 @@ in
           RuntimeDirectory = "prosody";
           PIDFile = "/run/prosody/prosody.pid";
           Environment = "PROSODY_CONFIG=/run/prosody/prosody.cfg.lua";
+          ExecStartPre = "${pkgs.envsubst}/bin/envsubst -i /etc/prosody/prosody.cfg.lua -o /run/prosody/prosody.cfg.lua";
           ExecStart = "${lib.getExe cfg.package} -F";
           Restart = "on-abnormal";
 

--- a/nixos/modules/services/networking/rosenpass.nix
+++ b/nixos/modules/services/networking/rosenpass.nix
@@ -235,15 +235,12 @@ in
             "pqsk:${cfg.settings.secret_key}"
             "pqpk:${cfg.settings.public_key}"
           ];
+          ExecStartPre = "${getExe pkgs.envsubst} -i '${config}' -o \"$CONFIG\"";
+          ExecStart = "${lib.getExe cfg.package} exchange-config \"$CONFIG\"";
         };
 
         # See <https://www.freedesktop.org/software/systemd/man/systemd.unit.html#Specifiers>
         environment.CONFIG = "%t/${serviceConfig.RuntimeDirectory}/config.toml";
-
-        script = ''
-          ${getExe pkgs.envsubst} -i ${config} -o "$CONFIG"
-          rosenpass exchange-config "$CONFIG"
-        '';
       };
   };
 }

--- a/nixos/modules/services/networking/wireguard-networkd.nix
+++ b/nixos/modules/services/networking/wireguard-networkd.nix
@@ -23,6 +23,7 @@ let
   inherit (lib.options) literalExpression mkOption;
   inherit (lib.strings) hasInfix replaceStrings;
   inherit (lib.trivial) flip pipe;
+  inherit (lib.meta) getExe';
 
   removeNulls = filterAttrs (_: v: v != null);
 
@@ -102,16 +103,15 @@ let
       description = "Wireguard dynamic endpoint refresh (${name})";
       after = [ "network-online.target" ];
       wants = [ "network-online.target" ];
-      path = with pkgs; [
-        iproute2
-        systemd
-      ];
       # networkd doesn't automatically refresh peer endpoints.
       # See: https://github.com/systemd/systemd/issues/9911
-      script = ''
-        touch /etc/systemd/network/40-${name}.netdev
-        networkctl reload
-      '';
+      serviceConfig = {
+        Type = "oneshot";
+        ExecStart = [
+          "-${lib.getExe' pkgs.coreutils "touch"} /etc/systemd/network/40-${name}.netdev"
+          "${getExe' pkgs.systemd "networkctl"} reload"
+        ];
+      };
     };
 
   # netdev config must be a real file (not a symlink to a store file)

--- a/nixos/modules/services/web-apps/hedgedoc.nix
+++ b/nixos/modules/services/web-apps/hedgedoc.nix
@@ -291,23 +291,21 @@ in
       documentation = [ "https://docs.hedgedoc.org/" ];
       wantedBy = [ "multi-user.target" ];
       after = [ "network.target" ];
-      preStart =
-        let
-          configFile = settingsFormat.generate "hedgedoc-config.json" {
-            production = cfg.settings;
-          };
-        in
-        ''
-          ${pkgs.envsubst}/bin/envsubst \
-            -o /run/${name}/config.json \
-            -i ${configFile}
-          ${pkgs.coreutils}/bin/mkdir -p ${cfg.settings.uploadsPath}
-        '';
       serviceConfig = {
         User = name;
         Group = name;
 
         Restart = "always";
+        ExecStartPre =
+          let
+            configFile = settingsFormat.generate "hedgedoc-config.json" {
+              production = cfg.settings;
+            };
+          in
+          [
+            "${pkgs.envsubst}/bin/envsubst -o /run/${name}/config.json -i ${configFile}"
+            "${pkgs.coreutils}/bin/mkdir -p ${cfg.settings.uploadsPath}"
+          ];
         ExecStart = lib.getExe cfg.package;
         RuntimeDirectory = [ name ];
         StateDirectory = [ name ];

--- a/nixos/modules/services/web-apps/karakeep.nix
+++ b/nixos/modules/services/web-apps/karakeep.nix
@@ -205,18 +205,20 @@ in
       wantedBy = [ "multi-user.target" ];
       after = [ "network.target" ];
       partOf = [ "karakeep.service" ];
-      script = ''
-        export HOME="$CACHE_DIRECTORY"
-        exec ${cfg.browser.exe} \
-          --headless --no-sandbox --disable-gpu --disable-dev-shm-usage \
-          --remote-debugging-address=127.0.0.1 \
-          --remote-debugging-port=${toString cfg.browser.port} \
-          --hide-scrollbars \
-          --user-data-dir="$STATE_DIRECTORY"
-      '';
+      environment.HOME = "%C/karakeep";
+
       serviceConfig = {
         Type = "simple";
         Restart = "on-failure";
+
+        ExecStart = ''
+          ${cfg.browser.exe} \
+            --headless --no-sandbox --disable-gpu --disable-dev-shm-usage \
+            --remote-debugging-address=127.0.0.1 \
+            --remote-debugging-port=${toString cfg.browser.port} \
+            --hide-scrollbars \
+            --user-data-dir="''${STATE_DIRECTORY}"
+        '';
 
         CacheDirectory = "karakeep-browser";
         StateDirectory = "karakeep-browser";

--- a/nixos/modules/services/web-apps/plantuml-server.nix
+++ b/nixos/modules/services/web-apps/plantuml-server.nix
@@ -104,21 +104,22 @@ in
         PLANTUML_STATS = if cfg.plantumlStats then "on" else "off";
         HTTP_AUTHORIZATION = cfg.httpAuthorization;
       };
-      script = ''
-        ${cfg.packages.jdk}/bin/java \
-          -jar ${cfg.packages.jetty}/start.jar \
-            --module=http,ee11-deploy,ee11-jsp \
-            -Djetty.home=${cfg.packages.jetty} \
-            -Djetty.base=${cfg.package} \
-            -Djetty.http.host=${cfg.listenHost} \
-            -Djetty.http.port=${toString cfg.listenPort}
-      '';
 
       serviceConfig = {
         User = cfg.user;
         Group = cfg.group;
         StateDirectory = mkIf (cfg.home == "/var/lib/plantuml") "plantuml";
         StateDirectoryMode = mkIf (cfg.home == "/var/lib/plantuml") "0750";
+
+        ExecStart = ''
+          ${cfg.packages.jdk}/bin/java \
+            -jar ${cfg.packages.jetty}/start.jar \
+              --module=http,ee11-deploy,ee11-jsp \
+              -Djetty.home=${cfg.packages.jetty} \
+              -Djetty.base=${cfg.package} \
+              -Djetty.http.host=${cfg.listenHost} \
+              -Djetty.http.port=${toString cfg.listenPort}
+        '';
 
         # Hardening
         AmbientCapabilities = [ "" ];


### PR DESCRIPTION
This PR goes over a few nixos modules where `script`/`preStart` was easily replacable with `ExecStart`/`ExecStartPre`.
This gets rid of unnecessary bash wrappers, and lets you see the command being run directly when running `systemctl cat <name>.service`.

It also makes some of the services usable with the bashless profile.

Since this is more or less a manual treewide, this is a single PR in a set of PRs that has been split into reviewable chunks.

Part 1: #481637
Part 2: #481638
Part 3: #481639

<details>
<summary>NixOS test coverage</summary>

Modules with the checkbox checked have tests.

- [ ] bcg
- [X] ghostunnel
- [X] hedgedoc
- [X] honk
- [X] invidious
- [X] karakeep
- [X] keepalived
- [X] plantuml-server
- [X] powerdns
- [ ] prometheus-exporters.junos-czerwonk
- [X] prometheus-exporters.mail
- [X] prosody
- [ ] rosenpass (#549663)
- [ ] sachet
- [X] telegraf
- [X] turn-rs
- [X] wireguard-networkd

`nix build .#nixosTests.ghostunnel .#nixosTests.ghostunnel-modular .#nixosTests.hedgedoc .#nixosTests.honk .#nixosTests.invidious .#nixosTests.karakeep .#nixosTests.keepalived.iptables .#nixosTests.keepalived.nftables .#nixosTests.plantuml-server .#nixosTests.powerdns .#nixosTests.prometheus-exporters.mail .#nixosTests.prosody .#nixosTests.prosody-mysql .#nixosTests.telegraf .#nixosTests.turn-rs .#nixosTests.wireguard.wireguard-networkd-linux-latest -L`

</details>


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
