### PR TITLE
reversal-icon-theme: fix options to reflect upstream updates

### DIFF
--- a/pkgs/by-name/re/reversal-icon-theme/package.nix
+++ b/pkgs/by-name/re/reversal-icon-theme/package.nix
@@ -8,7 +8,6 @@
   hicolor-icon-theme,
   numix-icon-theme-circle,
   gitUpdater,
-  allColorVariants ? false,
   colorVariants ? [ ],
 }:
 
@@ -17,16 +16,18 @@ let
 in
 lib.checkListOfEnum "${pname}: color variants"
   [
-    "-blue"
-    "-red"
-    "-pink"
-    "-purple"
-    "-green"
-    "-orange"
-    "-brown"
-    "-grey"
-    "-black"
-    "-cyan"
+    "black"
+    "blue"
+    "brown"
+    "cyan"
+    "green"
+    "grey"
+    "lightblue"
+    "orange"
+    "pink"
+    "purple"
+    "red"
+    "all"
   ]
   colorVariants
 
@@ -73,7 +74,7 @@ lib.checkListOfEnum "${pname}: color variants"
       mkdir -p $out/share/icons
 
       name= ./install.sh \
-        ${if allColorVariants then "-a" else toString colorVariants} \
+        -t ${toString colorVariants} \
         -d $out/share/icons
 
       rm $out/share/icons/*/{AUTHORS,COPYING}


### PR DESCRIPTION
Upstream has changed options handling:

- `collorVariants` does not use a dash at the beginning anymore
- new color variant: `lightblue`
- `allColorvariants` has been removed
- to install all color variants, use the color variant `all`

Closes https://github.com/NixOS/nixpkgs/issues/481518

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
