### PR TITLE
[25.11] wlc: 1.16.1 -> 1.17.2

### DIFF
--- a/pkgs/by-name/wl/wlc/package.nix
+++ b/pkgs/by-name/wl/wlc/package.nix
@@ -6,12 +6,12 @@
 
 python3.pkgs.buildPythonPackage rec {
   pname = "wlc";
-  version = "1.16.1";
+  version = "1.17.1";
   pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-gTVt5cxz8tk63mnTZAtzcYdy4m0NVR0y6xjmVICw7pg=";
+    hash = "sha256-FtxJ1clfvJCggg4h9Lzwq4S4KyejJxppjrB3i7Jiy/Y=";
   };
 
   build-system = with python3.pkgs; [ setuptools ];

--- a/pkgs/by-name/wl/wlc/package.nix
+++ b/pkgs/by-name/wl/wlc/package.nix
@@ -6,12 +6,12 @@
 
 python3.pkgs.buildPythonPackage rec {
   pname = "wlc";
-  version = "1.17.1";
+  version = "1.17.2";
   pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-FtxJ1clfvJCggg4h9Lzwq4S4KyejJxppjrB3i7Jiy/Y=";
+    hash = "sha256-9BM2xNbiNy8efpkZjEhQ2OSl0RJiOGSut16o8yMA14A=";
   };
 
   build-system = with python3.pkgs; [ setuptools ];


### PR DESCRIPTION
Fixes CVE-2026-22251, CVE-2026-22250 and CVE-2026-23535.

The potential BC in 1.17.0 is caused by the security fix for CVE-2026-22251.

Fixes #481080

Changes:
https://github.com/WeblateOrg/wlc/releases/tag/1.17.0
https://github.com/WeblateOrg/wlc/releases/tag/1.17.1
https://github.com/WeblateOrg/wlc/releases/tag/1.17.2

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test


## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 481896`
Commit: `60048372f7e490a73b29afc9e5f49036e74e70b9`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 2 packages built:</summary>
  <ul>
    <li>wlc</li>
    <li>wlc.dist</li>
  </ul>
</details>