### PR TITLE
haskellPackages: fix strictDeps build for a few packages

### DIFF
--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -1027,6 +1027,7 @@ builtins.intersectAttrs super {
     (disableCabalFlag "no-exe")
     enableSeparateBinOutput
     (addBuildDepend self.optparse-applicative)
+    (addTestToolDepend self.hspec-discover)
   ];
 
   # Compile manpages (which are in RST and are compiled with Sphinx).

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -517,6 +517,9 @@ builtins.intersectAttrs super {
   # Fix strictDeps build error "could not execute: hspec-discover"
   unliftio = addTestToolDepends [ self.hspec-discover ] super.unliftio;
 
+  # Fix strictDeps build error "could not execute: hspec-discover"
+  word8 = addTestToolDepends [ self.hspec-discover ] super.word8;
+
   # Test suite requires running a database server. Testing is done upstream.
   hasql = dontCheck super.hasql;
   hasql-dynamic-statements = dontCheck super.hasql-dynamic-statements;

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -509,6 +509,9 @@ builtins.intersectAttrs super {
   lz4-frame-conduit = addTestToolDepends [ pkgs.lz4 ] super.lz4-frame-conduit;
 
   # Fix strictDeps build error "could not execute: hspec-discover"
+  http-types = addTestToolDepends [ self.hspec-discover ] super.http-types;
+
+  # Fix strictDeps build error "could not execute: hspec-discover"
   safe-exceptions = addTestToolDepends [ self.hspec-discover ] super.safe-exceptions;
 
   # Fix strictDeps build error "could not execute: hspec-discover"

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -511,6 +511,9 @@ builtins.intersectAttrs super {
   # Fix strictDeps build error "could not execute: hspec-discover"
   safe-exceptions = addTestToolDepends [ self.hspec-discover ] super.safe-exceptions;
 
+  # Fix strictDeps build error "could not execute: hspec-discover"
+  unliftio = addTestToolDepends [ self.hspec-discover ] super.unliftio;
+
   # Test suite requires running a database server. Testing is done upstream.
   hasql = dontCheck super.hasql;
   hasql-dynamic-statements = dontCheck super.hasql-dynamic-statements;

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -508,10 +508,8 @@ builtins.intersectAttrs super {
 
   lz4-frame-conduit = addTestToolDepends [ pkgs.lz4 ] super.lz4-frame-conduit;
 
-  safe-exceptions = overrideCabal (drv: {
-    # Fix strictDeps build error "could not execute: hspec-discover"
-    testToolDepends = drv.testToolDepends or [ ] ++ [ self.hspec-discover ];
-  }) super.safe-exceptions;
+  # Fix strictDeps build error "could not execute: hspec-discover"
+  safe-exceptions = addTestToolDepends [ self.hspec-discover ] super.safe-exceptions;
 
   # Test suite requires running a database server. Testing is done upstream.
   hasql = dontCheck super.hasql;

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -509,6 +509,9 @@ builtins.intersectAttrs super {
   lz4-frame-conduit = addTestToolDepends [ pkgs.lz4 ] super.lz4-frame-conduit;
 
   # Fix strictDeps build error "could not execute: hspec-discover"
+  http-date = addTestToolDepends [ self.hspec-discover ] super.http-date;
+
+  # Fix strictDeps build error "could not execute: hspec-discover"
   http-types = addTestToolDepends [ self.hspec-discover ] super.http-types;
 
   # Fix strictDeps build error "could not execute: hspec-discover"

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -509,6 +509,9 @@ builtins.intersectAttrs super {
   lz4-frame-conduit = addTestToolDepends [ pkgs.lz4 ] super.lz4-frame-conduit;
 
   # Fix strictDeps build error "could not execute: hspec-discover"
+  hspec-wai = addTestToolDepends [ self.hspec-discover ] super.hspec-wai;
+
+  # Fix strictDeps build error "could not execute: hspec-discover"
   http-date = addTestToolDepends [ self.hspec-discover ] super.http-date;
 
   # Fix strictDeps build error "could not execute: hspec-discover"

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -508,22 +508,22 @@ builtins.intersectAttrs super {
 
   lz4-frame-conduit = addTestToolDepends [ pkgs.lz4 ] super.lz4-frame-conduit;
 
-  # Fix strictDeps build error "could not execute: hspec-discover"
+  # Package does not declare tool dependency hspec-discover
   hspec-wai = addTestToolDepends [ self.hspec-discover ] super.hspec-wai;
 
-  # Fix strictDeps build error "could not execute: hspec-discover"
+  # Package does not declare tool dependency hspec-discover
   http-date = addTestToolDepends [ self.hspec-discover ] super.http-date;
 
-  # Fix strictDeps build error "could not execute: hspec-discover"
+  # Package does not declare tool dependency hspec-discover
   http-types = addTestToolDepends [ self.hspec-discover ] super.http-types;
 
-  # Fix strictDeps build error "could not execute: hspec-discover"
+  # Package does not declare tool dependency hspec-discover
   safe-exceptions = addTestToolDepends [ self.hspec-discover ] super.safe-exceptions;
 
-  # Fix strictDeps build error "could not execute: hspec-discover"
+  # Package does not declare tool dependency hspec-discover
   unliftio = addTestToolDepends [ self.hspec-discover ] super.unliftio;
 
-  # Fix strictDeps build error "could not execute: hspec-discover"
+  # Package does not declare tool dependency hspec-discover
   word8 = addTestToolDepends [ self.hspec-discover ] super.word8;
 
   # Test suite requires running a database server. Testing is done upstream.
@@ -1039,6 +1039,7 @@ builtins.intersectAttrs super {
     (disableCabalFlag "no-exe")
     enableSeparateBinOutput
     (addBuildDepend self.optparse-applicative)
+    # Package does not declare tool dependency hspec-discover
     (addTestToolDepend self.hspec-discover)
   ];
 


### PR DESCRIPTION
motivation: https://github.com/NixOS/nixpkgs/issues/178468

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
