### PR TITLE
 oxidized-web: 0.18.0 -> 0.18.1

### DIFF
--- a/pkgs/by-name/ox/oxidized/Gemfile
+++ b/pkgs/by-name/ox/oxidized/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
 gem 'oxidized', '0.35.0'
-gem 'oxidized-web', '0.18.0'
+gem 'oxidized-web', '0.18.1'
 gem 'oxidized-script', '0.7.0'
 gem 'psych', '~> 5.0'

--- a/pkgs/by-name/ox/oxidized/Gemfile.lock
+++ b/pkgs/by-name/ox/oxidized/Gemfile.lock
@@ -49,16 +49,16 @@ GEM
     oxidized-script (0.7.0)
       oxidized (~> 0.29)
       slop (~> 4.6)
-    oxidized-web (0.18.0)
-      charlock_holmes (>= 0.7.5, < 0.8.0)
+    oxidized-web (0.18.1)
+      charlock_holmes (~> 0.7)
       emk-sinatra-url-for (~> 0.2)
-      haml (>= 6.0.0, < 7.0.0)
-      htmlentities (>= 4.3.0, < 4.5.0)
-      json (>= 2.3.0, < 2.17.0)
+      haml (>= 6, < 7)
+      htmlentities (~> 4.3)
+      json (~> 2.3)
       oxidized (>= 0.34.1)
-      puma (>= 6.6, < 7.2)
-      sinatra (>= 4.1.1, < 4.3.0)
-      sinatra-contrib (>= 4.1.1, < 4.3.0)
+      puma (>= 6.6, < 8)
+      sinatra (~> 4.1)
+      sinatra-contrib (~> 4.1)
     psych (5.2.6)
       date
       stringio
@@ -107,7 +107,7 @@ PLATFORMS
 DEPENDENCIES
   oxidized (= 0.35.0)
   oxidized-script (= 0.7.0)
-  oxidized-web (= 0.18.0)
+  oxidized-web (= 0.18.1)
   psych (~> 5.0)
 
 BUNDLED WITH

--- a/pkgs/by-name/ox/oxidized/gemset.nix
+++ b/pkgs/by-name/ox/oxidized/gemset.nix
@@ -278,10 +278,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "19sz075liiqim98jvnb3jawxdpd8kk146bwvqzwvmimbgdzf8xfr";
+      sha256 = "1yx8q8v5ri2j7h7slpkk4plnrgc098l9avxnaavibj14fri3z26n";
       type = "gem";
     };
-    version = "0.18.0";
+    version = "0.18.1";
   };
   psych = {
     dependencies = [


### PR DESCRIPTION
Changelog : https://github.com/ytti/oxidized-web/releases/tag/0.18.1
Diff : https://github.com/ytti/oxidized-web/compare/0.18.0...0.18.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
