### PR TITLE
vimPluginsUpdater: fix script

### DIFF
--- a/pkgs/applications/editors/vim/plugins/utils/get-plugins.nix
+++ b/pkgs/applications/editors/vim/plugins/utils/get-plugins.nix
@@ -14,16 +14,15 @@ let
       "outputHash"
     ] value;
 
-  parse = name: value: {
-    pname = value.pname;
-    version = value.version;
+  parse = _name: value: {
+    inherit (value) pname version;
     homePage = value.meta.homepage;
     checksum =
       if hasChecksum value then
         {
           submodules = value.src.fetchSubmodules or false;
           sha256 = value.src.outputHash;
-          rev = value.src.rev;
+          inherit (value.src) rev;
         }
       else
         null;

--- a/pkgs/applications/editors/vim/plugins/utils/get-plugins.nix
+++ b/pkgs/applications/editors/vim/plugins/utils/get-plugins.nix
@@ -1,10 +1,9 @@
 with import <localpkgs> { };
 let
   inherit (vimUtils.override { inherit vim; }) buildVimPlugin;
-  inherit (neovimUtils) buildNeovimPlugin;
 
   generated = callPackage <localpkgs/pkgs/applications/editors/vim/plugins/generated.nix> {
-    inherit buildNeovimPlugin buildVimPlugin;
+    inherit buildVimPlugin;
   } { } { };
 
   hasChecksum =


### PR DESCRIPTION
buildNeovimPlugin removed in previous update, but get-plugins is trying to call package with removed argument.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
