### PR TITLE
appimageTools: unset QT_PLUGIN_PATH to avoid conflict between QT versions packaged by system & appimage

### DIFF
--- a/pkgs/build-support/appimage/appimage-exec.sh
+++ b/pkgs/build-support/appimage/appimage-exec.sh
@@ -74,6 +74,10 @@ apprun() {
   else echo "$(basename "$APPIMAGE")" installed in "$APPDIR"
   fi
 
+  # Fix potential for the appimages to try to import libraries from QT
+  # installed on the system, causing a version mismatch
+  unset QT_PLUGIN_PATH
+
   export PATH="$PATH:$PWD/usr/bin"
 }
 


### PR DESCRIPTION
Unsets `QT_PLUGIN_PATH` from appimages due to potential mismatch between QT versions inside the appimage and system.
If this mismatch is present, then the appimage would throw the following error (in this case, `5.15.18` is the QT5 version on my system, and `5.15.3` is the QT version in the appimage)
```
Cannot mix incompatible Qt library (5.15.18) with this library (5.15.3)
```

For my use, due to [stylix setting up kvantum](https://github.com/nix-community/stylix/blob/06684f00cfbee14da96fd4307b966884de272d3a/modules/qt/hm.nix#L121), the kvantum library gets added to `QT_PLUGIN_PATH` through [home-manager](https://github.com/nix-community/home-manager/blob/b56c5ad14fcf8b5bc887463552483bf000ca562a/modules/misc/qt.nix#L376) which causes [Overte's appimage](https://public.overte.org/build/overte/release/2025.12.1/Overte-2025.12.1-x86_64.AppImage) to crash with the error above.
Unsetting that environment variable fixes this issue.

Furthermore, the [QT dev docs](https://doc.qt.io/qt-6/deployment-plugins.html#the-plugin-directory) states the following. However, as all Nix apps are built with the same QT version, I think it should be fine.
> Do not export QT_PLUGIN_PATH as a system-wide environment variable because it can interfere with other Qt installations.

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

Note: While I did tick the `nixpkgs-review` box, it didn't fully succeed as some of the things depended on dead URLs.

Fixes https://github.com/NixOS/nixpkgs/issues/481467, Fixes https://github.com/NixOS/nixpkgs/issues/238820#issuecomment-1599456711