### PR TITLE
freetube: fix darwin

### DIFF
--- a/pkgs/by-name/fr/freetube/darwin-targets.patch
+++ b/pkgs/by-name/fr/freetube/darwin-targets.patch
@@ -1,0 +1,13 @@
+diff --git a/_scripts/build.js b/_scripts/build.js
+index ee1b7fa1c..1a4c9c6b2 100644
+--- a/_scripts/build.js
++++ b/_scripts/build.js
+@@ -16,7 +16,7 @@ if (platform === 'darwin') {
+     arch = Arch.arm64
+   }
+ 
+-  targets = Platform.MAC.createTarget(['DMG', 'zip', '7z'], arch)
++  targets = Platform.MAC.createTarget(['dir'], arch)
+ } else if (platform === 'win32') {
+   let arch = Arch.x64
+ 

--- a/pkgs/by-name/fr/freetube/package.nix
+++ b/pkgs/by-name/fr/freetube/package.nix
@@ -33,8 +33,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   postUnpack =
     if stdenvNoCC.hostPlatform.isDarwin then
       ''
-        cp -r ${electron.dist} electron-dist
-        chmod -R u+w electron-dist
+        cp -r ${electron.dist} source/electron-dist
+        chmod -R u+w source/electron-dist
       ''
     else
       ''
@@ -45,6 +45,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     (replaceVars ./patch-build-script.patch {
       electron-version = electron.version;
     })
+    ./darwin-targets.patch
   ];
 
   yarnOfflineCache = fetchYarnDeps {
@@ -74,7 +75,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     install -D _icons/icon.svg $out/share/icons/hicolor/scalable/apps/freetube.svg
   ''
   + lib.optionalString stdenvNoCC.hostPlatform.isDarwin ''
-    mkdir -p $out/Applications
+    mkdir -p $out/Applications $out/bin
     cp -r build/mac*/FreeTube.app $out/Applications
     ln -s "$out/Applications/FreeTube.app/Contents/MacOS/FreeTube" $out/bin/freetube
   ''
@@ -109,11 +110,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       ryand56
       sigmasquadron
       ddogfoodd
-    ];
-    badPlatforms = [
-      # output app is called "Electron.app" while derivation expects "FreeTube.app"
-      #see: https://github.com/NixOS/nixpkgs/pull/384596#issuecomment-2677141349
-      lib.systems.inspect.patterns.isDarwin
     ];
     inherit (electron.meta) platforms;
     mainProgram = "freetube";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The fix for darwin was putting electron-dist in the right place. Additionally, the build script's targets have to be limited since some of them won't build, and we only want the "dir" target anyway. The same could be done for linux, but I can't test that.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
