### PR TITLE
 treewide: remove superfluous pythonOlder "3.10"

### DIFF
--- a/pkgs/by-name/ca/canaille/package.nix
+++ b/pkgs/by-name/ca/canaille/package.nix
@@ -15,8 +15,6 @@ python.pkgs.buildPythonApplication rec {
   version = "0.0.74";
   pyproject = true;
 
-  disabled = python.pythonOlder "3.10";
-
   src = fetchFromGitLab {
     owner = "yaal";
     repo = "canaille";

--- a/pkgs/by-name/ma/matrix-zulip-bridge/package.nix
+++ b/pkgs/by-name/ma/matrix-zulip-bridge/package.nix
@@ -9,8 +9,6 @@ python3Packages.buildPythonApplication rec {
   version = "0.4.1";
   pyproject = true;
 
-  disabled = python3Packages.pythonOlder "3.10";
-
   src = fetchFromGitHub {
     owner = "GearKite";
     repo = "MatrixZulipBridge";

--- a/pkgs/by-name/py/pyprland/package.nix
+++ b/pkgs/by-name/py/pyprland/package.nix
@@ -10,8 +10,6 @@ python3Packages.buildPythonApplication rec {
   version = "2.5.1";
   pyproject = true;
 
-  disabled = python3Packages.pythonOlder "3.10";
-
   src = fetchFromGitHub {
     owner = "hyprland-community";
     repo = "pyprland";

--- a/pkgs/development/python-modules/abjad/default.nix
+++ b/pkgs/development/python-modules/abjad/default.nix
@@ -5,7 +5,6 @@
   ply,
   roman,
   uqbar,
-  pythonOlder,
   pythonAtLeast,
   pytestCheckHook,
   lilypond,
@@ -19,7 +18,7 @@ buildPythonPackage rec {
 
   # see issue upstream indicating Python 3.12 support will come
   # with version 3.20: https://github.com/Abjad/abjad/issues/1574
-  disabled = pythonOlder "3.10" || pythonAtLeast "3.12";
+  disabled = pythonAtLeast "3.12";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/aioitertools/default.nix
+++ b/pkgs/development/python-modules/aioitertools/default.nix
@@ -2,13 +2,9 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  pythonOlder,
 
   # native
   flit-core,
-
-  # propagates
-  typing-extensions,
 
   # tests
   unittestCheckHook,
@@ -25,8 +21,6 @@ buildPythonPackage rec {
   };
 
   build-system = [ flit-core ];
-
-  dependencies = lib.optionals (pythonOlder "3.10") [ typing-extensions ];
 
   nativeCheckInputs = [ unittestCheckHook ];
 

--- a/pkgs/development/python-modules/aiosmtpd/default.nix
+++ b/pkgs/development/python-modules/aiosmtpd/default.nix
@@ -6,7 +6,6 @@
   fetchFromGitHub,
   pytest-mock,
   pytestCheckHook,
-  pythonOlder,
   setuptools,
 
   # for passthru.tests
@@ -38,8 +37,8 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  # Fixes for Python 3.10 can't be applied easily, https://github.com/aio-libs/aiosmtpd/pull/294
-  doCheck = pythonOlder "3.10";
+  # Fixes can't be applied easily, https://github.com/aio-libs/aiosmtpd/pull/294
+  doCheck = false;
 
   disabledTests = [
     # Requires git

--- a/pkgs/development/python-modules/ansible-runner/default.nix
+++ b/pkgs/development/python-modules/ansible-runner/default.nix
@@ -13,8 +13,6 @@
   pexpect,
   python-daemon,
   pyyaml,
-  pythonOlder,
-  importlib-metadata,
 
   # tests
   addBinToPathHook,
@@ -58,8 +56,7 @@ buildPythonPackage rec {
     pexpect
     python-daemon
     pyyaml
-  ]
-  ++ lib.optionals (pythonOlder "3.10") [ importlib-metadata ];
+  ];
 
   nativeCheckInputs = [
     addBinToPathHook

--- a/pkgs/development/python-modules/babelfish/default.nix
+++ b/pkgs/development/python-modules/babelfish/default.nix
@@ -2,9 +2,7 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  pythonOlder,
   poetry-core,
-  importlib-metadata,
 }:
 
 buildPythonPackage rec {
@@ -18,8 +16,6 @@ buildPythonPackage rec {
   };
 
   build-system = [ poetry-core ];
-
-  dependencies = lib.optionals (pythonOlder "3.10") [ importlib-metadata ];
 
   # no tests executed
   doCheck = false;

--- a/pkgs/development/python-modules/bork/default.nix
+++ b/pkgs/development/python-modules/bork/default.nix
@@ -9,7 +9,6 @@
   setuptools,
   build,
   coloredlogs,
-  importlib-metadata,
   packaging,
   pip,
   toml,
@@ -45,8 +44,7 @@ buildPythonPackage rec {
     pip
     urllib3
   ]
-  ++ lib.optionals (pythonOlder "3.11") [ toml ]
-  ++ lib.optionals (pythonOlder "3.10") [ importlib-metadata ];
+  ++ lib.optionals (pythonOlder "3.11") [ toml ];
 
   pythonImportsCheck = [
     "bork"

--- a/pkgs/development/python-modules/cloup/default.nix
+++ b/pkgs/development/python-modules/cloup/default.nix
@@ -5,8 +5,6 @@
   pytestCheckHook,
   click,
   setuptools-scm,
-  pythonOlder,
-  typing-extensions,
 }:
 
 buildPythonPackage rec {
@@ -21,7 +19,7 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [ setuptools-scm ];
 
-  propagatedBuildInputs = [ click ] ++ lib.optionals (pythonOlder "3.10") [ typing-extensions ];
+  propagatedBuildInputs = [ click ];
 
   nativeCheckInputs = [ pytestCheckHook ];
 

--- a/pkgs/development/python-modules/datalad/default.nix
+++ b/pkgs/development/python-modules/datalad/default.nix
@@ -39,7 +39,6 @@
   colorama,
   # python-version-dependent
   pythonOlder,
-  importlib-metadata,
   typing-extensions,
   # tests
   pytest-xdist,
@@ -94,7 +93,6 @@ buildPythonPackage rec {
       looseversion
     ]
     ++ lib.optionals stdenv.hostPlatform.isWindows [ colorama ]
-    ++ lib.optionals (pythonOlder "3.10") [ importlib-metadata ]
     ++ lib.optionals (pythonOlder "3.11") [ typing-extensions ];
     downloaders = [
       boto3

--- a/pkgs/development/python-modules/dns-lexicon/default.nix
+++ b/pkgs/development/python-modules/dns-lexicon/default.nix
@@ -6,14 +6,12 @@
   cryptography,
   dnspython,
   fetchFromGitHub,
-  importlib-metadata,
   localzone,
   oci,
   poetry-core,
   pyotp,
   pytest-vcr,
   pytestCheckHook,
-  pythonOlder,
   pyyaml,
   requests,
   softlayer,
@@ -50,8 +48,7 @@ buildPythonPackage rec {
     pyyaml
     requests
     tldextract
-  ]
-  ++ lib.optionals (pythonOlder "3.10") [ importlib-metadata ];
+  ];
 
   optional-dependencies = {
     route53 = [ boto3 ];

--- a/pkgs/development/python-modules/fake-useragent/default.nix
+++ b/pkgs/development/python-modules/fake-useragent/default.nix
@@ -2,7 +2,6 @@
   lib,
   fetchFromGitHub,
   buildPythonPackage,
-  importlib-resources,
   setuptools,
   pythonOlder,
   pytestCheckHook,
@@ -25,8 +24,6 @@ buildPythonPackage rec {
   '';
 
   build-system = [ setuptools ];
-
-  dependencies = lib.optionals (pythonOlder "3.10") [ importlib-resources ];
 
   nativeCheckInputs = [ pytestCheckHook ];
 

--- a/pkgs/development/python-modules/falcon/default.nix
+++ b/pkgs/development/python-modules/falcon/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   pythonAtLeast,
-  pythonOlder,
   isPyPy,
   fetchFromGitHub,
 
@@ -21,7 +20,6 @@
   pyyaml,
   rapidjson,
   requests,
-  testtools,
   ujson,
   uvicorn,
   websockets,
@@ -72,8 +70,7 @@ buildPythonPackage rec {
     msgpack
     mujson
     ujson
-  ]
-  ++ lib.optionals (pythonOlder "3.10") [ testtools ];
+  ];
 
   enabledTestPaths = [ "tests" ];
 

--- a/pkgs/development/python-modules/globus-sdk/default.nix
+++ b/pkgs/development/python-modules/globus-sdk/default.nix
@@ -6,11 +6,9 @@
   flaky,
   pyjwt,
   pytestCheckHook,
-  pythonOlder,
   requests,
   responses,
   setuptools,
-  typing-extensions,
 }:
 
 buildPythonPackage rec {
@@ -35,8 +33,7 @@ buildPythonPackage rec {
     cryptography
     requests
     pyjwt
-  ]
-  ++ lib.optionals (pythonOlder "3.10") [ typing-extensions ];
+  ];
 
   nativeCheckInputs = [ pytestCheckHook ];
 

--- a/pkgs/development/python-modules/gymnasium/default.nix
+++ b/pkgs/development/python-modules/gymnasium/default.nix
@@ -12,8 +12,6 @@
   farama-notifications,
   numpy,
   typing-extensions,
-  pythonOlder,
-  importlib-metadata,
 
   # optional-dependencies
   # atari
@@ -56,8 +54,7 @@ buildPythonPackage rec {
     farama-notifications
     numpy
     typing-extensions
-  ]
-  ++ lib.optionals (pythonOlder "3.10") [ importlib-metadata ];
+  ];
 
   optional-dependencies = {
     atari = [

--- a/pkgs/development/python-modules/hypothesis/default.nix
+++ b/pkgs/development/python-modules/hypothesis/default.nix
@@ -102,13 +102,6 @@ buildPythonPackage rec {
     # calls script with the naked interpreter
     "test_constants_from_running_file"
   ]
-  ++ lib.optionals (pythonOlder "3.10") [
-    # not sure why these tests fail with only 3.9
-    # FileNotFoundError: [Errno 2] No such file or directory: 'git'
-    "test_observability"
-    "test_assume_has_status_reason"
-    "test_observability_captures_stateful_reprs"
-  ]
   ++ lib.optionals (pythonAtLeast "3.12") [
     # AssertionError: assert [b'def      \...   f(): pass'] == [b'def\\', b'    f(): pass']
     # https://github.com/HypothesisWorks/hypothesis/issues/4355

--- a/pkgs/development/python-modules/internetarchive/default.nix
+++ b/pkgs/development/python-modules/internetarchive/default.nix
@@ -10,8 +10,6 @@
   setuptools,
   tqdm,
   urllib3,
-  pythonOlder,
-  importlib-metadata,
 }:
 
 buildPythonPackage rec {
@@ -34,8 +32,7 @@ buildPythonPackage rec {
     jsonpatch
     schema
     urllib3
-  ]
-  ++ lib.optionals (pythonOlder "3.10") [ importlib-metadata ];
+  ];
 
   nativeCheckInputs = [
     responses

--- a/pkgs/development/python-modules/ipyparallel/default.nix
+++ b/pkgs/development/python-modules/ipyparallel/default.nix
@@ -4,13 +4,11 @@
   decorator,
   fetchPypi,
   hatchling,
-  importlib-metadata,
   ipykernel,
   ipython,
   jupyter-client,
   psutil,
   python-dateutil,
-  pythonOlder,
   pyzmq,
   tornado,
   tqdm,
@@ -48,8 +46,7 @@ buildPythonPackage rec {
     tornado
     tqdm
     traitlets
-  ]
-  ++ lib.optional (pythonOlder "3.10") importlib-metadata;
+  ];
 
   # Requires access to cluster
   doCheck = false;

--- a/pkgs/development/python-modules/jupyter-client/default.nix
+++ b/pkgs/development/python-modules/jupyter-client/default.nix
@@ -8,8 +8,6 @@
   pyzmq,
   tornado,
   traitlets,
-  pythonOlder,
-  importlib-metadata,
 }:
 
 buildPythonPackage rec {
@@ -31,8 +29,7 @@ buildPythonPackage rec {
     pyzmq
     tornado
     traitlets
-  ]
-  ++ lib.optionals (pythonOlder "3.10") [ importlib-metadata ];
+  ];
 
   pythonImportsCheck = [ "jupyter_client" ];
 

--- a/pkgs/development/python-modules/jupyterlab-server/default.nix
+++ b/pkgs/development/python-modules/jupyterlab-server/default.nix
@@ -2,10 +2,8 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  pythonOlder,
   hatchling,
   babel,
-  importlib-metadata,
   jinja2,
   json5,
   jsonschema,
@@ -45,8 +43,7 @@ buildPythonPackage rec {
     jupyter-server
     packaging
     requests
-  ]
-  ++ lib.optionals (pythonOlder "3.10") [ importlib-metadata ];
+  ];
 
   optional-dependencies = {
     openapi = [

--- a/pkgs/development/python-modules/jupyterlab/default.nix
+++ b/pkgs/development/python-modules/jupyterlab/default.nix
@@ -8,7 +8,6 @@
   hatchling,
   async-lru,
   httpx,
-  importlib-metadata,
   ipykernel,
   jinja2,
   jupyter-core,
@@ -75,8 +74,7 @@ buildPythonPackage rec {
     tornado
     traitlets
   ]
-  ++ lib.optionals (pythonOlder "3.11") [ tomli ]
-  ++ lib.optionals (pythonOlder "3.10") [ importlib-metadata ];
+  ++ lib.optionals (pythonOlder "3.11") [ tomli ];
 
   makeWrapperArgs = [
     "--set"

--- a/pkgs/development/python-modules/lacuscore/default.nix
+++ b/pkgs/development/python-modules/lacuscore/default.nix
@@ -4,7 +4,6 @@
   buildPythonPackage,
   defang,
   dnspython,
-  eval-type-backport,
   fetchFromGitHub,
   orjson,
   playwrightcapture,
@@ -51,8 +50,7 @@ buildPythonPackage rec {
   ++ playwrightcapture.optional-dependencies.recaptcha
   ++ redis.optional-dependencies.hiredis
   ++ ua-parser.optional-dependencies.regex
-  ++ lib.optionals (pythonOlder "3.11") [ async-timeout ]
-  ++ lib.optionals (pythonOlder "3.10") [ eval-type-backport ];
+  ++ lib.optionals (pythonOlder "3.11") [ async-timeout ];
 
   # Module has no tests
   doCheck = false;

--- a/pkgs/development/python-modules/marshmallow-dataclass/default.nix
+++ b/pkgs/development/python-modules/marshmallow-dataclass/default.nix
@@ -5,10 +5,8 @@
   marshmallow,
   pytestCheckHook,
   pythonAtLeast,
-  pythonOlder,
   setuptools,
   typeguard,
-  typing-extensions,
   typing-inspect,
 }:
 
@@ -29,8 +27,7 @@ buildPythonPackage rec {
   dependencies = [
     marshmallow
     typing-inspect
-  ]
-  ++ lib.optionals (pythonOlder "3.10") [ typing-extensions ];
+  ];
 
   nativeCheckInputs = [
     pytestCheckHook

--- a/pkgs/development/python-modules/mkdocs/default.nix
+++ b/pkgs/development/python-modules/mkdocs/default.nix
@@ -4,7 +4,6 @@
   buildPythonPackage,
   fetchFromGitHub,
   pythonAtLeast,
-  pythonOlder,
 
   # buildtime
   hatchling,
@@ -12,7 +11,6 @@
   # runtime deps
   click,
   ghp-import,
-  importlib-metadata,
   jinja2,
   markdown,
   markupsafe,
@@ -72,8 +70,7 @@ buildPythonPackage rec {
     pyyaml
     pyyaml-env-tag
     watchdog
-  ]
-  ++ lib.optionals (pythonOlder "3.10") [ importlib-metadata ];
+  ];
 
   optional-dependencies = {
     i18n = [ babel ];

--- a/pkgs/development/python-modules/mkdocstrings/default.nix
+++ b/pkgs/development/python-modules/mkdocstrings/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  importlib-metadata,
   jinja2,
   markdown,
   markupsafe,
@@ -11,7 +10,6 @@
   pdm-backend,
   pymdown-extensions,
   pytestCheckHook,
-  pythonOlder,
   dirty-equals,
 }:
 
@@ -41,9 +39,6 @@ buildPythonPackage rec {
     mkdocs
     mkdocs-autorefs
     pymdown-extensions
-  ]
-  ++ lib.optionals (pythonOlder "3.10") [
-    importlib-metadata
   ];
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/parver/default.nix
+++ b/pkgs/development/python-modules/parver/default.nix
@@ -2,14 +2,12 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  pythonOlder,
   setuptools,
   attrs,
   pytestCheckHook,
   hypothesis,
   pretend,
   arpeggio,
-  typing-extensions,
 }:
 
 buildPythonPackage rec {
@@ -27,8 +25,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     attrs
     arpeggio
-  ]
-  ++ lib.optionals (pythonOlder "3.10") [ typing-extensions ];
+  ];
 
   nativeCheckInputs = [
     pytestCheckHook

--- a/pkgs/development/python-modules/pcapy-ng/default.nix
+++ b/pkgs/development/python-modules/pcapy-ng/default.nix
@@ -6,7 +6,6 @@
   libpcap,
   pkgconfig,
   pytestCheckHook,
-  pythonOlder,
 }:
 
 buildPythonPackage rec {
@@ -36,7 +35,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "pcapy" ];
 
-  doCheck = pythonOlder "3.10";
+  doCheck = false;
 
   enabledTestPaths = [ "pcapytests.py" ];
 

--- a/pkgs/development/python-modules/pillow/default.nix
+++ b/pkgs/development/python-modules/pillow/default.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   buildPythonPackage,
-  pythonOlder,
   fetchFromGitHub,
 
   # build-system
@@ -26,7 +25,6 @@
   # optional dependencies
   defusedxml,
   olefile,
-  typing-extensions,
 
   # tests
   numpy,
@@ -100,7 +98,6 @@ buildPythonPackage rec {
   optional-dependencies = {
     fpx = [ olefile ];
     mic = [ olefile ];
-    typing = lib.optionals (pythonOlder "3.10") [ typing-extensions ];
     xmp = [ defusedxml ];
   };
 

--- a/pkgs/development/python-modules/plyara/default.nix
+++ b/pkgs/development/python-modules/plyara/default.nix
@@ -1,7 +1,6 @@
 {
   lib,
   buildPythonPackage,
-  pythonOlder,
   fetchFromGitHub,
   setuptools,
   ply,
@@ -17,8 +16,6 @@ buildPythonPackage rec {
   pname = "plyara";
   version = "2.2.8";
   pyproject = true;
-
-  disabled = pythonOlder "3.10"; # https://github.com/plyara/plyara: "Plyara requires Python 3.10+"
 
   src = fetchFromGitHub {
     owner = "plyara";

--- a/pkgs/development/python-modules/pure-python-adb/default.nix
+++ b/pkgs/development/python-modules/pure-python-adb/default.nix
@@ -3,7 +3,6 @@
   buildPythonPackage,
   fetchPypi,
   lib,
-  pythonOlder,
   pytestCheckHook,
 }:
 
@@ -21,7 +20,7 @@ buildPythonPackage rec {
     async = [ aiofiles ];
   };
 
-  doCheck = pythonOlder "3.10"; # all tests result in RuntimeError on 3.10
+  doCheck = false; # all tests result in RuntimeError
 
   nativeCheckInputs = [ pytestCheckHook ] ++ optional-dependencies.async;
 

--- a/pkgs/development/python-modules/pylint/default.nix
+++ b/pkgs/development/python-modules/pylint/default.nix
@@ -44,8 +44,7 @@ buildPythonPackage rec {
     platformdirs
     tomlkit
   ]
-  ++ lib.optionals (pythonOlder "3.11") [ tomli ]
-  ++ lib.optionals (pythonOlder "3.10") [ typing-extensions ];
+  ++ lib.optionals (pythonOlder "3.11") [ tomli ];
 
   nativeCheckInputs = [
     gitpython

--- a/pkgs/development/python-modules/pypdf2/default.nix
+++ b/pkgs/development/python-modules/pypdf2/default.nix
@@ -3,8 +3,6 @@
   fetchPypi,
   flit-core,
   lib,
-  pythonOlder,
-  typing-extensions,
 }:
 
 buildPythonPackage rec {
@@ -20,8 +18,6 @@ buildPythonPackage rec {
   };
 
   nativeBuildInputs = [ flit-core ];
-
-  dependencies = lib.optionals (pythonOlder "3.10") [ typing-extensions ];
 
   # no test
   doCheck = false;

--- a/pkgs/development/python-modules/pystache/default.nix
+++ b/pkgs/development/python-modules/pystache/default.nix
@@ -2,10 +2,8 @@
   lib,
   fetchFromGitHub,
   buildPythonPackage,
-  pythonOlder,
   setuptools,
   setuptools-scm,
-  importlib-metadata,
   pytestCheckHook,
 }:
 
@@ -24,10 +22,6 @@ buildPythonPackage rec {
   build-system = [
     setuptools
     setuptools-scm
-  ];
-
-  dependencies = lib.optionals (pythonOlder "3.10") [
-    importlib-metadata
   ];
 
   nativeCheckInputs = [ pytestCheckHook ];

--- a/pkgs/development/python-modules/quart-cors/default.nix
+++ b/pkgs/development/python-modules/quart-cors/default.nix
@@ -2,14 +2,12 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  pythonOlder,
 
   # build-system
   pdm-backend,
 
   # propagates
   quart,
-  typing-extensions,
 
   # tests
   pytestCheckHook,
@@ -31,7 +29,7 @@ buildPythonPackage rec {
 
   build-system = [ pdm-backend ];
 
-  dependencies = [ quart ] ++ lib.optionals (pythonOlder "3.10") [ typing-extensions ];
+  dependencies = [ quart ];
 
   pythonImportsCheck = [ "quart_cors" ];
 

--- a/pkgs/development/python-modules/quart/default.nix
+++ b/pkgs/development/python-modules/quart/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  pythonOlder,
 
   # build-system
   flit-core,
@@ -13,13 +12,11 @@
   click,
   flask,
   hypercorn,
-  importlib-metadata,
   itsdangerous,
   jinja2,
   markupsafe,
   pydata-sphinx-theme,
   python-dotenv,
-  typing-extensions,
   werkzeug,
 
   # tests
@@ -57,10 +54,6 @@ buildPythonPackage rec {
     pydata-sphinx-theme
     python-dotenv
     werkzeug
-  ]
-  ++ lib.optionals (pythonOlder "3.10") [
-    importlib-metadata
-    typing-extensions
   ];
 
   pythonImportsCheck = [ "quart" ];

--- a/pkgs/development/python-modules/segno/default.nix
+++ b/pkgs/development/python-modules/segno/default.nix
@@ -2,13 +2,9 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  pythonOlder,
 
   # build-system
   flit-core,
-
-  # dependencies
-  importlib-metadata,
 
   # tests
   pytestCheckHook,
@@ -29,8 +25,6 @@ buildPythonPackage rec {
   };
 
   nativeBuildInputs = [ flit-core ];
-
-  propagatedBuildInputs = lib.optionals (pythonOlder "3.10") [ importlib-metadata ];
 
   nativeCheckInputs = [
     pytestCheckHook

--- a/pkgs/development/python-modules/skytemple-ssb-debugger/default.nix
+++ b/pkgs/development/python-modules/skytemple-ssb-debugger/default.nix
@@ -6,7 +6,6 @@
   gobject-introspection,
   gtk3,
   gtksourceview4,
-  importlib-metadata,
   lib,
   ndspy,
   nest-asyncio,
@@ -14,7 +13,6 @@
   pycairo,
   pygobject3,
   pygtkspellcheck,
-  pythonOlder,
   range-typed-integers,
   skytemple-files,
   skytemple-icons,
@@ -56,8 +54,7 @@ buildPythonPackage rec {
     skytemple-files
     skytemple-icons
     skytemple-ssb-emulator
-  ]
-  ++ lib.optionals (pythonOlder "3.10") [ importlib-metadata ];
+  ];
 
   doCheck = false; # requires Pokémon Mystery Dungeon ROM
   pythonImportsCheck = [ "skytemple_ssb_debugger" ];

--- a/pkgs/development/python-modules/sphinx-autoapi/default.nix
+++ b/pkgs/development/python-modules/sphinx-autoapi/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  pythonOlder,
 
   # build-system
   flit-core,
@@ -12,7 +11,6 @@
   jinja2,
   pyyaml,
   sphinx,
-  stdlib-list,
 
   # tests
   beautifulsoup4,
@@ -38,9 +36,6 @@ buildPythonPackage rec {
     jinja2
     pyyaml
     sphinx
-  ]
-  ++ lib.optionals (pythonOlder "3.10") [
-    stdlib-list
   ];
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/sphinx/default.nix
+++ b/pkgs/development/python-modules/sphinx/default.nix
@@ -14,7 +14,6 @@
   alabaster,
   docutils,
   imagesize,
-  importlib-metadata,
   jinja2,
   packaging,
   pygments,
@@ -86,8 +85,7 @@ buildPythonPackage rec {
     # extra[docs]
     sphinxcontrib-websupport
   ]
-  ++ lib.optionals (pythonOlder "3.11") [ tomli ]
-  ++ lib.optionals (pythonOlder "3.10") [ importlib-metadata ];
+  ++ lib.optionals (pythonOlder "3.11") [ tomli ];
 
   __darwinAllowLocalNetworking = true;
 

--- a/pkgs/development/python-modules/sphinxcontrib-bibtex/default.nix
+++ b/pkgs/development/python-modules/sphinxcontrib-bibtex/default.nix
@@ -2,10 +2,8 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  pythonOlder,
   setuptools,
   docutils,
-  importlib-metadata,
   oset,
   pybtex,
   pybtex-docutils,
@@ -34,9 +32,6 @@ buildPythonPackage rec {
     pybtex
     pybtex-docutils
     sphinx
-  ]
-  ++ lib.optionals (pythonOlder "3.10") [
-    importlib-metadata
   ];
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/starlette/default.nix
+++ b/pkgs/development/python-modules/starlette/default.nix
@@ -19,7 +19,6 @@
 
   # tests
   pytestCheckHook,
-  pythonOlder,
   trio,
 
   # reverse dependencies
@@ -40,7 +39,7 @@ buildPythonPackage rec {
 
   build-system = [ hatchling ];
 
-  dependencies = [ anyio ] ++ lib.optionals (pythonOlder "3.10") [ typing-extensions ];
+  dependencies = [ anyio ];
 
   optional-dependencies.full = [
     itsdangerous

--- a/pkgs/development/python-modules/towncrier/default.nix
+++ b/pkgs/development/python-modules/towncrier/default.nix
@@ -5,7 +5,6 @@
   fetchPypi,
   git, # shells out to git
   hatchling,
-  importlib-resources,
   incremental,
   jinja2,
   mock,
@@ -32,7 +31,6 @@ buildPythonPackage rec {
     incremental
     jinja2
   ]
-  ++ lib.optionals (pythonOlder "3.10") [ importlib-resources ]
   ++ lib.optionals (pythonOlder "3.11") [ tomli ];
 
   preCheck = ''

--- a/pkgs/development/python-modules/twine/default.nix
+++ b/pkgs/development/python-modules/twine/default.nix
@@ -2,9 +2,7 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  pythonOlder,
   id,
-  importlib-metadata,
   keyring,
   packaging,
   pkginfo,
@@ -48,9 +46,6 @@ buildPythonPackage rec {
     rfc3986
     rich
     urllib3
-  ]
-  ++ lib.optionals (pythonOlder "3.10") [
-    importlib-metadata
   ];
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/typeguard/default.nix
+++ b/pkgs/development/python-modules/typeguard/default.nix
@@ -2,12 +2,10 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  pythonOlder,
   setuptools,
   setuptools-scm,
   pytestCheckHook,
   typing-extensions,
-  importlib-metadata,
   mypy,
   sphinxHook,
   sphinx-autodoc-typehints,
@@ -41,8 +39,7 @@ buildPythonPackage rec {
 
   dependencies = [
     typing-extensions
-  ]
-  ++ lib.optionals (pythonOlder "3.10") [ importlib-metadata ];
+  ];
 
   env.LC_ALL = "en_US.utf-8";
 

--- a/pkgs/development/python-modules/wandb/default.nix
+++ b/pkgs/development/python-modules/wandb/default.nix
@@ -32,7 +32,6 @@
   setproctitle,
   setuptools,
   pythonOlder,
-  eval-type-backport,
   typing-extensions,
 
   # tests
@@ -206,9 +205,6 @@ buildPythonPackage rec {
     setproctitle
     # setuptools is necessary since pkg_resources is required at runtime.
     setuptools
-  ]
-  ++ lib.optionals (pythonOlder "3.10") [
-    eval-type-backport
   ]
   ++ lib.optionals (pythonOlder "3.12") [
     typing-extensions

--- a/pkgs/tools/networking/maubot/default.nix
+++ b/pkgs/tools/networking/maubot/default.nix
@@ -44,7 +44,6 @@ let
     pname = "maubot";
     version = "0.5.1";
     format = "setuptools";
-    disabled = python.pythonOlder "3.10";
 
     src = fetchPypi {
       inherit pname version;


### PR DESCRIPTION
Tracking: https://github.com/NixOS/nixpkgs/issues/312288

Previous: https://github.com/NixOS/nixpkgs/pull/481332

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
