### PR TITLE
color-lsp: init at 0.2.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27091,6 +27091,12 @@
     githubId = 27378358;
     name = "tony";
   };
+  tonybutt = {
+    email = "anthony@abutt.io";
+    github = "tonybutt";
+    githubId = 38566841;
+    name = "Anthony Butt";
+  };
   toonn = {
     email = "nixpkgs@toonn.io";
     matrix = "@toonn:matrix.org";

--- a/pkgs/by-name/co/color-lsp/package.nix
+++ b/pkgs/by-name/co/color-lsp/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "color-lsp";
+  version = "0.2.2";
+
+  src = fetchFromGitHub {
+    owner = "huacnlee";
+    repo = "color-lsp";
+    rev = "v${version}";
+    hash = "sha256-U0pTzW2PCgMxVsa1QX9MC249PXXL2KvRSN1Em2WvIeI=";
+  };
+
+  cargoHash = "sha256-etK+9fcKS+y+0C36vJrMkQ0yyVSpCW/DLKg4nTw3LrE=";
+
+  # Only build the color-lsp binary, not the zed extension
+  cargoBuildFlags = [
+    "-p"
+    "color-lsp"
+  ];
+  cargoTestFlags = [
+    "-p"
+    "color-lsp"
+  ];
+
+  meta = {
+    description = "A document color language server supporting HEX, RGB, HSL, and named colors";
+    homepage = "https://github.com/huacnlee/color-lsp";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      tonybutt
+      matthiasbeyer
+    ];
+    mainProgram = "color-lsp";
+  };
+}


### PR DESCRIPTION
## Description                                                                                                             
                                                                                                                             
  Add color-lsp, a Language Server Protocol implementation for highlighting colors in documents. Supports HEX, RGB, HSL, and 
  named color formats.                                                                                                       
                                                                                                                             
  ## Things done                                                                                                             
                                                                                                                             
  - [x] Built on platform(s)                                                                                                 
    - [x] x86_64-linux                                                                                                       
  - [x] For new packages: added to `pkgs/by-name`                                                                            
  - [x] Tested via `nix-build -A color-lsp`                                                                                  
  - [x] Added myself to maintainers list                                                                                     
  - [ ] Tested via `nixos-rebuild` (not applicable - not a NixOS module)                                                     
  - [ ] Tested via `nix-darwin` (not applicable) 