### PR TITLE
[staging] prefetch-npm-deps: exclude deprecated field from packument whitelist

### DIFF
--- a/pkgs/build-support/node/prefetch-npm-deps/src/main.rs
+++ b/pkgs/build-support/node/prefetch-npm-deps/src/main.rs
@@ -65,8 +65,6 @@ const ALLOWED_VERSION_FIELDS: &[&str] = &[
     "cpu",
     // Lifecycle scripts
     "scripts",
-    // Version selection hint (npm-pick-manifest)
-    "deprecated",
 ];
 
 fn normalize_packument(


### PR DESCRIPTION
The 'deprecated' field can be modified by package maintainers at any time via 'npm deprecate', even for already-published versions. This causes hash mismatches when the npm registry adds deprecation notices to packages that were previously not deprecated.

For lockfile-based installs, the version is already resolved, so the deprecation hint used by npm-pick-manifest for version selection is not needed. The only behavioral change is that users won't see deprecation warnings during 'npm install', which is an acceptable tradeoff for reproducible builds.

This was discovered when tar@7.5.2 was deprecated upstream, breaking builds in downstream projects using fetcherVersion=2.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
