### PR TITLE
nixos/systemd: expose factory reset functionality and add repart test case

### DIFF
--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -213,6 +213,12 @@ let
     # Capsule support
     "capsule@.service"
     "capsule.slice"
+
+    # Factory reset
+    "factory-reset.target"
+    "systemd-factory-reset-request.service"
+    "systemd-factory-reset-reboot.service"
+    "systemd-tpm2-clear.service"
   ]
   ++ cfg.additionalUpstreamSystemUnits;
 
@@ -222,6 +228,7 @@ let
     "local-fs.target.wants"
     "multi-user.target.wants"
     "timers.target.wants"
+    "factory-reset.target.wants"
   ];
 
   proxy_env = config.networking.proxy.envVars;

--- a/nixos/modules/system/boot/systemd/initrd.nix
+++ b/nixos/modules/system/boot/systemd/initrd.nix
@@ -65,6 +65,8 @@ let
     "syslog.socket"
     "systemd-ask-password-console.path"
     "systemd-ask-password-console.service"
+    "systemd-factory-reset-complete.service"
+    "factory-reset-now.target"
     "systemd-fsck@.service"
     "systemd-halt.service"
     "systemd-hibernate-resume.service"
@@ -555,6 +557,7 @@ in
         "${cfg.package}/lib/systemd/systemd-sysctl"
         "${cfg.package}/lib/systemd/systemd-bsod"
         "${cfg.package}/lib/systemd/systemd-sysroot-fstab-check"
+        "${cfg.package}/lib/systemd/systemd-factory-reset"
 
         # generators
         "${cfg.package}/lib/systemd/system-generators/systemd-debug-generator"
@@ -562,6 +565,7 @@ in
         "${cfg.package}/lib/systemd/system-generators/systemd-gpt-auto-generator"
         "${cfg.package}/lib/systemd/system-generators/systemd-hibernate-resume-generator"
         "${cfg.package}/lib/systemd/system-generators/systemd-run-generator"
+        "${cfg.package}/lib/systemd/system-generators/systemd-factory-reset-generator"
 
         # utilities needed by systemd
         "${cfg.package.util-linux}/bin/mount"


### PR DESCRIPTION
Exposes https://systemd.io/FACTORY_RESET/ and provides a minmal test, i.e. it doesn't cover TPM reset through PPI.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
