### PR TITLE
systemd-verify-units-hook: init

### DIFF
--- a/doc/hooks/systemd-verify-units-hook.section.md
+++ b/doc/hooks/systemd-verify-units-hook.section.md
@@ -1,0 +1,77 @@
+# systemd-verify-units-hook {#systemd-verify-units-hook}
+
+The `systemd-verify-units-hook` derivation adds `systemdVerifyUnitsPhase` to the [`preInstallCheckHooks`](#ssec-installCheck-phase),
+which finds all systemd units in all outputs and verifies them using `systemd-analyze verify --man=no --recursive-errors=no`.
+It should be used in any package that vendors its own systemd units, to ensure that all keys and sections are valid.
+
+The hook runs in `installCheckPhase`, requiring `doInstallCheck` is enabled for the hook to take effect:
+
+```nix
+{
+  lib,
+  stdenv,
+  systemd-verify-units-hook,
+  # ...
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  # ...
+
+  nativeInstallCheckInputs = [ systemd-verify-units-hook ];
+  doInstallCheck = true;
+
+  # ...
+})
+```
+
+Note that for [`buildPythonPackage`](#buildpythonpackage-function) and [`buildPythonApplication`](#buildpythonapplication-function), `doInstallCheck` is enabled by default.
+
+All outputs are scanned for their `/{etc,lib}/share/systemd/system` paths by default, as well as any extra paths listed.
+If no unit files are found, the hook is basically a no-op.
+
+The `systemd-verify-units-hook` adds a dependency on `systemd`.
+It is internally guarded behind `hostPlatform` supporting systemd and `buildPlatform` being able to execute `systemd`.
+The hook does not need explicit platform checks in the places where it is used.
+
+By default, the hook is configured to allow a set of known non-standard keys in systemd unit files, that is commonly used in NixOS.
+
+## Variables controlling systemd-verify-units-hook {#systemd-verify-units-hook-variables-controlling}
+
+### systemd-verify-units-hook Exclusive Variables {#systemd-verify-units-hook-exclusive-variables}
+
+#### `dontSystemdVerifyUnits` {#dont-systemd-verify-units}
+
+The hook can be disabled by setting this variable to `true`.
+
+#### `systemdVerifySkipDefaultPaths` {#systemd-verify-skip-default-paths}
+
+Whether to skip verifying units in the default systemd unit paths:
+
+- `/etc/share/systemd/system`
+- `/lib/share/systemd/system`
+
+#### `systemdVerifyExtraUnits` {#systemd-verify-extra-units}
+
+A list of additional paths to systemd unit files to verify.
+
+These paths can include glob patterns.
+
+#### `systemdVerifySkipUnits` {#systemd-verify-skip-units}
+
+A list of paths to systemd unit files to skip verifying.
+
+These paths can either be the relative path within the package output to the unit file,
+or the base name of the unit file.
+
+#### `systemdVerifyAllowUnknownKeys` {#systemd-verify-allow-unknown-keys}
+
+A list of extra keys in the systemd unit files to allow, despite systemd not recognizing them by default.
+
+#### `systemdVerifyAllowUnknownSections` {#systemd-verify-allow-unknown-sections}
+
+A list of extra sections in the systemd unit files to allow, despite systemd not recognizing them by default.
+
+
+#### `systemdVerifyDisableDefaultUnknownKeys` {#systemd-verify-disable-default-unknown-keys}
+
+Whether to disable the default set of allowed unknown keys in systemd unit files.

--- a/doc/nav.json
+++ b/doc/nav.json
@@ -326,6 +326,9 @@
               "file": "hooks/scons.section.md"
             },
             {
+              "file": "hooks/systemd-verify-units-hook.section.md"
+            },
+            {
               "file": "hooks/tauri.section.md"
             },
             {

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -108,6 +108,9 @@
   "dev-environments": [
     "index.html#dev-environments"
   ],
+  "dont-systemd-verify-units": [
+    "index.html#dont-systemd-verify-units"
+  ],
   "ex-build-helpers-extendMkDerivation": [
     "index.html#ex-build-helpers-extendMkDerivation"
   ],
@@ -956,6 +959,33 @@
   ],
   "glibcxxassertions": [
     "index.html#glibcxxassertions"
+  ],
+  "systemd-verify-allow-unknown-keys": [
+    "index.html#systemd-verify-allow-unknown-keys"
+  ],
+  "systemd-verify-allow-unknown-sections": [
+    "index.html#systemd-verify-allow-unknown-sections"
+  ],
+  "systemd-verify-disable-default-unknown-keys": [
+    "index.html#systemd-verify-disable-default-unknown-keys"
+  ],
+  "systemd-verify-extra-units": [
+    "index.html#systemd-verify-extra-units"
+  ],
+  "systemd-verify-skip-default-paths": [
+    "index.html#systemd-verify-skip-default-paths"
+  ],
+  "systemd-verify-skip-units": [
+    "index.html#systemd-verify-skip-units"
+  ],
+  "systemd-verify-units-hook": [
+    "index.html#systemd-verify-units-hook"
+  ],
+  "systemd-verify-units-hook-exclusive-variables": [
+    "index.html#systemd-verify-units-hook-exclusive-variables"
+  ],
+  "systemd-verify-units-hook-variables-controlling": [
+    "index.html#systemd-verify-units-hook-variables-controlling"
   ],
   "tester-modularServiceCompliance": [
     "index.html#tester-modularServiceCompliance"

--- a/pkgs/by-name/sy/systemd-verify-units-hook/hook.sh
+++ b/pkgs/by-name/sy/systemd-verify-units-hook/hook.sh
@@ -1,0 +1,180 @@
+#! @shell@
+
+# shellcheck shell=bash
+
+systemdVerifyUnitsHook() {
+    runHook preSystemdVerifyUnits
+    echo "Executing systemdVerifyUnitsPhase"
+
+    declare -a unitsToCheck
+    readarray -d '' -t unitsToCheck < <(
+      shopt -s nullglob
+
+      if [[ -z "${systemdVerifySkipDefaultPaths-}" ]]; then
+          declare output
+          for output in $(getAllOutputNames); do
+              (
+                IFS=
+                declare unit
+                for unit in "${!output}"/{etc,lib}/systemd/system/*.{service,socket,device,mount,automount,swap,target,path,timer,snapshot,slice,scope}; do
+                    printf "%s\0" "$unit"
+                done
+                declare override
+                for override in "${!output}"/{etc,lib}/systemd/system/*.{service,socket,device,mount,automount,swap,target,path,timer,snapshot,slice,scope}.d/*; do
+                    printf "%s\0" "$override"
+                done
+              )
+          done
+      fi
+
+      declare -a systemdVerifyExtraUnitsArray=()
+      concatTo systemdVerifyExtraUnitsArray systemdVerifyExtraUnits
+
+      if [[ ${#systemdVerifyExtraUnitsArray[@]} -gt 0 ]]; then
+          declare globPattern
+          for globPattern in "${systemdVerifyExtraUnitsArray[@]}"; do
+              (
+                IFS=
+                declare expanded
+                for expanded in $globPattern; do
+                    if [[ -f "$expanded" ]]; then
+                        printf "%s\0" "$expanded"
+                    fi
+                done
+              )
+          done
+      fi
+    )
+
+    declare -a skipPatterns=()
+    concatTo skipPatterns systemdVerifySkipUnits
+
+    declare -a filteredUnits=()
+    declare -A seen=()
+    declare unit
+    for unit in "${unitsToCheck[@]}"; do
+        declare skipUnit=false
+        declare skipPattern
+        for skipPattern in "${skipPatterns[@]}"; do
+            if [[ "$unit" == *"$skipPattern"* || "$(basename "$unit")" == "$skipPattern" ]]; then
+                skipUnit=true
+                break
+            fi
+        done
+        if [[ $skipUnit == true ]]; then
+            printf "Skipping systemd unit: %s\n" "$unit"
+        else
+            if [[ -z "${seen[$unit]-}" ]]; then
+                seen[$unit]=1
+                filteredUnits+=("$unit")
+            fi
+        fi
+    done
+
+    # See ../../sw/switch-to-configuration-ng/src/src/main.rs
+    declare -a defaultAllowedUnknownKeys=(
+      'X-NotSocketActivated'
+      'X-OnlyManualStart'
+      'X-Reload-Triggers'
+      'X-ReloadIfChanged'
+      'X-Restart-Triggers'
+      'X-RestartIfChanged'
+      'X-StopIfChanged'
+      'X-StopOnConfiguration'
+      'X-StopOnReconfiguration'
+      'X-StopOnRemoval'
+    )
+
+    declare -A allowedUnknownKeys=()
+    if [[ -z "${systemdVerifyDisableDefaultUnknownKeys-}" ]]; then
+        declare defaultKey
+        for defaultKey in "${defaultAllowedUnknownKeys[@]}"; do
+            allowedUnknownKeys["$defaultKey"]=1
+        done
+    fi
+
+    declare -a systemdVerifyAllowUnknownKeysArray=()
+    concatTo systemdVerifyAllowUnknownKeysArray systemdVerifyAllowUnknownKeys
+    declare key
+    for key in "${systemdVerifyAllowUnknownKeysArray[@]}"; do
+        allowedUnknownKeys["$key"]=1
+    done
+
+    declare -A allowedUnknownSections=()
+    declare -a systemdVerifyAllowUnknownSectionsArray=()
+    concatTo systemdVerifyAllowUnknownSectionsArray systemdVerifyAllowUnknownSections
+    declare section
+    for section in "${systemdVerifyAllowUnknownSectionsArray[@]}"; do
+        allowedUnknownSections["$section"]=1
+    done
+
+    if [[ ${#filteredUnits[@]} -gt 0 ]]; then
+        declare unit
+        for unit in "${filteredUnits[@]}"; do
+            printf "Verifying systemd unit: %s\n" "$unit"
+
+            # NOTE: systemd-analyze needs /run/systemd; bubblewrap is used to provide a fake environment.
+            declare -a bwrapFlags=(
+                --dev /dev
+                --bind "/nix" "/nix"
+                --tmpfs "$HOME"
+                --tmpfs /tmp
+                --bind /bin /bin
+                --bind /tmp /run/systemd
+                --bind "$unit" "$unit"
+            )
+            declare output
+            for output in $(getAllOutputNames); do
+                bwrapFlags+=(--bind "${!output}" "${!output}")
+            done
+
+            #TODO: test manpages too
+            set +e
+            declare systemdAnalayzeStderr="$('@bwrap@' "${bwrapFlags[@]}" '@systemdanalyze@' verify --man=no --recursive-errors=no "$unit" 2>&1 1>/dev/null)"
+            declare exitCode="$?"
+            set -e
+
+            declare isError=false
+            declare line
+            while IFS= read -r line; do
+                if [[ $line =~ ^.*Unknown\ key\ \'([^\']+)\'\ in\ section\ \[([^\]]+)\],\ ignoring\.?$ ]]; then
+                    declare keyname="${BASH_REMATCH[1]}"
+                    declare sectionname="${BASH_REMATCH[2]}"
+                    if [[ -n "${allowedUnknownKeys[$keyname]-}" || -n "${allowedUnknownSections[$sectionname]-}" ]]; then
+                        continue
+                    fi
+                fi
+
+                if [[ $line =~ ^.*Unknown\ section\ \'([^\']+)\'\.\ Ignoring\.$ ]]; then
+                    declare sectionname="${BASH_REMATCH[1]}"
+                    if [[ -n "${allowedUnknownSections[$sectionname]-}" ]]; then
+                        continue
+                    fi
+                fi
+
+                if [[ -n "$line" ]]; then
+                    printf '%s\n' "$line" >&2
+                    isError=true
+                fi
+            done <<< "$systemdAnalayzeStderr"
+
+            if [[ $isError == true ]]; then
+                printf "systemd-analyze verify failed for unit: %s\n" "$unit" >&2
+                if [[ "$exitCode" -eq 0 ]]; then
+                    exitCode=1
+                fi
+                exit "$exitCode"
+            fi
+        done
+    else
+        echo "No systemd units to verify"
+    fi
+
+    runHook postSystemdVerifyUnits
+    echo "Finished systemdVerifyUnitsPhase"
+}
+
+if [[ -z "${dontSystemdVerifyUnits-}" && -n '@systemdanalyze@' ]]; then
+    echo "Using systemdVerifyUnitsHook"
+    preInstallCheckHooks+=(systemdVerifyUnitsHook)
+fi

--- a/pkgs/by-name/sy/systemd-verify-units-hook/package.nix
+++ b/pkgs/by-name/sy/systemd-verify-units-hook/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  makeSetupHook,
+  systemd,
+  stdenv,
+  bash,
+  callPackage,
+  bubblewrap,
+}:
+let
+  # systemd units can only be checked if systemd (specifically, 'systemd-analyze') can be executed on build platform
+  # If cross-compiling linux -> non-linux, systemd unts are still checked, even if they end up being unused.
+  # This is not a problem:
+  # - If there are no systemd units, the hook is a noop
+  # - If the systemd units are broken, they should be flagged as such
+  # - If units are not needed on a target platform where they are broken, they should be deleted from package output
+  applyHook = lib.meta.availableOn stdenv.buildPlatform systemd;
+in
+makeSetupHook {
+  name = "systemd-verify-units-hook";
+  substitutions = {
+    shell = "${bash}/bin/bash";
+    systemdanalyze = if applyHook then lib.getExe' systemd "systemd-analyze" else "";
+    bwrap = if applyHook then lib.getExe bubblewrap else "";
+  };
+
+  passthru.tests = {
+    simple = callPackage ./test.nix { };
+    simple-structured-attrs = callPackage ./test.nix { structuredAttrs = true; };
+  };
+
+  meta = {
+    description = "Check validity of systemd units in outputs";
+    platforms = systemd.meta.platforms;
+    maintainers = with lib.maintainers; [ h7x4 ];
+  };
+} ./hook.sh

--- a/pkgs/by-name/sy/systemd-verify-units-hook/test.nix
+++ b/pkgs/by-name/sy/systemd-verify-units-hook/test.nix
@@ -1,0 +1,118 @@
+{
+  lib,
+  stdenv,
+  systemd-verify-units-hook,
+  structuredAttrs ? false,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  name = "systemd-verify-units-hook-test";
+
+  __structuredAttrs = structuredAttrs;
+
+  nativeInstallCheckInputs = [
+    systemd-verify-units-hook
+  ];
+
+  dontUnpack = true;
+  doInstallCheck = true;
+
+  unitValid = ''
+    [Unit]
+    Description=Valid Unit
+
+    [Service]
+    ExecStart=/bin/sh -c 'exit 0'
+
+    [Install]
+    WantedBy=multi-user.target
+  '';
+
+  unitWithUnknownKey = ''
+    [Unit]
+    Description=Invalid Unit
+
+    [Service]
+    ExecStart=/bin/sh -c 'exit 0'
+    UnknownKey=somevalue
+
+    [Install]
+    WantedBy=multi-user.target
+  '';
+
+  unitWithUnknownSection = ''
+    [Unit]
+    Description=Invalid Unit
+
+    [Service]
+    ExecStart=/bin/sh -c 'exit 0'
+
+    [UnknownSection]
+    SomeKey=somevalue
+
+    [Install]
+    WantedBy=multi-user.target
+  '';
+
+  unitWithCustomLocation = ''
+    [Unit]
+    Description=Custom Location Unit
+
+    [Service]
+    ExecStart=/bin/sh -c 'exit 0'
+
+    [Install]
+    WantedBy=multi-user.target
+  '';
+
+  unitToSkip = ''
+    broken
+  '';
+
+  unitInPathWithSpace = ''
+    [Unit]
+    Description=Unit in a path with a space
+
+    [Service]
+    ExecStart=/bin/sh -c 'exit 0'
+
+    [Install]
+    WantedBy=multi-user.target
+  '';
+
+  systemdVerifyExtraUnits = [
+    "${placeholder "out"}/opt/custom/systemd/system/*"
+    "${placeholder "out"}/opt/custom location/systemd/system/*"
+  ];
+  systemdVerifySkipUnits = [ "unitToSkip.service" ];
+  systemdVerifyAllowUnknownKeys = [ "UnknownKey" ];
+  systemdVerifyAllowUnknownSections = [ "UnknownSection" ];
+
+  installPhase =
+    let
+      defaultInstallUnits = [
+        "unitValid"
+        "unitWithUnknownKey"
+        "unitWithUnknownSection"
+        "unitWithCustomLocation"
+        "unitToSkip"
+        "unitInPathWithSpace"
+      ];
+    in
+    ''
+      runHook preInstall
+
+      ${lib.concatMapStringsSep "\n" (u: ''
+        install -Dm644 <(printf '%s' "''${${u}}") "$out/etc/systemd/system/${u}.service"
+      '') defaultInstallUnits}
+
+      install -Dm644 <(printf '%s' "''${unitWithCustomLocation}") "$out/opt/custom/systemd/system/my-unit.service"
+      install -Dm644 <(printf '%s' "''${unitInPathWithSpace}") "$out/opt/custom location/systemd/system/spaced-unit.service"
+
+      runHook postInstall
+    '';
+
+  postInstallCheck = ''
+    echo "test passed"
+  '';
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR introduces a new hook for statically checking systemd units. By including it in `nativeInstallCheckInputs` and enabling `installCheckPhase`, it will run all units found in the default locations, as well as any locations specified.

There was a bit of an issue with running `systemd-analyze verify` inside the nix sandbox, because `/run/systemd` is not there and it doesn't seem like it's possible do make it. I eventually landed on working around it with bubblewrap, but if anyone has a better solution I'm all ears.

Another issue I met along the way was with man. I was originally planning to set `$PATH` and `$MANPATH` so that `systemd-analyze verify` would have everything it needed to check the manpages in `[Unit].Documentation=` directives, but it seemingly didn't want to pick up one or both of the envvars (probably `$MANPATH`, but I haven't verified). Left a TODO for this.

It would be cool if this could be run on all units in an entire nixos configuration, or a subset of them, but I'll leave that as a future idea for now.

Part of the code is copied from `udevCheckHook`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
