### PR TITLE
stalwart-mail: rename to stalwart; nixos/stalwart-mail: move to stalwart

### DIFF
--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -111,6 +111,8 @@
   retained for packages that have not completed migration. `asio_1_10` has been removed as no packages depend on it anymore.
   `asio` also no longer propagates `boost` as it is used independent from `boost` in most cases.
 
+- `stalwart-mail` has been renamed to `stalwart`
+
 - Ethercalc and its associated module have been removed, as the package is unmaintained and cannot be installed from source with npm now.
 
 - `coreth` has been removed, as upstream has moved it into `avalanchego`.

--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -983,8 +983,7 @@ Make sure to also check the many updates in the [Nixpkgs library](#sec-release-2
   [services.sitespeed-io](#opt-services.sitespeed-io.enable).
 
 - [stalwart-mail](https://stalw.art), an all-in-one email server (SMTP, IMAP,
-  JMAP). Available as
-  [services.stalwart-mail](#opt-services.stalwart-mail.enable).
+  JMAP). Available as `services.stalwart-mail`.
 
 
 - [tang](https://github.com/latchset/tang), a server for binding data to

--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -741,7 +741,7 @@ Use `services.pipewire.extraConfig` or `services.pipewire.configPackages` for Pi
 
 - `services.soju` now has a wrapper for the `sojuctl` command, pointed at the service config file. It also has the new option `adminSocket.enable`, which creates a unix admin socket at `/run/soju/admin`.
 
-- `services.stalwart-mail` uses the legacy version 0.6.X as default because newer `stalwart-mail` versions require a [manual upgrade process](https://github.com/stalwartlabs/mail-server/blob/main/UPGRADING.md). Change [`services.stalwart-mail.package`](#opt-services.stalwart-mail.package) to `pkgs.stalwart-mail` if you wish to switch to the new version.
+- `services.stalwart-mail` uses the legacy version 0.6.X as default because newer `stalwart-mail` versions require a [manual upgrade process](https://github.com/stalwartlabs/mail-server/blob/main/UPGRADING.md). Change `services.stalwart-mail.package` to `pkgs.stalwart-mail` if you wish to switch to the new version.
 
 - `services.teeworlds` module now has a wealth of configuration options, including a new `package` option.
 

--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -508,8 +508,7 @@
 
 - Legacy package `stalwart-mail_0_6` was dropped, please note the
   [manual upgrade process](https://github.com/stalwartlabs/mail-server/blob/main/UPGRADING.md)
-  before changing the package to `pkgs.stalwart-mail` in
-  [`services.stalwart-mail.package`](#opt-services.stalwart-mail.package).
+  before changing the package to `pkgs.stalwart-mail` in `services.stalwart-mail.package`.
 
 - `nomad_1_5` and `nomad_1_6` were dropped, as [they have reached end-of-life upstream](https://support.hashicorp.com/hc/en-us/articles/360021185113-Support-Period-and-End-of-Life-EOL-Policy). Evaluating them will throw an error.
 

--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -75,6 +75,11 @@ of pulling the upstream container image from Docker Hub. If you want the old beh
 }
 ```
 
+- `services.stalwart-mail` has been renamed to `services.stalwart` to align with upstream re-brand as an e-mail and collaboration server. Other notable breaking changes to module:
+
+  - `systemd.services.stalwart` owned by `stalwart:stalwart`. The `user` and `group` are configurable via `services.stalwart.user` and `services.stalwart.group`, respectively. By default, if `stateVersion` is older than `26.05`, will fallback to legacy value of `stalwart-mail` for both `user` and `group`.
+  - Default value for `services.stalwart.dataDir` has changed to `/var/lib/stalwart`. If `stateVersion` is older than `26.05`, will fallback to legacy value of `/var/lib/stalwart-mail`.
+
 - Ethercalc and its associated module have been removed, as the package is unmaintained and cannot be installed from source with npm now.
 
 - `services.cgit` before always had the git-http-backend and its "export all" setting enabled, which sidestepped any access control configured in cgit's settings. Now you have to make a decision and either enable or disable `services.cgit.gitHttpBackend.checkExportOkFiles` (or disable the git-http-backend).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -778,7 +778,7 @@
   ./services/mail/rss2email.nix
   ./services/mail/schleuder.nix
   ./services/mail/spamassassin.nix
-  ./services/mail/stalwart-mail.nix
+  ./services/mail/stalwart.nix
   ./services/mail/sympa.nix
   ./services/mail/tlsrpt.nix
   ./services/mail/zeyple.nix

--- a/nixos/modules/services/mail/stalwart.nix
+++ b/nixos/modules/services/mail/stalwart.nix
@@ -170,7 +170,7 @@ in
       users = {
         ${cfg.user} = {
           isSystemUser = true;
-          group = "${cfg.group}";
+          inherit (cfg) group;
         };
       };
     };
@@ -220,8 +220,8 @@ in
           StateDirectory = if useLegacyDefault then "stalwart-mail" else "stalwart";
 
           # Upstream uses "stalwart" as the username since 0.12.0
-          User = "${cfg.user}";
-          Group = "${cfg.group}";
+          User = cfg.user;
+          Group = cfg.group;
 
           # Bind standard privileged ports
           AmbientCapabilities = [ "CAP_NET_BIND_SERVICE" ];

--- a/nixos/modules/services/mail/stalwart.nix
+++ b/nixos/modules/services/mail/stalwart.nix
@@ -154,7 +154,7 @@ in
           );
         in
         {
-          path = "/var/cache/stalwart";
+          path = if useLegacyDefault then "/var/cache/stalwart-mail" else "/var/cache/stalwart";
           resource = lib.mkIf hasHttpListener (lib.mkDefault "file://${cfg.package.webadmin}/webadmin.zip");
         };
     };

--- a/nixos/modules/services/mail/stalwart.nix
+++ b/nixos/modules/services/mail/stalwart.nix
@@ -180,7 +180,7 @@ in
     ];
 
     systemd = {
-      services.stalwart-mail = {
+      services.stalwart = {
         description = "Stalwart Server";
         wantedBy = [ "multi-user.target" ];
         after = [
@@ -220,8 +220,8 @@ in
           StateDirectory = if useLegacyDefault then "stalwart-mail" else "stalwart";
 
           # Upstream uses "stalwart" as the username since 0.12.0
-          User = if useLegacyDefault then "stalwart-mail" else "${cfg.user}";
-          Group = if useLegacyDefault then "stalwart-mail" else "${cfg.group}";
+          User = "${cfg.user}";
+          Group = "${cfg.group}";
 
           # Bind standard privileged ports
           AmbientCapabilities = [ "CAP_NET_BIND_SERVICE" ];

--- a/nixos/modules/services/mail/stalwart.nix
+++ b/nixos/modules/services/mail/stalwart.nix
@@ -45,7 +45,7 @@ in
       inherit (configFormat) type;
       default = { };
       description = ''
-        Configuration options for the Stalwart collaboration and e-mail server.
+        Configuration options for the Stalwart server.
         See <https://stalw.art/docs/category/configuration> for available options.
 
         By default, the module is configured to store everything locally.

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1477,7 +1477,7 @@ in
   sslh = handleTest ./sslh.nix { };
   sssd-ldap = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./sssd-ldap.nix { };
   sssd-legacy-config = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./sssd-legacy-config.nix { };
-  stalwart-mail = runTest ./stalwart/stalwart-mail.nix;
+  stalwart = runTest ./stalwart/stalwart.nix;
   stargazer = runTest ./web-servers/stargazer.nix;
   starship = runTest ./starship.nix;
   startx = import ./startx.nix { inherit pkgs runTest; };

--- a/nixos/tests/stalwart/stalwart-config.nix
+++ b/nixos/tests/stalwart/stalwart-config.nix
@@ -7,7 +7,7 @@ in
 {
   security.pki.certificateFiles = [ certs.ca.cert ];
 
-  services.stalwart-mail = {
+  services.stalwart = {
     enable = true;
     settings = {
       server.hostname = domain;

--- a/nixos/tests/stalwart/stalwart-config.nix
+++ b/nixos/tests/stalwart/stalwart-config.nix
@@ -54,7 +54,7 @@ in
 
       store."rocksdb" = {
         type = "rocksdb";
-        path = "/var/lib/stalwart-mail/data";
+        path = "/var/lib/stalwart/data";
         compression = "lz4";
       };
 

--- a/nixos/tests/stalwart/stalwart.nix
+++ b/nixos/tests/stalwart/stalwart.nix
@@ -1,4 +1,4 @@
-# Rudimentary test checking that the Stalwart email server can:
+# Rudimentary test checking that the Stalwart collaboration server can:
 # - receive some message through SMTP submission, then
 # - serve this message through IMAP.
 
@@ -8,13 +8,13 @@ let
 in
 { lib, ... }:
 {
-  name = "stalwart-mail";
+  name = "stalwart";
 
   nodes.main =
     { pkgs, ... }:
     {
       imports = [
-        ./stalwart-mail-config.nix
+        ./stalwart-config.nix
       ];
 
       environment.systemPackages = [
@@ -57,7 +57,7 @@ in
 
   testScript = # python
     ''
-      main.wait_for_unit("stalwart-mail.service")
+      main.wait_for_unit("stalwart.service")
       main.wait_for_open_port(587)
       main.wait_for_open_port(143)
       main.wait_for_open_port(80)
@@ -65,14 +65,14 @@ in
       main.succeed("test-smtp-submission")
 
       # restart stalwart to test rocksdb compaction of existing database
-      main.succeed("systemctl restart stalwart-mail.service")
+      main.succeed("systemctl restart stalwart.service")
       main.wait_for_open_port(587)
       main.wait_for_open_port(143)
       main.wait_for_open_port(80)
 
       main.succeed("test-imap-read")
 
-      main.succeed("test -d /var/cache/stalwart-mail/STALWART_WEBADMIN")
+      main.succeed("test -d /var/cache/stalwart/STALWART_WEBADMIN")
       main.succeed("curl --fail http://localhost")
     '';
 

--- a/nixos/tests/stalwart/stalwart.nix
+++ b/nixos/tests/stalwart/stalwart.nix
@@ -1,4 +1,4 @@
-# Rudimentary test checking that the Stalwart collaboration server can:
+# Rudimentary test checking that the Stalwart server can:
 # - receive some message through SMTP submission, then
 # - serve this message through IMAP.
 

--- a/nixos/tests/stalwart/stalwart.nix
+++ b/nixos/tests/stalwart/stalwart.nix
@@ -72,7 +72,7 @@ in
 
       main.succeed("test-imap-read")
 
-      main.succeed("test -d /var/cache/stalwart/STALWART_WEBADMIN")
+      main.succeed("test -d /var/cache/stalwart-mail/STALWART_WEBADMIN || test -d /var/cache/stalwart/STALWART_WEBADMIN")
       main.succeed("curl --fail http://localhost")
     '';
 

--- a/pkgs/by-name/st/stalwart-cli/package.nix
+++ b/pkgs/by-name/st/stalwart-cli/package.nix
@@ -2,11 +2,11 @@
   lib,
   rustPlatform,
   versionCheckHook,
-  stalwart-mail,
+  stalwart,
 }:
 
 rustPlatform.buildRustPackage {
-  inherit (stalwart-mail) src version cargoDeps;
+  inherit (stalwart) src version cargoDeps;
   pname = "stalwart-cli";
 
   cargoBuildFlags = [
@@ -25,7 +25,7 @@ rustPlatform.buildRustPackage {
   dontVersionCheck = true;
 
   meta = {
-    inherit (stalwart-mail.meta) license homepage changelog;
+    inherit (stalwart.meta) license homepage changelog;
     description = "Stalwart Mail Server CLI";
     mainProgram = "stalwart-cli";
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/st/stalwart/package.nix
+++ b/pkgs/by-name/st/stalwart/package.nix
@@ -20,7 +20,7 @@
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
-  pname = "stalwart-mail" + (lib.optionalString stalwartEnterprise "-enterprise");
+  pname = "stalwart" + (lib.optionalString stalwartEnterprise "-enterprise");
   version = "0.15.4";
 
   src = fetchFromGitHub {
@@ -87,7 +87,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
     mkdir -p $out/lib/systemd/system
 
-    substitute resources/systemd/stalwart-mail.service $out/lib/systemd/system/stalwart-mail.service \
+    substitute resources/systemd/stalwart-mail.service $out/lib/systemd/system/stalwart.service \
       --replace-fail "__PATH__" "$out"
   '';
 
@@ -185,20 +185,20 @@ rustPlatform.buildRustPackage (finalAttrs: {
     webadmin = buildPackages.callPackage ./webadmin.nix { };
     spam-filter = callPackage ./spam-filter.nix { };
     updateScript = nix-update-script { };
-    tests.stalwart-mail = nixosTests.stalwart-mail;
+    tests.stalwart = nixosTests.stalwart;
   };
 
   meta = {
-    description = "Secure & Modern All-in-One Mail Server (IMAP, JMAP, SMTP)";
-    homepage = "https://github.com/stalwartlabs/mail-server";
-    changelog = "https://github.com/stalwartlabs/mail-server/blob/main/CHANGELOG.md";
+    description = "Secure, modern, and all-in-one mail & collaboration server fluent in IMAP, JMAP, SMTP, CalDAV, CardDAV, and WebDAV";
+    homepage = "https://github.com/stalwartlabs/stalwart";
+    changelog = "https://github.com/stalwartlabs/stalwart/blob/main/CHANGELOG.md";
     license = [
       lib.licenses.agpl3Only
     ]
     ++ lib.optionals stalwartEnterprise [
       {
         fullName = "Stalwart Enterprise License 1.0 (SELv1) Agreement";
-        url = "https://github.com/stalwartlabs/mail-server/blob/main/LICENSES/LicenseRef-SEL.txt";
+        url = "https://github.com/stalwartlabs/stalwart/blob/main/LICENSES/LicenseRef-SEL.txt";
         free = false;
         redistributable = false;
       }

--- a/pkgs/by-name/st/stalwart/package.nix
+++ b/pkgs/by-name/st/stalwart/package.nix
@@ -189,7 +189,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
   };
 
   meta = {
-    description = "Secure, modern, and all-in-one mail & collaboration server fluent in IMAP, JMAP, SMTP, CalDAV, CardDAV, and WebDAV";
+    description = "Secure, modern, all-in-one mail and collaboration server";
+    longDescription = ''
+      Secure, scalable and fluent in every protocol (IMAP, JMAP, SMTP, CalDAV, CardDAV, WebDAV).
+    '';
     homepage = "https://github.com/stalwartlabs/stalwart";
     changelog = "https://github.com/stalwartlabs/stalwart/blob/main/CHANGELOG.md";
     license = [

--- a/pkgs/by-name/st/stalwart/spam-filter.nix
+++ b/pkgs/by-name/st/stalwart/spam-filter.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   meta = {
-    description = "Secure, modern, and all-in-one mail & collaboration server, Stalwart (spam-filter module)";
+    description = "Spam filter module for the Stalwart server";
     homepage = "https://github.com/stalwartlabs/spam-filter";
     changelog = "https://github.com/stalwartlabs/spam-filter/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = with lib.licenses; [

--- a/pkgs/by-name/st/stalwart/spam-filter.nix
+++ b/pkgs/by-name/st/stalwart/spam-filter.nix
@@ -2,7 +2,7 @@
   lib,
   fetchFromGitHub,
   stdenv,
-  stalwart-mail,
+  stalwart,
   nix-update-script,
 }:
 
@@ -31,13 +31,13 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   meta = {
-    description = "Secure & modern all-in-one mail server Stalwart (spam-filter module)";
+    description = "Secure, modern, and all-in-one mail & collaboration server, Stalwart (spam-filter module)";
     homepage = "https://github.com/stalwartlabs/spam-filter";
     changelog = "https://github.com/stalwartlabs/spam-filter/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = with lib.licenses; [
       mit
       asl20
     ];
-    inherit (stalwart-mail.meta) maintainers;
+    inherit (stalwart.meta) maintainers;
   };
 })

--- a/pkgs/by-name/st/stalwart/webadmin.nix
+++ b/pkgs/by-name/st/stalwart/webadmin.nix
@@ -68,7 +68,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   };
 
   meta = {
-    description = "Secure, modern, and all-in-one mail & collaboration server, Stalwart (webadmin module)";
+    description = "Web administration module for the Stalwart server";
     homepage = "https://github.com/stalwartlabs/webadmin";
     changelog = "https://github.com/stalwartlabs/webadmin/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.agpl3Only;

--- a/pkgs/by-name/st/stalwart/webadmin.nix
+++ b/pkgs/by-name/st/stalwart/webadmin.nix
@@ -1,7 +1,7 @@
 {
   lib,
   rustPlatform,
-  stalwart-mail,
+  stalwart,
   fetchFromGitHub,
   trunk,
   tailwindcss_3,
@@ -68,10 +68,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
   };
 
   meta = {
-    description = "Secure & modern all-in-one mail server Stalwart (webadmin module)";
+    description = "Secure, modern, and all-in-one mail & collaboration server, Stalwart (webadmin module)";
     homepage = "https://github.com/stalwartlabs/webadmin";
     changelog = "https://github.com/stalwartlabs/webadmin/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.agpl3Only;
-    inherit (stalwart-mail.meta) maintainers;
+    inherit (stalwart.meta) maintainers;
   };
 })

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1662,6 +1662,7 @@ mapAliases {
   src = throw "The \"src\" package has been renamed to \"simple-revision-control\". If you encounter this error and did not intend to use that package you may have a falsely constructed overlay."; # Added 2025-11-19
   ssm-agent = throw "'ssm-agent' has been renamed to/replaced by 'amazon-ssm-agent'"; # Converted to throw 2025-10-27
   stacer = throw "'stacer' has been removed because it was abandoned upstream and relied upon vulnerable software"; # Added 2025-11-08
+  stalwart-mail = warnAlias "'stalwart-mail' has been renamed to/replaced by 'stalwart'" stalwart; # Added 2026-01-19
   starpls-bin = throw "'starpls-bin' has been renamed to/replaced by 'starpls'"; # Converted to throw 2025-10-27
   station = throw "station has been removed from nixpkgs, as there were no committers among its maintainers to unblock security issues"; # Added 2025-06-16
   steam-run-native = throw "'steam-run-native' has been renamed to/replaced by 'steam-run'"; # Converted to throw 2025-10-27

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8982,10 +8982,10 @@ with pkgs;
     enableAirplay2 = true;
   };
 
-  stalwart-mail-webadmin = stalwart-mail.webadmin;
-  stalwart-mail-spam-filter = stalwart-mail.spam-filter;
+  stalwart-webadmin = stalwart.webadmin;
+  stalwart-spam-filter = stalwart.spam-filter;
 
-  stalwart-mail-enterprise = stalwart-mail.override {
+  stalwart-enterprise = stalwart.override {
     stalwartEnterprise = true;
   };
 


### PR DESCRIPTION
* update package, service, and test modules to reflect upstream name change
* update metadata for package
* update references to `stalwart-mail` from `stalwart` in downstream/sub-packages (stalwart.webadmin, stalwart.spam-filter, stalwart-cli)
* define alias for `stalwart-mail` to `stalwart`
* update references to `stalwart-mail` in rl docs, `all-packages.nix`, nixostests

Related to: NixOS/nixpkgs#473375


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
