### PR TITLE
nixos/keycloak: update with better systemd-creds support via ImportCredential

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -306,3 +306,5 @@ See <https://github.com/NixOS/nixpkgs/issues/481673>.
     ```
 
     **Do not set this globally!** This makes your setup inherently less secure.
+
+- `services.keycloak` now supports secrets to be configured as systemd credential names, rather than being configured as a path. This is more flexible: it allows use of encrypted credentials, as well as resolving secrets from systemd credential stores.

--- a/nixos/modules/services/web-apps/keycloak.md
+++ b/nixos/modules/services/web-apps/keycloak.md
@@ -41,13 +41,13 @@ External database access can also be configured by setting
 appropriate. Note that you need to manually create the database
 and allow the configured database user full access to it.
 
-[](#opt-services.keycloak.database.passwordFile)
-must be set to the path to a file containing the password used
-to log in to the database. If [](#opt-services.keycloak.database.host)
-and [](#opt-services.keycloak.database.createLocally)
-are kept at their defaults, the database role
-`keycloak` with that password is provisioned
-on the local database instance.
+[](#opt-services.keycloak.database.passwordCredential)
+must be set to the name of a systemd credential containing the
+password used to log in to the database. If
+[](#opt-services.keycloak.database.host) and
+[](#opt-services.keycloak.database.createLocally) are kept at
+their defaults, the database role `keycloak` with that password
+is provisioned on the local database instance.
 
 ::: {.warning}
 The path should be provided as a string, not a Nix path, since Nix
@@ -110,9 +110,10 @@ network.
 
 HTTPS support requires a TLS/SSL certificate and a private key,
 both [PEM formatted](https://en.wikipedia.org/wiki/Privacy-Enhanced_Mail).
-Their paths should be set through
-[](#opt-services.keycloak.sslCertificate) and
-[](#opt-services.keycloak.sslCertificateKey).
+The names of their systemd credentials should be set through
+[](#opt-services.keycloak.sslCertCredential) and
+[](#opt-services.keycloak.sslKeyCredential), and they should be enabled
+through [](#opt-services.keycloak.enableSSL).
 
 ::: {.warning}
  The paths should be provided as a strings, not a Nix paths,
@@ -157,9 +158,10 @@ A basic configuration with some custom settings could look like this:
       hostname-strict-backchannel = true;
     };
     initialAdminPassword = "e6Wcm0RrtegMEHl"; # change on first login
-    sslCertificate = "/run/keys/ssl_cert";
-    sslCertificateKey = "/run/keys/ssl_key";
-    database.passwordFile = "/run/keys/db_password";
+    enableSSL = true;
+    sslCertCredential = "systemd.credential.ssl_cert";
+    sslKeyCredential = "systemd.credential.ssl_key";
+    database.passwordCredential = "systemd.credential.db_password";
   };
 }
 ```

--- a/nixos/modules/services/web-apps/keycloak.nix
+++ b/nixos/modules/services/web-apps/keycloak.nix
@@ -757,6 +757,12 @@ in
                 "${cfg.sslCertCredential}:ssl_cert"
                 "${cfg.sslKeyCredential}:ssl_key"
               ];
+            ConditionCredential =
+              secretCreds
+              ++ optionals (cfg.enableSSL) [
+                cfg.sslCertCredential
+                cfg.sslKeyCredential
+              ];
             BindReadOnlyPaths = [
               "%d/ssl_cert:/run/keycloak/ssl/ssl_cert"
               "%d/ssl_key:/run/keycloak/ssl/ssl_key"

--- a/nixos/tests/keycloak.nix
+++ b/nixos/tests/keycloak.nix
@@ -34,19 +34,24 @@ let
                 127.0.0.1 ${certs.domain}
               '';
 
+              virtualisation.credentials = {
+                "keycloak.db_password".text = ''wzf6\"vO"Cb\nP>p#6;c&o?eu=q'THE'''H''''E'';
+                "keycloak.ssl_cert".source = "${certs.${certs.domain}.cert}";
+                "keycloak.ssl_key".source = "${certs.${certs.domain}.key}";
+              };
+
               services.keycloak = {
                 enable = true;
                 settings = {
                   hostname = certs.domain;
                 };
                 inherit initialAdminPassword;
-                sslCertificate = "${certs.${certs.domain}.cert}";
-                sslCertificateKey = "${certs.${certs.domain}.key}";
+                enableSSL = true;
                 database = {
                   type = databaseType;
                   username = "bogus";
                   name = "also bogus";
-                  passwordFile = "${pkgs.writeText "dbPassword" ''wzf6\"vO"Cb\nP>p#6;c&o?eu=q'THE'''H''''E''}";
+                  enablePassword = true;
                 };
                 plugins = with config.services.keycloak.package.plugins; [
                   keycloak-discord


### PR DESCRIPTION
Instead of passing secrets to keycloak via filesystem paths and LoadCredentials, we use credential names and ImportCredentials. This is more flexible, allowing credentials to be resolved by different systemd mechanisms, and allowing encrypted creds to be used.

### Alternatives

#### Disable a credential by setting it to null

This would mean e.g. folding the `passwordCredential` and `enablePassword` options into a single option, with `null` representing disabling the password. But then we have to pick either "default disabled" or have a "default name", we can't have it both ways. Meaning we'd either remove the default names like `keycloak.db_password` and always expect the user to configure a name, or we'd keep the default name and if the user wants to disable a cred they must explicitly set it to null.

#### No name options at all

We could go the other way and remove the `passwordCredential`, `sslCertCredential`, etc. options and prescribe that credential's must be passed in with the default names.

This is maybe a bit less flexible as you then can't easily support using the same credential between multiple services that expect it by different names.

The generic _secret options could be specified as `my_keycloak_option._secret = true` and then the credential name derived as `keycloak.settings.my_keycloak_option`.

#### No enable options

We could remove the `enablePassword`, `enableSSL` options and say that whether these options are enabled is determined dynamically by the presence of the appropriate credentials.

This is arguably less safe as there is no verification that the intended secrets are provided... if creds get misconfigured accidentally and stop being presented to the service it may just silently continue to work with e.g. passwords or certs accidentally disabled.

#### No name *or* enable options

As both of the above, and now there are no options relating to secrets. The generic _secret options could still be handled with a single glob pattern e.g. `ImportCredential = "keycloak.settings.*"` and dynamically mapped into the settings. This makes configuration a bit more dynamic and a bit more complex to add to the config - we can't statically template them and use `replace-secret`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
