### PR TITLE
ipu6, icamerasrc: update packages, fix platform-specific hal 

### DIFF
--- a/pkgs/by-name/ip/ipu6-camera-bins/package.nix
+++ b/pkgs/by-name/ip/ipu6-camera-bins/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     repo = "ipu6-camera-bins";
     owner = "intel";
-    rev = "30e87664829782811a765b0ca9eea3a878a7ff29";
+    tag = "20250923_ov02e"; # Released on 2025-06-27
     hash = "sha256-YPPzuK13o2jnRSB3ORoMUU5E9/IifKVSetAqZHRofhw=";
   };
 

--- a/pkgs/development/libraries/gstreamer/default.nix
+++ b/pkgs/development/libraries/gstreamer/default.nix
@@ -3,6 +3,8 @@
   lib,
   newScope,
   apple-sdk,
+  ipu6ep-camera-hal,
+  ipu6epmtl-camera-hal,
 }:
 
 lib.makeScope newScope (
@@ -38,8 +40,12 @@ lib.makeScope newScope (
     gst-vaapi = callPackage ./vaapi { };
 
     icamerasrc-ipu6 = callPackage ./icamerasrc { };
-    icamerasrc-ipu6ep = callPackage ./icamerasrc { };
-    icamerasrc-ipu6epmtl = callPackage ./icamerasrc { };
+    icamerasrc-ipu6ep = callPackage ./icamerasrc {
+      ipu6-camera-hal = ipu6ep-camera-hal;
+    };
+    icamerasrc-ipu6epmtl = callPackage ./icamerasrc {
+      ipu6-camera-hal = ipu6epmtl-camera-hal;
+    };
 
     # note: gst-python is in ../../python-modules/gst-python - called under python3Packages
   }

--- a/pkgs/development/libraries/gstreamer/icamerasrc/default.nix
+++ b/pkgs/development/libraries/gstreamer/icamerasrc/default.nix
@@ -13,13 +13,13 @@
 
 stdenv.mkDerivation {
   pname = "icamerasrc-${ipu6-camera-hal.ipuVersion}";
-  version = "unstable-2024-09-29";
+  version = "unstable-2025-12-26";
 
   src = fetchFromGitHub {
     owner = "intel";
     repo = "icamerasrc";
-    tag = "20240926_1446";
-    hash = "sha256-BpIZxkPmSVKqPntwBJjGmCaMSYFCEZHJa4soaMAJRWE=";
+    tag = "20251226_1140_191_PTL_PV_IoT";
+    hash = "sha256-BYURJfNz4D8bXbSeuWyUYnoifozFOq6rSfG9GBKVoHo=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/ipu6-camera-hal/default.nix
+++ b/pkgs/development/libraries/ipu6-camera-hal/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "intel";
     repo = "ipu6-camera-hal";
-    rev = "c933525a6efe8229a7129b7b0b66798f19d2bef7";
+    tag = "20250923_ov02e"; # Released on 2025-06-27
     hash = "sha256-ZWwszteRmUBn0wGgN5rmzw/onfzBoPGadcmpk+93kAM=";
   };
 

--- a/pkgs/os-specific/linux/ipu6-drivers/default.nix
+++ b/pkgs/os-specific/linux/ipu6-drivers/default.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation rec {
   pname = "ipu6-drivers";
-  version = "unstable-2025-09-16";
+  version = "unstable-2025-11-12";
 
   src = fetchFromGitHub {
     owner = "intel";
     repo = "ipu6-drivers";
-    rev = "69b2fde9edcbc24128b91541fdf2791fbd4bf7a4";
-    hash = "sha256-uiRbbSw7tQ3Fn297D1I7i7hyaNtpOWER4lvPMSTpwpk=";
+    tag = "20251104_0740_359"; # Released on 2025-11-12
+    hash = "sha256-TiuMzG9VgoJb013hvZHZ4uPMBNvT/tmK1V8SYBwJYB4=";
   };
 
   patches = [


### PR DESCRIPTION
This PR updates the IPU6 camera stack to latest compatible upstream versions and fixes a regression where `icamerasrc-ipu6ep` and `icamerasrc-ipu6epmtl` GStreamer plugins were built with the wrong platform-specific `ipu6-camera-hal` variant, breaking Intel IPU6 camera support for Alder Lake, Raptor Lake, and Meteor Lake systems.

Tested on Lenovo X1 Yoga Gen 8 (ipu6ep), the webcam now works for me with this PR.

- **ipu6-camera-bins**: migrate same rev to tag (20250923_ov02e), most recent
- **ipu6-camera-hal**: migrate same rev to tag (20250923_ov02e), most recent
- **icamerasrc**: unstable-2024-09-29 -> unstable-2025-12-26 (20251226_1140_191_PTL_PV_IoT)
- **ipu6-drivers**: unstable-2025-09-16 -> unstable-2025-11-12 (20251104_0740_359)

When users configure their system with:
```nix
hardware.ipu6 = {
  enable = true;
  platform = "ipu6ep";  # or "ipu6epmtl"
};
```

The module correctly selects the platform-specific `icamerasrc` package based on the `platform` setting. However, all three variants (`icamerasrc-ipu6`, `icamerasrc-ipu6ep`, and `icamerasrc-ipu6epmtl`) were being built with the default `ipu6-camera-hal` (Tiger Lake), instead of their respective platform-specific HAL libraries.

- https://github.com/NixOS/nixpkgs/pull/225160 and https://github.com/NixOS/nixpkgs/pull/225292 initially added IPU6 support with correct implementation
- https://github.com/NixOS/nixpkgs/commit/6835a72af649f4b0720cc005d458ddf7234b9630 added Meteor Lake support, correctly implementing all three variants
- https://github.com/NixOS/nixpkgs/pull/455935 converted `gst_all_1` to use `lib.makeScope` for better package extensibility. During this refactoring, the `ipu6ep-camera-hal` and `ipu6epmtl-camera-hal` parameters were (accidentally) removed, breaking the platform-specific overrides

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
