### PR TITLE
phpstan: 2.1.32 -> 2.1.34, switch to PHAR distribution, move to pkgs/by-name

### DIFF
--- a/pkgs/by-name/ph/phpstan/package.nix
+++ b/pkgs/by-name/ph/phpstan/package.nix
@@ -1,23 +1,37 @@
 {
-  fetchFromGitHub,
+  stdenv,
   lib,
+  fetchFromGitHub,
   php,
   versionCheckHook,
+  makeBinaryWrapper,
 }:
 
-php.buildComposerProject2 (finalAttrs: {
+stdenv.mkDerivation (finalAttrs: {
   pname = "phpstan";
-  version = "2.1.32";
+  version = "2.1.34";
 
   src = fetchFromGitHub {
     owner = "phpstan";
-    repo = "phpstan-src";
+    repo = "phpstan";
     tag = finalAttrs.version;
-    hash = "sha256-fP+R22TN3I/Afn+N/6sqlYuN0GxTzPt3bSZjtFrkr1A=";
+    hash = "sha256-/SSOLJiZunLDoxsKmVxICjymFLLu0aOXCTn2jNklTyA=";
   };
 
-  composerStrictValidation = false;
-  vendorHash = "sha256-NW5yx9jD7aXmqq9kzSNr/U1CkW0VN8qm0yHOQlxVi0c=";
+  nativeBuildInputs = [
+    makeBinaryWrapper
+  ];
+
+  postInstall = ''
+    install -D ./phpstan.phar $out/libexec/phpstan/phpstan.phar
+    makeWrapper ${lib.getExe php} $out/bin/phpstan \
+      --add-flags "$out/libexec/phpstan/phpstan.phar" \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          php
+        ]
+      }
+  '';
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -251,14 +251,13 @@ lib.makeScope pkgs.newScope (
 
       phpspy = callPackage ../development/php-packages/phpspy { };
 
-      phpstan = callPackage ../development/php-packages/phpstan { };
-
       psalm = callPackage ../development/php-packages/psalm { };
     }
     // lib.optionalAttrs config.allowAliases {
       deployer = throw "`php8${lib.versions.minor php.version}Packages.deployer` has been removed, use `deployer`";
       phpcbf = throw "`php8${lib.versions.minor php.version}Packages.phpcbf` has been removed, use `php-codesniffer` instead which contains both `phpcs` and `phpcbf`.";
       phpcs = throw "`php8${lib.versions.minor php.version}Packages.phpcs` has been removed, use `php-codesniffer` instead which contains both `phpcs` and `phpcbf`.";
+      phpstan = throw "`php8${lib.versions.minor php.version}Packages.phpstan` has been removed, use `phpstan` instead.";
       psysh = throw "`php8${lib.versions.minor php.version}Packages.psysh` has been removed, use `psysh`";
     };
 


### PR DESCRIPTION
As advised by @ondrejmirtes, this PR switch from source distribution of PHPStan to PHAR since using sources to build it is no longer working since 2.1.32, see https://github.com/NixOS/nixpkgs/issues/474098

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
