### PR TITLE
python3Packages.wrapPython: use pkgsBuildTarget.makeWrapper by default

### DIFF
--- a/pkgs/by-name/ya/yaml-merge/package.nix
+++ b/pkgs/by-name/ya/yaml-merge/package.nix
@@ -3,7 +3,6 @@
   stdenv,
   fetchFromGitHub,
   python3Packages,
-  pkgsHostTarget,
 }:
 
 stdenv.mkDerivation {
@@ -19,9 +18,7 @@ stdenv.mkDerivation {
 
   pythonPath = with python3Packages; [ pyyaml ];
   nativeBuildInputs = [
-    # Not `python3Packages.wrapPython` to workaround `python3Packages.wrapPython.__spliced.buildHost` having the wrong `pythonHost`
-    # See https://github.com/NixOS/nixpkgs/issues/434307
-    pkgsHostTarget.python3Packages.wrapPython
+    python3Packages.wrapPython
   ];
 
   installPhase = ''

--- a/pkgs/development/interpreters/python/hooks/default.nix
+++ b/pkgs/development/interpreters/python/hooks/default.nix
@@ -473,9 +473,7 @@ in
     } ./wheel-unpack-hook.sh
   ) { };
 
-  wrapPython = callPackage ../wrap-python.nix {
-    inherit (pkgs.buildPackages) makeWrapper;
-  };
+  wrapPython = callPackage ../wrap-python.nix { };
 
   sphinxHook = callPackage (
     { makePythonHook, installShellFiles }:

--- a/pkgs/development/interpreters/python/wrap-python.nix
+++ b/pkgs/development/interpreters/python/wrap-python.nix
@@ -2,12 +2,12 @@
   lib,
   python,
   makePythonHook,
-  makeWrapper,
+  pkgsBuildTarget,
 }:
 
 makePythonHook {
   name = "wrap-python-hook";
-  propagatedBuildInputs = [ makeWrapper ];
+  propagatedBuildInputs = [ pkgsBuildTarget.makeWrapper ];
   substitutions.sitePackages = python.sitePackages;
   substitutions.executable = python.interpreter;
   substitutions.python = python.pythonOnBuildForHost;


### PR DESCRIPTION
## Things done

Solve #211340 . When merged against branch master, this works for `yaml-merge` edited in this commit too.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
