### PR TITLE
python3Packages.beartype: 0.21.0 -> 0.22.9

### DIFF
--- a/pkgs/development/python-modules/apache-beam/default.nix
+++ b/pkgs/development/python-modules/apache-beam/default.nix
@@ -86,6 +86,7 @@ buildPythonPackage rec {
   '';
 
   pythonRelaxDeps = [
+    "beartype"
     "grpcio"
     "jsonpickle"
 

--- a/pkgs/development/python-modules/beartype/default.nix
+++ b/pkgs/development/python-modules/beartype/default.nix
@@ -4,29 +4,20 @@
   fetchFromGitHub,
   hatchling,
   pytestCheckHook,
-  pythonAtLeast,
   typing-extensions,
 }:
 
 buildPythonPackage rec {
   pname = "beartype";
-  version = "0.21.0";
+  version = "0.22.9";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "beartype";
     repo = "beartype";
     tag = "v${version}";
-    hash = "sha256-oD7LS+c+mZ8W4YnAaAYxQkbUlmO8E2TPxy0PBI7Jr7A=";
+    hash = "sha256-F9x2qvzll1nUcTQZjaky+0ukP1RXoW35crzfS/pmvTs=";
   };
-
-  # Several tests fail with:
-  # - beartype.roar.BeartypeDecorHintNonpepException
-  # - RuntimeError: There is no current event loop in thread 'MainThread'
-  # - Failed: DID NOT RAISE <class 'beartype.roar.BeartypeDecorHintNonpepException'>
-  # - AssertionError
-  # - ...
-  disabled = pythonAtLeast "3.14";
 
   build-system = [ hatchling ];
 
@@ -36,15 +27,6 @@ buildPythonPackage rec {
   ];
 
   pythonImportsCheck = [ "beartype" ];
-
-  disabledTests = [
-    # No warnings of type (<class 'beartype.roar._roarwarn.BeartypeValeLambdaWarning'>,) were emitted.
-    "test_is_hint_pep593_beartype"
-  ]
-  ++ lib.optionals (pythonAtLeast "3.13") [
-    # this test is not run upstream, and broke in 3.13 (_nparams removed)
-    "test_door_is_subhint"
-  ];
 
   meta = {
     description = "Fast runtime type checking for Python";


### PR DESCRIPTION
Diff: https://github.com/beartype/beartype/compare/v0.21.0...v0.22.9

Changelog:
https://github.com/beartype/beartype/releases/tag/v0.22.0
           https://github.com/beartype/beartype/releases/tag/v0.22.1
           https://github.com/beartype/beartype/releases/tag/v0.22.2
           https://github.com/beartype/beartype/releases/tag/v0.22.3
           https://github.com/beartype/beartype/releases/tag/v0.22.4
           https://github.com/beartype/beartype/releases/tag/v0.22.5
           https://github.com/beartype/beartype/releases/tag/v0.22.6
           https://github.com/beartype/beartype/releases/tag/v0.22.7
           https://github.com/beartype/beartype/releases/tag/v0.22.8
           https://github.com/beartype/beartype/releases/tag/v0.22.9

closes https://github.com/NixOS/nixpkgs/pull/450633
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
