### PR TITLE
rune-languageserver: 0.13.4 -> 0.14.1

### DIFF
--- a/pkgs/by-name/ru/rune-languageserver/package.nix
+++ b/pkgs/by-name/ru/rune-languageserver/package.nix
@@ -2,27 +2,39 @@
   lib,
   rustPlatform,
   fetchCrate,
+  versionCheckHook,
+  nix-update-script,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rune-languageserver";
-  version = "0.13.4";
+  version = "0.14.1";
 
   src = fetchCrate {
-    inherit pname version;
-    hash = "sha256-Kw6Qh/9eQPMj4V689+7AxuJB+aCciK3FZTfcdhyZXGY=";
+    inherit (finalAttrs) pname version;
+    hash = "sha256-0b8XGbMQqMolOdQEMjpwHAVI3A4fXemyCowN39qY16A=";
   };
 
-  cargoHash = "sha256-YviRACndc4r4ul72ZF3I/R/nEsIoML2Ek2xqUUE3FDQ=";
+  cargoHash = "sha256-QrzOpfDpG08IUoydvSoh0qxJ0vg86391NnyEyJeZr54=";
 
   env = {
-    RUNE_VERSION = version;
+    RUNE_VERSION = finalAttrs.version;
+  };
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
+
+  passthru = {
+    updateScript = nix-update-script { };
   };
 
   meta = {
     description = "Language server for the Rune Language, an embeddable dynamic programming language for Rust";
     homepage = "https://crates.io/crates/rune-languageserver";
-    changelog = "https://github.com/rune-rs/rune/releases/tag/${version}";
+    downloadPage = "https://github.com/rune-rs/rune";
+    changelog = "https://github.com/rune-rs/rune/releases/tag/${finalAttrs.version}";
     license = with lib.licenses; [
       asl20
       mit
@@ -30,4 +42,4 @@ rustPlatform.buildRustPackage rec {
     maintainers = [ ];
     mainProgram = "rune-languageserver";
   };
-}
+})


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://diff.rs/rune-languageserver/0.13.4/0.14.1
Changelog: https://github.com/rune-rs/rune/releases/tag/0.14.1

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test