### PR TITLE
various: switch from rec to finalAttrs in buildPythonPackage

### DIFF
--- a/pkgs/by-name/ar/arouteserver/package.nix
+++ b/pkgs/by-name/ar/arouteserver/package.nix
@@ -5,7 +5,7 @@
   bgpq4,
 }:
 
-python3Packages.buildPythonPackage rec {
+python3Packages.buildPythonPackage (finalAttrs: {
   pname = "arouteserver";
   version = "1.23.2";
   pyproject = true;
@@ -13,7 +13,7 @@ python3Packages.buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "pierky";
     repo = "arouteserver";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-qPU1eBEAlF6wcI1KEBtSuf0a+pKsqoCN0mtAPjIr+0c=";
   };
 
@@ -59,11 +59,11 @@ python3Packages.buildPythonPackage rec {
     description = "Automatically build (and test) feature-rich configurations for BGP route servers";
     mainProgram = "arouteserver";
     homepage = "https://github.com/pierky/arouteserver";
-    changelog = "https://github.com/pierky/arouteserver/blob/v${version}/CHANGES.rst";
+    changelog = "https://github.com/pierky/arouteserver/blob/v${finalAttrs.version}/CHANGES.rst";
     license = with lib.licenses; [ gpl3Only ];
     maintainers = with lib.maintainers; [
       marcel
       johannwagner
     ];
   };
-}
+})

--- a/pkgs/by-name/au/audiomatch/package.nix
+++ b/pkgs/by-name/au/audiomatch/package.nix
@@ -4,14 +4,14 @@
   fetchFromGitHub,
   python3Packages,
 }:
-python3Packages.buildPythonPackage rec {
+python3Packages.buildPythonPackage (finalAttrs: {
   version = "0.2.2";
   pname = "audiomatch";
   pyproject = true;
   src = fetchFromGitHub {
     owner = "unmade";
     repo = "audiomatch";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-I7gTP2lwg4EDNmI+tVmI721/nEDShb7q21tD9tRbskY=";
   };
 
@@ -36,10 +36,10 @@ python3Packages.buildPythonPackage rec {
   meta = {
     homepage = "https://github.com/unmade/audiomatch";
     description = "A small command-line tool to find similar audio files";
-    changelog = "https://github.com/unmade/audiomatch/releases/tag/${version}";
+    changelog = "https://github.com/unmade/audiomatch/releases/tag/${finalAttrs.version}";
     license = lib.licenses.mit;
     platforms = lib.platforms.all;
     mainProgram = "audiomatch";
     maintainers = with lib.maintainers; [ leha44581 ];
   };
-}
+})

--- a/pkgs/by-name/au/auto-cpufreq/package.nix
+++ b/pkgs/by-name/au/auto-cpufreq/package.nix
@@ -11,7 +11,7 @@
   nixosTests,
 }:
 
-python3Packages.buildPythonPackage rec {
+python3Packages.buildPythonPackage (finalAttrs: {
   pname = "auto-cpufreq";
   version = "3.0.0";
   pyproject = true;
@@ -19,14 +19,14 @@ python3Packages.buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "AdnanHodzic";
     repo = "auto-cpufreq";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-X+2RxD4+F8LBqvJNRh6FduRLU4a2SnZQ8a9BCN6Ty1E=";
   };
 
   patches = [
     # hardcodes version output
     (replaceVars ./fix-version-output.patch {
-      inherit version;
+      inherit (finalAttrs) version;
     })
 
     # patch to prevent script copying and to disable install
@@ -123,4 +123,4 @@ python3Packages.buildPythonPackage rec {
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ sarcasticadmin ];
   };
-}
+})

--- a/pkgs/by-name/co/commitizen/package.nix
+++ b/pkgs/by-name/co/commitizen/package.nix
@@ -10,7 +10,7 @@
   writableTmpDirAsHomeHook,
 }:
 
-python3Packages.buildPythonPackage rec {
+python3Packages.buildPythonPackage (finalAttrs: {
   pname = "commitizen";
   version = "4.13.9";
   pyproject = true;
@@ -18,7 +18,7 @@ python3Packages.buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "commitizen-tools";
     repo = "commitizen";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-bT154qRnZCf3StYs+acv4Be/SUCA5ovGjY/j2EDmUEc=";
   };
 
@@ -110,7 +110,7 @@ python3Packages.buildPythonPackage rec {
   meta = {
     description = "Tool to create committing rules for projects, auto bump versions, and generate changelogs";
     homepage = "https://github.com/commitizen-tools/commitizen";
-    changelog = "https://github.com/commitizen-tools/commitizen/blob/${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/commitizen-tools/commitizen/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
     mainProgram = "cz";
     maintainers = with lib.maintainers; [
@@ -118,4 +118,4 @@ python3Packages.buildPythonPackage rec {
       anthonyroussel
     ];
   };
-}
+})

--- a/pkgs/by-name/ea/easyeda2kicad/package.nix
+++ b/pkgs/by-name/ea/easyeda2kicad/package.nix
@@ -4,13 +4,13 @@
   fetchPypi,
 }:
 
-python3Packages.buildPythonPackage rec {
+python3Packages.buildPythonPackage (finalAttrs: {
   pname = "easyeda2kicad";
   version = "1.0.1";
   pyproject = true;
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-EipI+vo7kY5zAYXJc900IYOSi4oNviRDbRPVi5ApDoQ=";
   };
 
@@ -30,4 +30,4 @@ python3Packages.buildPythonPackage rec {
     maintainers = with lib.maintainers; [ ChocolateLoverRaj ];
     mainProgram = "easyeda2kicad";
   };
-}
+})

--- a/pkgs/by-name/fa/fastcov/package.nix
+++ b/pkgs/by-name/fa/fastcov/package.nix
@@ -7,7 +7,7 @@
   libgcc,
 }:
 
-python3Packages.buildPythonPackage rec {
+python3Packages.buildPythonPackage (finalAttrs: {
   pname = "fastcov";
   version = "1.16";
   pyproject = true;
@@ -15,7 +15,7 @@ python3Packages.buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "RPGillespie6";
     repo = "fastcov";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-frpX0b8jqKfsxQrts5XkOkjgKlmi7p1r/+Mu7Dl4mm8=";
   };
 
@@ -67,10 +67,10 @@ python3Packages.buildPythonPackage rec {
   meta = {
     description = "Massively parallelized gcov wrapper";
     homepage = "https://github.com/RPGillespie6/fastcov";
-    changelog = "https://github.com/RPGillespie6/fastcov/releases/tag/v${version}";
+    changelog = "https://github.com/RPGillespie6/fastcov/releases/tag/v${finalAttrs.version}";
     maintainers = with lib.maintainers; [ bot-wxt1221 ];
     platforms = lib.platforms.linux;
     license = lib.licenses.mit;
     mainProgram = "fastcov";
   };
-}
+})

--- a/pkgs/by-name/fw/fw-fanctrl/package.nix
+++ b/pkgs/by-name/fw/fw-fanctrl/package.nix
@@ -5,7 +5,7 @@
   fetchFromGitHub,
 }:
 
-python3Packages.buildPythonPackage rec {
+python3Packages.buildPythonPackage (finalAttrs: {
   pname = "fw-fanctrl";
   version = "1.0.4";
   pyproject = true;
@@ -13,7 +13,7 @@ python3Packages.buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "TamtamHero";
     repo = "fw-fanctrl";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-lwuBbyJnWUAXkKemhsdx73fAzO2QX2n81az074hGkzI=";
   };
 
@@ -40,4 +40,4 @@ python3Packages.buildPythonPackage rec {
     license = lib.licenses.bsd3;
     maintainers = [ lib.maintainers.Svenum ];
   };
-}
+})

--- a/pkgs/by-name/ga/garmin-grafana/package.nix
+++ b/pkgs/by-name/ga/garmin-grafana/package.nix
@@ -3,7 +3,7 @@
   python3Packages,
   lib,
 }:
-python3Packages.buildPythonPackage rec {
+python3Packages.buildPythonPackage (finalAttrs: {
   pname = "garmin-grafana";
   version = "0.5.0";
 
@@ -12,7 +12,7 @@ python3Packages.buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "arpanghosh8453";
     repo = "garmin-grafana";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-NrT4erpdWwqFBUumQdd5GqpmhIayszzkPd8fUgDRwXY=";
   };
 
@@ -45,10 +45,10 @@ python3Packages.buildPythonPackage rec {
       for visualizing long-term health trends with Grafana
     '';
     homepage = "https://github.com/arpanghosh8453/garmin-grafana";
-    changelog = "https://github.com/arpanghosh8453/garmin-grafana/releases/tag/v${version}";
+    changelog = "https://github.com/arpanghosh8453/garmin-grafana/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ aciceri ];
     mainProgram = "garmin-fetch";
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/gp/gp-saml-gui/package.nix
+++ b/pkgs/by-name/gp/gp-saml-gui/package.nix
@@ -9,9 +9,9 @@
   gobject-introspection,
   openconnect,
 }:
-python3Packages.buildPythonPackage rec {
+python3Packages.buildPythonPackage (finalAttrs: {
   pname = "gp-saml-gui";
-  version = "0.1+20240731-${lib.strings.substring 0 7 src.rev}";
+  version = "0.1+20240731-${lib.strings.substring 0 7 finalAttrs.src.rev}";
   format = "setuptools";
 
   src = fetchFromGitHub {
@@ -53,4 +53,4 @@ python3Packages.buildPythonPackage rec {
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ pallix ];
   };
-}
+})

--- a/pkgs/by-name/ht/httpy-cli/package.nix
+++ b/pkgs/by-name/ht/httpy-cli/package.nix
@@ -5,13 +5,13 @@
   curl,
 }:
 
-python3Packages.buildPythonPackage rec {
+python3Packages.buildPythonPackage (finalAttrs: {
   pname = "httpy-cli";
   version = "1.1.0";
   pyproject = true;
 
   src = fetchPypi {
-    inherit version;
+    inherit (finalAttrs) version;
     pname = "httpy-cli";
     hash = "sha256-uhF/jF4buHMDiXOuuqjskynioz4qVBevQhdcUbH+91Q=";
   };
@@ -51,4 +51,4 @@ python3Packages.buildPythonPackage rec {
     mainProgram = "httpy";
     maintainers = with lib.maintainers; [ eymeric ];
   };
-}
+})

--- a/pkgs/by-name/hy/hyp/package.nix
+++ b/pkgs/by-name/hy/hyp/package.nix
@@ -4,13 +4,13 @@
   fetchPypi,
 }:
 
-python3Packages.buildPythonPackage rec {
+python3Packages.buildPythonPackage (finalAttrs: {
   pname = "hyp-server";
   version = "1.2.0";
   pyproject = true;
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     sha256 = "1lafjdcn9nnq6xc3hhyizfwh6l69lc7rixn6dx65aq71c913jc15";
   };
 
@@ -29,4 +29,4 @@ python3Packages.buildPythonPackage rec {
     maintainers = with lib.maintainers; [ rnhmjoj ];
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/by-name/in/infisicalsdk/package.nix
+++ b/pkgs/by-name/in/infisicalsdk/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
 }:
 
-python3Packages.buildPythonPackage rec {
+python3Packages.buildPythonPackage (finalAttrs: {
   pname = "infisicalsdk";
   version = "1.0.16";
   pyproject = true;
@@ -12,7 +12,7 @@ python3Packages.buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "Infisical";
     repo = "python-sdk-official";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-2bfT99ynl14CSbqIOG2SMQb3oW+uAWD+iJifdMQG8CE=";
   };
 
@@ -35,4 +35,4 @@ python3Packages.buildPythonPackage rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ artur-sannikov ];
   };
-}
+})

--- a/pkgs/by-name/ip/iplookup-gtk/package.nix
+++ b/pkgs/by-name/ip/iplookup-gtk/package.nix
@@ -11,7 +11,7 @@
   libadwaita,
 }:
 
-python3Packages.buildPythonPackage rec {
+python3Packages.buildPythonPackage (finalAttrs: {
   pname = "iplookup-gtk";
   version = "0.5.0";
   pyproject = false; # Built with meson
@@ -19,7 +19,7 @@ python3Packages.buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "Bytezz";
     repo = "IPLookup-gtk";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-pRTN91uwjYu3Li4NbDvJ6l9gikBnXj0j+ApMWpuLUTU=";
   };
 
@@ -49,10 +49,10 @@ python3Packages.buildPythonPackage rec {
   meta = {
     description = "Find info about an IP address";
     homepage = "https://github.com/Bytezz/IPLookup-gtk";
-    changelog = "https://github.com/Bytezz/IPLookup-gtk/releases/tag/${src.tag}";
+    changelog = "https://github.com/Bytezz/IPLookup-gtk/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.gpl3Plus;
     mainProgram = "iplookup";
     maintainers = with lib.maintainers; [ aleksana ];
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/le/lesscpy/package.nix
+++ b/pkgs/by-name/le/lesscpy/package.nix
@@ -4,13 +4,13 @@
   fetchPypi,
 }:
 
-python3Packages.buildPythonPackage rec {
+python3Packages.buildPythonPackage (finalAttrs: {
   pname = "lesscpy";
   version = "0.15.1";
   pyproject = true;
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-EEXRepj2iGRsp1jf8lTm6cA3RWSOBRoIGwOVw7d8gkw=";
   };
 
@@ -32,4 +32,4 @@ python3Packages.buildPythonPackage rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ s1341 ];
   };
-}
+})

--- a/pkgs/by-name/li/lice/package.nix
+++ b/pkgs/by-name/li/lice/package.nix
@@ -4,14 +4,14 @@
   fetchPypi,
 }:
 
-python3Packages.buildPythonPackage rec {
+python3Packages.buildPythonPackage (finalAttrs: {
   pname = "lice";
   version = "0.6";
   pyproject = true;
 
   # github is missing tags
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-LZU2YPdJiepaCH/TWNrtJiuyPlJP6t1+c3a2uHL0fmo=";
   };
 
@@ -30,4 +30,4 @@ python3Packages.buildPythonPackage rec {
     mainProgram = "lice";
   };
 
-}
+})

--- a/pkgs/by-name/me/meerk40t-camera/package.nix
+++ b/pkgs/by-name/me/meerk40t-camera/package.nix
@@ -4,13 +4,13 @@
   fetchPypi,
 }:
 
-python3Packages.buildPythonPackage rec {
+python3Packages.buildPythonPackage (finalAttrs: {
   pname = "meerk40t-camera";
   version = "0.1.9";
   format = "setuptools";
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-uGCBHdgWoorVX2XqMCg0YBweb00sQ9ZSbJe8rlGeovs=";
   };
 
@@ -33,4 +33,4 @@ python3Packages.buildPythonPackage rec {
     license = lib.licenses.mit;
     homepage = "https://github.com/meerk40t/meerk40t-camera";
   };
-}
+})

--- a/pkgs/by-name/my/mybbscan/package.nix
+++ b/pkgs/by-name/my/mybbscan/package.nix
@@ -6,7 +6,7 @@
   python3Packages,
 }:
 
-python3Packages.buildPythonPackage rec {
+python3Packages.buildPythonPackage (finalAttrs: {
   pname = "my-b-bscan";
   version = "3.2.0";
   pyproject = false;
@@ -14,7 +14,7 @@ python3Packages.buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "0xB9";
     repo = "MyBBscan";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-cX1483JK+bejQWua9d7V3GDw6cPPvlnLX5w2XQjqMOQ=";
   };
 
@@ -43,4 +43,4 @@ python3Packages.buildPythonPackage rec {
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/by-name/ne/nengo-gui/package.nix
+++ b/pkgs/by-name/ne/nengo-gui/package.nix
@@ -4,7 +4,7 @@
   python3Packages,
 }:
 
-python3Packages.buildPythonPackage rec {
+python3Packages.buildPythonPackage (finalAttrs: {
   pname = "nengo-gui";
   version = "0.4.9";
   format = "setuptools";
@@ -12,7 +12,7 @@ python3Packages.buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "nengo";
     repo = "nengo-gui";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     sha256 = "sha256-aBi4roe9pqPmpbW5zrbDoIvyH5mTKgIzL2O5j1+VBMY=";
   };
 
@@ -28,4 +28,4 @@ python3Packages.buildPythonPackage rec {
     license = lib.licenses.unfreeRedistributable;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/by-name/ni/niriswitcher/package.nix
+++ b/pkgs/by-name/ni/niriswitcher/package.nix
@@ -9,7 +9,7 @@
   nix-update-script,
 }:
 
-python3Packages.buildPythonPackage rec {
+python3Packages.buildPythonPackage (finalAttrs: {
   pname = "niriswitcher";
   version = "0.7.1";
   pyproject = true;
@@ -17,7 +17,7 @@ python3Packages.buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "isaksamsten";
     repo = "niriswitcher";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-qsw2D9Q9ZJYBsRECzT+qoytYMda4uZxX321/YxNWk9o=";
   };
 
@@ -54,4 +54,4 @@ python3Packages.buildPythonPackage rec {
     mainProgram = "niriswitcher";
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/ni/nix-heuristic-gc/package.nix
+++ b/pkgs/by-name/ni/nix-heuristic-gc/package.nix
@@ -7,14 +7,14 @@
   boost,
   python3Packages,
 }:
-python3Packages.buildPythonPackage rec {
+python3Packages.buildPythonPackage (finalAttrs: {
   pname = "nix-heuristic-gc";
   version = "0.7.3";
   format = "setuptools";
   src = fetchFromGitHub {
     owner = "risicle";
     repo = "nix-heuristic-gc";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-aTwILsqqlV0DEm9AhDKd6HCB022BbebPH/VwzDgzS4E=";
   };
 
@@ -51,4 +51,4 @@ python3Packages.buildPythonPackage rec {
       me-and
     ];
   };
-}
+})

--- a/pkgs/by-name/nw/nwg-clipman/package.nix
+++ b/pkgs/by-name/nw/nwg-clipman/package.nix
@@ -11,7 +11,7 @@
   nix-update-script,
 }:
 
-python3Packages.buildPythonPackage rec {
+python3Packages.buildPythonPackage (finalAttrs: {
   pname = "nwg-clipman";
   version = "0.2.8";
   pyproject = true;
@@ -19,7 +19,7 @@ python3Packages.buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "nwg-piotr";
     repo = "nwg-clipman";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-GVA842yCSSO2vDD51AObEQNhDVuRIdH1c6BF1tv2Q8E=";
   };
 
@@ -62,10 +62,10 @@ python3Packages.buildPythonPackage rec {
   meta = {
     description = "GTK3-based GUI for cliphist";
     homepage = "https://github.com/nwg-piotr/nwg-clipman";
-    changelog = "https://github.com/nwg-piotr/nwg-clipman/releases/tag/v${version}";
+    changelog = "https://github.com/nwg-piotr/nwg-clipman/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ averyanalex ];
     platforms = lib.platforms.linux;
     mainProgram = "nwg-clipman";
   };
-}
+})

--- a/pkgs/by-name/nw/nwg-wrapper/package.nix
+++ b/pkgs/by-name/nw/nwg-wrapper/package.nix
@@ -9,7 +9,7 @@
   wlr-randr,
 }:
 
-python3Packages.buildPythonPackage rec {
+python3Packages.buildPythonPackage (finalAttrs: {
   pname = "nwg-wrapper";
   version = "0.1.3";
   pyproject = true;
@@ -17,7 +17,7 @@ python3Packages.buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "nwg-piotr";
     repo = "nwg-wrapper";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     sha256 = "sha256-GKDAdjO67aedCEFHKDukQ+oPMomTPwFE/CvJu112fus=";
   };
 
@@ -57,4 +57,4 @@ python3Packages.buildPythonPackage rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ artturin ];
   };
-}
+})

--- a/pkgs/by-name/op/open-fprintd/package.nix
+++ b/pkgs/by-name/op/open-fprintd/package.nix
@@ -6,7 +6,7 @@
   wrapGAppsNoGuiHook,
 }:
 
-python3Packages.buildPythonPackage rec {
+python3Packages.buildPythonPackage (finalAttrs: {
   pname = "open-fprintd";
   version = "0.7";
   format = "setuptools";
@@ -14,7 +14,7 @@ python3Packages.buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "uunicorn";
     repo = "open-fprintd";
-    rev = version;
+    rev = finalAttrs.version;
     hash = "sha256-4TraOKvBc7ddqcY73aCuKgfwx4fNoaPHVG8so8Dc5Bw=";
   };
 
@@ -58,4 +58,4 @@ python3Packages.buildPythonPackage rec {
     license = lib.licenses.gpl2Only;
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/op/openwebrx/package.nix
+++ b/pkgs/by-name/op/openwebrx/package.nix
@@ -19,7 +19,7 @@
 
 let
 
-  js8py = python3Packages.buildPythonPackage rec {
+  js8py = python3Packages.buildPythonPackage (finalAttrs: {
     pname = "js8py";
     version = "0.1.1";
     format = "setuptools";
@@ -27,7 +27,7 @@ let
     src = fetchFromGitHub {
       owner = "jketterl";
       repo = "js8py";
-      tag = version;
+      tag = finalAttrs.version;
       hash = "sha256-nAj8fI4MkAKr+LjvJQbz7Px8TVAYA9AwZYWy8Cj7AMk=";
     };
 
@@ -41,16 +41,16 @@ let
       description = "Library to decode the output of the js8 binary of JS8Call";
       license = lib.licenses.gpl3Only;
     };
-  };
+  });
 
-  owrx_connector = stdenv.mkDerivation rec {
+  owrx_connector = stdenv.mkDerivation (finalAttrs: {
     pname = "owrx_connector";
     version = "0.6.0";
 
     src = fetchFromGitHub {
       owner = "jketterl";
       repo = "owrx_connector";
-      tag = version;
+      tag = finalAttrs.version;
       hash = "sha256-1H0TJ8QN3b6Lof5TWvyokhCeN+dN7ITwzRvEo2X8OWc=";
     };
 
@@ -83,10 +83,10 @@ let
       license = lib.licenses.gpl3Only;
       platforms = lib.platforms.unix;
     };
-  };
+  });
 
 in
-python3Packages.buildPythonApplication rec {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "openwebrx";
   version = "1.2.2";
   format = "setuptools";
@@ -94,7 +94,7 @@ python3Packages.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "jketterl";
     repo = "openwebrx";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-i3Znp5Sxs/KtJazHh2v9/2P+3cEocWB5wIpF7E4pK9s=";
   };
 
@@ -135,4 +135,4 @@ python3Packages.buildPythonApplication rec {
     mainProgram = "openwebrx";
     license = lib.licenses.gpl3Only;
   };
-}
+})

--- a/pkgs/by-name/op/opsdroid/package.nix
+++ b/pkgs/by-name/op/opsdroid/package.nix
@@ -4,7 +4,7 @@
   python3Packages,
 }:
 
-python3Packages.buildPythonPackage rec {
+python3Packages.buildPythonPackage (finalAttrs: {
   pname = "opsdroid";
   version = "0.30.0";
   pyproject = true;
@@ -12,7 +12,7 @@ python3Packages.buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "opsdroid";
     repo = "opsdroid";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-7H44wdhJD4Z6OP1sUmSGlepuvx+LlwKLq7iR8cwqR24=";
   };
 
@@ -66,10 +66,10 @@ python3Packages.buildPythonPackage rec {
   meta = {
     description = "Open source chat-ops bot framework";
     homepage = "https://opsdroid.dev";
-    changelog = "https://github.com/opsdroid/opsdroid/releases/tag/v${version}";
+    changelog = "https://github.com/opsdroid/opsdroid/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.asl20;
     maintainers = [ ];
     platforms = lib.platforms.unix;
     mainProgram = "opsdroid";
   };
-}
+})

--- a/pkgs/by-name/ov/overturemaps/package.nix
+++ b/pkgs/by-name/ov/overturemaps/package.nix
@@ -4,13 +4,13 @@
   fetchPypi,
 }:
 
-python3Packages.buildPythonPackage rec {
+python3Packages.buildPythonPackage (finalAttrs: {
   pname = "overturemaps";
   version = "0.20.0";
   pyproject = true;
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-rvc1MpqCdRGuMWS5CSDev9SFgyVX8VczopXU/lWAyxg=";
   };
 
@@ -36,4 +36,4 @@ python3Packages.buildPythonPackage rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ crimeminister ];
   };
-}
+})

--- a/pkgs/by-name/pl/play-with-mpv/package.nix
+++ b/pkgs/by-name/pl/play-with-mpv/package.nix
@@ -7,20 +7,20 @@
 }:
 
 let
-  install-freedesktop = python3Packages.buildPythonPackage rec {
+  install-freedesktop = python3Packages.buildPythonPackage (finalAttrs: {
     pname = "install-freedesktop";
     version = "0.1.2-1-g2673e8d";
     format = "setuptools";
 
     src = fetchurl {
-      name = "Thann-install_freedesktop-${version}.tar.gz";
+      name = "Thann-install_freedesktop-${finalAttrs.version}.tar.gz";
       url = "https://github.com/thann/install_freedesktop/tarball/2673e8da4a67bee0ffc52a0ea381a541b4becdd4";
       hash = "sha256-O08G0iMGsF1DSyliXOHTIsOxDdJPBabNLXRhz5osDUk=";
     };
 
     # package has no tests
     doCheck = false;
-  };
+  });
 in
 python3Packages.buildPythonApplication {
   pname = "play-with-mpv";

--- a/pkgs/by-name/pr/present/package.nix
+++ b/pkgs/by-name/pr/present/package.nix
@@ -19,13 +19,13 @@ let
     }
   );
 in
-pythonPackages.buildPythonPackage rec {
+pythonPackages.buildPythonPackage (finalAttrs: {
   pname = "present";
   version = "0.6.0";
   pyproject = true;
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-l9W5L4LD9qRo3rLBkgd2I/aDaj+ucib5UYg+X4RYg6c=";
   };
 
@@ -51,4 +51,4 @@ pythonPackages.buildPythonPackage rec {
     maintainers = [ ];
     mainProgram = "present";
   };
-}
+})

--- a/pkgs/by-name/py/pydf/package.nix
+++ b/pkgs/by-name/py/pydf/package.nix
@@ -4,13 +4,13 @@
   fetchPypi,
 }:
 
-python3Packages.buildPythonPackage rec {
+python3Packages.buildPythonPackage (finalAttrs: {
   pname = "pydf";
   version = "12";
   pyproject = true;
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     sha256 = "7f47a7c3abfceb1ac04fc009ded538df1ae449c31203962a1471a4eb3bf21439";
   };
 
@@ -29,4 +29,4 @@ python3Packages.buildPythonPackage rec {
     license = lib.licenses.publicDomain;
     maintainers = with lib.maintainers; [ monsieurp ];
   };
-}
+})

--- a/pkgs/by-name/py/pyrseas/package.nix
+++ b/pkgs/by-name/py/pyrseas/package.nix
@@ -5,7 +5,7 @@
 }:
 
 let
-  pgdbconn = python3Packages.buildPythonPackage rec {
+  pgdbconn = python3Packages.buildPythonPackage (finalAttrs: {
     pname = "pgdbconn";
     version = "0.8.0";
     pyproject = true;
@@ -13,7 +13,7 @@ let
     src = fetchFromGitHub {
       owner = "perseas";
       repo = "pgdbconn";
-      tag = "v${version}";
+      tag = "v${finalAttrs.version}";
       sha256 = "09r4idk5kmqi3yig7ip61r6js8blnmac5n4q32cdcbp1rcwzdn6z";
     };
 
@@ -25,10 +25,10 @@ let
     dependencies = with python3Packages; [
       psycopg2
     ];
-  };
+  });
 in
 
-python3Packages.buildPythonApplication rec {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "pyrseas";
   version = "0.9.1";
   pyproject = true;
@@ -36,7 +36,7 @@ python3Packages.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "perseas";
     repo = "Pyrseas";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     sha256 = "sha256-+MxnxvbLMxK1Ak+qKpKe3GHbzzC+XHO0eR7rl4ON9H4=";
   };
 
@@ -59,4 +59,4 @@ python3Packages.buildPythonApplication rec {
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ pmeunier ];
   };
-}
+})

--- a/pkgs/by-name/qn/qnotero/package.nix
+++ b/pkgs/by-name/qn/qnotero/package.nix
@@ -6,7 +6,7 @@
   libsForQt5,
 }:
 
-python3Packages.buildPythonPackage rec {
+python3Packages.buildPythonPackage (finalAttrs: {
   pname = "qnotero";
 
   version = "2.3.1";
@@ -15,7 +15,7 @@ python3Packages.buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "ealbiter";
     repo = "qnotero";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     sha256 = "sha256-Rym7neluRbYCpuezRQyLc6gSl3xbVR9fvhOxxW5+Nzo=";
   };
 
@@ -60,4 +60,4 @@ python3Packages.buildPythonPackage rec {
     broken = stdenv.hostPlatform.isDarwin; # Build fails even after adding cx-freeze to `buildInputs`
     maintainers = [ lib.maintainers.nico202 ];
   };
-}
+})

--- a/pkgs/by-name/ri/rivalcfg/package.nix
+++ b/pkgs/by-name/ri/rivalcfg/package.nix
@@ -4,7 +4,7 @@
   python3Packages,
 }:
 
-python3Packages.buildPythonPackage rec {
+python3Packages.buildPythonPackage (finalAttrs: {
   pname = "rivalcfg";
   version = "4.15.0";
   pyproject = true;
@@ -12,7 +12,7 @@ python3Packages.buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "flozz";
     repo = "rivalcfg";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     sha256 = "sha256-UqVogJLv+sNhAxdMjBEvhBQw6LU+QUq1IekvWpeeMqk=";
   };
 
@@ -50,4 +50,4 @@ python3Packages.buildPythonPackage rec {
     maintainers = with lib.maintainers; [ ornxka ];
     mainProgram = "rivalcfg";
   };
-}
+})

--- a/pkgs/by-name/sc/scuba/package.nix
+++ b/pkgs/by-name/sc/scuba/package.nix
@@ -25,7 +25,7 @@ let
     cargoHash = "sha256-YUYo2B5hzzmDeNiWUC+198Qbz+JPgUJfpAqyPWAXTRA=";
   };
 in
-python3Packages.buildPythonPackage rec {
+python3Packages.buildPythonPackage {
   pname = "scuba";
   inherit src version;
   pyproject = true;

--- a/pkgs/by-name/so/sosreport/package.nix
+++ b/pkgs/by-name/so/sosreport/package.nix
@@ -5,7 +5,7 @@
   gettext,
 }:
 
-python3Packages.buildPythonPackage rec {
+python3Packages.buildPythonPackage (finalAttrs: {
   pname = "sosreport";
   version = "4.11.1";
   pyproject = true;
@@ -13,7 +13,7 @@ python3Packages.buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "sosreport";
     repo = "sos";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-HKGGA9SHCJjAaCPduPx1plUJ10nt3JYAr10J/69Sm/0=";
   };
 
@@ -50,4 +50,4 @@ python3Packages.buildPythonPackage rec {
     maintainers = [ ];
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/ta/tauon/package.nix
+++ b/pkgs/by-name/ta/tauon/package.nix
@@ -30,13 +30,13 @@
 
 let
   # fork of pypresence, to be reverted if/when there's an upstream release
-  lynxpresence = python3Packages.buildPythonPackage rec {
+  lynxpresence = python3Packages.buildPythonPackage (finalAttrs: {
     pname = "lynxpresence";
     version = "4.6.2";
     pyproject = true;
 
     src = fetchPypi {
-      inherit pname version;
+      inherit (finalAttrs) pname version;
       hash = "sha256-w4WShLTTSf4JGQVL4lTkbOLL8C7cjnf8WwHyfwKK2zA=";
     };
 
@@ -44,9 +44,9 @@ let
 
     doCheck = false; # tests require internet connection
     pythonImportsCheck = [ "lynxpresence" ];
-  };
+  });
 in
-python3Packages.buildPythonApplication rec {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "tauon";
   version = "9.1.3";
   pyproject = true;
@@ -54,7 +54,7 @@ python3Packages.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "Taiko2k";
     repo = "Tauon";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-Z/+8UCtwvY9000b1Y+HaTIehK8axzyR+eeeBPhllS4U=";
   };
 
@@ -162,9 +162,9 @@ python3Packages.buildPythonApplication rec {
     description = "Linux desktop music player from the future";
     mainProgram = "tauon";
     homepage = "https://tauonmusicbox.rocks/";
-    changelog = "https://github.com/Taiko2k/Tauon/releases/tag/v${version}";
+    changelog = "https://github.com/Taiko2k/Tauon/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.gpl3;
     maintainers = with lib.maintainers; [ jansol ];
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
-}
+})

--- a/pkgs/by-name/te/tesh/package.nix
+++ b/pkgs/by-name/te/tesh/package.nix
@@ -4,25 +4,28 @@
   fetchFromGitHub,
 }:
 
-let
-  version = "0.3.2";
-in
-python3Packages.buildPythonPackage rec {
+python3Packages.buildPythonPackage (finalAttrs: {
   pname = "tesh";
-  inherit version;
+  version = "0.3.2";
 
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "OceanSprint";
     repo = "tesh";
-    rev = version;
+    rev = finalAttrs.version;
     hash = "sha256-GIwg7Cv7tkLu81dmKT65c34eeVnRR5MIYfNwTE7j2Vs=";
   };
 
-  checkInputs = [ python3Packages.pytest ];
-  nativeBuildInputs = [ python3Packages.poetry-core ];
-  propagatedBuildInputs = with python3Packages; [
+  checkInputs = [
+    python3Packages.pytest
+  ];
+
+  build-system = [
+    python3Packages.poetry-core
+  ];
+
+  dependencies = with python3Packages; [
     click
     pexpect
     distutils
@@ -31,4 +34,4 @@ python3Packages.buildPythonPackage rec {
   meta = {
     license = lib.licenses.mit;
   };
-}
+})

--- a/pkgs/by-name/th/thinkpad-scripts/package.nix
+++ b/pkgs/by-name/th/thinkpad-scripts/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
 }:
 
-python3Packages.buildPythonPackage rec {
+python3Packages.buildPythonPackage (finalAttrs: {
   pname = "thinkpad-scripts";
   version = "4.12.0";
   pyproject = true;
@@ -12,7 +12,7 @@ python3Packages.buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "martin-ueding";
     repo = "thinkpad-scripts";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-foraZWLYV/Rg+TcKy3atAwhXqCBeQeXs+orzWzLqTSE=";
   };
 
@@ -30,4 +30,4 @@ python3Packages.buildPythonPackage rec {
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ dawidsowa ];
   };
-}
+})

--- a/pkgs/by-name/um/umu-launcher-unwrapped/package.nix
+++ b/pkgs/by-name/um/umu-launcher-unwrapped/package.nix
@@ -12,19 +12,19 @@
   versionCheckHook,
   nix-update-script,
 }:
-python3Packages.buildPythonPackage rec {
+python3Packages.buildPythonPackage (finalAttrs: {
   pname = "umu-launcher-unwrapped";
   version = "1.4.0";
 
   src = fetchFromGitHub {
     owner = "Open-Wine-Components";
     repo = "umu-launcher";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-7BdA/iAAIn2NR/uLzxdvsIh5/1SZacSfkiXJVJBT3EQ=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
+    inherit (finalAttrs) src;
     hash = "sha256-CVcbktCBRZGnEuDVvl2iJpRgKh+ShFe5mjT6oMHIjtQ=";
   };
 
@@ -72,7 +72,7 @@ python3Packages.buildPythonPackage rec {
     "PYTHONDIR=$(PREFIX)/${python3Packages.python.sitePackages}"
     "PYTHON_INTERPRETER=${lib.getExe python3Packages.python}"
     # Override RELEASEDIR to avoid running `git describe`
-    "RELEASEDIR=${pname}-${version}"
+    "RELEASEDIR=umu-launcher-unwrapped-${finalAttrs.version}"
     "SHELL_INTERPRETER=${lib.getExe bash}"
   ];
 
@@ -94,7 +94,7 @@ python3Packages.buildPythonPackage rec {
 
   meta = {
     description = "Unified launcher for Windows games on Linux using the Steam Linux Runtime and Tools";
-    changelog = "https://github.com/Open-Wine-Components/umu-launcher/releases/tag/${version}";
+    changelog = "https://github.com/Open-Wine-Components/umu-launcher/releases/tag/${finalAttrs.version}";
     homepage = "https://github.com/Open-Wine-Components/umu-launcher";
     license = lib.licenses.gpl3;
     mainProgram = "umu-run";
@@ -105,4 +105,4 @@ python3Packages.buildPythonPackage rec {
     ];
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/un/unsilence/package.nix
+++ b/pkgs/by-name/un/unsilence/package.nix
@@ -4,7 +4,7 @@
   python3Packages,
   ffmpeg,
 }:
-python3Packages.buildPythonPackage rec {
+python3Packages.buildPythonPackage (finalAttrs: {
   pname = "unsilence";
   version = "1.0.9";
   pyproject = true;
@@ -12,7 +12,7 @@ python3Packages.buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "lagmoellertim";
     repo = "unsilence";
-    rev = version;
+    rev = finalAttrs.version;
     hash = "sha256-M4Ek1JZwtr7vIg14aTa8h4otIZnPQfKNH4pZE4GpiBQ=";
   };
 
@@ -40,4 +40,4 @@ python3Packages.buildPythonPackage rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ esau79p ];
   };
-}
+})

--- a/pkgs/by-name/xb/xborders/package.nix
+++ b/pkgs/by-name/xb/xborders/package.nix
@@ -10,7 +10,7 @@
   replaceVars,
 }:
 
-python3Packages.buildPythonPackage rec {
+python3Packages.buildPythonPackage (finalAttrs: {
   pname = "xborders";
   version = "3.4"; # in version.txt
   pyproject = true;
@@ -44,8 +44,8 @@ python3Packages.buildPythonPackage rec {
   postPatch =
     let
       setup = replaceVars ./setup.py {
-        desc = meta.description; # "description" is reserved
-        inherit pname version;
+        desc = finalAttrs.meta.description; # "description" is reserved
+        inherit (finalAttrs) pname version;
       };
     in
     ''
@@ -60,4 +60,4 @@ python3Packages.buildPythonPackage rec {
     platforms = lib.platforms.linux;
     mainProgram = "xborders";
   };
-}
+})

--- a/pkgs/by-name/xe/xed/package.nix
+++ b/pkgs/by-name/xe/xed/package.nix
@@ -10,7 +10,7 @@
 
 let
   # mbuild is a custom build system used only to build xed
-  mbuild = python3Packages.buildPythonPackage rec {
+  mbuild = python3Packages.buildPythonPackage (finalAttrs: {
     pname = "mbuild";
     version = "2024.11.04";
     pyproject = true;
@@ -18,7 +18,7 @@ let
     src = fetchFromGitHub {
       owner = "intelxed";
       repo = "mbuild";
-      tag = "v${version}";
+      tag = "v${finalAttrs.version}";
       hash = "sha256-iQVykBG3tEPxI1HmqBkvO1q+K8vi64qBfVC63/rcTOk=";
     };
 
@@ -29,7 +29,7 @@ let
       homepage = "https://github.com/intelxed/mbuild";
       license = lib.licenses.asl20;
     };
-  };
+  });
 
 in
 stdenv.mkDerivation (finalAttrs: {

--- a/pkgs/by-name/ya/yams/package.nix
+++ b/pkgs/by-name/ya/yams/package.nix
@@ -4,7 +4,7 @@
   python3Packages,
 }:
 
-python3Packages.buildPythonPackage rec {
+python3Packages.buildPythonPackage (finalAttrs: {
   pname = "yams";
   # nixpkgs-update: no auto update
   version = "0.7.3";
@@ -13,7 +13,7 @@ python3Packages.buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "Berulacks";
     repo = "yams";
-    rev = version;
+    rev = finalAttrs.version;
     sha256 = "1zkhcys9i0s6jkaz24an690rvnkv1r84jxpaa84sf46abi59ijh8";
   };
 
@@ -37,4 +37,4 @@ python3Packages.buildPythonPackage rec {
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ ccellado ];
   };
-}
+})

--- a/pkgs/by-name/yu/yubikey-manager/package.nix
+++ b/pkgs/by-name/yu/yubikey-manager/package.nix
@@ -9,7 +9,7 @@
   buildPackages,
 }:
 
-python3Packages.buildPythonPackage rec {
+python3Packages.buildPythonPackage (finalAttrs: {
   pname = "yubikey-manager";
   version = "5.9.1";
   pyproject = true;
@@ -17,7 +17,7 @@ python3Packages.buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "Yubico";
     repo = "yubikey-manager";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-ldJZWKzXDyBTHkrhiIRI4RFCBEZxVPiHBqzmcCT7PYc=";
   };
 
@@ -74,7 +74,7 @@ python3Packages.buildPythonPackage rec {
 
   meta = {
     homepage = "https://developers.yubico.com/yubikey-manager";
-    changelog = "https://github.com/Yubico/yubikey-manager/releases/tag/${src.tag}";
+    changelog = "https://github.com/Yubico/yubikey-manager/releases/tag/${finalAttrs.src.tag}";
     description = "Command line tool for configuring any YubiKey over all USB transports";
 
     license = lib.licenses.bsd2;
@@ -87,4 +87,4 @@ python3Packages.buildPythonPackage rec {
     ];
     mainProgram = "ykman";
   };
-}
+})

--- a/pkgs/development/python-modules/stac-validator/default.nix
+++ b/pkgs/development/python-modules/stac-validator/default.nix
@@ -12,7 +12,7 @@
   requests,
   tqdm,
 }:
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "stac-validator";
   version = "4.1.0";
   pyproject = true;
@@ -20,7 +20,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "stac-utils";
     repo = "stac-validator";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-qO1DRYpPn+zarHTj2mZQ2LJ2uhmS1bax6Yxy035ZEUA=";
   };
 
@@ -46,4 +46,4 @@ buildPythonPackage rec {
     license = lib.licenses.asl20;
     teams = [ lib.teams.geospatial ];
   };
-}
+})


### PR DESCRIPTION
This pull request refactors several Python package definitions to use the `finalAttrs` argument with `python3Packages.buildPythonPackage` instead of the older `rec` pattern. This change standardizes how attributes like `version`, `pname`, and `src` are referenced within each package, improving consistency and maintainability across the codebase.

Key changes by theme:

**Refactoring to Use `finalAttrs` Pattern:**
* Updated all package definitions to use `python3Packages.buildPythonPackage (finalAttrs: { ... })` instead of the previous `rec { ... }` syntax, enabling more robust and predictable attribute referencing.

**Consistent Attribute Referencing:**
* Replaced direct references to `version`, `pname`, and `src` with `finalAttrs.version`, `finalAttrs.pname`, and `finalAttrs.src` respectively throughout the package files, including in `src`, `tag`, `changelog`, and patch sections.

**Changelog and Metadata Updates:**
* Updated `changelog` and other metadata fields to use `finalAttrs.version` or `finalAttrs.src.tag` for constructing URLs, ensuring that metadata always matches the actual build inputs.

**Patch and Inherit Usage:**
* Changed patch sections and `inherit` statements to use `inherit (finalAttrs) version` or `pname` where appropriate, making sure patches receive the correct version values from the final attributes.

**Consistent Closing Syntax:**
* Updated all package definitions to close with `})` instead of `}` to match the new function argument style.

These changes modernize the packaging style and reduce the risk of attribute mismatches or future refactoring errors.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
