### PR TITLE
typst: add `fonts` to the wrapper

### DIFF
--- a/doc/languages-frameworks/typst.section.md
+++ b/doc/languages-frameworks/typst.section.md
@@ -15,6 +15,16 @@ typst.withPackages (
 )
 ```
 
+For more customisation options, you can invoke the wrapper directly:
+
+```nix
+typst.wrapper {
+  packages = p: [ ];
+  fonts = [ ];
+  extraWrapperArgs = [ ];
+}
+```
+
 ### Handling Outdated Package Hashes {#typst-handling-outdated-package-hashes}
 
 Since **Typst Universe** does not provide a way to fetch a package with a specific hash, the package hashes in `nixpkgs` can sometimes be outdated. To resolve this issue, you can manually override the package source using the following approach:

--- a/pkgs/by-name/ty/typst/package.nix
+++ b/pkgs/by-name/ty/typst/package.nix
@@ -71,7 +71,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   passthru = {
     updateScript = nix-update-script { };
     packages = callPackage ./typst-packages.nix { };
-    withPackages = callPackage ./with-packages.nix { };
+    wrapper = callPackage ./wrapper.nix { };
+    withPackages = ps: finalAttrs.passthru.wrapper { packages = ps; };
   };
 
   meta = {

--- a/pkgs/by-name/ty/typst/wrapper.nix
+++ b/pkgs/by-name/ty/typst/wrapper.nix
@@ -8,12 +8,18 @@
 
 lib.makeOverridable (
   { ... }@typstPkgs:
-  f:
+  {
+    packages ? (ps: [ ]),
+    fonts ? [ ],
+    extraWrapperArgs ? [ ],
+  }:
   buildEnv {
     inherit (typst) meta;
     name = "${typst.name}-env";
 
-    paths = lib.foldl' (acc: p: acc ++ lib.singleton p ++ p.propagatedBuildInputs) [ ] (f typstPkgs);
+    paths = lib.foldl' (acc: p: acc ++ lib.singleton p ++ p.propagatedBuildInputs) [ ] (
+      packages typstPkgs
+    );
 
     pathsToLink = [ "/lib/typst-packages" ];
 
@@ -28,7 +34,12 @@ lib.makeOverridable (
       cp -r ${typst}/share $out/share
       mkdir -p $out/bin
 
-      makeWrapper "${lib.getExe typst}" "$out/bin/typst" --set TYPST_PACKAGE_CACHE_PATH $TYPST_LIB_DIR
+      TYPST_FONT_PATHS=${lib.escapeShellArg (lib.concatStringsSep ":" fonts)}
+
+      makeWrapper "${lib.getExe typst}" "$out/bin/typst" \
+        --set TYPST_PACKAGE_CACHE_PATH $TYPST_LIB_DIR \
+        ''${TYPST_FONT_PATHS:+--set TYPST_FONT_PATHS "$TYPST_FONT_PATHS"} \
+        ${lib.escapeShellArgs extraWrapperArgs}
     '';
   }
 ) typstPackages


### PR DESCRIPTION
Introduces `typst.wrapper` with the following arguments:

- `packages`. For backwards compatibility, `typst.withPackages f` is equivalent to `typst.wrapper { packages = f; }`.
- `fonts` allows specifying extra fonts via `TYPST_FONT_PATHS`.
- `extraWrapperArgs` for extra arguments to `makeWrapper`.

This breaks `typst.withPackages.override` (one must use `typst.wrapper.override` instead), but I don't think that is very useful anyway since you can directly supply the overridden packages as arguments.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
