### PR TITLE
spidermonkey_140: 140.6.0 -> 140.7.0

### DIFF
--- a/pkgs/development/interpreters/spidermonkey/140.nix
+++ b/pkgs/development/interpreters/spidermonkey/140.nix
@@ -1,4 +1,4 @@
 import ./common.nix {
-  version = "140.6.0";
-  hash = "sha512-7WZle9Sy2UeRiSJh18DA2VC09jDRKrKKd32TOTQnRRqaoSXloB7hXyrA/zeNC+B0oIWD3P/TVgkRK6Tm+a2nmA==";
+  version = "140.7.0";
+  hash = "sha512-d4Gx4gMTDBzfKgwuywWpz6gkx11Gfn+sp4tmvVVoyCEyQRKuy3dIg9n0R69/pK3jZIj/EBclWvVRDI9kGZDkcg==";
 }


### PR DESCRIPTION



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
