### PR TITLE
python3Packages.pocket-tts: 1.0.1 -> 1.0.2

### DIFF
--- a/pkgs/development/python-modules/pocket-tts/default.nix
+++ b/pkgs/development/python-modules/pocket-tts/default.nix
@@ -22,18 +22,21 @@
   typer,
   typing-extensions,
   uvicorn,
+
+  # optional-dependencies
+  soundfile,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "pocket-tts";
-  version = "1.0.1";
+  version = "1.0.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "kyutai-labs";
     repo = "pocket-tts";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-VFLpUsHnQYSr5RgNKJOX1TD30o1A8rG4cs2VeZWriaU=";
+    hash = "sha256-m//UCZEENE5bl9TV0rDCA3Th1TykvC5oZLay+f7lEr8=";
   };
 
   build-system = [
@@ -61,6 +64,12 @@ buildPythonPackage (finalAttrs: {
     typing-extensions
     uvicorn
   ];
+
+  optional-dependencies = {
+    audio = [
+      soundfile
+    ];
+  };
 
   pythonImportsCheck = [ "pocket_tts" ];
 


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/kyutai-labs/pocket-tts/compare/v1.0.1...v1.0.2
Changelog: https://github.com/kyutai-labs/pocket-tts/releases/tag/v1.0.2

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test