### PR TITLE
 space-station-14-launcher: 0.36.1 -> 0.37.1; add coca to maintainers

### DIFF
--- a/pkgs/by-name/sp/space-station-14-launcher/package.nix
+++ b/pkgs/by-name/sp/space-station-14-launcher/package.nix
@@ -134,7 +134,7 @@ buildDotnetModule rec {
     description = "Launcher for Space Station 14, a multiplayer game about paranoia and disaster";
     homepage = "https://spacestation14.io";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.coca ];
     platforms = [ "x86_64-linux" ];
     mainProgram = "SS14.Launcher";
   };

--- a/pkgs/by-name/sp/space-station-14-launcher/package.nix
+++ b/pkgs/by-name/sp/space-station-14-launcher/package.nix
@@ -38,7 +38,7 @@
 }:
 buildDotnetModule rec {
   pname = "space-station-14-launcher";
-  version = "0.36.1";
+  version = "0.37.1";
 
   # Workaround to prevent buildDotnetModule from overriding assembly versions.
   name = "space-station-14-launcher-${version}";
@@ -48,7 +48,7 @@ buildDotnetModule rec {
     owner = "space-wizards";
     repo = "SS14.Launcher";
     tag = "v${version}";
-    hash = "sha256-6wH2CkTuwy+a3EGpKrdLDsIaQ7oZc2I1OLdmAREMazw=";
+    hash = "sha256-83eBAT+NuwwpC30Xc5bJEs++tTYlY3akMaizQgNHOsA=";
     fetchSubmodules = true;
   };
 
@@ -66,9 +66,7 @@ buildDotnetModule rec {
     inherit version;
   };
 
-  dotnet-sdk = dotnetCorePackages.sdk_10_0 // {
-    inherit (dotnetCorePackages.sdk_8_0) packages;
-  };
+  dotnet-sdk = dotnetCorePackages.sdk_10_0;
   dotnet-runtime = dotnetCorePackages.runtime_10_0;
 
   dotnetFlags = [

--- a/pkgs/by-name/sp/space-station-14-launcher/package.nix
+++ b/pkgs/by-name/sp/space-station-14-launcher/package.nix
@@ -36,14 +36,17 @@
   # Path to set ROBUST_SOUNDFONT_OVERRIDE to, essentially the default soundfont used.
   soundfont-path ? "${soundfont-fluid}/share/soundfonts/FluidR3_GM2-2.sf2",
 }:
-buildDotnetModule rec {
+let
   pname = "space-station-14-launcher";
   version = "0.37.1";
+in
+buildDotnetModule rec {
+  inherit pname;
 
   # Workaround to prevent buildDotnetModule from overriding assembly versions.
-  name = "space-station-14-launcher-${version}";
+  # If you inherit version it will break loading Robust.LoaderApi when connecting to a server!
+  name = "${pname}-${version}";
 
-  # A bit redundant but I don't trust this package to be maintained by anyone else.
   src = fetchFromGitHub {
     owner = "space-wizards";
     repo = "SS14.Launcher";
@@ -111,9 +114,9 @@ buildDotnetModule rec {
 
   desktopItems = [
     (makeDesktopItem {
-      name = "space-station-14-launcher";
+      name = pname;
       exec = meta.mainProgram;
-      icon = "space-station-14-launcher";
+      icon = pname;
       desktopName = "Space Station 14 Launcher";
       comment = meta.description;
       categories = [ "Game" ];
@@ -125,7 +128,7 @@ buildDotnetModule rec {
     mkdir -p $out/lib/space-station-14-launcher/loader
     cp -r SS14.Loader/bin/${buildType}/*/*/* $out/lib/space-station-14-launcher/loader/
 
-    icoFileToHiColorTheme SS14.Launcher/Assets/icon.ico space-station-14-launcher $out
+    icoFileToHiColorTheme SS14.Launcher/Assets/icon.ico ${pname} $out
   '';
 
   meta = {


### PR DESCRIPTION
Changelog: https://github.com/space-wizards/SS14.Launcher/releases/tag/v0.37.0 & https://github.com/space-wizards/SS14.Launcher/releases/tag/v0.37.1

Added things such as pname and split out version to keep the file in sync with the version in the SS14.Launcher.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
