### PR TITLE
python3Packages.apache-beam: 2.69.0 -> 2.70.0

### DIFF
--- a/pkgs/development/python-modules/apache-beam/default.nix
+++ b/pkgs/development/python-modules/apache-beam/default.nix
@@ -59,19 +59,20 @@
   sqlalchemy,
   tenacity,
   testcontainers,
+  which,
   pythonAtLeast,
 }:
 
 buildPythonPackage rec {
   pname = "apache-beam";
-  version = "2.69.0";
+  version = "2.70.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "apache";
     repo = "beam";
     tag = "v${version}";
-    hash = "sha256-7trrdGQ9jkzG+5/PyBMvHXjR0B4HjOxBhUuxXEcKkLg=";
+    hash = "sha256-sySHoknK2FmiAEOpRdF9i3vA6NvnDrZyBCghVoyEzLw=";
   };
 
   sourceRoot = "${src.name}/sdks/python";
@@ -170,6 +171,7 @@ buildPythonPackage rec {
     sqlalchemy
     tenacity
     testcontainers
+    which
   ];
 
   # Make sure we're running the tests for the actually installed
@@ -196,6 +198,9 @@ buildPythonPackage rec {
     #     E   NameError: name 'MySqlContainer' is not defined
     #
     "apache_beam/io/external/xlang_jdbcio_it_test.py"
+
+    # AttributeError: '_TruncatingFileHandle' object has no attribute 'close'.
+    "apache_beam/ml/rag/ingestion/milvus_search_it_test.py"
 
     # These tests depend on the availability of specific servers backends.
     "apache_beam/runners/portability/flink_runner_test.py"


### PR DESCRIPTION
Diff: https://github.com/apache/beam/compare/v2.69.0...v2.70.0

Changelog: https://github.com/apache/beam/blob/v2.70.0/CHANGES.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
