### PR TITLE
ctpv: build on aarch64-linux and darwin

### DIFF
--- a/pkgs/by-name/ct/ctpv/package.nix
+++ b/pkgs/by-name/ct/ctpv/package.nix
@@ -39,23 +39,29 @@ stdenv.mkDerivation rec {
 
   makeFlags = [ "PREFIX=$(out)" ];
 
+  CFLAGS = [ "-fsigned-char" ];
+
   preFixup = ''
     wrapProgram $out/bin/ctpv \
       --prefix PATH ":" "${
-        lib.makeBinPath [
-          atool # for archive files
-          bat
-          chafa # for image files on Wayland
-          delta # for diff files
-          ffmpeg
-          ffmpegthumbnailer
-          fontforge
-          glow # for markdown files
-          imagemagick
-          jq # for json files
-          poppler-utils # for pdf files
-          ueberzug # for image files on X11
-        ]
+        lib.makeBinPath (
+          [
+            atool # for archive files
+            bat
+            chafa # for image files on Wayland
+            delta # for diff files
+            ffmpeg
+            ffmpegthumbnailer
+            fontforge
+            glow # for markdown files
+            imagemagick
+            jq # for json files
+            poppler-utils # for pdf files
+          ]
+          ++ (lib.optionals stdenv.isLinux [
+            ueberzug # for image files on X11
+          ])
+        )
       }";
   '';
 
@@ -66,7 +72,7 @@ stdenv.mkDerivation rec {
     description = "File previewer for a terminal";
     homepage = "https://github.com/NikitaIvanovV/ctpv";
     license = lib.licenses.mit;
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
     maintainers = [ lib.maintainers.wesleyjrz ];
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Make ctpv also buildable on aarch64-linux and aarch64-darwin.
- aarch64-linux: Requires compiler flag fix from https://github.com/NikitaIvanovV/ctpv/issues/101, which this PR adds
- aarch64-darwin: ueberzug is not available on darwin, so this is made conditional

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
