### PR TITLE
python3Packages.weasyprint: 66.0 -> 68.0

### DIFF
--- a/pkgs/development/python-modules/tinycss2/default.nix
+++ b/pkgs/development/python-modules/tinycss2/default.nix
@@ -10,7 +10,7 @@
 
 buildPythonPackage rec {
   pname = "tinycss2";
-  version = "1.4.0";
+  version = "1.5.1";
   pyproject = true;
 
   src = fetchFromGitHub {
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     tag = "v${version}";
     # for tests
     fetchSubmodules = true;
-    hash = "sha256-GVymUobWAE0YS65lti9dXRIIGpx0YkwF/vSb3y7cpYY=";
+    hash = "sha256-ZVmdHrqfF5fvBvHLaG2B4m1zek4wfEYArkntWzOqhfM=";
   };
 
   build-system = [ flit-core ];

--- a/pkgs/development/python-modules/weasyprint/default.nix
+++ b/pkgs/development/python-modules/weasyprint/default.nix
@@ -32,7 +32,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "weasyprint";
-  version = "66.0";
+  version = "68.0";
   pyproject = true;
 
   __darwinAllowLocalNetworking = true;
@@ -41,7 +41,7 @@ buildPythonPackage (finalAttrs: {
     owner = "Kozea";
     repo = "WeasyPrint";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-wmEDVEbikBpOQ5394IBPWQRjWZOLfMzEGxTtq4tt2Tw=";
+    hash = "sha256-kAJgSQz1RKrPwzO7I5xHXyXcXYJtvca9izjrAgTy3ek=";
   };
 
   patches = [
@@ -99,6 +99,8 @@ buildPythonPackage (finalAttrs: {
     "test_woff_simple"
     # AssertionError
     "test_2d_transform"
+    # Reported upstream: https://github.com/Kozea/WeasyPrint/issues/2666
+    "test_text_stroke"
   ];
 
   FONTCONFIG_FILE = "${fontconfig.out}/etc/fonts/fonts.conf";

--- a/pkgs/development/python-modules/weasyprint/library-paths.patch
+++ b/pkgs/development/python-modules/weasyprint/library-paths.patch
@@ -1,14 +1,14 @@
 diff --git a/weasyprint/text/ffi.py b/weasyprint/text/ffi.py
-index b5a9cf2..9380a79 100644
+index f57da3c..c50e41d 100644
 --- a/weasyprint/text/ffi.py
 +++ b/weasyprint/text/ffi.py
-@@ -444,25 +444,12 @@ if hasattr(os, 'add_dll_directory') and not hasattr(sys, 'frozen'):  # pragma: n
+@@ -473,25 +473,12 @@ if hasattr(os, 'add_dll_directory') and not hasattr(sys, 'frozen'):  # pragma: n
          with suppress((OSError, FileNotFoundError)):
              os.add_dll_directory(dll_directory)
  
 -gobject = _dlopen(
 -    ffi, 'libgobject-2.0-0', 'gobject-2.0-0', 'gobject-2.0',
--    'libgobject-2.0.so.0', 'libgobject-2.0.dylib', 'libgobject-2.0-0.dll')
+-    'libgobject-2.0.so.0', 'libgobject-2.0.0.dylib', 'libgobject-2.0-0.dll')
 -pango = _dlopen(
 -    ffi, 'libpango-1.0-0', 'pango-1.0-0', 'pango-1.0', 'libpango-1.0.so.0',
 -    'libpango-1.0.dylib', 'libpango-1.0-0.dll')
@@ -25,12 +25,12 @@ index b5a9cf2..9380a79 100644
 -pangoft2 = _dlopen(
 -    ffi, 'libpangoft2-1.0-0', 'pangoft2-1.0-0', 'pangoft2-1.0',
 -    'libpangoft2-1.0.so.0', 'libpangoft2-1.0.dylib', 'libpangoft2-1.0-0.dll')
-+gobject = _dlopen(ffi, "@gobject@")
-+pango = _dlopen(ffi, "@pango@")
-+harfbuzz = _dlopen(ffi, "@harfbuzz@")
-+harfbuzz_subset = _dlopen(ffi, "@harfbuzz_subset@", allow_fail=True)
-+fontconfig = _dlopen(ffi, "@fontconfig@")
-+pangoft2 = _dlopen(ffi, "@pangoft2@")
++gobject = _dlopen(ffi, '@gobject@')
++pango = _dlopen(ffi, '@pango@')
++harfbuzz = _dlopen(ffi, '@harfbuzz@')
++harfbuzz_subset = _dlopen(ffi, '@harfbuzz_subset@', allow_fail=True)
++fontconfig = _dlopen(ffi, '@fontconfig@')
++pangoft2 = _dlopen(ffi, '@pangoft2@')
  
  gobject.g_type_init()
  


### PR DESCRIPTION
This updates `python3Packages.weasyprint` from 66.0 to 68.0.

This update resolves NixOS/nixpkgs#481891

Patchnotes: https://github.com/Kozea/WeasyPrint/releases/tag/v68.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
