### PR TITLE
nixos/polkit: add `packages` option

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -81,6 +81,8 @@
 
 - `security.polkit.enablePkexecWrapper` has been introduced, making the `pkexec` setuid wrapper opt-in.
 
+- `security.polkit` has gotten a new option `security.polkit.packages`. This makes it impossible to write polkit rules and actions through `environment.etc."polkit-1/{actions,rules.d}/*"`. Additional rules can likely be moved to `security.extraConfig`, actions will have to be added to `security.polkit.packages` by using functions like `pkgs.writeTextDir`. See the option documentation for an example.
+
 - Apache Kafka has dropped support for ZooKeeper mode. The `apacheKafka_3_9` and `apacheKafka_4_0` packages have been removed, as every remaining packaged version is KRaft-only. The `services.apache-kafka.zookeeper` option (previously an alias for `services.apache-kafka.settings."zookeeper.connect"`) has been removed; migrate your cluster to [KRaft](#module-services-apache-kafka-kraft) mode instead.
 
 - When Avahi's mDNS resolver is enabled (`services.avahi.nssmdns4` or `services.avahi.nssmdns6`), only the minimal mDNS resolver is enabled by default to avoid adding a 5 second delay to every failed reverse hostname lookup (e.g., delaying ping by 5 seconds). The "full" mDNS resolver now remains disabled unless `services.avahi.nssmdnsFull` is also enabled. Users who have customized [`/etc/mdns.allow`](https://github.com/avahi/nss-mdns/tree/master#etcmdnsallow) to allow mDNS domains not ending `.local` must enable `services.avahi.nssmdnsFull` to continue to resolve such domains.

--- a/nixos/modules/security/polkit.nix
+++ b/nixos/modules/security/polkit.nix
@@ -62,6 +62,28 @@ in
       '';
     };
 
+    packages = lib.mkOption {
+      type = lib.types.listOf lib.types.package;
+      default = [ ];
+      example = lib.literalExpression ''
+        with pkgs; [
+          udisks
+          rtkit
+          (writeTextDir "share/polkit-1/rules.d/20-other.rules" '''
+            ...
+          ''')
+          (writeTextDir "share/polkit-1/actions/org.example.MyService1.policy" '''
+            ...
+          ''')
+        ]
+      '';
+      description = ''
+        Packages containing polkit rulesets and actions to be added to the system.
+
+        The items should be located in {file}`@out@/share/polkit-1/` in the packages specified.
+      '';
+    };
+
     extraConfig = mkOption {
       type = types.lines;
       default = "";
@@ -114,7 +136,7 @@ in
     systemd.services.polkit = {
       restartTriggers = [ config.system.path ];
       reloadTriggers = [
-        config.environment.etc."polkit-1/rules.d/10-nixos.rules".source
+        config.environment.etc."polkit-1".source
       ];
       serviceConfig.ExecStart = [
         # nuke default ExecStart
@@ -162,16 +184,29 @@ in
     # The polkit daemon reads action/rule files
     environment.pathsToLink = [ "/share/polkit-1" ];
 
+    environment.etc."polkit-1".source = pkgs.symlinkJoin {
+      name = "polkit-rules";
+      paths = [
+        cfg.packages
+        (pkgs.linkFarm "polkitd-conf-dir" {
+          "share/polkit-1/polkitd.conf" = iniFmt.generate "polkitd.conf" cfg.settings;
+        })
+      ];
+      stripPrefix = "/share/polkit-1";
+    };
+
     # PolKit rules for NixOS.
-    environment.etc."polkit-1/rules.d/10-nixos.rules".text = ''
-      polkit.addAdminRule(function(action, subject) {
-        return [${lib.concatStringsSep ", " (map (i: "\"${i}\"") cfg.adminIdentities)}];
-      });
+    security.polkit.packages = [
+      # TODO: validation on compilation (at least against typos)
+      (pkgs.writeTextDir "share/polkit-1/rules.d/10-nixos.rules" ''
+        polkit.addAdminRule(function(action, subject) {
+          return [${lib.concatStringsSep ", " (map (i: "\"${i}\"") cfg.adminIdentities)}];
+        });
 
-      ${cfg.extraConfig}
-    ''; # TODO: validation on compilation (at least against typos)
+        ${cfg.extraConfig}
+      '')
+    ];
 
-    environment.etc."polkit-1/polkitd.conf".source = iniFmt.generate "polkitd.conf" cfg.settings;
     security.pam.services.polkit-1 = { };
 
     security.wrappers.pkexec = {

--- a/nixos/modules/security/rtkit.nix
+++ b/nixos/modules/security/rtkit.nix
@@ -39,8 +39,7 @@ in
   config = lib.mkIf cfg.enable {
     security.polkit.enable = true;
 
-    # To make polkit pickup rtkit policies
-    environment.systemPackages = [ cfg.package ];
+    security.polkit.packages = [ cfg.package ];
 
     services.dbus.packages = [ cfg.package ];
 

--- a/nixos/modules/services/display-managers/gdm.nix
+++ b/nixos/modules/services/display-managers/gdm.nix
@@ -276,7 +276,9 @@ in
     ];
     environment.systemPackages = [
       pkgs.adwaita-icon-theme
-      pkgs.gdm # For polkit rules
+    ];
+    security.polkit.packages = [
+      pkgs.gdm
     ];
 
     # We dont use the upstream gdm service

--- a/nixos/modules/services/networking/sing-box.nix
+++ b/nixos/modules/services/networking/sing-box.nix
@@ -41,8 +41,7 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    # for polkit rules
-    environment.systemPackages = [ cfg.package ];
+    security.polkit.packages = [ cfg.package ];
     services.dbus.packages = [ cfg.package ];
     systemd.packages = [ cfg.package ];
 

--- a/nixos/modules/services/security/timekpr.nix
+++ b/nixos/modules/services/security/timekpr.nix
@@ -36,7 +36,9 @@ in
     };
 
     environment.systemPackages = [
-      # Add timekpr to system packages so that polkit can find it
+      cfg.package
+    ];
+    security.polkit.packages = [
       cfg.package
     ];
     services.dbus.enable = true;

--- a/nixos/modules/services/video/mirakurun.nix
+++ b/nixos/modules/services/video/mirakurun.nix
@@ -134,7 +134,7 @@ in
   };
 
   config = mkIf cfg.enable {
-    environment.systemPackages = [ mirakurun ] ++ optional cfg.allowSmartCardAccess polkitRule;
+    environment.systemPackages = [ mirakurun ];
     environment.etc = {
       "mirakurun/server.yml".source = settingsFmt.generate "server.yml" cfg.serverSettings;
       "mirakurun/tuners.yml" = mkIf (cfg.tunerSettings != null) {
@@ -150,6 +150,8 @@ in
         group = groupname;
       };
     };
+
+    security.polkit.packages = lib.mkIf cfg.allowSmartCardAccess [ polkitRule ];
 
     networking.firewall = mkIf cfg.openFirewall {
       allowedTCPPorts = mkIf (cfg.port != null) [ cfg.port ];

--- a/nixos/modules/virtualisation/spice-usb-redirection.nix
+++ b/nixos/modules/virtualisation/spice-usb-redirection.nix
@@ -18,7 +18,7 @@
   };
 
   config = lib.mkIf config.virtualisation.spiceUSBRedirection.enable {
-    environment.systemPackages = [ pkgs.spice-gtk ]; # For polkit actions
+    security.polkit.packages = [ pkgs.spice-gtk ];
     security.wrappers.spice-client-glib-usb-acl-helper = {
       owner = "root";
       group = "root";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR introduces a `security.polkit.packages` option. We have this types of option for dbus and systemd already, but for polkit you had to add the packages to `environment.systemPackages` with the side effect of cluttering up `bin` and other directories.

I have migrated some modules that contained a comment stating polkit was the only reason for including a package in `systemPackages`.

This is a breaking change that will affect some people, I have added a release note about this. [A GitHub search shows about 50 cases](https://github.com/search?q=lang%3Anix+-is%3Afork+%22environment.etc.%5C%22polkit-1%22&type=code), although some of those are likely manual forks and nixpkgs modules.

There isn't any test for polkit at the moment, but the rtkit test depends heavily on polkit, so I've used this to verify that the changes look okay.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
