### PR TITLE
bolt-launcher: 0.20.0 -> 0.21.0

### DIFF
--- a/pkgs/by-name/bo/bolt-launcher/package.nix
+++ b/pkgs/by-name/bo/bolt-launcher/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitHub,
+  fetchFromGitea,
   makeWrapper,
   cmake,
   ninja,
@@ -24,27 +24,28 @@
 }:
 let
   cef = cef-binary.override {
-    version = "126.2.18";
-    gitRevision = "3647d39";
-    chromiumVersion = "126.0.6478.183";
+    version = "141.0.7";
+    gitRevision = "a5714cc";
+    chromiumVersion = "141.0.7390.108";
 
     srcHashes = {
-      aarch64-linux = "sha256-Ni5aEbI+WuMnbT8gPWMONN5NkTySw7xJvnM6U44Njao=";
-      x86_64-linux = "sha256-YwND4zsndvmygJxwmrCvaFuxjJO704b6aDVSJqpEOKc=";
+      aarch64-linux = "sha256-2A0hVzUVMBemhjnFE/CrKs4CU96Qkxy8S/SieaEJjwE=";
+      x86_64-linux = "sha256-tZzUxeXxbYP8YfIQLbiSyihPcjZM9cd2Ad8gGCSvdGk=";
     };
   };
 in
 let
   bolt = stdenv.mkDerivation (finalAttrs: {
     pname = "bolt-launcher";
-    version = "0.20.0";
+    version = "0.20.6";
 
-    src = fetchFromGitHub {
+    src = fetchFromGitea {
+      domain = "codeberg.org";
       owner = "AdamCake";
-      repo = "bolt";
+      repo = "Bolt";
       tag = finalAttrs.version;
       fetchSubmodules = true;
-      hash = "sha256-Gh1xaYAysZshEGzljnEYJuK8Mv4cwSWH1W4rEu2F/0s=";
+      hash = "sha256-m0s+RNoHJ//HGTZ3zU+sW+MXM1/GcQbMbBmAJfy47W0=";
     };
 
     nativeBuildInputs = [

--- a/pkgs/by-name/bo/bolt-launcher/package.nix
+++ b/pkgs/by-name/bo/bolt-launcher/package.nix
@@ -37,7 +37,7 @@ in
 let
   bolt = stdenv.mkDerivation (finalAttrs: {
     pname = "bolt-launcher";
-    version = "0.20.6";
+    version = "0.21.0";
 
     src = fetchFromGitea {
       domain = "codeberg.org";
@@ -45,7 +45,7 @@ let
       repo = "Bolt";
       tag = finalAttrs.version;
       fetchSubmodules = true;
-      hash = "sha256-m0s+RNoHJ//HGTZ3zU+sW+MXM1/GcQbMbBmAJfy47W0=";
+      hash = "sha256-QQJKUCxeff56ghwP00uF4GI35vSAPWM+JphTEUfWOUo=";
     };
 
     nativeBuildInputs = [


### PR DESCRIPTION
Latest release: https://codeberg.org/Adamcake/Bolt/releases/tag/0.21.0
Changelog: https://codeberg.org/Adamcake/Bolt/compare/0.20.0...0.21.0

Package changes:

- Version bump from 0.20.0 -> 0.20.6 and 0.20.6 -> 0.21.0, minor changes regarding CEF and RS3 plugin loader
- Now using CEF 141.0.7
- Switched from GitHub to Codeberg, since it was archived in GitHub and Codeberg is the current upstream source

Tested basic functionality playing OSRS and RS3, @JasperSurmont please give it a try and leave a review when possible.

closes https://github.com/NixOS/nixpkgs/pull/466944

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
