### PR TITLE
groff: 1.23.0 -> 1.24.1

### DIFF
--- a/pkgs/by-name/gr/groff/package.nix
+++ b/pkgs/by-name/gr/groff/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  fetchFromGitHub,
   perl,
   enableGhostscript ? false,
   ghostscript,
@@ -17,6 +18,7 @@
   iconv,
   enableLibuchardet ? false,
   libuchardet, # for detecting input file encoding in preconv(1)
+  enableUrwFonts ? false,
   buildPackages,
   autoreconfHook,
   pkg-config,
@@ -24,7 +26,15 @@
   bison,
   bashNonInteractive,
 }:
-
+let
+  urw-fonts = fetchFromGitHub {
+    name = "groff-urw-base35-fonts";
+    owner = "ArtifexSoftware";
+    repo = "urw-base35-fonts";
+    tag = "20200910";
+    hash = "sha256-YQl5IDtodcbTV3D6vtJi7CwxVtHHl58fG6qCAoSaP4U=";
+  };
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "groff";
   version = "1.24.1";
@@ -90,21 +100,23 @@ stdenv.mkDerivation (finalAttrs: {
   # Builds running without a chroot environment may detect the presence
   # of /usr/X11 in the host system, leading to an impure build of the
   # package. To avoid this issue, X11 support is explicitly disabled.
-  configureFlags =
-    lib.optionals (!enableGhostscript) [
-      "--without-x"
-    ]
-    ++ [
-      "ac_cv_path_PERL=${buildPackages.perl}/bin/perl"
-      "--enable-year2038"
-    ]
-    ++ lib.optionals enableGhostscript [
-      "--with-gs=${lib.getExe ghostscript}"
-      "--with-appdefdir=${placeholder "out"}/lib/X11/app-defaults"
-    ]
-    ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
-      "gl_cv_func_signbit=yes"
-    ];
+  configureFlags = [
+    "ac_cv_path_PERL=${buildPackages.perl}/bin/perl"
+    "--enable-year2038"
+  ]
+  ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+    "gl_cv_func_signbit=yes"
+  ]
+  ++ lib.optionals enableGhostscript [
+    "--with-gs=${lib.getExe ghostscript}"
+    "--with-appdefdir=${placeholder "out"}/lib/X11/app-defaults"
+  ]
+  ++ lib.optionals (!enableGhostscript) [
+    "--without-x"
+  ]
+  ++ lib.optionals enableUrwFonts [
+    "--with-urw-fonts-dir=${urw-fonts}/fonts"
+  ];
 
   postConfigure = ''
     # Move mom docs instead of linking them to avoid dangling symlinks

--- a/pkgs/by-name/gr/groff/package.nix
+++ b/pkgs/by-name/gr/groff/package.nix
@@ -27,18 +27,12 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "groff";
-  version = "1.23.0";
+  version = "1.24.1";
 
   src = fetchurl {
     url = "mirror://gnu/groff/groff-${finalAttrs.version}.tar.gz";
-    hash = "sha256-a5dX9ZK3UYtJAutq9+VFcL3Mujeocf3bLTCuOGNRHBM=";
+    hash = "sha256-dOKBl5W2r/QxrqyYPWOpyJaO6roqLrp9+LpMe0Hnz9g=";
   };
-
-  patches = [
-    # Backport e49b934 "Fix underspecified `getenv()` prototype." for non-glibc systems with C23
-    # This can be dropped in the next release, when the local getopt implementation in libgroff is removed
-    ./fix-underspecified-getenv-prototype.patch
-  ];
 
   outputs = [
     "out"
@@ -51,25 +45,19 @@ stdenv.mkDerivation (finalAttrs: {
   enableParallelBuilding = true;
 
   postPatch = ''
-    # BASH_PROG gets replaced with a path to the build bash which doesn't get automatically patched by patchShebangs
+    # POSIX_SHELL_PROG gets replaced with a path to the build bash which doesn't get automatically patched by patchShebangs
     substituteInPlace contrib/gdiffmk/gdiffmk.sh \
-      --replace "@BASH_PROG@" "/bin/sh"
+      --replace-fail "@POSIX_SHELL_PROG@" "/bin/sh"
   ''
   + lib.optionalString enableHtml ''
     substituteInPlace src/preproc/html/pre-html.cpp \
-      --replace "psselect" "${psutils}/bin/psselect" \
-      --replace "pnmcut" "${lib.getBin netpbm}/bin/pnmcut" \
-      --replace "pnmcrop" "${lib.getBin netpbm}/bin/pnmcrop" \
-      --replace "pnmtopng" "${lib.getBin netpbm}/bin/pnmtopng"
+      --replace-fail "pamcut" "${lib.getExe' netpbm "pamcut"}" \
+      --replace-fail "pnmcrop" "${lib.getExe' netpbm "pnmcrop"}" \
+      --replace-fail "pnmtopng" "${lib.getExe' netpbm "pnmtopng"}"
     substituteInPlace tmac/www.tmac.in \
-      --replace "pnmcrop" "${lib.getBin netpbm}/bin/pnmcrop" \
-      --replace "pngtopnm" "${lib.getBin netpbm}/bin/pngtopnm" \
-      --replace "@PNMTOPS_NOSETPAGE@" "${lib.getBin netpbm}/bin/pnmtops -nosetpage"
-  ''
-  + lib.optionalString (enableGhostscript || enableHtml) ''
-    substituteInPlace contrib/pdfmark/pdfroff.sh \
-      --replace '$GROFF_GHOSTSCRIPT_INTERPRETER' "${lib.getBin ghostscript}/bin/gs" \
-      --replace '$GROFF_AWK_INTERPRETER' "${lib.getBin gawk}/bin/gawk"
+      --replace-fail "pnmcrop" "${lib.getExe' netpbm "pnmcrop"}" \
+      --replace-fail "pngtopnm" "${lib.getExe' netpbm "pngtopnm"}" \
+      --replace-fail "@PNMTOPS_NOSETPAGE@" "${lib.getExe' netpbm "pnmtops"} -nosetpage"
   '';
 
   strictDeps = true;
@@ -108,24 +96,37 @@ stdenv.mkDerivation (finalAttrs: {
     ]
     ++ [
       "ac_cv_path_PERL=${buildPackages.perl}/bin/perl"
+      "--enable-year2038"
     ]
     ++ lib.optionals enableGhostscript [
-      "--with-gs=${lib.getBin ghostscript}/bin/gs"
-      "--with-awk=${lib.getBin gawk}/bin/gawk"
-      "--with-appresdir=${placeholder "out"}/lib/X11/app-defaults"
+      "--with-gs=${lib.getExe ghostscript}"
+      "--with-appdefdir=${placeholder "out"}/lib/X11/app-defaults"
     ]
     ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
       "gl_cv_func_signbit=yes"
     ];
 
+  postConfigure = ''
+    # Move mom docs instead of linking them to avoid dangling symlinks
+    substituteInPlace Makefile \
+      --replace-fail '$(LN_S) $(exampledir)' 'mv $(exampledir)'
+  '';
+
   makeFlags = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
     # Trick to get the build system find the proper 'native' groff
     # http://www.mail-archive.com/bug-groff@gnu.org/msg01335.html
-    "GROFF_BIN_PATH=${buildPackages.groff}/bin"
-    "GROFFBIN=${buildPackages.groff}/bin/groff"
+    "GROFF_BIN_PATH=${lib.getBin buildPackages.groff}/bin"
+    "GROFFBIN=${lib.getExe buildPackages.groff}"
   ];
 
   doCheck = true;
+
+  preCheck = ''
+    # The neqn-smoke-test fails on nixpkgs because neqn exec's eqn,
+    # but eqn, isn't in the PATH in the nixpkgs test env, to remedy
+    # that GROFF_BIN_PATH is set as follows:
+    export GROFF_BIN_PATH=.
+  '';
 
   postInstall = ''
     for f in 'man.local' 'mdoc.local'; do
@@ -146,16 +147,10 @@ stdenv.mkDerivation (finalAttrs: {
     moveToOutput bin/afmtodit $perl
     moveToOutput bin/gperl $perl
     moveToOutput bin/chem $perl
-
     moveToOutput bin/gpinyin $perl
     moveToOutput lib/groff/gpinyin $perl
-    substituteInPlace $perl/bin/gpinyin \
-      --replace $out/lib/groff/gpinyin $perl/lib/groff/gpinyin
-
     moveToOutput bin/grog $perl
     moveToOutput lib/groff/grog $perl
-    substituteInPlace $perl/bin/grog \
-      --replace $out/lib/groff/grog $perl/lib/groff/grog
 
     find $perl/ -type f -print0 | xargs --null sed -i 's|${buildPackages.perl}|${perl}|'
   '';


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

* ~~Update gnulib since groff 1.24.x depends on it (I'm curious to see what implications for other packages arise from this)~~
* Adapt to upstream source tree changes, e.g. pdfroff was removed
* Replace `lib.getBin` with `lib.getExe` and `lib.getExe'`
* Add `enableUrwFonts` option to include URW fonts for a more complete (PDF) typesetting experience
* ~~Include URW fonts to improve available fonts for PDF output (❓ are we okay with this? FYI: not including URW fonts leads to a build error, which has been [reported upstream](https://mail.gnu.org/archive/html/groff/2026-01/msg00076.html))~~
* Add `--enable-year2038` to `configureFlags` (❓ are we okay with this?)
* Remove `--with-awk` from `configureFlags` as it was [removed upstream](https://cgit.git.savannah.gnu.org/cgit/groff.git/commit/?id=f107252c3c0d3b70236e0db5a56238a406231bf5)
* Rename `--with-appresdir` to `--with-appdefdir` in `configureFlags` as it was [renamed upstream](https://cgit.git.savannah.gnu.org/cgit/groff.git/commit/?id=775ffb86589a0fd1e16d329ade6ebc81e859363a)
* Introduce `finalAttrs`
* Remove superfluous `${pname}`
* Use `--replace-fail` instead of `--replace`

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
