### PR TITLE
mtpfs: 1.1 -> 0-unstable-2024-12-10 (`gcc-15` build fix)

### DIFF
--- a/pkgs/by-name/mt/mtpfs/package.nix
+++ b/pkgs/by-name/mt/mtpfs/package.nix
@@ -1,20 +1,25 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
+  autoreconfHook,
   pkg-config,
   fuse,
   libmtp,
   glib,
   libmad,
   libid3tag,
+  unstableGitUpdater,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "mtpfs";
-  version = "1.1";
+  version = "0-unstable-2024-12-10";
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+  ];
   buildInputs = [
     fuse
     libmtp
@@ -23,9 +28,16 @@ stdenv.mkDerivation (finalAttrs: {
     libmad
   ];
 
-  src = fetchurl {
-    url = "https://www.adebenham.com/files/mtp/mtpfs-${finalAttrs.version}.tar.gz";
-    sha256 = "07acrqb17kpif2xcsqfqh5j4axvsa4rnh6xwnpqab5b9w5ykbbqv";
+  src = fetchFromGitHub {
+    owner = "cjd";
+    repo = "mtpfs";
+    rev = "1177d6cfd8916915f5db7d9b5c6fc9e6eafae6e6";
+    hash = "sha256-/84C8FUW+7U7u7yOzVB6ROoIUKtyIBG0wdD5t53yays=";
+  };
+
+  # Use unstable version to pull in gcc-15 fix until the next release
+  # is out: https://github.com/cjd/mtpfs/pull/28
+  passthru.updateScript = unstableGitUpdater {
   };
 
   meta = {


### PR DESCRIPTION
Without the chnage the build fails as https://hydra.nixos.org/build/318062477:

    mtpfs.c:1302:16: error: initialization of 'int (*)(const char *, mode_t)' {aka 'int (*)(const char *, unsigned int)'} from incompatible pointer type 'int (*)(void)' [-Wincompatible-pointer-types]
     1302 |     .chmod   = mtpfs_blank,
          |                ^~~~~~~~~~~


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
