### PR TITLE
pragtical: 3.7.0 -> 3.8.1

### DIFF
--- a/pkgs/by-name/pr/pragtical/package.nix
+++ b/pkgs/by-name/pr/pragtical/package.nix
@@ -5,6 +5,8 @@
   fetchpatch,
   cacert,
   meson,
+  cmake,
+  git,
   ninja,
   pkg-config,
   freetype,
@@ -14,17 +16,18 @@
   libzip,
   lua5_4,
   luajit,
-  mbedtls_2,
+  mbedtls,
   pcre2,
   sdl3,
+  sdl3-image,
   xz,
   zlib,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "pragtical";
-  version = "3.7.0";
-  pluginManagerVersion = "1.4.0";
+  version = "3.8.1";
+  pluginManagerVersion = "1.4.7.1";
   linenoiseRev = "e78e236c8d85c078fdd9fc4e1f08716058aa1a42";
 
   src = fetchFromGitHub {
@@ -50,23 +53,16 @@ stdenv.mkDerivation (finalAttrs: {
       find subprojects -type d -name .git -prune -execdir rm -r {} +
     '';
 
-    hash = "sha256-oqXv08TvZWVRsSCX6V9oAGHkFS0hL/gm3tGdiivOI6Q=";
+    hash = "sha256-b4qbNkqwyu4Ofaz3hof8lheOKYoerA2hfKMSNsTpHVY=";
   };
-
-  patches = [
-    # https://github.com/pragtical/pragtical/pull/334
-    (fetchpatch {
-      name = "fix-dirmonitor-backend-detection.patch";
-      url = "https://github.com/pragtical/pragtical/commit/5cf26e1f6a491f28d761390309dd77a795bdae9d.patch";
-      hash = "sha256-eD17ItcsyRTKn6jydyW3J2lFq/hl3qHUmQ2LC4LXKC0=";
-    })
-  ];
 
   strictDeps = true;
 
   nativeBuildInputs = [
     lua5_4 # needed for built-time lua bytecode generation
     meson
+    cmake
+    git
     ninja
     pkg-config
   ];
@@ -79,9 +75,10 @@ stdenv.mkDerivation (finalAttrs: {
     libzip
     lua5_4
     luajit
-    mbedtls_2
+    mbedtls
     pcre2
     sdl3
+    sdl3-image
     xz
     zlib
   ];


### PR DESCRIPTION
- PACKAGE: Updated pragtical, including new requirements
- SECURITY: Replaced unmaintained mbedtls2 with mbedtls3 (see https://github.com/pragtical/pragtical/issues/412#issuecomment-3769241711)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
