### PR TITLE
cdesktopenv: 2.5.1 -> 2.5.3

### DIFF
--- a/pkgs/by-name/cd/cdesktopenv/package.nix
+++ b/pkgs/by-name/cd/cdesktopenv/package.nix
@@ -4,7 +4,7 @@
   fetchurl,
   libX11,
   bison,
-  ksh,
+  mksh,
   perl,
   libXinerama,
   libXt,
@@ -33,15 +33,18 @@
   flex,
   libXpm,
   rpcsvc-proto,
+  sessreg,
+  pkg-config,
+  lmdb,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "cde";
-  version = "2.5.1";
+  version = "2.5.3";
 
   src = fetchurl {
-    url = "mirror://sourceforge/cdesktopenv/cde-${version}.tar.gz";
-    hash = "sha256-caslezz2kbljwApv5igDPH345PK2YqQUTi1YZgvM1Dw=";
+    url = "mirror://sourceforge/cdesktopenv/cde-${finalAttrs.version}.tar.gz";
+    hash = "sha256-K1jAjr8Ka7nUoyGRzSXiBPXYy6gbzKo2/HL1xKqXmFQ=";
   };
 
   postPatch = ''
@@ -62,7 +65,7 @@ stdenv.mkDerivation rec {
     done
 
     substituteInPlace configure.ac \
-      --replace "-I/usr/include/tirpc" "-I${libtirpc.dev}/include/tirpc"
+      --replace-warn "-I/usr/include/tirpc" "-I${libtirpc.dev}/include/tirpc"
 
     patchShebangs autogen.sh config.rpath contrib programs
   '';
@@ -82,9 +85,11 @@ stdenv.mkDerivation rec {
     libXScrnSaver
     tcl
     libXaw
-    ksh
+    mksh
     libxcrypt
     libXpm
+    sessreg
+    lmdb
   ];
   nativeBuildInputs = [
     bison
@@ -100,9 +105,14 @@ stdenv.mkDerivation rec {
     perl
     flex
     rpcsvc-proto
+    pkg-config
   ];
 
   enableParallelBuilding = true;
+
+  # Can probably remove after next release
+  # https://sourceforge.net/p/cdesktopenv/code/ci/f0154141b1f1501490bac8e0235214bf8f00f715/
+  env.NIX_CFLAGS_COMPILE = "-std=gnu17";
 
   preConfigure = ''
     export LOCALE_ARCHIVE="${glibcLocales}/lib/locale/locale-archive"
@@ -123,4 +133,4 @@ stdenv.mkDerivation rec {
     maintainers = [ ];
     platforms = lib.platforms.linux;
   };
-}
+})


### PR DESCRIPTION
Part of #475479
This supercedes a PR that was closed for moderation reasons, I've just updated it now that we have a tag on an updated version, so I hope that's okay to do (original was #414552).

The compilation takes a while, I'll post nixpkgs-review when it's done
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
