### PR TITLE
wxmp3gain: init at 4.2

### DIFF
--- a/pkgs/by-name/wx/wxmp3gain/package.nix
+++ b/pkgs/by-name/wx/wxmp3gain/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  gettext,
+  wxGTK32,
+  mp3gain,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "wxmp3gain";
+  version = "4.2";
+
+  src = fetchFromGitHub {
+    owner = "cfgnunes";
+    repo = "wxmp3gain";
+    rev = version;
+    hash = "sha256-264HSGJXXt27ZiiDUsIIjCuU2WFB0sEkwnglTH5xXww=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    gettext
+  ];
+
+  buildInputs = [
+    wxGTK32
+    mp3gain
+  ];
+
+  postInstall = ''
+    # Make data/ reachable next to the binary as expected by getDataDir()
+    ln -s ../share/wxmp3gain/data $out/bin/data
+  '';
+
+  meta = {
+    description = "Free front-end for the MP3gain";
+    longDescription = ''
+      wxMP3gain is a free front-end for MP3gain, providing a graphical
+      interface to analyze and adjust the volume of MP3 files without
+      re-encoding.
+    '';
+    homepage = "https://github.com/cfgnunes/wxmp3gain";
+    license = lib.licenses.gpl3Plus;
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+    mainProgram = "wxmp3gain";
+  };
+}


### PR DESCRIPTION
Add [wxmp3gain](https://github.com/cfgnunes/wxmp3gain/tree/main), a GUI for mp3gain to normalize .MP3 audio volume.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
