### PR TITLE
scrutiny*: 0.8.1 -> 1.9.1; change upstream; add new ZFS collector

### DIFF
--- a/pkgs/by-name/sc/scrutiny-collector-zfs/package.nix
+++ b/pkgs/by-name/sc/scrutiny-collector-zfs/package.nix
@@ -8,14 +8,14 @@
 }:
 
 buildGoModule (finalAttrs: {
-  version = "1.7.2";
+  version = "1.9.1";
   pname = "scrutiny-collector-zfs";
 
   src = fetchFromGitHub {
     owner = "Starosdev";
     repo = "scrutiny";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-xoXL8yLrYyjpkxLmbFQz/pp2BauJAU82x1FcslHCPoE=";
+    hash = "sha256-t0oy1y8aJadgmQE/pR/8kwW4GAuKvsUtU76aV1nhww0=";
   };
 
   subPackages = "collector/cmd/collector-zfs";

--- a/pkgs/by-name/sc/scrutiny-collector-zfs/package.nix
+++ b/pkgs/by-name/sc/scrutiny-collector-zfs/package.nix
@@ -1,0 +1,53 @@
+{
+  buildGoModule,
+  fetchFromGitHub,
+  makeWrapper,
+  zfs,
+  lib,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  version = "1.7.2";
+  pname = "scrutiny-collector-zfs";
+
+  src = fetchFromGitHub {
+    owner = "Starosdev";
+    repo = "scrutiny";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-xoXL8yLrYyjpkxLmbFQz/pp2BauJAU82x1FcslHCPoE=";
+  };
+
+  subPackages = "collector/cmd/collector-zfs";
+
+  vendorHash = "sha256-nfL+44lKBmAcScoV0AHotSotQz4Z3kHIpePERuncM6c=";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  env.CGO_ENABLED = 0;
+
+  ldflags = [ "-extldflags=-static" ];
+
+  tags = [ "static" ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    cp $GOPATH/bin/collector-zfs $out/bin/scrutiny-collector-zfs
+    wrapProgram $out/bin/scrutiny-collector-zfs \
+      --prefix PATH : ${lib.makeBinPath [ zfs ]}
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "ZFS pool metrics collector for Scrutiny";
+    homepage = "https://github.com/Starosdev/scrutiny";
+    changelog = "https://github.com/Starosdev/scrutiny/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ samasaur ];
+    mainProgram = "scrutiny-collector-zfs";
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/sc/scrutiny-collector/package.nix
+++ b/pkgs/by-name/sc/scrutiny-collector/package.nix
@@ -8,22 +8,22 @@
   nix-update-script,
 }:
 let
-  version = "0.8.1";
+  version = "1.7.2";
 in
 buildGoModule rec {
   inherit version;
   pname = "scrutiny-collector";
 
   src = fetchFromGitHub {
-    owner = "AnalogJ";
+    owner = "Starosdev";
     repo = "scrutiny";
     tag = "v${version}";
-    hash = "sha256-WoU5rdsIEhZQ+kPoXcestrGXC76rFPvhxa0msXjFsNg=";
+    hash = "sha256-xoXL8yLrYyjpkxLmbFQz/pp2BauJAU82x1FcslHCPoE=";
   };
 
   subPackages = "collector/cmd/collector-metrics";
 
-  vendorHash = "sha256-SiQw6pq0Fyy8Ia39S/Vgp9Mlfog2drtVn43g+GXiQuI=";
+  vendorHash = "sha256-nfL+44lKBmAcScoV0AHotSotQz4Z3kHIpePERuncM6c=";
 
   nativeBuildInputs = [ makeWrapper ];
 
@@ -47,9 +47,10 @@ buildGoModule rec {
 
   meta = {
     description = "Hard disk metrics collector for Scrutiny";
-    homepage = "https://github.com/AnalogJ/scrutiny";
+    homepage = "https://github.com/Starosdev/scrutiny";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ samasaur ];
     mainProgram = "scrutiny-collector-metrics";
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/sc/scrutiny-collector/package.nix
+++ b/pkgs/by-name/sc/scrutiny-collector/package.nix
@@ -7,17 +7,15 @@
   lib,
   nix-update-script,
 }:
-let
+
+buildGoModule (finalAttrs: {
   version = "1.7.2";
-in
-buildGoModule rec {
-  inherit version;
   pname = "scrutiny-collector";
 
   src = fetchFromGitHub {
     owner = "Starosdev";
     repo = "scrutiny";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-xoXL8yLrYyjpkxLmbFQz/pp2BauJAU82x1FcslHCPoE=";
   };
 
@@ -48,9 +46,10 @@ buildGoModule rec {
   meta = {
     description = "Hard disk metrics collector for Scrutiny";
     homepage = "https://github.com/Starosdev/scrutiny";
+    changelog = "https://github.com/Starosdev/scrutiny/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ samasaur ];
     mainProgram = "scrutiny-collector-metrics";
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/sc/scrutiny-collector/package.nix
+++ b/pkgs/by-name/sc/scrutiny-collector/package.nix
@@ -9,14 +9,14 @@
 }:
 
 buildGoModule (finalAttrs: {
-  version = "1.7.2";
+  version = "1.9.1";
   pname = "scrutiny-collector";
 
   src = fetchFromGitHub {
     owner = "Starosdev";
     repo = "scrutiny";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-xoXL8yLrYyjpkxLmbFQz/pp2BauJAU82x1FcslHCPoE=";
+    hash = "sha256-t0oy1y8aJadgmQE/pR/8kwW4GAuKvsUtU76aV1nhww0=";
   };
 
   subPackages = "collector/cmd/collector-metrics";

--- a/pkgs/by-name/sc/scrutiny/package.nix
+++ b/pkgs/by-name/sc/scrutiny/package.nix
@@ -33,13 +33,13 @@ let
 in
 buildGoModule (finalAttrs: {
   pname = "scrutiny";
-  version = "1.7.2";
+  version = "1.9.1";
 
   src = fetchFromGitHub {
     owner = "Starosdev";
     repo = "scrutiny";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-xoXL8yLrYyjpkxLmbFQz/pp2BauJAU82x1FcslHCPoE=";
+    hash = "sha256-t0oy1y8aJadgmQE/pR/8kwW4GAuKvsUtU76aV1nhww0=";
   };
 
   subPackages = "webapp/backend/cmd/scrutiny";

--- a/pkgs/by-name/sc/scrutiny/package.nix
+++ b/pkgs/by-name/sc/scrutiny/package.nix
@@ -8,13 +8,13 @@
 }:
 let
   pname = "scrutiny";
-  version = "0.8.1";
+  version = "1.7.2";
 
   src = fetchFromGitHub {
-    owner = "AnalogJ";
+    owner = "Starosdev";
     repo = "scrutiny";
     tag = "v${version}";
-    hash = "sha256-WoU5rdsIEhZQ+kPoXcestrGXC76rFPvhxa0msXjFsNg=";
+    hash = "sha256-xoXL8yLrYyjpkxLmbFQz/pp2BauJAU82x1FcslHCPoE=";
   };
 
   frontend = buildNpmPackage {
@@ -22,7 +22,7 @@ let
     pname = "${pname}-webapp";
     src = "${src}/webapp/frontend";
 
-    npmDepsHash = "sha256-M8P41LPg7oJ/C9abDuNM5Mn+OO0zK56CKi2BwLxv8oQ=";
+    npmDepsHash = "sha256-lOEHLXY13qxWWl2cnmbbqbXXKcg7PNMEMdRhE2HGrAM=";
 
     buildPhase = ''
       runHook preBuild
@@ -34,7 +34,7 @@ let
     installPhase = ''
       runHook preInstall
       mkdir $out
-      cp -r dist/* $out
+      cp -r dist/browser/* $out
       runHook postInstall
     '';
 
@@ -46,7 +46,7 @@ buildGoModule rec {
 
   subPackages = "webapp/backend/cmd/scrutiny";
 
-  vendorHash = "sha256-SiQw6pq0Fyy8Ia39S/Vgp9Mlfog2drtVn43g+GXiQuI=";
+  vendorHash = "sha256-nfL+44lKBmAcScoV0AHotSotQz4Z3kHIpePERuncM6c=";
 
   env.CGO_ENABLED = 0;
 
@@ -64,10 +64,10 @@ buildGoModule rec {
 
   meta = {
     description = "Hard Drive S.M.A.R.T Monitoring, Historical Trends & Real World Failure Thresholds";
-    homepage = "https://github.com/AnalogJ/scrutiny";
-    changelog = "https://github.com/AnalogJ/scrutiny/releases/tag/v${version}";
+    homepage = "https://github.com/Starosdev/scrutiny";
+    changelog = "https://github.com/Starosdev/scrutiny/releases/tag/v${version}";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ samasaur ];
     mainProgram = "scrutiny";
     platforms = lib.platforms.linux;
   };


### PR DESCRIPTION
- Updates scrutiny to point to a maintained fork
- Updates from v0.8.1 (last tagged release on original repo) to v1.9.1 (latest tagged release on fork)
- Adds ZFS collector (new feature introduced in fork)
- Updates NixOS module to run the ZFS collector
- Adds myself as a maintainer to all three packages and the NixOS module

Closes #480393.

My main concern here is that (based on [the upstream issue](https://github.com/AnalogJ/scrutiny/issues/506)) the fork I'm updating the package to point to, though it does seem to be the fork people have converged on, isn't officially sanctioned by the original author, so it might be worth waiting for that.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
