### PR TITLE
tini: fix build with musl libc 1.2.5

### DIFF
--- a/pkgs/by-name/ti/tini/package.nix
+++ b/pkgs/by-name/ti/tini/package.nix
@@ -27,6 +27,10 @@ stdenv.mkDerivation rec {
       url = "https://github.com/krallin/tini/commit/071c715e376e9ee0ac1a196fe8c38bcb61ad385c.patch";
       hash = "sha256-idnYcVuhCXQuhFSqcrNjbCLhR4HNlv8QonrtBqEbo3A=";
     })
+    (fetchpatch {
+      url = "https://github.com/krallin/tini/commit/924c4bd6028457188942ecbfdc75e6a343fa9395.patch";
+      hash = "sha256-i6xcf+qpjD+7ZQY3ueiDaxO4+UA2LutLCZLNmT+ji1s=";
+    })
   ];
 
   postPatch = "sed -i /tini-static/d CMakeLists.txt";


### PR DESCRIPTION
Adds upstream patch to fix build with musl libc 1.2.5, which removed `basename()` from `<string.h>`.
The patch includes `<libgen.h>` for the POSIX-compliant `basename()`.

Upstream commit: https://github.com/krallin/tini/commit/924c4bd6028457188942ecbfdc75e6a343fa9395

Fixes `pkgsStatic.tini` build failure:
```
error: implicit declaration of function 'basename' [-Wimplicit-function-declaration]
```

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
