### PR TITLE
drum-machine: 1.5.0 -> 2.2.0

### DIFF
--- a/pkgs/by-name/dr/drum-machine/package.nix
+++ b/pkgs/by-name/dr/drum-machine/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   appstream,
+  blueprint-compiler,
   desktop-file-utils,
   fetchFromGitHub,
   glib,
@@ -18,20 +19,21 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "drum-machine";
-  version = "1.5.0";
+  version = "2.2.0";
   pyproject = false;
 
   src = fetchFromGitHub {
     owner = "Revisto";
     repo = "drum-machine";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-F3h3BxLNkJq0jpfNOGcTbckpc8CksyA3Bc8GNKviB+I=";
+    hash = "sha256-CBDRoUD4kvbqkyUzxmPEcbW4UJLycRAYC4s40fZ0xYY=";
   };
 
   strictDeps = true;
 
   nativeBuildInputs = [
     appstream
+    blueprint-compiler
     desktop-file-utils
     glib
     gobject-introspection


### PR DESCRIPTION
Diff: https://github.com/Revisto/drum-machine/compare/v1.5.0...v2.2.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
