### PR TITLE
phantom: init at 0-unstable-2025-12-22

### DIFF
--- a/pkgs/by-name/ph/phantom/package.nix
+++ b/pkgs/by-name/ph/phantom/package.nix
@@ -1,0 +1,52 @@
+{
+  stdenv,
+  fetchFromGitea,
+  qt6,
+  cmark-gfm,
+  cmake,
+  ninja,
+  lib
+}:
+
+stdenv.mkDerivation {
+  pname = "phantom";
+  version = "0-unstable-2025-12-22";
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "ItsZariep";
+    repo = "Phantom";
+    rev = "7bba1e0a2d9b33d881fb999bb543324d14355505";
+    hash = lib.fakeHash;
+  };
+
+  nativeBuildInputs = [
+    qt6.wrapQtAppsHook
+    cmake
+    ninja
+  ];
+
+  buildInputs = [
+    qt6.qtbase
+    qt6.qtwebengine
+    cmark-gfm
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp sqlauncher $out/bin
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Multi-tabbed Markdown editor with live preview";
+    homepage = "https://codeberg.org/ItsZariep/Phantom";
+    license = licenses.gpl3Only;
+    mainProgram = "phantom";
+    platforms = platforms.all;
+    maintainers = with maintainers; [ reylak ];
+  };
+}


### PR DESCRIPTION
Packaged Phantom, a Markdown editor for support for multi-tab to make more efficient and consume less resources on the system.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.