### PR TITLE
(Part 5) various: replace `systemd.services.<name>.{script,preStart}` with `ExecStart{,Pre}`

### DIFF
--- a/nixos/modules/services/misc/airsonic.nix
+++ b/nixos/modules/services/misc/airsonic.nix
@@ -131,15 +131,15 @@ in
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
 
-      preStart = ''
-        # Install transcoders.
-        rm -rf ${cfg.home}/transcode
-        mkdir -p ${cfg.home}/transcode
-        for exe in ${toString cfg.transcoders}; do
-          ln -sf "$exe" ${cfg.home}/transcode
-        done
-      '';
       serviceConfig = {
+        # Install transcoders.
+        ExecStartPre = [
+          "${lib.getExe' pkgs.coreutils "rm"} -rf '${cfg.home}/transcode'"
+          "${lib.getExe' pkgs.coreutils "mkdir"} -p '${cfg.home}/transcode'"
+        ]
+        ++ map (
+          exe: "${lib.getExe' pkgs.coreutils "ln"} -sf '${exe}' '${cfg.home}/transcode'"
+        ) cfg.transcoders;
         ExecStart = ''
           ${cfg.jre}/bin/java -Xmx${toString cfg.maxMemory}m \
           -Dairsonic.home=${cfg.home} \

--- a/nixos/modules/services/misc/mqtt2influxdb.nix
+++ b/nixos/modules/services/misc/mqtt2influxdb.nix
@@ -236,14 +236,12 @@ in
         description = "BigClown MQTT to InfluxDB bridge";
         wantedBy = [ "multi-user.target" ];
         wants = lib.mkIf config.services.mosquitto.enable [ "mosquitto.service" ];
-        preStart = ''
-          umask 077
-          ${pkgs.envsubst}/bin/envsubst -i "${configFile}" -o "${finalConfig}"
-        '';
         serviceConfig = {
           EnvironmentFile = cfg.environmentFiles;
+          ExecStartPre = lib.mkIf envConfig "${pkgs.envsubst}/bin/envsubst -i '${configFile}' -o \"${finalConfig}\"";
           ExecStart = "${lib.getExe cfg.package} -dc ${finalConfig}";
           RuntimeDirectory = "mqtt2influxdb";
+          RuntimeDirectoryMode = "0700";
         };
       };
   };

--- a/nixos/modules/services/monitoring/grafana.nix
+++ b/nixos/modules/services/monitoring/grafana.nix
@@ -2087,13 +2087,13 @@ in
       ]
       ++ lib.optional usePostgresql "postgresql.target"
       ++ lib.optional useMysql "mysql.service";
-      script = ''
-        set -o errexit -o pipefail -o nounset -o errtrace
-        shopt -s inherit_errexit
-
-        exec ${lib.getExe cfg.package} server -homepath ${cfg.dataDir} -config ${configFile}
-      '';
       serviceConfig = {
+        ExecStartPre = [
+          "${lib.getExe' pkgs.coreutils "ln"} -fs ${cfg.package}/share/grafana/conf ${cfg.dataDir}"
+          "${lib.getExe' pkgs.coreutils "ln"} -fs ${cfg.package}/share/grafana/tools ${cfg.dataDir}"
+        ];
+        ExecStart = "${lib.getExe cfg.package} server -homepath ${cfg.dataDir} -config ${configFile}";
+
         WorkingDirectory = cfg.dataDir;
         User = "grafana";
         Restart = "on-failure";
@@ -2136,10 +2136,6 @@ in
         ++ lib.optionals (cfg.settings.server.protocol == "socket") [ "@chown" ];
         UMask = "0027";
       };
-      preStart = ''
-        ln -fs ${cfg.package}/share/grafana/conf ${cfg.dataDir}
-        ln -fs ${cfg.package}/share/grafana/tools ${cfg.dataDir}
-      '';
     };
 
     networking.firewall.allowedTCPPorts = mkIf cfg.openFirewall [ cfg.settings.server.http_port ];

--- a/nixos/modules/services/monitoring/kthxbye.nix
+++ b/nixos/modules/services/monitoring/kthxbye.nix
@@ -137,23 +137,23 @@ in
     systemd.services.kthxbye = {
       description = "kthxbye Alertmanager ack management daemon";
       wantedBy = [ "multi-user.target" ];
-      script = ''
-        ${cfg.package}/bin/kthxbye \
-          -alertmanager.timeout ${cfg.alertmanager.timeout} \
-          -alertmanager.uri ${cfg.alertmanager.uri} \
-          -extend-by ${cfg.extendBy} \
-          -extend-if-expiring-in ${cfg.extendIfExpiringIn} \
-          -extend-with-prefix ${cfg.extendWithPrefix} \
-          -interval ${cfg.interval} \
-          -listen ${cfg.listenAddress}:${toString cfg.port} \
-          ${lib.optionalString cfg.logJSON "-log-json"} \
-          ${lib.optionalString (cfg.maxDuration != null) "-max-duration ${cfg.maxDuration}"} \
-          ${lib.concatStringsSep " " cfg.extraOptions}
-      '';
       serviceConfig = {
         Type = "simple";
         DynamicUser = true;
         Restart = "on-failure";
+        ExecStart = ''
+          ${cfg.package}/bin/kthxbye \
+            -alertmanager.timeout ${cfg.alertmanager.timeout} \
+            -alertmanager.uri ${cfg.alertmanager.uri} \
+            -extend-by ${cfg.extendBy} \
+            -extend-if-expiring-in ${cfg.extendIfExpiringIn} \
+            -extend-with-prefix ${cfg.extendWithPrefix} \
+            -interval ${cfg.interval} \
+            -listen ${cfg.listenAddress}:${toString cfg.port} \
+            ${lib.optionalString cfg.logJSON "-log-json"} \
+            ${lib.optionalString (cfg.maxDuration != null) "-max-duration ${cfg.maxDuration}"} \
+            ${lib.concatStringsSep " " cfg.extraOptions}
+        '';
       };
     };
 

--- a/nixos/modules/services/monitoring/prometheus/alertmanager.nix
+++ b/nixos/modules/services/monitoring/prometheus/alertmanager.nix
@@ -200,11 +200,8 @@ in
         wantedBy = [ "multi-user.target" ];
         wants = [ "network-online.target" ];
         after = [ "network-online.target" ];
-        preStart = ''
-          ${lib.getBin pkgs.envsubst}/bin/envsubst -o "/tmp/alert-manager-substituted.yaml" \
-                                                   -i "${alertmanagerYml}"
-        '';
         serviceConfig = {
+          ExecStartPre = "${lib.getBin pkgs.envsubst}/bin/envsubst -i '${alertmanagerYml}' -o '/tmp/alert-manager-substituted.yaml'";
           ExecStart =
             "${cfg.package}/bin/alertmanager"
             + lib.optionalString (lib.length cmdlineArgs != 0) (

--- a/nixos/modules/services/network-filesystems/openafs/server.nix
+++ b/nixos/modules/services/network-filesystems/openafs/server.nix
@@ -357,11 +357,16 @@ in
         unitConfig.ConditionPathExists = [
           "|/etc/openafs/server/KeyFileExt"
         ];
-        preStart = ''
-          mkdir -m 0755 -p /var/openafs
-          ${optionalString (netInfo != null) "cp ${netInfo} /var/openafs/netInfo"}
-        '';
         serviceConfig = {
+          ExecStartPre = [
+            "${lib.getExe' pkgs.coreutils "mkdir"} -m 0755 -p /var/openafs"
+          ]
+          ++ lib.optionals (netInfo != null) [
+            "${lib.getExe' pkgs.coreutils "cp"} ${netInfo} /var/openafs/netInfo"
+          ]
+          ++ lib.optionals useBuCellServDB [
+            "${lib.getExe' pkgs.coreutils "cp"} ${buCellServDB}"
+          ];
           ExecStart = "${openafsBin}/bin/bosserver -nofork";
           ExecStop = "${openafsBin}/bin/bos shutdown localhost -wait -localauth";
         };

--- a/nixos/modules/services/networking/dnscache.nix
+++ b/nixos/modules/services/networking/dnscache.nix
@@ -108,17 +108,16 @@ in
         daemontools
         djbdns
       ];
-      preStart = ''
-        rm -rf /var/lib/dnscache
-        dnscache-conf dnscache dnscache /var/lib/dnscache ${config.services.dnscache.ip}
-        rm -rf /var/lib/dnscache/root
-        ln -sf ${dnscache-root} /var/lib/dnscache/root
-      '';
-      script = ''
-        cd /var/lib/dnscache/
-        ${lib.optionalString cfg.forwardOnly "export FORWARDONLY=1"}
-        exec ./run
-      '';
+      environment.FORWARDONLY = lib.mkIf cfg.forwardOnly "1";
+      serviceConfig.StateDirectory = "dnscache";
+      serviceConfig.WorkingDirectory = "/var/lib/dnscache";
+      serviceConfig.ExecStartPre = [
+        "${lib.getExe' pkgs.coreutils "rm"} -rf /var/lib/dnscache"
+        "${lib.getExe' pkgs.djbdns "dnscache-conf"} dnscache dnscache /var/lib/dnscache ${config.services.dnscache.ip}"
+        "${lib.getExe' pkgs.coreutils "rm"} -rf /var/lib/dnscache/root"
+        "${lib.getExe' pkgs.coreutils "ln"} -sf ${dnscache-root} /var/lib/dnscache/root"
+      ];
+      serviceConfig.ExecStart = "/var/lib/dnscache/run";
     };
   };
 }

--- a/nixos/modules/services/networking/murmur.nix
+++ b/nixos/modules/services/networking/murmur.nix
@@ -355,17 +355,13 @@ in
       ]
       ++ lib.optional (cfg.tls.useACMEHost != null) "acme-${cfg.tls.useACMEHost}.service";
       wants = lib.mkIf (cfg.tls.useACMEHost != null) [ "acme-${cfg.tls.useACMEHost}.service" ];
-      preStart = ''
-        ${pkgs.envsubst}/bin/envsubst \
-          -o /run/murmur/murmurd.ini \
-          -i ${configFile}
-      '';
 
       serviceConfig = {
         # murmurd doesn't fork when logging to the console.
         Type = if forking then "forking" else "simple";
         PIDFile = lib.mkIf forking "/run/murmur/murmurd.pid";
         EnvironmentFile = lib.mkIf (cfg.environmentFile != null) cfg.environmentFile;
+        ExecStartPre = "${pkgs.envsubst}/bin/envsubst -i '${configFile}' -o /run/murmur/murmurd.ini";
         ExecStart = "${cfg.package}/bin/mumble-server -ini /run/murmur/murmurd.ini";
         Restart = "always";
         LogsDirectory = lib.mkIf cfg.logToFile "murmur";

--- a/nixos/modules/services/networking/openvpn.nix
+++ b/nixos/modules/services/networking/openvpn.nix
@@ -83,11 +83,14 @@ let
   restartService = optionalAttrs cfg.restartAfterSleep {
     openvpn-restart = {
       wantedBy = [ "sleep.target" ];
-      script =
-        let
-          unitNames = map (n: "openvpn-${n}.service") (builtins.attrNames cfg.servers);
-        in
-        "systemctl try-restart ${lib.escapeShellArgs unitNames}";
+      serviceConfig = {
+        Type = "oneshot";
+        ExecStart =
+          let
+            unitNames = map (n: "openvpn-${n}.service") (builtins.attrNames cfg.servers);
+          in
+          "systemctl try-restart ${lib.escapeShellArgs unitNames}";
+      };
       description = "Restart system OpenVPN connections when returning from sleep";
     };
   };

--- a/nixos/modules/services/networking/webhook.nix
+++ b/nixos/modules/services/networking/webhook.nix
@@ -208,31 +208,31 @@ in
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
       environment = config.networking.proxy.envVars // cfg.environment;
-      script =
-        let
-          args = [
-            "-ip"
-            cfg.ip
-            "-port"
-            (toString cfg.port)
-            "-urlprefix"
-            cfg.urlPrefix
-          ]
-          ++ concatMap (hook: [
-            "-hooks"
-            hook
-          ]) hookFiles
-          ++ optional cfg.enableTemplates "-template"
-          ++ optional cfg.verbose "-verbose"
-          ++ cfg.extraArgs;
-        in
-        ''
-          ${cfg.package}/bin/webhook ${escapeShellArgs args}
-        '';
       serviceConfig = {
         Restart = "on-failure";
         User = cfg.user;
         Group = cfg.group;
+        ExecStart =
+          let
+            args = [
+              "-ip"
+              cfg.ip
+              "-port"
+              (toString cfg.port)
+              "-urlprefix"
+              cfg.urlPrefix
+            ]
+            ++ concatMap (hook: [
+              "-hooks"
+              hook
+            ]) hookFiles
+            ++ optional cfg.enableTemplates "-template"
+            ++ optional cfg.verbose "-verbose"
+            ++ cfg.extraArgs;
+          in
+          ''
+            ${cfg.package}/bin/webhook ${escapeShellArgs args}
+          '';
       };
     };
   };

--- a/nixos/modules/services/search/meilisearch.nix
+++ b/nixos/modules/services/search/meilisearch.nix
@@ -195,15 +195,6 @@ in
       wantedBy = [ "multi-user.target" ];
       after = [ "network.target" ];
 
-      preStart = lib.mkMerge [
-        ''
-          install -m 700 '${configFile}' "$RUNTIME_DIRECTORY/config.toml"
-        ''
-        (lib.mkIf (cfg.masterKeyFile != null) ''
-          ${lib.getExe pkgs.replace-secret} '${master-key-placeholder}' "$CREDENTIALS_DIRECTORY/master_key" "$RUNTIME_DIRECTORY/config.toml"
-        '')
-      ];
-
       environment = builtins.listToAttrs (
         map (secret: {
           name = secret.environment;
@@ -223,6 +214,12 @@ in
             secret: lib.mkIf (secret.setting != null) [ "${secret.name}:${secret.setting}" ]
           ) secrets-with-path
         );
+        ExecStartPre = [
+          "${lib.getExe' pkgs.coreutils "install"} -m 700 '${configFile}' \"\${RUNTIME_DIRECTORY}/config.toml\""
+        ]
+        ++ lib.optionals (cfg.masterKeyFile != null) [
+          "${lib.getExe pkgs.replace-secret} '${master-key-placeholder}' \"\${CREDENTIALS_DIRECTORY}/master_key\" \"\${RUNTIME_DIRECTORY}/config.toml\""
+        ];
         ExecStart = "${lib.getExe cfg.package} --config-file-path \${RUNTIME_DIRECTORY}/config.toml";
         StateDirectory = "meilisearch";
         WorkingDirectory = "%S/meilisearch";

--- a/nixos/modules/services/web-apps/sogo.nix
+++ b/nixos/modules/services/web-apps/sogo.nix
@@ -151,15 +151,14 @@ in
       description = "SOGo tmpwatch";
 
       startAt = [ "hourly" ];
-      script = ''
-        SOGOSPOOL=/var/lib/sogo/spool
-
-        find "$SOGOSPOOL" -type f -user sogo -atime +23 -delete > /dev/null
-        find "$SOGOSPOOL" -mindepth 1 -type d -user sogo -empty -delete > /dev/null
-      '';
 
       serviceConfig = {
         Type = "oneshot";
+
+        ExecStart = [
+          "find /var/lib/sogo/spool -type f -user sogo -atime +23 -delete"
+          "find /var/lib/sogo/spool -mindepth 1 -type d -user sogo -empty -delete"
+        ];
 
         ProtectSystem = "strict";
         ProtectHome = true;

--- a/nixos/modules/services/web-apps/wiki-js.nix
+++ b/nixos/modules/services/web-apps/wiki-js.nix
@@ -138,19 +138,18 @@ in
         openssh
       ];
 
-      preStart = ''
-        ln -sf ${configFile} /var/lib/${cfg.stateDirectoryName}/config.yml
-        ln -sf ${pkgs.wiki-js}/server /var/lib/${cfg.stateDirectoryName}
-        ln -sf ${pkgs.wiki-js}/assets /var/lib/${cfg.stateDirectoryName}
-        ln -sf ${pkgs.wiki-js}/package.json /var/lib/${cfg.stateDirectoryName}/package.json
-      '';
-
       serviceConfig = {
         EnvironmentFile = mkIf (cfg.environmentFile != null) cfg.environmentFile;
         StateDirectory = cfg.stateDirectoryName;
         WorkingDirectory = "/var/lib/${cfg.stateDirectoryName}";
         DynamicUser = true;
         PrivateTmp = true;
+        ExecStartPre = [
+          "${lib.getExe' pkgs.coreutils "ln"} -sf ${configFile} /var/lib/${cfg.stateDirectoryName}/config.yml"
+          "${lib.getExe' pkgs.coreutils "ln"} -sf ${pkgs.wiki-js}/server /var/lib/${cfg.stateDirectoryName}"
+          "${lib.getExe' pkgs.coreutils "ln"} -sf ${pkgs.wiki-js}/assets /var/lib/${cfg.stateDirectoryName}"
+          "${lib.getExe' pkgs.coreutils "ln"} -sf ${pkgs.wiki-js}/package.json /var/lib/${cfg.stateDirectoryName}/package.json"
+        ];
         ExecStart = "${pkgs.lib.getExe pkgs.nodejs-slim} ${pkgs.wiki-js}/server";
       };
     };

--- a/nixos/modules/services/web-servers/traefik.nix
+++ b/nixos/modules/services/web-servers/traefik.nix
@@ -130,12 +130,9 @@ in
       startLimitBurst = 5;
       serviceConfig = {
         EnvironmentFile = cfg.environmentFiles;
-        ExecStartPre = lib.optional (cfg.environmentFiles != [ ]) (
-          pkgs.writeShellScript "pre-start" ''
-            umask 077
-            ${pkgs.envsubst}/bin/envsubst -i "${staticConfigFile}" > "${finalStaticConfigFile}"
-          ''
-        );
+        ExecStartPre = lib.optional (
+          cfg.environmentFiles != [ ]
+        ) "${pkgs.envsubst}/bin/envsubst -i '${staticConfigFile}' -o '${finalStaticConfigFile}'";
         ExecStart = "${cfg.package}/bin/traefik --configfile=${finalStaticConfigFile}";
         Type = "simple";
         User = "traefik";
@@ -152,6 +149,7 @@ in
         ProtectSystem = "full";
         ReadWritePaths = [ cfg.dataDir ];
         RuntimeDirectory = "traefik";
+        RuntimeDirectoryMode = "0700";
         WorkingDirectory = cfg.dataDir;
       };
     };


### PR DESCRIPTION
This PR goes over a few nixos modules where `script`/`preStart` was easily replacable with `ExecStart`/`ExecStartPre`.
This gets rid of unnecessary bash wrappers, and lets you see the command being run directly when running `systemctl cat <name>.service`.

It also makes some of the services usable with the bashless profile.

Since this is more or less a manual treewide, this is a single PR in a set of PRs that has been split into reviewable chunks.

Part 1: #481637
Part 2: #481638
Part 3: #481639
Part 4: #481640

<details>
<summary>NixOS test coverage</summary>

Modules with the checkbox checked have tests.

- [X] airsonic
- [X] davis
- [ ] dnscache
- [X] grafana
- [X] guix
- [X] kthxbye
- [X] meilisearch
- [ ] mqtt2influxdb
- [X] murmur (via mumble, botamusique)
- [X] openafs
- [X] openvpn (via initrd-network-openvpn/)
- [X] pihole-ftl
- [X] prometheus.alertmanager
- [X] sogo
- [X] traefik
- [X] webhook
- [ ] wg-access-server (broken on master)
- [X] wiki-js
- [ ] zitadel

`nix build .#nixosTests.airsonic .#nixosTests.davis .#nixosTests.grafana.basic .#nixosTests.grafana.provision .#nixosTests.guix.basic .#nixosTests.guix.publish .#nixosTests.kthxbye .#nixosTests.meilisearch .#nixosTests.mumble .#nixosTests.botamusique .#nixosTests.openafs .#nixosTests.initrd-network-openvpn .#nixosTests.pihole-ftl.basic .#nixosTests.pihole-ftl.dnsmasq .#nixosTests.prometheus.alertmanager .#nixosTests.sogo .#nixosTests.traefik .#nixosTests.webhook .#nixosTests.wiki-js -L`

</details>


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
