### PR TITLE
python3Packages.dill: 0.4.0-unstable-2025-11-09 -> 0.4.1

### DIFF
--- a/pkgs/development/python-modules/dill/default.nix
+++ b/pkgs/development/python-modules/dill/default.nix
@@ -12,17 +12,17 @@
 
 buildPythonPackage rec {
   pname = "dill";
-  version = "0.4.0-unstable-2025-11-09";
+  version = "0.4.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "uqfoundation";
     repo = "dill";
-    rev = "d948ecd748772f2812361982ec1496da0cd47b53";
-    hash = "sha256-/A84BpZnwSwsEYqLL0Xdf8OjJtg1UMu6dig3QEN+n1A=";
+    tag = version;
+    hash = "sha256-Yh9WvescLgV7DmxGBTGKsb29+eRzF9qjZMg0DQQyLyY=";
   };
 
-  nativeBuildInputs = [ setuptools ];
+  build-system = [ setuptools ];
 
   checkPhase = ''
     runHook preCheck
@@ -39,7 +39,7 @@ buildPythonPackage rec {
   meta = {
     description = "Serialize all of python (almost)";
     homepage = "https://github.com/uqfoundation/dill/";
-    changelog = "https://github.com/uqfoundation/dill/releases/tag/dill-${version}";
+    changelog = "https://github.com/uqfoundation/dill/releases/tag/${src.tag}";
     license = lib.licenses.bsd3;
   };
 }


### PR DESCRIPTION
Diff: https://github.com/uqfoundation/dill/compare/d948ecd748772f2812361982ec1496da0cd47b53...0.4.1

Changelog: https://github.com/uqfoundation/dill/releases/tag/0.4.1


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
