### PR TITLE
various: use pname instead of name

### DIFF
--- a/pkgs/by-name/al/alsa-topology-conf/package.nix
+++ b/pkgs/by-name/al/alsa-topology-conf/package.nix
@@ -4,12 +4,12 @@
   fetchurl,
 }:
 
-stdenv.mkDerivation rec {
-  name = "alsa-topology-conf-${version}";
+stdenv.mkDerivation (finalAttrs: {
+  pname = "alsa-topology-conf";
   version = "1.2.5.1";
 
   src = fetchurl {
-    url = "mirror://alsa/lib/${name}.tar.bz2";
+    url = "mirror://alsa/lib/alsa-topology-conf-${finalAttrs.version}.tar.bz2";
     hash = "sha256-98W64VRavNc4JLyX9OcsNA4Rq+oYi6DxwG9eCtd2sXk=";
   };
 
@@ -37,4 +37,4 @@ stdenv.mkDerivation rec {
     maintainers = [ lib.maintainers.roastiek ];
     platforms = lib.platforms.linux ++ lib.platforms.freebsd;
   };
-}
+})

--- a/pkgs/by-name/au/autotier/package.nix
+++ b/pkgs/by-name/au/autotier/package.nix
@@ -13,7 +13,7 @@
   installShellFiles,
 }:
 stdenv.mkDerivation (finalAttrs: {
-  name = "autotier";
+  pname = "autotier";
   version = "1.2.0";
   src = fetchFromGitHub {
     owner = "45Drives";

--- a/pkgs/by-name/bi/bigpemu/package.nix
+++ b/pkgs/by-name/bi/bigpemu/package.nix
@@ -27,7 +27,7 @@ let
   };
 in
 buildFHSEnv {
-  name = "bigpemu";
+  pname = "bigpemu";
   version = bigpemu-unwrapped.version;
   targetPkgs = pkgs: [
     glui

--- a/pkgs/by-name/bo/bork/package.nix
+++ b/pkgs/by-name/bo/bork/package.nix
@@ -11,7 +11,7 @@ let
   zig = zig_0_14;
 in
 stdenvNoCC.mkDerivation {
-  name = "bork";
+  pname = "bork";
   version = "0.4.0-unstable-2025-04-18";
 
   src = fetchFromGitHub {

--- a/pkgs/by-name/li/lib45d/package.nix
+++ b/pkgs/by-name/li/lib45d/package.nix
@@ -5,7 +5,7 @@
   lib,
 }:
 stdenv.mkDerivation (finalAttrs: {
-  name = "lib45d";
+  pname = "lib45d";
   version = "0.3.6";
   src = fetchFromGitHub {
     owner = "45Drives";

--- a/pkgs/by-name/li/libclipboard/package.nix
+++ b/pkgs/by-name/li/libclipboard/package.nix
@@ -10,7 +10,7 @@
 }:
 
 stdenv.mkDerivation (finalAttrs: {
-  name = "libclipboard";
+  pname = "libclipboard";
   version = "1.1";
 
   src = fetchFromGitHub {

--- a/pkgs/by-name/li/libcsa/package.nix
+++ b/pkgs/by-name/li/libcsa/package.nix
@@ -5,7 +5,7 @@
   unstableGitUpdater,
 }:
 stdenv.mkDerivation (finalAttrs: {
-  name = "csa";
+  pname = "csa";
   version = "1.26-unstable-2024-03-22";
 
   src = fetchFromGitHub {

--- a/pkgs/by-name/li/libdjinterop/package.nix
+++ b/pkgs/by-name/li/libdjinterop/package.nix
@@ -12,7 +12,7 @@
 }:
 
 stdenv.mkDerivation (finalAttrs: {
-  name = "libdjinterop";
+  pname = "libdjinterop";
 
   version = "0.26.1";
 

--- a/pkgs/by-name/li/libgnunetchat/package.nix
+++ b/pkgs/by-name/li/libgnunetchat/package.nix
@@ -15,7 +15,7 @@
 }:
 
 stdenv.mkDerivation (finalAttrs: {
-  name = "libgnunetchat";
+  pname = "libgnunetchat";
   version = "0.6.0";
 
   src = fetchgit {

--- a/pkgs/by-name/ro/ropebwt2/package.nix
+++ b/pkgs/by-name/ro/ropebwt2/package.nix
@@ -5,7 +5,7 @@
   zlib,
 }:
 stdenv.mkDerivation {
-  name = "ropebwt2";
+  pname = "ropebwt2";
   version = "0-unstable-2021-02-01";
   src = fetchFromGitHub {
     owner = "lh3";

--- a/pkgs/by-name/ru/ruqola/package.nix
+++ b/pkgs/by-name/ru/ruqola/package.nix
@@ -10,7 +10,7 @@
 }:
 
 stdenv.mkDerivation (finalAttrs: {
-  name = "ruqola";
+  pname = "ruqola";
   version = "2.5.1";
 
   src = fetchFromGitLab {

--- a/pkgs/by-name/se/serenityos-emoji-font/package.nix
+++ b/pkgs/by-name/se/serenityos-emoji-font/package.nix
@@ -10,7 +10,7 @@
 let
 
   pixart2svg = stdenvNoCC.mkDerivation {
-    name = "pixart2svg";
+    pname = "pixart2svg";
     version = "0-unstable-2021-07-18";
 
     src = fetchzip {
@@ -51,7 +51,7 @@ let
 
 in
 stdenvNoCC.mkDerivation {
-  name = "serenityos-emoji-font";
+  pname = "serenityos-emoji-font";
   version = "0-unstable-2025-05-31";
 
   src = fetchFromGitHub {

--- a/pkgs/by-name/si/sigtop/package.nix
+++ b/pkgs/by-name/si/sigtop/package.nix
@@ -7,7 +7,7 @@
 }:
 
 buildGoModule rec {
-  name = "sigtop";
+  pname = "sigtop";
   version = "0.22.0";
 
   src = fetchFromGitHub {

--- a/pkgs/by-name/so/source-sans-pro/package.nix
+++ b/pkgs/by-name/so/source-sans-pro/package.nix
@@ -10,7 +10,7 @@
 # with older documents/templates/etc.
 
 stdenvNoCC.mkDerivation rec {
-  name = "source-sans-pro-${version}";
+  pname = "source-sans-pro";
   version = "3.006";
 
   src = fetchzip {

--- a/pkgs/by-name/sx/sxcs/package.nix
+++ b/pkgs/by-name/sx/sxcs/package.nix
@@ -7,7 +7,7 @@
 }:
 
 stdenv.mkDerivation (finalAttrs: {
-  name = "sxcs";
+  pname = "sxcs";
   version = "1.1.0";
 
   src = fetchFromGitea {

--- a/pkgs/by-name/wk/wkhtmltopdf/package.nix
+++ b/pkgs/by-name/wk/wkhtmltopdf/package.nix
@@ -92,7 +92,7 @@ let
 in
 stdenv.mkDerivation (
   {
-    name = "wkhtmltopdf";
+    pname = "wkhtmltopdf";
 
     dontStrip = true;
 


### PR DESCRIPTION
This replaces `name` with `pname` in cases where it looks like a simple typo.

Works towards #103997

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
