### PR TITLE
skills-ref: init at 0.1.0-unstable-2026-02-15

### DIFF
--- a/pkgs/by-name/sk/skills-ref/package.nix
+++ b/pkgs/by-name/sk/skills-ref/package.nix
@@ -1,0 +1,1 @@
+{ python3Packages }: with python3Packages; toPythonApplication skills-ref

--- a/pkgs/development/python-modules/skills-ref/default.nix
+++ b/pkgs/development/python-modules/skills-ref/default.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildPythonPackage,
+  click,
+  fetchFromGitHub,
+  hatchling,
+  nix-update-script,
+  strictyaml,
+}:
+
+buildPythonPackage {
+  pname = "skills-ref";
+  version = "0.1.0-unstable-2026-02-15";
+  __structuredAttrs = true;
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "agentskills";
+    repo = "agentskills";
+    rev = "492e1b71046249d085444cad81d47985836c451b";
+    hash = "sha256-1yWmiz9x5cOtSybkT3YVDYhVj2XUm3NL3IvgrStuf4s=";
+  };
+  sourceRoot = "source/skills-ref";
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    click
+    strictyaml
+  ];
+
+  pythonImportsCheck = [ "skills_ref" ];
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
+
+  meta = {
+    description = "Reference library for Agent Skills";
+    homepage = "https://github.com/agentskills/agentskills";
+    license = lib.licenses.asl20;
+    mainProgram = "skills-ref";
+    maintainers = with lib.maintainers; [ steveej ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17402,6 +17402,8 @@ self: super: with self; {
 
   skidl = callPackage ../development/python-modules/skidl { };
 
+  skills-ref = callPackage ../development/python-modules/skills-ref { };
+
   skl2onnx = callPackage ../development/python-modules/skl2onnx { };
 
   sklearn-compat = callPackage ../development/python-modules/sklearn-compat { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
