### PR TITLE
glibcLocales{,Utf8}: signal availability via `meta.platforms`, not `null`

### DIFF
--- a/nixos/modules/installer/cd-dvd/installation-cd-graphical-calamares.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-graphical-calamares.nix
@@ -14,14 +14,18 @@ in
   # required for kpmcore to work correctly
   programs.partition-manager.enable = true;
 
-  environment.systemPackages = with pkgs; [
-    # Calamares for graphical installation
-    calamares-nixos
-    calamares-nixos-autostart
-    calamares-nixos-extensions
-    # Get list of locales
-    glibcLocales
-  ];
+  environment.systemPackages =
+    with pkgs;
+    [
+      # Calamares for graphical installation
+      calamares-nixos
+      calamares-nixos-autostart
+      calamares-nixos-extensions
+    ]
+    ++ lib.optionals (lib.meta.availableOn stdenv.hostPlatform glibcLocales) [
+      # Get list of locales
+      glibcLocales
+    ];
 
   # Support choosing from any locale
   i18n.supportedLocales = [ "all" ];

--- a/pkgs/applications/audio/mopidy/moped.nix
+++ b/pkgs/applications/audio/mopidy/moped.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   pythonPackages,
   fetchPypi,
   mopidy,
@@ -18,7 +19,9 @@ pythonPackages.buildPythonApplication rec {
   };
 
   LC_ALL = "en_US.UTF-8";
-  buildInputs = [ glibcLocales ];
+  buildInputs = lib.optionals (lib.meta.availableOn stdenv.hostPlatform glibcLocales) [
+    glibcLocales
+  ];
 
   build-system = [ pythonPackages.setuptools ];
 

--- a/pkgs/applications/audio/quodlibet/default.nix
+++ b/pkgs/applications/audio/quodlibet/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   fetchFromGitHub,
   tag ? "",
 
@@ -132,7 +133,9 @@ python3.pkgs.buildPythonApplication rec {
     glibcLocales
     hicolor-icon-theme
     xvfb-run
-    writableTmpDirAsHomeHook
+  ]
+  ++ lib.optionals (lib.meta.availableOn stdenv.buildPlatform glibcLocales) [
+    glibcLocales
   ]
   ++ (with python3.pkgs; [
     polib

--- a/pkgs/applications/networking/instant-messengers/profanity/default.nix
+++ b/pkgs/applications/networking/instant-messengers/profanity/default.nix
@@ -57,8 +57,10 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     autoconf-archive
     autoreconfHook
-    glibcLocales
     pkg-config
+  ]
+  ++ lib.optionals (lib.meta.availableOn stdenv.buildPlatform glibcLocales) [
+    glibcLocales
   ];
 
   buildInputs = [

--- a/pkgs/applications/science/logic/cedille/default.nix
+++ b/pkgs/applications/science/logic/cedille/default.nix
@@ -35,9 +35,7 @@ stdenv.mkDerivation rec {
   ];
 
   LANG = "en_US.UTF-8";
-  LOCALE_ARCHIVE = lib.optionalString (
-    stdenv.buildPlatform.libc == "glibc"
-  ) "${buildPackages.glibcLocales}/lib/locale/locale-archive";
+  LOCALE_ARCHIVE = lib.optionalString (lib.meta.availableOn stdenv.buildPlatform buildPackages.glibcLocales) "${buildPackages.glibcLocales}/lib/locale/locale-archive";
 
   postPatch = ''
     patchShebangs create-libraries.sh

--- a/pkgs/applications/science/logic/tamarin-prover/default.nix
+++ b/pkgs/applications/science/logic/tamarin-prover/default.nix
@@ -173,7 +173,7 @@ mkDerivation (
     postInstall = ''
       wrapProgram $out/bin/tamarin-prover \
     ''
-    + lib.optionalString stdenv.hostPlatform.isLinux ''
+    + lib.optionalString (lib.meta.availableOn stdenv.hostPlatform glibcLocales) ''
       --set LOCALE_ARCHIVE "${glibcLocales}/lib/locale/locale-archive" \
     ''
     + ''

--- a/pkgs/build-support/build-fhsenv-bubblewrap/buildFHSEnv.nix
+++ b/pkgs/build-support/build-fhsenv-bubblewrap/buildFHSEnv.nix
@@ -66,25 +66,29 @@ let
   # these match the host's architecture, glibc_multi is used for multilib
   # builds. glibcLocales must be before glibc or glibc_multi as otherwiese
   # the wrong LOCALE_ARCHIVE will be used where only C.UTF-8 is available.
-  baseTargetPaths = with pkgs; [
-    glibcLocales
-    (if isMultiBuild then glibc_multi else glibc)
-    gcc.cc.lib
-    bashInteractiveFHS
-    coreutils
-    less
-    shadow
-    su
-    gawk
-    diffutils
-    findutils
-    gnused
-    gnugrep
-    gnutar
-    gzip
-    bzip2
-    xz
-  ];
+  baseTargetPaths =
+    with pkgs;
+    lib.optionals (lib.meta.availableOn stdenv.hostPlatform glibcLocales) [
+      glibcLocales
+    ]
+    ++ [
+      (if isMultiBuild then glibc_multi else glibc)
+      gcc.cc.lib
+      bashInteractiveFHS
+      coreutils
+      less
+      shadow
+      su
+      gawk
+      diffutils
+      findutils
+      gnused
+      gnugrep
+      gnutar
+      gzip
+      bzip2
+      xz
+    ];
   baseMultiPaths = with pkgsi686Linux; [
     gcc.cc.lib
   ];

--- a/pkgs/build-support/build-fhsenv-chroot/env.nix
+++ b/pkgs/build-support/build-fhsenv-chroot/env.nix
@@ -51,25 +51,29 @@ let
   # these match the host's architecture, glibc_multi is used for multilib
   # builds. glibcLocales must be before glibc or glibc_multi as otherwiese
   # the wrong LOCALE_ARCHIVE will be used where only C.UTF-8 is available.
-  basePkgs = with pkgs; [
-    glibcLocales
-    (if isMultiBuild then glibc_multi else glibc)
-    (toString gcc.cc.lib)
-    bashInteractiveFHS
-    coreutils
-    less
-    shadow
-    su
-    gawk
-    diffutils
-    findutils
-    gnused
-    gnugrep
-    gnutar
-    gzip
-    bzip2
-    xz
-  ];
+  basePkgs =
+    with pkgs;
+    lib.optionals (lib.meta.availableOn stdenv.hostPlatform glibcLocales) [
+      glibcLocales
+    ]
+    ++ [
+      (if isMultiBuild then glibc_multi else glibc)
+      (toString gcc.cc.lib)
+      bashInteractiveFHS
+      coreutils
+      less
+      shadow
+      su
+      gawk
+      diffutils
+      findutils
+      gnused
+      gnugrep
+      gnutar
+      gzip
+      bzip2
+      xz
+    ];
   baseMultiPkgs = with pkgsi686Linux; [
     (toString gcc.cc.lib)
   ];

--- a/pkgs/build-support/build-graalvm-native-image/default.nix
+++ b/pkgs/build-support/build-graalvm-native-image/default.nix
@@ -60,11 +60,15 @@ lib.extendMkDerivation {
 
       inherit dontUnpack strictDeps __structuredAttrs;
 
-      nativeBuildInputs = (args.nativeBuildInputs or [ ]) ++ [
-        graalvmDrv
-        glibcLocales
-        removeReferencesTo
-      ];
+      nativeBuildInputs =
+        (args.nativeBuildInputs or [ ])
+        ++ [
+          graalvmDrv
+          removeReferencesTo
+        ]
+        ++ lib.optionals (lib.meta.availableOn stdenv.buildPlatform glibcLocales) [
+          glibcLocales
+        ];
 
       # `nativeBuildInputs` does not allow `graalvmDrv`'s propagatedBuildInput to reach here this package.
       # As its `propagatedBuildInputs` is required for the build process with `native-image`, we must add it here as well.

--- a/pkgs/build-support/fetchsvn/default.nix
+++ b/pkgs/build-support/fetchsvn/default.nix
@@ -62,8 +62,8 @@ else
     nativeBuildInputs = [
       cacert
       subversion
-      glibcLocales
     ]
+    ++ lib.optional (lib.meta.availableOn stdenvNoCC.buildPlatform glibcLocales) glibcLocales
     ++ lib.optional sshSupport openssh;
 
     SVN_SSH = if sshSupport then "${buildPackages.openssh}/bin/ssh" else null;

--- a/pkgs/build-support/fetchzip/default.nix
+++ b/pkgs/build-support/fetchzip/default.nix
@@ -7,11 +7,12 @@
 
 {
   lib,
+  stdenv,
+  buildPackages,
   repoRevToNameMaybe,
   fetchurl,
   withUnzip ? true,
   unzip,
-  glibcLocalesUtf8,
 }:
 
 lib.extendMkDerivation {
@@ -69,10 +70,14 @@ lib.extendMkDerivation {
       # UTF-8 aware locale:
       #   https://github.com/NixOS/nixpkgs/issues/176225#issuecomment-1146617263
       nativeBuildInputs =
-        lib.optionals withUnzip [
-          unzip
-          glibcLocalesUtf8
-        ]
+        lib.optionals withUnzip (
+          [
+            unzip
+          ]
+          ++ lib.optionals (lib.meta.availableOn stdenv.buildPlatform buildPackages.glibcLocalesUtf8) [
+            buildPackages.glibcLocalesUtf8
+          ]
+        )
         ++ nativeBuildInputs;
 
       postFetch = ''

--- a/pkgs/by-name/ar/argc/package.nix
+++ b/pkgs/by-name/ar/argc/package.nix
@@ -43,7 +43,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   env = {
     LANG = "C.UTF-8";
   }
-  // lib.optionalAttrs (glibcLocales != null) {
+  // lib.optionalAttrs (lib.meta.availableOn stdenv.hostPlatform glibcLocales) {
     LOCALE_ARCHIVE = "${glibcLocales}/lib/locale/locale-archive";
   };
 

--- a/pkgs/by-name/bl/blesh/package.nix
+++ b/pkgs/by-name/bl/blesh/package.nix
@@ -21,6 +21,8 @@ stdenvNoCC.mkDerivation rec {
   doCheck = true;
   nativeCheckInputs = [
     bashInteractive
+  ]
+  ++ lib.optionals (lib.meta.availableOn stdenvNoCC.buildPlatform glibcLocales) [
     glibcLocales
   ];
   preCheck = "export LC_ALL=en_US.UTF-8";

--- a/pkgs/by-name/bl/bluespec/package.nix
+++ b/pkgs/by-name/bl/bluespec/package.nix
@@ -237,7 +237,7 @@ stdenv.mkDerivation rec {
 
   # bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
   LOCALE_ARCHIVE = lib.optionalString (
-    withSuiteCheck && stdenv.hostPlatform.isLinux
+    withSuiteCheck && lib.meta.availableOn stdenv.hostPlatform glibcLocales
   ) "${glibcLocales}/lib/locale/locale-archive";
 
   nativeCheckInputs = [

--- a/pkgs/by-name/ca/castget/package.nix
+++ b/pkgs/by-name/ca/castget/package.nix
@@ -46,9 +46,11 @@ stdenv.mkDerivation (finalAttrs: {
   ];
   nativeBuildInputs = [
     autoreconfHook
+    pkg-config
+  ]
+  ++ lib.optionals (lib.meta.availableOn stdenv.buildPlatform glibcLocales) [
     # See comment on locale above
     glibcLocales
-    pkg-config
   ];
 
   meta = {

--- a/pkgs/by-name/ca/casync/package.nix
+++ b/pkgs/by-name/ca/casync/package.nix
@@ -50,8 +50,10 @@ stdenv.mkDerivation {
     sphinx
   ];
   nativeCheckInputs = [
-    glibcLocales
     rsync
+  ]
+  ++ lib.optionals (lib.meta.availableOn stdenv.buildPlatform glibcLocales) [
+    glibcLocales
   ]
   ++ lib.optionals udevSupport [
     udevCheckHook

--- a/pkgs/by-name/de/devenv/package.nix
+++ b/pkgs/by-name/de/devenv/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   fetchFromGitHub,
   fetchpatch2,
   gitMinimal,
@@ -94,7 +95,7 @@ rustPlatform.buildRustPackage {
 
   postInstall =
     let
-      setDefaultLocaleArchive = lib.optionalString (glibcLocalesUtf8 != null) ''
+      setDefaultLocaleArchive = lib.optionalString (lib.meta.availableOn stdenv.hostPlatform glibcLocalesUtf8) ''
         --set-default LOCALE_ARCHIVE ${glibcLocalesUtf8}/lib/locale/locale-archive
       '';
     in

--- a/pkgs/by-name/de/devpi-client/package.nix
+++ b/pkgs/by-name/de/devpi-client/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   devpi-server,
   git,
   glibcLocales,
@@ -24,7 +25,9 @@ python3.pkgs.buildPythonApplication rec {
     setuptools-changelog-shortener
   ];
 
-  buildInputs = [ glibcLocales ];
+  buildInputs = lib.optionals (lib.meta.availableOn stdenv.hostPlatform glibcLocales) [
+    glibcLocales
+  ];
 
   dependencies = with python3.pkgs; [
     build

--- a/pkgs/by-name/dt/dtee/package.nix
+++ b/pkgs/by-name/dt/dtee/package.nix
@@ -53,6 +53,8 @@ stdenv.mkDerivation (finalAttrs: {
     coreutils
     diffutils
     findutils
+  ]
+  ++ lib.optionals (lib.meta.availableOn stdenv.buildPlatform glibcLocales) [
     glibcLocales # For tests that check translations work
   ];
 

--- a/pkgs/by-name/ev/eventstore/package.nix
+++ b/pkgs/by-name/ev/eventstore/package.nix
@@ -34,8 +34,10 @@ buildDotnetModule rec {
 
   nativeBuildInputs = [
     git
-    glibcLocales
     bintools
+  ]
+  ++ lib.optionals (lib.meta.availableOn stdenv.buildPlatform glibcLocales) [
+    glibcLocales
   ];
 
   runtimeDeps = [ mono ];

--- a/pkgs/by-name/fh/fheroes2/package.nix
+++ b/pkgs/by-name/fh/fheroes2/package.nix
@@ -31,13 +31,15 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     gettext
-    glibcLocalesUtf8
     libpng
     SDL2
     SDL2_image
     SDL2_mixer
     SDL2_ttf
     zlib
+  ]
+  ++ lib.optionals (lib.meta.availableOn stdenv.hostPlatform glibcLocalesUtf8) [
+    glibcLocalesUtf8
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [ libiconv ];
 

--- a/pkgs/by-name/fi/file-roller/package.nix
+++ b/pkgs/by-name/fi/file-roller/package.nix
@@ -34,7 +34,6 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     desktop-file-utils
     gettext
-    glibcLocales
     itstool
     libxml2
     meson
@@ -42,6 +41,9 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
     python3
     wrapGAppsHook4
+  ]
+  ++ lib.optionals (lib.meta.availableOn stdenv.buildPlatform glibcLocales) [
+    glibcLocales
   ];
 
   buildInputs = [

--- a/pkgs/by-name/fi/fish/package.nix
+++ b/pkgs/by-name/fi/fish/package.nix
@@ -347,10 +347,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeCheckInputs = [
     coreutils
-    glibcLocales
     (python3.withPackages (ps: [ ps.pexpect ]))
     procps
     sphinx
+  ]
+  ++ lib.optionals (lib.meta.availableOn stdenv.buildPlatform glibcLocales) [
+    glibcLocales
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # For the getconf command, used in default-setup-path.fish

--- a/pkgs/by-name/ge/geary/package.nix
+++ b/pkgs/by-name/ge/geary/package.nix
@@ -100,6 +100,8 @@ stdenv.mkDerivation rec {
     gnutls # for certtool
     cacert # trust store for glib-networking
     xvfb-run
+  ]
+  ++ lib.optionals (lib.meta.availableOn stdenv.buildPlatform glibcLocales) [
     glibcLocales # required by Geary.ImapDb.DatabaseTest/utf8_case_insensitive_collation
   ];
 

--- a/pkgs/by-name/gi/github-runner/package.nix
+++ b/pkgs/by-name/gi/github-runner/package.nix
@@ -103,7 +103,7 @@ buildDotnetModule (finalAttrs: {
                      'true'
   '';
 
-  DOTNET_SYSTEM_GLOBALIZATION_INVARIANT = isNull glibcLocales;
+  DOTNET_SYSTEM_GLOBALIZATION_INVARIANT = !(lib.meta.availableOn stdenv.hostPlatform glibcLocales);
   LOCALE_ARCHIVE = lib.optionalString (
     !finalAttrs.DOTNET_SYSTEM_GLOBALIZATION_INVARIANT
   ) "${glibcLocales}/lib/locale/locale-archive";

--- a/pkgs/by-name/gn/gnucash/package.nix
+++ b/pkgs/by-name/gn/gnucash/package.nix
@@ -94,6 +94,9 @@ stdenv.mkDerivation (finalAttrs: {
     webkitgtk_4_1
     py
   ]
+  ++ lib.optionals (lib.meta.availableOn stdenv.hostPlatform glibcLocales) [
+    glibcLocales
+  ]
   ++ (with perlPackages; [
     JSONParse
     FinanceQuote

--- a/pkgs/by-name/gr/gramps/package.nix
+++ b/pkgs/by-name/gr/gramps/package.nix
@@ -61,11 +61,13 @@ python3Packages.buildPythonApplication (finalAttrs: {
   ];
 
   nativeCheckInputs = [
-    glibcLocales
     python3Packages.unittestCheckHook
     python3Packages.jsonschema
     python3Packages.mock
     python3Packages.lxml
+  ]
+  ++ lib.optionals (lib.meta.availableOn stdenv.buildPlatform glibcLocales) [
+    glibcLocales
   ]
   # TODO: use JHBuild to build the Gramps' bundle
   ++ lib.optionals stdenv.hostPlatform.isDarwin [

--- a/pkgs/by-name/gs/gspeech/package.nix
+++ b/pkgs/by-name/gs/gspeech/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   fetchFromGitHub,
   python3,
   gtk3,
@@ -47,9 +48,11 @@ python3.pkgs.buildPythonApplication rec {
   ];
 
   buildInputs = [
-    glibcLocales
     gtk3
     python3
+  ]
+  ++ lib.optionals (lib.meta.availableOn stdenv.hostPlatform glibcLocales) [
+    glibcLocales
   ];
 
   propagatedBuildInputs = with python3.pkgs; [

--- a/pkgs/by-name/gt/gtimelog/package.nix
+++ b/pkgs/by-name/gt/gtimelog/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   fetchFromGitHub,
   python3Packages,
   wrapGAppsHook3,
@@ -31,10 +32,12 @@ python3Packages.buildPythonApplication rec {
     gobject-introspection
   ];
   buildInputs = [
-    glibcLocales
     gtk3
     libsoup_3
     libsecret
+  ]
+  ++ lib.optionals (lib.meta.availableOn stdenv.hostPlatform glibcLocales) [
+    glibcLocales
   ];
   propagatedBuildInputs = with python3Packages; [
     pygobject3

--- a/pkgs/by-name/gu/guix/package.nix
+++ b/pkgs/by-name/gu/guix/package.nix
@@ -69,7 +69,6 @@ stdenv.mkDerivation rec {
     git
     graphviz
     gettext
-    glibcLocales
     guile
     guile-avahi
     guile-gcrypt
@@ -91,6 +90,9 @@ stdenv.mkDerivation rec {
     scheme-bytestructures
     slirp4netns
     texinfo
+  ]
+  ++ lib.optionals (lib.meta.availableOn stdenv.buildPlatform glibcLocales) [
+    glibcLocales
   ];
 
   buildInputs = [

--- a/pkgs/by-name/ha/harlequin/package.nix
+++ b/pkgs/by-name/ha/harlequin/package.nix
@@ -35,7 +35,9 @@ python3Packages.buildPythonApplication rec {
 
   build-system = with python3Packages; [ hatchling ];
 
-  nativeBuildInputs = [ glibcLocales ];
+  nativeBuildInputs = lib.optionals (lib.meta.availableOn stdenv.buildPlatform glibcLocales) [
+    glibcLocales
+  ];
 
   dependencies =
     with python3Packages;

--- a/pkgs/by-name/he/hentai-at-home/package.nix
+++ b/pkgs/by-name/he/hentai-at-home/package.nix
@@ -23,9 +23,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   ];
 
   LANG = "en_US.UTF-8";
-  LOCALE_ARCHIVE = lib.optionalString (
-    stdenvNoCC.buildPlatform.libc == "glibc"
-  ) "${buildPackages.glibcLocales}/lib/locale/locale-archive";
+  LOCALE_ARCHIVE = lib.optionalString (lib.meta.availableOn stdenvNoCC.buildPlatform buildPackages.glibcLocales) "${buildPackages.glibcLocales}/lib/locale/locale-archive";
 
   makeFlags = [ "all" ];
   enableParallelBuilding = false;

--- a/pkgs/by-name/ht/httpstat/package.nix
+++ b/pkgs/by-name/ht/httpstat/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   fetchFromGitHub,
   curl,
   python3Packages,
@@ -20,7 +21,9 @@ python3Packages.buildPythonApplication rec {
   build-system = with python3Packages; [ setuptools ];
 
   doCheck = false; # No tests
-  buildInputs = [ glibcLocales ];
+  buildInputs = lib.optionals (lib.meta.availableOn stdenv.hostPlatform glibcLocales) [
+    glibcLocales
+  ];
   runtimeDeps = [ curl ];
 
   LC_ALL = "en_US.UTF-8";

--- a/pkgs/by-name/hy/hydra/package.nix
+++ b/pkgs/by-name/hy/hydra/package.nix
@@ -207,12 +207,14 @@ stdenv.mkDerivation (finalAttrs: {
   nativeCheckInputs = [
     cacert
     foreman
-    glibcLocales
     python3
     netcat
     nix-eval-jobs
     openldap
     postgresql
+  ]
+  ++ lib.optionals (lib.meta.availableOn stdenv.buildPlatform glibcLocales) [
+    glibcLocales
   ];
 
   env = {

--- a/pkgs/by-name/i3/i3minator/package.nix
+++ b/pkgs/by-name/i3/i3minator/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   fetchFromGitHub,
   python3Packages,
   glibcLocales,
@@ -18,7 +19,9 @@ python3Packages.buildPythonApplication rec {
   };
 
   LC_ALL = "en_US.UTF-8";
-  buildInputs = [ glibcLocales ];
+  buildInputs = lib.optionals (lib.meta.availableOn stdenv.hostPlatform glibcLocales) [
+    glibcLocales
+  ];
 
   build-system = [
     python3Packages.setuptools

--- a/pkgs/by-name/kh/khal/package.nix
+++ b/pkgs/by-name/kh/khal/package.nix
@@ -36,11 +36,13 @@ python3Packages.buildPythonApplication rec {
   ];
 
   nativeBuildInputs = [
-    glibcLocales
     installShellFiles
     sphinxHook
     python3Packages.sphinx-rtd-theme
     python3Packages.sphinxcontrib-newsfeed
+  ]
+  ++ lib.optionals (lib.meta.availableOn stdenv.buildPlatform glibcLocales) [
+    glibcLocales
   ];
 
   dependencies = with python3Packages; [

--- a/pkgs/by-name/li/libaccounts-glib/package.nix
+++ b/pkgs/by-name/li/libaccounts-glib/package.nix
@@ -43,13 +43,15 @@ stdenv.mkDerivation rec {
     check
     docbook_xml_dtd_43
     docbook_xsl
-    glibcLocales
     gobject-introspection
     gtk-doc
     meson
     ninja
     pkg-config
     vala
+  ]
+  ++ lib.optionals (lib.meta.availableOn stdenv.buildPlatform glibcLocales) [
+    glibcLocales
   ]
   ++ lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
     mesonEmulatorHook

--- a/pkgs/by-name/li/libarchive/package.nix
+++ b/pkgs/by-name/li/libarchive/package.nix
@@ -5,8 +5,8 @@
   acl,
   attr,
   autoreconfHook,
+  buildPackages,
   bzip2,
-  glibcLocalesUtf8,
   lzo,
   openssl,
   pkg-config,
@@ -79,8 +79,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     autoreconfHook
-    glibcLocalesUtf8 # test_I test requires an UTF-8 locale
     pkg-config
+  ]
+  ++ lib.optionals (lib.meta.availableOn stdenv.buildPlatform buildPackages.glibcLocalesUtf8) [
+    buildPackages.glibcLocalesUtf8 # test_I test requires an UTF-8 locale
   ];
 
   buildInputs = [

--- a/pkgs/by-name/li/libgudev/package.nix
+++ b/pkgs/by-name/li/libgudev/package.nix
@@ -63,8 +63,10 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   checkInputs = [
-    glibcLocales
     umockdev
+  ]
+  ++ lib.optionals (lib.meta.availableOn stdenv.hostPlatform glibcLocales) [
+    glibcLocales
   ];
 
   doCheck = withIntrospection;

--- a/pkgs/by-name/mi/minigalaxy/package.nix
+++ b/pkgs/by-name/mi/minigalaxy/package.nix
@@ -55,11 +55,15 @@ python3Packages.buildPythonApplication rec {
     requests
   ];
 
-  nativeCheckInputs = with python3Packages; [
-    glibcLocales
-    pytestCheckHook
-    simplejson
-  ];
+  nativeCheckInputs =
+    with python3Packages;
+    [
+      pytestCheckHook
+      simplejson
+    ]
+    ++ lib.optionals (lib.meta.availableOn stdenv.buildPlatform glibcLocales) [
+      glibcLocales
+    ];
 
   preCheck = ''
     export HOME=$(mktemp -d)

--- a/pkgs/by-name/ms/msbuild/package.nix
+++ b/pkgs/by-name/ms/msbuild/package.nix
@@ -57,7 +57,7 @@ mkPackage rec {
 
   # https://github.com/NixOS/nixpkgs/issues/38991
   # bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
-  LOCALE_ARCHIVE = lib.optionalString stdenv.hostPlatform.isLinux "${glibcLocales}/lib/locale/locale-archive";
+  LOCALE_ARCHIVE = lib.optionalString (lib.meta.availableOn stdenv.hostPlatform glibcLocales) "${glibcLocales}/lib/locale/locale-archive";
 
   postPatch = ''
     # not patchShebangs, there is /bin/bash in the body of the script as well

--- a/pkgs/by-name/ms/msbuild/package.nix
+++ b/pkgs/by-name/ms/msbuild/package.nix
@@ -51,7 +51,7 @@ mkPackage rec {
     makeWrapper
   ];
 
-  buildInputs = [
+  buildInputs = lib.optionals (lib.meta.availableOn stdenv.hostPlatform glibcLocales) [
     glibcLocales
   ];
 

--- a/pkgs/by-name/mu/mu/package.nix
+++ b/pkgs/by-name/mu/mu/package.nix
@@ -86,6 +86,8 @@ stdenv.mkDerivation (finalAttrs: {
     meson
     ninja
     python3
+  ]
+  ++ lib.optionals (lib.meta.availableOn stdenv.buildPlatform glibcLocales) [
     glibcLocales
   ];
 

--- a/pkgs/by-name/ne/neovim-unwrapped/package.nix
+++ b/pkgs/by-name/ne/neovim-unwrapped/package.nix
@@ -143,8 +143,10 @@ stdenv.mkDerivation (
       utf8proc
     ]
     ++ lib.optionals finalAttrs.finalPackage.doCheck [
-      glibcLocales
       procps
+    ]
+    ++ lib.optionals (glibcLocales != null && lib.meta.availableOn stdenv.hostPlatform glibcLocales) [
+      glibcLocales
     ]
     ++ lib.optionals (stdenv.hostPlatform.libc != "glibc") [
       # Provide libintl for non-glibc platforms

--- a/pkgs/by-name/ne/neovim-unwrapped/package.nix
+++ b/pkgs/by-name/ne/neovim-unwrapped/package.nix
@@ -14,7 +14,7 @@
   buildPackages,
   treesitter-parsers ? import ./treesitter-parsers.nix { inherit fetchurl; },
   fixDarwinDylibNames,
-  glibcLocales ? null,
+  glibcLocales,
   procps ? null,
   versionCheckHook,
   nix-update-script,
@@ -145,7 +145,7 @@ stdenv.mkDerivation (
     ++ lib.optionals finalAttrs.finalPackage.doCheck [
       procps
     ]
-    ++ lib.optionals (glibcLocales != null && lib.meta.availableOn stdenv.hostPlatform glibcLocales) [
+    ++ lib.optionals (lib.meta.availableOn stdenv.hostPlatform glibcLocales) [
       glibcLocales
     ]
     ++ lib.optionals (stdenv.hostPlatform.libc != "glibc") [

--- a/pkgs/by-name/oc/ocrodjvu/package.nix
+++ b/pkgs/by-name/oc/ocrodjvu/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   python3Packages,
   fetchFromGitHub,
   djvulibre,
@@ -51,10 +52,12 @@ python3Packages.buildPythonApplication rec {
     python3Packages.unittestCheckHook
     python3Packages.pillow
     djvulibre
-    glibcLocales
     libxml2
     libxml2Python
     tesseract5
+  ]
+  ++ lib.optionals (lib.meta.availableOn stdenv.buildPlatform glibcLocales) [
+    glibcLocales
   ];
 
   unittestFlagsArray = [

--- a/pkgs/by-name/on/onnxruntime/package.nix
+++ b/pkgs/by-name/on/onnxruntime/package.nix
@@ -156,12 +156,14 @@ effectiveStdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     eigen
-    glibcLocales
     howard-hinnant-date
     libpng
     nlohmann_json
     microsoft-gsl
     zlib
+  ]
+  ++ lib.optionals (lib.meta.availableOn effectiveStdenv.hostPlatform glibcLocales) [
+    glibcLocales
   ]
   ++ lib.optionals (lib.meta.availableOn effectiveStdenv.hostPlatform cpuinfo) [
     cpuinfo

--- a/pkgs/by-name/op/opustags/package.nix
+++ b/pkgs/by-name/op/opustags/package.nix
@@ -35,8 +35,10 @@ stdenv.mkDerivation rec {
 
   nativeCheckInputs = [
     ffmpeg
-    glibcLocales
     perl
+  ]
+  ++ lib.optionals (lib.meta.availableOn stdenv.buildPlatform glibcLocales) [
+    glibcLocales
   ]
   ++ (with perlPackages; [
     ListMoreUtils

--- a/pkgs/by-name/py/pytrainer/package.nix
+++ b/pkgs/by-name/py/pytrainer/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   python3,
   fetchFromGitHub,
   fetchpatch,
@@ -92,9 +93,11 @@ python.pkgs.buildPythonApplication rec {
   ];
 
   nativeCheckInputs = [
-    glibcLocales
     perl
     xvfb-run
+  ]
+  ++ lib.optionals (lib.meta.availableOn stdenv.buildPlatform glibcLocales) [
+    glibcLocales
   ]
   ++ (with python.pkgs; [
     mysqlclient

--- a/pkgs/by-name/ra/rabbitmq-server/package.nix
+++ b/pkgs/by-name/ra/rabbitmq-server/package.nix
@@ -68,6 +68,8 @@ stdenv.mkDerivation (finalAttrs: {
     beamPackages.elixir
     libxml2
     libxslt
+  ]
+  ++ lib.optionals (lib.meta.availableOn stdenv.hostPlatform glibcLocales) [
     glibcLocales
   ];
 

--- a/pkgs/by-name/te/telepathy-glib/package.nix
+++ b/pkgs/by-name/te/telepathy-glib/package.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
     python3
   ];
 
-  buildInputs = [
+  buildInputs = lib.optionals (lib.meta.availableOn stdenv.hostPlatform glibcLocales) [
     glibcLocales
   ];
 

--- a/pkgs/by-name/to/tomlplusplus/package.nix
+++ b/pkgs/by-name/to/tomlplusplus/package.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
   ];
 
-  checkInputs = [
+  checkInputs = lib.optionals (lib.meta.availableOn stdenv.hostPlatform glibcLocales) [
     glibcLocales
   ];
 

--- a/pkgs/by-name/to/topydo/package.nix
+++ b/pkgs/by-name/to/topydo/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   python3,
   fetchFromGitHub,
   fetchpatch,
@@ -27,14 +28,18 @@ python3.pkgs.buildPythonApplication rec {
     })
   ];
 
-  propagatedBuildInputs = with python3.pkgs; [
-    arrow
-    glibcLocales
-    icalendar
-    prompt-toolkit
-    urwid
-    watchdog
-  ];
+  propagatedBuildInputs =
+    with python3.pkgs;
+    [
+      arrow
+      icalendar
+      prompt-toolkit
+      urwid
+      watchdog
+    ]
+    ++ lib.optionals (lib.meta.availableOn stdenv.hostPlatform glibcLocales) [
+      glibcLocales
+    ];
 
   nativeCheckInputs = with python3.pkgs; [
     freezegun

--- a/pkgs/by-name/ts/tsduck/package.nix
+++ b/pkgs/by-name/ts/tsduck/package.nix
@@ -43,12 +43,14 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     curl
-    glibcLocales
     jdk
     libedit
     librist
     openssl
     srt
+  ]
+  ++ lib.optionals (lib.meta.availableOn stdenv.hostPlatform glibcLocales) [
+    glibcLocales
   ];
 
   enableParallelBuilding = true;

--- a/pkgs/by-name/vi/vit/package.nix
+++ b/pkgs/by-name/vi/vit/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   python3Packages,
   fetchPypi,
   taskwarrior2,
@@ -26,7 +27,9 @@ buildPythonApplication rec {
     urwid
   ];
 
-  nativeCheckInputs = [ glibcLocales ];
+  nativeCheckInputs = lib.optionals (lib.meta.availableOn stdenv.buildPlatform glibcLocales) [
+    glibcLocales
+  ];
 
   makeWrapperArgs = [
     "--suffix"

--- a/pkgs/by-name/xo/xonsh/unwrapped.nix
+++ b/pkgs/by-name/xo/xonsh/unwrapped.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
 
@@ -53,13 +54,15 @@ buildPythonPackage rec {
     addBinToPathHook
     writableTmpDirAsHomeHook
     gitMinimal
-    glibcLocales
     pip
     pyte
     pytest-mock
     pytest-subprocess
     pytestCheckHook
     requests
+  ]
+  ++ lib.optionals (lib.meta.availableOn stdenv.buildPlatform glibcLocales) [
+    glibcLocales
   ];
 
   disabledTests = [

--- a/pkgs/by-name/zu/zulip-term/package.nix
+++ b/pkgs/by-name/zu/zulip-term/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   python3,
   fetchFromGitHub,
   glibcLocales,
@@ -71,14 +72,15 @@ buildPythonApplication rec {
     zulip
   ];
 
-  nativeCheckInputs = [
-    glibcLocales
-  ]
-  ++ (with python3.pkgs; [
-    pytestCheckHook
-    pytest-cov-stub
-    pytest-mock
-  ]);
+  nativeCheckInputs =
+    lib.optionals (lib.meta.availableOn stdenv.buildPlatform glibcLocales) [
+      glibcLocales
+    ]
+    ++ (with python3.pkgs; [
+      pytestCheckHook
+      pytest-cov-stub
+      pytest-mock
+    ]);
 
   disabledTests = [
     # these break the build but don't seem to affect

--- a/pkgs/desktops/lomiri/development/geonames/default.nix
+++ b/pkgs/desktops/lomiri/development/geonames/default.nix
@@ -76,7 +76,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   # Tests need to be able to check locale
   LC_ALL = lib.optionalString finalAttrs.finalPackage.doCheck "en_US.UTF-8";
-  nativeCheckInputs = [
+  nativeCheckInputs = lib.optionals (lib.meta.availableOn stdenv.buildPlatform glibcLocales) [
     glibcLocales
   ];
 

--- a/pkgs/desktops/lomiri/development/libusermetrics/default.nix
+++ b/pkgs/desktops/lomiri/development/libusermetrics/default.nix
@@ -84,6 +84,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeCheckInputs = [
     dbus
+  ]
+  ++ lib.optionals (lib.meta.availableOn stdenv.buildPlatform glibcLocales) [
     glibcLocales
   ];
 

--- a/pkgs/development/compilers/dotnet/vmr.nix
+++ b/pkgs/development/compilers/dotnet/vmr.nix
@@ -385,7 +385,7 @@ stdenv.mkDerivation {
   # https://github.com/NixOS/nixpkgs/issues/38991
   # bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
   LOCALE_ARCHIVE = lib.optionalString (
-    isLinux && glibcLocales != null
+    isLinux && lib.meta.availableOn stdenv.hostPlatform glibcLocales
   ) "${glibcLocales}/lib/locale/locale-archive";
 
   # clang: error: argument unused during compilation: '-Wa,--compress-debug-sections' [-Werror,-Wunused-command-line-argument]

--- a/pkgs/development/compilers/dotnet/vmr.nix
+++ b/pkgs/development/compilers/dotnet/vmr.nix
@@ -384,9 +384,7 @@ stdenv.mkDerivation {
 
   # https://github.com/NixOS/nixpkgs/issues/38991
   # bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
-  LOCALE_ARCHIVE = lib.optionalString (
-    isLinux && lib.meta.availableOn stdenv.hostPlatform glibcLocales
-  ) "${glibcLocales}/lib/locale/locale-archive";
+  LOCALE_ARCHIVE = lib.optionalString (lib.meta.availableOn stdenv.hostPlatform glibcLocales) "${glibcLocales}/lib/locale/locale-archive";
 
   # clang: error: argument unused during compilation: '-Wa,--compress-debug-sections' [-Werror,-Wunused-command-line-argument]
   # caused by separateDebugInfo

--- a/pkgs/development/compilers/ghc/common-hadrian.nix
+++ b/pkgs/development/compilers/ghc/common-hadrian.nix
@@ -577,7 +577,7 @@ stdenv.mkDerivation (
       ''
         export LANG="en_US.UTF-8"
       ''
-      + lib.optionalString (stdenv.buildPlatform.libc == "glibc") ''
+      + lib.optionalString (lib.meta.availableOn stdenv.buildPlatform buildPackages.glibcLocales) ''
         export LOCALE_ARCHIVE="${buildPackages.glibcLocales}/lib/locale/locale-archive"
       ''
     )

--- a/pkgs/development/compilers/ghc/common-make-native-bignum.nix
+++ b/pkgs/development/compilers/ghc/common-make-native-bignum.nix
@@ -450,7 +450,7 @@ stdenv.mkDerivation (
       ''
         export LANG="en_US.UTF-8"
       ''
-      + lib.optionalString (stdenv.buildPlatform.libc == "glibc") ''
+      + lib.optionalString (lib.meta.availableOn stdenv.buildPlatform buildPackages.glibcLocales) ''
         export LOCALE_ARCHIVE="${buildPackages.glibcLocales}/lib/locale/locale-archive"
       ''
     )

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -80,7 +80,6 @@ let
     removeReferencesTo
     pkg-config
     coreutils
-    glibcLocales
     emscripten
     ;
 
@@ -657,8 +656,8 @@ lib.fix (
       propagatedBuildInputs = optionals isLibrary propagatedBuildInputs;
 
       env =
-        optionalAttrs (stdenv.buildPlatform.libc == "glibc") {
-          LOCALE_ARCHIVE = "${glibcLocales}/lib/locale/locale-archive";
+        optionalAttrs (lib.meta.availableOn stdenv.buildPlatform buildPackages.glibcLocales) {
+          LOCALE_ARCHIVE = "${buildPackages.glibcLocales}/lib/locale/locale-archive";
         }
         // env';
 
@@ -1069,24 +1068,7 @@ lib.fix (
               "NIX_${ghcCommandCaps}_LIBDIR" =
                 if ghc.isHaLVM or false then "${ghcEnv}/lib/HaLVM-${ghc.version}" else "${ghcEnv}/${ghcLibdir}";
             }
-            // optionalAttrs (stdenv.buildPlatform.libc == "glibc") {
-              # TODO: Why is this written in terms of `buildPackages`, unlike
-              # the outer `env`?
-              #
-              # According to @sternenseemann [1]:
-              #
-              # > The condition is based on `buildPlatform`, so it needs to
-              # > match. `LOCALE_ARCHIVE` is set to accompany `LANG` which
-              # > concerns things we execute on the build platform like
-              # > `haddock`.
-              # >
-              # > Arguably the outer non `buildPackages` one is incorrect and
-              # > probably works by accident in most cases since the locale
-              # > archive is not platform specific (the trouble is that it
-              # > may sometimes be impossible to cross-compile). At least
-              # > that would be my assumption.
-              #
-              # [1]: https://github.com/NixOS/nixpkgs/pull/424368#discussion_r2202683378
+            // optionalAttrs (lib.meta.availableOn stdenv.buildPlatform buildPackages.glibcLocales) {
               LOCALE_ARCHIVE = "${buildPackages.glibcLocales}/lib/locale/locale-archive";
             }
             // env';

--- a/pkgs/development/haskell-modules/generic-stack-builder.nix
+++ b/pkgs/development/haskell-modules/generic-stack-builder.nix
@@ -38,7 +38,8 @@ stdenv.mkDerivation (
     # `--option sandbox false` to be able to build this
     __noChroot = true;
 
-    buildInputs = buildInputs ++ lib.optional (stdenv.hostPlatform.libc == "glibc") glibcLocales;
+    buildInputs =
+      buildInputs ++ lib.optional (lib.meta.availableOn stdenv.hostPlatform glibcLocales) glibcLocales;
 
     nativeBuildInputs = nativeBuildInputs ++ [
       ghc

--- a/pkgs/development/haskell-modules/make-package-set.nix
+++ b/pkgs/development/haskell-modules/make-package-set.nix
@@ -182,9 +182,7 @@ let
         preferLocalBuild = true;
         allowSubstitutes = false;
         LANG = "en_US.UTF-8";
-        LOCALE_ARCHIVE = pkgs.lib.optionalString (
-          buildPlatform.libc == "glibc"
-        ) "${buildPackages.glibcLocales}/lib/locale/locale-archive";
+        LOCALE_ARCHIVE = pkgs.lib.optionalString (lib.meta.availableOn stdenv.buildPlatform buildPackages.glibcLocales) "${buildPackages.glibcLocales}/lib/locale/locale-archive";
       }
       ''
         export HOME="$TMP"

--- a/pkgs/development/interpreters/octave/build-env.nix
+++ b/pkgs/development/interpreters/octave/build-env.nix
@@ -19,8 +19,7 @@
 let
   packages = computeRequiredOctavePackages extraLibs;
 
-  # glibcLocalesUtf8 is null on darwin
-  localeArchiveArgs = lib.optionalString (glibcLocalesUtf8 != null) ''
+  localeArchiveArgs = lib.optionalString (lib.meta.availableOn stdenv.hostPlatform glibcLocalesUtf8) ''
     --set LOCALE_ARCHIVE "${glibcLocalesUtf8}/lib/locale/locale-archive"
   '';
 

--- a/pkgs/development/libraries/glibc/locales.nix
+++ b/pkgs/development/libraries/glibc/locales.nix
@@ -104,6 +104,9 @@
         export LOCALE_ARCHIVE=@out@/lib/locale/locale-archive
       '';
 
-      meta.description = "Locale information for the GNU C Library";
+      meta = {
+        description = "Locale information for the GNU C Library";
+        platforms = with lib.systems.inspect; patternLogicalAnd patterns.isLinux patterns.isGnu;
+      };
     }
   )

--- a/pkgs/development/misc/resholve/oildev.nix
+++ b/pkgs/development/misc/resholve/oildev.nix
@@ -94,9 +94,7 @@
     '';
 
     # See earlier note on glibcLocales TODO: verify needed?
-    LOCALE_ARCHIVE = lib.optionalString (
-      stdenv.buildPlatform.libc == "glibc"
-    ) "${glibcLocales}/lib/locale/locale-archive";
+    LOCALE_ARCHIVE = lib.optionalString (lib.meta.availableOn stdenv.hostPlatform glibcLocales) "${glibcLocales}/lib/locale/locale-archive";
 
     # not exhaustive; sample what resholve uses as a sanity check
     pythonImportsCheck = [

--- a/pkgs/development/perl-modules/Po4a/default.nix
+++ b/pkgs/development/perl-modules/Po4a/default.nix
@@ -54,6 +54,8 @@ buildPerlPackage rec {
       docbook_sgml_dtd_41
       opensp
       kpsewhich-stub
+    ]
+    ++ lib.optionals (lib.meta.availableOn stdenv.buildPlatform glibcLocales) [
       glibcLocales
     ];
   patches = [

--- a/pkgs/development/python-modules/agate/default.nix
+++ b/pkgs/development/python-modules/agate/default.nix
@@ -43,10 +43,12 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     cssselect
-    glibcLocales
     lxml
     pyicu
     pytestCheckHook
+  ]
+  ++ lib.optionals (lib.meta.availableOn stdenv.buildPlatform glibcLocales) [
+    glibcLocales
   ];
 
   disabledTests = lib.optionals stdenv.isDarwin [

--- a/pkgs/development/python-modules/ansible-runner/default.nix
+++ b/pkgs/development/python-modules/ansible-runner/default.nix
@@ -61,7 +61,6 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     addBinToPathHook
     ansible-core # required to place ansible CLI onto the PATH in tests
-    glibcLocales
     mock
     openssh
     pytest-mock
@@ -70,6 +69,9 @@ buildPythonPackage rec {
     pytestCheckHook
     versionCheckHook
     writableTmpDirAsHomeHook
+  ]
+  ++ lib.optionals (lib.meta.availableOn stdenv.buildPlatform glibcLocales) [
+    glibcLocales
   ];
 
   preCheck = ''

--- a/pkgs/development/python-modules/autopep8/default.nix
+++ b/pkgs/development/python-modules/autopep8/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
   glibcLocales,
@@ -27,8 +28,10 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ pycodestyle ] ++ lib.optionals (pythonOlder "3.11") [ tomli ];
 
   nativeCheckInputs = [
-    glibcLocales
     pytestCheckHook
+  ]
+  ++ lib.optionals (lib.meta.availableOn stdenv.buildPlatform glibcLocales) [
+    glibcLocales
   ];
 
   env.LC_ALL = "en_US.UTF-8";

--- a/pkgs/development/python-modules/babel/default.nix
+++ b/pkgs/development/python-modules/babel/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchPypi,
   isPyPy,
@@ -29,10 +30,12 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     freezegun
-    glibcLocales
     pytestCheckHook
     # https://github.com/python-babel/babel/issues/988#issuecomment-1521765563
     pytz
+  ]
+  ++ lib.optionals (lib.meta.availableOn stdenv.buildPlatform glibcLocales) [
+    glibcLocales
   ]
   ++ lib.optionals isPyPy [ tzdata ];
 

--- a/pkgs/development/python-modules/beaker/default.nix
+++ b/pkgs/development/python-modules/beaker/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
   glibcLocales,
@@ -45,7 +46,6 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
-    glibcLocales
     python-memcached
     mock
     pylibmc
@@ -53,6 +53,9 @@ buildPythonPackage rec {
     redis
     webtest
     pytestCheckHook
+  ]
+  ++ lib.optionals (lib.meta.availableOn stdenv.buildPlatform glibcLocales) [
+    glibcLocales
   ];
 
   # Can not run memcached tests because it immediately tries to connect.

--- a/pkgs/development/python-modules/blessed/default.nix
+++ b/pkgs/development/python-modules/blessed/default.nix
@@ -34,6 +34,8 @@ buildPythonPackage {
   nativeCheckInputs = [
     pytestCheckHook
     mock
+  ]
+  ++ lib.optionals (lib.meta.availableOn stdenv.buildPlatform glibcLocales) [
     glibcLocales
   ];
 

--- a/pkgs/development/python-modules/cmd2/default.nix
+++ b/pkgs/development/python-modules/cmd2/default.nix
@@ -36,10 +36,12 @@ buildPythonPackage rec {
   doCheck = true;
 
   nativeCheckInputs = [
-    glibcLocales
     pytestCheckHook
     pytest-cov-stub
     pytest-mock
+  ]
+  ++ lib.optionals (lib.meta.availableOn stdenv.buildPlatform glibcLocales) [
+    glibcLocales
   ];
 
   disabledTests = [

--- a/pkgs/development/python-modules/djmail/default.nix
+++ b/pkgs/development/python-modules/djmail/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchPypi,
   glibcLocales,
@@ -24,7 +25,9 @@ buildPythonPackage rec {
     sha256 = "cf3ce7626305d218a8bf2b6a219266ef8061aceeefc1c70a54170f4105465202";
   };
 
-  nativeBuildInputs = [ glibcLocales ];
+  nativeBuildInputs = lib.optionals (lib.meta.availableOn stdenv.buildPlatform glibcLocales) [
+    glibcLocales
+  ];
 
   LC_ALL = "en_US.UTF-8";
 

--- a/pkgs/development/python-modules/dulwich/default.nix
+++ b/pkgs/development/python-modules/dulwich/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   cargo,
   fastimport,
@@ -69,8 +70,10 @@ buildPythonPackage rec {
     gevent
     geventhttpclient
     git
-    glibcLocales
     pytestCheckHook
+  ]
+  ++ lib.optionals (lib.meta.availableOn stdenv.buildPlatform glibcLocales) [
+    glibcLocales
   ]
   ++ lib.concatAttrValues optional-dependencies;
 

--- a/pkgs/development/python-modules/fs/default.nix
+++ b/pkgs/development/python-modules/fs/default.nix
@@ -50,7 +50,7 @@ buildPythonPackage rec {
     psutil
     pytestCheckHook
   ]
-  ++ lib.optionals isPyPy [
+  ++ lib.optionals (isPyPy && lib.meta.availableOn stdenv.buildPlatform glibcLocales) [
     glibcLocales
   ];
 

--- a/pkgs/development/python-modules/junitparser/default.nix
+++ b/pkgs/development/python-modules/junitparser/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
   glibcLocales,
@@ -22,6 +23,8 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
     lxml
+  ]
+  ++ lib.optionals (lib.meta.availableOn stdenv.buildPlatform glibcLocales) [
     glibcLocales
   ];
 

--- a/pkgs/development/python-modules/libarchive-c/default.nix
+++ b/pkgs/development/python-modules/libarchive-c/default.nix
@@ -40,9 +40,11 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "libarchive" ];
 
   nativeCheckInputs = [
-    glibcLocales
     mock
     pytestCheckHook
+  ]
+  ++ lib.optionals (lib.meta.availableOn stdenv.buildPlatform glibcLocales) [
+    glibcLocales
   ];
 
   meta = {

--- a/pkgs/development/python-modules/mail-parser/default.nix
+++ b/pkgs/development/python-modules/mail-parser/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   python,
   glibcLocales,
@@ -24,7 +25,9 @@ buildPythonPackage rec {
 
   LC_ALL = "en_US.utf-8";
 
-  nativeBuildInputs = [ glibcLocales ];
+  nativeBuildInputs = lib.optionals (lib.meta.availableOn stdenv.buildPlatform glibcLocales) [
+    glibcLocales
+  ];
 
   build-system = [ setuptools ];
 

--- a/pkgs/development/python-modules/musicbrainzngs/default.nix
+++ b/pkgs/development/python-modules/musicbrainzngs/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchPypi,
   pkgs,
@@ -15,7 +16,9 @@ buildPythonPackage rec {
     sha256 = "09z6k07pxncfgfc8clfmmxl2xqbd7h8x8bjzwr95hc0bzl00275b";
   };
 
-  buildInputs = [ pkgs.glibcLocales ];
+  buildInputs = lib.optionals (lib.meta.availableOn stdenv.hostPlatform pkgs.glibcLocales) [
+    pkgs.glibcLocales
+  ];
 
   LC_ALL = "en_US.UTF-8";
 

--- a/pkgs/development/python-modules/natsort/default.nix
+++ b/pkgs/development/python-modules/natsort/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fastnumbers,
   fetchPypi,
@@ -26,10 +27,12 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
-    glibcLocales
     hypothesis
     pytest-mock
     pytestCheckHook
+  ]
+  ++ lib.optionals (lib.meta.availableOn stdenv.buildPlatform glibcLocales) [
+    glibcLocales
   ];
 
   disabledTests = [

--- a/pkgs/development/python-modules/nbval/default.nix
+++ b/pkgs/development/python-modules/nbval/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchPypi,
   setuptools,
@@ -24,7 +25,9 @@ buildPythonPackage rec {
     hash = "sha256-d8lXl2B7CpaLq9JZfuNJQQLSXDrTdDXeu9rA5G43kJQ=";
   };
 
-  buildInputs = [ glibcLocales ];
+  buildInputs = lib.optionals (lib.meta.availableOn stdenv.hostPlatform glibcLocales) [
+    glibcLocales
+  ];
 
   build-system = [ setuptools ];
 

--- a/pkgs/development/python-modules/nipype/default.nix
+++ b/pkgs/development/python-modules/nipype/default.nix
@@ -78,12 +78,14 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pybids
-    glibcLocales
     mock
     pytest
     pytest-forked
     pytest-xdist
     which
+  ]
+  ++ lib.optionals (lib.meta.availableOn stdenv.buildPlatform glibcLocales) [
+    glibcLocales
   ];
 
   # checks on darwin inspect memory which doesn't work in build environment

--- a/pkgs/development/python-modules/pelican/default.nix
+++ b/pkgs/development/python-modules/pelican/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
 
@@ -61,11 +62,13 @@ buildPythonPackage rec {
   pythonRelaxDeps = [ "pygments" ];
 
   buildInputs = [
-    glibcLocales
     pandoc
     git
     markdown
     typogrify
+  ]
+  ++ lib.optionals (lib.meta.availableOn stdenv.hostPlatform glibcLocales) [
+    glibcLocales
   ];
 
   dependencies = [

--- a/pkgs/development/python-modules/pweave/default.nix
+++ b/pkgs/development/python-modules/pweave/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchPypi,
   mock,
@@ -26,6 +27,8 @@ buildPythonPackage rec {
 
   buildInputs = [
     mock
+  ]
+  ++ lib.optionals (lib.meta.availableOn stdenv.hostPlatform pkgs.glibcLocales) [
     pkgs.glibcLocales
   ];
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/pyfaidx/default.nix
+++ b/pkgs/development/python-modules/pyfaidx/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
   glibcLocales,
@@ -40,6 +41,8 @@ buildPythonPackage rec {
     biopython
     htslib
     fsspec
+  ]
+  ++ lib.optionals (lib.meta.availableOn stdenv.buildPlatform glibcLocales) [
     glibcLocales
   ];
 

--- a/pkgs/development/python-modules/pymatgen/default.nix
+++ b/pkgs/development/python-modules/pymatgen/default.nix
@@ -69,6 +69,8 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     cython
+  ]
+  ++ lib.optionals (lib.meta.availableOn stdenv.buildPlatform glibcLocales) [
     glibcLocales
   ];
 

--- a/pkgs/development/python-modules/pypdf3/default.nix
+++ b/pkgs/development/python-modules/pypdf3/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchPypi,
   glibcLocales,
@@ -19,7 +20,9 @@ buildPythonPackage (finalAttrs: {
   };
 
   LC_ALL = "en_US.UTF-8";
-  buildInputs = [ glibcLocales ];
+  buildInputs = lib.optionals (lib.meta.availableOn stdenv.hostPlatform glibcLocales) [
+    glibcLocales
+  ];
 
   checkPhase = ''
     ${python.interpreter} -m unittest tests/*.py

--- a/pkgs/development/python-modules/pyspnego/default.nix
+++ b/pkgs/development/python-modules/pyspnego/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   cryptography,
   fetchFromGitHub,
@@ -39,9 +40,11 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "spnego" ];
 
   nativeCheckInputs = [
-    glibcLocales
     pytest-mock
     pytestCheckHook
+  ]
+  ++ lib.optionals (lib.meta.availableOn stdenv.buildPlatform glibcLocales) [
+    glibcLocales
   ];
 
   env.LC_ALL = "en_US.UTF-8";

--- a/pkgs/development/python-modules/python-bugzilla/default.nix
+++ b/pkgs/development/python-modules/python-bugzilla/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchPypi,
   setuptools,
@@ -26,8 +27,10 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
-    glibcLocalesUtf8
     responses
+  ]
+  ++ lib.optionals (lib.meta.availableOn stdenv.buildPlatform glibcLocalesUtf8) [
+    glibcLocalesUtf8
   ];
 
   preCheck = ''

--- a/pkgs/development/python-modules/rainbowstream/default.nix
+++ b/pkgs/development/python-modules/rainbowstream/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   arrow,
   buildPythonPackage,
   fetchFromGitHub,
@@ -32,9 +33,11 @@ buildPythonPackage {
 
   buildInputs = [
     freetype
-    glibcLocales
     libjpeg
     zlib
+  ]
+  ++ lib.optionals (lib.meta.availableOn stdenv.hostPlatform glibcLocales) [
+    glibcLocales
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/rpmfluff/default.nix
+++ b/pkgs/development/python-modules/rpmfluff/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchurl,
   glibcLocales,
@@ -16,7 +17,9 @@ buildPythonPackage rec {
   };
 
   LC_ALL = "en_US.utf-8";
-  buildInputs = [ glibcLocales ];
+  buildInputs = lib.optionals (lib.meta.availableOn stdenv.hostPlatform glibcLocales) [
+    glibcLocales
+  ];
 
   meta = {
     description = "Lightweight way of building RPMs, and sabotaging them";

--- a/pkgs/development/python-modules/scikit-learn/default.nix
+++ b/pkgs/development/python-modules/scikit-learn/default.nix
@@ -46,6 +46,8 @@ buildPythonPackage rec {
   buildInputs = [
     numpy.blas
     pillow
+  ]
+  ++ lib.optionals (lib.meta.availableOn stdenv.hostPlatform glibcLocales) [
     glibcLocales
   ]
   ++ lib.optionals stdenv.cc.isClang [ llvmPackages.openmp ];

--- a/pkgs/development/python-modules/scrapy/default.nix
+++ b/pkgs/development/python-modules/scrapy/default.nix
@@ -85,7 +85,6 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     botocore
-    glibcLocales
     jmespath
     pexpect
     pytest-asyncio
@@ -96,6 +95,9 @@ buildPythonPackage rec {
     sybil
     testfixtures
     uvloop
+  ]
+  ++ lib.optionals (lib.meta.availableOn stdenv.buildPlatform glibcLocales) [
+    glibcLocales
   ];
 
   LC_ALL = "en_US.UTF-8";

--- a/pkgs/development/python-modules/seekpath/default.nix
+++ b/pkgs/development/python-modules/seekpath/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
   setuptools,
@@ -35,7 +36,9 @@ buildPythonPackage rec {
     bz = [ scipy ];
   };
 
-  nativeBuildInputs = [ glibcLocales ];
+  nativeBuildInputs = lib.optionals (lib.meta.availableOn stdenv.hostPlatform glibcLocales) [
+    glibcLocales
+  ];
 
   pythonImportsCheck = [ "seekpath" ];
 

--- a/pkgs/development/python-modules/sniffio/default.nix
+++ b/pkgs/development/python-modules/sniffio/default.nix
@@ -1,6 +1,7 @@
 {
   buildPythonPackage,
   lib,
+  stdenv,
   fetchPypi,
   setuptools,
   setuptools-scm,
@@ -27,7 +28,9 @@ buildPythonPackage rec {
     setuptools-scm
   ];
 
-  buildInputs = [ glibcLocales ];
+  buildInputs = lib.optionals (lib.meta.availableOn stdenv.hostPlatform glibcLocales) [
+    glibcLocales
+  ];
 
   nativeCheckInputs = [
     curio

--- a/pkgs/development/python-modules/sympy/default.nix
+++ b/pkgs/development/python-modules/sympy/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchPypi,
   glibcLocales,
@@ -19,7 +20,9 @@ buildPythonPackage rec {
     hash = "sha256-09P+jfHloLQvDnvfUFQWl9vn0jdG6JSZDAMOKwXnJRc=";
   };
 
-  nativeCheckInputs = [ glibcLocales ];
+  nativeCheckInputs = lib.optionals (lib.meta.availableOn stdenv.buildPlatform glibcLocales) [
+    glibcLocales
+  ];
 
   propagatedBuildInputs = [ mpmath ];
 

--- a/pkgs/development/python-modules/tensorflow/default.nix
+++ b/pkgs/development/python-modules/tensorflow/default.nix
@@ -313,7 +313,6 @@ let
     buildInputs = [
       jemalloc
       mpi
-      glibcLocales
       git
 
       # libs taken from system through the TF_SYS_LIBS mechanism
@@ -336,6 +335,9 @@ let
       }))
       snappy-cpp
       sqlite
+    ]
+    ++ lib.optionals (lib.meta.availableOn stdenv.hostPlatform glibcLocales) [
+      glibcLocales
     ]
     ++ lib.optionals cudaSupport [
       cudatoolkit

--- a/pkgs/development/python-modules/twisted/default.nix
+++ b/pkgs/development/python-modules/twisted/default.nix
@@ -215,6 +215,8 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     gitMinimal
+  ]
+  ++ lib.optionals (lib.meta.availableOn stdenv.buildPlatform glibcLocales) [
     glibcLocales
   ]
   ++ optional-dependencies.test

--- a/pkgs/development/python-modules/typeguard/default.nix
+++ b/pkgs/development/python-modules/typeguard/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchPypi,
   setuptools,
@@ -29,12 +30,14 @@ buildPythonPackage rec {
   ];
 
   build-system = [
-    glibcLocales
     setuptools
     setuptools-scm
     sphinxHook
     sphinx-autodoc-typehints
     sphinx-rtd-theme
+  ]
+  ++ lib.optionals (lib.meta.availableOn stdenv.buildPlatform glibcLocales) [
+    glibcLocales
   ];
 
   dependencies = [

--- a/pkgs/development/python-modules/u-msgpack-python/default.nix
+++ b/pkgs/development/python-modules/u-msgpack-python/default.nix
@@ -1,6 +1,7 @@
 {
   buildPythonPackage,
   lib,
+  stdenv,
   fetchPypi,
   glibcLocales,
   unittestCheckHook,
@@ -18,7 +19,9 @@ buildPythonPackage rec {
 
   env.LC_ALL = "en_US.UTF-8";
 
-  buildInputs = [ glibcLocales ];
+  buildInputs = lib.optionals (lib.meta.availableOn stdenv.hostPlatform glibcLocales) [
+    glibcLocales
+  ];
 
   nativeCheckInputs = [ unittestCheckHook ];
 

--- a/pkgs/development/python-modules/urwid/default.nix
+++ b/pkgs/development/python-modules/urwid/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   exceptiongroup,
   fetchFromGitHub,
@@ -57,8 +58,10 @@ buildPythonPackage rec {
   };
 
   nativeCheckInputs = [
-    glibcLocales
     pytestCheckHook
+  ]
+  ++ lib.optionals (lib.meta.availableOn stdenv.buildPlatform glibcLocales) [
+    glibcLocales
   ]
   ++ lib.concatAttrValues optional-dependencies;
 

--- a/pkgs/development/python-modules/whichcraft/default.nix
+++ b/pkgs/development/python-modules/whichcraft/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchPypi,
   pytest,
@@ -17,7 +18,9 @@ buildPythonPackage rec {
   };
 
   LC_ALL = "en_US.utf-8";
-  buildInputs = [ glibcLocales ];
+  buildInputs = lib.optionals (lib.meta.availableOn stdenv.hostPlatform glibcLocales) [
+    glibcLocales
+  ];
 
   nativeCheckInputs = [ pytest ];
 

--- a/pkgs/development/tools/ilspycmd/default.nix
+++ b/pkgs/development/tools/ilspycmd/default.nix
@@ -28,7 +28,7 @@ buildDotnetModule (finalAttrs: {
 
   # https://github.com/NixOS/nixpkgs/issues/38991
   # bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
-  env.LOCALE_ARCHIVE = lib.optionalString stdenvNoCC.hostPlatform.isLinux "${glibcLocales}/lib/locale/locale-archive";
+  env.LOCALE_ARCHIVE = lib.optionalString (lib.meta.availableOn stdenvNoCC.hostPlatform glibcLocales) "${glibcLocales}/lib/locale/locale-archive";
 
   dotnet-sdk = dotnetCorePackages.sdk_8_0;
 

--- a/pkgs/development/tools/misc/texinfo/common.nix
+++ b/pkgs/development/tools/misc/texinfo/common.nix
@@ -130,7 +130,9 @@ stdenv.mkDerivation {
   ];
 
   nativeCheckInputs = [ procps ] ++ optionals stdenv.buildPlatform.isFreeBSD [ freebsd.locale ];
-  checkInputs = optionals (lib.versionAtLeast version "7.2") [ glibcLocales ];
+  checkInputs = optionals (
+    lib.versionAtLeast version "7.2" && lib.meta.availableOn stdenv.hostPlatform glibcLocales
+  ) [ glibcLocales ];
 
   doCheck = interactive && !stdenv.hostPlatform.isDarwin && !stdenv.hostPlatform.isSunOS; # flaky
 

--- a/pkgs/misc/source-and-tags/default.nix
+++ b/pkgs/misc/source-and-tags/default.nix
@@ -84,7 +84,7 @@
                     # without this creating tag files for lifted-base fails
                     export LC_ALL=en_US.UTF-8
                     export LANG=en_US.UTF-8
-                    ${lib.optionalString stdenv.hostPlatform.isLinux "export LOCALE_ARCHIVE=${glibcLocales}/lib/locale/locale-archive;"}
+                    ${lib.optionalString (lib.meta.availableOn stdenv.hostPlatform glibcLocales) "export LOCALE_ARCHIVE=${glibcLocales}/lib/locale/locale-archive;"}
 
                     ${toString hasktags}/bin/hasktags --ignore-close-implementation --ctags .
                     mv tags \$TAG_FILE

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -333,7 +333,6 @@ stdenv.mkDerivation (finalAttrs: {
     gperf
     ninja
     meson
-    glibcLocales
     m4
     autoPatchelfHook
 
@@ -355,6 +354,9 @@ stdenv.mkDerivation (finalAttrs: {
       ++ lib.optional withEfi ps.pyelftools
       ++ lib.optional (withUkify && finalAttrs.finalPackage.doCheck) ps.pefile
     ))
+  ]
+  ++ lib.optionals (lib.meta.availableOn stdenv.buildPlatform glibcLocales) [
+    glibcLocales
   ]
   ++ lib.optionals withLibBPF [
     bpftools

--- a/pkgs/servers/dict/wiktionary/default.nix
+++ b/pkgs/servers/dict/wiktionary/default.nix
@@ -20,8 +20,10 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     python3
     dict
-    glibcLocales
     libfaketime
+  ]
+  ++ lib.optionals (lib.meta.availableOn stdenv.buildPlatform glibcLocales) [
+    glibcLocales
   ];
 
   dontUnpack = true;

--- a/pkgs/shells/bash/5.nix
+++ b/pkgs/shells/bash/5.nix
@@ -174,12 +174,16 @@ lib.warnIf (withDocs != null)
       tests.withChecks = fa.finalPackage.overrideAttrs (attrs: {
         doCheck = true;
 
-        nativeCheckInputs = attrs.nativeCheckInputs or [ ] ++ [
-          util-linuxMinimal
-          libredirect.hook
-          glibcLocales
-          gnused
-        ];
+        nativeCheckInputs =
+          attrs.nativeCheckInputs or [ ]
+          ++ [
+            util-linuxMinimal
+            libredirect.hook
+            gnused
+          ]
+          ++ lib.optionals (lib.meta.availableOn stdenv.buildPlatform glibcLocales) [
+            glibcLocales
+          ];
 
         meta = attrs.meta // {
           # Ignore Darwin for now, because the tests fail in many more ways than on Linux

--- a/pkgs/tools/text/gawk/default.nix
+++ b/pkgs/tools/text/gawk/default.nix
@@ -17,11 +17,9 @@
      || stdenv.hostPlatform.isFreeBSD
   */
   doCheck ? (interactive && stdenv.hostPlatform.isLinux),
-  glibcLocales ? null,
+  glibcLocales,
   locale ? null,
 }:
-
-assert (doCheck && stdenv.hostPlatform.isLinux) -> glibcLocales != null;
 
 stdenv.mkDerivation rec {
   pname = "gawk" + lib.optionalString interactive "-interactive";
@@ -49,7 +47,7 @@ stdenv.mkDerivation rec {
   ++ lib.optionals interactive [
     removeReferencesTo
   ]
-  ++ lib.optionals (doCheck && stdenv.hostPlatform.isLinux) [
+  ++ lib.optionals (doCheck && lib.meta.availableOn stdenv.buildPlatform glibcLocales) [
     glibcLocales
   ];
 

--- a/pkgs/tools/text/gawk/gawkextlib.nix
+++ b/pkgs/tools/text/gawk/gawkextlib.nix
@@ -162,7 +162,9 @@ let
     mbs = buildExtension {
       inherit gawkextlib;
       name = "mbs";
-      extraBuildInputs = [ glibcLocales ];
+      extraBuildInputs = lib.optionals (lib.meta.availableOn stdenv.hostPlatform glibcLocales) [
+        glibcLocales
+      ];
       #! "spät": length: 5, mbs_length: 6, wcswidth: 4
       doCheck = !stdenv.hostPlatform.isDarwin;
     };

--- a/pkgs/tools/text/gnugrep/default.nix
+++ b/pkgs/tools/text/gnugrep/default.nix
@@ -1,8 +1,8 @@
 {
   lib,
   stdenv,
+  buildPackages,
   updateAutotoolsGnuConfigScriptsHook,
-  glibcLocales,
   fetchurl,
   pcre2,
   libiconv,
@@ -49,7 +49,9 @@ stdenv.mkDerivation {
 
   nativeCheckInputs = [
     perl
-    glibcLocales
+  ]
+  ++ lib.optionals (lib.meta.availableOn stdenv.buildPlatform buildPackages.glibcLocales) [
+    buildPackages.glibcLocales
   ];
   outputs = [
     "out"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6903,24 +6903,15 @@ with pkgs;
         package = windows.mcfgthreads;
       };
 
-  # Only supported on Linux and only on glibc
-  glibcLocales =
-    if stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isGnu then
-      callPackage ../development/libraries/glibc/locales.nix {
-        stdenv = if (!stdenv.cc.isGNU) then gccStdenv else stdenv;
-        withLinuxHeaders = !stdenv.cc.isGNU;
-      }
-    else
-      null;
-  glibcLocalesUtf8 =
-    if stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isGnu then
-      callPackage ../development/libraries/glibc/locales.nix {
-        stdenv = if (!stdenv.cc.isGNU) then gccStdenv else stdenv;
-        withLinuxHeaders = !stdenv.cc.isGNU;
-        allLocales = false;
-      }
-    else
-      null;
+  glibcLocales = callPackage ../development/libraries/glibc/locales.nix {
+    stdenv = if (!stdenv.cc.isGNU) then gccStdenv else stdenv;
+    withLinuxHeaders = !stdenv.cc.isGNU;
+  };
+  glibcLocalesUtf8 = callPackage ../development/libraries/glibc/locales.nix {
+    stdenv = if (!stdenv.cc.isGNU) then gccStdenv else stdenv;
+    withLinuxHeaders = !stdenv.cc.isGNU;
+    allLocales = false;
+  };
 
   glibcInfo = callPackage ../development/libraries/glibc/info.nix { };
 

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -36638,7 +36638,9 @@ with self;
       url = "mirror://cpan/authors/id/K/KU/KUBOTA/Text-WrapI18N-0.06.tar.gz";
       hash = "sha256-S9KaF/DCx5LRLBAFs8J28qsPrjnACFmuF0HXlBhGpIg=";
     };
-    buildInputs = lib.optionals (!stdenv.hostPlatform.isDarwin) [ pkgs.glibcLocales ];
+    buildInputs = lib.optionals (lib.meta.availableOn stdenv.hostPlatform pkgs.glibcLocales) [
+      pkgs.glibcLocales
+    ];
     propagatedBuildInputs = [ TextCharWidth ];
     preConfigure = ''
       substituteInPlace WrapI18N.pm --replace '/usr/bin/locale' '${pkgs.unixtools.locale}/bin/locale'


### PR DESCRIPTION
motivated by [this PR suggestion](https://github.com/NixOS/nixpkgs/pull/480143?notification_referrer_id=NT_kwHOBlxDuNoAI1JlcG9zaXRvcnk7NDU0MjcxNjtJc3N1ZTszODE0NzA2MDc1#discussion_r2699348510)

    several packages _happened_ to eval for musl even when consuming a null `glibcLocales`, as a result of
    stdenv.mkDerivation gracefully handling `null` in `buildInputs` et al.
    it's not always clear whether that was desired, or incidental, but
    i've made a best effort with this change to preserve that behavior by
    moving `glibcLocales` into a conditional in these cases.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
