### PR TITLE
twemoji-color-font-src: init at 15.1.0

### DIFF
--- a/pkgs/by-name/tw/twemoji-color-font-src/package.nix
+++ b/pkgs/by-name/tw/twemoji-color-font-src/package.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nix-update-script,
+  twemoji-color-font,
+  imagemagick,
+  inkscape,
+  nodePackages,
+  potrace,
+  scfbuild,
+  which,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "twemoji-color-font";
+  version = "15.1.0";
+
+  src = fetchFromGitHub {
+    owner = "13rac1";
+    repo = "twemoji-color-font";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-Nx6zyj6FLFFyWz0vbbN3eYk2WRns7IVG6lDvLOmSf6E=";
+  };
+
+  nativeBuildInputs = [
+    imagemagick
+    inkscape
+    nodePackages.svgo
+    potrace
+    scfbuild
+    which
+  ];
+
+  # silence inkscape errors about non-writable home
+  preBuild = "export HOME=\"$NIX_BUILD_ROOT\"";
+  buildFlags = [
+    "SCFBUILD=${scfbuild}/bin/scfbuild"
+    "linux-package"
+  ];
+  enableParallelBuilding = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 build/TwitterColorEmoji-SVGinOT.ttf $out/share/fonts/truetype/TwitterColorEmoji-SVGinOT.ttf
+    install -Dm644 linux/fontconfig/46-twemoji-color.conf $out/etc/fonts/conf.d/46-twemoji-color.conf
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    inherit (twemoji-color-font.meta)
+      description
+      longDescription
+      homepage
+      downloadPage
+      license
+      ;
+    maintainers = [ lib.maintainers.ncfavier ];
+    hydraPlatforms = [ ]; # https://github.com/NixOS/nixpkgs/issues/97871
+  };
+})

--- a/pkgs/by-name/tw/twemoji-color-font/package.nix
+++ b/pkgs/by-name/tw/twemoji-color-font/package.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
   passthru.updateScript = nix-update-script { };
 
   meta = {
-    description = "Color emoji SVGinOT font using Twitter Unicode 10 emoji with diversity and country flags";
+    description = "Color emoji SVGinOT font using Twitter Unicode 15 emoji with diversity and country flags";
     longDescription = ''
       A color and B&W emoji SVGinOT font built from the Twitter Emoji for
       Everyone artwork with support for ZWJ, skin tone diversity and country


### PR DESCRIPTION
Following the discussion in https://github.com/NixOS/nixpkgs/issues/97871, the source package was converted to a binary package. This PR resurrects the source package under a different name, and exempts it from Hydra builds. This makes it easier to apply patches (like [Unicode 17 support](https://github.com/13rac1/twemoji-color-font/pull/170)).

On my laptop, this builds in ~8m39s.

Ideas for a better attribute name are welcome.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
