### PR TITLE
[staging-next] rocmPackages.migraphx: fix abseil include

### DIFF
--- a/pkgs/development/rocm-modules/migraphx/default.nix
+++ b/pkgs/development/rocm-modules/migraphx/default.nix
@@ -147,7 +147,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   postPatch = ''
-    export CXXFLAGS+=" -w -isystem${rocmlir}/include/rocmlir -I${half}/include -I${abseil-cpp}/include -I${hipblas-common}/include"
+    export CXXFLAGS+=" -w -isystem${rocmlir}/include/rocmlir -I${half}/include -I${lib.getInclude abseil-cpp}/include -I${hipblas-common}/include"
     patchShebangs tools
 
     # `error: '__clang_hip_runtime_wrapper.h' file not found [clang-diagnostic-error]`


### PR DESCRIPTION
currently errors with:

    cd /build/source/build/src/tf && /nix/store/pbmzp0a639n7bgch2ayainja9bvhfri9-clr-7.0.2/bin/amdclang++  -isystem /build/source/build/src/tf -isystem /nix/store/kiqarh0s4z2kcd7p3sq049kcc85syww8-protobuf-32.1/inclu>
    In file included from /build/source/build/src/onnx/onnx.pb.cc:6:
    In file included from /build/source/build/src/onnx/onnx.pb.h:20:
    /nix/store/kiqarh0s4z2kcd7p3sq049kcc85syww8-protobuf-32.1/include/google/protobuf/io/coded_stream.h:101:10: fatal error: 'absl/base/optimization.h' file not found
      101 | #include "absl/base/optimization.h"
          |          ^~~~~~~~~~~~~~~~~~~~~~~~~~
    [  5%] Building CXX object src/targets/gpu/CMakeFiles/embed_lib_migraphx_kernels.dir/migraphx/kernels/copy.hpp.cpp.o
    cd /build/source/build/src/targets/gpu && /nix/store/pbmzp0a639n7bgch2ayainja9bvhfri9-clr-7.0.2/bin/amdclang++  -I/build/source/build/src/targets/gpu/embed/migraphx_kernels/include -w -isystem/nix/store/46my897r>
    In file included from /build/source/build/src/tf/graph.pb.cc:6:
    In file included from /build/source/build/src/tf/graph.pb.h:20:
    /nix/store/kiqarh0s4z2kcd7p3sq049kcc85syww8-protobuf-32.1/include/google/protobuf/io/coded_stream.h:101:10: fatal error: 'absl/base/optimization.h' file not found
      101 | #include "absl/base/optimization.h"
          |          ^~~~~~~~~~~~~~~~~~~~~~~~~~


https://hydra.nixos.org/build/319556415

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
