### PR TITLE
isabelle: fixup and make vscode work

### DIFF
--- a/pkgs/by-name/is/isabelle/components/isabelle-linter.nix
+++ b/pkgs/by-name/is/isabelle/components/isabelle-linter.nix
@@ -1,11 +1,11 @@
 {
-  stdenv,
+  stdenvNoCC,
   lib,
   fetchFromGitHub,
   isabelle,
 }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "isabelle-linter";
   version = "2025-1-1.0.0";
 

--- a/pkgs/by-name/is/isabelle/fix-copied-permissions.patch
+++ b/pkgs/by-name/is/isabelle/fix-copied-permissions.patch
@@ -1,0 +1,10 @@
+--- a/src/Pure/System/isabelle_system.scala
++++ b/src/Pure/System/isabelle_system.scala
+@@ -214,6 +214,7 @@ object Isabelle_System {
+         Files.copy(src.toPath, target.toPath,
+           StandardCopyOption.COPY_ATTRIBUTES,
+           StandardCopyOption.REPLACE_EXISTING)
++        target.setWritable(true)
+       }
+       catch {
+         case ERROR(msg) =>

--- a/pkgs/by-name/is/isabelle/package.nix
+++ b/pkgs/by-name/is/isabelle/package.nix
@@ -119,6 +119,12 @@ stdenv.mkDerivation (finalAttrs: {
     net-tools
   ];
 
+  patches = [
+    # Make "isabelle build" work when generating documents
+    # See: https://github.com/NixOS/nixpkgs/issues/289529
+    ./fix-copied-permissions.patch
+  ];
+
   propagatedBuildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ procps ];
 
   sourceRoot = "${finalAttrs.dirname}${lib.optionalString stdenv.hostPlatform.isDarwin ".app"}";

--- a/pkgs/by-name/is/isabelle/package.nix
+++ b/pkgs/by-name/is/isabelle/package.nix
@@ -88,7 +88,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "isabelle";
-  version = "2025-1";
+  version = "2025-2";
 
   dirname = "Isabelle${finalAttrs.version}";
 
@@ -96,17 +96,17 @@ stdenv.mkDerivation (finalAttrs: {
     if stdenv.hostPlatform.isDarwin then
       fetchurl {
         url = "https://isabelle.in.tum.de/website-${finalAttrs.dirname}/dist/${finalAttrs.dirname}_macos.tar.gz";
-        hash = "sha256-WKlrsXP6oZHy6NTaaQYpddtgE2QGhBZ4uKai61dtQ14=";
+        hash = "sha256-jxh0luKV8WmVLpRHRa+eSuAMnBzS7UytvPfYmOREkT4=";
       }
     else if stdenv.hostPlatform.isx86 then
       fetchurl {
         url = "https://isabelle.in.tum.de/website-${finalAttrs.dirname}/dist/${finalAttrs.dirname}_linux.tar.gz";
-        hash = "sha256-0SA28X3fIKMV3wZtlJvBxq9MZkI6GevVuSNzgqJ4xQU=";
+        hash = "sha256-ogpQe8fBJw2L6WqfP77AY0U4d4nS3CxNPfYmDUe/szw=";
       }
     else
       fetchurl {
         url = "https://isabelle.in.tum.de/website-${finalAttrs.dirname}/dist/${finalAttrs.dirname}_linux_arm.tar.gz";
-        hash = "sha256-BUhdK8qhdV2Den+4bbdd9T6MD/BtGpxp+1Axj21NxrI=";
+        hash = "sha256-ZQqWabSgh2da+zQpTYLe0vBwTUfVgN2e1FzdyfF2S90=";
       };
 
   nativeBuildInputs = [ java ];

--- a/pkgs/by-name/is/isabelle/package.nix
+++ b/pkgs/by-name/is/isabelle/package.nix
@@ -19,6 +19,7 @@
   isabelle-components,
   symlinkJoin,
   fetchhg,
+  electron,
 }:
 
 let
@@ -192,10 +193,15 @@ stdenv.mkDerivation (finalAttrs: {
     arch=${
       if stdenv.hostPlatform.system == "aarch64-linux" then "arm64-linux" else stdenv.hostPlatform.system
     }
-    for f in contrib/*/$arch/{z3,nunchaku,spass,zipperposition}; do
+    for f in contrib/*/$arch/{z3,nunchaku,SPASS,zipperposition}; do
       patchelf --set-interpreter $(cat ${stdenv.cc}/nix-support/dynamic-linker) "$f"${lib.optionalString stdenv.hostPlatform.isAarch64 " || true"}
     done
     patchelf --set-interpreter $(cat ${stdenv.cc}/nix-support/dynamic-linker) contrib/bash_process-*/$arch/bash_process
+
+    ln -sf ${electron}/bin/electron contrib/vscodium-*/*/electron
+    rm contrib/vscodium-*/*/*.so{,.*}
+    rm contrib/vscodium-*/*/chrome*
+
     for d in contrib/kodkodi-*/jni/$arch; do
       patchelf --set-rpath "${
         lib.concatStringsSep ":" [
@@ -279,7 +285,12 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = [
       lib.maintainers.jvanbruegge
     ];
-    platforms = lib.platforms.unix;
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
   };
 
   passthru.withComponents =

--- a/pkgs/by-name/is/isabelle/package.nix
+++ b/pkgs/by-name/is/isabelle/package.nix
@@ -290,6 +290,7 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.bsd3;
     maintainers = [
       lib.maintainers.jvanbruegge
+      lib.maintainers.sempiternal-aurora
     ];
     platforms = [
       "x86_64-linux"


### PR DESCRIPTION
supersedes #289575, closes #275159 and #289529

Closes #289575
Closes #275159
Closes #289529

- Makes vscodium run by replacing the electron binary on linux only
  - Can't use nixos vscodium because it needs isabelle specific patches for symbols and custom fonts
  - Also remove the unused libraries and executables
  - doesn't work because nixos doesn't package electron for macos, can consider maybe patching the rpath of electron, but that's not for this pr
- Includes copy permissions fix from #289575, including the platforms changes
- Change stdenv of isabelle-linter as it doesn't need a c compiler to build.
- Bumps Isabelle version to 2025.2
- Uses nix built csdp and cvc5, and exposes the packages with isabelle unique versions through passthru

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
