### PR TITLE
emacs: bump elisp packages

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-devel-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-devel-generated.nix
@@ -9,10 +9,10 @@
     elpaBuild {
       pname = "a68-mode";
       ename = "a68-mode";
-      version = "1.2.0.20251029.224619";
+      version = "1.2.0.20251231.12038";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/a68-mode-1.2.0.20251029.224619.tar";
-        sha256 = "11ncmphflg94r4g3qk2l9383aq26n0fd6izm1wrcdmqw0gj7n5rx";
+        url = "https://elpa.gnu.org/devel/a68-mode-1.2.0.20251231.12038.tar";
+        sha256 = "0hb9j7hfng2scjw43jhh0899wa1765ix3mfylrh33xpdi6y2dk4c";
       };
       packageRequires = [ ];
       meta = {
@@ -333,10 +333,10 @@
     elpaBuild {
       pname = "altcaps";
       ename = "altcaps";
-      version = "1.3.0.0.20250128.71323";
+      version = "1.3.0.0.20260111.105148";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/altcaps-1.3.0.0.20250128.71323.tar";
-        sha256 = "0ilfba0cz5rh1dwgbj9cvbj46kc98ipa2yw8cjcvr7267y30d2a3";
+        url = "https://elpa.gnu.org/devel/altcaps-1.3.0.0.20260111.105148.tar";
+        sha256 = "1ps97855lps0vpw3h0saxx7z0ckdr0fn3zwlvxmh3fbl29w3c9jr";
       };
       packageRequires = [ ];
       meta = {
@@ -461,10 +461,10 @@
     elpaBuild {
       pname = "auctex";
       ename = "auctex";
-      version = "14.1.0.0.20251213.191246";
+      version = "14.1.2.0.20260117.200713";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/auctex-14.1.0.0.20251213.191246.tar";
-        sha256 = "1awhnwjndlkh07ngr2p6g4w2xsimhkj80w32cgpzy2b0h7zfdf9q";
+        url = "https://elpa.gnu.org/devel/auctex-14.1.2.0.20260117.200713.tar";
+        sha256 = "064xvk5pwpnxlxxrgqhiv5r1cmmfcmqlpqnyzn71njslyf3z0321";
       };
       packageRequires = [ ];
       meta = {
@@ -719,10 +719,10 @@
     elpaBuild {
       pname = "beframe";
       ename = "beframe";
-      version = "1.4.0.0.20251212.54745";
+      version = "1.4.0.0.20260111.104742";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/beframe-1.4.0.0.20251212.54745.tar";
-        sha256 = "1x8h0plhv15vc1sy4xk75dng2ckj60asfjgs4a0barrxj08d7qv4";
+        url = "https://elpa.gnu.org/devel/beframe-1.4.0.0.20260111.104742.tar";
+        sha256 = "04v315xmppvd0jv2dwmyj9679dwkiwkil3r6sfb6i48wc3b0ryzj";
       };
       packageRequires = [ ];
       meta = {
@@ -761,10 +761,10 @@
     elpaBuild {
       pname = "bind-key";
       ename = "bind-key";
-      version = "2.4.1.0.20250611.62842";
+      version = "2.4.1.0.20260101.125434";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/bind-key-2.4.1.0.20250611.62842.tar";
-        sha256 = "1wrkvjcbbki9lnlcq1miw3gnyayzmjg2wqrxwpyaq8429xh275qq";
+        url = "https://elpa.gnu.org/devel/bind-key-2.4.1.0.20260101.125434.tar";
+        sha256 = "02g0ig9lbga1yr6c41gg30qqnfb98xfp5f15xsyl29vvd8q3fksy";
       };
       packageRequires = [ ];
       meta = {
@@ -902,10 +902,10 @@
     elpaBuild {
       pname = "breadcrumb";
       ename = "breadcrumb";
-      version = "1.0.1.0.20250208.145328";
+      version = "1.0.1.0.20260110.120308";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/breadcrumb-1.0.1.0.20250208.145328.tar";
-        sha256 = "1bj75faninnkm2cdy1x4c6f9kamf8wkwc1rf4il5khi6gyr0ki2z";
+        url = "https://elpa.gnu.org/devel/breadcrumb-1.0.1.0.20260110.120308.tar";
+        sha256 = "0g5gcq3iqvrkfi6iwbiiyrcwac36czxrfqi9gybipd9k11fqplcr";
       };
       packageRequires = [ project ];
       meta = {
@@ -1015,10 +1015,10 @@
     elpaBuild {
       pname = "buframe";
       ename = "buframe";
-      version = "0.2.0.20251126.123915";
+      version = "0.2.0.20260106.114915";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/buframe-0.2.0.20251126.123915.tar";
-        sha256 = "0m0m5fllpl12d4d4nkq0g34h78qzlvjh0acjvch0zygxvisdi91g";
+        url = "https://elpa.gnu.org/devel/buframe-0.2.0.20260106.114915.tar";
+        sha256 = "169q9hl2l3axzs9x4w8gy65r21rzpswh25whi3bwvllcmkskf6k8";
       };
       packageRequires = [ timeout ];
       meta = {
@@ -1106,10 +1106,10 @@
     elpaBuild {
       pname = "cape";
       ename = "cape";
-      version = "2.4.0.20251221.184323";
+      version = "2.5.0.20260117.195328";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/cape-2.4.0.20251221.184323.tar";
-        sha256 = "1ids0jxls7cw4vfznvc01q6579sdn6xr46x8q1yq11zab4g9yx1m";
+        url = "https://elpa.gnu.org/devel/cape-2.5.0.20260117.195328.tar";
+        sha256 = "0j8h5hl8d7nlwi5dnngjzp48d11z2mlkyhg5l1f9h4sz7lss9rc2";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1319,10 +1319,10 @@
     elpaBuild {
       pname = "colorful-mode";
       ename = "colorful-mode";
-      version = "1.2.5.0.20251121.52839";
+      version = "1.2.5.0.20260105.102832";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/colorful-mode-1.2.5.0.20251121.52839.tar";
-        sha256 = "0rph93j55d3b3kl2yhwfazf4aqs7grzr0q5shk13skp8s1gpg3cc";
+        url = "https://elpa.gnu.org/devel/colorful-mode-1.2.5.0.20260105.102832.tar";
+        sha256 = "1a4rjn7h6wzj2y9armqdjhhrfdwmnf2rhi8r66d7b2bxj32xkhi3";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1387,10 +1387,10 @@
     elpaBuild {
       pname = "company";
       ename = "company";
-      version = "1.0.2.0.20251021.221153";
+      version = "1.0.2.0.20260108.3608";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/company-1.0.2.0.20251021.221153.tar";
-        sha256 = "1p31ws9qx4qmwh0yqc6am454ywnls34nkqicfc3mkq6q54r7ffmn";
+        url = "https://elpa.gnu.org/devel/company-1.0.2.0.20260108.3608.tar";
+        sha256 = "0py7kj5470b5i7mq7kfnbqh90q487nj4dnvk50yji1pdw5x6s9wj";
       };
       packageRequires = [ ];
       meta = {
@@ -1483,10 +1483,10 @@
     elpaBuild {
       pname = "compat";
       ename = "compat";
-      version = "30.1.0.1.0.20251104.142701";
+      version = "30.1.0.1.0.20260104.150319";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/compat-30.1.0.1.0.20251104.142701.tar";
-        sha256 = "1xkgp3rf8rzqf4jnvj2mklvvimq6cb99ivahc1rwrm9vm1y2gn8z";
+        url = "https://elpa.gnu.org/devel/compat-30.1.0.1.0.20260104.150319.tar";
+        sha256 = "0p714qzrbk9nix3n2fhd6gqkm0zcx7yykrx9fq1p6iq90y894pzb";
       };
       packageRequires = [ seq ];
       meta = {
@@ -1504,10 +1504,10 @@
     elpaBuild {
       pname = "cond-star";
       ename = "cond-star";
-      version = "1.0.0.20251218.104812";
+      version = "1.0.0.20260101.125434";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/cond-star-1.0.0.20251218.104812.tar";
-        sha256 = "08p7mznd4gpd73db2bxnspq5f2l10m4gzdwx7y1s7k3rlcpjryix";
+        url = "https://elpa.gnu.org/devel/cond-star-1.0.0.20260101.125434.tar";
+        sha256 = "0gmnc3vzid3w49m6j35kg2i2rzg7x2v8yl7c678ldh841rzmvmqz";
       };
       packageRequires = [ ];
       meta = {
@@ -1547,10 +1547,10 @@
     elpaBuild {
       pname = "consult";
       ename = "consult";
-      version = "3.1.0.20251129.75827";
+      version = "3.3.0.20260118.74435";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/consult-3.1.0.20251129.75827.tar";
-        sha256 = "1kpgxwhrh3r1br95rdinsj8gy07a7vy01s35l2ngm24f91nkrhrk";
+        url = "https://elpa.gnu.org/devel/consult-3.3.0.20260118.74435.tar";
+        sha256 = "1vb3bn9lv9drw43x2272aavdi019wccmz132r5ywlx540dr9lmm1";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1570,10 +1570,10 @@
     elpaBuild {
       pname = "consult-denote";
       ename = "consult-denote";
-      version = "0.4.2.0.20251222.50446";
+      version = "0.4.2.0.20260111.182520";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/consult-denote-0.4.2.0.20251222.50446.tar";
-        sha256 = "05ip842d06rc8i8bjybx9gyw60ll4qycnrkdf8zy9xv81k869saz";
+        url = "https://elpa.gnu.org/devel/consult-denote-0.4.2.0.20260111.182520.tar";
+        sha256 = "1z7dhkp7yy6qn0dr1r5ziwc3p1wbx6cvrh5cr5h8czh6prhswwx4";
       };
       packageRequires = [
         consult
@@ -1660,10 +1660,10 @@
     elpaBuild {
       pname = "corfu";
       ename = "corfu";
-      version = "2.6.0.20251220.205704";
+      version = "2.8.0.20260118.74606";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/corfu-2.6.0.20251220.205704.tar";
-        sha256 = "0601wrvk4yq3a7qaacksv825897ivb0c9mcmhp97snzd974n6r81";
+        url = "https://elpa.gnu.org/devel/corfu-2.8.0.20260118.74606.tar";
+        sha256 = "1fbvaiycmj1mpncxmmzyprqrymzn09b6zdldcbay6xywmvvdvcml";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1877,10 +1877,10 @@
     elpaBuild {
       pname = "cursory";
       ename = "cursory";
-      version = "1.2.0.0.20250722.60609";
+      version = "1.2.0.0.20260111.105552";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/cursory-1.2.0.0.20250722.60609.tar";
-        sha256 = "140g6vi060ns4dippvq8z2j6ydsb54ygdk0scvg7igk2j0zndg35";
+        url = "https://elpa.gnu.org/devel/cursory-1.2.0.0.20260111.105552.tar";
+        sha256 = "0plc6a5rh2wigpif1p9wkvdjqjppakhzkviywzn7z1fxiyrldq2m";
       };
       packageRequires = [ ];
       meta = {
@@ -1941,10 +1941,10 @@
     elpaBuild {
       pname = "dape";
       ename = "dape";
-      version = "0.25.0.0.20251125.164207";
+      version = "0.25.0.0.20260107.224854";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/dape-0.25.0.0.20251125.164207.tar";
-        sha256 = "01r4l7mjcls9x76s8mnxl2hjmj8wa75z3lsrssn4gza8pc22gx6m";
+        url = "https://elpa.gnu.org/devel/dape-0.25.0.0.20260107.224854.tar";
+        sha256 = "1z3xms1jzhdx0m3r4i9a7nlwrcz1agdlxb92f7gqc8rh9jpvlvmh";
       };
       packageRequires = [ jsonrpc ];
       meta = {
@@ -2028,10 +2028,10 @@
     elpaBuild {
       pname = "debbugs";
       ename = "debbugs";
-      version = "0.46.0.20251109.133812";
+      version = "0.46.0.20260101.132314";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/debbugs-0.46.0.20251109.133812.tar";
-        sha256 = "0c12aikl1yxclrmfb0gkrvic9ldmsj9j14v4905sc78ng4h4v695";
+        url = "https://elpa.gnu.org/devel/debbugs-0.46.0.20260101.132314.tar";
+        sha256 = "1rg2dmbrm9135mfpdwim50r37frpm0k24fxl80h79iyilzqhbgmy";
       };
       packageRequires = [ soap-client ];
       meta = {
@@ -2075,10 +2075,10 @@
     elpaBuild {
       pname = "denote";
       ename = "denote";
-      version = "4.1.3.0.20251222.45943";
+      version = "4.1.3.0.20260118.70827";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/denote-4.1.3.0.20251222.45943.tar";
-        sha256 = "1p1brgv965szn7rmqr74r3rvl7bpyxl1jdlpl3mfbc40barz19q5";
+        url = "https://elpa.gnu.org/devel/denote-4.1.3.0.20260118.70827.tar";
+        sha256 = "0mgkmzjqgfr4rlfib0sa9jkqmbzg5q1hgifdg1xadiga24g8krk2";
       };
       packageRequires = [ ];
       meta = {
@@ -2097,10 +2097,10 @@
     elpaBuild {
       pname = "denote-journal";
       ename = "denote-journal";
-      version = "0.2.2.0.20251215.75458";
+      version = "0.2.2.0.20260111.93423";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/denote-journal-0.2.2.0.20251215.75458.tar";
-        sha256 = "0m91rdpd45b0rfwm7r8d50lzl2f0pl5lj4ggx7g70y6asv6xf0k6";
+        url = "https://elpa.gnu.org/devel/denote-journal-0.2.2.0.20260111.93423.tar";
+        sha256 = "0cjzvjfa1yirryqim0a1nhgryj8723bflccs9kaphvwrb3m6kfis";
       };
       packageRequires = [ denote ];
       meta = {
@@ -2119,10 +2119,10 @@
     elpaBuild {
       pname = "denote-markdown";
       ename = "denote-markdown";
-      version = "0.2.1.0.20251201.50143";
+      version = "0.2.1.0.20260111.93101";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/denote-markdown-0.2.1.0.20251201.50143.tar";
-        sha256 = "0vk7adg7naf3r3fw5fms0j4sy3wfjy0c7rpg6cxphmrwmsbqwibi";
+        url = "https://elpa.gnu.org/devel/denote-markdown-0.2.1.0.20260111.93101.tar";
+        sha256 = "0gpqcwpy2x329v73fbg7yq0zzhjy1651iffcf2y6vyirw4yy7mmx";
       };
       packageRequires = [ denote ];
       meta = {
@@ -2163,10 +2163,10 @@
     elpaBuild {
       pname = "denote-org";
       ename = "denote-org";
-      version = "0.2.1.0.20251214.51953";
+      version = "0.2.1.0.20260111.181548";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/denote-org-0.2.1.0.20251214.51953.tar";
-        sha256 = "1yqvnmnk68228h8l1s20fg9vj307v4pngh9ank3k3im1yp9cmiif";
+        url = "https://elpa.gnu.org/devel/denote-org-0.2.1.0.20260111.181548.tar";
+        sha256 = "0gk0vr82snjl4n7glx2j7xskwqqrd84r1ifijcpnsj9pl9l114bm";
       };
       packageRequires = [ denote ];
       meta = {
@@ -2207,10 +2207,10 @@
     elpaBuild {
       pname = "denote-sequence";
       ename = "denote-sequence";
-      version = "0.2.0.0.20251216.160327";
+      version = "0.2.0.0.20260111.183716";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/denote-sequence-0.2.0.0.20251216.160327.tar";
-        sha256 = "14rgr8j25pd6ifbfv79sc2kjqc47c273bmcc5j24vaa0kfvsz3xd";
+        url = "https://elpa.gnu.org/devel/denote-sequence-0.2.0.0.20260111.183716.tar";
+        sha256 = "0i0krqc9hncsnbbp2bjqkpsi16ia57kbqw0p7x3v2g217jq4anvj";
       };
       packageRequires = [ denote ];
       meta = {
@@ -2229,10 +2229,10 @@
     elpaBuild {
       pname = "denote-silo";
       ename = "denote-silo";
-      version = "0.2.0.0.20251215.75639";
+      version = "0.2.0.0.20260111.93458";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/denote-silo-0.2.0.0.20251215.75639.tar";
-        sha256 = "1yx3qwjx74x72h8xdqyh9frhray7crfwpdkdpx8y3xglgrl44q4j";
+        url = "https://elpa.gnu.org/devel/denote-silo-0.2.0.0.20260111.93458.tar";
+        sha256 = "0f57s97k267vd4wm9ps9q57wsrq5djrcsxmmkwlqngmr1yrnnhla";
       };
       packageRequires = [ denote ];
       meta = {
@@ -2315,10 +2315,10 @@
     elpaBuild {
       pname = "dicom";
       ename = "dicom";
-      version = "1.2.0.20251218.225138";
+      version = "1.3.0.20260117.164829";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/dicom-1.2.0.20251218.225138.tar";
-        sha256 = "0nvywq796fd12zf27rvdyln3k17nwfi0aayg19j1w8j877cb6lp6";
+        url = "https://elpa.gnu.org/devel/dicom-1.3.0.20260117.164829.tar";
+        sha256 = "1gl3fxb051iam2vlxz43zcbw7wlp2vfid2mmdrsmyf3v3j6l5y1d";
       };
       packageRequires = [ compat ];
       meta = {
@@ -2492,10 +2492,10 @@
     elpaBuild {
       pname = "dired-preview";
       ename = "dired-preview";
-      version = "0.6.0.0.20250720.94036";
+      version = "0.6.0.0.20260111.184511";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/dired-preview-0.6.0.0.20250720.94036.tar";
-        sha256 = "09cvi5kcdzghm1l657jnfsvdnfnkfnl76m9vnai49z53a66iivkc";
+        url = "https://elpa.gnu.org/devel/dired-preview-0.6.0.0.20260111.184511.tar";
+        sha256 = "0jrz2bv87vkj9j1dgm0lidy2c3m58a2110v88c1iffjh9c17qb61";
       };
       packageRequires = [ ];
       meta = {
@@ -2543,6 +2543,28 @@
       packageRequires = [ cl-lib ];
       meta = {
         homepage = "https://elpa.gnu.org/devel/dismal.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  disproject = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+      transient,
+    }:
+    elpaBuild {
+      pname = "disproject";
+      ename = "disproject";
+      version = "2.2.0.0.20260114.143840";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/devel/disproject-2.2.0.0.20260114.143840.tar";
+        sha256 = "17314yb73ral42gsb9ylr1r136jra406n17szcwbw10qliswi7k1";
+      };
+      packageRequires = [ transient ];
+      meta = {
+        homepage = "https://elpa.gnu.org/devel/disproject.html";
         license = lib.licenses.free;
       };
     }
@@ -2661,10 +2683,10 @@
     elpaBuild {
       pname = "doric-themes";
       ename = "doric-themes";
-      version = "0.5.0.0.20251211.64439";
+      version = "0.6.0.0.20260117.121125";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/doric-themes-0.5.0.0.20251211.64439.tar";
-        sha256 = "0pizr1qp7jjll04v1x8a6kw4briv58clvg10851wfv9zcbkn9krb";
+        url = "https://elpa.gnu.org/devel/doric-themes-0.6.0.0.20260117.121125.tar";
+        sha256 = "1lzwv1hypgcyzxd0aj0ilm5lkbszpl8g96k2mmfd59pkn3fxvbmz";
       };
       packageRequires = [ ];
       meta = {
@@ -2747,10 +2769,10 @@
     elpaBuild {
       pname = "easy-kill";
       ename = "easy-kill";
-      version = "0.9.5.0.20220511.55730";
+      version = "0.9.5.0.20260112.113033";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/easy-kill-0.9.5.0.20220511.55730.tar";
-        sha256 = "0il8lhi2j80sz63lnjkayryikcya03zn3z40bnfjbsydpyqj4kzd";
+        url = "https://elpa.gnu.org/devel/easy-kill-0.9.5.0.20260112.113033.tar";
+        sha256 = "0889d9hri58hfxj03ga98ji7m6z3jdpi23r72jcf7wmks1546j24";
       };
       packageRequires = [ cl-lib ];
       meta = {
@@ -2885,10 +2907,10 @@
     elpaBuild {
       pname = "ef-themes";
       ename = "ef-themes";
-      version = "2.0.1.0.20251126.165108";
+      version = "2.0.1.0.20260119.182016";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/ef-themes-2.0.1.0.20251126.165108.tar";
-        sha256 = "0indsg2qydwq3rfq227aw9qp8pb1s9n2z8c98bf0qds27slfs93n";
+        url = "https://elpa.gnu.org/devel/ef-themes-2.0.1.0.20260119.182016.tar";
+        sha256 = "0vz1v02jdxyyq4ia6i28avxkvhfasynjp9mzz3a3fmj3aqa5k86y";
       };
       packageRequires = [ modus-themes ];
       meta = {
@@ -2913,10 +2935,10 @@
     elpaBuild {
       pname = "eglot";
       ename = "eglot";
-      version = "1.19.0.20251221.174923";
+      version = "1.21.0.20260117.150219";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/eglot-1.19.0.20251221.174923.tar";
-        sha256 = "0j325nqybhrbbg8js3242vjf1qpaj98prxw5k0vd6kkqbihjvpdw";
+        url = "https://elpa.gnu.org/devel/eglot-1.21.0.20260117.150219.tar";
+        sha256 = "00wqgprz4dav11k6qds5mpac8v553gww96ik9h5pp8m70hpayah5";
       };
       packageRequires = [
         eldoc
@@ -2989,10 +3011,10 @@
     elpaBuild {
       pname = "eldoc";
       ename = "eldoc";
-      version = "1.16.0.0.20251022.171210";
+      version = "1.16.0.0.20260101.125434";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/eldoc-1.16.0.0.20251022.171210.tar";
-        sha256 = "12c7wwlawf5xwc6rg7qij7y92yf53vcwv78spmp4jprzx4h7aj06";
+        url = "https://elpa.gnu.org/devel/eldoc-1.16.0.0.20260101.125434.tar";
+        sha256 = "1c29yb3x2sfnqq690hgvw0f4wsf1aj327k137hwcz6pgc6llgg76";
       };
       packageRequires = [ ];
       meta = {
@@ -3086,10 +3108,10 @@
     elpaBuild {
       pname = "ellama";
       ename = "ellama";
-      version = "1.9.1.0.20251220.224607";
+      version = "1.10.10.0.20260115.215017";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/ellama-1.9.1.0.20251220.224607.tar";
-        sha256 = "1sad5lbi75x4sd5ss748dgvvkckz4wj3ffwjn4m3gk7gzyvf10hm";
+        url = "https://elpa.gnu.org/devel/ellama-1.10.10.0.20260115.215017.tar";
+        sha256 = "0465all7jia8q1ls9aqpn8hqjyprmzx4k5dr7i5fx8zhmxa8pigp";
       };
       packageRequires = [
         compat
@@ -3222,10 +3244,10 @@
     elpaBuild {
       pname = "emms";
       ename = "emms";
-      version = "24.0.20251201.101049";
+      version = "25.0.20260113.142250";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/emms-24.0.20251201.101049.tar";
-        sha256 = "01wk4j2hm1wwsx2wqjj1sfh5skngynw494i9jzpas1q7mqqf7fhy";
+        url = "https://elpa.gnu.org/devel/emms-25.0.20260113.142250.tar";
+        sha256 = "1qg6nicdg49qzpq0bcc3drh7ags63izxpsjrwbfh7x7mw4lazp68";
       };
       packageRequires = [
         cl-lib
@@ -3311,10 +3333,10 @@
     elpaBuild {
       pname = "erc";
       ename = "erc";
-      version = "5.6.2snapshot0.20251027.192944";
+      version = "5.6.2snapshot0.20260111.52503";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/erc-5.6.2snapshot0.20251027.192944.tar";
-        sha256 = "0hhdh7lqfv22774l0b2pgac1k75k00hf8wwi5v5w51qz5sn4v24w";
+        url = "https://elpa.gnu.org/devel/erc-5.6.2snapshot0.20260111.52503.tar";
+        sha256 = "1s2n8gab2m97wmqanzvqxqzr2l25zwaczrgfhk23l2xr9rqq2x16";
       };
       packageRequires = [ compat ];
       meta = {
@@ -3358,10 +3380,10 @@
     elpaBuild {
       pname = "ess";
       ename = "ess";
-      version = "25.1.0.0.20251212.93713";
+      version = "25.1.0.0.20251230.111114";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/ess-25.1.0.0.20251212.93713.tar";
-        sha256 = "1a1swv20ww61g3mc9qxcc8hl5c2k4yvlqvhr0nx2fbbxs4n5ypjd";
+        url = "https://elpa.gnu.org/devel/ess-25.1.0.0.20251230.111114.tar";
+        sha256 = "1ybpalv1868brh0y6c1kx1vvqhxbbpw5066448vrnylsjrz99y7c";
       };
       packageRequires = [ ];
       meta = {
@@ -3451,10 +3473,10 @@
     elpaBuild {
       pname = "external-completion";
       ename = "external-completion";
-      version = "0.1.0.20250806.111358";
+      version = "0.1.0.20260101.125434";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/external-completion-0.1.0.20250806.111358.tar";
-        sha256 = "15r86524q9645xcdhb0ciygfrcnjy9sfihk50i39wqzv9nnp4dhq";
+        url = "https://elpa.gnu.org/devel/external-completion-0.1.0.20260101.125434.tar";
+        sha256 = "0ca24q2l56i5p03l4h1r5qvrqvsc5330csc7aj205hl94wpmhz1z";
       };
       packageRequires = [ ];
       meta = {
@@ -3474,10 +3496,10 @@
     elpaBuild {
       pname = "exwm";
       ename = "exwm";
-      version = "0.34.0.20251218.214313";
+      version = "0.34.0.20260101.133557";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/exwm-0.34.0.20251218.214313.tar";
-        sha256 = "0g8vnf6ksy6fnjh5q15p89vhp6ma62v0hw3r85c249s4zc9w79yp";
+        url = "https://elpa.gnu.org/devel/exwm-0.34.0.20260101.133557.tar";
+        sha256 = "0f84qsamhhrg71qfs4s3klf61idg8kfs40b0fw9kbd5hm1y9jcrc";
       };
       packageRequires = [
         compat
@@ -3608,10 +3630,10 @@
     elpaBuild {
       pname = "flymake";
       ename = "flymake";
-      version = "1.4.3.0.20251130.182434";
+      version = "1.4.3.0.20260111.34201";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/flymake-1.4.3.0.20251130.182434.tar";
-        sha256 = "0sbgjaymf9xg0q5rbykic4i4dfp26lh4adwhp8lla21gzygvdfda";
+        url = "https://elpa.gnu.org/devel/flymake-1.4.3.0.20260111.34201.tar";
+        sha256 = "18l49lgq8856zl1gjqakv8q18wp5k93lfyaxlay15szpcb3nimrk";
       };
       packageRequires = [
         eldoc
@@ -3696,10 +3718,10 @@
     elpaBuild {
       pname = "fontaine";
       ename = "fontaine";
-      version = "3.0.1.0.20250710.40159";
+      version = "3.0.1.0.20260111.105528";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/fontaine-3.0.1.0.20250710.40159.tar";
-        sha256 = "0sb35y50ja6k2fagxaibbi85xq8q3g25k5ci9pwgi355s24yzq77";
+        url = "https://elpa.gnu.org/devel/fontaine-3.0.1.0.20260111.105528.tar";
+        sha256 = "121cm1fjp3simkkql85lf3l03k5amn5fxphcm2c693h5dqldmdkl";
       };
       packageRequires = [ ];
       meta = {
@@ -4166,10 +4188,10 @@
     elpaBuild {
       pname = "greader";
       ename = "greader";
-      version = "0.13.1.0.20251125.85919";
+      version = "0.13.1.0.20260103.220605";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/greader-0.13.1.0.20251125.85919.tar";
-        sha256 = "1k9r0k74wajvmgdsg9dih53h8kp1rd82jyqvivibkrfh5mm0c17l";
+        url = "https://elpa.gnu.org/devel/greader-0.13.1.0.20260103.220605.tar";
+        sha256 = "0sshlb52x8mwcg76arabxavyn6dj63flkkin5n7pdh4hkll0d2gq";
       };
       packageRequires = [
         compat
@@ -4428,10 +4450,10 @@
     elpaBuild {
       pname = "hyperbole";
       ename = "hyperbole";
-      version = "9.0.2pre0.20251213.222302";
+      version = "9.0.2pre0.20260111.164604";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/hyperbole-9.0.2pre0.20251213.222302.tar";
-        sha256 = "1jz5ppskq7xrcjxmayzak4msack80rdjhn6iahcjw8psdjzclcx6";
+        url = "https://elpa.gnu.org/devel/hyperbole-9.0.2pre0.20260111.164604.tar";
+        sha256 = "1f23ai3xhcpf0ka8djpjxc7f2mm3fxb3xvnfma8dgyggw5hgq7lf";
       };
       packageRequires = [ ];
       meta = {
@@ -4492,10 +4514,10 @@
     elpaBuild {
       pname = "indent-bars";
       ename = "indent-bars";
-      version = "0.9.2.0.20251215.220701";
+      version = "1.0.0.0.20260118.100043";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/indent-bars-0.9.2.0.20251215.220701.tar";
-        sha256 = "0gjs9vv769adsjck7ilwyb9g3c6l62bnpcscdwqa9b95vrljnqhv";
+        url = "https://elpa.gnu.org/devel/indent-bars-1.0.0.0.20260118.100043.tar";
+        sha256 = "0mc85hal6vsfbw69mzwpn2n9nnqyhzga91vk5b9vdipn616h1w07";
       };
       packageRequires = [ compat ];
       meta = {
@@ -4826,10 +4848,10 @@
     elpaBuild {
       pname = "jinx";
       ename = "jinx";
-      version = "2.5.0.20251129.80022";
+      version = "2.6.0.20260117.165000";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/jinx-2.5.0.20251129.80022.tar";
-        sha256 = "1idmm627z78477d5q8rm99cb3nwhqb6hz8zsas0lbdrd8q4ynqjy";
+        url = "https://elpa.gnu.org/devel/jinx-2.6.0.20260117.165000.tar";
+        sha256 = "1yn9rprxwzvhp5aifz3chxd62jgrr3d174f0frrg2f1hc8dr4gb5";
       };
       packageRequires = [ compat ];
       meta = {
@@ -4912,10 +4934,10 @@
     elpaBuild {
       pname = "jsonrpc";
       ename = "jsonrpc";
-      version = "1.0.27.0.20251208.214131";
+      version = "1.0.27.0.20260111.34201";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/jsonrpc-1.0.27.0.20251208.214131.tar";
-        sha256 = "0liiaa9xgkjaz6aqajm9qaxj13n1l1b5wpn878fvzrhsn2hlacrd";
+        url = "https://elpa.gnu.org/devel/jsonrpc-1.0.27.0.20260111.34201.tar";
+        sha256 = "0c1lv0lzrx72qfzjrp7zvmz7iqzlic282hc9g9rgxwg03kp2jq4m";
       };
       packageRequires = [ ];
       meta = {
@@ -5160,10 +5182,10 @@
     elpaBuild {
       pname = "let-alist";
       ename = "let-alist";
-      version = "1.0.6.0.20250201.73956";
+      version = "1.0.6.0.20260101.125434";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/let-alist-1.0.6.0.20250201.73956.tar";
-        sha256 = "0qnp9dnnjmygirg8qncnc3mdi6kj08x63njsj6qwbb3276rr18w8";
+        url = "https://elpa.gnu.org/devel/let-alist-1.0.6.0.20260101.125434.tar";
+        sha256 = "0gfphdxvlfdp3g8wm6c51dbnx7s9ghpj1pm6xfibvwh5j8yla1xb";
       };
       packageRequires = [ ];
       meta = {
@@ -5202,10 +5224,10 @@
     elpaBuild {
       pname = "lin";
       ename = "lin";
-      version = "1.1.0.0.20250728.43733";
+      version = "1.1.0.0.20260111.104855";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/lin-1.1.0.0.20250728.43733.tar";
-        sha256 = "0ki0wlkmzmv1byi3gvdrbjhiy3qjb3qka908m5svgwjdxcf6zi7m";
+        url = "https://elpa.gnu.org/devel/lin-1.1.0.0.20260111.104855.tar";
+        sha256 = "0q6h6xdkf4lhmnib3c9yy2rqil731dpfqn4fpc39br7cmzwzhibj";
       };
       packageRequires = [ ];
       meta = {
@@ -5227,10 +5249,10 @@
     elpaBuild {
       pname = "listen";
       ename = "listen";
-      version = "0.10.0.20251214.32417";
+      version = "0.10.1.0.20260105.223313";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/listen-0.10.0.20251214.32417.tar";
-        sha256 = "14azysr2cdjw23g6r7p4vmfbsk07mqzmm1dbhx7sa3ln6a004psr";
+        url = "https://elpa.gnu.org/devel/listen-0.10.1.0.20260105.223313.tar";
+        sha256 = "1aqjjyy6910kiga2di05mz182qr344pwp1iv23jlsm4r8zln6ydm";
       };
       packageRequires = [
         persist
@@ -5278,10 +5300,10 @@
     elpaBuild {
       pname = "llm";
       ename = "llm";
-      version = "0.28.2.0.20251218.214040";
+      version = "0.28.5.0.20260110.215927";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/llm-0.28.2.0.20251218.214040.tar";
-        sha256 = "0g2a7q5szf8iki1xs53sgmpy5dk2nshazkh9si6sacr1zklf5iyy";
+        url = "https://elpa.gnu.org/devel/llm-0.28.5.0.20260110.215927.tar";
+        sha256 = "1pljk62skgv02fv18gs0dvkq6wy7z6aya2qxhlgrh41hifb14837";
       };
       packageRequires = [
         compat
@@ -5411,10 +5433,10 @@
     elpaBuild {
       pname = "logos";
       ename = "logos";
-      version = "1.2.0.0.20251126.175507";
+      version = "1.2.0.0.20260111.105252";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/logos-1.2.0.0.20251126.175507.tar";
-        sha256 = "0wns1k4f7hcqy147r6siv37i2al9dfwdlk8la48x27jr89v6s68y";
+        url = "https://elpa.gnu.org/devel/logos-1.2.0.0.20260111.105252.tar";
+        sha256 = "0566wrazp2z0np1rx6fqv6541b6a37j1k4x9rrnylzk9sgcnr1qp";
       };
       packageRequires = [ ];
       meta = {
@@ -5496,10 +5518,10 @@
     elpaBuild {
       pname = "map";
       ename = "map";
-      version = "3.3.1.0.20251101.195205";
+      version = "3.3.1.0.20260101.125434";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/map-3.3.1.0.20251101.195205.tar";
-        sha256 = "0iaxap5cck1nrsnh3n96g3d5i6d613mdggshdhjapfr2v85xwg9w";
+        url = "https://elpa.gnu.org/devel/map-3.3.1.0.20260101.125434.tar";
+        sha256 = "1darxw7vam0zc0rsxm2v0a239rpc1hnaqqkakmryac2kazbsjg7n";
       };
       packageRequires = [ ];
       meta = {
@@ -5518,10 +5540,10 @@
     elpaBuild {
       pname = "marginalia";
       ename = "marginalia";
-      version = "2.6.0.20251219.142200";
+      version = "2.8.0.20260117.165105";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/marginalia-2.6.0.20251219.142200.tar";
-        sha256 = "00cvpa4wrzncgw7az6679cka8ldbcvg6gnmqbfrgd1iwn0571rvk";
+        url = "https://elpa.gnu.org/devel/marginalia-2.8.0.20260117.165105.tar";
+        sha256 = "0y5cmg778w0mik4pkbb2l9x7qp456dhrhcbyapr5g4ym2jl1id25";
       };
       packageRequires = [ compat ];
       meta = {
@@ -5624,10 +5646,10 @@
     elpaBuild {
       pname = "matlab-mode";
       ename = "matlab-mode";
-      version = "7.4.1.0.20251126.215443";
+      version = "7.4.2.0.20251229.125049";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/matlab-mode-7.4.1.0.20251126.215443.tar";
-        sha256 = "11xpz32z6mb182g0463hwpf5zndk29x6d39d6krca4apqblfmj87";
+        url = "https://elpa.gnu.org/devel/matlab-mode-7.4.2.0.20251229.125049.tar";
+        sha256 = "1rff2njap1ymgmydhsjif1i09x3rnj6xa1xz7x3pp8jyvg5vkzwp";
       };
       packageRequires = [ ];
       meta = {
@@ -5645,10 +5667,10 @@
     elpaBuild {
       pname = "mct";
       ename = "mct";
-      version = "1.1.0.0.20250827.55853";
+      version = "1.1.0.0.20260110.55916";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/mct-1.1.0.0.20250827.55853.tar";
-        sha256 = "0hspc3q453k7wmaiwh9q4b83n41l5fp2nc6di3slzghpjfnskpp6";
+        url = "https://elpa.gnu.org/devel/mct-1.1.0.0.20260110.55916.tar";
+        sha256 = "1721nlynl8qq610zczqbjvbj6bgb4pvm9gqqayg3sn5ns2zs71q1";
       };
       packageRequires = [ ];
       meta = {
@@ -5905,10 +5927,10 @@
     elpaBuild {
       pname = "modus-themes";
       ename = "modus-themes";
-      version = "5.1.0.0.20251219.130658";
+      version = "5.2.0.0.20260113.43126";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/modus-themes-5.1.0.0.20251219.130658.tar";
-        sha256 = "14yk9040cr29s895phmp9px3x5yaxnwmvd3v5z52pz0lz0nf01y7";
+        url = "https://elpa.gnu.org/devel/modus-themes-5.2.0.0.20260113.43126.tar";
+        sha256 = "18wyzmpqax2zy37nm6naf8j059690ghxqkqa9qlqi6297wva229z";
       };
       packageRequires = [ ];
       meta = {
@@ -6247,10 +6269,10 @@
     elpaBuild {
       pname = "notmuch-indicator";
       ename = "notmuch-indicator";
-      version = "1.2.0.0.20250729.50820";
+      version = "1.3.0.0.20260118.63859";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/notmuch-indicator-1.2.0.0.20250729.50820.tar";
-        sha256 = "0wfkrpw1v0h5zjhd47q9m36nbr9ykhqmvzv0bx4rps1k7mbxvv8x";
+        url = "https://elpa.gnu.org/devel/notmuch-indicator-1.3.0.0.20260118.63859.tar";
+        sha256 = "037k14ipdns0wwb0qssz805km2fd781y86d7dfwjzbfjpab0b7jy";
       };
       packageRequires = [ ];
       meta = {
@@ -6268,10 +6290,10 @@
     elpaBuild {
       pname = "ntlm";
       ename = "ntlm";
-      version = "2.1.0.0.20251116.182803";
+      version = "2.1.0.0.20260101.125434";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/ntlm-2.1.0.0.20251116.182803.tar";
-        sha256 = "0qvzs9m9n6bdm4hmw24pl5f991fy3113h4rw1201knyw67g8a4k4";
+        url = "https://elpa.gnu.org/devel/ntlm-2.1.0.0.20260101.125434.tar";
+        sha256 = "0pi2psl9d6jbc4pd3bx4ffmcmk1j3xrl6mk8xxakk5jsnkhlw535";
       };
       packageRequires = [ ];
       meta = {
@@ -6439,10 +6461,10 @@
     elpaBuild {
       pname = "orderless";
       ename = "orderless";
-      version = "1.5.0.20251128.202853";
+      version = "1.5.0.20260117.174956";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/orderless-1.5.0.20251128.202853.tar";
-        sha256 = "0lpz5vzb1ldlxkln9jqhvz0kx3s09q36gdy99r3m10jwfknhq9ka";
+        url = "https://elpa.gnu.org/devel/orderless-1.5.0.20260117.174956.tar";
+        sha256 = "1qrriyzh3gxd8w2v70njlf85yx6m6krkpdmigngbz1zlaw0axnrg";
       };
       packageRequires = [ compat ];
       meta = {
@@ -6460,10 +6482,10 @@
     elpaBuild {
       pname = "org";
       ename = "org";
-      version = "9.8pre0.20251220.112221";
+      version = "9.8pre0.20260113.104754";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/org-9.8pre0.20251220.112221.tar";
-        sha256 = "0i28i0nw93mrbkrrpyi6wipkrb1wf2ahnc7hrzqfws2riwwmnkfj";
+        url = "https://elpa.gnu.org/devel/org-9.8pre0.20260113.104754.tar";
+        sha256 = "161gp3vgl4i99l1z3dc9afs5gigdlflnpxsy78axh35bkli4b1ky";
       };
       packageRequires = [ ];
       meta = {
@@ -6482,10 +6504,10 @@
     elpaBuild {
       pname = "org-contacts";
       ename = "org-contacts";
-      version = "1.1.0.20250905.33527";
+      version = "1.2.0.20260114.75421";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/org-contacts-1.1.0.20250905.33527.tar";
-        sha256 = "1d5d41lrliv30ngqx974lsm3am8k6zll8mh940a777isc4mglvhn";
+        url = "https://elpa.gnu.org/devel/org-contacts-1.2.0.20260114.75421.tar";
+        sha256 = "0x84lmaq5xr8i03hn0k5yvlmv79k6vhgdczavii5pbz6n3ggdhfs";
       };
       packageRequires = [ org ];
       meta = {
@@ -6531,10 +6553,10 @@
     elpaBuild {
       pname = "org-gnosis";
       ename = "org-gnosis";
-      version = "0.1.1.0.20251005.85757";
+      version = "0.1.1.0.20260111.154709";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/org-gnosis-0.1.1.0.20251005.85757.tar";
-        sha256 = "1gwdkrs6r8cxab45xx5f47j4mhsm35iz2kzr7pl21i0nqcr9g2h4";
+        url = "https://elpa.gnu.org/devel/org-gnosis-0.1.1.0.20260111.154709.tar";
+        sha256 = "0il5nqmd6qj3ypglsdfcc4rxpzfrqdp8s4rg7f4jjd5qy2l3kwnw";
       };
       packageRequires = [
         compat
@@ -6579,10 +6601,10 @@
     elpaBuild {
       pname = "org-modern";
       ename = "org-modern";
-      version = "1.11.0.20251219.142444";
+      version = "1.12.0.20260117.165215";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/org-modern-1.11.0.20251219.142444.tar";
-        sha256 = "0plbsm7d7zbammxy74cs9mvc6f1jqzx5m01wfkp0knhfywni6pnx";
+        url = "https://elpa.gnu.org/devel/org-modern-1.12.0.20260117.165215.tar";
+        sha256 = "1izgb25clhfm94091bkw7qb0lanx07d5757w5a7m0z1qcdqpfayw";
       };
       packageRequires = [
         compat
@@ -6673,10 +6695,10 @@
     elpaBuild {
       pname = "org-transclusion";
       ename = "org-transclusion";
-      version = "1.4.0.0.20251218.161651";
+      version = "1.4.0.0.20260115.191247";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/org-transclusion-1.4.0.0.20251218.161651.tar";
-        sha256 = "15z4lw3sz69j9q2x4i9kjvcp0c2r9m5hhrhvq6d6varlsvxd2lf9";
+        url = "https://elpa.gnu.org/devel/org-transclusion-1.4.0.0.20260115.191247.tar";
+        sha256 = "0wjnq0c93jn7w4bqk5l79fvd0x557wgc99fv2xfqr1bzinhss2cy";
       };
       packageRequires = [ org ];
       meta = {
@@ -6759,10 +6781,10 @@
     elpaBuild {
       pname = "osm";
       ename = "osm";
-      version = "1.12.0.20251221.184448";
+      version = "2.1.0.20260118.165714";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/osm-1.12.0.20251221.184448.tar";
-        sha256 = "1532c2zi5qqr0k5xcjl4vpmj717l74mv2z44yiqvnxkr58xghhk0";
+        url = "https://elpa.gnu.org/devel/osm-2.1.0.20260118.165714.tar";
+        sha256 = "177f9ygbfyxb5vghp5c1cq6qy9fjz0ryf0srp3zla42zjfjnd4al";
       };
       packageRequires = [ compat ];
       meta = {
@@ -6887,10 +6909,10 @@
     elpaBuild {
       pname = "parser-generator";
       ename = "parser-generator";
-      version = "0.2.7.0.20251221.222232";
+      version = "0.2.8.0.20251225.164758";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/parser-generator-0.2.7.0.20251221.222232.tar";
-        sha256 = "1jjipwac85qw15igyx1skgc7jqajsfc3ks5ypdhrg2bv6v6xiwvn";
+        url = "https://elpa.gnu.org/devel/parser-generator-0.2.8.0.20251225.164758.tar";
+        sha256 = "12vd2kc1z0n7zcq5ld7rqkrqzcpgjb9b4pfqbkca5h8gvfyjav48";
       };
       packageRequires = [ ];
       meta = {
@@ -7015,10 +7037,10 @@
     elpaBuild {
       pname = "phps-mode";
       ename = "phps-mode";
-      version = "0.4.51.0.20250428.55352";
+      version = "0.4.52.0.20260109.100035";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/phps-mode-0.4.51.0.20250428.55352.tar";
-        sha256 = "1r0faz9ijidagzcbphz7w2qwbxbdyznxk9ffx2rmrhjbizknrcm9";
+        url = "https://elpa.gnu.org/devel/phps-mode-0.4.52.0.20260109.100035.tar";
+        sha256 = "0la7152a0abgdn3kh9rz6xgn46k1r70aglia4k490nyih7ypdy7p";
       };
       packageRequires = [ ];
       meta = {
@@ -7313,10 +7335,10 @@
     elpaBuild {
       pname = "preview-auto";
       ename = "preview-auto";
-      version = "0.4.1.0.20250831.100412";
+      version = "0.4.1.0.20251222.150444";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/preview-auto-0.4.1.0.20250831.100412.tar";
-        sha256 = "0lr67fldqw76r7p8q7lbsw156k50k2adrp90m5n7w7gdsydqycdp";
+        url = "https://elpa.gnu.org/devel/preview-auto-0.4.1.0.20251222.150444.tar";
+        sha256 = "1lrj5053zndswqy914ngxvprcvrgdrrvwr6vlwgjdvmlpk1fyk5i";
       };
       packageRequires = [ auctex ];
       meta = {
@@ -7357,10 +7379,10 @@
     elpaBuild {
       pname = "project";
       ename = "project";
-      version = "0.11.1.0.20251219.75658";
+      version = "0.11.2.0.20260115.65220";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/project-0.11.1.0.20251219.75658.tar";
-        sha256 = "186siyk941vxqln0y2sw0bvwk00pc4cqgqhy6g45z1q9iv8hnz78";
+        url = "https://elpa.gnu.org/devel/project-0.11.2.0.20260115.65220.tar";
+        sha256 = "0aah8nssxagr5znf08fs5zzdzin8iipk9chhhfv5l1dpqdi200r1";
       };
       packageRequires = [ xref ];
       meta = {
@@ -7420,10 +7442,10 @@
     elpaBuild {
       pname = "pulsar";
       ename = "pulsar";
-      version = "1.3.2.0.20251215.144925";
+      version = "1.3.2.0.20260111.105226";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/pulsar-1.3.2.0.20251215.144925.tar";
-        sha256 = "0liawy1x096cisj13dxhv2dcrvvh6fwln41qg3wis5n7lc2y676f";
+        url = "https://elpa.gnu.org/devel/pulsar-1.3.2.0.20260111.105226.tar";
+        sha256 = "0lj8slzakg34f66ig4lq91hvqq92ja2vapwm9af8d1rphpz6qnil";
       };
       packageRequires = [ ];
       meta = {
@@ -7443,10 +7465,10 @@
     elpaBuild {
       pname = "pyim";
       ename = "pyim";
-      version = "5.3.5.0.20251125.83959";
+      version = "5.3.6.0.20251230.80953";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/pyim-5.3.5.0.20251125.83959.tar";
-        sha256 = "0l3kdkjl3p5mz8cnjf3j4cm35yri5z5lqcg2mchp1ig3i9v16jhz";
+        url = "https://elpa.gnu.org/devel/pyim-5.3.6.0.20251230.80953.tar";
+        sha256 = "0vqy4vxsw6inghfjmk7bqry8zw9rm9yaz1zffr19a8nwqiwbvszc";
       };
       packageRequires = [
         async
@@ -7493,10 +7515,10 @@
     elpaBuild {
       pname = "python";
       ename = "python";
-      version = "0.30.0.20251109.72005";
+      version = "0.30.0.20260117.160903";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/python-0.30.0.20251109.72005.tar";
-        sha256 = "1xrhr5qpxv6nxvi1xrrp3ynq71iviaphs5rnnry0k56x1f66d08l";
+        url = "https://elpa.gnu.org/devel/python-0.30.0.20260117.160903.tar";
+        sha256 = "04m2p8054yfd0152dr7m08b4jszb15j91v3l97ailcasqfvwk80s";
       };
       packageRequires = [
         compat
@@ -7691,10 +7713,10 @@
     elpaBuild {
       pname = "realgud";
       ename = "realgud";
-      version = "1.5.1.0.20251024.174500";
+      version = "1.6.0.0.20260111.74248";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/realgud-1.5.1.0.20251024.174500.tar";
-        sha256 = "027v496szcwn1ldhvjs6sd0hfnsc2jlbbg71v775ijym4w97wz1k";
+        url = "https://elpa.gnu.org/devel/realgud-1.6.0.0.20260111.74248.tar";
+        sha256 = "1ma8nahs8gy8wmjwmdazbnfwc52kcgy3pwbnawmp3sycz8kvdpqq";
       };
       packageRequires = [
         load-relative
@@ -7770,10 +7792,10 @@
     elpaBuild {
       pname = "realgud-lldb";
       ename = "realgud-lldb";
-      version = "1.0.2.0.20241118.210939";
+      version = "1.0.2.0.20260105.115809";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/realgud-lldb-1.0.2.0.20241118.210939.tar";
-        sha256 = "1wpl9608rg6a6nbrnqmhhd8wwwdaf6cpw4lxv59bz2n903bbyr1d";
+        url = "https://elpa.gnu.org/devel/realgud-lldb-1.0.2.0.20260105.115809.tar";
+        sha256 = "0a2wcq67lxvq4033bal1rvha1f6x6day2db7z36hc3wqcd0l6zxa";
       };
       packageRequires = [
         load-relative
@@ -8338,10 +8360,10 @@
     elpaBuild {
       pname = "show-font";
       ename = "show-font";
-      version = "1.0.0.0.20250907.131347";
+      version = "1.0.0.0.20260111.105401";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/show-font-1.0.0.0.20250907.131347.tar";
-        sha256 = "13z63f0sxpl078hzqd1v3naynb4j9h6c26xpxkjifjsl3rw333ch";
+        url = "https://elpa.gnu.org/devel/show-font-1.0.0.0.20260111.105401.tar";
+        sha256 = "146mmg4kv3sz9bd4b1026fsws16w3nz99m4sbkhgwaf09mrr2bkl";
       };
       packageRequires = [ ];
       meta = {
@@ -8380,10 +8402,10 @@
     elpaBuild {
       pname = "site-lisp";
       ename = "site-lisp";
-      version = "0.3.0pre0.20251211.192642";
+      version = "0.3.0.0.20251230.232614";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/site-lisp-0.3.0pre0.20251211.192642.tar";
-        sha256 = "0ffpq8749w3kg5kgmf01g09khbihxda4raf2ncml6xsijp6m9bj5";
+        url = "https://elpa.gnu.org/devel/site-lisp-0.3.0.0.20251230.232614.tar";
+        sha256 = "0j6gv9ccjfix0dslqfkf5n0w2x13k7a1ilq2y09k66ymcyvinkf9";
       };
       packageRequires = [ ];
       meta = {
@@ -8529,10 +8551,10 @@
     elpaBuild {
       pname = "so-long";
       ename = "so-long";
-      version = "1.1.2.0.20250315.100518";
+      version = "1.1.2.0.20260101.125434";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/so-long-1.1.2.0.20250315.100518.tar";
-        sha256 = "0jjf9y2swl23njng62l43avy37s4ca18z8g647mkp50rx02j9q8b";
+        url = "https://elpa.gnu.org/devel/so-long-1.1.2.0.20260101.125434.tar";
+        sha256 = "060z86ks3dckap8wppyalh7c75d125jw3np4khya1974sw58wfrm";
       };
       packageRequires = [ ];
       meta = {
@@ -8551,10 +8573,10 @@
     elpaBuild {
       pname = "soap-client";
       ename = "soap-client";
-      version = "3.2.3.0.20250226.15703";
+      version = "3.2.3.0.20260101.125434";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/soap-client-3.2.3.0.20250226.15703.tar";
-        sha256 = "0nnksnwhx9fhj3lrc8s1l2c075xgpcfz5hmdk253835n0wzfz3n5";
+        url = "https://elpa.gnu.org/devel/soap-client-3.2.3.0.20260101.125434.tar";
+        sha256 = "0qdr97gqjaj8pli78aapq1hfrpwgdkapsdfqj64cwc3jcbzw5554";
       };
       packageRequires = [ cl-lib ];
       meta = {
@@ -8615,10 +8637,10 @@
     elpaBuild {
       pname = "spacious-padding";
       ename = "spacious-padding";
-      version = "0.8.0.0.20251213.180643";
+      version = "0.8.0.0.20260111.105014";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/spacious-padding-0.8.0.0.20251213.180643.tar";
-        sha256 = "1y12mhzp5mai61fwrypln9arkirxr05njkf0fm924jp7nwnbbacs";
+        url = "https://elpa.gnu.org/devel/spacious-padding-0.8.0.0.20260111.105014.tar";
+        sha256 = "0yxml44g1lc0r2jca9qwbkqv3d2jx79nvyhw1gxx6wjj76wlwzwf";
       };
       packageRequires = [ ];
       meta = {
@@ -8812,10 +8834,10 @@
     elpaBuild {
       pname = "standard-themes";
       ename = "standard-themes";
-      version = "3.0.2.0.20251130.170153";
+      version = "3.0.2.0.20260111.90308";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/standard-themes-3.0.2.0.20251130.170153.tar";
-        sha256 = "04r8sswyzkmmx16jx603c45ahc67wdx574xli3969cm06hnbizvv";
+        url = "https://elpa.gnu.org/devel/standard-themes-3.0.2.0.20260111.90308.tar";
+        sha256 = "17nkzfq0cfk0rylrqwfxmlyhk6l8csdvhk99s741d9vlzbmas1x0";
       };
       packageRequires = [ modus-themes ];
       meta = {
@@ -8854,10 +8876,10 @@
     elpaBuild {
       pname = "substitute";
       ename = "substitute";
-      version = "0.4.0.0.20251218.52712";
+      version = "0.5.0.0.20260105.62903";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/substitute-0.4.0.0.20251218.52712.tar";
-        sha256 = "0hlbqwpa7sqy46l37dylr29v93in75my4hj6wxni1w7xa846l0xr";
+        url = "https://elpa.gnu.org/devel/substitute-0.5.0.0.20260105.62903.tar";
+        sha256 = "13bgq1niji5nxy1f543nhwlvpa00n00ypg519fm6s9ylmg9gza4z";
       };
       packageRequires = [ ];
       meta = {
@@ -8875,10 +8897,10 @@
     elpaBuild {
       pname = "svg";
       ename = "svg";
-      version = "1.1.0.20250101.73917";
+      version = "1.1.0.20260101.125434";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/svg-1.1.0.20250101.73917.tar";
-        sha256 = "1sacdwkqh5vb9bnd1vmxjk35nl9rzakh5v9mpzslh2mjysx61bmm";
+        url = "https://elpa.gnu.org/devel/svg-1.1.0.20260101.125434.tar";
+        sha256 = "1h1npvbwv5mgcqd1wg35hh6v1zkxl0bghgdp320p55hvzp18f2j2";
       };
       packageRequires = [ ];
       meta = {
@@ -9005,10 +9027,10 @@
     elpaBuild {
       pname = "sxhkdrc-mode";
       ename = "sxhkdrc-mode";
-      version = "1.2.0.0.20250814.70257";
+      version = "1.2.0.0.20260111.105425";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/sxhkdrc-mode-1.2.0.0.20250814.70257.tar";
-        sha256 = "1zjkhhpsiq5wdp2lyq98zrxj52c5h6kr4vn9dfimgkx3z3z8dcgl";
+        url = "https://elpa.gnu.org/devel/sxhkdrc-mode-1.2.0.0.20260111.105425.tar";
+        sha256 = "07a9ykifnan2wljglkrl7yk2s3ihb8ij47bqlkq7c6w74symgz7z";
       };
       packageRequires = [ ];
       meta = {
@@ -9185,10 +9207,10 @@
     elpaBuild {
       pname = "tempel";
       ename = "tempel";
-      version = "1.9.0.20251130.84712";
+      version = "1.9.0.20260119.133441";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/tempel-1.9.0.20251130.84712.tar";
-        sha256 = "0jsxpvivnkc5cjwcrh17zqr5a02cg8magyj4shlb0qzm13gsrsmg";
+        url = "https://elpa.gnu.org/devel/tempel-1.9.0.20260119.133441.tar";
+        sha256 = "1a642c0rasmyx94i7bjg9lpqj0sr624zi3vwz1jn2bxjfv3p3jpk";
       };
       packageRequires = [ compat ];
       meta = {
@@ -9220,7 +9242,7 @@
   ) { };
   test-simple = callPackage (
     {
-      cl-lib ? null,
+      compat,
       elpaBuild,
       fetchurl,
       lib,
@@ -9228,12 +9250,12 @@
     elpaBuild {
       pname = "test-simple";
       ename = "test-simple";
-      version = "1.3.1.0.20251124.94637";
+      version = "1.3.2.0.20260118.164127";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/test-simple-1.3.1.0.20251124.94637.tar";
-        sha256 = "119lz1ddsqn6hzidx4s85p42c2a62xm55c8p6xjkr0c7radyxww3";
+        url = "https://elpa.gnu.org/devel/test-simple-1.3.2.0.20260118.164127.tar";
+        sha256 = "0plxxqm2qvnhr697x1ivdlawf8759aqg05im7zcja8bbc5mc16nv";
       };
-      packageRequires = [ cl-lib ];
+      packageRequires = [ compat ];
       meta = {
         homepage = "https://elpa.gnu.org/devel/test-simple.html";
         license = lib.licenses.free;
@@ -9376,10 +9398,10 @@
     elpaBuild {
       pname = "tmr";
       ename = "tmr";
-      version = "1.2.1.0.20251019.73644";
+      version = "1.2.1.0.20260119.190816";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/tmr-1.2.1.0.20251019.73644.tar";
-        sha256 = "0q67k82yqdvvgglhmdlmkmvf1dy1pwqyfhj3b1d9nmm603j1yql4";
+        url = "https://elpa.gnu.org/devel/tmr-1.2.1.0.20260119.190816.tar";
+        sha256 = "0c331q79fgvm0rhp2am836mqv70grzrdjvs10x8a74hmn9f0qr79";
       };
       packageRequires = [ ];
       meta = {
@@ -9444,10 +9466,10 @@
     elpaBuild {
       pname = "track-changes";
       ename = "track-changes";
-      version = "1.4.0.20250312.1734";
+      version = "1.5.0.20260101.125434";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/track-changes-1.4.0.20250312.1734.tar";
-        sha256 = "003cp1sz74nj92dbvcm4gzsr546v5l38ifi76371lv3j5wxjfgsi";
+        url = "https://elpa.gnu.org/devel/track-changes-1.5.0.20260101.125434.tar";
+        sha256 = "1mdjnchrg3rc4f331m4hv7y2n6s9f9qs629sx3rsp0rcirir8mh6";
       };
       packageRequires = [ ];
       meta = {
@@ -9465,10 +9487,10 @@
     elpaBuild {
       pname = "tramp";
       ename = "tramp";
-      version = "2.8.0.5.0.20251129.84238";
+      version = "2.8.1.0.20260111.85658";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/tramp-2.8.0.5.0.20251129.84238.tar";
-        sha256 = "1rfp3rd37bmnx6z4d6s3ksppmcishq233hfagj6yw98xmj5pyvsy";
+        url = "https://elpa.gnu.org/devel/tramp-2.8.1.0.20260111.85658.tar";
+        sha256 = "0ya9jdsd2h91rc37qxm15aniivlrnmlmqzmk2hlrqdy0qpkismw8";
       };
       packageRequires = [ ];
       meta = {
@@ -9487,10 +9509,10 @@
     elpaBuild {
       pname = "tramp-hlo";
       ename = "tramp-hlo";
-      version = "0.0.2.0.20251217.141452";
+      version = "0.0.2.0.20251231.3054";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/tramp-hlo-0.0.2.0.20251217.141452.tar";
-        sha256 = "0pf0iph98xs3m30gri8vn720icf1hx2543p8y48k90b8jhi4k9v2";
+        url = "https://elpa.gnu.org/devel/tramp-hlo-0.0.2.0.20251231.3054.tar";
+        sha256 = "0gs9bb7w18ln46zi2h128rg3hv89cd2ixcg9i89s8d92ya4ff572";
       };
       packageRequires = [ tramp ];
       meta = {
@@ -9574,10 +9596,10 @@
     elpaBuild {
       pname = "transient";
       ename = "transient";
-      version = "0.11.0.0.20251215.220901";
+      version = "0.12.0.0.20260118.132220";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/transient-0.11.0.0.20251215.220901.tar";
-        sha256 = "0fkmfybvwb8j3lai105npmfa5blg3vlgv9qnmi11g185pan4l09l";
+        url = "https://elpa.gnu.org/devel/transient-0.12.0.0.20260118.132220.tar";
+        sha256 = "1b0x7ljqgxdc9dw63v7jvqzhs7vkck54xjvyfx9fhsiq2ijnw3yp";
       };
       packageRequires = [
         compat
@@ -9823,10 +9845,10 @@
     elpaBuild {
       pname = "url-http-oauth";
       ename = "url-http-oauth";
-      version = "0.8.4.0.20250626.204641";
+      version = "0.8.5.0.20251229.211304";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/url-http-oauth-0.8.4.0.20250626.204641.tar";
-        sha256 = "1krqpp8zvc79xqb8jn9pq9scxrv8cj8bim53nspr67v0z21y3wzc";
+        url = "https://elpa.gnu.org/devel/url-http-oauth-0.8.5.0.20251229.211304.tar";
+        sha256 = "17r54w32j97x52yxwxgadwxkfbh3d7byhn3f752dvd1r6jksn415";
       };
       packageRequires = [ ];
       meta = {
@@ -9866,10 +9888,10 @@
     elpaBuild {
       pname = "use-package";
       ename = "use-package";
-      version = "2.4.6.0.20251211.73227";
+      version = "2.4.6.0.20260101.125434";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/use-package-2.4.6.0.20251211.73227.tar";
-        sha256 = "1bkjw1hhn8mjjlyqyqha9gykiiyf06aims2x2jlpmrqwp7sbww03";
+        url = "https://elpa.gnu.org/devel/use-package-2.4.6.0.20260101.125434.tar";
+        sha256 = "1i460law39bbfsy2y55jirnab3yv2g88qgx4n88lygq1drvc3qrg";
       };
       packageRequires = [ bind-key ];
       meta = {
@@ -9913,10 +9935,10 @@
     elpaBuild {
       pname = "valign";
       ename = "valign";
-      version = "3.1.1.0.20210501.211155";
+      version = "3.1.1.0.20251228.153858";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/valign-3.1.1.0.20210501.211155.tar";
-        sha256 = "1w5by0y4552c2qlm708b3523fp9sgizd0zxrwk2k1v6qwh04pa67";
+        url = "https://elpa.gnu.org/devel/valign-3.1.1.0.20251228.153858.tar";
+        sha256 = "1ah9qdxlc2m6k536dyc6pfxvh1jmbfxcpcybka4r447dssq5ysfz";
       };
       packageRequires = [ ];
       meta = {
@@ -9999,10 +10021,10 @@
     elpaBuild {
       pname = "vc-jj";
       ename = "vc-jj";
-      version = "0.5.0.20251221.141753";
+      version = "0.5.0.20260119.103313";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/vc-jj-0.5.0.20251221.141753.tar";
-        sha256 = "0jz530g3y3had0crnsl9hi01av5ihhb6ga3rsh71rmpcmgs1d1h2";
+        url = "https://elpa.gnu.org/devel/vc-jj-0.5.0.20260119.103313.tar";
+        sha256 = "0h4lz3mr7iwd2ik17my467pa7k47xz5y67ccwmgkgyq2wkr2s4dm";
       };
       packageRequires = [ compat ];
       meta = {
@@ -10110,10 +10132,10 @@
     elpaBuild {
       pname = "verilog-mode";
       ename = "verilog-mode";
-      version = "2025.11.8.248496848.0.20251108.183358";
+      version = "2026.1.18.88738971.0.20260118.95917";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/verilog-mode-2025.11.8.248496848.0.20251108.183358.tar";
-        sha256 = "1hi0lh5zkkskac9vjxhjir503jam8vrl5ziimx9h96xvgcvzkl88";
+        url = "https://elpa.gnu.org/devel/verilog-mode-2026.1.18.88738971.0.20260118.95917.tar";
+        sha256 = "1h5mp70kg1w85g0kx6ipdczkza553d7mzffxx832j4wx3wr5afql";
       };
       packageRequires = [ ];
       meta = {
@@ -10132,10 +10154,10 @@
     elpaBuild {
       pname = "vertico";
       ename = "vertico";
-      version = "2.6.0.20251120.114024";
+      version = "2.7.0.20260119.65523";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/vertico-2.6.0.20251120.114024.tar";
-        sha256 = "18zn72wm5fs4azpb2wznjf849di9ykpagx1r0ic8ck2pgmiq1crg";
+        url = "https://elpa.gnu.org/devel/vertico-2.7.0.20260119.65523.tar";
+        sha256 = "131534qw0g88fyr4klk226abywm0vxzvwmq06pp4zf4k4114d2hy";
       };
       packageRequires = [ compat ];
       meta = {
@@ -10391,10 +10413,10 @@
     elpaBuild {
       pname = "which-key";
       ename = "which-key";
-      version = "3.6.1.0.20250330.141700";
+      version = "3.6.1.0.20260101.125434";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/which-key-3.6.1.0.20250330.141700.tar";
-        sha256 = "0gg43zbsvfkhzbaw3msvd6kvimkdih2j15g63dz3nfq11m9iw70l";
+        url = "https://elpa.gnu.org/devel/which-key-3.6.1.0.20260101.125434.tar";
+        sha256 = "0pifacbpkjyg6111msqa75w2xrfm7j8g3shnla1iygz2w923ga34";
       };
       packageRequires = [ ];
       meta = {
@@ -10434,10 +10456,10 @@
     elpaBuild {
       pname = "window-tool-bar";
       ename = "window-tool-bar";
-      version = "0.3.0.20250313.50858";
+      version = "0.3.0.20260101.125434";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/window-tool-bar-0.3.0.20250313.50858.tar";
-        sha256 = "00cvxm8qgfck1ydc3089c4p707wmqb2x0z2nc8xjzb38p4khw0pr";
+        url = "https://elpa.gnu.org/devel/window-tool-bar-0.3.0.20260101.125434.tar";
+        sha256 = "1n8w2c017mzbpjikj0h8qxr6zf37vklnz5sw5zvjaji8k4dd1zxd";
       };
       packageRequires = [ compat ];
       meta = {
@@ -10630,10 +10652,10 @@
     elpaBuild {
       pname = "xelb";
       ename = "xelb";
-      version = "0.22.0.20251204.72237";
+      version = "0.22.0.20260101.133501";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/xelb-0.22.0.20251204.72237.tar";
-        sha256 = "1n34ycv1wkcj7i8dhr1zx2chmh7jz106ma86s69aysh9awnj5xww";
+        url = "https://elpa.gnu.org/devel/xelb-0.22.0.20260101.133501.tar";
+        sha256 = "1ksx3g7gzfj8y3xb2ziz309xw9g1nchkhif9wxrm0g0gqx6cmmbr";
       };
       packageRequires = [ compat ];
       meta = {
@@ -10698,10 +10720,10 @@
     elpaBuild {
       pname = "xref";
       ename = "xref";
-      version = "1.7.0.0.20251018.61546";
+      version = "1.7.0.0.20260101.125434";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/xref-1.7.0.0.20251018.61546.tar";
-        sha256 = "1rjs45x2fsdyrccj6fsil30c01qpf5mp5wkxk2n1zxas7b4wk0yz";
+        url = "https://elpa.gnu.org/devel/xref-1.7.0.0.20260101.125434.tar";
+        sha256 = "0rp9r6s7k20jhhq2nbd0n8i42i5j0cjgni8b8xf7v22f4mksl5pk";
       };
       packageRequires = [ ];
       meta = {
@@ -10740,10 +10762,10 @@
     elpaBuild {
       pname = "yaml";
       ename = "yaml";
-      version = "1.2.1.0.20251029.205644";
+      version = "1.2.3.0.20260113.65351";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/yaml-1.2.1.0.20251029.205644.tar";
-        sha256 = "06cgcl18jff3dqi8qva0qxr8332blzdps0wrkc7ql8hk5a7iwds1";
+        url = "https://elpa.gnu.org/devel/yaml-1.2.3.0.20260113.65351.tar";
+        sha256 = "09ffagrz3qnbca8z4wm6bvxmdfnl2355sz9vgs9x3cavmy3pfy1x";
       };
       packageRequires = [ ];
       meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
@@ -440,10 +440,10 @@
     elpaBuild {
       pname = "auctex";
       ename = "auctex";
-      version = "14.1.0";
+      version = "14.1.2";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/auctex-14.1.0.tar";
-        sha256 = "0cb5f86p7yxqx27wck2a3wgsxrzhv5rrgn88wpias1w7v2lbsw2j";
+        url = "https://elpa.gnu.org/packages/auctex-14.1.2.tar";
+        sha256 = "0dp95siam576ji9ccznd7abclrxv14xbcmbkqaawf73q2rmfjwip";
       };
       packageRequires = [ ];
       meta = {
@@ -1085,10 +1085,10 @@
     elpaBuild {
       pname = "cape";
       ename = "cape";
-      version = "2.4";
+      version = "2.5";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/cape-2.4.tar";
-        sha256 = "12xr8gqhwyhvyh8nh8g0n675xsrja5i1m558likfa6np42iw79pc";
+        url = "https://elpa.gnu.org/packages/cape-2.5.tar";
+        sha256 = "1xfrz3pvryp0b5x14dy04s97j3ir0iqxaij77a64gqvpmfjg154i";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1527,10 +1527,10 @@
     elpaBuild {
       pname = "consult";
       ename = "consult";
-      version = "3.1";
+      version = "3.3";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/consult-3.1.tar";
-        sha256 = "1yc2q9jmcdvvpg59qlvysj29x9hnimbn2jhgr3s64kfnr2gcaj5c";
+        url = "https://elpa.gnu.org/packages/consult-3.3.tar";
+        sha256 = "02gbd92hkxd34q9ba0fymwjfxl780bfrkfb78wvn53z08z4snkvn";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1640,10 +1640,10 @@
     elpaBuild {
       pname = "corfu";
       ename = "corfu";
-      version = "2.6";
+      version = "2.8";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/corfu-2.6.tar";
-        sha256 = "0pk3hbml8zcpr2y46xc46wb0lghfc103r3ypmpivynncnxm4yg78";
+        url = "https://elpa.gnu.org/packages/corfu-2.8.tar";
+        sha256 = "06hg8q3apv8j4jb08rjjihijfy8jkd89v5x57lblhzzich2z8rwz";
       };
       packageRequires = [ compat ];
       meta = {
@@ -2274,10 +2274,10 @@
     elpaBuild {
       pname = "dicom";
       ename = "dicom";
-      version = "1.2";
+      version = "1.3";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/dicom-1.2.tar";
-        sha256 = "1k1n7i2nzbcs8jqnhiksh79xyp80x94h18jwgl7s0c0akcp8365n";
+        url = "https://elpa.gnu.org/packages/dicom-1.3.tar";
+        sha256 = "05n9azzj0wskzd0jzyqhfk3blss31wjzp8wkqam79hq0j6daf6g5";
       };
       packageRequires = [ compat ];
       meta = {
@@ -2620,10 +2620,10 @@
     elpaBuild {
       pname = "doric-themes";
       ename = "doric-themes";
-      version = "0.5.0";
+      version = "0.6.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/doric-themes-0.5.0.tar";
-        sha256 = "11889xskdp42ckbk75wiy1f5sdy1ia04ndn48vn2dw57pcgmjcnw";
+        url = "https://elpa.gnu.org/packages/doric-themes-0.6.0.tar";
+        sha256 = "0rfdlzxg5xsmx4qzv9ffsp82immwaj44q2kmqr9lrrzqw185gwxy";
       };
       packageRequires = [ ];
       meta = {
@@ -2872,10 +2872,10 @@
     elpaBuild {
       pname = "eglot";
       ename = "eglot";
-      version = "1.19";
+      version = "1.21";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/eglot-1.19.tar";
-        sha256 = "0bsz3grw41nh5r76brfdb4gb3hncs5chlhwsqm6qqg0ach69m7zi";
+        url = "https://elpa.gnu.org/packages/eglot-1.21.tar";
+        sha256 = "03fx22rv8ijxq0jnn7xlfqhkpk2b109ygpjbcchp41sa4q7d6nbl";
       };
       packageRequires = [
         eldoc
@@ -3045,10 +3045,10 @@
     elpaBuild {
       pname = "ellama";
       ename = "ellama";
-      version = "1.9.1";
+      version = "1.10.10";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/ellama-1.9.1.tar";
-        sha256 = "0hbzscvh7kfccnr2r2q59r2kk91x28f7wr3cbfmlvixy9wxwb0v8";
+        url = "https://elpa.gnu.org/packages/ellama-1.10.10.tar";
+        sha256 = "1j04fmkhrdj5xnvh1c3x2s2fdn6mv2q2gckjgpi4n2wnyd87mdgg";
       };
       packageRequires = [
         compat
@@ -3181,10 +3181,10 @@
     elpaBuild {
       pname = "emms";
       ename = "emms";
-      version = "24";
+      version = "25";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/emms-24.tar";
-        sha256 = "1nl152v27ryxq3g2dzg52xv3znw08wh486ax5dxkd2wvj6rv0dbg";
+        url = "https://elpa.gnu.org/packages/emms-25.tar";
+        sha256 = "1p194bgysn0mmnaz0n9j236dmz53dlyg202xgq03bi5sl7lrffgp";
       };
       packageRequires = [
         cl-lib
@@ -4453,10 +4453,10 @@
     elpaBuild {
       pname = "indent-bars";
       ename = "indent-bars";
-      version = "0.9.2";
+      version = "1.0.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/indent-bars-0.9.2.tar";
-        sha256 = "030haxxla7m6p2zks9g50dj8rr8grm67n2ig7zd3k20h1yrfm6q0";
+        url = "https://elpa.gnu.org/packages/indent-bars-1.0.0.tar";
+        sha256 = "0iifmipmbry7r2xsq4i2q1k2awcy4z7v3bd509r50i3mc5002ssf";
       };
       packageRequires = [ compat ];
       meta = {
@@ -4787,10 +4787,10 @@
     elpaBuild {
       pname = "jinx";
       ename = "jinx";
-      version = "2.5";
+      version = "2.6";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/jinx-2.5.tar";
-        sha256 = "0ggivcvm6kwnw6yk86vkvahfxzn72nw848nzzj77jkcf6717x8lb";
+        url = "https://elpa.gnu.org/packages/jinx-2.6.tar";
+        sha256 = "0ypskc341xixx47b9zbcf890jfbwi96y4lnp005mh2bz27z8pvqc";
       };
       packageRequires = [ compat ];
       meta = {
@@ -5188,10 +5188,10 @@
     elpaBuild {
       pname = "listen";
       ename = "listen";
-      version = "0.10";
+      version = "0.10.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/listen-0.10.tar";
-        sha256 = "0n7shxxyy8zbxkz0g15mi4hrgc4kz2wp3rczcm0g9amcd0k7fc0h";
+        url = "https://elpa.gnu.org/packages/listen-0.10.1.tar";
+        sha256 = "1ypiv56cj5qiwf3bzipb7ahc3j1adx0fczv0kxfa0j2xc5ndn7z1";
       };
       packageRequires = [
         persist
@@ -5239,10 +5239,10 @@
     elpaBuild {
       pname = "llm";
       ename = "llm";
-      version = "0.28.2";
+      version = "0.28.5";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/llm-0.28.2.tar";
-        sha256 = "1xib4i7z5xj5j3ldw4bk3nl99rmq933glkf3ap2gjw9fr0nxq6fb";
+        url = "https://elpa.gnu.org/packages/llm-0.28.5.tar";
+        sha256 = "0imqqp95knnjx9c2x0ipgpr82j23jiqldldkff9qx19qkp66jq9l";
       };
       packageRequires = [
         compat
@@ -5477,10 +5477,10 @@
     elpaBuild {
       pname = "marginalia";
       ename = "marginalia";
-      version = "2.6";
+      version = "2.8";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/marginalia-2.6.tar";
-        sha256 = "082jkql871dflsnswdbxrifyfq4hi1r2f12kwsvkdxcsc93s32s8";
+        url = "https://elpa.gnu.org/packages/marginalia-2.8.tar";
+        sha256 = "0gshbibjpzi1cxvyg1jvxgp9a1n7pgizf8nibx6kmj10liilcjmk";
       };
       packageRequires = [ compat ];
       meta = {
@@ -5583,10 +5583,10 @@
     elpaBuild {
       pname = "matlab-mode";
       ename = "matlab-mode";
-      version = "7.4.1";
+      version = "7.4.2";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/matlab-mode-7.4.1.tar";
-        sha256 = "14y8hbkk7cz5s1kpv9id5i4kp4y36zvdznjygqp6yp0b6d3w3kc8";
+        url = "https://elpa.gnu.org/packages/matlab-mode-7.4.2.tar";
+        sha256 = "03dfhmcmd7c5iyzv6p5p56cr88nx10jvkvmlan7953g2w10nh836";
       };
       packageRequires = [ ];
       meta = {
@@ -5843,10 +5843,10 @@
     elpaBuild {
       pname = "modus-themes";
       ename = "modus-themes";
-      version = "5.1.0";
+      version = "5.2.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/modus-themes-5.1.0.tar";
-        sha256 = "0n7mhf3zp96srm7d0i87ps18h08k3pap904y78xz22xhm98ljsnl";
+        url = "https://elpa.gnu.org/packages/modus-themes-5.2.0.tar";
+        sha256 = "1715x863mbvcc2lqf61lll5j50zhpc0jysdgd7v0ajznx40kqmxv";
       };
       packageRequires = [ ];
       meta = {
@@ -6182,10 +6182,10 @@
     elpaBuild {
       pname = "notmuch-indicator";
       ename = "notmuch-indicator";
-      version = "1.2.0";
+      version = "1.3.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/notmuch-indicator-1.2.0.tar";
-        sha256 = "1n525slxs0l5nbila1sy62fz384yz7f54nrq1ixdlq0j3czgh9kz";
+        url = "https://elpa.gnu.org/packages/notmuch-indicator-1.3.0.tar";
+        sha256 = "00497l8gz6vpf7yciq4bd2spyil9bf73vn7s8as2sr8l0izr3psd";
       };
       packageRequires = [ ];
       meta = {
@@ -6417,10 +6417,10 @@
     elpaBuild {
       pname = "org-contacts";
       ename = "org-contacts";
-      version = "1.1";
+      version = "1.2";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/org-contacts-1.1.tar";
-        sha256 = "0gqanhnrxajx5cf7g9waks23sclbmvmwjqrs0q4frcih3gs2nhix";
+        url = "https://elpa.gnu.org/packages/org-contacts-1.2.tar";
+        sha256 = "1icdwijxii3f14f8w1wh8pcg9xy4r1hlii7lzgb7jjswxn303gaj";
       };
       packageRequires = [ org ];
       meta = {
@@ -6514,10 +6514,10 @@
     elpaBuild {
       pname = "org-modern";
       ename = "org-modern";
-      version = "1.11";
+      version = "1.12";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/org-modern-1.11.tar";
-        sha256 = "1y97pwywbhv3a1nz7acm717jkl72jr3c38qwyx7kxk6vda9b745a";
+        url = "https://elpa.gnu.org/packages/org-modern-1.12.tar";
+        sha256 = "18ymshg86vigqmwrlxw2jk5v5mzjymvjqa8mkrr6nq3b9lwxv816";
       };
       packageRequires = [
         compat
@@ -6694,10 +6694,10 @@
     elpaBuild {
       pname = "osm";
       ename = "osm";
-      version = "1.12";
+      version = "2.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/osm-1.12.tar";
-        sha256 = "0lv2dhqgf46jx557idyv5qwjqn57r8gv2ghjghicx95k0bskf1p2";
+        url = "https://elpa.gnu.org/packages/osm-2.1.tar";
+        sha256 = "1nwr32n7cmfa2ckym0srs0fn3426slrhxiykx971s9sgjxydlqq2";
       };
       packageRequires = [ compat ];
       meta = {
@@ -6822,10 +6822,10 @@
     elpaBuild {
       pname = "parser-generator";
       ename = "parser-generator";
-      version = "0.2.7";
+      version = "0.2.8";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/parser-generator-0.2.7.tar";
-        sha256 = "1i9c34rp6bpkakp5a7nr95xz4z30lilfnaz0ld7gyzh3grrq11py";
+        url = "https://elpa.gnu.org/packages/parser-generator-0.2.8.tar";
+        sha256 = "04cwf0qi14lr548wv3n2srx960s1py98y4y93bj34g0hr32rvapk";
       };
       packageRequires = [ ];
       meta = {
@@ -6950,10 +6950,10 @@
     elpaBuild {
       pname = "phps-mode";
       ename = "phps-mode";
-      version = "0.4.51";
+      version = "0.4.52";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/phps-mode-0.4.51.tar";
-        sha256 = "1qiy16gh24sh274sasshxb230r2r2bx1b7awr9php854840p7pvx";
+        url = "https://elpa.gnu.org/packages/phps-mode-0.4.52.tar";
+        sha256 = "00cspfmy6c5vkcbaj7dw5w068f1849wvzw5hdp0yxyqgw7wrfdfp";
       };
       packageRequires = [ ];
       meta = {
@@ -7250,10 +7250,10 @@
     elpaBuild {
       pname = "project";
       ename = "project";
-      version = "0.11.1";
+      version = "0.11.2";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/project-0.11.1.tar";
-        sha256 = "1973d6z7nx9pp5gadqk8p71v6s5wqja40a0f8zjrn6rrnfarrcd0";
+        url = "https://elpa.gnu.org/packages/project-0.11.2.tar";
+        sha256 = "0gyjdqxsblsmh2higkr2a6vfl051hpqzm0pxrzwsg2766xmldgqk";
       };
       packageRequires = [ xref ];
       meta = {
@@ -7336,10 +7336,10 @@
     elpaBuild {
       pname = "pyim";
       ename = "pyim";
-      version = "5.3.5";
+      version = "5.3.6";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/pyim-5.3.5.tar";
-        sha256 = "1s452swgbkbnpfhiwmipmvbqn6wkf6f7dq63gr349h7n29nbnnnk";
+        url = "https://elpa.gnu.org/packages/pyim-5.3.6.tar";
+        sha256 = "00szld154fgbrrpn0p8lxbjg73kc9kx49x6lz2y5y2jm0yxn58gm";
       };
       packageRequires = [
         async
@@ -7583,10 +7583,10 @@
     elpaBuild {
       pname = "realgud";
       ename = "realgud";
-      version = "1.5.1";
+      version = "1.6.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/realgud-1.5.1.tar";
-        sha256 = "1iisvzxvdsifxkz7b2wacw85dkjagrmbcdhcfsnswnfbp3r3kg35";
+        url = "https://elpa.gnu.org/packages/realgud-1.6.0.tar";
+        sha256 = "1z0dn55wgrqsql19psas4p2492hvnddfzsb5z6nha5268p0ax9i8";
       };
       packageRequires = [
         load-relative
@@ -8225,10 +8225,10 @@
     elpaBuild {
       pname = "site-lisp";
       ename = "site-lisp";
-      version = "0.2.0";
+      version = "0.3.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/site-lisp-0.2.0.tar";
-        sha256 = "17wwn1wjkq4vjzhgzq5pyn5x6bzai6nwmxcsp9d375b88qwp973n";
+        url = "https://elpa.gnu.org/packages/site-lisp-0.3.0.tar";
+        sha256 = "0wbxx6n42sqd0857nq0fd3dz04d27vj00vyi75g9k5hr2fa6racc";
       };
       packageRequires = [ ];
       meta = {
@@ -8678,10 +8678,10 @@
     elpaBuild {
       pname = "substitute";
       ename = "substitute";
-      version = "0.4.0";
+      version = "0.5.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/substitute-0.4.0.tar";
-        sha256 = "1385q9h9qhz84y1fm1fd1n48wypkgq4h3hhhk08877ppx58xsa6g";
+        url = "https://elpa.gnu.org/packages/substitute-0.5.0.tar";
+        sha256 = "1l8jaqmmxsv10c7giy9paxq4jdsnikwgyhnkj2vnk9s9panjngbw";
       };
       packageRequires = [ ];
       meta = {
@@ -9019,7 +9019,7 @@
   ) { };
   test-simple = callPackage (
     {
-      cl-lib ? null,
+      compat,
       elpaBuild,
       fetchurl,
       lib,
@@ -9027,12 +9027,12 @@
     elpaBuild {
       pname = "test-simple";
       ename = "test-simple";
-      version = "1.3.1";
+      version = "1.3.2";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/test-simple-1.3.1.tar";
-        sha256 = "11sgc7187l1a4f1x1f6z58dy7pc7n1999id50rjifkvk901x0qd1";
+        url = "https://elpa.gnu.org/packages/test-simple-1.3.2.tar";
+        sha256 = "1pw60mpjncapgzgsgml8xsy2bkpmw1p082q427vl9g8lxiq555qb";
       };
-      packageRequires = [ cl-lib ];
+      packageRequires = [ compat ];
       meta = {
         homepage = "https://elpa.gnu.org/packages/test-simple.html";
         license = lib.licenses.free;
@@ -9243,10 +9243,10 @@
     elpaBuild {
       pname = "track-changes";
       ename = "track-changes";
-      version = "1.4";
+      version = "1.5";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/track-changes-1.4.tar";
-        sha256 = "0ygc53dm144ld4f7ig1fh1z345gnkrin7q108kj9d4dhgp8f2381";
+        url = "https://elpa.gnu.org/packages/track-changes-1.5.tar";
+        sha256 = "0ylvxd5iijihqa5l9w6k6hmwaf09hw98k4f9g2hxfbn8sifvgb53";
       };
       packageRequires = [ ];
       meta = {
@@ -9264,10 +9264,10 @@
     elpaBuild {
       pname = "tramp";
       ename = "tramp";
-      version = "2.8.0.5";
+      version = "2.8.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/tramp-2.8.0.5.tar";
-        sha256 = "18qazsfc1j15rm3l9qybzbkm892apdwqd6pp2mymprshpyhgc7a7";
+        url = "https://elpa.gnu.org/packages/tramp-2.8.1.tar";
+        sha256 = "0c0k9a69m1li6z1k36q0gmkwks106ghsmz4iz3k9c18979jmn0y1";
       };
       packageRequires = [ ];
       meta = {
@@ -9373,10 +9373,10 @@
     elpaBuild {
       pname = "transient";
       ename = "transient";
-      version = "0.11.0";
+      version = "0.12.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/transient-0.11.0.tar";
-        sha256 = "09rdjkmmg7b3r2d55ff2r11hklglq14xknmn2ywc53qglxxsn0im";
+        url = "https://elpa.gnu.org/packages/transient-0.12.0.tar";
+        sha256 = "0ml92xzbs57npwwyp46p03kd9xi9lhr5hvbrw6nayyc51hm4c7vk";
       };
       packageRequires = [
         compat
@@ -9622,10 +9622,10 @@
     elpaBuild {
       pname = "url-http-oauth";
       ename = "url-http-oauth";
-      version = "0.8.4";
+      version = "0.8.5";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/url-http-oauth-0.8.4.tar";
-        sha256 = "10iznck31ilfjwjbbwfalqchg260yqypai487436cc0s1fm47vvf";
+        url = "https://elpa.gnu.org/packages/url-http-oauth-0.8.5.tar";
+        sha256 = "17j1bzvg9a6k1fqkwphlkrqyihpgp5zia3hgbnjkz7j76adbxmgv";
       };
       packageRequires = [ ];
       meta = {
@@ -9909,10 +9909,10 @@
     elpaBuild {
       pname = "verilog-mode";
       ename = "verilog-mode";
-      version = "2025.11.8.248496848";
+      version = "2026.1.18.88738971";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/verilog-mode-2025.11.8.248496848.tar";
-        sha256 = "0w10f8gh2adabd5phgqqka4i0jq1g86bvq9yv3whnaxwiyf0m676";
+        url = "https://elpa.gnu.org/packages/verilog-mode-2026.1.18.88738971.tar";
+        sha256 = "1m215m38mia2wiq1zzyy85k268pch10yzf3p4i0nk5s7ijxl6ls4";
       };
       packageRequires = [ ];
       meta = {
@@ -9931,10 +9931,10 @@
     elpaBuild {
       pname = "vertico";
       ename = "vertico";
-      version = "2.6";
+      version = "2.7";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/vertico-2.6.tar";
-        sha256 = "11lm8bqk0scpa4szlmsrhv8k3ll57a6jhbiimvbm44l8jh3qkk9c";
+        url = "https://elpa.gnu.org/packages/vertico-2.7.tar";
+        sha256 = "0vqi5rv4dkfynhz27i1ll49waih4racig611a31caz2kchf3pzvm";
       };
       packageRequires = [ compat ];
       meta = {
@@ -10538,10 +10538,10 @@
     elpaBuild {
       pname = "yaml";
       ename = "yaml";
-      version = "1.2.1";
+      version = "1.2.3";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/yaml-1.2.1.tar";
-        sha256 = "14asp31dba2ab1hjvxjqdk99kzl82r7yjmrw6nk65i1wsnk14a6i";
+        url = "https://elpa.gnu.org/packages/yaml-1.2.3.tar";
+        sha256 = "0wyvhh4ij22wdd3g5jkg2mnyglbk2k7mf2jv48jkpb5jc4kf6jvr";
       };
       packageRequires = [ ];
       meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -1752,13 +1752,6 @@ let
 
           workgroups2 = ignoreCompilationError super.workgroups2; # elisp error
 
-          ws-butler = super.ws-butler.overrideAttrs (old: {
-            # TODO: Remove override when URL was updated in MELPA.
-            src = old.src.override {
-              url = "https://https.git.savannah.gnu.org/git/elpa/nongnu.git";
-            };
-          });
-
           # https://github.com/nicklanasa/xcode-mode/issues/28
           xcode-mode = addPackageRequires super.xcode-mode [ self.hydra ];
 

--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -858,18 +858,6 @@ let
 
           auto-indent-mode = ignoreCompilationError super.auto-indent-mode; # elisp error
 
-          auto-virtualenv = super.auto-virtualenv.overrideAttrs (
-            finalAttrs: previousAttrs: {
-              patches = previousAttrs.patches or [ ] ++ [
-                (pkgs.fetchpatch {
-                  name = "do-not-error-if-the-optional-projectile-is-not-available.patch";
-                  url = "https://github.com/marcwebbie/auto-virtualenv/pull/14/commits/9a068974a4e12958200c12c6a23372fa736523c1.patch";
-                  hash = "sha256-bqrroFf5AD5SHx6uzBFdVwTv3SbFiO39T+0x03Ves/k=";
-                })
-              ];
-            }
-          );
-
           aws-ec2 = ignoreCompilationError super.aws-ec2; # elisp error
 
           badger-theme = ignoreCompilationError super.badger-theme; # elisp error

--- a/pkgs/applications/editors/emacs/elisp-packages/nongnu-devel-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/nongnu-devel-generated.nix
@@ -42,6 +42,27 @@
       };
     }
   ) { };
+  age = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "age";
+      ename = "age";
+      version = "0.1.9.0.20250806.132339";
+      src = fetchurl {
+        url = "https://elpa.nongnu.org/nongnu-devel/age-0.1.9.0.20250806.132339.tar";
+        sha256 = "1n7lvx7bcniwylsq339pyxs26ragcq4wy7lz3xzvry54bha3jxfn";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.nongnu.org/nongnu-devel/age.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
   aidermacs = callPackage (
     {
       compat,
@@ -438,10 +459,10 @@
     elpaBuild {
       pname = "blueprint-ts-mode";
       ename = "blueprint-ts-mode";
-      version = "0.0.3.0.20250702.131748";
+      version = "0.0.3.0.20260110.82453";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/blueprint-ts-mode-0.0.3.0.20250702.131748.tar";
-        sha256 = "1w0annw8qrf6pik02i4f7nq469spninjzjgfvkkk56h2cabxf29n";
+        url = "https://elpa.nongnu.org/nongnu-devel/blueprint-ts-mode-0.0.3.0.20260110.82453.tar";
+        sha256 = "1j0cx4w8ps6bmp0yybzj1db2aw12pgkv5pb0vcnsplwcp552rzd0";
       };
       packageRequires = [ ];
       meta = {
@@ -572,10 +593,10 @@
     elpaBuild {
       pname = "cider";
       ename = "cider";
-      version = "1.20.0.0.20251105.93303";
+      version = "1.21.0snapshot0.20260116.151439";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/cider-1.20.0.0.20251105.93303.tar";
-        sha256 = "17gkyg3zpj3941h1cs1chdf2hg0slpwla4r91xhxz3akfjrjmq80";
+        url = "https://elpa.nongnu.org/nongnu-devel/cider-1.21.0snapshot0.20260116.151439.tar";
+        sha256 = "0llq2w0calxzcqh6pf23cp7fwl2pzj117hd9fawmq0lrbxkxqpk2";
       };
       packageRequires = [
         clojure-mode
@@ -601,10 +622,10 @@
     elpaBuild {
       pname = "clojure-mode";
       ename = "clojure-mode";
-      version = "5.20.0.0.20250528.61040";
+      version = "5.20.0.0.20260116.81811";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/clojure-mode-5.20.0.0.20250528.61040.tar";
-        sha256 = "071zs4y4ishjkzwr0dsmd3280vpl92vdpy8f1hwa85lz6i4kyr4r";
+        url = "https://elpa.nongnu.org/nongnu-devel/clojure-mode-5.20.0.0.20260116.81811.tar";
+        sha256 = "0bymqysm90zxz09mrljyrihk255kmisfz48mbrc0z267gj26zz00";
       };
       packageRequires = [ ];
       meta = {
@@ -664,10 +685,10 @@
     elpaBuild {
       pname = "cond-let";
       ename = "cond-let";
-      version = "0.2.0.0.20251130.194747";
+      version = "0.2.1.0.20260118.133210";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/cond-let-0.2.0.0.20251130.194747.tar";
-        sha256 = "04z5jawq9ibk94ri8lbx0hrmj88g040gz2by0nqjknvncd0skfkf";
+        url = "https://elpa.nongnu.org/nongnu-devel/cond-let-0.2.1.0.20260118.133210.tar";
+        sha256 = "0wmj57krcv3k9lvj2a9lzg155rfg5vvzl518mfx08bn5ycb6w9ra";
       };
       packageRequires = [ ];
       meta = {
@@ -687,10 +708,10 @@
     elpaBuild {
       pname = "consult-flycheck";
       ename = "consult-flycheck";
-      version = "1.0.0.20250923.111441";
+      version = "1.1.0.20260117.165420";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/consult-flycheck-1.0.0.20250923.111441.tar";
-        sha256 = "1lky8vw8x641qnjf8ah1mlchirf3nfyqs5gskqh91q9iq0y48yxj";
+        url = "https://elpa.nongnu.org/nongnu-devel/consult-flycheck-1.1.0.20260117.165420.tar";
+        sha256 = "0jv0kdy91gynlv292qy86n33b2hnryhmyzyk5c5n0vmik3zijyay";
       };
       packageRequires = [
         consult
@@ -802,10 +823,10 @@
     elpaBuild {
       pname = "cycle-at-point";
       ename = "cycle-at-point";
-      version = "0.2.0.20250913.225149";
+      version = "0.2.0.20260111.124011";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/cycle-at-point-0.2.0.20250913.225149.tar";
-        sha256 = "12x1dfcqhx9gf6ll51a4na4vwnvq1m95lkzg22jwdhhxfbp7h7l3";
+        url = "https://elpa.nongnu.org/nongnu-devel/cycle-at-point-0.2.0.20260111.124011.tar";
+        sha256 = "0jnd8r1xpyyklbpvy18mxz3slcl0jz6zi41vymzgmv9a6xig5cvs";
       };
       packageRequires = [ recomplete ];
       meta = {
@@ -951,10 +972,10 @@
     elpaBuild {
       pname = "diff-ansi";
       ename = "diff-ansi";
-      version = "0.2.0.20251214.63409";
+      version = "0.2.0.20260108.151229";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/diff-ansi-0.2.0.20251214.63409.tar";
-        sha256 = "0jfh065kv633zrdb92nik4g0a4bdnjxjyinhqys4gpzxmy0wcp78";
+        url = "https://elpa.nongnu.org/nongnu-devel/diff-ansi-0.2.0.20260108.151229.tar";
+        sha256 = "0b1i031fyjszinpngz804di4fng6i71pcmckq05z75p3gjjfyx2j";
       };
       packageRequires = [ ];
       meta = {
@@ -994,10 +1015,10 @@
     elpaBuild {
       pname = "doc-show-inline";
       ename = "doc-show-inline";
-      version = "0.1.0.20251126.114419";
+      version = "0.1.0.20260108.134251";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/doc-show-inline-0.1.0.20251126.114419.tar";
-        sha256 = "0r1ly44d1ysqhns72r1mzss6g9ng2300mdqxkqgbb9i0is0nwxql";
+        url = "https://elpa.nongnu.org/nongnu-devel/doc-show-inline-0.1.0.20260108.134251.tar";
+        sha256 = "0i8npz6a4zyxy1w0kksflamn6w6r3wfv977s6hvprax4ajasmhzk";
       };
       packageRequires = [ ];
       meta = {
@@ -1143,10 +1164,10 @@
     elpaBuild {
       pname = "editorconfig";
       ename = "editorconfig";
-      version = "0.11.0.0.20251220.225022";
+      version = "0.11.0.0.20260117.231845";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/editorconfig-0.11.0.0.20251220.225022.tar";
-        sha256 = "1a15m4ddajqalycfl5gkdc7q6lyip2l7yjxvyqcvfahkdb7b9bk1";
+        url = "https://elpa.nongnu.org/nongnu-devel/editorconfig-0.11.0.0.20260117.231845.tar";
+        sha256 = "1ys0m58c19598l6cakzl8m3931fcbs9f4c2fk76qhc5142np20w8";
       };
       packageRequires = [ ];
       meta = {
@@ -1208,10 +1229,10 @@
     elpaBuild {
       pname = "eldoc-mouse";
       ename = "eldoc-mouse";
-      version = "3.0.0.20251219.110114";
+      version = "3.0.2.0.20251228.31655";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/eldoc-mouse-3.0.0.20251219.110114.tar";
-        sha256 = "1wj918ddfkljyajjp1j4bh0i5ph8882zicwyknk4a39f450p0abv";
+        url = "https://elpa.nongnu.org/nongnu-devel/eldoc-mouse-3.0.2.0.20251228.31655.tar";
+        sha256 = "0wjk8wxsf8l4sxp9xbmi0ihq8d6z5m60789hiyv4whhy67cwlwk8";
       };
       packageRequires = [
         eglot
@@ -1274,10 +1295,10 @@
     elpaBuild {
       pname = "emacsql";
       ename = "emacsql";
-      version = "4.3.3.0.20251130.200513";
+      version = "4.3.4.0.20260104.4346";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/emacsql-4.3.3.0.20251130.200513.tar";
-        sha256 = "1lv6w8p24db90i2zmqzi3g7r3r4jdhr7jk8rzhy16mmm3ggz5cay";
+        url = "https://elpa.nongnu.org/nongnu-devel/emacsql-4.3.4.0.20260104.4346.tar";
+        sha256 = "1gpbv5plfcjzvf03gwgq0b2n0kff9xqwk32jpdl9209d8fmiw2q8";
       };
       packageRequires = [ ];
       meta = {
@@ -1303,6 +1324,28 @@
       packageRequires = [ ];
       meta = {
         homepage = "https://elpa.nongnu.org/nongnu-devel/engine-mode.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  esxml = callPackage (
+    {
+      cl-lib ? null,
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "esxml";
+      ename = "esxml";
+      version = "0.3.8.0.20250421.163204";
+      src = fetchurl {
+        url = "https://elpa.nongnu.org/nongnu-devel/esxml-0.3.8.0.20250421.163204.tar";
+        sha256 = "15yqrpnw8nd3ksmqwmsq1b0z39df4c3vqxsl7cyzwyjmrh4djfk6";
+      };
+      packageRequires = [ cl-lib ];
+      meta = {
+        homepage = "https://elpa.nongnu.org/nongnu-devel/esxml.html";
         license = lib.licenses.free;
       };
     }
@@ -1589,10 +1632,10 @@
     elpaBuild {
       pname = "evil-numbers";
       ename = "evil-numbers";
-      version = "0.7.0.20251216.5449";
+      version = "0.7.0.20260102.82951";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/evil-numbers-0.7.0.20251216.5449.tar";
-        sha256 = "0q4ky9cvdql17fa9r41mkr4p9873k81vnzzl0smcki6jm2dj1ik9";
+        url = "https://elpa.nongnu.org/nongnu-devel/evil-numbers-0.7.0.20260102.82951.tar";
+        sha256 = "03nxzdaxnlfmn6w3sgwixmqqv275rskxkjc93zwac55i9h3xn0kb";
       };
       packageRequires = [ evil ];
       meta = {
@@ -2300,10 +2343,10 @@
     elpaBuild {
       pname = "git-modes";
       ename = "git-modes";
-      version = "1.4.7.0.20251130.194845";
+      version = "1.4.8.0.20260101.183425";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/git-modes-1.4.7.0.20251130.194845.tar";
-        sha256 = "164d45b8inhzb4valpnls0zcdjf04mkrhhxf6aag1pjm3n6nmj7v";
+        url = "https://elpa.nongnu.org/nongnu-devel/git-modes-1.4.8.0.20260101.183425.tar";
+        sha256 = "1lw8cwrg66gw4pxbf6kwzglddc9jszz55nw1z0hpaiaz24yi17lg";
       };
       packageRequires = [ compat ];
       meta = {
@@ -2325,10 +2368,10 @@
     elpaBuild {
       pname = "gnosis";
       ename = "gnosis";
-      version = "0.5.8.0.20251108.184759";
+      version = "0.5.8.0.20260114.45444";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/gnosis-0.5.8.0.20251108.184759.tar";
-        sha256 = "1v2v2mhragjxr74c323jr5bgxl267n0khyzcm7qj9z39v0lq6xzx";
+        url = "https://elpa.nongnu.org/nongnu-devel/gnosis-0.5.8.0.20260114.45444.tar";
+        sha256 = "17w44h3rsk5l8h48mgxz7wsmn3856zkqdiwzy4f1s8x55riqq7k3";
       };
       packageRequires = [
         compat
@@ -2394,10 +2437,10 @@
     elpaBuild {
       pname = "gnuplot";
       ename = "gnuplot";
-      version = "0.11.0.20250724.153116";
+      version = "0.11.0.20260117.175416";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/gnuplot-0.11.0.20250724.153116.tar";
-        sha256 = "0fynfi8yzvmn63awmq0hikf2qwch6l5d1crbc4xzgdz5a132w8c7";
+        url = "https://elpa.nongnu.org/nongnu-devel/gnuplot-0.11.0.20260117.175416.tar";
+        sha256 = "06hx09gk1l6z67n5djryw2h9dvp7d9drcq5xawcrxbvbx836fwir";
       };
       packageRequires = [ compat ];
       meta = {
@@ -2501,10 +2544,10 @@
     elpaBuild {
       pname = "gptel";
       ename = "gptel";
-      version = "0.9.9.3.0.20251217.182413";
+      version = "0.9.9.3.0.20260115.231046";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/gptel-0.9.9.3.0.20251217.182413.tar";
-        sha256 = "0wr8sr2ynxqnl5pr4ipvw84nbxnsi66msr85rfzfqgxhygg17hbw";
+        url = "https://elpa.nongnu.org/nongnu-devel/gptel-0.9.9.3.0.20260115.231046.tar";
+        sha256 = "05bjx9458zx5la3s16z2j7m69aapwmpf7vcfkhwsgnh52703qzxv";
       };
       packageRequires = [
         compat
@@ -2525,10 +2568,10 @@
     elpaBuild {
       pname = "graphql-mode";
       ename = "graphql-mode";
-      version = "1.0.0.0.20251213.111057";
+      version = "1.0.0.0.20260102.175142";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/graphql-mode-1.0.0.0.20251213.111057.tar";
-        sha256 = "124rip18n6q2xycizvwd753b8waxi2ljpgm32p481yl4w8hgj75i";
+        url = "https://elpa.nongnu.org/nongnu-devel/graphql-mode-1.0.0.0.20260102.175142.tar";
+        sha256 = "0bpjij54jnn4jamcdvdxbsmza0g6c3h41300sn5yk4p8g8x85fcr";
       };
       packageRequires = [ ];
       meta = {
@@ -2698,10 +2741,10 @@
     elpaBuild {
       pname = "helm";
       ename = "helm";
-      version = "4.0.6.0.20251212.55548";
+      version = "4.0.6.0.20260108.71401";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/helm-4.0.6.0.20251212.55548.tar";
-        sha256 = "0xp1rjm1nfq3k87hp73282xydllmm6pqbpxnpbrzp5zp00l6wwvl";
+        url = "https://elpa.nongnu.org/nongnu-devel/helm-4.0.6.0.20260108.71401.tar";
+        sha256 = "03sxqk99cxvvm2mwhb8wj81ixgv5cc692k29kni3zm5g6n4p18wl";
       };
       packageRequires = [
         helm-core
@@ -2723,10 +2766,10 @@
     elpaBuild {
       pname = "helm-core";
       ename = "helm-core";
-      version = "4.0.6.0.20251212.55548";
+      version = "4.0.6.0.20260108.71401";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/helm-core-4.0.6.0.20251212.55548.tar";
-        sha256 = "1l79l1wk5p8808ycfn8azz6jpi7hbq4s95kw85867qx8lkg0vi4h";
+        url = "https://elpa.nongnu.org/nongnu-devel/helm-core-4.0.6.0.20260108.71401.tar";
+        sha256 = "1z6ka0dbjgw8i9brl26miivddiwgbw641zqd27mxqlmhb3xq5n28";
       };
       packageRequires = [ async ];
       meta = {
@@ -2786,10 +2829,10 @@
     elpaBuild {
       pname = "hl-block-mode";
       ename = "hl-block-mode";
-      version = "0.2.0.20251126.113654";
+      version = "0.2.0.20251230.73140";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/hl-block-mode-0.2.0.20251126.113654.tar";
-        sha256 = "1jn3gl3i77zhh62yzax40qh1ralvrdjpq4ivlvhqspf2nbsqgqdw";
+        url = "https://elpa.nongnu.org/nongnu-devel/hl-block-mode-0.2.0.20251230.73140.tar";
+        sha256 = "0dzp8yqh6s1gy9hj0sri46zsl0zjdsbrhxgvg65lnfd86rv2ln9z";
       };
       packageRequires = [ ];
       meta = {
@@ -2911,10 +2954,10 @@
     elpaBuild {
       pname = "idle-highlight-mode";
       ename = "idle-highlight-mode";
-      version = "1.1.5.0.20251214.61439";
+      version = "1.1.5.0.20260108.131100";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/idle-highlight-mode-1.1.5.0.20251214.61439.tar";
-        sha256 = "1d3lrjwvw721i39xq3wa7p9xp15rsvxnbpa33gcpzxpmhasyhpyr";
+        url = "https://elpa.nongnu.org/nongnu-devel/idle-highlight-mode-1.1.5.0.20260108.131100.tar";
+        sha256 = "0s1snfinjjhfp08ilwf1f6p6w55k95b79ymz8y0rp6dc7drlk59h";
       };
       packageRequires = [ ];
       meta = {
@@ -3001,10 +3044,10 @@
     elpaBuild {
       pname = "inf-ruby";
       ename = "inf-ruby";
-      version = "2.9.0.0.20250212.2927";
+      version = "2.9.0.0.20251224.21617";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/inf-ruby-2.9.0.0.20250212.2927.tar";
-        sha256 = "0hnwrybc89fdpkn3l1ff4x3vf5c2d6rgjjxbwyikk67b6p405zm7";
+        url = "https://elpa.nongnu.org/nongnu-devel/inf-ruby-2.9.0.0.20251224.21617.tar";
+        sha256 = "0km80n6bfhdfr3cq9lw8aq63z8931s4yxd40vqxjqcvp1py9c01b";
       };
       packageRequires = [ ];
       meta = {
@@ -3022,10 +3065,10 @@
     elpaBuild {
       pname = "inkpot-theme";
       ename = "inkpot-theme";
-      version = "0.1.0.20250303.103930";
+      version = "0.1.0.20260106.3820";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/inkpot-theme-0.1.0.20250303.103930.tar";
-        sha256 = "02lkb9yl83bkad0jj6im6yhv160fsk0zf02zi9y9fzqx4p4qrn1g";
+        url = "https://elpa.nongnu.org/nongnu-devel/inkpot-theme-0.1.0.20260106.3820.tar";
+        sha256 = "17770z3r4ayjfj6l1dc21vmdwmzfw87dggsrln9p7l3b972xif3a";
       };
       packageRequires = [ ];
       meta = {
@@ -3043,10 +3086,10 @@
     elpaBuild {
       pname = "isl";
       ename = "isl";
-      version = "1.6.0.20251120.44129";
+      version = "1.6.0.20260105.45206";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/isl-1.6.0.20251120.44129.tar";
-        sha256 = "0zql7y0r33k503qdr4wbbkvjkgb3b71kx2qd0frw91iy5y9w41k2";
+        url = "https://elpa.nongnu.org/nongnu-devel/isl-1.6.0.20260105.45206.tar";
+        sha256 = "07srq23d165cbk2c31ibi5snh113qg387ycdfkndffc7s1n3jr7f";
       };
       packageRequires = [ ];
       meta = {
@@ -3123,6 +3166,27 @@
       };
     }
   ) { };
+  javelin = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "javelin";
+      ename = "javelin";
+      version = "0.2.3.0.20260105.173516";
+      src = fetchurl {
+        url = "https://elpa.nongnu.org/nongnu-devel/javelin-0.2.3.0.20260105.173516.tar";
+        sha256 = "0vv0kk0pvdmyr7arargdxrldkk4m8b43i2jb0w4lia5pfn66h6kl";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.nongnu.org/nongnu-devel/javelin.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
   jinja2-mode = callPackage (
     {
       elpaBuild,
@@ -3175,10 +3239,10 @@
     elpaBuild {
       pname = "keycast";
       ename = "keycast";
-      version = "1.4.6.0.20251130.194925";
+      version = "1.4.7.0.20260101.183551";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/keycast-1.4.6.0.20251130.194925.tar";
-        sha256 = "02plsbrvxj5v8w6cds2avv8cg7dgil3ix8pmnqcdxa65dq9pvlm7";
+        url = "https://elpa.nongnu.org/nongnu-devel/keycast-1.4.7.0.20260101.183551.tar";
+        sha256 = "1p0kzw0ciygp5xgyv2c7z9byn7x1x8zdrd7x3mlizjh3mpmwyl3k";
       };
       packageRequires = [ compat ];
       meta = {
@@ -3244,10 +3308,10 @@
     elpaBuild {
       pname = "llama";
       ename = "llama";
-      version = "1.0.2.0.20251130.195527";
+      version = "1.0.3.0.20260101.183011";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/llama-1.0.2.0.20251130.195527.tar";
-        sha256 = "0h9lq099y93yz4x7w6nx2sf8jhzzfyn1bvwzgzjxvvpf3pir5h1x";
+        url = "https://elpa.nongnu.org/nongnu-devel/llama-1.0.3.0.20260101.183011.tar";
+        sha256 = "1z3j7rg8v7hrgjhz914gqms6566hvxrhs3ylxg3ljbrz1rql23a2";
       };
       packageRequires = [ compat ];
       meta = {
@@ -3297,10 +3361,10 @@
     elpaBuild {
       pname = "loopy";
       ename = "loopy";
-      version = "0.15.0.0.20251217.225540";
+      version = "0.15.0.0.20260110.235316";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/loopy-0.15.0.0.20251217.225540.tar";
-        sha256 = "08a1lc0x6qjp5phv1pr3dajckxd7phb3qgynl3w6nhngfijrr1sj";
+        url = "https://elpa.nongnu.org/nongnu-devel/loopy-0.15.0.0.20260110.235316.tar";
+        sha256 = "0kg0qszanbmfsdgakpdxaa9bp6jv44900slhk96kkip9r8im3yg5";
       };
       packageRequires = [
         compat
@@ -3325,10 +3389,10 @@
     elpaBuild {
       pname = "loopy-dash";
       ename = "loopy-dash";
-      version = "0.13.0.0.20250114.23438";
+      version = "0.13.0.0.20251226.203150";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/loopy-dash-0.13.0.0.20250114.23438.tar";
-        sha256 = "1gbhs3agzf5pg6x3c87ccwxwfppg27jh6zpjc12hv9fgj5pajir3";
+        url = "https://elpa.nongnu.org/nongnu-devel/loopy-dash-0.13.0.0.20251226.203150.tar";
+        sha256 = "1xcda0jnbprs09d9yxfrqcapk2s5kz83nkl321yi9bnk9j1vsi6k";
       };
       packageRequires = [
         dash
@@ -3424,10 +3488,10 @@
     elpaBuild {
       pname = "magit";
       ename = "magit";
-      version = "4.4.2.0.20251220.91723";
+      version = "4.5.0.0.20260116.172240";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/magit-4.4.2.0.20251220.91723.tar";
-        sha256 = "1dbi6x28kr81w2w6h3z559zv3f6dxm6cpf680hafg22kqi9iz6xr";
+        url = "https://elpa.nongnu.org/nongnu-devel/magit-4.5.0.0.20260116.172240.tar";
+        sha256 = "12y9glvz78dbziimfpfylskigg0qzhn09rlfiigbjhj3436pqp9p";
       };
       packageRequires = [
         compat
@@ -3457,10 +3521,10 @@
     elpaBuild {
       pname = "magit-section";
       ename = "magit-section";
-      version = "4.4.2.0.20251220.91723";
+      version = "4.5.0.0.20260116.172240";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/magit-section-4.4.2.0.20251220.91723.tar";
-        sha256 = "1ipg6p17gfk5xmfvr2qkjk7mhnprd0pdm8slfzfyl6acla0qc6hr";
+        url = "https://elpa.nongnu.org/nongnu-devel/magit-section-4.5.0.0.20260116.172240.tar";
+        sha256 = "1jax2rfr5znpr4miscy8byx7yimzq1qizdb1ldv4dhv6vwbmaa3z";
       };
       packageRequires = [
         compat
@@ -3687,10 +3751,10 @@
     elpaBuild {
       pname = "multiple-cursors";
       ename = "multiple-cursors";
-      version = "1.5.0.0.20251006.133827";
+      version = "1.5.0.0.20260117.123334";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/multiple-cursors-1.5.0.0.20251006.133827.tar";
-        sha256 = "0lm29y8vhb1l9aprinpwngwhkh6h0vvihg3hfnf3nr1sh7lcmqzc";
+        url = "https://elpa.nongnu.org/nongnu-devel/multiple-cursors-1.5.0.0.20260117.123334.tar";
+        sha256 = "1qnn3zx296zjvs9y10gq9a7n9ja68ipsvk0qbh48ib6z8n0b4sgh";
       };
       packageRequires = [ cl-lib ];
       meta = {
@@ -3767,6 +3831,28 @@
       };
     }
   ) { };
+  nov = callPackage (
+    {
+      elpaBuild,
+      esxml,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "nov";
+      ename = "nov";
+      version = "0.5.0.0.20251213.150137";
+      src = fetchurl {
+        url = "https://elpa.nongnu.org/nongnu-devel/nov-0.5.0.0.20251213.150137.tar";
+        sha256 = "1wmbxiw06xcc2gg7cyxn6519bmla20vi7plhhlfn3wlw00wjll9r";
+      };
+      packageRequires = [ esxml ];
+      meta = {
+        homepage = "https://elpa.nongnu.org/nongnu-devel/nov.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
   oblivion-theme = callPackage (
     {
       elpaBuild,
@@ -3776,10 +3862,10 @@
     elpaBuild {
       pname = "oblivion-theme";
       ename = "oblivion-theme";
-      version = "0.1.0.20240320.115258";
+      version = "0.1.0.20260108.134901";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/oblivion-theme-0.1.0.20240320.115258.tar";
-        sha256 = "1m0r9laf3wk7pmw5p46cwh0k05lqs1p5806c1czqrqq35z29flwh";
+        url = "https://elpa.nongnu.org/nongnu-devel/oblivion-theme-0.1.0.20260108.134901.tar";
+        sha256 = "0qzb511qjbisywf29x29qg47dzh4gpxnxz776rq14h61w6jb1n9a";
       };
       packageRequires = [ ];
       meta = {
@@ -3819,10 +3905,10 @@
     elpaBuild {
       pname = "org-auto-tangle";
       ename = "org-auto-tangle";
-      version = "0.6.0.0.20250429.50000";
+      version = "0.6.0.0.20251230.141613";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/org-auto-tangle-0.6.0.0.20250429.50000.tar";
-        sha256 = "0sbvkj1b8ibjq95ahhbw9qp488da3s3v5m4dfp6l8p4hdlz0xi4h";
+        url = "https://elpa.nongnu.org/nongnu-devel/org-auto-tangle-0.6.0.0.20251230.141613.tar";
+        sha256 = "18fq0wapd636lph3gm1ji4smp95mizcmvwk4j3ac7mk362wy4aab";
       };
       packageRequires = [ async ];
       meta = {
@@ -4028,10 +4114,10 @@
     elpaBuild {
       pname = "orgit";
       ename = "orgit";
-      version = "2.1.0.0.20251130.195559";
+      version = "2.1.1.0.20260101.185122";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/orgit-2.1.0.0.20251130.195559.tar";
-        sha256 = "0nk3m3cddy98njh1x1gcvx37a680wpddk09qdmcvs95hkchdj1z5";
+        url = "https://elpa.nongnu.org/nongnu-devel/orgit-2.1.1.0.20260101.185122.tar";
+        sha256 = "04437y8svn6i05rwvlnna0cca2dnj1h59wlsiknpw4bfikx5svm6";
       };
       packageRequires = [
         compat
@@ -4252,10 +4338,10 @@
     elpaBuild {
       pname = "pdf-tools";
       ename = "pdf-tools";
-      version = "1.1.0.0.20240429.40722";
+      version = "1.3.0.0.20260108.170248";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/pdf-tools-1.1.0.0.20240429.40722.tar";
-        sha256 = "1799picrndkixcwhvvs0r1hkbjiw1hm2bq9wyj40ryx2a4y900n8";
+        url = "https://elpa.nongnu.org/nongnu-devel/pdf-tools-1.3.0.0.20260108.170248.tar";
+        sha256 = "01q2sbvzhm9m00j542rgbfhinimxavnz4lflf66ccqpcmajzya24";
       };
       packageRequires = [
         let-alist
@@ -4277,10 +4363,10 @@
     elpaBuild {
       pname = "pg";
       ename = "pg";
-      version = "0.61.0.20251201.135921";
+      version = "0.62.0.20251230.93152";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/pg-0.61.0.20251201.135921.tar";
-        sha256 = "0z56akyvih8k2gv5khfwlxwk03yc7nvivad23fnbf30g6n29rfb7";
+        url = "https://elpa.nongnu.org/nongnu-devel/pg-0.62.0.20251230.93152.tar";
+        sha256 = "1k0miw933f4526wikl6s22h286hilzmq322i17igsnzi0b1d3304";
       };
       packageRequires = [ peg ];
       meta = {
@@ -4340,10 +4426,10 @@
     elpaBuild {
       pname = "popup";
       ename = "popup";
-      version = "0.5.9.0.20251120.211937";
+      version = "0.5.9.0.20251231.162233";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/popup-0.5.9.0.20251120.211937.tar";
-        sha256 = "1f6rl4prpsp77khcc8j5vbq5qnnpf16g5n82h0dc9z6chdb2y9xs";
+        url = "https://elpa.nongnu.org/nongnu-devel/popup-0.5.9.0.20251231.162233.tar";
+        sha256 = "0w6f04gx4k3das0p8hdx178ldvwwx8jbzns1n1kwwgc1i5x8fl51";
       };
       packageRequires = [ ];
       meta = {
@@ -4382,10 +4468,10 @@
     elpaBuild {
       pname = "projectile";
       ename = "projectile";
-      version = "2.9.1.0.20250716.140530";
+      version = "2.9.1.0.20260109.133628";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/projectile-2.9.1.0.20250716.140530.tar";
-        sha256 = "0y4vk9jb1knblzfaj28rvqkpgqwp58lhbgwab8p0nnnfjh269y4z";
+        url = "https://elpa.nongnu.org/nongnu-devel/projectile-2.9.1.0.20260109.133628.tar";
+        sha256 = "0y7mf322fa533h2jc0hwwr1nh0m7bk6xzbcc1w4x7iiq520rs3mf";
       };
       packageRequires = [ ];
       meta = {
@@ -4403,10 +4489,10 @@
     elpaBuild {
       pname = "proof-general";
       ename = "proof-general";
-      version = "4.6snapshot0.20251120.174626";
+      version = "4.6snapshot0.20260113.122819";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/proof-general-4.6snapshot0.20251120.174626.tar";
-        sha256 = "1ayyczx5n1rccmd29aa0pn49i008jjiakgq8qxz0imkn1ri5g1kv";
+        url = "https://elpa.nongnu.org/nongnu-devel/proof-general-4.6snapshot0.20260113.122819.tar";
+        sha256 = "0cwxfbad97py7lax387dv5drwmwgmi3qcy191fq1sdj8pc9c7b1v";
       };
       packageRequires = [ ];
       meta = {
@@ -4447,10 +4533,10 @@
     elpaBuild {
       pname = "racket-mode";
       ename = "racket-mode";
-      version = "1.0.20251220.93632";
+      version = "1.0.20260117.121353";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/racket-mode-1.0.20251220.93632.tar";
-        sha256 = "0dy7qyq9blqbkvjsz23cnrp4y2c1l5gsqr3cylriiwwab9zz6gm5";
+        url = "https://elpa.nongnu.org/nongnu-devel/racket-mode-1.0.20260117.121353.tar";
+        sha256 = "0zycibkfrckgmqc5ss0fv1kz3yin9xldg1bx13rvj59m7qp6fkaj";
       };
       packageRequires = [ compat ];
       meta = {
@@ -4531,10 +4617,10 @@
     elpaBuild {
       pname = "recomplete";
       ename = "recomplete";
-      version = "0.2.0.20251214.115024";
+      version = "0.2.0.20260108.132129";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/recomplete-0.2.0.20251214.115024.tar";
-        sha256 = "1w1vs21fha8qk4fd0gfr4j3b7p9p3an2qw1acdzyg05rqij91w80";
+        url = "https://elpa.nongnu.org/nongnu-devel/recomplete-0.2.0.20260108.132129.tar";
+        sha256 = "1vr39dvac87ikgf07r492yrmxnsfmdz816gyygb3rrj8fpjxp80f";
       };
       packageRequires = [ ];
       meta = {
@@ -4657,10 +4743,10 @@
     elpaBuild {
       pname = "rust-mode";
       ename = "rust-mode";
-      version = "1.0.6.0.20251120.211427";
+      version = "1.0.6.0.20260118.53640";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/rust-mode-1.0.6.0.20251120.211427.tar";
-        sha256 = "1jif5r4r7s991kr4x381ipqnhivi96il7vq9c26f4vc16nrm6imm";
+        url = "https://elpa.nongnu.org/nongnu-devel/rust-mode-1.0.6.0.20260118.53640.tar";
+        sha256 = "1lzaji5bxznmm55xnyz93q2rf3x7p3873z0gw3ml08mng0gj99w7";
       };
       packageRequires = [ ];
       meta = {
@@ -4705,10 +4791,10 @@
     elpaBuild {
       pname = "scad-mode";
       ename = "scad-mode";
-      version = "97.0.0.20251007.170238";
+      version = "98.0.0.20260117.165324";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/scad-mode-97.0.0.20251007.170238.tar";
-        sha256 = "1r0bnwg0li1caq8q29hz9f25y8mpkq5iqx5gnd86il58wwx13r96";
+        url = "https://elpa.nongnu.org/nongnu-devel/scad-mode-98.0.0.20260117.165324.tar";
+        sha256 = "0b3327x1vx2mr538kghga9hmv1jn1i8zbnj2879wh4abhahdc0fw";
       };
       packageRequires = [ compat ];
       meta = {
@@ -4726,10 +4812,10 @@
     elpaBuild {
       pname = "scala-mode";
       ename = "scala-mode";
-      version = "1.1.1.0.20241231.83915";
+      version = "1.1.1.0.20260118.94206";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/scala-mode-1.1.1.0.20241231.83915.tar";
-        sha256 = "079w6awnk36h33fz4gsqcnc3llsfmv1pmwzqyy8vv27x65i9fxjs";
+        url = "https://elpa.nongnu.org/nongnu-devel/scala-mode-1.1.1.0.20260118.94206.tar";
+        sha256 = "172vfh3a91angf9xj17x5kw8gpinhmk08g3jpwwzq02m6y6ipkn9";
       };
       packageRequires = [ ];
       meta = {
@@ -4747,10 +4833,10 @@
     elpaBuild {
       pname = "scroll-on-drag";
       ename = "scroll-on-drag";
-      version = "0.1.0.20251215.114338";
+      version = "0.1.0.20260108.131616";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/scroll-on-drag-0.1.0.20251215.114338.tar";
-        sha256 = "1wz49169gbifwiqpg66v2h6dwb1zvz0brlgc7dd0mbm713frr9y4";
+        url = "https://elpa.nongnu.org/nongnu-devel/scroll-on-drag-0.1.0.20260108.131616.tar";
+        sha256 = "0hzpppp25wd9cli833gyw73nbkb8rs9pi2ivdgxnwj5ca9bwp8vw";
       };
       packageRequires = [ ];
       meta = {
@@ -4768,10 +4854,10 @@
     elpaBuild {
       pname = "scroll-on-jump";
       ename = "scroll-on-jump";
-      version = "0.3.0.20251213.114045";
+      version = "0.3.0.20260108.130950";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/scroll-on-jump-0.3.0.20251213.114045.tar";
-        sha256 = "15hk8k8dsvsw67fivbbqasdbqf2i36sqr5l8d1p316zsf0y972ja";
+        url = "https://elpa.nongnu.org/nongnu-devel/scroll-on-jump-0.3.0.20260108.130950.tar";
+        sha256 = "1jwsiqrn5q7vldbajyn76w4h2pffmgcv2hakgzsyjbfafvrzvqpj";
       };
       packageRequires = [ ];
       meta = {
@@ -4832,10 +4918,10 @@
     elpaBuild {
       pname = "slime";
       ename = "slime";
-      version = "2.32snapshot0.20251222.163254";
+      version = "2.32snapshot0.20260119.50517";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/slime-2.32snapshot0.20251222.163254.tar";
-        sha256 = "1z33c3bm4lfcw0c2gy4r4vxs80rxgwzjv9g959mv0h23d4gacs5k";
+        url = "https://elpa.nongnu.org/nongnu-devel/slime-2.32snapshot0.20260119.50517.tar";
+        sha256 = "07nff1w56vv3qr6s2rx6ppwp9gc43pxnglgzanasygxs2fghn477";
       };
       packageRequires = [ macrostep ];
       meta = {
@@ -4938,10 +5024,10 @@
     elpaBuild {
       pname = "spell-fu";
       ename = "spell-fu";
-      version = "0.3.0.20251126.52910";
+      version = "0.3.0.20260108.133641";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/spell-fu-0.3.0.20251126.52910.tar";
-        sha256 = "1ljqxf86zwvld6963a6cf3mri5x1x40g371jdfr42wcvjpp72wdc";
+        url = "https://elpa.nongnu.org/nongnu-devel/spell-fu-0.3.0.20260108.133641.tar";
+        sha256 = "1yrv1a3k6nk92bhs4gsqpb1gc7x55gpp365ykpx6zj0hiapfhq80";
       };
       packageRequires = [ ];
       meta = {
@@ -4980,10 +5066,10 @@
     elpaBuild {
       pname = "standard-keys-mode";
       ename = "standard-keys-mode";
-      version = "1.0.0.0.20250905.172556";
+      version = "1.0.0.0.20260105.112114";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/standard-keys-mode-1.0.0.0.20250905.172556.tar";
-        sha256 = "1vxzb1a5qmafs3n9a74fkyb888qk3q1zfm61ywjjsfs7bj4z87fg";
+        url = "https://elpa.nongnu.org/nongnu-devel/standard-keys-mode-1.0.0.0.20260105.112114.tar";
+        sha256 = "0haqds9h15rk61rnwrs0a37gwhm1gm4j6fj9a9i7fkvca2qfyb3d";
       };
       packageRequires = [ ];
       meta = {
@@ -5043,10 +5129,10 @@
     elpaBuild {
       pname = "subed";
       ename = "subed";
-      version = "1.2.25.0.20251220.184030";
+      version = "1.3.1.0.20260103.134523";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/subed-1.2.25.0.20251220.184030.tar";
-        sha256 = "1vlhmchh9vzzcpy0q7b35g79ar67rfh168l4mrc03iqgd4hs6m5j";
+        url = "https://elpa.nongnu.org/nongnu-devel/subed-1.3.1.0.20260103.134523.tar";
+        sha256 = "0m68rngydjpk2q0y766p0hbj1l6aixj3j3yl3dwmwwmbn03phfsp";
       };
       packageRequires = [ ];
       meta = {
@@ -5348,10 +5434,10 @@
     elpaBuild {
       pname = "treesit-fold";
       ename = "treesit-fold";
-      version = "0.2.1.0.20251221.4029";
+      version = "0.2.1.0.20260117.211549";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/treesit-fold-0.2.1.0.20251221.4029.tar";
-        sha256 = "0kp2baa4g4d7yxldlyh6c3jvxs8ajl9apj7823vqphdh8kr7gl67";
+        url = "https://elpa.nongnu.org/nongnu-devel/treesit-fold-0.2.1.0.20260117.211549.tar";
+        sha256 = "1zznirq9lvrhqhm3xc6sf0ap157dl16ybcncighl6p641zb292b5";
       };
       packageRequires = [ ];
       meta = {
@@ -5475,10 +5561,10 @@
     elpaBuild {
       pname = "undo-fu";
       ename = "undo-fu";
-      version = "0.5.0.20251126.50949";
+      version = "0.5.0.20260108.32351";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/undo-fu-0.5.0.20251126.50949.tar";
-        sha256 = "0l14yi8ls2gqj66yqxrdzkyv7zyb1zh3jfksarn6c63v1lqpx1rx";
+        url = "https://elpa.nongnu.org/nongnu-devel/undo-fu-0.5.0.20260108.32351.tar";
+        sha256 = "16jc23g4xcalbdzjsynq9nw0h7jj0v9r3cxf8jbmrp85zdpyjzk0";
       };
       packageRequires = [ ];
       meta = {
@@ -5496,10 +5582,10 @@
     elpaBuild {
       pname = "undo-fu-session";
       ename = "undo-fu-session";
-      version = "0.7.0.20251210.212915";
+      version = "0.7.0.20260108.131306";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/undo-fu-session-0.7.0.20251210.212915.tar";
-        sha256 = "11z40939vc3mqa82k85v4ybzr3x5w1577816qqqnipw2q0c04fh5";
+        url = "https://elpa.nongnu.org/nongnu-devel/undo-fu-session-0.7.0.20260108.131306.tar";
+        sha256 = "0ykdif99h5618nssnh24yqjhv47cci69x2c1g1fwb96j371ckwlj";
       };
       packageRequires = [ ];
       meta = {
@@ -5581,10 +5667,10 @@
     elpaBuild {
       pname = "vm";
       ename = "vm";
-      version = "8.3.0snapshot0.20251221.132827";
+      version = "8.3.3snapshot0.20251229.112614";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/vm-8.3.0snapshot0.20251221.132827.tar";
-        sha256 = "1h2d49nv3hhv8lczlgw4k76fjjbkjfrj3sn5mvgxgxwc9jzgpmfj";
+        url = "https://elpa.nongnu.org/nongnu-devel/vm-8.3.3snapshot0.20251229.112614.tar";
+        sha256 = "0j96fzmqljhyk0dxkwzs6y4j4x9clyslndbspcisx0qskqa3p0fg";
       };
       packageRequires = [ vcard ];
       meta = {
@@ -5649,10 +5735,10 @@
     elpaBuild {
       pname = "wfnames";
       ename = "wfnames";
-      version = "1.2.0.20240822.162149";
+      version = "1.2.0.20260105.45812";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/wfnames-1.2.0.20240822.162149.tar";
-        sha256 = "0wcnw48gpf0frx9fdhz4f4cxisb4v7dwbhd9q3i7j1ivdd07diwg";
+        url = "https://elpa.nongnu.org/nongnu-devel/wfnames-1.2.0.20260105.45812.tar";
+        sha256 = "116d5j1sqb0fbqlfaxxiaraw8c6mg69nw5mn412zwrvbq4vgpp4c";
       };
       packageRequires = [ ];
       meta = {
@@ -5713,10 +5799,10 @@
     elpaBuild {
       pname = "with-editor";
       ename = "with-editor";
-      version = "3.4.7.0.20251130.184451";
+      version = "3.4.8.0.20260104.4109";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/with-editor-3.4.7.0.20251130.184451.tar";
-        sha256 = "13a9k7mg0bdp7m41zzpngqzk2pkrwz4is61qcbcyyv4dn5f62ipg";
+        url = "https://elpa.nongnu.org/nongnu-devel/with-editor-3.4.8.0.20260104.4109.tar";
+        sha256 = "1688qk4i4r131w0m2iss3p9yjlqs2a5r2nw9kfw7ziypqkmc6pp5";
       };
       packageRequires = [ compat ];
       meta = {
@@ -5823,10 +5909,10 @@
     elpaBuild {
       pname = "xah-fly-keys";
       ename = "xah-fly-keys";
-      version = "28.11.20251212190757.0.20251212.191201";
+      version = "28.11.20260106081151.0.20260106.81408";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/xah-fly-keys-28.11.20251212190757.0.20251212.191201.tar";
-        sha256 = "10ksjc2cjyc82r0h5klqr3jk4n3q8bydxfqmdiwy40n2fr4jcjvz";
+        url = "https://elpa.nongnu.org/nongnu-devel/xah-fly-keys-28.11.20260106081151.0.20260106.81408.tar";
+        sha256 = "0bfjylai4ck3nb73h6863gbb0pka84gh7wys5h2dq1k5bhx8sfqi";
       };
       packageRequires = [ ];
       meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/nongnu-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/nongnu-generated.nix
@@ -42,6 +42,27 @@
       };
     }
   ) { };
+  age = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "age";
+      ename = "age";
+      version = "0.1.9";
+      src = fetchurl {
+        url = "https://elpa.nongnu.org/nongnu/age-0.1.9.tar";
+        sha256 = "0y8vlr8w4xfapixdr35acmcsll06kci04rsz5pzi20amkhrj9i50";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.nongnu.org/nongnu/age.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
   aidermacs = callPackage (
     {
       compat,
@@ -687,10 +708,10 @@
     elpaBuild {
       pname = "cond-let";
       ename = "cond-let";
-      version = "0.2.0";
+      version = "0.2.1";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/cond-let-0.2.0.tar";
-        sha256 = "1vycjql5i9k9k8nmrpjx393qaw5vh9jy9f7riggsxgd80xky35zi";
+        url = "https://elpa.nongnu.org/nongnu/cond-let-0.2.1.tar";
+        sha256 = "1q5gjb3v0xk6azrjbpyyxabrfd68i4gqw4r9dk2wnvbw0vcr21qf";
       };
       packageRequires = [ ];
       meta = {
@@ -710,10 +731,10 @@
     elpaBuild {
       pname = "consult-flycheck";
       ename = "consult-flycheck";
-      version = "1.0";
+      version = "1.1";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/consult-flycheck-1.0.tar";
-        sha256 = "17kc7v50zq69l4803nh8sjnqwi59p09wjzqkwka6g4dapya3h2xy";
+        url = "https://elpa.nongnu.org/nongnu/consult-flycheck-1.1.tar";
+        sha256 = "0nanxx0fbj6w9sxzz4ys8nxpv63al3m4lliy30y4ydiaig2a0abc";
       };
       packageRequires = [
         consult
@@ -1232,10 +1253,10 @@
     elpaBuild {
       pname = "eldoc-mouse";
       ename = "eldoc-mouse";
-      version = "3.0";
+      version = "3.0.2";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/eldoc-mouse-3.0.tar";
-        sha256 = "16v5v15505q1whsrxz4w4x1ba62w5f4i4g5sdgwrwyahzq2a9kcp";
+        url = "https://elpa.nongnu.org/nongnu/eldoc-mouse-3.0.2.tar";
+        sha256 = "0ljivs5wpmwc74l4w6fqn0j7ppyf9zc1v3ggx06z1w4jgx15q51d";
       };
       packageRequires = [
         eglot
@@ -1298,10 +1319,10 @@
     elpaBuild {
       pname = "emacsql";
       ename = "emacsql";
-      version = "4.3.3";
+      version = "4.3.4";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/emacsql-4.3.3.tar";
-        sha256 = "0j1q33wfyqrif7zf9qzvh74yxpsqvp800nm0blkr745881k6cmwr";
+        url = "https://elpa.nongnu.org/nongnu/emacsql-4.3.4.tar";
+        sha256 = "0gf58p86qrysaq576yvz80zi9mmfzij8pcp5lh75v2y6xc4b9hpw";
       };
       packageRequires = [ ];
       meta = {
@@ -1328,6 +1349,28 @@
       packageRequires = [ cl-lib ];
       meta = {
         homepage = "https://elpa.nongnu.org/nongnu/engine-mode.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  esxml = callPackage (
+    {
+      cl-lib ? null,
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "esxml";
+      ename = "esxml";
+      version = "0.3.8";
+      src = fetchurl {
+        url = "https://elpa.nongnu.org/nongnu/esxml-0.3.8.tar";
+        sha256 = "1r3hjjidqafr1drc0v0v7blglhf5mp544s6i4hc6xwkhg0amhd92";
+      };
+      packageRequires = [ cl-lib ];
+      meta = {
+        homepage = "https://elpa.nongnu.org/nongnu/esxml.html";
         license = lib.licenses.free;
       };
     }
@@ -2316,10 +2359,10 @@
     elpaBuild {
       pname = "git-modes";
       ename = "git-modes";
-      version = "1.4.7";
+      version = "1.4.8";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/git-modes-1.4.7.tar";
-        sha256 = "1rg38m9mx0vrbyn0d05n3zk2pnkp7122s33nlcj33xr7kslv46ci";
+        url = "https://elpa.nongnu.org/nongnu/git-modes-1.4.8.tar";
+        sha256 = "08bgjpns90c36cdb6qbc24d41z1jg94mwsc91irpsmsvivxw1ksr";
       };
       packageRequires = [ compat ];
       meta = {
@@ -3138,6 +3181,27 @@
       };
     }
   ) { };
+  javelin = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "javelin";
+      ename = "javelin";
+      version = "0.2.3";
+      src = fetchurl {
+        url = "https://elpa.nongnu.org/nongnu/javelin-0.2.3.tar";
+        sha256 = "1abk4sb3vp04qkzdil54bfph4xdpgq5nz41ay8dz4gnipwfdwdwg";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.nongnu.org/nongnu/javelin.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
   jinja2-mode = callPackage (
     {
       elpaBuild,
@@ -3190,10 +3254,10 @@
     elpaBuild {
       pname = "keycast";
       ename = "keycast";
-      version = "1.4.6";
+      version = "1.4.7";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/keycast-1.4.6.tar";
-        sha256 = "0vvkcvir2wqgn6wl8yw689f7sx1qqvcynyyvd61b9c1jf8av90cd";
+        url = "https://elpa.nongnu.org/nongnu/keycast-1.4.7.tar";
+        sha256 = "0ipjn0b9jr6m7a88f76mz6j5na20hix94h8c5ghv705izjlqla0w";
       };
       packageRequires = [ compat ];
       meta = {
@@ -3259,10 +3323,10 @@
     elpaBuild {
       pname = "llama";
       ename = "llama";
-      version = "1.0.2";
+      version = "1.0.3";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/llama-1.0.2.tar";
-        sha256 = "10dvvw6w082gdhq7an4z3krl94q0910fvap3p39gs8pmd898a9f7";
+        url = "https://elpa.nongnu.org/nongnu/llama-1.0.3.tar";
+        sha256 = "03ynn3hcwlw8pdbpybx0q269nidmdwdsbgrvfwf63f8qb6406v63";
       };
       packageRequires = [ compat ];
       meta = {
@@ -3439,10 +3503,10 @@
     elpaBuild {
       pname = "magit";
       ename = "magit";
-      version = "4.4.2";
+      version = "4.5.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/magit-4.4.2.tar";
-        sha256 = "0l0fvf4gx4xj7474h5k00p4aa33y7z7x9lgy41vxi47vbifki2yk";
+        url = "https://elpa.nongnu.org/nongnu/magit-4.5.0.tar";
+        sha256 = "080hc0y9pah86g7nw1x1gh2issap54r8dg9vzpm2l923cxy9jnbp";
       };
       packageRequires = [
         compat
@@ -3472,10 +3536,10 @@
     elpaBuild {
       pname = "magit-section";
       ename = "magit-section";
-      version = "4.4.2";
+      version = "4.5.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/magit-section-4.4.2.tar";
-        sha256 = "00324rd8r0pcdpgls1m0awjbms68fglsi045b8zrk6q6ahz1v08x";
+        url = "https://elpa.nongnu.org/nongnu/magit-section-4.5.0.tar";
+        sha256 = "1k63g8ayvg152r16ml5ph8q07qs5a424vs4i5q32icvl78v6cn2z";
       };
       packageRequires = [
         compat
@@ -3789,6 +3853,28 @@
       };
     }
   ) { };
+  nov = callPackage (
+    {
+      elpaBuild,
+      esxml,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "nov";
+      ename = "nov";
+      version = "0.5.0";
+      src = fetchurl {
+        url = "https://elpa.nongnu.org/nongnu/nov-0.5.0.tar";
+        sha256 = "1isr91a4wkpy81nn620r10gwi6v1z6phb4wmf2zf1g3i0czzpz4x";
+      };
+      packageRequires = [ esxml ];
+      meta = {
+        homepage = "https://elpa.nongnu.org/nongnu/nov.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
   oblivion-theme = callPackage (
     {
       elpaBuild,
@@ -4040,6 +4126,7 @@
   orgit = callPackage (
     {
       compat,
+      cond-let,
       elpaBuild,
       fetchurl,
       lib,
@@ -4049,13 +4136,14 @@
     elpaBuild {
       pname = "orgit";
       ename = "orgit";
-      version = "2.1.0";
+      version = "2.1.1";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/orgit-2.1.0.tar";
-        sha256 = "1wncvmg6x6w0pw9d2xl7i3m621q7jmx7sl76llnf29vbrdq7yiq9";
+        url = "https://elpa.nongnu.org/nongnu/orgit-2.1.1.tar";
+        sha256 = "1rnrmd6pb9257alarv6l1s4s4gxyy5k1hwhvhq28ll581m9sz4r7";
       };
       packageRequires = [
         compat
+        cond-let
         magit
         org
       ];
@@ -4272,10 +4360,10 @@
     elpaBuild {
       pname = "pdf-tools";
       ename = "pdf-tools";
-      version = "1.1.0";
+      version = "1.3.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/pdf-tools-1.1.0.tar";
-        sha256 = "0shlpdy07pk9qj5a7d7yivpvgp5bh65psm0g9wkrvyhpkc93aylc";
+        url = "https://elpa.nongnu.org/nongnu/pdf-tools-1.3.0.tar";
+        sha256 = "0kxv31jh8spndkf0lm2z6ibh9mna055ck4dmzbvws7rfk208rxip";
       };
       packageRequires = [
         let-alist
@@ -4297,10 +4385,10 @@
     elpaBuild {
       pname = "pg";
       ename = "pg";
-      version = "0.61";
+      version = "0.62";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/pg-0.61.tar";
-        sha256 = "0vzx2nsxvl9a77mfri1cqmxibd15c4is61lazs2hl8cqzw7msxjl";
+        url = "https://elpa.nongnu.org/nongnu/pg-0.62.tar";
+        sha256 = "1fxg2irjbc85rr0czqj7cmy7pxh5l9sa69244dgr5ix6b7901dwd";
       };
       packageRequires = [ peg ];
       meta = {
@@ -4467,10 +4555,10 @@
     elpaBuild {
       pname = "racket-mode";
       ename = "racket-mode";
-      version = "1.0.20251220.93632";
+      version = "1.0.20260117.121353";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/racket-mode-1.0.20251220.93632.tar";
-        sha256 = "1ldf75h7wdk6a27bqg7bgrdylsy5dydx0lg8fzqcmz1s40cb01qi";
+        url = "https://elpa.nongnu.org/nongnu/racket-mode-1.0.20260117.121353.tar";
+        sha256 = "1qfhrdrmbd4nzvf3hixxkqjmjv1fyccg9z8im1fc3wl2ck2q1166";
       };
       packageRequires = [ compat ];
       meta = {
@@ -4721,10 +4809,10 @@
     elpaBuild {
       pname = "scad-mode";
       ename = "scad-mode";
-      version = "97.0";
+      version = "98.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/scad-mode-97.0.tar";
-        sha256 = "0javyq4jqjx3anci18d8fdfz10pm1kfh9nfyw7v9flkvsxhala65";
+        url = "https://elpa.nongnu.org/nongnu/scad-mode-98.0.tar";
+        sha256 = "0ksiz8rxxykm2lnc2lil1qndpl0lxcw8fa9nlh420xva9m3s9sda";
       };
       packageRequires = [ compat ];
       meta = {
@@ -5059,10 +5147,10 @@
     elpaBuild {
       pname = "subed";
       ename = "subed";
-      version = "1.2.25";
+      version = "1.3.1";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/subed-1.2.25.tar";
-        sha256 = "1w4r1xh8i7fvaifq50x3s21d31bp53hrvfsw1xp5lnh68xbx9and";
+        url = "https://elpa.nongnu.org/nongnu/subed-1.3.1.tar";
+        sha256 = "04c7yzv5dif8rxxn1lkn2xhb614nw5mycjsihxvl21443539n9ic";
       };
       packageRequires = [ ];
       meta = {
@@ -5610,6 +5698,28 @@
       };
     }
   ) { };
+  vm = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+      vcard,
+    }:
+    elpaBuild {
+      pname = "vm";
+      ename = "vm";
+      version = "8.3.2";
+      src = fetchurl {
+        url = "https://elpa.nongnu.org/nongnu/vm-8.3.2.tar";
+        sha256 = "0s2l4sjzgq4mm82dq6856wncsdvwsgk569i2rybbcsbw6v4hyvwv";
+      };
+      packageRequires = [ vcard ];
+      meta = {
+        homepage = "https://elpa.nongnu.org/nongnu/vm.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
   web-mode = callPackage (
     {
       elpaBuild,
@@ -5730,10 +5840,10 @@
     elpaBuild {
       pname = "with-editor";
       ename = "with-editor";
-      version = "3.4.7";
+      version = "3.4.8";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/with-editor-3.4.7.tar";
-        sha256 = "06z64yp4dxwnrz5n6bwd3yf2h0502f2gx6zgnzsni8pk6zsb1l22";
+        url = "https://elpa.nongnu.org/nongnu/with-editor-3.4.8.tar";
+        sha256 = "1v6y13kahqahrvip1lzjb2baznd5g84x0p0pdaq56nqdh51mb04b";
       };
       packageRequires = [ compat ];
       meta = {
@@ -5840,10 +5950,10 @@
     elpaBuild {
       pname = "xah-fly-keys";
       ename = "xah-fly-keys";
-      version = "28.11.20251212190757";
+      version = "28.11.20260106081151";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/xah-fly-keys-28.11.20251212190757.tar";
-        sha256 = "1v8bv4lzbj0qnnpkj54sk1h33ycbxb9xr3slbg78m5llncch7x7b";
+        url = "https://elpa.nongnu.org/nongnu/xah-fly-keys-28.11.20260106081151.tar";
+        sha256 = "1xp3x69fxzv805wkiwl8fynpgzr4ap1fx67fqrmw5m0vi856qhbx";
       };
       packageRequires = [ ];
       meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/recipes-archive-melpa.json
+++ b/pkgs/applications/editors/emacs/elisp-packages/recipes-archive-melpa.json
@@ -353,19 +353,20 @@
   "repo": "mgrbyte/emacs-abyss-theme",
   "unstable": {
    "version": [
-    20170808,
-    1345
+    20260103,
+    1924
    ],
-   "commit": "18791c6e8d9cc2b4815c9f08627a2e94fc0eeb14",
-   "sha256": "07z0djv7h3yrv4iw9n633j6dxzxb4nnzijsqkmz22ik6fbwxg5mh"
+   "commit": "e8326ed9955d0897cc68fb38d488985a045c868c",
+   "sha256": "072ignp5ncj5xhjw1hrlkq9by7a0f96lak00c758b2malnxwaddp"
   },
   "stable": {
    "version": [
     0,
-    7
+    7,
+    1
    ],
-   "commit": "18791c6e8d9cc2b4815c9f08627a2e94fc0eeb14",
-   "sha256": "07z0djv7h3yrv4iw9n633j6dxzxb4nnzijsqkmz22ik6fbwxg5mh"
+   "commit": "e8326ed9955d0897cc68fb38d488985a045c868c",
+   "sha256": "072ignp5ncj5xhjw1hrlkq9by7a0f96lak00c758b2malnxwaddp"
   }
  },
  {
@@ -1008,8 +1009,8 @@
   "repo": "xcwen/ac-php",
   "unstable": {
    "version": [
-    20240426,
-    653
+    20260114,
+    607
    ],
    "deps": [
     "dash",
@@ -1019,8 +1020,8 @@
     "s",
     "xcscope"
    ],
-   "commit": "810ea813840b980b4f9b43c954e998032fe23f8a",
-   "sha256": "02dv077kn41kd5nr8v1g5cwar8q43s005q5x338ahknbgscys718"
+   "commit": "b7448b8bcdff20a2818a64d804cb3d14c1737b46",
+   "sha256": "005cv05dma6086x9qrwqqbcscdflyb1685azc700pcwzv0ggzr11"
   },
   "stable": {
    "version": [
@@ -1598,20 +1599,20 @@
   "repo": "xenodium/acp.el",
   "unstable": {
    "version": [
-    20251219,
-    2135
+    20260118,
+    1815
    ],
-   "commit": "7b67facc657a7388a53ea8bba5d6e7eba20fa3e0",
-   "sha256": "0znm5qihx2qy3hgw0idg8j7bnhz8k3yaadff3y6696qckdh0qlnr"
+   "commit": "9ab9b8f25cd7f42955171d471da5c3d016d1ef5a",
+   "sha256": "0lg5rli3xvkfp0gvpz1bmdv8m8h8abkn1zklxrpgfisxb5axyzii"
   },
   "stable": {
    "version": [
     0,
     8,
-    1
+    3
    ],
-   "commit": "9caa610d8d56b1001c6a5d17bddb508f1734f5b6",
-   "sha256": "0dialj0qjkz1i8i7d500n86z5qpzllm71fl2y73s98sbxq2bl1mk"
+   "commit": "9ab9b8f25cd7f42955171d471da5c3d016d1ef5a",
+   "sha256": "0lg5rli3xvkfp0gvpz1bmdv8m8h8abkn1zklxrpgfisxb5axyzii"
   }
  },
  {
@@ -1835,11 +1836,11 @@
   "repo": "thierryvolpiatto/addressbook-bookmark",
   "unstable": {
    "version": [
-    20251106,
-    1903
+    20260105,
+    453
    ],
-   "commit": "a93118ce6cb69c5766f5f74fab32b0108d410827",
-   "sha256": "0j0v3vixa9wji2jyh5l55fdw6dgs2w9688lgvj8wfhnb0pq7r0sn"
+   "commit": "469faa4206e6503d9c045fecb2ec0af8e1dcf504",
+   "sha256": "12hs3i85cnp8wvxzz5ng8ghrggxicg6mmpx5i31phm27qgyzvz2q"
   },
   "stable": {
    "version": [
@@ -1953,14 +1954,14 @@
   "repo": "minad/affe",
   "unstable": {
    "version": [
-    20250921,
-    1712
+    20260104,
+    1058
    ],
    "deps": [
     "consult"
    ],
-   "commit": "10fc401cf2d35bafb7220b9456af7dbfd064e1f2",
-   "sha256": "1ga1zrwh5xfvmmr3sfbzmh6k8wmvca1mb0hqqwmpj9q9i1s76c0c"
+   "commit": "295e2fb26a2de66e13c0f8414d1ada5b090a1011",
+   "sha256": "0mq4hf7mflb42nq40p2d5dfmrjbzhihc3gbv63ys9f5icmi07f6j"
   },
   "stable": {
    "version": [
@@ -2136,26 +2137,28 @@
   "repo": "xenodium/agent-shell",
   "unstable": {
    "version": [
-    20251221,
-    2111
+    20260119,
+    2116
    ],
    "deps": [
     "acp",
     "shell-maker"
    ],
-   "commit": "013d968e387f489d6e977dfd90b96c13279f357f",
-   "sha256": "0rxb89bdp2lqqjw3qyxhkwmh7h35pvz135sqx2qsk89cdrz03r7z"
+   "commit": "b47e18587a5215231dcc94c9e44a7bbdc96135fe",
+   "sha256": "05v064mikr8zbizb1mm2z5yjs3869nlaj84xrsd22xiajp4ak3n4"
   },
   "stable": {
    "version": [
-    152
+    0,
+    30,
+    1
    ],
    "deps": [
     "acp",
     "shell-maker"
    ],
-   "commit": "d3c7c7edcbf4a310915082474aab2d23922796ec",
-   "sha256": "12zxb8v5dbk2k49s2a6qmljr7s4rx3qp0rfnrl3nska3slz24yxj"
+   "commit": "25c54b06dca83c5854896df5dac3c0cdab2ed7fe",
+   "sha256": "1bki2f04czm3rq3dpnmplw6gqvcx0i83n15g2llf4qswdxwrkz0w"
   }
  },
  {
@@ -2291,6 +2294,37 @@
    ],
    "commit": "45bf75f17752c8e8dd4c8a4531c0aa419cdccb84",
    "sha256": "03xypgq6vy7819r42g23kgn7p775bc0v9blzhi0zp5c61p4cw8v3"
+  }
+ },
+ {
+  "ename": "ai-code",
+  "commit": "3751d27902c40d37f780bc8304d9a54fb23cc929",
+  "sha256": "1ans15163afvmh3l6mn1j8h5sbkivxqmf9v9wcbgs33xrnl6xc85",
+  "fetcher": "github",
+  "repo": "tninja/ai-code-interface.el",
+  "unstable": {
+   "version": [
+    20260116,
+    1534
+   ],
+   "deps": [
+    "magit",
+    "transient"
+   ],
+   "commit": "007fd8f7e19b37f1969035480823ef759215140c",
+   "sha256": "15fc2xaq7ldqrin2wn98k5f3sjk7ml9f7j723nlxp3lirgyyb04c"
+  },
+  "stable": {
+   "version": [
+    0,
+    91
+   ],
+   "deps": [
+    "magit",
+    "transient"
+   ],
+   "commit": "934763b559686fe6920a5fbcbae2df9d5647c15a",
+   "sha256": "0742rc6mvrr46w2h6vn6saq6br3hi8nqm681cb367kmwkd3wakv7"
   }
  },
  {
@@ -2477,6 +2511,30 @@
   }
  },
  {
+  "ename": "alabaster-themes",
+  "commit": "acf95de2fbd6b416a9eb6c8fb60f377e639aa19e",
+  "sha256": "16zyh0a13q3px668yhv69xi5nxxwrmbdsp8hiirsn82v39jalq1g",
+  "fetcher": "github",
+  "repo": "vedang/alabaster-themes",
+  "unstable": {
+   "version": [
+    20260113,
+    657
+   ],
+   "commit": "2d3dcfc6ac8988d23f8065a580f7dcf4ff607e56",
+   "sha256": "1lfbl3amw7vjv73p88hgg0kyb70bqc5ksil44a296x32fjwpchzy"
+  },
+  "stable": {
+   "version": [
+    2,
+    1,
+    1
+   ],
+   "commit": "73b9500231f4d6313a4088f85f45b3d95226e639",
+   "sha256": "0k8xgv46gpnjz68xg7ylr2lzr1nw45prnngk5skkqjz6r89kv2b6"
+  }
+ },
+ {
   "ename": "alan-mode",
   "commit": "a3c6e6adb1a63534275f9d3d3d0fe0f5e85c549b",
   "sha256": "1i3vhqdrp8zdmkzgyri5z7vh1j0mykcp7mkjxjc7293ncsj310d8",
@@ -2576,11 +2634,11 @@
   "repo": "jgkamat/alda-mode",
   "unstable": {
    "version": [
-    20230406,
-    1927
+    20251223,
+    6
    ],
-   "commit": "580f6e94c93aead91406d00a42ccf9040a898cb8",
-   "sha256": "1zqlq63kdzq8swiwdzpn7419bz0h7a2d2fnx32w2ack7z0yqkxri"
+   "commit": "bde0e9c5df2810deb48df57f46bb3a1a51d7a8f6",
+   "sha256": "1s5ik631id6svpsljl2pvf8sy1rfwyl0w0g3fb1ir9ykdawf5siv"
   },
   "stable": {
    "version": [
@@ -3024,11 +3082,11 @@
   "repo": "jcs-elpa/alt-codes",
   "unstable": {
    "version": [
-    20250101,
-    1002
+    20260101,
+    557
    ],
-   "commit": "24e3740f88c29efda5c4791720a55c4c548b1ed8",
-   "sha256": "15r3iz438r47bcl2jdx1n81rv061yz8wczhpq83qllfrr94clr90"
+   "commit": "1a4df7f34b1072ef199aba602c6c3901d3da5bb1",
+   "sha256": "0wwk4895d04vnyfnszmrffq9f9cz5mlj37w9w239kk92pp8p74fj"
   },
   "stable": {
    "version": [
@@ -3038,6 +3096,21 @@
    ],
    "commit": "b36c2b2bccc628da1579016381d5c3195c9e12b2",
    "sha256": "19nqpg91in65gj59zndhncx6c1005k0wh05rprv1z6465j5gd40g"
+  }
+ },
+ {
+  "ename": "amaranth-dark-theme",
+  "commit": "fcc217d6c08152e270fcee3d7040cf6dbbceebc1",
+  "sha256": "0la44l4dy4iz9dwx0shcwjn59pw871abx8x6qdn53v5mkbf0i71p",
+  "fetcher": "github",
+  "repo": "a9sk/amaranth-dark-theme",
+  "unstable": {
+   "version": [
+    20251228,
+    1916
+   ],
+   "commit": "624e0b5ef632b3adfdc03e44dce7a98cd48d47ed",
+   "sha256": "1lp42p0bbpya2b517rkc3cy69i39vvlkjrbac1v75v767g7sfb4v"
   }
  },
  {
@@ -3456,11 +3529,11 @@
   "repo": "anki-editor/anki-editor",
   "unstable": {
    "version": [
-    20251222,
-    1345
+    20260108,
+    1020
    ],
-   "commit": "59d75f6b6b632c2616c85ff19f39cb9e85a3d8a7",
-   "sha256": "091hlynq7yj0cn82mnj12wh1x8b7d1j8wk1gir65hrz6xiclwbsh"
+   "commit": "d50f9e35015df768feeb7efab17f6af6f938ce13",
+   "sha256": "1k713drlqmy2yq4i32f5r6vi1shkw60kn66dv2yk60pb7fzlbyiq"
   }
  },
  {
@@ -3989,11 +4062,11 @@
   "repo": "radian-software/apheleia",
   "unstable": {
    "version": [
-    20251213,
-    2023
+    20251223,
+    1924
    ],
-   "commit": "8a6b75008d0cb5c5dabb08281ad2393ba4341d1c",
-   "sha256": "1rl088zp1r37ycpx1lqxxn1va2qpyadj0xj420wdyc4s8zb94jl6"
+   "commit": "426616cf1799dbce89800ae2fe9f155311436503",
+   "sha256": "0kv879kv9xqp9gcdjvn1xs6lzy4ylhpi9xflvgpm2kmynjgs2hc6"
   },
   "stable": {
    "version": [
@@ -4975,11 +5048,11 @@
   "repo": "jonathanchu/atom-one-dark-theme",
   "unstable": {
    "version": [
-    20210128,
-    1640
+    20260119,
+    1824
    ],
-   "commit": "b34b62e85593812b55ee552a1cb0eecfb04767bb",
-   "sha256": "1n98fxspx1qmm5p5s591jy2baviqy8b5hjn9hsrvqbmixc7arrhv"
+   "commit": "bba02fb2672a4c439d71920d8e068a3ff2ed463e",
+   "sha256": "02p7lyxr3y0ahl0avziyja55pw9xryji5na1q47k4dcmhk81jx1k"
   },
   "stable": {
    "version": [
@@ -5286,15 +5359,15 @@
   "repo": "emacs-grammarly/auth-source-keytar",
   "unstable": {
    "version": [
-    20250101,
-    849
+    20251231,
+    1726
    ],
    "deps": [
     "keytar",
     "s"
    ],
-   "commit": "2dd34b937e99e367386679e9f42d6ea0411ffe12",
-   "sha256": "12kmh1pix5rzfzdd23a3j8s95l4fppg46nwvgihp639vllb0bkyn"
+   "commit": "ae32dd807aa3cff59e4384ce8c9d7de259e45998",
+   "sha256": "19wwql7zsh0zylw5l0n4cdzgimim6my086i9zqikdqcqqvsny3h6"
   },
   "stable": {
    "version": [
@@ -5399,20 +5472,20 @@
   "repo": "emacscollective/auto-compile",
   "unstable": {
    "version": [
-    20251111,
-    1802
+    20260101,
+    1821
    ],
-   "commit": "7d314cc13515a1bd6ded29e69a9d4be4aff205c3",
-   "sha256": "1qdg4acschcjp3z7bqwafjcc819kmy1h2mfmap15qp92mlb1w1cn"
+   "commit": "eaed414fa7dae04c7701dbc591de52fb3e81aa91",
+   "sha256": "02i7ak9sgzhfxyhil0w579d8xpa9p151l7x797pyv29ffi5brc4h"
   },
   "stable": {
    "version": [
     2,
     1,
-    1
+    2
    ],
-   "commit": "37b0394b1ed61650df269ab82b2ed09a5a86454c",
-   "sha256": "12knl2m3zww2ayl4fmpvwdjpd0qjfzlfmjslb0r6pfkwj7ixy1da"
+   "commit": "eaed414fa7dae04c7701dbc591de52fb3e81aa91",
+   "sha256": "02i7ak9sgzhfxyhil0w579d8xpa9p151l7x797pyv29ffi5brc4h"
   }
  },
  {
@@ -5423,14 +5496,14 @@
   "repo": "auto-complete/auto-complete",
   "unstable": {
    "version": [
-    20251123,
-    1919
+    20251231,
+    1622
    ],
    "deps": [
     "popup"
    ],
-   "commit": "1dbfb343412f9444dcd2d9a08b7b42c7270c9547",
-   "sha256": "1yvqswh481arfjc1ylvyfrdr4klqwwj0rk50l33b0q1mrp98cx1j"
+   "commit": "07f9915e08342410b933145d7934998709753a29",
+   "sha256": "01yjzim26vq64ng6v5xhrkrs9mgkfpf3p6h2f7f8pijxanbcjxnv"
   },
   "stable": {
    "version": [
@@ -5775,14 +5848,14 @@
   "repo": "elp-revive/auto-highlight-symbol",
   "unstable": {
    "version": [
-    20240627,
-    650
+    20260101,
+    552
    ],
    "deps": [
     "ht"
    ],
-   "commit": "fe230750fdd3de07f71e776cb3270754e0865234",
-   "sha256": "0y5jcx8fkljfcsl5g92fzwq4x0ifr843bi9hy452kwgim6afi9ri"
+   "commit": "e84da32e7cf1baefb0a9eef42a2fc842cf18f8b3",
+   "sha256": "132d7rafq08n1blnanshr9fvpgdw20chk18yjrh323gmksrwnm7f"
   },
   "stable": {
    "version": [
@@ -5928,11 +6001,11 @@
   "repo": "emacs-vs/auto-rename-tag",
   "unstable": {
    "version": [
-    20250101,
-    906
+    20260101,
+    547
    ],
-   "commit": "b38895ff4821df3a0461959146e9f912d2acde4e",
-   "sha256": "1zyjrbvn9wijwxbxds5rjzdbcnkz2pa06invm9pjiwh01zxniwzh"
+   "commit": "ace6de8bc8200aa9c9f37c8266d0e1b51627b559",
+   "sha256": "11ljvixggkigzlgm1nh56aqvsdaabbx55m1j6354dsja2v20vxkr"
   },
   "stable": {
    "version": [
@@ -6077,26 +6150,26 @@
   "repo": "marcwebbie/auto-virtualenv",
   "unstable": {
    "version": [
-    20250608,
-    1633
+    20260106,
+    1436
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "b39a7496cc4e226ef1f9fcdfeb5a12400f71c982",
-   "sha256": "09ndlyvqgfbbn2jixpa5lc9rx10q8dyha06iz21qs9wvczcnq3h6"
+   "commit": "0b6ba18f0b449a40e9ff438b4e910b58b8804282",
+   "sha256": "1acg8g1gqqk38x28pz9wd4wf2dg3rqf71da63wyj8020in7967df"
   },
   "stable": {
    "version": [
     2,
-    3,
+    4,
     0
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "b39a7496cc4e226ef1f9fcdfeb5a12400f71c982",
-   "sha256": "09ndlyvqgfbbn2jixpa5lc9rx10q8dyha06iz21qs9wvczcnq3h6"
+   "commit": "0b6ba18f0b449a40e9ff438b4e910b58b8804282",
+   "sha256": "1acg8g1gqqk38x28pz9wd4wf2dg3rqf71da63wyj8020in7967df"
   }
  },
  {
@@ -6828,28 +6901,28 @@
   "repo": "tarsius/backline",
   "unstable": {
    "version": [
-    20251101,
-    1936
+    20260101,
+    1825
    ],
    "deps": [
     "compat",
     "outline-minor-faces"
    ],
-   "commit": "821dab84aba746247be184066b2a69a6545ed346",
-   "sha256": "0ap3vfrxpvxgg0lv0blwkqnyv8rfwfl6zazky2nsg22kp3wd1ij4"
+   "commit": "ba263f5ea3dc1818c7a61b50acec52fe2cce02ca",
+   "sha256": "02wk8qhy1ns1dfbgid7z77hjiywmx5ngv3bvli5h5js1zkj9fcr9"
   },
   "stable": {
    "version": [
     1,
     2,
-    1
+    2
    ],
    "deps": [
     "compat",
     "outline-minor-faces"
    ],
-   "commit": "821dab84aba746247be184066b2a69a6545ed346",
-   "sha256": "0ap3vfrxpvxgg0lv0blwkqnyv8rfwfl6zazky2nsg22kp3wd1ij4"
+   "commit": "ba263f5ea3dc1818c7a61b50acec52fe2cce02ca",
+   "sha256": "02wk8qhy1ns1dfbgid7z77hjiywmx5ngv3bvli5h5js1zkj9fcr9"
   }
  },
  {
@@ -7093,11 +7166,11 @@
   "repo": "tinted-theming/base16-emacs",
   "unstable": {
    "version": [
-    20251214,
-    144
+    20260118,
+    148
    ],
-   "commit": "4166d35bb193f0d619072d671fbb1c76b750eb6f",
-   "sha256": "1s7n9rfjqm1zsj5sgvd3rkf8hpmrxrarf3qk1wkziir2vk6xkh6m"
+   "commit": "1d9457c3940b42a7db586ee9b1249d86d1facbdb",
+   "sha256": "1mlhbpv3xbka8r2p9zxmnvsgvlpijiv4nyyj0z9zf9n33rq7rs19"
   },
   "stable": {
    "version": [
@@ -7727,11 +7800,11 @@
   "repo": "dholm/benchmark-init-el",
   "unstable": {
    "version": [
-    20250313,
-    1200
+    20260108,
+    1447
    ],
-   "commit": "6507caa3c4cb2a6c9b85c771c5e9e5aeb7d745bc",
-   "sha256": "0ylfqr1ddkgvd2i57q46cpq2709iynji8m8vxhyg7dygmjijm1f2"
+   "commit": "54b9703389f25012e4cc20fe4a0d4ea253ce4820",
+   "sha256": "1hqcsdbfplxwdadmhwpwd645da1k21bkixnbqvl908lvlda0mzgn"
   },
   "stable": {
    "version": [
@@ -7879,11 +7952,11 @@
   "repo": "jcs-elpa/better-scroll",
   "unstable": {
    "version": [
-    20250101,
-    1002
+    20260101,
+    557
    ],
-   "commit": "14c700f8b43771a47f16b3385adbbddb741a03eb",
-   "sha256": "198bg0x8vq55lw6wx7ayql6ypfvxy8ms1nn9vrbsbh3c57pja10y"
+   "commit": "f87c21c7b29ba1545f7e1f050325dd85d478de76",
+   "sha256": "0cb8ik4ha1a54fq94kp1bl9m6kc4dbiq6q3mibvll8zrpdnwsvck"
   },
   "stable": {
    "version": [
@@ -7990,19 +8063,19 @@
   "repo": "kristjoc/bible-gateway",
   "unstable": {
    "version": [
-    20251219,
-    2150
+    20260105,
+    1259
    ],
-   "commit": "c9769ead9dc0bc9dbde015dfc367342a2c1c4bc3",
-   "sha256": "0xbgb6vb37l54yf5849w10brdzp47l17ql4pxy68zfr21q6g4vn2"
+   "commit": "8616ccb52a370c0d4ffca441a4bc2410a869e3b0",
+   "sha256": "16drh2mqvrvgi1dyblk0kw8yzswhccwniqlgs734jjgkfpvk0qks"
   },
   "stable": {
    "version": [
     1,
-    4
+    5
    ],
-   "commit": "b16fe8da14a90ee785d77d8c8c2af94df39a04bd",
-   "sha256": "1x92yxnhbyvhp4amw1m01vmyccxsfvv4nwvcy76kkhpni9dzsyvf"
+   "commit": "8616ccb52a370c0d4ffca441a4bc2410a869e3b0",
+   "sha256": "16drh2mqvrvgi1dyblk0kw8yzswhccwniqlgs734jjgkfpvk0qks"
   }
  },
  {
@@ -8243,26 +8316,26 @@
   "repo": "tarsius/bicycle",
   "unstable": {
    "version": [
-    20251212,
-    2319
+    20260101,
+    1825
    ],
    "deps": [
     "compat"
    ],
-   "commit": "80643a60f8066cba20a51f419be0c168af7fcbd7",
-   "sha256": "0mhwvv7q743d3m4il8ds1j8qskb9qbp541v89g6sqbz3f4d32am9"
+   "commit": "9da65dcb0e8ea6a9fe2b02d3be3cd4f2f4e29977",
+   "sha256": "113aj4mc3dz199826sy69nja9qys3637947alq3mv185gbaz4gdd"
   },
   "stable": {
    "version": [
     1,
     1,
-    1
+    2
    ],
    "deps": [
     "compat"
    ],
-   "commit": "baeb42c79fa213c1e47ab1158c01abdf0a4c54d3",
-   "sha256": "0mihvfhs3klm3ydc9zicfs4cpbyg48wdkw0wp7nk6bifa8a28j7s"
+   "commit": "9da65dcb0e8ea6a9fe2b02d3be3cd4f2f4e29977",
+   "sha256": "113aj4mc3dz199826sy69nja9qys3637947alq3mv185gbaz4gdd"
   }
  },
  {
@@ -8273,20 +8346,20 @@
   "repo": "riscy/bifocal-mode",
   "unstable": {
    "version": [
-    20200325,
-    539
+    20251231,
+    2025
    ],
-   "commit": "773a6dde790c4a240e643a9071e4c7bce09d40de",
-   "sha256": "11dirb13hblfa95hqqshrsjri4d4qzcq5qhhnd4xqajdchr62758"
+   "commit": "4e4f1084dc3dd95dfe0905854530e95dbf6c6c5b",
+   "sha256": "01n6xjq7rsnxr9lgf1danpj4vsi0p47napd2pg9sszi2zwpq11bw"
   },
   "stable": {
    "version": [
     0,
     0,
-    6
+    7
    ],
-   "commit": "773a6dde790c4a240e643a9071e4c7bce09d40de",
-   "sha256": "11dirb13hblfa95hqqshrsjri4d4qzcq5qhhnd4xqajdchr62758"
+   "commit": "4e4f1084dc3dd95dfe0905854530e95dbf6c6c5b",
+   "sha256": "01n6xjq7rsnxr9lgf1danpj4vsi0p47napd2pg9sszi2zwpq11bw"
   }
  },
  {
@@ -8616,16 +8689,16 @@
   "repo": "canatella/bitbake-el",
   "unstable": {
    "version": [
-    20240605,
-    1322
+    20251230,
+    1237
    ],
    "deps": [
     "dash",
     "mmm-mode",
     "s"
    ],
-   "commit": "8285f46fe19cb99fe5ed42d38de0fe5c51c98fb0",
-   "sha256": "1a929lxra50f99vc865iy2icprq3m40zg2zsgr5hxd2pvcpch927"
+   "commit": "44513a330d3bb2bceb1bfd99b4eb63b37f681369",
+   "sha256": "0zbbxgi87594aikvc89fq66sky9xp1kfmif74jbdkyfjjkydkzz0"
   }
  },
  {
@@ -9027,14 +9100,14 @@
   "repo": "lapislazuli/blue.el",
   "unstable": {
    "version": [
-    20251204,
-    2112
+    20251223,
+    1409
    ],
    "deps": [
     "magit-section"
    ],
-   "commit": "1d130e8042dcbe8eca0bf87c2adc60d6a7287150",
-   "sha256": "0290fi2drxqf5axak6cjgkjc83dz2znc13w41xqkd7whzr17xfmf"
+   "commit": "b2778111dba48b0d7db4c17cbe352b541e6e7707",
+   "sha256": "1wd4wg6mjsmxhxpx72hgqz9wnss0n060kdcf9i7llk1gsw4bcmjr"
   }
  },
  {
@@ -9350,11 +9423,11 @@
   "repo": "ideasman42/emacs-bookmark-in-project",
   "unstable": {
    "version": [
-    20251214,
-    537
+    20260108,
+    1305
    ],
-   "commit": "7839b4c9cd79d3993774867a97c9c5cf83944862",
-   "sha256": "1cd617p5d195m05lvmvihk13hmmwg4pxji23dryvd59xrl87zclh"
+   "commit": "bf923ddd3e74fe99e086221e461a5fa7599d0644",
+   "sha256": "0is4gxsbfi1kxs0fwj44q09pi6k00karsrp6w87i1ixjfvanlliz"
   }
  },
  {
@@ -9437,28 +9510,28 @@
   "repo": "emacscollective/borg",
   "unstable": {
    "version": [
-    20251130,
-    1841
+    20260114,
+    1146
    ],
    "deps": [
     "epkg",
     "magit"
    ],
-   "commit": "eea04635be203f500a9f94024416518b84649528",
-   "sha256": "17rgki7zbj1s8ldpfg8k5nv0l8rzc90n5rq4d3ywrq69ak8w58jp"
+   "commit": "9482e00eb06dfbc599eac58bb73ec53700793b3e",
+   "sha256": "0kxgai33b8irl08gbmfbrsqnvbfh702hvbrwi740a0zz7dwnq7iw"
   },
   "stable": {
    "version": [
     4,
-    3,
+    4,
     0
    ],
    "deps": [
     "epkg",
     "magit"
    ],
-   "commit": "28e6ba50fab83ffbcb0484dbdb1d5c180537235a",
-   "sha256": "0mwl0k98bidg7klays3ir7yag9q98f23sasias1f4phk7qxmb6sc"
+   "commit": "61f9e083b8d9f9ca196758729adce2c286841991",
+   "sha256": "18vnf0lkkribkinl0xr074vx1yhqmllxysbcgcf8p2vy92n4spzl"
   }
  },
  {
@@ -9616,11 +9689,11 @@
   "repo": "tarsius/paren-face",
   "unstable": {
    "version": [
-    20251101,
-    2048
+    20260101,
+    1846
    ],
-   "commit": "b121bc08ecb0c11a89705ed9f77c5343e2baec04",
-   "sha256": "0bs5hdn7agyr0r0ywblpihp4x3gn89xdfvzsb8wlyd0gvc2rx6g9"
+   "commit": "2c279a236404b2eebacb435aa92d5e9c97939c03",
+   "sha256": "06ypi3hgrr9rigcb9gy5j4l9f3z7lnz1rssv1pqda55srkvcp39x"
   }
  },
  {
@@ -9664,11 +9737,11 @@
   "repo": "ideasman42/emacs-bray",
   "unstable": {
    "version": [
-    20251012,
-    25
+    20260108,
+    326
    ],
-   "commit": "d17c245a15bae1ba8aa83bb1fb71508e04ac1258",
-   "sha256": "0rlf3afq661aaj9pbzd4nmmzj5nd35y6kg2wv3d449fbfhpy11nx"
+   "commit": "ad06429ac60a5e90e2c2de6ea24ec561cecfb2d0",
+   "sha256": "05v26sa59ya0713w10hirqckdc28dn8hxkc0zj148djc5kcbk256"
   }
  },
  {
@@ -9801,16 +9874,16 @@
   "repo": "rmuslimov/browse-at-remote",
   "unstable": {
    "version": [
-    20230223,
-    554
+    20251223,
+    2328
    ],
    "deps": [
     "cl-lib",
     "f",
     "s"
    ],
-   "commit": "1c2a565bb7275bf78f23d471e32dd8c696523b8c",
-   "sha256": "1vyybg5yvhm0b1cz7sll6x314iqwvk2zk96pv18nb1bga2nk775q"
+   "commit": "27b17cc63b9f9dca893425908373251eb9b10f44",
+   "sha256": "0kbxag8krbj1s50arc8axvkx0v62akqv2m8c2rkcjg5qh0670dkf"
   },
   "stable": {
    "version": [
@@ -9919,25 +9992,28 @@
   "repo": "plandes/bshell",
   "unstable": {
    "version": [
-    20240112,
-    2303
+    20260107,
+    1914
    ],
    "deps": [
-    "buffer-manage"
+    "buffer-manage",
+    "dash"
    ],
-   "commit": "d59559cf7c5dded8b9639346ae5c1384d8b9be4e",
-   "sha256": "0shfv1lxhz5k07jppdn0shm0pv1lzwsncfyniwm15fwhvb71bzhv"
+   "commit": "c13907ac0d2d8eda58c0e35d99179ed8c0e4c25a",
+   "sha256": "10pl094zvj889jlik0drww6iwgaf6b8ssxipa89v0ibh7fcczr80"
   },
   "stable": {
    "version": [
     1,
+    1,
     0
    ],
    "deps": [
-    "buffer-manage"
+    "buffer-manage",
+    "dash"
    ],
-   "commit": "57f3409168ec9649508e3ee30d0d2de8f81b960e",
-   "sha256": "1pmaz7gw45y7mlina3h0db26khdsbmlcw7adkvri33sgrr9x83q7"
+   "commit": "c13907ac0d2d8eda58c0e35d99179ed8c0e4c25a",
+   "sha256": "10pl094zvj889jlik0drww6iwgaf6b8ssxipa89v0ibh7fcczr80"
   }
  },
  {
@@ -10229,11 +10305,11 @@
   "repo": "jamescherti/buffer-terminator.el",
   "unstable": {
    "version": [
-    20250911,
-    2238
+    20260114,
+    1535
    ],
-   "commit": "68552751bcfd049e72a5b81b3077b121ec7a7d01",
-   "sha256": "1m0ymnpn5haa2xg7dh4j5nqsix86gg21z1jxd93kj75ivk6r11m6"
+   "commit": "543c96ff73e38f51543747aee4665649525b0cf2",
+   "sha256": "15d6dw3hpwjz22cw9rv8a0cqx06nsxc1shwjx91r7d0s8v9fmhkg"
   },
   "stable": {
    "version": [
@@ -10307,11 +10383,11 @@
   "repo": "jcs-elpa/buffer-wrap",
   "unstable": {
    "version": [
-    20250101,
-    1003
+    20260101,
+    558
    ],
-   "commit": "60f205258981d3433700b9c1c8d14026a001bd5e",
-   "sha256": "1v7jzhqgp884avhi7wk5vnyr8f37ivqpl9dh7hvxqqw3qrybnvdi"
+   "commit": "53a098384c17ae5140e525aeeeece3b14d35e12f",
+   "sha256": "0h09mwkvc0fjqb4xx299v1sabbp4i68wp0k1l99c1xxlvcz5zy2r"
   },
   "stable": {
    "version": [
@@ -10346,11 +10422,11 @@
   "repo": "jamescherti/bufferfile.el",
   "unstable": {
    "version": [
-    20251011,
-    1158
+    20260114,
+    1535
    ],
-   "commit": "e4e5c46fcf656fa06f7388b514fbf17636bba424",
-   "sha256": "0g5fmmfh5l9zraw05hws4kwfzrbj4b5qfl178nph6lzw39dzc953"
+   "commit": "6bcff99b4e78a83ffaa15f1ce95f4f0421db64b0",
+   "sha256": "0cxs6phsvm5dbfxvw36sv8av4n436rc9w9wv2245ba6m1kr7f9bv"
   },
   "stable": {
    "version": [
@@ -11351,16 +11427,16 @@
   "repo": "beacoder/call-graph",
   "unstable": {
    "version": [
-    20250106,
-    1659
+    20251227,
+    222
    ],
    "deps": [
     "beacon",
     "ivy",
     "tree-mode"
    ],
-   "commit": "20dd4de35197d4d9d618615f4d13b31d4b5345fe",
-   "sha256": "0nsi6h0clbq7allvk8kyw8h1myhzi42lk9hn3gq40nw62v04y0rk"
+   "commit": "95008f18991691fc117c12e84cde2b9dc04e4e4b",
+   "sha256": "0r06sixyj5s7gvy255bhbwcicc2xwcsklqrv65xbx4y1ycjls2r3"
   },
   "stable": {
    "version": [
@@ -11513,25 +11589,25 @@
   "repo": "minad/cape",
   "unstable": {
    "version": [
-    20251221,
-    1843
+    20260117,
+    1953
    ],
    "deps": [
     "compat"
    ],
-   "commit": "281ef8d6f44faa12d6eb9990366ac4bc920c62b1",
-   "sha256": "0s2pirvws93nrrfcz1bwzbvmzgd5sv4hrf2012i5ag42c0skdqmh"
+   "commit": "dfb3bca62238aab8f64ec319a77a125df86a0eee",
+   "sha256": "0bi81w8qpl9gwfj0423bcsnl2wady2jvsxbc5ai7mb9mc1qzyvgg"
   },
   "stable": {
    "version": [
     2,
-    4
+    5
    ],
    "deps": [
     "compat"
    ],
-   "commit": "281ef8d6f44faa12d6eb9990366ac4bc920c62b1",
-   "sha256": "0s2pirvws93nrrfcz1bwzbvmzgd5sv4hrf2012i5ag42c0skdqmh"
+   "commit": "96162aab2a22158ccc40b0f5c90f61e77b03c4f8",
+   "sha256": "12jk8jjk38mfldsgnimnsggxan5a5amzf2z17pwjq7dxhn87168j"
   }
  },
  {
@@ -11542,11 +11618,11 @@
   "repo": "capnproto/capnproto",
   "unstable": {
    "version": [
-    20210707,
-    2310
+    20260106,
+    2017
    ],
-   "commit": "f7fccad7d737f77896211bec1173117497634143",
-   "sha256": "1iq5aksrj2svhmgfn2jhc3rcls6s5ypf967ww8vhi0q0r3rkznx9"
+   "commit": "92327754f61963a2b4f0edbd299246ed1d42e665",
+   "sha256": "0f9hla2rz4ypwgj2gp3ws0rf881pz4xfwia9y202v7j0hrcx0wa0"
   },
   "stable": {
    "version": [
@@ -11626,20 +11702,20 @@
   "repo": "ayrat555/cargo-mode",
   "unstable": {
    "version": [
-    20250529,
-    1140
+    20260114,
+    839
    ],
-   "commit": "b1fb87c17fcd22d798bb04115e65ecf83e8c929a",
-   "sha256": "0nprja97788hsrm5p168ib7mzyqn0n37kz4cl857nbb372r1gvm5"
+   "commit": "33528954218f8957a26f3fef506c3537823d569d",
+   "sha256": "12vx9ggw35prxncxnjdxnf79dil76mgmipqxlg1nc5bdlp9plf6d"
   },
   "stable": {
    "version": [
     0,
     0,
-    9
+    10
    ],
-   "commit": "b1fb87c17fcd22d798bb04115e65ecf83e8c929a",
-   "sha256": "0nprja97788hsrm5p168ib7mzyqn0n37kz4cl857nbb372r1gvm5"
+   "commit": "33528954218f8957a26f3fef506c3537823d569d",
+   "sha256": "12vx9ggw35prxncxnjdxnf79dil76mgmipqxlg1nc5bdlp9plf6d"
   }
  },
  {
@@ -11841,28 +11917,28 @@
   "repo": "kickingvegas/casual",
   "unstable": {
    "version": [
-    20251202,
-    2123
+    20260107,
+    910
    ],
    "deps": [
     "csv-mode",
     "transient"
    ],
-   "commit": "f38fb5e5d850d96d57559526bff973f41cf73940",
-   "sha256": "10hdhpgsxhvyi6ybcvlfhwm88q34sgsb43jvgg7m4jm98n1nvima"
+   "commit": "1620d8ac1f555b4b4299fb7a852d59ddeaaae2e4",
+   "sha256": "0w3p5zdd1wbx8jyk22z0z952wpkfxlrzliihr6gcvid7d249pjhf"
   },
   "stable": {
    "version": [
     2,
-    11,
-    2
+    12,
+    1
    ],
    "deps": [
     "csv-mode",
     "transient"
    ],
-   "commit": "f38fb5e5d850d96d57559526bff973f41cf73940",
-   "sha256": "10hdhpgsxhvyi6ybcvlfhwm88q34sgsb43jvgg7m4jm98n1nvima"
+   "commit": "1620d8ac1f555b4b4299fb7a852d59ddeaaae2e4",
+   "sha256": "0w3p5zdd1wbx8jyk22z0z952wpkfxlrzliihr6gcvid7d249pjhf"
   }
  },
  {
@@ -12280,14 +12356,14 @@
   "repo": "ema2159/centaur-tabs",
   "unstable": {
    "version": [
-    20241215,
-    1321
+    20260115,
+    2125
    ],
    "deps": [
     "powerline"
    ],
-   "commit": "35389777bc7c4972e302d3793e1a5250f501404d",
-   "sha256": "1y2l3h850msrgpnjbzndacfbkcrvqmqym8zr2mrx3wilpnb8ba4v"
+   "commit": "5ad22d9a6a5d056a07f08b6fe6253f2a71f94ad8",
+   "sha256": "1izf6kpsbr3zjb8cl17gs416yqr2sm4wcxs4bn6lhhym5vqcim3x"
   },
   "stable": {
    "version": [
@@ -12484,16 +12560,16 @@
   "repo": "worr/cfn-mode",
   "unstable": {
    "version": [
-    20251214,
-    908
+    20260118,
+    907
    ],
    "deps": [
     "f",
     "s",
     "yaml-mode"
    ],
-   "commit": "3eaff0fa545774761fb6b86783b5c9e538a825b6",
-   "sha256": "0jmh2ymc1z15800w924dmnf9s0lhrq3016zqvn29v4y0g5b7282l"
+   "commit": "e52b95671b6834395463096a9431149ecf0a1a20",
+   "sha256": "0553fw3fd7phk0bbmdysx3gxr513f2aqm83yhmpphzkj50w91wm8"
   },
   "stable": {
    "version": [
@@ -13168,25 +13244,26 @@
   "repo": "plandes/choice-program",
   "unstable": {
    "version": [
-    20250113,
-    429
+    20260107,
+    1854
    ],
    "deps": [
     "dash"
    ],
-   "commit": "09e5bf8fa73c22bc23b1afec35da6410d8b167bd",
-   "sha256": "0r295srslbk0nbbnhwg2l9lnpag7g19g63hgsrjac0qxyg9hli0g"
+   "commit": "acacd3409d60b7aa5c53d07290a8dfc31b919971",
+   "sha256": "0z46pkwc15p1lag5i5n6hmfj9abb0bpk1m61knwls31rmqrq6cj4"
   },
   "stable": {
    "version": [
     0,
-    15
+    16,
+    1
    ],
    "deps": [
     "dash"
    ],
-   "commit": "09e5bf8fa73c22bc23b1afec35da6410d8b167bd",
-   "sha256": "0r295srslbk0nbbnhwg2l9lnpag7g19g63hgsrjac0qxyg9hli0g"
+   "commit": "acacd3409d60b7aa5c53d07290a8dfc31b919971",
+   "sha256": "0z46pkwc15p1lag5i5n6hmfj9abb0bpk1m61knwls31rmqrq6cj4"
   }
  },
  {
@@ -13444,8 +13521,8 @@
   "repo": "clojure-emacs/cider",
   "unstable": {
    "version": [
-    20251105,
-    925
+    20260116,
+    1514
    ],
    "deps": [
     "clojure-mode",
@@ -13456,8 +13533,8 @@
     "spinner",
     "transient"
    ],
-   "commit": "8e3091e8c427cc18f1cc511d5d5aa15424cddb62",
-   "sha256": "08hd281ybskkhir170hr3xpga1b1hwpph7rd0fk6fvm0ngdgxazs"
+   "commit": "31c05c0a417c2c3dec97135c3dab3cd9c8322e53",
+   "sha256": "1gc5rn0v81alpairwd07asaxmjc9bsh08nv0rdscy7prq9jfgd4n"
   },
   "stable": {
    "version": [
@@ -13938,8 +14015,8 @@
   "repo": "andras-simonyi/citeproc-el",
   "unstable": {
    "version": [
-    20251103,
-    716
+    20260113,
+    1047
    ],
    "deps": [
     "compat",
@@ -13951,8 +14028,8 @@
     "s",
     "string-inflection"
    ],
-   "commit": "a3d62ab8e40a75fcfc6e4c0c107e3137b4db6db8",
-   "sha256": "1ffxh22xhzg582hbpsxr6cyjfyvvv5yqn3k39qxmkxbxk0g6hair"
+   "commit": "4bde999a41803fe519ea80eab8b813d53503eebd",
+   "sha256": "07ssnxri3hwzqxa2777zw2grbncznh6n7k4vfsfgyj42vcqm9g19"
   },
   "stable": {
    "version": [
@@ -15061,29 +15138,30 @@
   "repo": "magit/closql",
   "unstable": {
    "version": [
-    20251215,
-    1734
+    20260101,
+    1828
    ],
    "deps": [
     "compat",
     "cond-let",
     "emacsql"
    ],
-   "commit": "cbead2f2958449e6a1c4e93e956ef20c56593bc0",
-   "sha256": "1kcbzj21mkfmmn1awax1hb24ykw7dxg52xb93bqabk26vh5qxnjj"
+   "commit": "947426d0c93e5ad5374c464b2f121c36cdaf2132",
+   "sha256": "08zxrzwpsixcc9ma7zps21krm0fn7l97aawhhacn2yf1mjja0p5s"
   },
   "stable": {
    "version": [
     2,
-    3,
-    2
+    4,
+    0
    ],
    "deps": [
     "compat",
+    "cond-let",
     "emacsql"
    ],
-   "commit": "4a60723ae4bfe809a9affcf3306cb40e0ca1ca6c",
-   "sha256": "110xlykmgd77z908l54kws7qcgj9hk7r33zmbk13dabl3wf8yzzk"
+   "commit": "947426d0c93e5ad5374c464b2f121c36cdaf2132",
+   "sha256": "08zxrzwpsixcc9ma7zps21krm0fn7l97aawhhacn2yf1mjja0p5s"
   }
  },
  {
@@ -15163,14 +15241,14 @@
   "repo": "joostkremers/criticmarkup-emacs",
   "unstable": {
    "version": [
-    20240422,
-    725
+    20251229,
+    930
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "a9381f57f3005a9b26f81085ecb2accf680c6f6b",
-   "sha256": "0c3hry0rvjrqi67caxqjdmsx2pzd3ybgsyzi6jfnlwzsw5iwyjqi"
+   "commit": "5c9fadbae23d5ba51b65a4620354621ee8c1907d",
+   "sha256": "1lg22rj7axrpay8r5gdpiffm9lz27pmkv86nmh72am2bb4094c1p"
   },
   "stable": {
    "version": [
@@ -15337,11 +15415,11 @@
   "repo": "tumashu/cnfonts",
   "unstable": {
    "version": [
-    20241120,
-    2133
+    20251223,
+    636
    ],
-   "commit": "0b4fb8c2f743594010bb8137db6e71087efdaf67",
-   "sha256": "01dkmzc88knh06r0fb78vknjlh006v8rkrjwr88g5757jf3bvlb5"
+   "commit": "9daace1a96febb4f8ec72f1a845a4e63ae56bc4c",
+   "sha256": "13i2kbrrxbqjmh76644gbrbfc5ap8nqhzkv4i0y2f7591i6dpmjh"
   },
   "stable": {
    "version": [
@@ -15813,14 +15891,14 @@
   "repo": "ankurdave/color-identifiers-mode",
   "unstable": {
    "version": [
-    20251205,
-    2247
+    20251227,
+    1110
    ],
    "deps": [
     "dash"
    ],
-   "commit": "a868ccaeb2be5109391f8cb66004c9f457f0506f",
-   "sha256": "0h6lrlkkbclwhhh664nld27z28fmdp4am2ga79427mzpb8llpkl9"
+   "commit": "adcdbbe9c69edeb207f2b066db071057f3f612d6",
+   "sha256": "0y65bbbiwgrqp3bhzmrgqbqx032mmdp0xrqn8h68r7n7d669kx95"
   },
   "stable": {
    "version": [
@@ -15953,11 +16031,11 @@
   "repo": "purcell/color-theme-sanityinc-tomorrow",
   "unstable": {
    "version": [
-    20251107,
-    1433
+    20260105,
+    1047
    ],
-   "commit": "f3f05e31cd9fd2e99e8d7859a8d46a549fac9537",
-   "sha256": "0b719v2k58iac24gbzx2cvl0f608i4zlabzqxpr05hyaayl92jjn"
+   "commit": "22107d90816293c361b777b1f8dfd6ba0be00f7b",
+   "sha256": "0kplsngi22m7i7wy9crizfqbsc6kfmx6h6svr2kirdglabjsnakm"
   },
   "stable": {
    "version": [
@@ -16056,14 +16134,14 @@
   "repo": "jcs-elpa/com-css-sort",
   "unstable": {
    "version": [
-    20250101,
-    1004
+    20260101,
+    558
    ],
    "deps": [
     "s"
    ],
-   "commit": "4c6f8bfd88c0bcee9ac121f013d1fcd88f462bae",
-   "sha256": "1vf6w0kjzingidqd7bcvfvd5xlgzj9gbvj510xm42bbnsy6a90fh"
+   "commit": "244f910ef55c853e75b0109b7fd96ce742a13461",
+   "sha256": "0qgk3y1vcym5lvc7lv3mswzargwgi990mipflfgfxjqqriv5jfyy"
   },
   "stable": {
    "version": [
@@ -16440,11 +16518,11 @@
   "repo": "company-mode/company-mode",
   "unstable": {
    "version": [
-    20251021,
-    2211
+    20260108,
+    36
    ],
-   "commit": "4ff89f7369227fbb89fe721d1db707f1af74cd0f",
-   "sha256": "054k6xwh8vkbj0j8jj6wnkh12fnqhdkcw5djqz05x1pm413zyixl"
+   "commit": "fad9f207e00a851c0d96dd532c1b175326ac3e3d",
+   "sha256": "0c7wm5wkq94j64v7ivk2aq3172lg3cd4nn77l5k7aszh3rqlhrnm"
   },
   "stable": {
    "version": [
@@ -16805,15 +16883,15 @@
   "repo": "emacs-eask/company-eask",
   "unstable": {
    "version": [
-    20240329,
-    1742
+    20251231,
+    1607
    ],
    "deps": [
     "company",
     "eask"
    ],
-   "commit": "3d8973a70f01121cad052b352ec0a3d76d8110d2",
-   "sha256": "0vl5isff47c4z0za49zhy7qzskysxcbyhlgvkk35nbiyrcdfazdw"
+   "commit": "8011dc5c6c931760a80189d1695147cad674e568",
+   "sha256": "14v24rlw1h2101ps3ykmpa91pgmjkyf1d6zaz2d6pffdclp9ag7v"
   },
   "stable": {
    "version": [
@@ -16869,16 +16947,16 @@
   "repo": "jcs-elpa/company-emojify",
   "unstable": {
    "version": [
-    20250101,
-    1006
+    20260101,
+    558
    ],
    "deps": [
     "company",
     "emojify",
     "ht"
    ],
-   "commit": "7eff81607354feb9992ab6ff0f2c44c5a0dab229",
-   "sha256": "1ifqbrf5p3rs7wjlfcwra8g42gcih68sr39rbhmzrnxbn6hrhz27"
+   "commit": "e7dcd46effa607c18cb4bde51a59dc310ceeac1c",
+   "sha256": "1ln80c2rxnv4mfbnzyqy9b2zx1jj95l156hjpjxcpy3z13c1rby0"
   },
   "stable": {
    "version": [
@@ -16993,16 +17071,16 @@
   "repo": "jcs-elpa/company-fuzzy",
   "unstable": {
    "version": [
-    20250602,
-    1018
+    20260101,
+    558
    ],
    "deps": [
     "company",
     "ht",
     "s"
    ],
-   "commit": "e2da8ca84c9ba0a4fe6fa0ccdad83ce47aa14828",
-   "sha256": "1rfj4kivlc67xgh9garagzz082h1am25m2narr4kc33260bk0sq1"
+   "commit": "4b023aa623272675112ea57a50f286475ca620d2",
+   "sha256": "1mmcnnhwvrlgqzxr2nfq447y22ph3m7iv8lv6hpd7n614w57wykx"
   },
   "stable": {
    "version": [
@@ -18338,11 +18416,11 @@
   "repo": "jamescherti/compile-angel.el",
   "unstable": {
    "version": [
-    20251116,
-    2222
+    20260114,
+    1601
    ],
-   "commit": "95a0d01dc9c6eeac5023465fadf8ab82726df097",
-   "sha256": "0c5n6qwjjv3wn2cdmh31zgpwzz3vkdq2jmzyals7h2ag1s7cxq4r"
+   "commit": "59b431c6a55b8aeb36f536756890adc3b70ee205",
+   "sha256": "0hkn932lbnq4dp7zkw6gvb23xcs3253hava738cdhbw2b2kj32rr"
   },
   "stable": {
    "version": [
@@ -18474,8 +18552,8 @@
   "repo": "mkcms/compiler-explorer.el",
   "unstable": {
    "version": [
-    20251020,
-    1212
+    20260113,
+    1505
    ],
    "deps": [
     "eldoc",
@@ -18483,13 +18561,13 @@
     "plz",
     "seq"
    ],
-   "commit": "efad3b9f92098d2eb28d6ae47b71e8853f6dfb49",
-   "sha256": "1j1pkz8pq035s20bwi0biqbjs3wnm0azddqscsld0kxmgcgqf082"
+   "commit": "79a4c4be96a3210ccc85d2e7f1acbc1a4bcf86d5",
+   "sha256": "0zapy5fjzfw7rxw7wkwvq27wbqsic7l7wjv0wlb5djyfjcax9g5q"
   },
   "stable": {
    "version": [
     0,
-    7,
+    8,
     0
    ],
    "deps": [
@@ -18498,8 +18576,8 @@
     "plz",
     "seq"
    ],
-   "commit": "9e32e10b13a53b1fbf5471c34e4c0ea7a5db9057",
-   "sha256": "0gmf0q8s4n4x5v3nj0yanmc5nrjcca4049h7xg5dvd3250y0a1ar"
+   "commit": "b2ea96c2989a953aca02ccfc966877fb6c538521",
+   "sha256": "1vg9x8rg2p58dkg09gxf7lmw1fsd9qrhkjamj4q1fzdxkxhskg9p"
   }
  },
  {
@@ -18635,20 +18713,20 @@
   "repo": "tarsius/cond-let",
   "unstable": {
    "version": [
-    20251101,
-    1942
+    20260118,
+    1332
    ],
-   "commit": "288b7d36563223ebaf64cb220a3b270bdffb63f1",
-   "sha256": "0jdhdngczdwj44wk3zsb9ab5dv5j9bflfwg22hay1rrzq5jiihyw"
+   "commit": "e08a9ccf29e28aae43988458789dea04a562ccd1",
+   "sha256": "198yk7fr28n85mglmq41r8ir3vl1fk0000z1a79hb7xmplkk6c3d"
   },
   "stable": {
    "version": [
     0,
     2,
-    0
+    1
    ],
-   "commit": "288b7d36563223ebaf64cb220a3b270bdffb63f1",
-   "sha256": "0jdhdngczdwj44wk3zsb9ab5dv5j9bflfwg22hay1rrzq5jiihyw"
+   "commit": "0430bd1eb3493ea90d69feb6b7eb7dac3e10d0ba",
+   "sha256": "0611cz5warp6w4zvy4q1mkxkgypnlfwwz52h94n8mgqxa0r3rhvs"
   }
  },
  {
@@ -18882,25 +18960,25 @@
   "repo": "minad/consult",
   "unstable": {
    "version": [
-    20251129,
-    758
+    20260118,
+    744
    ],
    "deps": [
     "compat"
    ],
-   "commit": "d0370320d9fdde5ac6e0a27720f51138315af882",
-   "sha256": "1qhmlig5z5gmavzw4l7ml3rqgr6aa7as80wxrdigf5i6mdn58z67"
+   "commit": "312f2db1a23ef5428ab9553679147d5ff3a4e57d",
+   "sha256": "1q046nfhikklz137yccsxnak91hdh38gjpl1nbssh0nmqcfgkmvs"
   },
   "stable": {
    "version": [
     3,
-    1
+    3
    ],
    "deps": [
     "compat"
    ],
-   "commit": "d0370320d9fdde5ac6e0a27720f51138315af882",
-   "sha256": "1qhmlig5z5gmavzw4l7ml3rqgr6aa7as80wxrdigf5i6mdn58z67"
+   "commit": "312f2db1a23ef5428ab9553679147d5ff3a4e57d",
+   "sha256": "1q046nfhikklz137yccsxnak91hdh38gjpl1nbssh0nmqcfgkmvs"
   }
  },
  {
@@ -19136,27 +19214,27 @@
   "repo": "minad/consult-flycheck",
   "unstable": {
    "version": [
-    20250923,
-    1114
+    20260117,
+    1654
    ],
    "deps": [
     "consult",
     "flycheck"
    ],
-   "commit": "062e223bc6cf5f2126d7a107a35069c33c018c36",
-   "sha256": "0g30317fhjy3n4vgjc1m556h9fxayswzbbrriy2irc40fbxyrx91"
+   "commit": "9fe96c4b75c8566170ad41a04c3849d2e2606104",
+   "sha256": "0ga6mqskgmq979nj6ri89x85chcfw0pxhx2vz1xgssz10hwpbla9"
   },
   "stable": {
    "version": [
     1,
-    0
+    1
    ],
    "deps": [
     "consult",
     "flycheck"
    ],
-   "commit": "0662839aa5db429130f5ffd15c14d4a980b2e694",
-   "sha256": "1yi2qa4gbxlyhwc4rj3iidgr1dpdij68gbkgkk55l53p3yl1p2ww"
+   "commit": "9fe96c4b75c8566170ad41a04c3849d2e2606104",
+   "sha256": "0ga6mqskgmq979nj6ri89x85chcfw0pxhx2vz1xgssz10hwpbla9"
   }
  },
  {
@@ -19572,15 +19650,15 @@
   "repo": "Qkessler/consult-project-extra",
   "unstable": {
    "version": [
-    20250926,
-    603
+    20260117,
+    813
    ],
    "deps": [
     "consult",
     "project"
    ],
-   "commit": "8067e2c0ca29432514dabfb47a45cf1132a03789",
-   "sha256": "18y1f3z7l563pbnn67fs8jz3dsr04gpgyi1ijshpq40c7ncsnpmf"
+   "commit": "2b3fa36fd3a14deacf594f4acd54d220d6890c55",
+   "sha256": "1k1z8rsqqri4dpvc7vnrgc2s53h538vyllvc700wci1zk5pa9khj"
   },
   "stable": {
    "version": [
@@ -19752,6 +19830,25 @@
    ],
    "commit": "06837dc61a3b8f38dec0ad62b33293fc50ca03d2",
    "sha256": "1bc4pl4bkxz8mj3bij0zn3b6sws49c10a77mgs0mkz9c7n2f6hkd"
+  }
+ },
+ {
+  "ename": "consult-vulpea",
+  "commit": "7f2dcc8c1adf0032f741e218cea8d99b65af6371",
+  "sha256": "0as451yzmcznphn2graci1ap5bnw86y0r0dn865m030mgcyrl522",
+  "fetcher": "github",
+  "repo": "fabcontigiani/consult-vulpea",
+  "unstable": {
+   "version": [
+    20260105,
+    2319
+   ],
+   "deps": [
+    "consult",
+    "vulpea"
+   ],
+   "commit": "1596d44b17d39882e96d20e9a387eab3df6143a2",
+   "sha256": "03vd0dr8l850vb1iih45i5xpp6sa5l5bj53rwc0x0ahzxv0mv1hw"
   }
  },
  {
@@ -19969,8 +20066,8 @@
   "repo": "chep/copilot-chat.el",
   "unstable": {
    "version": [
-    20251211,
-    520
+    20260105,
+    858
    ],
    "deps": [
     "aio",
@@ -19982,8 +20079,8 @@
     "shell-maker",
     "transient"
    ],
-   "commit": "ca446c226f08ae13fa6d173f4e3094a2e54adf09",
-   "sha256": "0k9masn4937sx4j6sd5cw7fqi9q8v8n06i0ajsrk9c46zvs18afl"
+   "commit": "9dd4b0c72e5e2af16b340a22a427105854f4e745",
+   "sha256": "0jlqf4mabynzwsl3s4vwha5lw1ipva9xkdin92qslmb8lkffr9r7"
   },
   "stable": {
    "version": [
@@ -20154,25 +20251,25 @@
   "repo": "minad/corfu",
   "unstable": {
    "version": [
-    20251222,
-    1050
+    20260118,
+    746
    ],
    "deps": [
     "compat"
    ],
-   "commit": "4be939efc6e40b3c028167343b930faf6017a555",
-   "sha256": "0lc996gynw2zdqkj4szaib0fg6336bhnvf9lp175p3cd4vf5gvcd"
+   "commit": "fbbcdf9578a8fbea4d6956fc3bdf2dcb776b8d8b",
+   "sha256": "0aliis64ifr17xyig99gbh0xczdkdlb4snq5pbrlnrjhzk1cksy4"
   },
   "stable": {
    "version": [
     2,
-    6
+    8
    ],
    "deps": [
     "compat"
    ],
-   "commit": "81af89b43aceb5714fcd21daabcfd4b77008e22e",
-   "sha256": "0psy7ximwnansy9pppcw1l2fryr15v2vqgj81q649743py6nd60l"
+   "commit": "fbbcdf9578a8fbea4d6956fc3bdf2dcb776b8d8b",
+   "sha256": "0aliis64ifr17xyig99gbh0xczdkdlb4snq5pbrlnrjhzk1cksy4"
   }
  },
  {
@@ -20382,14 +20479,14 @@
   "repo": "ideasman42/emacs-counsel-at-point",
   "unstable": {
    "version": [
-    20240616,
-    2345
+    20251230,
+    1124
    ],
    "deps": [
     "counsel"
    ],
-   "commit": "7da3813fe01e5a7a651632b1af031891c009b559",
-   "sha256": "15mq1lkjf72fb7g2di8gwvqk6iads2znhzbpx2khchia1vl30qba"
+   "commit": "720347962085ed4f0efe5db797882cf3f35ad68c",
+   "sha256": "0b2b8lpqq0cnsxkrypirvhigrcpmnrz2mfwpdfhqzm7sfd0amvg1"
   }
  },
  {
@@ -21554,11 +21651,11 @@
   "repo": "crystal-lang-tools/emacs-crystal-mode",
   "unstable": {
    "version": [
-    20250203,
-    1157
+    20260111,
+    2220
    ],
-   "commit": "39993f821e6d7ca1da125d0ceba6218c3ca4c5b7",
-   "sha256": "09097r4l4gzasg7zcamdbmd5rgmw1piz5z9wfhmvfxp65gwv25cl"
+   "commit": "559e1d8ff9bb87a4e937978001386bfb58b113a0",
+   "sha256": "0mf2cl99y187c1v0cw192jchdwivm5c1m1154hnl6kyks2wkh7l2"
   },
   "stable": {
    "version": [
@@ -21791,15 +21888,15 @@
   "repo": "neeasade/ct.el",
   "unstable": {
    "version": [
-    20250221,
-    2339
+    20260114,
+    1214
    ],
    "deps": [
     "dash",
     "hsluv"
    ],
-   "commit": "e3d082136e06c0ec777ab032bec5a785239f412b",
-   "sha256": "06gs6r2b8ldhjaigdbp9dnspbikajkkqarwif8y7q8mwiv63m6ib"
+   "commit": "66fb78baf83525ca068c3ddd156ef0989a65bf9d",
+   "sha256": "0f7gcvphf23i7gghvybh3cgbam4dnm8cn57c4p1q1m0qbdimd9w7"
   }
  },
  {
@@ -22402,14 +22499,14 @@
   "repo": "ideasman42/emacs-cycle-at-point",
   "unstable": {
    "version": [
-    20250913,
-    2251
+    20260111,
+    1240
    ],
    "deps": [
     "recomplete"
    ],
-   "commit": "c390803221816319ae6edcea470d12a4849606af",
-   "sha256": "0yd2x7fhn5fw0yb462y5ih6p6bg1sjz8cs48mjhnqr06p6h4jp0a"
+   "commit": "0af1fa35f49d320960870b9dbcb4d03440139fdf",
+   "sha256": "154sh14iqdwf02qdl8h8jsrr8rw60479bh6n1p1mx2xvx2yjpad1"
   }
  },
  {
@@ -22772,11 +22869,11 @@
   "repo": "rails-to-cosmos/danneskjold-theme",
   "unstable": {
    "version": [
-    20250302,
-    1553
+    20251229,
+    1605
    ],
-   "commit": "597cdf9135ce6cced22e46f81598723f11dbdcc5",
-   "sha256": "1zlhch5hhkgvzqn2d3ji6asxxi9gljj68l91xplrfdvg4ydy9lvn"
+   "commit": "c0e62d8dfef828d9977b67190dab77a7f9b2c189",
+   "sha256": "1j02p5asqy5lqbkmbw88zvs88zbc7261cml18wy87p42a9ccw74v"
   }
  },
  {
@@ -22828,8 +22925,8 @@
   "repo": "emacs-lsp/dap-mode",
   "unstable": {
    "version": [
-    20251105,
-    2320
+    20260104,
+    1524
    ],
    "deps": [
     "bui",
@@ -22842,8 +22939,8 @@
     "posframe",
     "s"
    ],
-   "commit": "ab96fc8e8df4ae23eb895aea6bed5b2a329d5f23",
-   "sha256": "10h2xscf4zb94r5hk9sjfgs9jfb3m06w3acv91b3v4pknamx3qid"
+   "commit": "ded79ff0637f0ceb04380926a5ce4c40ef0a4f4c",
+   "sha256": "116wr8dvs7bcf5xc7kbmfdpzn4l3ck3gkjk711a2bhirqlrqjxww"
   },
   "stable": {
    "version": [
@@ -23100,11 +23197,11 @@
   "repo": "nameiwillforget/d-emacs",
   "unstable": {
    "version": [
-    20251107,
-    1324
+    20260105,
+    2019
    ],
-   "commit": "ae3135b143027d857b3581dc93a4eb77773f1e67",
-   "sha256": "0shywyniid34psk1jp5x7sa9xh6z73lpg3ns8820qncn29dldwy9"
+   "commit": "5bdba90f2600fbe4c0ddf75d8b190fc9218a5476",
+   "sha256": "10zr2xf4zfgx2z0pf2kv42jclg3c28kjsniwmcgqw0ldjlx89yl6"
   }
  },
  {
@@ -23218,11 +23315,11 @@
   "repo": "emacs-dashboard/emacs-dashboard",
   "unstable": {
    "version": [
-    20250708,
-    57
+    20251231,
+    1631
    ],
-   "commit": "8c2cf0cfde4f5dac8c477f755380fffef6824108",
-   "sha256": "1fv33zivsjj0jnyisiqsif0ghj9wpklhlljpr219bqzh5pfa1r60"
+   "commit": "49de4c16624f6a86a5beb1196f68f02636a74d1b",
+   "sha256": "0p5v0bnvzngzz4jyr11jl44d1akywzwx3irbkbn6k0a5c4545caf"
   },
   "stable": {
    "version": [
@@ -23261,14 +23358,14 @@
   "repo": "emacs-dashboard/dashboard-ls",
   "unstable": {
    "version": [
-    20250226,
-    929
+    20251231,
+    1631
    ],
    "deps": [
     "dashboard"
    ],
-   "commit": "68ecc61d7302ccb71b0197096e8c9d80a03ad9b5",
-   "sha256": "15cryscf3x5f55hcvh28kqnblkvdvkhzbj9f62hj2wj2ka61r1bg"
+   "commit": "e6f1ae4e4f4efbc1d3c4cff84b220f44e963e6ab",
+   "sha256": "10rbxwz2zppsvq111ksvrkx22c1ak00p1w1bza4xwzc7aak0h0ix"
   },
   "stable": {
    "version": [
@@ -23706,11 +23803,11 @@
   "url": "https://salsa.debian.org/emacsen-team/debian-el.git",
   "unstable": {
    "version": [
-    20250411,
-    2043
+    20251227,
+    312
    ],
-   "commit": "ce6df85ee3c4220aedbaecdb6d623fb7b0707b21",
-   "sha256": "1sk82ad5c75kzbg0ym0z7qix7vlld7vxxk4jf4yijnwf5jnj75gj"
+   "commit": "9637930ced261a08fbc10b83a35786593ae54ad2",
+   "sha256": "15c52nc6ikn689vnkd5klmnk8kgc4x546q9mqch461l0ydja72nz"
   },
   "stable": {
    "version": [
@@ -23984,8 +24081,8 @@
   "repo": "jcs-elpa/define-it",
   "unstable": {
    "version": [
-    20250101,
-    1006
+    20260101,
+    558
    ],
    "deps": [
     "define-word",
@@ -23996,8 +24093,8 @@
     "s",
     "wiki-summary"
    ],
-   "commit": "28e5ad9ef4bba59b61a9f1f4f5efe545e892540b",
-   "sha256": "1p08p54h5idsm1jv4hy8716c1n72qd5mph7lkb7hwxkcgp4i0raj"
+   "commit": "f33effcfcd4ef73cefd5d1c32991c5802269643e",
+   "sha256": "1645xxv7x93z4fj05imrddbmbn7qj152vbv5yh8implqwf0mnlyw"
   },
   "stable": {
    "version": [
@@ -24314,8 +24411,8 @@
   "repo": "swflint/denote-sections",
   "unstable": {
    "version": [
-    20240608,
-    1629
+    20260112,
+    1809
    ],
    "deps": [
     "citar",
@@ -24323,8 +24420,8 @@
     "denote",
     "universal-sidecar"
    ],
-   "commit": "00c7084652fa32f9f4ab504facaaed623f299684",
-   "sha256": "0cd9207b9gwbxgv1vvlfk9yv9fy51697fwpr6j0s9v2px3jv9ahj"
+   "commit": "ea81318cf1c7d7281047a6b3a2ac8fb76c8535d7",
+   "sha256": "09qjwy90b5xpgzaplvw6vpwwhpa5484yjq9291b992h031gjvygw"
   }
  },
  {
@@ -24421,15 +24518,15 @@
   "repo": "swflint/denote-sections",
   "unstable": {
    "version": [
-    20240608,
-    1629
+    20260112,
+    1809
    ],
    "deps": [
     "denote",
     "universal-sidecar"
    ],
-   "commit": "00c7084652fa32f9f4ab504facaaed623f299684",
-   "sha256": "0cd9207b9gwbxgv1vvlfk9yv9fy51697fwpr6j0s9v2px3jv9ahj"
+   "commit": "ea81318cf1c7d7281047a6b3a2ac8fb76c8535d7",
+   "sha256": "09qjwy90b5xpgzaplvw6vpwwhpa5484yjq9291b992h031gjvygw"
   }
  },
  {
@@ -24810,25 +24907,25 @@
   "repo": "minad/dicom",
   "unstable": {
    "version": [
-    20251218,
-    2251
+    20260117,
+    1648
    ],
    "deps": [
     "compat"
    ],
-   "commit": "608963ef1475335d7466b50c38c5aaaeeb4cf98a",
-   "sha256": "1zsgjc3ahp9pdbjxhs4jxlf4v7fjsr7dy5j95r4k62pk8qf4ykwn"
+   "commit": "03a12498905ef80d67ff53d138d415d828ceb12f",
+   "sha256": "0k4gq0bznkq8i017xpycmyii5x48xqcq8x04p3r5a7qg9ljlwvfk"
   },
   "stable": {
    "version": [
     1,
-    2
+    3
    ],
    "deps": [
     "compat"
    ],
-   "commit": "161d7b6b990cf608f5f71b4a6c840cfa57107d35",
-   "sha256": "1inmzamm88zzq98x5xjc97c0kk9mgdmj9jw6vklmhiady2v8jy6y"
+   "commit": "03a12498905ef80d67ff53d138d415d828ceb12f",
+   "sha256": "0k4gq0bznkq8i017xpycmyii5x48xqcq8x04p3r5a7qg9ljlwvfk"
   }
  },
  {
@@ -24925,11 +25022,11 @@
   "repo": "ideasman42/emacs-diff-ansi",
   "unstable": {
    "version": [
-    20251216,
-    227
+    20260108,
+    1512
    ],
-   "commit": "dd600ebdc632c8f525dcba392526e6e56fcbca61",
-   "sha256": "0i4m3i8xkivdzwhjg0rsdmnzg3k8239q5mv0nhcq9425d04gwim8"
+   "commit": "98f1837840e9afedbff48969b2bd8468af7ceef3",
+   "sha256": "1hrhg1zly19c7fplswb2jcspsf0rcjwkh28pjrgrinw9n7dvwzqm"
   }
  },
  {
@@ -25078,16 +25175,30 @@
   "repo": "pkryger/difftastic.el",
   "unstable": {
    "version": [
-    20251217,
-    921
+    20260112,
+    1401
    ],
    "deps": [
     "compat",
     "magit",
     "transient"
    ],
-   "commit": "1ed9a8459d84b7489efb2094250485c5e2913149",
-   "sha256": "02p0p7r6d4390cvjqhnfnvvh2zbm0my1vwyf5zf3jmps8widn1s9"
+   "commit": "b33554a22c637f147d07c15fa9539c72bcfcfca0",
+   "sha256": "1rc5gnb1hdlh7gjpg8igrrzcvxk53h76mcbnbhmfdhxfixb2xh8r"
+  },
+  "stable": {
+   "version": [
+    1,
+    0,
+    0
+   ],
+   "deps": [
+    "compat",
+    "magit",
+    "transient"
+   ],
+   "commit": "b33554a22c637f147d07c15fa9539c72bcfcfca0",
+   "sha256": "1rc5gnb1hdlh7gjpg8igrrzcvxk53h76mcbnbhmfdhxfixb2xh8r"
   }
  },
  {
@@ -25254,26 +25365,26 @@
   "repo": "tarsius/dim-autoload",
   "unstable": {
    "version": [
-    20251101,
-    2000
+    20260101,
+    1826
    ],
    "deps": [
     "compat"
    ],
-   "commit": "793b259f6ad2c1b47152986ec2d39622792fb3d2",
-   "sha256": "077p2xxmjji9ngdm39cv1lc8nd6vby1fxbmha7xmzq7z7xsib340"
+   "commit": "503eee682c2fcc24e05a765ac28e847be950bad9",
+   "sha256": "1f0nwz85dhnf0via74yw21f30mg3afkfng5w6ssrny906jzg3pnp"
   },
   "stable": {
    "version": [
     2,
     1,
-    1
+    2
    ],
    "deps": [
     "compat"
    ],
-   "commit": "793b259f6ad2c1b47152986ec2d39622792fb3d2",
-   "sha256": "077p2xxmjji9ngdm39cv1lc8nd6vby1fxbmha7xmzq7z7xsib340"
+   "commit": "503eee682c2fcc24e05a765ac28e847be950bad9",
+   "sha256": "1f0nwz85dhnf0via74yw21f30mg3afkfng5w6ssrny906jzg3pnp"
   }
  },
  {
@@ -25337,11 +25448,11 @@
   "repo": "jcs-elpa/diminish-buffer",
   "unstable": {
    "version": [
-    20250101,
-    1007
+    20260101,
+    558
    ],
-   "commit": "6cc16c7b29b7f77b7df1fc59287551b1120a7bf7",
-   "sha256": "1j106rc9prcyj1l7yqlgvgryklma4zhg7gwx9zxm5k99c513bij1"
+   "commit": "bd94b5b58655454728b655a30c93c0347749cf37",
+   "sha256": "1vcvqy23w2kqjxqc7951ai1vg4imjnsl3hpa1dcn3as48m7rjhaf"
   },
   "stable": {
    "version": [
@@ -25425,11 +25536,11 @@
   "repo": "jamescherti/dir-config.el",
   "unstable": {
    "version": [
-    20251103,
-    1431
+    20260114,
+    1604
    ],
-   "commit": "727e34c77b2b43c6b0d0bc10556ece8c21bd1f9e",
-   "sha256": "18r6qk706yajv646g1jglhv5gncm0yp6r9f5fgavjikzf6gzwdlg"
+   "commit": "4ac26d4698b841f438c0896896f39db90c120571",
+   "sha256": "07l5g77j5dd4hfdyzd4rf3jgrw5sqqzdx2j6gzi6km5n7076qxbv"
   },
   "stable": {
    "version": [
@@ -25623,14 +25734,26 @@
   "repo": "meedstrom/dired-du-duc",
   "unstable": {
    "version": [
-    20251221,
-    1514
+    20251223,
+    1946
    ],
    "deps": [
     "dired-du"
    ],
-   "commit": "4948e2ce646fb6ddcf6a2f14ce42c3a07a828ae1",
-   "sha256": "06arxvkxc2zdz5l2syn7q8ajq5xm0f978ngj8pkw4wg6nfbifdh5"
+   "commit": "8b72d0a3c42332f23ca3c9fe7a940c9c0db2e474",
+   "sha256": "03bm2k4niwjkj5sy481qi5hzkr8bk1x15l7g7rzw5irrmrzv03gb"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    2
+   ],
+   "deps": [
+    "dired-du"
+   ],
+   "commit": "a90e13b6e4b7e39c9b7c57b9111bf33261431dc8",
+   "sha256": "18qaw3n9jgp5wky515kz4a15dz4xklha16yr7cdwpzgk3mlgrm13"
   }
  },
  {
@@ -26430,14 +26553,14 @@
   "repo": "Boruch-Baum/emacs-diredc",
   "unstable": {
    "version": [
-    20251124,
-    1412
+    20260106,
+    554
    ],
    "deps": [
     "key-assist"
    ],
-   "commit": "11ffa50763ac06a4aa356ba27f8ce5b57a0ac36c",
-   "sha256": "1a5zzhzm1ia6f3ri4j1sgja404y3zc0rdm4dy3sl8rsrgv8k3307"
+   "commit": "812a0e1892a318cf6cfd69d1296480e810e5d790",
+   "sha256": "18qax2d1yj3yyp0alwh54w2zirf0hj0kzns0728axcgmi1h5l0hw"
   },
   "stable": {
    "version": [
@@ -26836,21 +26959,6 @@
   }
  },
  {
-  "ename": "disk",
-  "commit": "e6e75695594ce17b618ad8786c8a04e283f68b11",
-  "sha256": "1jzkqgjw8xl0jc6ssl5bsdjp2dxw88nss6szvjv7frrhsncaq28h",
-  "fetcher": "github",
-  "repo": "kensanata/disk",
-  "unstable": {
-   "version": [
-    20171116,
-    731
-   ],
-   "commit": "283e54e3be7d08f959076240b2ab324e25632137",
-   "sha256": "15fkfl9kjlpsg9p5g0xhm384ipvrzclwxvqk8vz1zixq0wam2ajm"
-  }
- },
- {
   "ename": "dispass",
   "commit": "855ea20024b606314f8590129259747cac0bcc97",
   "sha256": "09c9v41rh63hjpdh377rbfvpial33r41dn5bss3632fi34az5l9n",
@@ -26924,14 +27032,14 @@
   "repo": "aurtzy/disproject",
   "unstable": {
    "version": [
-    20251007,
-    310
+    20260114,
+    1438
    ],
    "deps": [
     "transient"
    ],
-   "commit": "c2b14a5e1b1e9173b5089102a737e4ed110cd2b6",
-   "sha256": "14q4cvr0kq6c072fiv8bl9dzkw409bjcr7s9h85jf1lnvjj1v446"
+   "commit": "9282473adbf450785741fe6cd02abf6ffed7b9f0",
+   "sha256": "0jv05m258ygwkg1714kw600b75wpimhh37xfl726lgn37zaz523r"
   },
   "stable": {
    "version": [
@@ -27372,11 +27480,11 @@
   "repo": "ideasman42/emacs-doc-show-inline",
   "unstable": {
    "version": [
-    20251126,
-    1144
+    20260108,
+    1342
    ],
-   "commit": "87993d064d02dcdbb3dcfd883e4a0b498b0978d8",
-   "sha256": "1cv4iikmzgydzsjmm2jayyaims2cnijjfhc931q24p7dc6p3fr8l"
+   "commit": "4a81b89873f8d3594b7d7b65c15f86ec6c49e40c",
+   "sha256": "16fm0dcqc6g8xzy0090lgi3pcasim9mdbyp8ap96gjk8y7byqlna"
   }
  },
  {
@@ -27439,8 +27547,8 @@
   "repo": "Silex/docker.el",
   "unstable": {
    "version": [
-    20251028,
-    1026
+    20260115,
+    1341
    ],
    "deps": [
     "aio",
@@ -27449,8 +27557,8 @@
     "tablist",
     "transient"
    ],
-   "commit": "375e0ed45bb1edc655d9ae2943a09864bec1fcba",
-   "sha256": "102hn0m91shyiz25x2c5ihhzbc8a3i9vnlkfcb3xm3w3nrqa5w64"
+   "commit": "f69f331e767109bf456bf7780d2a8982f9d23b22",
+   "sha256": "1ha9j13l256dky0fgbzi8ndbb1yj996q1j4q42vbiidrfinxpfl5"
   },
   "stable": {
    "version": [
@@ -27662,14 +27770,14 @@
   "repo": "emacs-vs/docstr",
   "unstable": {
    "version": [
-    20250101,
-    908
+    20260101,
+    548
    ],
    "deps": [
     "s"
    ],
-   "commit": "76bfff172a1b915165854ed1ad3478d0366d528f",
-   "sha256": "1w1lbaj51q9j0b8x2xf29lbc5hjb6fmhy19m533f31likm2cjjk2"
+   "commit": "c83e3d24b610168477466aab7ca691cbe7c36484",
+   "sha256": "1ss9cic7qymh40ksklmqdvd7nvi44i0zpgr32iqgvzlc9j71r8ps"
   },
   "stable": {
    "version": [
@@ -27805,10 +27913,10 @@
  },
  {
   "ename": "doom",
-  "commit": "0960deb3b1d106ad2ffa95a44f34cb9efc026f01",
-  "sha256": "1ji2fdiw5b13n76nv2wvkz6v155b0qgh1rxwmv3m5nnrbmklfjh5",
-  "fetcher": "github",
-  "repo": "kensanata/doom",
+  "commit": "72d186e58bf4303eb6023d16b11e42548f3c3100",
+  "sha256": "1anqdnxlrf4g8akrvmdpdakx7naiy7vz5nnqip7rn1pa5pcjzigq",
+  "fetcher": "git",
+  "url": "https://src.alexschroeder.ch/doom.git",
   "unstable": {
    "version": [
     20180301,
@@ -27840,16 +27948,16 @@
   "repo": "seagle0128/doom-modeline",
   "unstable": {
    "version": [
-    20251219,
-    240
+    20260110,
+    517
    ],
    "deps": [
     "compat",
     "nerd-icons",
     "shrink-path"
    ],
-   "commit": "2d40bdb8f317425153ea6b685be6435392d9406d",
-   "sha256": "01445nc0kx900079ki14gh1cb9wwhipxzkc0b4x8b8jbbrfiw1bj"
+   "commit": "9ac20488c56be0e88611881beb713cc58e02eff3",
+   "sha256": "1c22gyckinxhz3qixbh05i7qgnwpag9xy78mb6rf4hyr00b3yqpz"
   },
   "stable": {
    "version": [
@@ -27904,14 +28012,14 @@
   "repo": "doomemacs/themes",
   "unstable": {
    "version": [
-    20251211,
-    106
+    20260117,
+    2323
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "ad9b1bd1c21e25f044a4d2c3db41734666b00d16",
-   "sha256": "0lpbphra73whcghl5dq8q93ryxzn7kr8gj4mzbisfplyfcl83h0h"
+   "commit": "53645a905dfb3055db52f5d418d5ef612027e062",
+   "sha256": "1pqmk6mi1nk3axkb0zfcy7x8vqz5984km0vqp6mmh0sd2ysc4rdl"
   },
   "stable": {
    "version": [
@@ -28649,16 +28757,16 @@
   "repo": "jacktasia/dumb-jump",
   "unstable": {
    "version": [
-    20250822,
-    2314
+    20260119,
+    2346
    ],
    "deps": [
     "dash",
     "popup",
     "s"
    ],
-   "commit": "a9a7e1711ee100747877528bb3531b947233a99e",
-   "sha256": "0wyv9kcyh5fx3997n0d57wdnkrz56ybc2d7i651357a80c802c4i"
+   "commit": "5bfea588a5f67ccf163bbe5084ee0c92e43869cf",
+   "sha256": "1bi69qb9w7x1w9irf2smv82jafy9z5fa4qlzqjrfcqv701kf67zf"
   },
   "stable": {
    "version": [
@@ -28717,20 +28825,20 @@
   "repo": "ocaml/dune",
   "unstable": {
    "version": [
-    20250903,
-    1130
+    20260112,
+    1835
    ],
-   "commit": "1e54fd3f450aae7fb41ffb6b7c8b7a5aed754777",
-   "sha256": "1z4ji0jwwwxsx0ffw0klnkvaql8m2mqyi9h308y23waaf8dr3g94"
+   "commit": "832d2384ce30cf98e32d797aecf81088d1bd354b",
+   "sha256": "12y6j141znv9k1hknavr8i19wlc5009cgz8d6xgw4w42ghsmcppf"
   },
   "stable": {
    "version": [
     3,
-    20,
-    2
+    21,
+    0
    ],
-   "commit": "1e54fd3f450aae7fb41ffb6b7c8b7a5aed754777",
-   "sha256": "1z4ji0jwwwxsx0ffw0klnkvaql8m2mqyi9h308y23waaf8dr3g94"
+   "commit": "832d2384ce30cf98e32d797aecf81088d1bd354b",
+   "sha256": "12y6j141znv9k1hknavr8i19wlc5009cgz8d6xgw4w42ghsmcppf"
   }
  },
  {
@@ -28869,11 +28977,11 @@
   "repo": "sadiq/dwim-coder-mode",
   "unstable": {
    "version": [
-    20250622,
-    409
+    20260114,
+    852
    ],
-   "commit": "ce1383d3bcfef68fba6c632556d1a09045343781",
-   "sha256": "1fpizdald5ghrmhidwmypf81lw238lfzzmyzrqih9pgi3nkmgbnq"
+   "commit": "bc8b308e5fe82951d3843b5913c6d34c11c07098",
+   "sha256": "1bv9l872b0wr269j4dhky51kqpv11l7mx68wzyk0xc5xjrfvy5ak"
   }
  },
  {
@@ -28884,11 +28992,11 @@
   "repo": "xenodium/dwim-shell-command",
   "unstable": {
    "version": [
-    20251211,
-    1325
+    20260112,
+    1233
    ],
-   "commit": "35ca64d529987578dbbdf3f07d34310ee727b4a5",
-   "sha256": "1sh49z46dy6jvqqb95p237qwfl5vncxbq9r93qcjnsk6y0iy43fy"
+   "commit": "1227c014d08c116d8fd446cf5eeb27c566289644",
+   "sha256": "1vw09zsdjif2s7hb40l3j1akxw6gwin9rwfk460d1y7f0kgpgc8w"
   },
   "stable": {
    "version": [
@@ -29457,20 +29565,20 @@
   "repo": "emacs-eask/eask",
   "unstable": {
    "version": [
-    20251215,
-    731
+    20260117,
+    1610
    ],
-   "commit": "97ffac19407c499db8852b1cd5276b8005123a7d",
-   "sha256": "0gym2b8y53680wnsrai1m2jk7yslf8lckd9p9wpn5d16ngsbhknd"
+   "commit": "e8857600be6b9c3e40edbff6fd56fcfbc6286679",
+   "sha256": "1v9m78wxvjzw8k77gf3vffzla8r3bcgihdkr6sfmiqb7hz3z9v3n"
   },
   "stable": {
    "version": [
     0,
     12,
-    0
+    2
    ],
-   "commit": "e1b4a0eb476a40518ee29b84f2987e310d4e33a2",
-   "sha256": "0pg2cv0rlwiivfq6gy1db1q1y7imns8wid5i2glag7xyh05bncbg"
+   "commit": "d5e665fcc63af17bf2177ecc371dda1f999788aa",
+   "sha256": "01y5bq6mmsla21i2656ran3vc3hyzry4yh0rs6vjyikg1f0vagk4"
   }
  },
  {
@@ -29481,14 +29589,14 @@
   "repo": "emacs-eask/eask-mode",
   "unstable": {
    "version": [
-    20250101,
-    836
+    20251231,
+    1607
    ],
    "deps": [
     "eask"
    ],
-   "commit": "9bab3ad0d9a7df6284daed9ecd2cbd89298b958f",
-   "sha256": "07651b7hblvhh4fw0ak9l9ny20cgsx2qxb3v09xyxnr1n9yl45i3"
+   "commit": "0970dc6f4f8008d58261e36b9b824a0ffa6b9882",
+   "sha256": "085vnsaqf2c032sp06lqg4yd8m8a77156a7657a70rh7hjhsafqv"
   },
   "stable": {
    "version": [
@@ -29508,8 +29616,8 @@
   "repo": "emacs-eask/easky",
   "unstable": {
    "version": [
-    20250630,
-    1831
+    20251231,
+    1607
    ],
    "deps": [
     "ansi",
@@ -29518,13 +29626,13 @@
     "lv",
     "marquee-header"
    ],
-   "commit": "8c9f23446e3e728fc9fb12e3cc02b9b67c1e837d",
-   "sha256": "1bxqcalzmp5in4lni72fpa5ya761hddygcvxgz7kzc6lnx9nxm7n"
+   "commit": "efe25f0c1ba483378854795fcfe7fa0367cebf27",
+   "sha256": "1zsn8p8lyik7ib5ks8jvglbi8f9lh8f3xfkz6x33711v1zygy985"
   },
   "stable": {
    "version": [
     0,
-    1,
+    2,
     0
    ],
    "deps": [
@@ -29534,8 +29642,8 @@
     "lv",
     "marquee-header"
    ],
-   "commit": "ad528fd56ff4e25deec747dcfc815f4edf56ee68",
-   "sha256": "1mi1xxg26s7sxkwb06yzaq0r270cdlhchlwf0aq678n2h11xzhc5"
+   "commit": "f68ef0376b16aa3cebe651a8782cf9076ea0f7dd",
+   "sha256": "1jb0yvxlz35r394n1i44yv4yjkvdj17d17cxd3w3xxwy78r1lp5v"
   }
  },
  {
@@ -29599,28 +29707,28 @@
   "repo": "masasam/emacs-easy-hugo",
   "unstable": {
    "version": [
-    20251220,
-    949
+    20260112,
+    502
    ],
    "deps": [
     "request",
     "transient"
    ],
-   "commit": "dafe607c5192d14234639fb45c65a5644a0adb23",
-   "sha256": "1dhqh72dfahs41s5i5hi95zziwfr4gzw44kl2p269msz2w74csdx"
+   "commit": "f39adb614ce2c8969aeb7198e9677a189e391a14",
+   "sha256": "1rz0y51b8k4lzn8mhcza3l63vai3y499mxfjwqdzl5vkj36sf94h"
   },
   "stable": {
    "version": [
     3,
     13,
-    62
+    64
    ],
    "deps": [
     "request",
     "transient"
    ],
-   "commit": "dafe607c5192d14234639fb45c65a5644a0adb23",
-   "sha256": "1dhqh72dfahs41s5i5hi95zziwfr4gzw44kl2p269msz2w74csdx"
+   "commit": "f39adb614ce2c8969aeb7198e9677a189e391a14",
+   "sha256": "1rz0y51b8k4lzn8mhcza3l63vai3y499mxfjwqdzl5vkj36sf94h"
   }
  },
  {
@@ -29661,14 +29769,14 @@
   "repo": "leoliu/easy-kill",
   "unstable": {
    "version": [
-    20220511,
-    557
+    20260112,
+    1130
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "de7d66c3c864a4722a973ee9bc228a14be49ba0c",
-   "sha256": "0zr836c9c5bhf0cslwk6jqf1xn9w6wfjn4faisq5v8ydyxn78925"
+   "commit": "3401ab7427e34f8913374311bf75d342462fc9b0",
+   "sha256": "1rxl0whamvyz0mkgd57s4kxjd9dyr38vx18brhfyr3icspxf8qx9"
   },
   "stable": {
    "version": [
@@ -29691,26 +29799,26 @@
   "repo": "knu/easy-kill-extras.el",
   "unstable": {
    "version": [
-    20240122,
-    1649
+    20260108,
+    1716
    ],
    "deps": [
     "easy-kill"
    ],
-   "commit": "6ec0a1ff47aee681f7aa7af4250ede75815385f2",
-   "sha256": "05lgmy3fqyp6kb0756f36ajpij5lnz29b2wvq7jkbdl0k8c3f6wk"
+   "commit": "3fea06322d76be78e66074b9a9dad9a6d4aa6bcd",
+   "sha256": "0wa2x8dwpfs5f2w2ylv2s1lk9wgis7scvg4cskrxc7k8b82jk1qm"
   },
   "stable": {
    "version": [
     0,
     9,
-    14
+    15
    ],
    "deps": [
     "easy-kill"
    ],
-   "commit": "ff9de0c9186f8e43cb29611c78756b14e728dbb3",
-   "sha256": "0a3zlp6vsz47rnj8cr2az71cdinkm951jp67yl1cbk2z0v1szjy7"
+   "commit": "7aad156fb9017facbe81076c00a07335ee1fec37",
+   "sha256": "0ml6y02777zwdkdwar6c1v9hyf31vpj2275wf33h7rwchbw1xbq6"
   }
  },
  {
@@ -29759,11 +29867,11 @@
   "repo": "jamescherti/easysession.el",
   "unstable": {
    "version": [
-    20251113,
-    1422
+    20260118,
+    36
    ],
-   "commit": "f30ffdf6e270e0420df99b1265081800a36ca4d5",
-   "sha256": "1vv55xbvfir7x1iilsrwrxl1jgz1929zwqygwms48pf835rh24gl"
+   "commit": "314b167ce85807895a1025c692ed4e73e1709b77",
+   "sha256": "1wi44gpilq67x2aik3fg75rmnpw31jf8ngycagc391z44s301w7n"
   },
   "stable": {
    "version": [
@@ -29946,8 +30054,23 @@
   "repo": "editor-code-assistant/eca-emacs",
   "unstable": {
    "version": [
-    20251220,
-    2211
+    20260116,
+    1933
+   ],
+   "deps": [
+    "compat",
+    "dash",
+    "f",
+    "markdown-mode"
+   ],
+   "commit": "ac426986a117e5c1ef3be1aae568991a152a5aa3",
+   "sha256": "0vn48cmyz8vm84i67rygimdmpq1a78ggiygziri9mrg4mhg1azls"
+  },
+  "stable": {
+   "version": [
+    0,
+    4,
+    1
    ],
    "deps": [
     "compat",
@@ -29957,21 +30080,6 @@
    ],
    "commit": "d2a0a738e68c3d5ac8e4137de1e5bebf3637517d",
    "sha256": "17a53j4pr4liyyf854x04xk4qrd38z45j3x4gqlfj8sp9c67r1l7"
-  },
-  "stable": {
-   "version": [
-    0,
-    4,
-    0
-   ],
-   "deps": [
-    "compat",
-    "dash",
-    "f",
-    "markdown-mode"
-   ],
-   "commit": "65d2d2c51ffad6930874e7e6af07b59545a6c351",
-   "sha256": "1a299xbcvc8p1xb8k7xjcb2x46fxafb8ps15pdz3qlqw836fybbm"
   }
  },
  {
@@ -30143,74 +30251,6 @@
    ],
    "commit": "28a989232c276ee7fc5112c9050b1c29f628be9f",
    "sha256": "0kc51bb5jxrsra9ycg43n35dd8kngby321qbcixaj68cksf0whrm"
-  }
- },
- {
-  "ename": "ede-php-autoload-composer-installers",
-  "commit": "6e0e9058593b32b8d9fd7873d4698b4dd516930f",
-  "sha256": "0s7dv81niz4h8kj0648x2nbmz47hqxchfs2rjmjpy2lcbifvj268",
-  "fetcher": "github",
-  "repo": "xendk/ede-php-autoload-composer-installers",
-  "unstable": {
-   "version": [
-    20170221,
-    2026
-   ],
-   "deps": [
-    "ede-php-autoload",
-    "f",
-    "s"
-   ],
-   "commit": "3e2fde975a06757b363e235c67e6341ebe668f60",
-   "sha256": "11sjq86nm7yqxi0y5n37c2c3w0p6mc28n85j40qj8nd7b2nb9s3j"
-  },
-  "stable": {
-   "version": [
-    0,
-    1,
-    0
-   ],
-   "deps": [
-    "ede-php-autoload",
-    "f",
-    "s"
-   ],
-   "commit": "f9942e07d0773444040084ac84652e69f0fd46d5",
-   "sha256": "04gw8ma5c898ai7haxvdagmxx8zw9ncc9v0cv8a5ddg6arvzkl1z"
-  }
- },
- {
-  "ename": "ede-php-autoload-drupal",
-  "commit": "532fec4788350cc11893c32e3895f06510a39d35",
-  "sha256": "139sr7jy5hb8h5zmw5mw01r0dy7yvbbyaxzj62m1a589n8w6a964",
-  "fetcher": "github",
-  "repo": "xendk/ede-php-autoload-drupal",
-  "unstable": {
-   "version": [
-    20170316,
-    2158
-   ],
-   "deps": [
-    "ede-php-autoload",
-    "f",
-    "s"
-   ],
-   "commit": "54a04241d94fabc4f4d16ae4dc8ba4f0c6e3b435",
-   "sha256": "1ckfja95zk4f7fgvycia7nxhxjgz4byrz30ic63f6kcq4dx78scs"
-  },
-  "stable": {
-   "version": [
-    0,
-    1,
-    1
-   ],
-   "deps": [
-    "ede-php-autoload",
-    "f",
-    "s"
-   ],
-   "commit": "6b62ffa7a69f52aab79067eaed80b2720f7e3fc2",
-   "sha256": "001yhxngr6h7v1sjz0wskd5dv6fiby7m1mbc8vdz1h93150wzahp"
   }
  },
  {
@@ -30387,11 +30427,11 @@
   "repo": "stsquad/emacs_chrome",
   "unstable": {
    "version": [
-    20250417,
-    1401
+    20260104,
+    1224
    ],
-   "commit": "e45b213a22bc93ca52962203784e7b5d25a53245",
-   "sha256": "0cshj27g2zgdi4jm8fqcc0qjfyfgxidrsls32p0ch626wzwdp4wh"
+   "commit": "c7cb4cb0043e4545588f110d6e48bf9230dbf354",
+   "sha256": "025c62lwnckhd40zg46rqqca1sswhz10nh1qvrpllkj0idq7xz9l"
   },
   "stable": {
    "version": [
@@ -30428,11 +30468,11 @@
   "repo": "editorconfig/editorconfig-emacs",
   "unstable": {
    "version": [
-    20251221,
-    650
+    20260118,
+    718
    ],
-   "commit": "6783cb2a9fb82dc152e633e2e40162c150a4e818",
-   "sha256": "1fha616s0r66dz0s8m0h0fj6y6rky76nrbh5aqzlfn5dbr6b3xxj"
+   "commit": "1e9931d5f38a8d8cb8a92cf726d64696550bfc95",
+   "sha256": "0pwm2fh4man3500fjdw8ibms3dcvakdmprb1vs94pkb9kjljfgq0"
   },
   "stable": {
    "version": [
@@ -30964,6 +31004,36 @@
   }
  },
  {
+  "ename": "eglot-python-preset",
+  "commit": "4129d73614441b2c120295be60187b93aa5c6f2f",
+  "sha256": "0wl5dzh1c73cd7dhqi19inhz94416rzw1h23gb5xppiii8i4ycsb",
+  "fetcher": "github",
+  "repo": "mwolson/eglot-python-preset",
+  "unstable": {
+   "version": [
+    20260108,
+    56
+   ],
+   "deps": [
+    "eglot"
+   ],
+   "commit": "5877dbd06c0fdd6c849e8d7836f7323d39ad9c27",
+   "sha256": "0nwvjg1ld5cs6kfz3gkj1l2fli52ygbka7yvw0bf3r7bg2xjxfxy"
+  },
+  "stable": {
+   "version": [
+    0,
+    2,
+    3
+   ],
+   "deps": [
+    "eglot"
+   ],
+   "commit": "5877dbd06c0fdd6c849e8d7836f7323d39ad9c27",
+   "sha256": "0nwvjg1ld5cs6kfz3gkj1l2fli52ygbka7yvw0bf3r7bg2xjxfxy"
+  }
+ },
+ {
   "ename": "eglot-signature-eldoc-talkative",
   "commit": "1839deb57d34adc76db0b1a1a877b3cb542a6810",
   "sha256": "1b1ymfm8nc505dy7c6cgmhac22pz98jb21gwnjynv5gbbqscb78s",
@@ -31061,11 +31131,11 @@
   "url": "https://forge.tedomum.net/hjuvi/eide.git",
   "unstable": {
    "version": [
-    20251122,
-    2140
+    20260107,
+    2102
    ],
-   "commit": "e3aeed7fcd2892b0d3d3b8f29743ec864ab7466d",
-   "sha256": "1xcbfbi9dgajsxg4ccxxyfd2k2srqjg1wlmb0hyq40b95h45y7m4"
+   "commit": "9918d623124fdb4111faf0cf6c3f55be43a6b070",
+   "sha256": "11wib1n3bix4qf5wl8kk1wf26afhxc8jyl324znq3aj5f1zx23kv"
   },
   "stable": {
    "version": [
@@ -31198,15 +31268,15 @@
   "repo": "ahyatt/ekg",
   "unstable": {
    "version": [
-    20251219,
-    454
+    20260119,
+    1613
    ],
    "deps": [
     "llm",
     "triples"
    ],
-   "commit": "c66fe562c2953304d404883b2811e6270d03cf74",
-   "sha256": "1ivk6dqmrpa278ir90k09l10lv5q3nyl96l100gfn1q008fkq6w5"
+   "commit": "bbd94e571990a31ecc3ab8108a02dd3b3aac2757",
+   "sha256": "1ygx250zf2km5v1hii239xc6ffkpaql945xdhj9k0w6hpvv4cgpp"
   },
   "stable": {
    "version": [
@@ -31253,11 +31323,11 @@
   "repo": "xgqt/xgqt-elisp-app-el-fetch",
   "unstable": {
    "version": [
-    20250105,
-    2335
+    20251225,
+    1426
    ],
-   "commit": "a1ae3704de96e6d622a67faacfae7a5993f96699",
-   "sha256": "122nn7qvsqr92ra06kfgfzxma3mljzx18c4l8fsa66lbwjgrxfmp"
+   "commit": "169e2bffe77b43577acbf83d7d8073b6808b880e",
+   "sha256": "03cp4hpaymyb0rrrdb897ppjbsd5cfzkvni6mz30zbn3hf0v4sdq"
   },
   "stable": {
    "version": [
@@ -31813,11 +31883,11 @@
   "repo": "vilij/slurpbarf-elcute",
   "unstable": {
    "version": [
-    20251018,
-    1822
+    20260102,
+    1001
    ],
-   "commit": "f590cc7f9308c37231693e41bf773da002542d51",
-   "sha256": "09m7s1xmb35q9i4969x3150d6ml1pap22vpjywdzw3s7gpkm8nxx"
+   "commit": "5ec0f75a308ab8ae1f29bbb3c18b63514fc83c20",
+   "sha256": "0aksjg9wrl0aifwdw4m41al1yqcp8nz2bmfxd5jvx89rl1a6ijpb"
   }
  },
  {
@@ -31891,14 +31961,14 @@
   "repo": "emacs-eask/eldoc-eask",
   "unstable": {
    "version": [
-    20250101,
-    837
+    20251231,
+    1607
    ],
    "deps": [
     "eask"
    ],
-   "commit": "2433fa00abfa8d4b384aff022f496287e0975776",
-   "sha256": "1mbh62advmgpmd022qijmy5yid3zjg3h6zvzvz1rwx401j40jqdc"
+   "commit": "d305a63c5e67a3e8a6ff448c7419bcc1ac05d5b4",
+   "sha256": "1lxh5b4rmkav3p44860i6492q6yj1nll935r0y649d66yaxh9rad"
   },
   "stable": {
    "version": [
@@ -31944,27 +32014,28 @@
   "repo": "huangfeiyu/eldoc-mouse",
   "unstable": {
    "version": [
-    20251219,
-    1101
+    20251228,
+    316
    ],
    "deps": [
     "eglot",
     "posframe"
    ],
-   "commit": "7b4e64be8c7ce44b7fb763f40e72f7900aa4b119",
-   "sha256": "0iqh6x152yhvxlcyjyd93404abx5xs1bhzf4fds410icgj7wwg8z"
+   "commit": "de48a1af46617861d38d9f96984869c21c0d887e",
+   "sha256": "1zzxndzwn94cnlz9lwjkmw7pvmqm80gm1hia66qqsgb2i6qwg8qm"
   },
   "stable": {
    "version": [
     3,
-    0
+    0,
+    2
    ],
    "deps": [
     "eglot",
     "posframe"
    ],
-   "commit": "0b84d1bb46992680181cf67b8f8aeaff3be5620b",
-   "sha256": "1lg1kbfshi99jy4a9wcaiw60rd2356skdvlk9cqsay69vh5ygba9"
+   "commit": "de48a1af46617861d38d9f96984869c21c0d887e",
+   "sha256": "1zzxndzwn94cnlz9lwjkmw7pvmqm80gm1hia66qqsgb2i6qwg8qm"
   }
  },
  {
@@ -32662,11 +32733,11 @@
   "repo": "ideasman42/emacs-elisp-autofmt",
   "unstable": {
    "version": [
-    20251209,
-    58
+    20260108,
+    2310
    ],
-   "commit": "aa0adce42f6f3cb25677aa4fb67c18bdf5526926",
-   "sha256": "1jiwd1jj178216pcm7vg3fkg7vwvdrknc6irbi87qffx3j2y9qax"
+   "commit": "e6c0aac8ebd8b7a7213fbf18934878735bf7ae26",
+   "sha256": "0a1yr4yhyvpxayxwj9jzmlbwmyv10l25lzwnb2b0x01bb4z51pwm"
   }
  },
  {
@@ -32767,26 +32838,26 @@
   "repo": "laurynas-biveinis/elisp-dev-mcp",
   "unstable": {
    "version": [
-    20251004,
-    1154
+    20260119,
+    1722
    ],
    "deps": [
     "mcp-server-lib"
    ],
-   "commit": "05bc3ca843ebbb243c22d2a44ea2fb47884f35e6",
-   "sha256": "03yv2p9jwqc1qv0ydb3v6qs4f408dpbs3jfm6whs1pb4n9g94b8q"
+   "commit": "8dc2dadd8b2590d8b0e6375325e6d09a7ca269bf",
+   "sha256": "1hi7dn0nvmy7lym23iz8zpl2i27hfnnng0fr0q14rd5psy52wpl1"
   },
   "stable": {
    "version": [
     1,
-    0,
-    0
+    1,
+    1
    ],
    "deps": [
     "mcp-server-lib"
    ],
-   "commit": "45ae39151b66b9bfaa6382b01820a7762ab23ade",
-   "sha256": "09pp594b19svzwq9f748mqfcp9prvppbdmld43sd6g78w92y8dzx"
+   "commit": "62e811321329b60bd3d288b0601eda7eb69eaa29",
+   "sha256": "11mhyibf8fimc9a4x3irza725qva09gqclqshfh179wd5gwmqinr"
   }
  },
  {
@@ -33038,8 +33109,8 @@
   "repo": "s-kostyaev/ellama",
   "unstable": {
    "version": [
-    20251220,
-    2246
+    20260119,
+    2229
    ],
    "deps": [
     "compat",
@@ -33047,14 +33118,14 @@
     "plz",
     "transient"
    ],
-   "commit": "dfda86230dd312ad259eb4b7b1264546f0a02810",
-   "sha256": "0acb9mk59fljwbap5y5llz95piwnq2q58vzy8k8kx09v69hv2h5s"
+   "commit": "c491bf4c5b6449751a55afa6772c8cdb0e167a41",
+   "sha256": "1sn6b8qfjgf8vx7sffzv8irhsk5ciy24q58ynfr354k5jpxxxkqm"
   },
   "stable": {
    "version": [
     1,
-    9,
-    1
+    10,
+    11
    ],
    "deps": [
     "compat",
@@ -33062,8 +33133,8 @@
     "plz",
     "transient"
    ],
-   "commit": "dfda86230dd312ad259eb4b7b1264546f0a02810",
-   "sha256": "0acb9mk59fljwbap5y5llz95piwnq2q58vzy8k8kx09v69hv2h5s"
+   "commit": "c491bf4c5b6449751a55afa6772c8cdb0e167a41",
+   "sha256": "1sn6b8qfjgf8vx7sffzv8irhsk5ciy24q58ynfr354k5jpxxxkqm"
   }
  },
  {
@@ -33802,28 +33873,28 @@
   "repo": "emacscollective/elx",
   "unstable": {
    "version": [
-    20251212,
-    1101
+    20260101,
+    1832
    ],
    "deps": [
     "compat",
     "llama"
    ],
-   "commit": "c640a3a86b96dcca03c444147e1a63540e6d561e",
-   "sha256": "08b31zzfrdi65zgjazygyznxy55jxr7zzmlk69kicbawxrv82cr4"
+   "commit": "5c700de6d3b4163b0a3ed3060f491c22b4bfaa85",
+   "sha256": "1naspqq3d93l8d2iba00gkhhvwxrj8nj5h459msd6in0s1lqc682"
   },
   "stable": {
    "version": [
     2,
     3,
-    1
+    2
    ],
    "deps": [
     "compat",
     "llama"
    ],
-   "commit": "0fb0bc2c33a0bff2d02848c70f17f3060810a114",
-   "sha256": "01iqjy7lzvyzb87v7hqrmcs0yp280vhb3xvlwysilm1w8qv3bqsn"
+   "commit": "5c700de6d3b4163b0a3ed3060f491c22b4bfaa85",
+   "sha256": "1naspqq3d93l8d2iba00gkhhvwxrj8nj5h459msd6in0s1lqc682"
   }
  },
  {
@@ -33918,20 +33989,20 @@
   "repo": "magit/emacsql",
   "unstable": {
    "version": [
-    20251130,
-    1841
+    20260101,
+    1849
    ],
-   "commit": "f177a41e93b92a4b1139a553eed5415ca33f439c",
-   "sha256": "1wn4p8hwxl8agzl4gh9qa2zca33zm68mdz0a9lln5q7rix06qd3w"
+   "commit": "c6a9d2373cc15184e4e34414b8574a896d070323",
+   "sha256": "10h0zb8pp4zbmsrkp8kd4a0rnclh6arbyg4f7n5l5n8cn0w2pf8l"
   },
   "stable": {
    "version": [
     4,
     3,
-    3
+    4
    ],
-   "commit": "138fae5c3f55c81a4eded42eabe4e33483de567e",
-   "sha256": "1vgdmsv6ljamz0bcm3q7mx1f3izcj90vk2w9ms1j4s3fvda4qkir"
+   "commit": "c6a9d2373cc15184e4e34414b8574a896d070323",
+   "sha256": "10h0zb8pp4zbmsrkp8kd4a0rnclh6arbyg4f7n5l5n8cn0w2pf8l"
   }
  },
  {
@@ -34309,28 +34380,28 @@
   "url": "https://git.savannah.gnu.org/git/emms.git",
   "unstable": {
    "version": [
-    20251201,
-    1510
+    20260113,
+    1922
    ],
    "deps": [
     "cl-lib",
     "nadvice",
     "seq"
    ],
-   "commit": "b5a5816e2b73952413927eacc5d701d524d0d494",
-   "sha256": "0yzxc749ms4zknylnggcmy0wn0qn6y12svz6wfx9lsh2is8flpn5"
+   "commit": "1d48a1133db2670d839f2cf2aff17d6c32aeb15f",
+   "sha256": "0pvlkybdpf1bfpjs0np89kfnxj3qjvyawk1g0b2l5jg21k6c20ww"
   },
   "stable": {
    "version": [
-    24
+    25
    ],
    "deps": [
     "cl-lib",
     "nadvice",
     "seq"
    ],
-   "commit": "99ebaae9f180dd6b2e5be363e709efa1da0014d6",
-   "sha256": "1x0lja7k2vn3dhnmhg3gvhiv6yid899k26f79c7slwfs0sl680yc"
+   "commit": "1d48a1133db2670d839f2cf2aff17d6c32aeb15f",
+   "sha256": "0pvlkybdpf1bfpjs0np89kfnxj3qjvyawk1g0b2l5jg21k6c20ww"
   }
  },
  {
@@ -34511,25 +34582,26 @@
   "repo": "alezost/emms-state.el",
   "unstable": {
    "version": [
-    20211023,
-    1942
+    20260102,
+    648
    ],
    "deps": [
     "emms"
    ],
-   "commit": "cdb3ee85369758727b3c082e4ade1ae2b559b334",
-   "sha256": "1gwn47nl003kwfaif3vh84p7rxfc3lilb6a3kk2hcczc5j65i13d"
+   "commit": "18128405c0a3659f493fceb3ea22e0a8a39125be",
+   "sha256": "14adgl6x8925zcqsp3rxyh37zs5pryysv4gs3w8g8zydnnpwnf9k"
   },
   "stable": {
    "version": [
     0,
-    2
+    2,
+    1
    ],
    "deps": [
     "emms"
    ],
-   "commit": "77930300222333b71eafd495cc1fee3a3585eb23",
-   "sha256": "1kipxa9ax8zi9qqk19mknpg7nnlzgr734kh9bnklydipwnsy00pi"
+   "commit": "18128405c0a3659f493fceb3ea22e0a8a39125be",
+   "sha256": "14adgl6x8925zcqsp3rxyh37zs5pryysv4gs3w8g8zydnnpwnf9k"
   }
  },
  {
@@ -34609,15 +34681,15 @@
   "repo": "jcs-elpa/emoji-github",
   "unstable": {
    "version": [
-    20250101,
-    1007
+    20260101,
+    559
    ],
    "deps": [
     "emojify",
     "request"
    ],
-   "commit": "ec055ddb0c650671112fb254257f413f4755e75a",
-   "sha256": "1cwsc0ghcbg1ixmwc0z8vjhkyvk1dvv43lmrhcz3g0fgqiz0ff4v"
+   "commit": "439c0471b16bc1d73e7d460e526a1b0fa14116c3",
+   "sha256": "0m5wkwgnp5q47k148xpwxzrpvdr4arsy9ny6xpjarsnwh6d1jrdi"
   },
   "stable": {
    "version": [
@@ -34886,11 +34958,11 @@
   "repo": "zenspider/enhanced-ruby-mode",
   "unstable": {
    "version": [
-    20251001,
-    2056
+    20260107,
+    824
    ],
-   "commit": "cec9ea862ef196113ef19b16e347a522bc8fdd88",
-   "sha256": "1nlg4fqra591fn1h5f2kpk1lamcj2r6mm6qg2fgbxb237abkqhfi"
+   "commit": "1a3a93a6ba51798baa7364589136d974b19fd8d8",
+   "sha256": "0k7pgs8mxl5aydjhlvznpg2yrdhwi1n3a9kx9jfimi0q81lka074"
   },
   "stable": {
    "version": [
@@ -34908,15 +34980,15 @@
   "repo": "jamescherti/enhanced-evil-paredit.el",
   "unstable": {
    "version": [
-    20251016,
-    1351
+    20260114,
+    1535
    ],
    "deps": [
     "evil",
     "paredit"
    ],
-   "commit": "58f607ded07383cd6db5a6a39cc0f76dea61c4f7",
-   "sha256": "1wqcs316amspqjgikaci9125rs27bkgck7w2658aacsghmd49y17"
+   "commit": "af4a8a8883842ec7ede17a53bb4f0102eb531371",
+   "sha256": "1k05l0lj90w0kgk8q0b1v1findbf63jf2prs972j00488684q5qy"
   },
   "stable": {
    "version": [
@@ -35229,8 +35301,8 @@
   "repo": "emacscollective/epkg",
   "unstable": {
    "version": [
-    20251108,
-    1325
+    20260105,
+    2201
    ],
    "deps": [
     "closql",
@@ -35238,14 +35310,14 @@
     "emacsql",
     "llama"
    ],
-   "commit": "a4c8dc4e760ff9d0079e25fa9000b06791ed009b",
-   "sha256": "12m0isjl74i5sflx2rij46838rdai4zdm725wg76234vb6j248xr"
+   "commit": "522b00c64aaf230215c6dde8f992e79ed38b9e42",
+   "sha256": "0fw9qla52s8ca8kiy98nn9gpyjnnsr8m0aic7n3ir724fkr6r56n"
   },
   "stable": {
    "version": [
     4,
     1,
-    1
+    2
    ],
    "deps": [
     "closql",
@@ -35253,8 +35325,8 @@
     "emacsql",
     "llama"
    ],
-   "commit": "6aabd58170b5385fecc873a9ea53432eb24cc993",
-   "sha256": "06dmsmjgqj5rfy72lkswba02w4rmfaj212qgdw9i8pw7s3fd4f37"
+   "commit": "0dcab271d547736791e13be49cd6ee3630110eb1",
+   "sha256": "1hm6f73lwqsrn89f3s7dx79nc67qvqs8v1jb3wbyq7wdify5mja0"
   }
  },
  {
@@ -35265,30 +35337,30 @@
   "repo": "emacscollective/epkg-marginalia",
   "unstable": {
    "version": [
-    20251101,
-    2117
+    20260101,
+    1857
    ],
    "deps": [
     "compat",
     "epkg",
     "marginalia"
    ],
-   "commit": "681295f585efdc3f615ba4be90a246eb46ef4018",
-   "sha256": "0kwqbvkyzwlpvlrp1lcr5fsn2q0h215q1wxa4hcv1bbbbla7kjhz"
+   "commit": "a42de3acf215bec1d3a06b63c98d0ad9182ce760",
+   "sha256": "14pbwh20vazrvxg4zmxvzpclpkkgrxd9qalrc1chgsr1zkdqff6s"
   },
   "stable": {
    "version": [
     1,
     1,
-    1
+    2
    ],
    "deps": [
     "compat",
     "epkg",
     "marginalia"
    ],
-   "commit": "681295f585efdc3f615ba4be90a246eb46ef4018",
-   "sha256": "0kwqbvkyzwlpvlrp1lcr5fsn2q0h215q1wxa4hcv1bbbbla7kjhz"
+   "commit": "a42de3acf215bec1d3a06b63c98d0ad9182ce760",
+   "sha256": "14pbwh20vazrvxg4zmxvzpclpkkgrxd9qalrc1chgsr1zkdqff6s"
   }
  },
  {
@@ -35452,14 +35524,14 @@
   "repo": "emacsomancer/equake",
   "unstable": {
    "version": [
-    20251208,
-    2019
+    20260102,
+    225
    ],
    "deps": [
     "dash"
    ],
-   "commit": "60e9cbfae7a79e14a8e95da1148122c05500eb20",
-   "sha256": "1q7nxyz6am155m4abhd8s5pik0wj0ck5gf6pgg5i4jcq7b81lzci"
+   "commit": "4469dd9eb1519f4d699d43d6cdb3a59488021fe8",
+   "sha256": "0hfp3hc743bwdzsldz2fkdc8l4r2pzgkmcxmp3qba0a15f0sv7pb"
   }
  },
  {
@@ -36006,19 +36078,20 @@
   "repo": "erlang/otp",
   "unstable": {
    "version": [
-    20250827,
-    800
+    20260114,
+    1445
    ],
-   "commit": "ed8445a63861f510d21e27c9122e4fafa8039d9d",
-   "sha256": "11f2kslkcbln9w0wlp1wvcx6nybp97ijf6wnv7l9pflw61521jq6"
+   "commit": "28fef74d7a13556a2bbd12a90b19a30e939f72ce",
+   "sha256": "0msms2hjfldnr2f76hjfhh2baxprlkbdaa4gwb30bmjs9bdvyqsy"
   },
   "stable": {
    "version": [
     28,
-    3
+    3,
+    1
    ],
-   "commit": "ab489c0b260c637a9487f8753909ea94dacbbec2",
-   "sha256": "142why4nsw8i6kvmnrj45wnsqw5qpp28gpwlv99j08n45riqjzia"
+   "commit": "aa5b1d3366762ff8f420f2aa6a52604b481530c9",
+   "sha256": "04wfdjacrar3x2xc7d28ld4dr24qx2nyf33pwfa5f1bd4nbgpicb"
   }
  },
  {
@@ -36088,11 +36161,11 @@
   "repo": "xiongtx/eros",
   "unstable": {
    "version": [
-    20230309,
-    615
+    20251226,
+    345
    ],
-   "commit": "a9a92bdc6be0521a6a06eb464be55ed61946639c",
-   "sha256": "04nkqsvh8c988hc3ajigs206ad64204qdhhqzdvm3k7m7qiiwga8"
+   "commit": "66ee90baa3162fea028f5101ddcc370f7d1d4fcf",
+   "sha256": "0mxknd96p2hblzsvgw10jidx4kg6djgazm2yq3a2hdb1kz8yb8v3"
   }
  },
  {
@@ -37111,11 +37184,11 @@
   "repo": "emacs-ess/ESS",
   "unstable": {
    "version": [
-    20251212,
-    937
+    20251230,
+    1711
    ],
-   "commit": "e39ca8fa7fce703aa2851e83987a412737d575f0",
-   "sha256": "15cmw66fg2m777zfhgc2rlwgvh3iw1iyq02y7w3d97jd6rcj60nw"
+   "commit": "f8c464dc1b017b5397f8ec9955f7856493af1179",
+   "sha256": "1994cbs4zjsw2a66l9n2bvjdhm5223ybj9n8b35cqc1qjfi72mmf"
   },
   "stable": {
    "version": [
@@ -38017,15 +38090,15 @@
   "repo": "emacs-evil/evil-collection",
   "unstable": {
    "version": [
-    20251205,
-    1511
+    20251226,
+    804
    ],
    "deps": [
     "annalist",
     "evil"
    ],
-   "commit": "cd6cdf337ea96abc742a97be61c817788f512413",
-   "sha256": "0sil02hh14lbfgsyrcxfnvfcqvsvr6wdh4yvamc5sy0zscc191m8"
+   "commit": "163792a823bcdb2dae7ac1bba4018adfac35dca2",
+   "sha256": "1vfhs1f4s0ygys9cs2iixv9f7rjf69gmvban68j92ndv6bvq31qg"
   },
   "stable": {
    "version": [
@@ -38437,6 +38510,36 @@
    ],
    "commit": "70a1154a531b7cfdbb9a31d6922482791e20a3a7",
    "sha256": "0nghisnc49ivh56mddfdlcbqv3y2vqzjvkpgwv3zp80ga6ghvdmz"
+  }
+ },
+ {
+  "ename": "evil-insert-plus",
+  "commit": "11de9d7b1891c44209edb4ddb70fa40c5b4a9c26",
+  "sha256": "0n2aksnrh8db307h2mr7cyrilvzhvh9mfk468pjmi74pqqdbm4sl",
+  "fetcher": "github",
+  "repo": "yad-tahir/evil-insert-plus",
+  "unstable": {
+   "version": [
+    20260119,
+    926
+   ],
+   "deps": [
+    "evil"
+   ],
+   "commit": "d264c13585f3b282552a27fa6c0e77c2b17afa7c",
+   "sha256": "0413q2rhbxnfcpahfzjfp4sgxrm642a96xmvkn1y0a9fh0x10p5n"
+  },
+  "stable": {
+   "version": [
+    0,
+    5,
+    3
+   ],
+   "deps": [
+    "evil"
+   ],
+   "commit": "d264c13585f3b282552a27fa6c0e77c2b17afa7c",
+   "sha256": "0413q2rhbxnfcpahfzjfp4sgxrm642a96xmvkn1y0a9fh0x10p5n"
   }
  },
  {
@@ -38857,14 +38960,15 @@
   "repo": "juliapath/evil-numbers",
   "unstable": {
    "version": [
-    20251216,
-    54
+    20260103,
+    850
    ],
    "deps": [
-    "evil"
+    "evil",
+    "shift-number"
    ],
-   "commit": "5362f19b78409b3220756cb2bf960a90d1196ee6",
-   "sha256": "1wqkhnk4nha0lzhy9gk99swdj4krqbaqv6aj4wasbh4zai0lqvpn"
+   "commit": "616aff9e5cee012954756ed2715209fa90308cdf",
+   "sha256": "07d14nn6mjzws6b34nl81as1qk5ym9b4lzybf791582bk559xwxl"
   },
   "stable": {
    "version": [
@@ -39489,6 +39593,24 @@
   }
  },
  {
+  "ename": "evil-tex-ts",
+  "commit": "bc19f5b9caa128954fa3734d5b62ddee539118dd",
+  "sha256": "1jbkpbyz3ykzsj11is99lzn6zgjai3r02wq7hdfrggiqrlbfzs0k",
+  "fetcher": "github",
+  "repo": "Prgebish/evil-tex-ts",
+  "unstable": {
+   "version": [
+    20251229,
+    2214
+   ],
+   "deps": [
+    "evil"
+   ],
+   "commit": "abeb89a410a2f2e2db0a6e632f11a44de7313f09",
+   "sha256": "1wydbln7wzizxy9kz0mfzb2vis8vlqxs4g8i8v8m6m0kk9f503wc"
+  }
+ },
+ {
   "ename": "evil-text-object-python",
   "commit": "0d0893b07bc4a057561a1c1a85b7520c50f31e12",
   "sha256": "0jdzs1yn8nrxq890427yjrxdvnzj8jy7bs3jj4w4c0fik26ngqhm",
@@ -39642,11 +39764,11 @@
   "repo": "meain/evil-textobj-tree-sitter",
   "unstable": {
    "version": [
-    20251118,
-    341
+    20260106,
+    1232
    ],
-   "commit": "d0d088c781b54534b49880819a40575b203dc6c8",
-   "sha256": "1g6zdpf5djalckn7kdhmvvzv3jlrh8pnf91w15aj0gzx6lgppykv"
+   "commit": "38e6cc59c29a1d86030364bccd89b78b44054396",
+   "sha256": "1y4p897jsdxh7s70znfnava6c4wzkxr4dgda263nwcsv4276n9ij"
   },
   "stable": {
    "version": [
@@ -40925,11 +41047,11 @@
   "repo": "WJCFerguson/emacs-faff-theme",
   "unstable": {
    "version": [
-    20251120,
-    1400
+    20251229,
+    2005
    ],
-   "commit": "e8b6b4b5669fb41f0dd4fdcbcb88b5b9ab803f53",
-   "sha256": "0m4li4qhxp5ay0zs6dgsqj7llh8kv4gmcs5jbdswcr631b2a4ax7"
+   "commit": "234889b84663e066eb8755528e8c35e2dd210704",
+   "sha256": "1ir3jv7zg1k4k85khlkbs5gg9niyr5rsynzlim7vqy5f9304779c"
   },
   "stable": {
    "version": [
@@ -41380,11 +41502,11 @@
   "repo": "yqrashawn/fd-dired",
   "unstable": {
    "version": [
-    20210723,
-    549
+    20260104,
+    335
    ],
-   "commit": "458464771bb220b6eb87ccfd4c985c436e57dc7e",
-   "sha256": "0253r4fbi9b8vk5akp1wz0krvik500jhy1hclwp1p0bwrq2irlml"
+   "commit": "c5b31aec25d20c3219e2635b82efeba532895278",
+   "sha256": "1y35hk2ng0nb5qm2x4pf6irr1qdxpz3l1sgjzsmmnlk02lql8zlg"
   },
   "stable": {
    "version": [
@@ -41564,15 +41686,15 @@
   "repo": "jcs-elpa/ffmpeg-player",
   "unstable": {
    "version": [
-    20250101,
-    1007
+    20260101,
+    559
    ],
    "deps": [
     "f",
     "s"
    ],
-   "commit": "dfc78152925c62a575bb135f320b74c1b4a71f2c",
-   "sha256": "1cyyw19z2aj1c62ckvfg0z07k14k2fpqw556p540yh9xdi2n0i1k"
+   "commit": "97205aa6c47875c75d10385f22ea0ef3c8a1a880",
+   "sha256": "0d4xqmb306zd18j735njzbj4s3k5kxfb1118fyfp1qqzala7y12f"
   },
   "stable": {
    "version": [
@@ -41793,11 +41915,11 @@
   "repo": "jcs-elpa/fill-page",
   "unstable": {
    "version": [
-    20250101,
-    1009
+    20260101,
+    559
    ],
-   "commit": "b72340d478eead21e409a7a380bc2a61bb4d8732",
-   "sha256": "0nasiwm4gzh6dgvn8xiiac4zbajgqsq550qlfdbrj29acqgr9bz0"
+   "commit": "c9bc538f72869f572bf71c95d2b9b6dac5b4b169",
+   "sha256": "1iwdzqyrwn5ayn6fl87nmkxrym5zsbf0sggcxm4dxi4q67dcshyp"
   },
   "stable": {
    "version": [
@@ -42031,8 +42153,8 @@
   "repo": "LaurenceWarne/finito.el",
   "unstable": {
    "version": [
-    20250907,
-    1936
+    20260111,
+    1424
    ],
    "deps": [
     "async",
@@ -42043,8 +42165,8 @@
     "s",
     "transient"
    ],
-   "commit": "be1c866c288bb0d92a24f8b5d4b64ea4d70355ef",
-   "sha256": "0cxnfi17p56lgy7qvqpqnnjdlc0ddbd2riln081g7x7301z44lc7"
+   "commit": "4f768de5ce9784ca54125c5056b0a026ba2eb42c",
+   "sha256": "0jgz7ryj9sm15drd3z9rbv9x206n5173kjhgiqd54zfc8y75divb"
   },
   "stable": {
    "version": [
@@ -42554,11 +42676,11 @@
   "repo": "seblemaguer/flatfluc-theme",
   "unstable": {
    "version": [
-    20230721,
-    538
+    20260105,
+    2045
    ],
-   "commit": "9c9ae6f34aa8fca537cdd8a899b337ba8302fb9d",
-   "sha256": "0nbb1dal3m1s3ryizkwvk3ck0axq62ngcwvrkjp3zx8nk3486jm5"
+   "commit": "483f25a8d5c332851f0b216bee58e33e95632769",
+   "sha256": "1m5xblp5ldy8gdvvcgi7hjscvqfj0dp1lbf0gqi2k2v5zvdz9f9y"
   }
  },
  {
@@ -43678,14 +43800,14 @@
   "repo": "flycheck/flycheck-deno",
   "unstable": {
    "version": [
-    20250226,
-    2238
+    20251231,
+    1618
    ],
    "deps": [
     "flycheck"
    ],
-   "commit": "d59b0cceb81b776a7143d7e25e06f7c3e71aa56f",
-   "sha256": "08gakqkigqzwg9884606z03jq3p3ccar1ad5xyapbfhmk5v0bqh5"
+   "commit": "27c2f2a4d5edcc4ddce06a42bf49a3f6b36e8f1f",
+   "sha256": "1cvyl5rgdx8b7ai7xlzxy2q2fb8vi1c71n6688vmlcdphww2wyai"
   },
   "stable": {
    "version": [
@@ -43830,14 +43952,14 @@
   "repo": "flycheck/flycheck-eask",
   "unstable": {
    "version": [
-    20250226,
-    939
+    20251231,
+    1617
    ],
    "deps": [
     "flycheck"
    ],
-   "commit": "8a7f847466935b5937e93f5ccbd4711812d962a3",
-   "sha256": "1rrrwr36m6ppscj6fjpsyfm8zkjmhg6asnbm26gsj1x0ln1k19xg"
+   "commit": "9141ad6b9ec2f2572a4dcddf54247825516c93b2",
+   "sha256": "0y7i6l31658wk9vq7zjda1b1vjjllap4q9lm7ar1ka40xf52vl68"
   },
   "stable": {
    "version": [
@@ -43860,15 +43982,27 @@
   "repo": "flycheck/flycheck-eglot",
   "unstable": {
    "version": [
-    20251218,
-    443
+    20260109,
+    1536
    ],
    "deps": [
     "eglot",
     "flycheck"
    ],
-   "commit": "8ed9ca960ebdf500dd56a5335f9090e3cbfcd6b2",
-   "sha256": "1371na84y11gs6q0hgn0wg93rllyzlf53w1x3fy5cbvidgh611a6"
+   "commit": "87cc55936f843f8e0b9ab0b6b5ae5c6d7170f600",
+   "sha256": "1z9wdqqf482535jwmf3iyv5b92nbm9l4cy4v2z2nga9fj0sdr3vp"
+  },
+  "stable": {
+   "version": [
+    1,
+    0
+   ],
+   "deps": [
+    "eglot",
+    "flycheck"
+   ],
+   "commit": "87cc55936f843f8e0b9ab0b6b5ae5c6d7170f600",
+   "sha256": "1z9wdqqf482535jwmf3iyv5b92nbm9l4cy4v2z2nga9fj0sdr3vp"
   }
  },
  {
@@ -44103,14 +44237,14 @@
   "repo": "flycheck/flycheck-google-cpplint",
   "unstable": {
    "version": [
-    20250226,
-    2239
+    20251231,
+    1618
    ],
    "deps": [
     "flycheck"
    ],
-   "commit": "bba4b07ef39fe2c1d404584c0a561e4e0c5dc90d",
-   "sha256": "095qgwj7146a5arnckajrmp0yqzmxas3bjvq2hqns8qlg381l7y0"
+   "commit": "cf9d93a89073c3259fcebd46a7bdf1c0b4733b41",
+   "sha256": "1l5r9nagz0kkfpqf40wcbgsb065f3yh1yyv3yzjn5i34i7c243s8"
   },
   "stable": {
    "version": [
@@ -44180,16 +44314,16 @@
   "repo": "emacs-grammarly/flycheck-grammarly",
   "unstable": {
    "version": [
-    20250226,
-    2244
+    20251231,
+    1727
    ],
    "deps": [
     "flycheck",
     "grammarly",
     "s"
    ],
-   "commit": "34ee0901e1de05b0c60208293c8beb9a4587e5c7",
-   "sha256": "11iir8bqrv1f1hl8prfm6dm30jql89sbby5vvzkcqgyfzwvrh60j"
+   "commit": "4b247b36785049eb987919cb2ba1715d698fc07b",
+   "sha256": "1b2czgypp96f3phcgkp7vnchlv3b8agsqy1vpagaafxwgv0za5zx"
   },
   "stable": {
    "version": [
@@ -44627,14 +44761,14 @@
   "repo": "emacs-languagetool/flycheck-languagetool",
   "unstable": {
    "version": [
-    20250407,
-    21
+    20260101,
+    535
    ],
    "deps": [
     "flycheck"
    ],
-   "commit": "e44bd8bf7ec481bf8911435544becc4bef74e9e8",
-   "sha256": "0ig23x32ihzgcw0h7xx2a66ic31ayxdriq8knf87fwqywms7xgs8"
+   "commit": "8889414ec50c3c4dfeef601900c63901a55a2237",
+   "sha256": "18133npi09ka6d8m0j4gg9m74l2j5fs5y5psfb1jj4j5wvydcxc4"
   },
   "stable": {
    "version": [
@@ -44925,25 +45059,6 @@
    ],
    "commit": "ecd03f83790611888d693c684d719e033f69cb40",
    "sha256": "00py39n1383761wq6wp194pvyk94ydqdbxj9kl64g9jnipkp7849"
-  }
- },
- {
-  "ename": "flycheck-pact",
-  "commit": "0ffc77b2ddcd4f9c27a2306459cf2fcde7880e3e",
-  "sha256": "1nxmh6p2id4cxzs7jxdrk88g8qmvk33nbzmrqhm7962iqizlvnrw",
-  "fetcher": "github",
-  "repo": "kadena-io/flycheck-pact",
-  "unstable": {
-   "version": [
-    20180920,
-    2052
-   ],
-   "deps": [
-    "flycheck",
-    "pact-mode"
-   ],
-   "commit": "0e10045064ef89ec8b6f5a473073d47b976a2ca3",
-   "sha256": "072jc0vrjg531ydk5bjrjpmbvdk81yw75jqjnvb7alkib6jn5f9r"
   }
  },
  {
@@ -45415,8 +45530,8 @@
   "repo": "flycheck/flycheck-rust",
   "unstable": {
    "version": [
-    20250226,
-    2240
+    20251231,
+    1617
    ],
    "deps": [
     "dash",
@@ -45424,8 +45539,8 @@
     "let-alist",
     "seq"
    ],
-   "commit": "2b544bab19b987bfb41d5d88801b89e29bdf69c7",
-   "sha256": "1kdvq7cdnx6pm8yjm1zyyyg9xj20y3lshcash4bpdmfiswki6y08"
+   "commit": "b9db73a7a5980ca884d5dd0cbe79b3291a185972",
+   "sha256": "1sbxxwjxwafa3sn3n3g7i8hmfmqd3sr4fyfdfa0z6pby82aakc70"
   },
   "stable": {
    "version": [
@@ -45873,11 +45988,11 @@
   "repo": "jamescherti/flymake-ansible-lint.el",
   "unstable": {
    "version": [
-    20251019,
-    1945
+    20260114,
+    1535
    ],
-   "commit": "c5375aea83586e1ae97e6c2fa74ea61cf44d98f4",
-   "sha256": "1w34h714q7gvhpazbqfh0b6vgm0sy7h5xkhsksdqy144agj7jja3"
+   "commit": "8eadddad5fac18cb5625f70371890813ff9d5b87",
+   "sha256": "0zwmk4g54k4c4zyhp0b5ysj17ga5i5qgs9wj9anl8b8lddh701mk"
   },
   "stable": {
    "version": [
@@ -45912,14 +46027,14 @@
   "repo": "jamescherti/flymake-bashate.el",
   "unstable": {
    "version": [
-    20250416,
-    1624
+    20260114,
+    1535
    ],
    "deps": [
     "flymake-quickdef"
    ],
-   "commit": "c599d3c15c6f174a54c1f3d0081311758e682089",
-   "sha256": "1xwngb8i39siw2wb0m4pvgwnd1ax5rl5xq9ny3s40bcxs262grm7"
+   "commit": "91a687fd2c10c09e3509ea32e91209877affe379",
+   "sha256": "10y3pwp8r5849wlldcrya26vfq4wiblb9bif522ya25784f8bydx"
   },
   "stable": {
    "version": [
@@ -46137,14 +46252,14 @@
   "repo": "flymake/flymake-eask",
   "unstable": {
    "version": [
-    20250101,
-    1000
+    20251231,
+    1620
    ],
    "deps": [
     "flymake-easy"
    ],
-   "commit": "96fd80e6ff2c34a5898906388cfb6462f9bec7f1",
-   "sha256": "0n14xrgq56pyfh04f2gkw2fcmn64j2adhdpzm41vvxi5fr5pca7a"
+   "commit": "b389846ee64cc56c25ffb162be4388f3f31ad809",
+   "sha256": "16aic2896g6w837qi4dfkfkxh1wq2y917jhh9yzrrg1mma2mk6dv"
   },
   "stable": {
    "version": [
@@ -46413,15 +46528,15 @@
   "repo": "emacs-grammarly/flymake-grammarly",
   "unstable": {
    "version": [
-    20250101,
-    849
+    20251231,
+    1727
    ],
    "deps": [
     "grammarly",
     "s"
    ],
-   "commit": "da1e8030e0148d098bf2cb66ac5402beb1d10825",
-   "sha256": "1nccblkrlijspzgg1fal4fw4chyp81ava63ax3wwy3l7d6nk2yg9"
+   "commit": "45ed9ff6ce87298271903aad5a839c34e940a296",
+   "sha256": "0c6hmhrsqkvfsc7b2nmy801mqwrryjf0zlzasy7lra7ix64d2c5j"
   },
   "stable": {
    "version": [
@@ -46700,14 +46815,14 @@
   "repo": "emacs-languagetool/flymake-languagetool",
   "unstable": {
    "version": [
-    20251107,
-    2140
+    20260101,
+    535
    ],
    "deps": [
     "compat"
    ],
-   "commit": "a697dccf2d537e7efd92fd80e6b480bacbd1b821",
-   "sha256": "1jhazxn8728fncvwa8rby99yaf65h2qx7728vrf3c36g052a364m"
+   "commit": "2fcba271ab1b8fc301812615a8c072c108ad96b3",
+   "sha256": "0385mcf8551dh769rh08az28swxj6dl1cnv6brd18x3dy815kl73"
   },
   "stable": {
    "version": [
@@ -47416,14 +47531,14 @@
   "repo": "konrad1977/flyover",
   "unstable": {
    "version": [
-    20251208,
-    647
+    20260111,
+    1120
    ],
    "deps": [
     "flymake"
    ],
-   "commit": "0446b4289bd7a3f169f2ab8eb6f6fa0365322bab",
-   "sha256": "0j7m3ma14q5gdlkhiq00f17v7sz8z7ddjv14hijxpmzqc2awrhyd"
+   "commit": "166da1cd3388c8dbbe0d514b3a1fe8397630d8d5",
+   "sha256": "03cily8i7zq860n7gf5qj68005jc1219m8rvd9m10snz8wrpdkkd"
   }
  },
  {
@@ -47449,20 +47564,20 @@
   "repo": "d12frosted/flyspell-correct",
   "unstable": {
    "version": [
-    20220520,
-    630
+    20260106,
+    955
    ],
-   "commit": "7d7b6b01188bd28e20a13736ac9f36c3367bd16e",
-   "sha256": "1b6h3wjmxg9d1d3mfvw6fsgkr1w0d14zxllv9jb5cscl5lq8rbmm"
+   "commit": "a5a41c0f3a7881bd3eba07bee424ecb7c7d5061e",
+   "sha256": "1f9q9i5k34kg13lnhl2vzc3w8gvh5mzpv557mj9sngaqvgw03nzx"
   },
   "stable": {
    "version": [
+    1,
     0,
-    6,
-    1
+    0
    ],
-   "commit": "7b4cf8c9ba5ac65e3bb2b62f5b72d45f4c9cf7b6",
-   "sha256": "1m5da6r82hk0c2x3lw03qnkk79sx67875afw0ybblj3cmfk6szd1"
+   "commit": "a5a41c0f3a7881bd3eba07bee424ecb7c7d5061e",
+   "sha256": "1f9q9i5k34kg13lnhl2vzc3w8gvh5mzpv557mj9sngaqvgw03nzx"
   }
  },
  {
@@ -47473,28 +47588,28 @@
   "repo": "d12frosted/flyspell-correct",
   "unstable": {
    "version": [
-    20220520,
-    630
+    20260106,
+    955
    ],
    "deps": [
     "avy-menu",
     "flyspell-correct"
    ],
-   "commit": "7d7b6b01188bd28e20a13736ac9f36c3367bd16e",
-   "sha256": "1b6h3wjmxg9d1d3mfvw6fsgkr1w0d14zxllv9jb5cscl5lq8rbmm"
+   "commit": "a5a41c0f3a7881bd3eba07bee424ecb7c7d5061e",
+   "sha256": "1f9q9i5k34kg13lnhl2vzc3w8gvh5mzpv557mj9sngaqvgw03nzx"
   },
   "stable": {
    "version": [
+    1,
     0,
-    6,
-    1
+    0
    ],
    "deps": [
     "avy-menu",
     "flyspell-correct"
    ],
-   "commit": "7b4cf8c9ba5ac65e3bb2b62f5b72d45f4c9cf7b6",
-   "sha256": "1m5da6r82hk0c2x3lw03qnkk79sx67875afw0ybblj3cmfk6szd1"
+   "commit": "a5a41c0f3a7881bd3eba07bee424ecb7c7d5061e",
+   "sha256": "1f9q9i5k34kg13lnhl2vzc3w8gvh5mzpv557mj9sngaqvgw03nzx"
   }
  },
  {
@@ -47505,28 +47620,28 @@
   "repo": "d12frosted/flyspell-correct",
   "unstable": {
    "version": [
-    20220520,
-    630
+    20260106,
+    955
    ],
    "deps": [
     "flyspell-correct",
     "helm"
    ],
-   "commit": "7d7b6b01188bd28e20a13736ac9f36c3367bd16e",
-   "sha256": "1b6h3wjmxg9d1d3mfvw6fsgkr1w0d14zxllv9jb5cscl5lq8rbmm"
+   "commit": "a5a41c0f3a7881bd3eba07bee424ecb7c7d5061e",
+   "sha256": "1f9q9i5k34kg13lnhl2vzc3w8gvh5mzpv557mj9sngaqvgw03nzx"
   },
   "stable": {
    "version": [
+    1,
     0,
-    6,
-    1
+    0
    ],
    "deps": [
     "flyspell-correct",
     "helm"
    ],
-   "commit": "7b4cf8c9ba5ac65e3bb2b62f5b72d45f4c9cf7b6",
-   "sha256": "1m5da6r82hk0c2x3lw03qnkk79sx67875afw0ybblj3cmfk6szd1"
+   "commit": "a5a41c0f3a7881bd3eba07bee424ecb7c7d5061e",
+   "sha256": "1f9q9i5k34kg13lnhl2vzc3w8gvh5mzpv557mj9sngaqvgw03nzx"
   }
  },
  {
@@ -47537,28 +47652,28 @@
   "repo": "d12frosted/flyspell-correct",
   "unstable": {
    "version": [
-    20220520,
-    630
+    20260106,
+    955
    ],
    "deps": [
     "flyspell-correct",
     "ivy"
    ],
-   "commit": "7d7b6b01188bd28e20a13736ac9f36c3367bd16e",
-   "sha256": "1b6h3wjmxg9d1d3mfvw6fsgkr1w0d14zxllv9jb5cscl5lq8rbmm"
+   "commit": "a5a41c0f3a7881bd3eba07bee424ecb7c7d5061e",
+   "sha256": "1f9q9i5k34kg13lnhl2vzc3w8gvh5mzpv557mj9sngaqvgw03nzx"
   },
   "stable": {
    "version": [
+    1,
     0,
-    6,
-    1
+    0
    ],
    "deps": [
     "flyspell-correct",
     "ivy"
    ],
-   "commit": "7b4cf8c9ba5ac65e3bb2b62f5b72d45f4c9cf7b6",
-   "sha256": "1m5da6r82hk0c2x3lw03qnkk79sx67875afw0ybblj3cmfk6szd1"
+   "commit": "a5a41c0f3a7881bd3eba07bee424ecb7c7d5061e",
+   "sha256": "1f9q9i5k34kg13lnhl2vzc3w8gvh5mzpv557mj9sngaqvgw03nzx"
   }
  },
  {
@@ -47569,28 +47684,28 @@
   "repo": "d12frosted/flyspell-correct",
   "unstable": {
    "version": [
-    20220520,
-    630
+    20260106,
+    955
    ],
    "deps": [
     "flyspell-correct",
     "popup"
    ],
-   "commit": "7d7b6b01188bd28e20a13736ac9f36c3367bd16e",
-   "sha256": "1b6h3wjmxg9d1d3mfvw6fsgkr1w0d14zxllv9jb5cscl5lq8rbmm"
+   "commit": "a5a41c0f3a7881bd3eba07bee424ecb7c7d5061e",
+   "sha256": "1f9q9i5k34kg13lnhl2vzc3w8gvh5mzpv557mj9sngaqvgw03nzx"
   },
   "stable": {
    "version": [
+    1,
     0,
-    6,
-    1
+    0
    ],
    "deps": [
     "flyspell-correct",
     "popup"
    ],
-   "commit": "7b4cf8c9ba5ac65e3bb2b62f5b72d45f4c9cf7b6",
-   "sha256": "1m5da6r82hk0c2x3lw03qnkk79sx67875afw0ybblj3cmfk6szd1"
+   "commit": "a5a41c0f3a7881bd3eba07bee424ecb7c7d5061e",
+   "sha256": "1f9q9i5k34kg13lnhl2vzc3w8gvh5mzpv557mj9sngaqvgw03nzx"
   }
  },
  {
@@ -48147,8 +48262,8 @@
   "repo": "magit/forge",
   "unstable": {
    "version": [
-    20251201,
-    1658
+    20260117,
+    1710
    ],
    "deps": [
     "closql",
@@ -48163,14 +48278,14 @@
     "transient",
     "yaml"
    ],
-   "commit": "325dbcd6fff652e28787950bada2484241dd3365",
-   "sha256": "1nn2ng5y2zws5683pc56blky5v1i150qx6yn3p6x7km4bw2035jl"
+   "commit": "3cde5fc0e17e9a30a0f3b49fcbc49b50a5ca49f3",
+   "sha256": "120ajxsdi2jm075d40ajsvv12vaq4w77d1jaxayanwfq8mppcld3"
   },
   "stable": {
    "version": [
     0,
     6,
-    2
+    3
    ],
    "deps": [
     "closql",
@@ -48185,8 +48300,8 @@
     "transient",
     "yaml"
    ],
-   "commit": "71910a26e360bfe88eb81b47f377f7694161fe9b",
-   "sha256": "05clfk3w81p36v86bc169am6kp6k61phrh8pwvmzhknmar1lspln"
+   "commit": "315e8e9a2b45d050ca7fc717595cc698e175b140",
+   "sha256": "0fg5r39l2y6smwkdzf0nwpa4hmgcj5mz28x8gwyvj9nfhgl4xg1j"
   }
  },
  {
@@ -48587,26 +48702,26 @@
   "repo": "tarsius/frameshot",
   "unstable": {
    "version": [
-    20251101,
-    2212
+    20260101,
+    1833
    ],
    "deps": [
     "compat"
    ],
-   "commit": "89ca25879b4c55da049f771870926a27bbfb1066",
-   "sha256": "0l10j1zb2fyy1j4xxks1r8hyx9vrjqd26llwc3x7chb2r2x5wyla"
+   "commit": "975450f325f0e29a73214deff011ad524f02bc74",
+   "sha256": "0ax9jkchlb1fc6fxw09zps6qhaazbpgm7b66hbsblkdy2apczcnm"
   },
   "stable": {
    "version": [
     1,
     2,
-    0
+    1
    ],
    "deps": [
     "compat"
    ],
-   "commit": "89ca25879b4c55da049f771870926a27bbfb1066",
-   "sha256": "0l10j1zb2fyy1j4xxks1r8hyx9vrjqd26llwc3x7chb2r2x5wyla"
+   "commit": "975450f325f0e29a73214deff011ad524f02bc74",
+   "sha256": "0ax9jkchlb1fc6fxw09zps6qhaazbpgm7b66hbsblkdy2apczcnm"
   }
  },
  {
@@ -48951,16 +49066,16 @@
   "repo": "waymondo/frog-jump-buffer",
   "unstable": {
    "version": [
-    20221114,
-    141
+    20251228,
+    555
    ],
    "deps": [
     "avy",
     "dash",
     "frog-menu"
    ],
-   "commit": "ab830cb7a5af9429866ba88fb37589a0366d8bf2",
-   "sha256": "0996896n7135xzxxhh50phhb1y06rcycj2gxx7p26p7aa72ambc3"
+   "commit": "e2beb322d4ef1baaaf191dbc6f50e19fa5781abf",
+   "sha256": "1b016y5q0lbcwn4bw84vw8ffkkrca9f63cwwpf7gyksdk26fqy1f"
   }
  },
  {
@@ -49348,11 +49463,11 @@
   "repo": "auto-complete/fuzzy-el",
   "unstable": {
    "version": [
-    20250101,
-    843
+    20251231,
+    1622
    ],
-   "commit": "09ef98ecdea03497ae309fd0ed740190e9a3492e",
-   "sha256": "1szzbkvb80hdz3889q1jb8jyn8fzdxsxrmz6qk8w9x4cc7xw70gf"
+   "commit": "3dc04f0a037d53d1174a1f38dce8a4b3498fa947",
+   "sha256": "1v9mdc1zwz23arh7rr30jglkhccl3aargpfk5ihksf5r6rg2vm93"
   },
   "stable": {
    "version": [
@@ -49434,26 +49549,26 @@
   "repo": "tarsius/fwb-cmds",
   "unstable": {
    "version": [
-    20251101,
-    2015
+    20260101,
+    1833
    ],
    "deps": [
     "compat"
    ],
-   "commit": "2c36c716a5cf86e790ad1acbd2a062230c78eec2",
-   "sha256": "0sp41dsqm8n2m8yc4y4nr7r6qqkc261jz75gi0vgf9pjx0qc8iys"
+   "commit": "d230b9e42f992d9a4c4b155ba7f1920e8577caca",
+   "sha256": "07h0h2jsb4imkc6n4wxc255f3glgq5kcl2xq85h0769qa28qy5w4"
   },
   "stable": {
    "version": [
     2,
     0,
-    4
+    5
    ],
    "deps": [
     "compat"
    ],
-   "commit": "2c36c716a5cf86e790ad1acbd2a062230c78eec2",
-   "sha256": "0sp41dsqm8n2m8yc4y4nr7r6qqkc261jz75gi0vgf9pjx0qc8iys"
+   "commit": "d230b9e42f992d9a4c4b155ba7f1920e8577caca",
+   "sha256": "07h0h2jsb4imkc6n4wxc255f3glgq5kcl2xq85h0769qa28qy5w4"
   }
  },
  {
@@ -49508,11 +49623,11 @@
   "repo": "bling/fzf.el",
   "unstable": {
    "version": [
-    20240822,
-    201
+    20260111,
+    1853
    ],
-   "commit": "641aef33c88df3733f13d559bcb2acc548a4a0c3",
-   "sha256": "1nyvam5jg4gih0x2rvwr4jn97lyhaic3adpdxpdfx682ckj1k2vp"
+   "commit": "7bd12faa84f0ddcbc1e76ab416bb43e36fbf9c1f",
+   "sha256": "07zfb7771kwwv99z1fdk9zb51swyl5i07ps53748n9yskivf16kx"
   },
   "stable": {
    "version": [
@@ -49574,11 +49689,11 @@
   "repo": "ShiroTakeda/gams-mode",
   "unstable": {
    "version": [
-    20251124,
-    1517
+    20260119,
+    217
    ],
-   "commit": "dfab98a2ef847bae4bc3ae3abdf638355efd73db",
-   "sha256": "0y5phgla7s9cxb4rwn9kc092wl55knv4iyf5621bc87b7ybma4q8"
+   "commit": "519c64f186515157b6a01143f438dc24148d8e58",
+   "sha256": "185r2x63cib0bjl68xxn52bvli7lfpy894l7n01wy3q05w4lfbws"
   },
   "stable": {
    "version": [
@@ -49666,11 +49781,11 @@
   "repo": "wavexx/gcode-mode.el",
   "unstable": {
    "version": [
-    20230823,
-    2141
+    20260108,
+    1713
    ],
-   "commit": "4b54553a698d81e52dde14037df94774c7f30b95",
-   "sha256": "13nafw4rz1xfzcag0390xxs1nqadplvkrkiw72h0i8y2kwa9yya3"
+   "commit": "a0423aab9aba9f2af8600809bcb1b927fa188d1d",
+   "sha256": "035gxc0xb7ma9ydcg2gxa5mnr16qlp5gd0xnafklkfmqrcfi3rxc"
   }
  },
  {
@@ -50659,8 +50774,8 @@
   "repo": "magit/ghub",
   "unstable": {
    "version": [
-    20251130,
-    1842
+    20260101,
+    1852
    ],
    "deps": [
     "compat",
@@ -50668,22 +50783,23 @@
     "llama",
     "treepy"
    ],
-   "commit": "9f416605d560ed2a6b62a87d1f624549901b1102",
-   "sha256": "1r22sj9l2zrxakja636pskl0lrkmgkrz7r0k0w6icn9836v2kjq1"
+   "commit": "278d9fb5f3f673a4ecfe551faeacc0dfd5de0783",
+   "sha256": "0bw8m3i05r6bm8drapxf8ldg71wgymkr15adl43lckp37kl7npyj"
   },
   "stable": {
    "version": [
     5,
     0,
-    2
+    3
    ],
    "deps": [
     "compat",
+    "cond-let",
     "llama",
     "treepy"
    ],
-   "commit": "447cb51fa7d19e1fb3844acdd2c540be04299ffb",
-   "sha256": "16ikjhps2ha23ab3w43vsz38l1hbjvwhk2dhajv6853gpx4xaipm"
+   "commit": "278d9fb5f3f673a4ecfe551faeacc0dfd5de0783",
+   "sha256": "0bw8m3i05r6bm8drapxf8ldg71wgymkr15adl43lckp37kl7npyj"
   }
  },
  {
@@ -51399,26 +51515,26 @@
   "repo": "magit/git-modes",
   "unstable": {
    "version": [
-    20251101,
-    2017
+    20260101,
+    1834
    ],
    "deps": [
     "compat"
    ],
-   "commit": "dfc450d79498b7997b1155ac76629ab01f7ef355",
-   "sha256": "0pjsxw5ni47c8mfd40l9x5fnpi1423djhxxr2ixvk81p7xcrcsyi"
+   "commit": "c3faeeea1982786f78d8c38397dec0f078eaec84",
+   "sha256": "12r2n3w3yigszh2cszfca1rmrifj2lib5aswcjrx4rd9pzziavzk"
   },
   "stable": {
    "version": [
     1,
     4,
-    7
+    8
    ],
    "deps": [
     "compat"
    ],
-   "commit": "dfc450d79498b7997b1155ac76629ab01f7ef355",
-   "sha256": "0pjsxw5ni47c8mfd40l9x5fnpi1423djhxxr2ixvk81p7xcrcsyi"
+   "commit": "c3faeeea1982786f78d8c38397dec0f078eaec84",
+   "sha256": "12r2n3w3yigszh2cszfca1rmrifj2lib5aswcjrx4rd9pzziavzk"
   }
  },
  {
@@ -51462,6 +51578,36 @@
    ],
    "commit": "288e5c4d0ff20a4e1ac9e72b6af632f67f1d7525",
    "sha256": "1hyq3il03cm6apfawps60r4km8r6pw0vphzba30smsqfk50z3ya3"
+  }
+ },
+ {
+  "ename": "git-sync-mode",
+  "commit": "210325da4e89b778877b88d1cb9afd0d92b1912b",
+  "sha256": "11hys6k4drkcg44symvyqjm5237vm0zk7yzrbpszfdfz772f9nlv",
+  "fetcher": "github",
+  "repo": "justinbarclay/git-sync-mode",
+  "unstable": {
+   "version": [
+    20260101,
+    2353
+   ],
+   "deps": [
+    "async-await"
+   ],
+   "commit": "9e602ebb0fa3c02a7987bb94ccfa0142fe00d1a9",
+   "sha256": "0896qzwq57klqa3bb86m4xasibrb95slq7awmavw5xzw38pq0rb9"
+  },
+  "stable": {
+   "version": [
+    0,
+    5,
+    0
+   ],
+   "deps": [
+    "async-await"
+   ],
+   "commit": "abdb08a7fd262d8bec4c967338e7715e43119499",
+   "sha256": "0bkc4b2kff0pivss2i4k5sjl0aj18k664q697l095lafbn2gf0a9"
   }
  },
  {
@@ -52568,8 +52714,8 @@
   "url": "https://git.thanosapollo.org/gnosis",
   "unstable": {
    "version": [
-    20251108,
-    939
+    20260114,
+    454
    ],
    "deps": [
     "compat",
@@ -52577,8 +52723,8 @@
     "org-gnosis",
     "transient"
    ],
-   "commit": "43b8ba93a7173543d16e08ebc30ce8ed3f793b7f",
-   "sha256": "0zlcw3qqpxar9sapds38w38yhxmndv7zb59xh206c0fwvymjfc1d"
+   "commit": "6bd8f4e5a84387b51df961db9703e9801f3610f7",
+   "sha256": "1x8d0dw1s6qhhhv2f90372nk0zwi3m405cga706xzrffr86mydyr"
   },
   "stable": {
    "version": [
@@ -52657,14 +52803,14 @@
   "repo": "emacs-gnuplot/gnuplot",
   "unstable": {
    "version": [
-    20250724,
-    1531
+    20260117,
+    1740
    ],
    "deps": [
     "compat"
    ],
-   "commit": "43e9674b869475b1c2a32f045c167673eb2faae0",
-   "sha256": "1l613l11l0w27z7qihv3ch5z8993rbajz61n2in83sk2xx53z1sf"
+   "commit": "e4d19faf760f9f261339586f723859ce7869e760",
+   "sha256": "1mnicmb79fvwmiwgsylvalf6qbmyig40kzdmibrz9wc39kkcmvfm"
   },
   "stable": {
    "version": [
@@ -53497,6 +53643,54 @@
   }
  },
  {
+  "ename": "go-template-helper-mode",
+  "commit": "42813923054563851b6cadd0f04ffe9fff58be92",
+  "sha256": "00np7ndvmi892v5bx8dzxf1x8rzmp6hf30ndy8ddk31895yc711m",
+  "fetcher": "codeberg",
+  "repo": "rch/go-template-helper-mode",
+  "unstable": {
+   "version": [
+    20260102,
+    1449
+   ],
+   "commit": "34ba1fa917da78f9926fa909056bd9e1e5dd2837",
+   "sha256": "179przj56648gxsqz0b0jzwj6b7d729ncabqzqgqfwyad9n2605b"
+  },
+  "stable": {
+   "version": [
+    1,
+    0,
+    1
+   ],
+   "commit": "34ba1fa917da78f9926fa909056bd9e1e5dd2837",
+   "sha256": "179przj56648gxsqz0b0jzwj6b7d729ncabqzqgqfwyad9n2605b"
+  }
+ },
+ {
+  "ename": "go-template-mode",
+  "commit": "4bd2603f9fbf22fae148ec8573bcd3b0fb3cce09",
+  "sha256": "0g5p7fszzrsk68y1myvsl4v0p7x4v1m3w9ffhfvkcyjj6g5ppvd6",
+  "fetcher": "codeberg",
+  "repo": "rch/go-template-mode",
+  "unstable": {
+   "version": [
+    20260102,
+    1442
+   ],
+   "commit": "f33b953f5301d079463b428393efcd83767a128c",
+   "sha256": "1s9b0z9i6mf1dqa1f3wzdmmqgwyq34q3vkfj6cbzsi3kzrq8s9nr"
+  },
+  "stable": {
+   "version": [
+    1,
+    0,
+    0
+   ],
+   "commit": "f33b953f5301d079463b428393efcd83767a128c",
+   "sha256": "1s9b0z9i6mf1dqa1f3wzdmmqgwyq34q3vkfj6cbzsi3kzrq8s9nr"
+  }
+ },
+ {
   "ename": "gobgen",
   "commit": "8c9fed22bb8dbfb359e4fdb0d802ed4b5781f50d",
   "sha256": "0fb0q9x7wj8gs1iyr87q1vpxmfa2d43zy6cgxpzmv2wc26x96vi7",
@@ -53591,11 +53785,11 @@
   "repo": "minad/goggles",
   "unstable": {
    "version": [
-    20250921,
-    1713
+    20260101,
+    1343
    ],
-   "commit": "6f87a700137c838568966bc8099dc15786897c32",
-   "sha256": "0jxvp11q4c18w8k7m4vi6sn0nx5wphf5wlq6mxvx34zk1pmw3scn"
+   "commit": "81adff62ca58aeead1f8c25ec64f1d4ddbc80f5e",
+   "sha256": "0q616zzbw6qrd2w0d6rjl0xvidbl5iq8llp95686f96xwrc0r78q"
   },
   "stable": {
    "version": [
@@ -54019,11 +54213,11 @@
   "repo": "emacs-vs/goto-char-preview",
   "unstable": {
    "version": [
-    20250101,
-    908
+    20260101,
+    549
    ],
-   "commit": "806baf183ca6f6c88aea7f79752e48c4f2f86c89",
-   "sha256": "01r828qpx9bz27nj4d2xj5sdzi5q71nfji21h735bn4r6q6p9hk9"
+   "commit": "b78fa6419466984b97459e95ffb77f3e9ae10a09",
+   "sha256": "0wz4ajn4d4b3rli1hvlh5vsdpm98m2wkdni6sw03m3wz4750brx6"
   },
   "stable": {
    "version": [
@@ -54106,11 +54300,11 @@
   "repo": "emacs-vs/goto-line-preview",
   "unstable": {
    "version": [
-    20250101,
-    908
+    20260101,
+    549
    ],
-   "commit": "fa34955bcd1166421757216013945bc9ed520dc5",
-   "sha256": "0x34xkg5g630yiihyqq09l21bfxvz0iz83fw470sq4j3qm6hnykr"
+   "commit": "ccc3c361da93f5bd44d697d22482f52fab735860",
+   "sha256": "08yw64chjd189is40yl9plxym35bb3zfmsb7k41h8rdgpcw7ib27"
   },
   "stable": {
    "version": [
@@ -54210,6 +54404,15 @@
    ],
    "commit": "b8aeca2c8fd5ed370dad0676da8f380627c916d5",
    "sha256": "1aczmvyaa0z5z4bxr87k8v3vs915331kccc85y2jm99rc3786r1q"
+  },
+  "stable": {
+   "version": [
+    0,
+    7,
+    3
+   ],
+   "commit": "b8aeca2c8fd5ed370dad0676da8f380627c916d5",
+   "sha256": "1aczmvyaa0z5z4bxr87k8v3vs915331kccc85y2jm99rc3786r1q"
   }
  },
  {
@@ -54238,11 +54441,11 @@
   "repo": "stuhlmueller/gpt.el",
   "unstable": {
    "version": [
-    20251214,
-    540
+    20260111,
+    423
    ],
-   "commit": "f2686a12e6703b970f569ad33762166a396bf2a2",
-   "sha256": "0c3vdx3dfnmrx7f5l87j9j7ha0jnbbgjyyql14bspc99wy0d1591"
+   "commit": "fb5b7a833116377f9aae05e3ddefec64805d7546",
+   "sha256": "15md8lpkkj1k9f0aaqqp98pzkklvc386i5ilawqq0mvq1kpzir2j"
   }
  },
  {
@@ -54309,15 +54512,15 @@
   "repo": "karthink/gptel",
   "unstable": {
    "version": [
-    20251218,
-    224
+    20260116,
+    710
    ],
    "deps": [
     "compat",
     "transient"
    ],
-   "commit": "0f65be08ead0c9bc882fad5a4dcb604448e366a6",
-   "sha256": "0vrzmxg5xaazjpagavbx297vk042qjvygy6ffbxgjvkz68j8vy7v"
+   "commit": "7f15e57e1a5c7dcc504457708645aef2deceb425",
+   "sha256": "0ljylls6537rxgy0ywc7paxz4ccgxizv1lzlb02hnb1xwrd5pmyz"
   },
   "stable": {
    "version": [
@@ -54342,8 +54545,8 @@
   "repo": "karthink/gptel-agent",
   "unstable": {
    "version": [
-    20251210,
-    453
+    20260114,
+    2340
    ],
    "deps": [
     "compat",
@@ -54351,8 +54554,8 @@
     "orderless",
     "yaml"
    ],
-   "commit": "99a8b940271fbe68cdfb7c2329d090dc4ef04b99",
-   "sha256": "1bmvdya60l120a18pl4j10n1pydmxr376f93d66s1dwkxp8jkiwy"
+   "commit": "ba4aed51fe4ae4ddf73dc538aeaec7fe9bc364be",
+   "sha256": "0476jbydk62f01vj9463c0h7fy4nibq351m4wy4dql04x6nhflx6"
   }
  },
  {
@@ -54401,6 +54604,25 @@
    ],
    "commit": "4ca046eca5e57b42c0886062e10c02611234e186",
    "sha256": "1ig9z5kv3jypv8bmvhlcy2pbpf7zyx7jj7x4cmdkng3sja4078r0"
+  }
+ },
+ {
+  "ename": "gptel-cpp-complete",
+  "commit": "14198c86535bd12b47436d5c6beb260e9d828611",
+  "sha256": "1x30vr22r8kdbhfdnhqk0yanqdfwqi88hzdqjpx6kpjjigy5m5la",
+  "fetcher": "github",
+  "repo": "beacoder/gptel-cpp-complete",
+  "unstable": {
+   "version": [
+    20260112,
+    803
+   ],
+   "deps": [
+    "eglot",
+    "gptel"
+   ],
+   "commit": "c38815f81f40ef519c2bcc5dfa9a29b72cc54a4c",
+   "sha256": "16pac2ahn0zqfr43nsfkmbqs7qlnmq6xhvg0f7b9313ndhi9q8xm"
   }
  },
  {
@@ -54480,11 +54702,11 @@
   "repo": "mkcms/gpx-mode",
   "unstable": {
    "version": [
-    20251208,
-    2014
+    20251228,
+    1347
    ],
-   "commit": "f9a34cf11a41b991ae93cce34a0b6fc3b2050f4a",
-   "sha256": "1w0651cln7pnvb3fj8x98djnmg14b2lh17qn7lpxqr1s41d53i4c"
+   "commit": "d97efb2c2701118f418c22ab1b6518bef0d79517",
+   "sha256": "1jsxpwkdj5mdg98c979w7zsmflip5fdry5bczdw4326a6b7mksic"
   },
   "stable": {
    "version": [
@@ -54633,16 +54855,16 @@
   "repo": "emacs-grammarly/grammarly",
   "unstable": {
    "version": [
-    20250101,
-    849
+    20251231,
+    1727
    ],
    "deps": [
     "request",
     "s",
     "websocket"
    ],
-   "commit": "c67f8d49bf89fb176e4a125b8fc4be4a41446a95",
-   "sha256": "1r9vbkqz9ynawyn7v98lqcadjdns6kyndazsbksxqd3myvf6m6la"
+   "commit": "aa079dca01e7dc35d993bdbdf2bcdccaf93a3d56",
+   "sha256": "0j45vdk305znvdbfky5n5f5ammanrl0zbplgkcp06bs056zm66m6"
   },
   "stable": {
    "version": [
@@ -54943,15 +55165,15 @@
   "repo": "michelangelo-rodriguez/greader",
   "unstable": {
    "version": [
-    20251125,
-    859
+    20260103,
+    2206
    ],
    "deps": [
     "compat",
     "seq"
    ],
-   "commit": "b25974aeae49f11b91bb78d94ab51913fdfcdc05",
-   "sha256": "1qkszb4yrfnzb2rqkf6vmzca53w68p78zb58frcxslxn7s5l7ih1"
+   "commit": "66a405e49df0421e4d3b8cd4fc81716a949a9568",
+   "sha256": "18hzfz4an0kl2n538qf6qy14diw2yr5bna1lafvz92spz3wyzs6w"
   }
  },
  {
@@ -55562,6 +55784,30 @@
   }
  },
  {
+  "ename": "guava-themes",
+  "commit": "96886e44814fc1e33d4fb14bfd5d0911f76e50a8",
+  "sha256": "1f1vzansvgpp020cmq331hhr214by07mllfkyqlyqsijh6nwnn90",
+  "fetcher": "github",
+  "repo": "bormoge/guava-themes",
+  "unstable": {
+   "version": [
+    20260119,
+    2115
+   ],
+   "commit": "983154f6922571b2cb34730808d6b396417b10ba",
+   "sha256": "0760bavqmbhjsd1ydiqm4h5c2kfmlvnn0mgf845k8qvghb9y14xx"
+  },
+  "stable": {
+   "version": [
+    0,
+    8,
+    0
+   ],
+   "commit": "983154f6922571b2cb34730808d6b396417b10ba",
+   "sha256": "0760bavqmbhjsd1ydiqm4h5c2kfmlvnn0mgf845k8qvghb9y14xx"
+  }
+ },
+ {
   "ename": "guess-language",
   "commit": "a6ff6bbfa11f08647bf17afe75bfb4dcafd86683",
   "sha256": "1sbvvzzdb76wf9km9sp6p6yp6cc3irvajz4fz78y90iw3dka2w6q",
@@ -55651,18 +55897,36 @@
   "repo": "guix/emacs-guix",
   "unstable": {
    "version": [
-    20250914,
-    1923
+    20260116,
+    1554
    ],
    "deps": [
     "bui",
     "dash",
     "edit-indirect",
     "geiser",
+    "magit-popup",
     "transient"
    ],
-   "commit": "324987fb4a3e67c6f0f565b6605b8fce559f60ee",
-   "sha256": "1bg8sy20rdpdv1vzim494jwrmd63rd1mn8v94rkdijs9a2cakdkq"
+   "commit": "72833603ee54c7a8d955415869a332419680ca50",
+   "sha256": "14639wg2717yawj4qhmmzvirrvjy0s1jw2j9wgyzc21h7hl016pz"
+  },
+  "stable": {
+   "version": [
+    0,
+    6,
+    1
+   ],
+   "deps": [
+    "bui",
+    "dash",
+    "edit-indirect",
+    "geiser",
+    "magit-popup",
+    "transient"
+   ],
+   "commit": "72833603ee54c7a8d955415869a332419680ca50",
+   "sha256": "14639wg2717yawj4qhmmzvirrvjy0s1jw2j9wgyzc21h7hl016pz"
   }
  },
  {
@@ -55688,11 +55952,11 @@
   "repo": "Overdr0ne/gumshoe",
   "unstable": {
    "version": [
-    20240902,
-    2137
+    20260110,
+    1840
    ],
-   "commit": "f84bec6057506ec3f145cd3e06b320f1e40efcdf",
-   "sha256": "13xp6cqblhdaah1h11gvxfz3hpi41hn1bp1pwdgpfk61p68iwpbf"
+   "commit": "2f4f54a584d4460b838ae8e366c07eb0f040d408",
+   "sha256": "0b4pprgqlbcl69whk7rwwdc5zqysxkgk74hmbbfp3r55mfi686ca"
   }
  },
  {
@@ -56626,11 +56890,11 @@
   "repo": "emacsorphanage/haxe-mode",
   "unstable": {
    "version": [
-    20240925,
-    754
+    20260103,
+    1757
    ],
-   "commit": "7a396e9f01f7c110dd120c6ffaea668f44991f51",
-   "sha256": "1mhrxri5pkqi4cmbwcf9f073vxbihxlv4vjv5vv5m33smnb3q97g"
+   "commit": "6ffa81f6d1fa81b7b9ae2e68d22b0d4c872cf59d",
+   "sha256": "13h39dmcmlpn2nai5j4d6pzaikai142bflk3iww5pijhs2z8qv94"
   },
   "stable": {
    "version": [
@@ -56838,15 +57102,15 @@
   "repo": "emacs-helm/helm",
   "unstable": {
    "version": [
-    20251212,
-    555
+    20260108,
+    714
    ],
    "deps": [
     "helm-core",
     "wfnames"
    ],
-   "commit": "08fb63fab625e90b699999151dada80232a7c81b",
-   "sha256": "04dka0myf6sfyc46myx6fqyfq42lxybd2y4cr0vsrfizqd3lmiks"
+   "commit": "3065b5d7c42fd2ba23ebd73cb25dc028990fc0bb",
+   "sha256": "11b3z2l8ml4d21fh64gwlzqsk4k8pq4ak6jhck5dzkz6gq4ln469"
   },
   "stable": {
    "version": [
@@ -57649,14 +57913,14 @@
   "repo": "emacs-helm/helm",
   "unstable": {
    "version": [
-    20251211,
-    709
+    20260104,
+    1441
    ],
    "deps": [
     "async"
    ],
-   "commit": "c9a6c2542e5ec48700d1a72632cef009e5ee3253",
-   "sha256": "1xjy0scdlg6dd86m33jgkzkx4zbp42i2634vf7g3jhi7z8hyia5h"
+   "commit": "cbbaff3c5a76b3ab91ba297844acce11980f55fd",
+   "sha256": "05zadb07hgsv4lphssawjsfdwi3c7rq2l6qf8yq5my6g6w372l88"
   },
   "stable": {
    "version": [
@@ -57937,16 +58201,16 @@
   "repo": "emacs-helm/helm-emms",
   "unstable": {
    "version": [
-    20250405,
-    1018
+    20260102,
+    537
    ],
    "deps": [
     "cl-lib",
     "emms",
     "helm"
    ],
-   "commit": "2e8b53a46b32f956efacfda2dbf3f1b0db867472",
-   "sha256": "0gv4pb6s4jimlddc047vl1pi7r3h56s7ldz3z8c4klf2j30096l9"
+   "commit": "ae442c2a338c9335cd8e2b27be623b135cde6107",
+   "sha256": "08wdgqyn8pfm7wfs82binm83n7z8d4li29vwr8pjy7r4syxi16y6"
   },
   "stable": {
    "version": [
@@ -58127,15 +58391,15 @@
   "repo": "emacs-helm/helm-firefox",
   "unstable": {
    "version": [
-    20220420,
-    1346
+    20260102,
+    537
    ],
    "deps": [
     "cl-lib",
     "helm"
    ],
-   "commit": "571cf8dfcbe43d91f9890eebefc88d7572c62e75",
-   "sha256": "0x93x29d74mqbq78jcxq06w9myfml7yni5p2zfdyqva7q725wsgb"
+   "commit": "9356ace9fac469b94121c36e5960cc1f5ce14663",
+   "sha256": "06y9c4csg4q5ilayvkzb9xrq02r86hs1g09ps4hyrckngwx0rmig"
   },
   "stable": {
    "version": [
@@ -58594,14 +58858,14 @@
   "repo": "emacsorphanage/helm-gtags",
   "unstable": {
    "version": [
-    20240925,
-    755
+    20260103,
+    1800
    ],
    "deps": [
     "helm"
    ],
-   "commit": "f51eec4a39d7a38a030fd37e40834f1ca9b61e00",
-   "sha256": "18iyc4klwp7zpccdhpyhvzi2lg61njdy6a6cfgx1h2kkpqxlccwv"
+   "commit": "6278f138896585dd60cd954f991cffcc0ebf6440",
+   "sha256": "0471bkm8mv8qh4x69kvz3cayhlyjwg6zi1yxaxl2prs0h5dyn11x"
   },
   "stable": {
    "version": [
@@ -59009,14 +59273,14 @@
   "repo": "emacs-helm/helm-ls-git",
   "unstable": {
    "version": [
-    20251026,
-    714
+    20260105,
+    455
    ],
    "deps": [
     "helm"
    ],
-   "commit": "d72786b5a87950a4d125456ff64a258a8388bf19",
-   "sha256": "18700qfy7p2vfhz7x3rkph2d285lqh0cazrzayg08pxd8nh8l2mc"
+   "commit": "dd0ed5847d4bf1b27e767cf194475ada88ee8898",
+   "sha256": "13sa7a9a6p7nwdw5kbf50x942s579z53qb30ic7401gk8va7ay3m"
   },
   "stable": {
    "version": [
@@ -60265,38 +60529,6 @@
   }
  },
  {
-  "ename": "helm-rubygems-org",
-  "commit": "655be547d57d358eff968f42c13dcf4371529a72",
-  "sha256": "04ni03ak53z3rggdgf68qh7ksgcf3s0f2cv6skwjqw7v8qhph6qs",
-  "fetcher": "github",
-  "repo": "neomantic/helm-rubygems-org",
-  "unstable": {
-   "version": [
-    20140826,
-    1156
-   ],
-   "deps": [
-    "cl-lib",
-    "helm"
-   ],
-   "commit": "6aaed984f698cbdf9f9aceb0221404563e28764d",
-   "sha256": "1sff8kagyhmwcxf9062il1077d4slvr2kq76abj496610gpb75i0"
-  },
-  "stable": {
-   "version": [
-    0,
-    0,
-    1
-   ],
-   "deps": [
-    "cl-lib",
-    "helm"
-   ],
-   "commit": "6aaed984f698cbdf9f9aceb0221404563e28764d",
-   "sha256": "1sff8kagyhmwcxf9062il1077d4slvr2kq76abj496610gpb75i0"
-  }
- },
- {
   "ename": "helm-safari",
   "commit": "553e27a3523ade9dc4951086d9340e8240d5d943",
   "sha256": "0lvwghcl5w67g0lc97r7hfvca7ss0mysy2mxj9axxbpyiq6fmh0y",
@@ -60356,15 +60588,15 @@
   "repo": "emacs-helm/helm-searcher",
   "unstable": {
    "version": [
-    20250814,
-    923
+    20251231,
+    1623
    ],
    "deps": [
     "helm",
     "searcher"
    ],
-   "commit": "8d1b99900d1c01892678c45e48e1959d454532ee",
-   "sha256": "0zl3vpma8id58nk0945z7j1h56vwswxy6zi9cibyrz8j3ghcbb9a"
+   "commit": "f81955c7197cdaaf96e4b643f1946d54912d6b8a",
+   "sha256": "1mmficnh03vqjdgjm00svng4j91w3br0c1r5xn0b4i2wz36n2rry"
   },
   "stable": {
    "version": [
@@ -60661,15 +60893,15 @@
   "repo": "emacs-helm/helm-system-packages",
   "unstable": {
    "version": [
-    20251217,
-    713
+    20260105,
+    509
    ],
    "deps": [
     "helm",
     "seq"
    ],
-   "commit": "1264926a5ae8974e1809fc02e8d059d6398d625f",
-   "sha256": "1hgjpmc84axim9k77amj0nqh003h8frpikx1blbg7kz72d7wmvy2"
+   "commit": "35aa6c08bc632d76c066aef0b079f6733219c634",
+   "sha256": "1cjz4590s42n5rfmzdwp40lqfqzp6rknvpw872r2d2vbgsyivfn3"
   },
   "stable": {
    "version": [
@@ -62141,11 +62373,11 @@
   "repo": "ideasman42/emacs-hl-block-mode",
   "unstable": {
    "version": [
-    20251126,
-    1136
+    20251230,
+    731
    ],
-   "commit": "8dbab7b71ee959e4e57f609a2483481603a97f71",
-   "sha256": "11mfhz2829qnm62v8kqvk2zn6yxdx3mpkc7vjz002nryqi14s3vd"
+   "commit": "8f66a89196dec2f9b5f9a58b769e64c190493064",
+   "sha256": "1nh5pv03hnqqsn2i7rgp8lzs05kp60ffl2x1i3h0pbvwb5vkwy30"
   }
  },
  {
@@ -62174,11 +62406,11 @@
   "repo": "ideasman42/emacs-hl-indent-scope",
   "unstable": {
    "version": [
-    20251126,
-    1145
+    20251231,
+    706
    ],
-   "commit": "b099b553d6a1a797a57a83203e41819718e24ca2",
-   "sha256": "1798pc52y9v3nf9d6frz9w4fv9h6mwy5kjzb07albbpp8gs8j9hk"
+   "commit": "38c8775dc575ecf6a35fa88946be3dfb5b489018",
+   "sha256": "0qmab8g6mwacvgyjjwdblzx9j5wgyzkwz7b54vj9r1v2as79idhb"
   }
  },
  {
@@ -62207,11 +62439,11 @@
   "repo": "ideasman42/emacs-hl-prog-extra",
   "unstable": {
    "version": [
-    20251126,
-    1139
+    20251224,
+    230
    ],
-   "commit": "c9cd44cc8346f9a044165658a13931f0304ae293",
-   "sha256": "01bvb07x3nslfcjvci7vfi4np3srn0chdwy02qcpvs07fwdmbwfn"
+   "commit": "1cfce465f59700820932ec71c019d821c6cea126",
+   "sha256": "0fl94alqmj1530l632wwv2s84jgvppbxsk3w5r6faddf03c8zpcm"
   }
  },
  {
@@ -62244,26 +62476,26 @@
   "repo": "tarsius/hl-todo",
   "unstable": {
    "version": [
-    20251101,
-    2019
+    20260101,
+    1834
    ],
    "deps": [
     "compat"
    ],
-   "commit": "94893087e0aca6642a3ebf11f46b3d5f47c1eb22",
-   "sha256": "1ym4al62ljnpr6zk459qwl1as8hf8grvigh28h635bc5mv6qnaj3"
+   "commit": "9540fc414014822dde00f0188b74e17ac99e916d",
+   "sha256": "01rfyp1iqiyp8k7fg16ji8p2dp74ffdhl4bdikfxb2sz4jbz8x80"
   },
   "stable": {
    "version": [
     3,
     9,
-    2
+    3
    ],
    "deps": [
     "compat"
    ],
-   "commit": "94893087e0aca6642a3ebf11f46b3d5f47c1eb22",
-   "sha256": "1ym4al62ljnpr6zk459qwl1as8hf8grvigh28h635bc5mv6qnaj3"
+   "commit": "9540fc414014822dde00f0188b74e17ac99e916d",
+   "sha256": "01rfyp1iqiyp8k7fg16ji8p2dp74ffdhl4bdikfxb2sz4jbz8x80"
   }
  },
  {
@@ -62661,26 +62893,26 @@
   "repo": "kaorahi/howm",
   "unstable": {
    "version": [
-    20251005,
-    1120
+    20260101,
+    1342
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "cc0ceaeed24f122fba89200888d367659cc8662e",
-   "sha256": "1h8s8avnyxm1vvlkmn6ka6kzw121i7pq54jzckssf9iwn2zgykk1"
+   "commit": "7e49045c23749b61d8c93df68ad9502292fd61bc",
+   "sha256": "15l27c1xj0krkinjp1xgk7gl227g67xylfhwxxs5ymijgswpzvjn"
   },
   "stable": {
    "version": [
     1,
     5,
-    5
+    6
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "15ef80bc6ed46447027b59769be16108a0fc4a9e",
-   "sha256": "1dmjcbwcghyppqrg383pkric5mjhrz95f7wlm8lxq8k6zkynm1hp"
+   "commit": "7e49045c23749b61d8c93df68ad9502292fd61bc",
+   "sha256": "15l27c1xj0krkinjp1xgk7gl227g67xylfhwxxs5ymijgswpzvjn"
   }
  },
  {
@@ -62860,11 +63092,11 @@
   "repo": "emacs-vs/htmltagwrap",
   "unstable": {
    "version": [
-    20250101,
-    907
+    20260101,
+    549
    ],
-   "commit": "66dd54079110b4b6d91bb81acf8a31649e3cb29f",
-   "sha256": "16ir33a328qwrmcy2ip9zidad5c5b46rwf3gmnf2rmsqdnxand3g"
+   "commit": "d5df47cf0a303ddad6b063c69db629d373ce2fd3",
+   "sha256": "1ymy51h270d9mng58b18xysvx4v5rkbqwna3pbd6wr9d6wq5hmsg"
   },
   "stable": {
    "version": [
@@ -63288,11 +63520,11 @@
   "url": "https://git.savannah.gnu.org/git/hyperbole.git",
   "unstable": {
    "version": [
-    20251214,
-    323
+    20260111,
+    1646
    ],
-   "commit": "b7cc26a2af8c33b2ce55a8304a811cbfdde341ea",
-   "sha256": "1r91brd937f297224l9h85wv7gqaiyvzcwbhkqiing5cc556nad0"
+   "commit": "b14310df58cc8bd33860e9bf548ee1497dc3fd20",
+   "sha256": "1xxzcr6v4qpmrz9380fil5bik0q45ww8iifgh2bl6ry7fnnpm3sc"
   },
   "stable": {
    "version": [
@@ -63461,19 +63693,20 @@
   "repo": "precompute/hyperstitional-themes",
   "unstable": {
    "version": [
-    20251214,
-    1417
+    20260112,
+    2116
    ],
-   "commit": "86b942006b6c201e0ee4608797d9acc0083f499a",
-   "sha256": "1mfqgywpzjm3hs5lmjzyvvc18navv93z6x7vaynb0micxcdvw8ly"
+   "commit": "cc8c33a23116ed112ef9ca3a973597f03dc41459",
+   "sha256": "00mli6mdgrs49ckgq4qwmzgzlsax36harhhhwmb7ab87g5a9jadc"
   },
   "stable": {
    "version": [
     3,
+    2,
     2
    ],
-   "commit": "86b942006b6c201e0ee4608797d9acc0083f499a",
-   "sha256": "1mfqgywpzjm3hs5lmjzyvvc18navv93z6x7vaynb0micxcdvw8ly"
+   "commit": "cc8c33a23116ed112ef9ca3a973597f03dc41459",
+   "sha256": "00mli6mdgrs49ckgq4qwmzgzlsax36harhhhwmb7ab87g5a9jadc"
   }
  },
  {
@@ -63541,11 +63774,11 @@
   "repo": "Stebalien/i3bar.el",
   "unstable": {
    "version": [
-    20250913,
-    1829
+    20260102,
+    1630
    ],
-   "commit": "75a81e8100884f679378db52a660b3963f2dbede",
-   "sha256": "12carbz9znnijzyc84hvvljhv8zybwzgk42nd57g5iqc637vmhhf"
+   "commit": "111448dc2f84566c656c471eb05a8cb6cd946de1",
+   "sha256": "0ddcfgpr1w7l71aq5k8sp3in1wz7vvnbxzkc354mldqvnw5ff0s4"
   }
  },
  {
@@ -63996,11 +64229,11 @@
   "repo": "ideasman42/emacs-idle-highlight-mode",
   "unstable": {
    "version": [
-    20251214,
-    614
+    20260108,
+    1311
    ],
-   "commit": "425f1b247ca5176d47ff1d8b07a6a9293a066f82",
-   "sha256": "1yxfih5r85xrr5j8lzcssj2pfqnnbvrc87jx6lw3wxpcy8sxcks6"
+   "commit": "83aa002c837fc6c6e4ce7069c169875beeb1d41e",
+   "sha256": "194jghi6wmyagcdslqhpmnjz3aj2s1binqzr74l3nkzvwhzbvvhx"
   }
  },
  {
@@ -64700,26 +64933,26 @@
   "repo": "tarsius/imake",
   "unstable": {
    "version": [
-    20251101,
-    2020
+    20260101,
+    1835
    ],
    "deps": [
     "compat"
    ],
-   "commit": "6a0bfeddb1565b4215c9228635c5897b487adb26",
-   "sha256": "0c12x1ycjk2bcigyw3fxa87hjkc5axa3zyxa02l5w0xfak0w76zb"
+   "commit": "c3d7fcc0d40676f47450891dc034511185566a0e",
+   "sha256": "1ch8ckb9gd89wr8v6150k0rnia54cbna9hxiivx3jnnr4lwn63lj"
   },
   "stable": {
    "version": [
     1,
     2,
-    5
+    6
    ],
    "deps": [
     "compat"
    ],
-   "commit": "6a0bfeddb1565b4215c9228635c5897b487adb26",
-   "sha256": "0c12x1ycjk2bcigyw3fxa87hjkc5axa3zyxa02l5w0xfak0w76zb"
+   "commit": "c3d7fcc0d40676f47450891dc034511185566a0e",
+   "sha256": "1ch8ckb9gd89wr8v6150k0rnia54cbna9hxiivx3jnnr4lwn63lj"
   }
  },
  {
@@ -64730,11 +64963,11 @@
   "repo": "QiangF/imbot",
   "unstable": {
    "version": [
-    20250108,
-    1419
+    20260108,
+    212
    ],
-   "commit": "3d4d5b0e73981a5249bcedfabd6bb188a1283075",
-   "sha256": "0smy2pnl8czqgr70zhrz3l6p5vi877y9hlws3izww2gnnvv4xrvb"
+   "commit": "a9f21234f37589f40bfe582d8e0bed82c879a50c",
+   "sha256": "1cqnmdc8yf1mq5f5gfw365cb3nw23m896abq4sg6prvm5xv682z8"
   }
  },
  {
@@ -64988,14 +65221,14 @@
   "repo": "jcs-elpa/impatient-showdown",
   "unstable": {
    "version": [
-    20250101,
-    1009
+    20260101,
+    600
    ],
    "deps": [
     "impatient-mode"
    ],
-   "commit": "5fa168ec9b74ba1579918eed01fde162d11e209a",
-   "sha256": "1z59h30mdv6ximzw29k18n758y1w15w62i9kdy8p66b002s4cx6w"
+   "commit": "19c4f7b2561bce8b0e186655660a22ed369707eb",
+   "sha256": "1ka7w1k4fz2yh0bk5vmfc8wxx85hbikm2i3aqc75ds9bgcv7px2y"
   },
   "stable": {
    "version": [
@@ -65155,11 +65388,11 @@
   "repo": "jcs-elpa/indent-control",
   "unstable": {
    "version": [
-    20250602,
-    1131
+    20260101,
+    600
    ],
-   "commit": "9bcc2d1a35772cd55d2b11536cb21ffcd7eea365",
-   "sha256": "0l94nx6kd804p6vyg8xbrhzk5lz9qdz9p7dqn37ayckpifwpnr7v"
+   "commit": "222fa01879c08adc5cc84cef6aa4fcff90c7c938",
+   "sha256": "0w5iq7mnyisa63f3rlcpaqbxy3h428ywxz7rkw5z0v2gbr480l11"
   },
   "stable": {
    "version": [
@@ -65473,11 +65706,11 @@
   "repo": "nonsequitur/inf-ruby",
   "unstable": {
    "version": [
-    20250212,
-    29
+    20251224,
+    216
    ],
-   "commit": "b8076aad10dfb0ba1e3a8b0d39c2b370dbe96ab0",
-   "sha256": "1ah4hfy17x4ikrg3q555q7qfmz021wmfm5v11l1id3aqfqira599"
+   "commit": "274398a24288a7db430a656b580ffbf889ca02aa",
+   "sha256": "0f7x6xyx3wmd81b1p1vl33vry4qkfpq7fiyzlj21ar4l9nm5h1va"
   },
   "stable": {
    "version": [
@@ -65618,6 +65851,30 @@
    ],
    "commit": "13dd9b6a7288e6bb692b210bcb9cd72016658dae",
    "sha256": "1h2q19574sc1lrxm9k78668pwcg3z17bnbgykmah01zlmbs264sx"
+  }
+ },
+ {
+  "ename": "info-nav",
+  "commit": "068d854cffaaf5208020597a55d3aa068fe3cf34",
+  "sha256": "136bgvaz6d8c2s4vz3d5j1d9g15ag76jdmqf89shg0ah6gi7lq41",
+  "fetcher": "codeberg",
+  "repo": "ggxx/info-nav",
+  "unstable": {
+   "version": [
+    20260113,
+    531
+   ],
+   "commit": "eede340e73cecf435bda4ad27d386a98b8c02f36",
+   "sha256": "1y11sh04msqq4k76k2d92bmwfzy6f59rdbwd6c2n4b62b8bq9329"
+  },
+  "stable": {
+   "version": [
+    1,
+    0,
+    3
+   ],
+   "commit": "eede340e73cecf435bda4ad27d386a98b8c02f36",
+   "sha256": "1y11sh04msqq4k76k2d92bmwfzy6f59rdbwd6c2n4b62b8bq9329"
   }
  },
  {
@@ -65767,11 +66024,11 @@
   "repo": "jamescherti/inhibit-mouse.el",
   "unstable": {
    "version": [
-    20251103,
-    1432
+    20260114,
+    1535
    ],
-   "commit": "442202e59d61b0f0c662f9dadfa8fd9ecc31991b",
-   "sha256": "17jkch53p0lk42mdg7119vzv68zdqpg7n1dr23sjxd6v8bg8rym7"
+   "commit": "448a86b679dc4d45ec74f94d1471b51850bfd6b8",
+   "sha256": "0vpcvw317sk5w6v5nwjnbb80lfs27nya186rfhpn2mgzrbg5h0md"
   },
   "stable": {
    "version": [
@@ -65830,14 +66087,14 @@
   "repo": "chaosemer/init-dir",
   "unstable": {
    "version": [
-    20240924,
-    150
+    20260104,
+    1727
    ],
    "deps": [
     "benchmark-init"
    ],
-   "commit": "406953deb5f29112ca02850885954f82abb1d334",
-   "sha256": "1gppwqb45acki4qhfmpsw8qp9yk8bi8sqcljij2pcc5cbqi1g7ll"
+   "commit": "cc5a4676cbc698144c7a9bca465fccb5bdd4ace4",
+   "sha256": "0y94qwjj1lxm6acmiwhbfra5r4r5qyh8bairh7r9qaqrxlnpnx58"
   },
   "stable": {
    "version": [
@@ -65996,11 +66253,11 @@
   "url": "https://repo.or.cz/inline-docs.git",
   "unstable": {
    "version": [
-    20230708,
-    222
+    20260115,
+    1353
    ],
-   "commit": "08eb99f65406993425ccf9937aad013436a7c6ef",
-   "sha256": "1iisz4vsbza658fdj455yambd5njjvid8m8jjmszpf8yi2rgyfd6"
+   "commit": "977e4b6bb2e636335c9e72cc9ef5c922296ec3ae",
+   "sha256": "0innnhcl4hpr9gvysv1lfwkbrvbvda9nmnda35n9kxjc8252sndx"
   }
  },
  {
@@ -66700,14 +66957,14 @@
   "repo": "jcs-elpa/isearch-project",
   "unstable": {
    "version": [
-    20250101,
-    1008
+    20260101,
+    600
    ],
    "deps": [
     "f"
    ],
-   "commit": "abd8ee560d1843f9ea01e1a823ddeafe9fbb0b21",
-   "sha256": "07jwn8f8dpcfbh88s7i942ppk6dwkwd3s2zp4qmyqvzlm7zm2m14"
+   "commit": "e67c997c9b36690a8b1b7712ff1ba9664020d8b2",
+   "sha256": "1bmbmv2a1c83cq07nbzypy4af73rdph78a5df7x6bp6c53slzbgd"
   },
   "stable": {
    "version": [
@@ -67660,15 +67917,15 @@
   "repo": "Andersbakken/rtags",
   "unstable": {
    "version": [
-    20250801,
-    1647
+    20251228,
+    2249
    ],
    "deps": [
     "ivy",
     "rtags"
    ],
-   "commit": "dd6b20f7e57a30f32a8ccbb6c22038383dba746b",
-   "sha256": "15rkzvh4i4s2sm1zrclqqs4dnmiik9rcf59jq382ah0afh96mh3b"
+   "commit": "829a6298d6bfba8ed541570fcbe3daf5ce3135d0",
+   "sha256": "1qzd08sc3kg0cmfssdbdn595iwwalxhb5b43dsamzgfc3xhd7qap"
   },
   "stable": {
    "version": [
@@ -67875,14 +68132,25 @@
   "repo": "sarg/wifi-manager",
   "unstable": {
    "version": [
-    20251221,
-    1835
+    20260113,
+    1101
    ],
    "deps": [
     "promise"
    ],
-   "commit": "ec2b209e408eef08d19fa135253aa22a0317815a",
-   "sha256": "0imxqvjw2if3chzj4jisz8035s61l4ldp36vl33wa15jzb0mxd33"
+   "commit": "e947dff1f5593b3b01b380cc195108649392b89a",
+   "sha256": "1kfcxbjx1xgqbxx3s921nbkk1fqhndr91cckps5wk12d3mh98lqw"
+  },
+  "stable": {
+   "version": [
+    0,
+    2
+   ],
+   "deps": [
+    "promise"
+   ],
+   "commit": "e947dff1f5593b3b01b380cc195108649392b89a",
+   "sha256": "1kfcxbjx1xgqbxx3s921nbkk1fqhndr91cckps5wk12d3mh98lqw"
   }
  },
  {
@@ -67946,15 +68214,15 @@
   "repo": "emacs-jabber/emacs-jabber",
   "unstable": {
    "version": [
-    20250310,
-    305
+    20260119,
+    1421
    ],
    "deps": [
     "fsm",
     "srv"
    ],
-   "commit": "30c023b6b54601594d347956cc2918e7841e5ed4",
-   "sha256": "0ain52p79sxll0bnsb4llfp1h4pqcqx3l6im4ibia06lg2aiqhpv"
+   "commit": "745e5f1354e99bfcee1aa097fb9d198cd701b463",
+   "sha256": "09rz0b8jlw9xpyxx7qfhh5hg5glkxfl1yzmzq2j2bk00iprmx0k0"
   },
   "stable": {
    "version": [
@@ -68045,6 +68313,21 @@
    ],
    "commit": "4e7a20db492719062f40b225ed730ed50be5db56",
    "sha256": "0krbd1qa2408a97pqhl7fv0x8x1n2l3qq33zzj4w4vv0c55jk43n"
+  }
+ },
+ {
+  "ename": "jade-schema-mode",
+  "commit": "366c410c1a28ca85243e9d4e5c6ee604ee299a40",
+  "sha256": "05x35ahb7xx0z1pybykjvd15r5zw1piirdg8bgi6ly67nkj5qayx",
+  "fetcher": "github",
+  "repo": "danjacka/jade-schema-mode",
+  "unstable": {
+   "version": [
+    20251223,
+    255
+   ],
+   "commit": "9cc4f9b780ff40afd8dde21ab7f53a16401c3d09",
+   "sha256": "1i9f61x8pdf26p640gqjh7vb9a2yiqv915immbmbgrp6rmpdh48h"
   }
  },
  {
@@ -68272,6 +68555,30 @@
    ],
    "commit": "864c1130e204b2072e1d19cd027b6fce8ebe6629",
    "sha256": "070r4mg4v937n4h2bmzdbn3vsmmq7ijz69nankqs761jxv5gcwlg"
+  }
+ },
+ {
+  "ename": "javelin",
+  "commit": "a5e9f1210e0d2ed83861af0c2e22ee6a292b420e",
+  "sha256": "15dikbh5zjyzzam9827awnjbdgm7yxz88xl3rjb8xnbcz8qjkx74",
+  "fetcher": "github",
+  "repo": "DamianB-BitFlipper/javelin.el",
+  "unstable": {
+   "version": [
+    20260105,
+    1728
+   ],
+   "commit": "e58733d6dfb3282d5b6ad4d295e8c71a8e5abc71",
+   "sha256": "198kxmcchmfblxphmwcgki15ymzz0kgmllmkdbgvs48bycpzp8kr"
+  },
+  "stable": {
+   "version": [
+    0,
+    2,
+    3
+   ],
+   "commit": "e58733d6dfb3282d5b6ad4d295e8c71a8e5abc71",
+   "sha256": "198kxmcchmfblxphmwcgki15ymzz0kgmllmkdbgvs48bycpzp8kr"
   }
  },
  {
@@ -68771,25 +69078,25 @@
   "repo": "minad/jinx",
   "unstable": {
    "version": [
-    20251129,
-    800
+    20260117,
+    1650
    ],
    "deps": [
     "compat"
    ],
-   "commit": "a678be8cf0888947789a10a493c8b1c3a7066f52",
-   "sha256": "1ql2gv9jrva5l16d9xm2fz77ganpri7p73br1k0sj9kvinkyqxyf"
+   "commit": "b412673dec759131fe0abb346998b55225fbe771",
+   "sha256": "1rkgp1j4pc9i2305fjs20nrvn11dg22rj5vmwf4520baj7asd8m3"
   },
   "stable": {
    "version": [
     2,
-    5
+    6
    ],
    "deps": [
     "compat"
    ],
-   "commit": "a678be8cf0888947789a10a493c8b1c3a7066f52",
-   "sha256": "1ql2gv9jrva5l16d9xm2fz77ganpri7p73br1k0sj9kvinkyqxyf"
+   "commit": "b412673dec759131fe0abb346998b55225fbe771",
+   "sha256": "1rkgp1j4pc9i2305fjs20nrvn11dg22rj5vmwf4520baj7asd8m3"
   }
  },
  {
@@ -69010,11 +69317,11 @@
   "repo": "SebastianMeisel/journalctl-mode",
   "unstable": {
    "version": [
-    20250922,
-    1323
+    20260110,
+    1949
    ],
-   "commit": "c5a6127ad831fa95a8e3b3fa207a011435ae887b",
-   "sha256": "13j0a8n10w41qz2vddjb4i6v0vn3k4f9b2pm1hasjmdw3a7lk9m3"
+   "commit": "0b9294f8f2b53375aa4f4fb3eb7f73be7cd15add",
+   "sha256": "1pjv868kdg1bzm1x9lf1izn3klj2vzlsh30sci30bz54q3qdb0gr"
   },
   "stable": {
    "version": [
@@ -70139,25 +70446,25 @@
   "repo": "shg/julia-vterm.el",
   "unstable": {
    "version": [
-    20250621,
-    854
+    20251229,
+    335
    ],
    "deps": [
     "vterm"
    ],
-   "commit": "742255606a7a7712566dd15759cf316d584a4dc7",
-   "sha256": "1a1x2f0xlzpnrya68lzfj9m9lwq8wl1nq7vvvlgrbchhlrb3bvji"
+   "commit": "1cf2958448df40ca3508964d0d1a78cf8be2453f",
+   "sha256": "0wiw25wc8fb35wj30pq33mvm5hvzry9fdz9f5csscwrp0hn75245"
   },
   "stable": {
    "version": [
     0,
-    27
+    29
    ],
    "deps": [
     "vterm"
    ],
-   "commit": "310fa8fc32e86d4e588985b0dd46e2162e42560f",
-   "sha256": "0anr5jycj9553wq3s9w3kkbj8ww33b2mv2b842x6c1mf57sz1ax0"
+   "commit": "1cf2958448df40ca3508964d0d1a78cf8be2453f",
+   "sha256": "0wiw25wc8fb35wj30pq33mvm5hvzry9fdz9f5csscwrp0hn75245"
   }
  },
  {
@@ -70752,11 +71059,11 @@
   "repo": "Fabiokleis/kanagawa-emacs",
   "unstable": {
    "version": [
-    20251222,
-    1218
+    20260102,
+    1542
    ],
-   "commit": "1eddb5fe124dbec2a4b65e3e314fa49e41f36122",
-   "sha256": "1skpw13k6561p3n0cac9jflb7m0z250n23npaq9swjv5kja1vpj9"
+   "commit": "95516102a673b924c0446ae548c9053773f878ea",
+   "sha256": "08fhqpskidi9i79y8i4j9z6r4gcwknx4z0yamr69qldb1xfybk5q"
   }
  },
  {
@@ -70831,28 +71138,28 @@
   "repo": "ogdenwebb/emacs-kaolin-themes",
   "unstable": {
    "version": [
-    20251007,
-    1241
+    20260114,
+    2021
    ],
    "deps": [
     "autothemer",
     "cl-lib"
    ],
-   "commit": "a0570401fa08fb6f3843e574d28823a8e079e943",
-   "sha256": "0qf5slf6ibi38v460wzbfm8sklpkzzq7hcb46dw13hiq2qmbkc1l"
+   "commit": "fc0337582f36167b74cbdc86a48471092c8f3262",
+   "sha256": "1lbqvs2jqvs6x8gj7bali24mw2fl6gk184zln6avy6wmam7n8dqi"
   },
   "stable": {
    "version": [
     1,
     7,
-    3
+    4
    ],
    "deps": [
     "autothemer",
     "cl-lib"
    ],
-   "commit": "4b64a70625c1640d369392e9a79cdfd534b8e4be",
-   "sha256": "00cav4pj69m1kv46y8lcgrb71jfjw6s5sqnnllp0fq5hqdxnmcw1"
+   "commit": "fc0337582f36167b74cbdc86a48471092c8f3262",
+   "sha256": "1lbqvs2jqvs6x8gj7bali24mw2fl6gk184zln6avy6wmam7n8dqi"
   }
  },
  {
@@ -71271,26 +71578,26 @@
   "repo": "tarsius/keycast",
   "unstable": {
    "version": [
-    20251101,
-    2021
+    20260101,
+    1835
    ],
    "deps": [
     "compat"
    ],
-   "commit": "090ade99c1c03830d45cc763e5733a1ca001c4e5",
-   "sha256": "1dnr2kfldbghq198bm5h784xmak6kybpfyq90bwwysd5dzli2i98"
+   "commit": "b831e380c4deb1d51ce5db0a965b96427aec52e4",
+   "sha256": "1bn30n0b0wsvzhpa4qsghh5acb82r07sw82xjwjqq26kckfisvkx"
   },
   "stable": {
    "version": [
     1,
     4,
-    6
+    7
    ],
    "deps": [
     "compat"
    ],
-   "commit": "090ade99c1c03830d45cc763e5733a1ca001c4e5",
-   "sha256": "1dnr2kfldbghq198bm5h784xmak6kybpfyq90bwwysd5dzli2i98"
+   "commit": "b831e380c4deb1d51ce5db0a965b96427aec52e4",
+   "sha256": "1bn30n0b0wsvzhpa4qsghh5acb82r07sw82xjwjqq26kckfisvkx"
   }
  },
  {
@@ -71374,26 +71681,26 @@
   "repo": "tarsius/keymap-utils",
   "unstable": {
    "version": [
-    20251212,
-    1059
+    20260101,
+    1836
    ],
    "deps": [
     "compat"
    ],
-   "commit": "20e2ebcdf0cb04666c6cf5060cc60078794db704",
-   "sha256": "0d4xqsscyd09djqk2cqyq5669cfy2x09nsql4zdy73y9zxkdbxxz"
+   "commit": "a3c94ce2c191eb990f9789456b82bf4870af04a0",
+   "sha256": "0ylbnlpgiwjb8g02ncr2r5d70hdkml6sl35gmv7b5yvpzki3jlnw"
   },
   "stable": {
    "version": [
     4,
     1,
-    1
+    2
    ],
    "deps": [
     "compat"
    ],
-   "commit": "b230f47067bd09d0c6ad783efcc763c2003f1617",
-   "sha256": "0hc99j6fcbfypaqp9ymv61d0swpx47m6qx4q77xlkrx58n2b7xnf"
+   "commit": "a3c94ce2c191eb990f9789456b82bf4870af04a0",
+   "sha256": "0ylbnlpgiwjb8g02ncr2r5d70hdkml6sl35gmv7b5yvpzki3jlnw"
   }
  },
  {
@@ -71509,11 +71816,11 @@
   "repo": "emacs-grammarly/keytar",
   "unstable": {
    "version": [
-    20250101,
-    849
+    20251231,
+    1727
    ],
-   "commit": "5b3501dc95755d85fcf21b00ae0d347446efe73b",
-   "sha256": "0qbabikk1ingkqgbwb4wk9m7zxhn2g1kgs0i0b6mccmn4134sizk"
+   "commit": "f0485df065bcdc8f446be3e00aa77a43629ec84e",
+   "sha256": "07a9zmv4zczx4vp0xwrvwdcfq1xq046cjmj2275nwxwwn8hyw4ab"
   },
   "stable": {
    "version": [
@@ -71620,15 +71927,15 @@
   "repo": "khoj-ai/khoj",
   "unstable": {
    "version": [
-    20251208,
-    432
+    20260102,
+    359
    ],
    "deps": [
     "dash",
     "transient"
    ],
-   "commit": "f4c519a9d00fcedfc8ab06e4f48307acc7555d39",
-   "sha256": "1hc8mlpm91n10y2i4c2p9hjmn09d3h5zmi45zijqm39b9j7h66ij"
+   "commit": "d55a00288bd6257d1b84f2a491ca24fb00530d43",
+   "sha256": "0rh0z021cw5199szvzdylpz6vi17j70l96mkrsmf3yyddgbm7n87"
   },
   "stable": {
    "version": [
@@ -71771,11 +72078,11 @@
   "repo": "jamescherti/kirigami.el",
   "unstable": {
    "version": [
-    20251202,
-    1126
+    20260114,
+    1604
    ],
-   "commit": "b23cae12111dd193b968d6e319dff8131e7796b0",
-   "sha256": "1hpvciaknziafbsrkdjyj0rp5dgvpcjvzs104h65f7x2z9gxynp9"
+   "commit": "40ea6e38f3845a4dd081111df0404dd5aca956de",
+   "sha256": "08rg7ppdnhjvj4qcr3w75xk4hisl5991x1q5bn0pnf4cjqa5z2in"
   },
   "stable": {
    "version": [
@@ -71875,14 +72182,14 @@
   "repo": "mew/kixtart-mode",
   "unstable": {
    "version": [
-    20251222,
-    1130
+    20260115,
+    1810
    ],
    "deps": [
     "eldoc"
    ],
-   "commit": "a889a37dbe96529b92372170092cc9bbf045fe83",
-   "sha256": "1aqs4x1dkkmx230p75jy9k99v40kq02jw2adgy9df65cln85jlaq"
+   "commit": "a09f91c6dda7a5eda5f5f0cd382bdcef1519720f",
+   "sha256": "1kn74c1h4c10d7l3c55qnhjxf80cfzqmq9ryx0gbpmg7gvq9ysqf"
   },
   "stable": {
    "version": [
@@ -72013,6 +72320,21 @@
    ],
    "commit": "f5e932036c16e2b61a63020e006fc601e38d181e",
    "sha256": "1gck7lvqxcr9ikrzlpvcf4408cq6i4s8ijgb0kdsbkfzv0w86934"
+  }
+ },
+ {
+  "ename": "koishi-theme",
+  "commit": "bf1934d14da27aa83c7c8288f2ffe4f7137c0870",
+  "sha256": "1qf16nmxb0g28l1iplfvm39xqfispvfxlhabx5wsq0rfx7kjxxdl",
+  "fetcher": "github",
+  "repo": "gynamics/koishi-theme.el",
+  "unstable": {
+   "version": [
+    20251222,
+    1209
+   ],
+   "commit": "68e265b379c6d1790fa0dc4a9665cbc6c4df1ccf",
+   "sha256": "0v1nig63c3clcqk4cqqwf0ip100ariji7irz5mdb7ggdxrkympdp"
   }
  },
  {
@@ -72567,8 +72889,8 @@
   "repo": "isamert/lab.el",
   "unstable": {
    "version": [
-    20251203,
-    1024
+    20260113,
+    1707
    ],
    "deps": [
     "async-await",
@@ -72578,8 +72900,8 @@
     "request",
     "s"
    ],
-   "commit": "a8e0064950166b0e77ab2038306eff49c058cae0",
-   "sha256": "0pfpmzgafd8j0aksbx8kwfhhryh3rdcpls4az51hmh2x5k3xklg0"
+   "commit": "547d9dd773dd3747c4345cf0b9111ac0ed8c14b4",
+   "sha256": "0picg91kraym4b26ay9iy7bibmfvdpl6xlrgrm6x7jsnvsxi66xf"
   },
   "stable": {
    "version": [
@@ -73938,11 +74260,11 @@
   "repo": "fniessen/emacs-leuven-theme",
   "unstable": {
    "version": [
-    20250917,
-    1957
+    20251223,
+    1627
    ],
-   "commit": "802f5593b83c680bd5152d3b3f98ca184eb481a7",
-   "sha256": "1aj3k1qcmfklfl8ipgnpghql8g4zjn442nsing1cb83cbjpj2gxa"
+   "commit": "1711662e934debdfa00884ebe23b8fc00f78a191",
+   "sha256": "074x226l2hscc82naqy9ws49mp038f6adn4r4b5x300nbzd8kjnl"
   },
   "stable": {
    "version": [
@@ -74271,14 +74593,14 @@
   "repo": "jcs-elpa/license-templates",
   "unstable": {
    "version": [
-    20250101,
-    1008
+    20260101,
+    600
    ],
    "deps": [
     "request"
    ],
-   "commit": "93c4374301aa3fdb3dc67e3a7513af02e536d367",
-   "sha256": "0vyq3qnb4f0ig0dd6pa6s7lzxjvl2rmpk1k3j708fwhf8yvkwzdh"
+   "commit": "c53a4e9f748be1a9c4c032602b927f9ab5a16702",
+   "sha256": "0w53q233p63n43z7amn1ri7064c5b6h4l7yyim3chr3k8xlhngwm"
   },
   "stable": {
    "version": [
@@ -74291,6 +74613,53 @@
    ],
    "commit": "ef80eff8b7be117f9c48bdc6d9a62e56b0a93554",
    "sha256": "1z6qd4bcpwdpvi6w9yrkrnk2ypllhm6k4zjl8v1p8k0j93dbn3ny"
+  }
+ },
+ {
+  "ename": "lichess",
+  "commit": "c5d9b5b9a3b682887441abbfbf966a4a4f1e2ce6",
+  "sha256": "1zxgwyb4yz16sxx45y3j1ss65fbb0m0pd4iqrn02a7z2ivlfky2x",
+  "fetcher": "github",
+  "repo": "tmythicator/Lichess.el",
+  "unstable": {
+   "version": [
+    20260119,
+    946
+   ],
+   "commit": "c0bd061a8759f436fb57a7f8a7ed379749dee6f0",
+   "sha256": "0lrc4rz9r7mh25jvb4b7jibxlq7mz2kcn16fd89b9yy8byx7bx87"
+  },
+  "stable": {
+   "version": [
+    0,
+    5
+   ],
+   "commit": "c0bd061a8759f436fb57a7f8a7ed379749dee6f0",
+   "sha256": "0lrc4rz9r7mh25jvb4b7jibxlq7mz2kcn16fd89b9yy8byx7bx87"
+  }
+ },
+ {
+  "ename": "life-calendar",
+  "commit": "d0f6a99d67005c5056d3bb527d611a4e0a841015",
+  "sha256": "19xya6h6f8pqr7c2akx8jkilmyl7jn57q8k31xpdd7glf1xj5drm",
+  "fetcher": "github",
+  "repo": "vshender/emacs-life-calendar",
+  "unstable": {
+   "version": [
+    20260111,
+    2324
+   ],
+   "commit": "9f618f7958282f04245a4a59214c7bfd255f73d4",
+   "sha256": "0a3n88nj0dky3jrysfmzj10drd1qv5k92hmzxpfnnv7n0vik9zix"
+  },
+  "stable": {
+   "version": [
+    0,
+    2,
+    0
+   ],
+   "commit": "9f618f7958282f04245a4a59214c7bfd255f73d4",
+   "sha256": "0a3n88nj0dky3jrysfmzj10drd1qv5k92hmzxpfnnv7n0vik9zix"
   }
  },
  {
@@ -74349,16 +74718,16 @@
   "repo": "emacs-vs/line-reminder",
   "unstable": {
    "version": [
-    20250101,
-    909
+    20260101,
+    549
    ],
    "deps": [
     "fringe-helper",
     "ht",
     "ov"
    ],
-   "commit": "bab0c4cbe344ca888842278e982155a3916617d0",
-   "sha256": "1xqs488zyd94p4hrfjzbaxs3fm45b60rnl0jjc1wgbqaksmqqbg1"
+   "commit": "4e0170c9e3ed9b41e13bd3a9bcaa6937bae58e40",
+   "sha256": "0ffwzrb2kads23818zi1fb85vflp0slrfa2q5pyacisizyniz29r"
   },
   "stable": {
    "version": [
@@ -74774,11 +75143,11 @@
   "repo": "rubikitch/lispxmp",
   "unstable": {
    "version": [
-    20170926,
-    23
+    20260103,
+    2307
    ],
-   "commit": "7ad077b4ee91ce8a42f84eeddb9fc7ea4eac7814",
-   "sha256": "1156jynii783v9sjj3a7s20ysa26mqaq22zk5nbia949hwbibx16"
+   "commit": "af33c88276706633a0c37dddd672b27867a4b543",
+   "sha256": "0m9099val44l7id3qalj33blzdyh79bfnfdy28a8wdjgbzlqpa89"
   }
  },
  {
@@ -75289,11 +75658,11 @@
   "repo": "donkirkby/live-py-plugin",
   "unstable": {
    "version": [
-    20241214,
-    1526
+    20260101,
+    1741
    ],
-   "commit": "87bfff4da227554162e1148ded42ef848248bacb",
-   "sha256": "0ikkfwcb58zraabn32zhdjrszgyrlsy5j5nspajzx2lni7nlws67"
+   "commit": "dab6ce73500602a5230a0115a9531e5729ce88ef",
+   "sha256": "0xkrbb89z9g9j8m221cwhzxkja51l61lkg3cm6kfin7sspy0wip4"
   },
   "stable": {
    "version": [
@@ -75403,26 +75772,26 @@
   "repo": "tarsius/llama",
   "unstable": {
    "version": [
-    20251101,
-    2002
+    20260101,
+    1830
    ],
    "deps": [
     "compat"
    ],
-   "commit": "e4803de8ab85991b6a944430bb4f543ea338636d",
-   "sha256": "0qrbw3asmwbqjpqpws8swvcjcmip89hanjmfczwcqassi5qa0h85"
+   "commit": "2a89ba755b0459914a44b1ffa793e57f759a5b85",
+   "sha256": "1fcribk74shqz757b8i4cybpia7j3x886lxfa5vlzxc3wwlf3x37"
   },
   "stable": {
    "version": [
     1,
     0,
-    2
+    3
    ],
    "deps": [
     "compat"
    ],
-   "commit": "e4803de8ab85991b6a944430bb4f543ea338636d",
-   "sha256": "0qrbw3asmwbqjpqpws8swvcjcmip89hanjmfczwcqassi5qa0h85"
+   "commit": "2a89ba755b0459914a44b1ffa793e57f759a5b85",
+   "sha256": "1fcribk74shqz757b8i4cybpia7j3x886lxfa5vlzxc3wwlf3x37"
   }
  },
  {
@@ -75592,11 +75961,14 @@
   "repo": "rocky/emacs-loc-changes",
   "unstable": {
    "version": [
-    20230214,
-    1036
+    20260118,
+    2151
    ],
-   "commit": "622371e432f50626aaac82f8ee2841f71685b0fb",
-   "sha256": "1kfgmpnj26h8y063rqs39k4c98yy840mkj2pblm7vm0s1fhddj1f"
+   "deps": [
+    "compat"
+   ],
+   "commit": "a1d2852c4422f09f385069127b93a5c455954e9b",
+   "sha256": "1mzw6ylxmhac1jx92m1yzriih3k8ixn9f25lv1iwflk2scncpii6"
   },
   "stable": {
    "version": [
@@ -75803,16 +76175,16 @@
   "repo": "jcs-elpa/logms",
   "unstable": {
    "version": [
-    20250101,
-    1008
+    20260101,
+    600
    ],
    "deps": [
     "f",
     "ht",
     "s"
    ],
-   "commit": "48d50cdc90b68b86333bcdb3f2ebfa4568db198c",
-   "sha256": "1a672vh25iy6552clg1gv594jibnsi4krjbbiv56pqj3brp043h1"
+   "commit": "7f430ce289d4f46597e67bf46a24e51a8d7471aa",
+   "sha256": "1ry8iim944q5qp3dxdmzzxk7yb0d8qgqc3awzic64p1d1xh1hsyr"
   },
   "stable": {
    "version": [
@@ -76058,8 +76430,8 @@
   "repo": "okamsn/loopy",
   "unstable": {
    "version": [
-    20251217,
-    2120
+    20260110,
+    2353
    ],
    "deps": [
     "compat",
@@ -76067,8 +76439,8 @@
     "seq",
     "stream"
    ],
-   "commit": "fff3936e6156a88b9b4f2e113fb0eaff5062952b",
-   "sha256": "13lid0scjxynqlvvigmakwfm01pvnbja9lc9ygiij9mzd1rf755l"
+   "commit": "7996ae466a321c1244903f2c579056d86a9db7a4",
+   "sha256": "03xa954pls07d9bvfcfyyhqd7q5n3jqk136yqrld6vz63c26zsvk"
   },
   "stable": {
    "version": [
@@ -76094,15 +76466,15 @@
   "repo": "okamsn/loopy-dash",
   "unstable": {
    "version": [
-    20241228,
-    323
+    20251226,
+    2031
    ],
    "deps": [
     "dash",
     "loopy"
    ],
-   "commit": "56c8413dbcffef2b1a0896d53584296619cb1504",
-   "sha256": "0j2aj1z6bh27710c57bkd296zyb12zml4p6jr0dzxrmfssh1w9dd"
+   "commit": "d60c4f49a640541e415e5471ad26c2d8e6886888",
+   "sha256": "0pwayqwyarbg26piwzxag13xbx3dzdx779c4n7crzjk4gj3d80fw"
   },
   "stable": {
    "version": [
@@ -76332,8 +76704,8 @@
   "repo": "emacs-grammarly/lsp-grammarly",
   "unstable": {
    "version": [
-    20250226,
-    2340
+    20251231,
+    1727
    ],
    "deps": [
     "grammarly",
@@ -76342,8 +76714,8 @@
     "request",
     "s"
    ],
-   "commit": "7b788f97d21d689d152c31e7876a04813391d48a",
-   "sha256": "1jh2hmlvb7v8srwkvazdvhcr33hdgs0f1r0ji1p6r68czfsxxmmg"
+   "commit": "4c3aa9e757ff9082a4d7ff104dd5ff0f28f0b811",
+   "sha256": "16ysivfk6lv8ndifxrhxya3hk3w3rv8p3bwy3ssz7g7q388n1k3v"
   },
   "stable": {
    "version": [
@@ -76596,14 +76968,14 @@
   "repo": "emacs-languagetool/lsp-ltex",
   "unstable": {
    "version": [
-    20250228,
-    2215
+    20260101,
+    535
    ],
    "deps": [
     "lsp-mode"
    ],
-   "commit": "3cfb4ed92b71ab63daaab77962fd6dd23a2851e7",
-   "sha256": "04hy89zd04vrpp558chv1rypkc6aqyjjz9z15jnd515gjy9r26r5"
+   "commit": "6adc2b4d32a907943a6ce06e2267090241e7af6a",
+   "sha256": "1rll8wa07inh39nnk7j0g8v9z4h4wfnqcff3dqq1kcnp5r5p4vpk"
   },
   "stable": {
    "version": [
@@ -76672,8 +77044,8 @@
   "repo": "emacs-lsp/lsp-mode",
   "unstable": {
    "version": [
-    20251221,
-    1949
+    20260119,
+    1235
    ],
    "deps": [
     "dash",
@@ -76684,8 +77056,8 @@
     "markdown-mode",
     "spinner"
    ],
-   "commit": "c6e3660d32813b02ba3de60045de734e680bbcc7",
-   "sha256": "0m4a37pdz9p6g2fv5s2ya4pbfkkx5rbivw484wd8wk1mbqr1n21b"
+   "commit": "7642778d595f0158d17740e40a47646cfecbe96a",
+   "sha256": "002402x4ba6fn6cdg2nh39c71hdwgvg0v9kq96d6a7k7gnafp9yh"
   },
   "stable": {
    "version": [
@@ -76919,14 +77291,14 @@
   "repo": "shader-ls/lsp-shader",
   "unstable": {
    "version": [
-    20250722,
-    2024
+    20251231,
+    1653
    ],
    "deps": [
     "lsp-mode"
    ],
-   "commit": "13d696b8d8ab5ca319cc5e4ae4a1045eae2a2413",
-   "sha256": "0xrnnj5vllpc82y19a2wij78vqsqrnn5piwalnf2vv6pg9fsa28k"
+   "commit": "f8772e749d212adf95b901c3c94c9c96f9da3707",
+   "sha256": "09j7i051qp6qi28sn52wzxqcl5sg7433a1q7f1qm3lsgdyq8zw7c"
   },
   "stable": {
    "version": [
@@ -77068,16 +77440,16 @@
   "repo": "emacs-lsp/lsp-ui",
   "unstable": {
    "version": [
-    20250804,
-    2109
+    20260104,
+    1525
    ],
    "deps": [
     "dash",
     "lsp-mode",
     "markdown-mode"
    ],
-   "commit": "dcce464bc5d171daebf19009fdfbbc959bf2e7cf",
-   "sha256": "04hszygj88mp3qhvi25x0hl3jfqflw45f4cy95npi96zamlmj203"
+   "commit": "ff349658ed69086bd18c336c8a071ba15f7fd574",
+   "sha256": "1gkqd9lqb1f6xxl6zf00lc8a14khsqjkjm4mx3253fagd6m242li"
   },
   "stable": {
    "version": [
@@ -77488,6 +77860,36 @@
   }
  },
  {
+  "ename": "macher",
+  "commit": "9cb51dfdd270fe2b48c305eda45b26cf0ec681b3",
+  "sha256": "1qnc1c56n3wfjc67iy1889b8wfyhfs7kyyp21jhi2dwrk7yjw1hm",
+  "fetcher": "github",
+  "repo": "kmontag/macher",
+  "unstable": {
+   "version": [
+    20260107,
+    2043
+   ],
+   "deps": [
+    "gptel"
+   ],
+   "commit": "eb9c108e400fe8bbb3c8724f45ef6bd0d2a2ae33",
+   "sha256": "17zm8apiyyb29xzqbgnqfqf82nlcfmx43sh7m413s23g584cnm6y"
+  },
+  "stable": {
+   "version": [
+    0,
+    5,
+    2
+   ],
+   "deps": [
+    "gptel"
+   ],
+   "commit": "eb9c108e400fe8bbb3c8724f45ef6bd0d2a2ae33",
+   "sha256": "17zm8apiyyb29xzqbgnqfqf82nlcfmx43sh7m413s23g584cnm6y"
+  }
+ },
+ {
   "ename": "macports",
   "commit": "90d3395497abafe2016555dc000c21fa0c829ec7",
   "sha256": "0s2ipwgwnrwp2x8gzlkr2y488ij4pah3mymjy3z2nivqs5lg5chv",
@@ -77734,8 +78136,8 @@
   "repo": "magit/magit",
   "unstable": {
    "version": [
-    20251217,
-    1836
+    20260116,
+    1722
    ],
    "deps": [
     "compat",
@@ -77746,14 +78148,14 @@
     "transient",
     "with-editor"
    ],
-   "commit": "655bc502a3bdd7f07928524515a736e4b8101eaf",
-   "sha256": "0ds8wj44i52668kz2jc0h64p3gi2f2qq3b9r6bg1rfqi69q6q3xn"
+   "commit": "fe0c43b6f5b3b20fce9ed30d203bf1267831b14f",
+   "sha256": "0nps2q7lfqvvjsca7vxvmk7j7crwvm18j08dy48yy4bn72h5nqhg"
   },
   "stable": {
    "version": [
     4,
-    4,
-    2
+    5,
+    0
    ],
    "deps": [
     "compat",
@@ -77764,8 +78166,8 @@
     "transient",
     "with-editor"
    ],
-   "commit": "b828afbb4b45641998fb6483a08effb1efb214e1",
-   "sha256": "0lsxldyjv2h69657pgrblhkxq8fvc0xdwlwpfmd09pb8zawygh2g"
+   "commit": "c800f79c2061621fde847f6a53129eca0e8da728",
+   "sha256": "04yxjkv5h3arcj1s0nq9kyh3l1z4c9wml35vb67jvv1h7mslwz55"
   }
  },
  {
@@ -77806,14 +78208,14 @@
   "repo": "ideasman42/emacs-magit-commit-mark",
   "unstable": {
    "version": [
-    20251126,
-    1131
+    20260105,
+    203
    ],
    "deps": [
     "magit"
    ],
-   "commit": "26db85085067c13d59e02742cc0e1232e1c3284f",
-   "sha256": "0rx1ahvxg4qilzkmmsrpdbv7kz7cscgnqddaqc84cr45fy6gqw18"
+   "commit": "ba986f350466a68d9937d0487e9b8f75303bc465",
+   "sha256": "0rhinmvpcyv17klix5bivw0ksfz4kzlwa9q6n8wkwikxpsh1m6ks"
   }
  },
  {
@@ -78342,8 +78744,8 @@
   "repo": "magit/magit",
   "unstable": {
    "version": [
-    20251220,
-    917
+    20260101,
+    1850
    ],
    "deps": [
     "compat",
@@ -78351,14 +78753,14 @@
     "llama",
     "seq"
    ],
-   "commit": "649b4c972151c0ee495876c0d4c8c13787614886",
-   "sha256": "0dh8rzmjakmjayrlxz5z47ql7jnkrzq9v4h0qpn96mlfm4ffm9rr"
+   "commit": "c800f79c2061621fde847f6a53129eca0e8da728",
+   "sha256": "04yxjkv5h3arcj1s0nq9kyh3l1z4c9wml35vb67jvv1h7mslwz55"
   },
   "stable": {
    "version": [
     4,
-    4,
-    2
+    5,
+    0
    ],
    "deps": [
     "compat",
@@ -78366,8 +78768,8 @@
     "llama",
     "seq"
    ],
-   "commit": "b828afbb4b45641998fb6483a08effb1efb214e1",
-   "sha256": "0lsxldyjv2h69657pgrblhkxq8fvc0xdwlwpfmd09pb8zawygh2g"
+   "commit": "c800f79c2061621fde847f6a53129eca0e8da728",
+   "sha256": "04yxjkv5h3arcj1s0nq9kyh3l1z4c9wml35vb67jvv1h7mslwz55"
   }
  },
  {
@@ -78920,11 +79322,11 @@
   "repo": "emacsorphanage/manage-minor-mode",
   "unstable": {
    "version": [
-    20240925,
-    754
+    20260103,
+    1800
    ],
-   "commit": "6d9458e275699f7d360b703c8919d350524ee2fb",
-   "sha256": "02wa8n781684rjr57sn70ypib6hh53dfr5ihv3ljdhxkr3nzby50"
+   "commit": "78ca421b501aa1f6b72a4ecdb9a1fe102055beed",
+   "sha256": "1hnmk03nr25asxcwc47rxs2dgq0zva3al4smc3sxnkw058m3hpjn"
   },
   "stable": {
    "version": [
@@ -78943,14 +79345,14 @@
   "repo": "jcs-elpa/manage-minor-mode-table",
   "unstable": {
    "version": [
-    20250101,
-    1012
+    20260101,
+    601
    ],
    "deps": [
     "manage-minor-mode"
    ],
-   "commit": "5fee7081b0ed78774448fc923cced0384a83d48c",
-   "sha256": "0wq739br7nqc15yvwajwag9fvbgj1wzs5mqr868canx8nz2s6vn1"
+   "commit": "15730e65792ba5e774562c2311c1674cedd7786e",
+   "sha256": "0pmvpai9s24qp845gxx61gk6mlgw90qqspkrydcsxdgnkg3jr6kw"
   },
   "stable": {
    "version": [
@@ -79030,25 +79432,25 @@
   "repo": "countvajhula/mantra",
   "unstable": {
    "version": [
-    20250920,
-    129
+    20260118,
+    752
    ],
    "deps": [
     "pubsub"
    ],
-   "commit": "ad46c9d7fdcd50d771f129fd458f85bf6e28dd9d",
-   "sha256": "0fa2apkjbdza282n5qhyjp3by4yhcmg8cqskg7qpas241bd2sfn5"
+   "commit": "49f885b8947662bc837297f5c8a225d65dafcacd",
+   "sha256": "0hxjjb68swaggp1z2r0dmc441iz7gsvykm2njizrkp9aimj59h55"
   },
   "stable": {
    "version": [
     0,
-    2
+    3
    ],
    "deps": [
     "pubsub"
    ],
-   "commit": "ad46c9d7fdcd50d771f129fd458f85bf6e28dd9d",
-   "sha256": "0fa2apkjbdza282n5qhyjp3by4yhcmg8cqskg7qpas241bd2sfn5"
+   "commit": "49f885b8947662bc837297f5c8a225d65dafcacd",
+   "sha256": "0hxjjb68swaggp1z2r0dmc441iz7gsvykm2njizrkp9aimj59h55"
   }
  },
  {
@@ -79095,25 +79497,25 @@
   "repo": "minad/marginalia",
   "unstable": {
    "version": [
-    20251219,
-    1422
+    20260119,
+    2125
    ],
    "deps": [
     "compat"
    ],
-   "commit": "c3e7b1904423bda143249c0d02cbb7cc7ed8bee0",
-   "sha256": "0hgjzd14qwh2434c94al05vq49gxw1b7k52ww9033hcrvpspgr6h"
+   "commit": "e980b562e5b5f6db0851675eb6576d4c4b228540",
+   "sha256": "12yik11xdsh4sl6g3vwpagz16bbahnlrfbqrjpiiqjvd51hzak4l"
   },
   "stable": {
    "version": [
     2,
-    6
+    8
    ],
    "deps": [
     "compat"
    ],
-   "commit": "c3e7b1904423bda143249c0d02cbb7cc7ed8bee0",
-   "sha256": "0hgjzd14qwh2434c94al05vq49gxw1b7k52ww9033hcrvpspgr6h"
+   "commit": "79c1dc2c63f710f7aad900881da49930af43d729",
+   "sha256": "0fni7zs7az5ljpvd7ianbd26h9qwwsmmwwsc0b6l6ahy94sbza6p"
   }
  },
  {
@@ -79516,11 +79918,11 @@
   "repo": "jcs-elpa/marquee-header",
   "unstable": {
    "version": [
-    20250101,
-    1012
+    20260101,
+    601
    ],
-   "commit": "5f40543099ffe55b64dbcc57308dff7efe948bbe",
-   "sha256": "11a20jy5zg7yp853grd3xjwvs6xb6sqbdq96hizvghj48jra5rl9"
+   "commit": "c0e884eea86ef818a652dba9a1719b50489813a6",
+   "sha256": "15yfd2r6wxaid12wvplzm6hzqmjvp7nrxlv98xzl23bdbnlabkb4"
   },
   "stable": {
    "version": [
@@ -79615,14 +80017,14 @@
   "repo": "deirn/mason.el",
   "unstable": {
    "version": [
-    20251212,
-    2009
+    20260107,
+    1801
    ],
    "deps": [
     "s"
    ],
-   "commit": "3d3bc83bbb364f913b7bfd3f198048ba4a57f06f",
-   "sha256": "0gdsds797r7hppl5wrmsnpn5fv85hcpby38m1cj2g5wchkk7md6x"
+   "commit": "47b6e24820fb65bc934fca3ebc17d215e9db9893",
+   "sha256": "17l921aw8a145hbg0viwa7kafk8w4k20xfbyf17kkvdzwlgvv30i"
   }
  },
  {
@@ -79792,11 +80194,11 @@
   "repo": "mathworks/Emacs-MATLAB-Mode",
   "unstable": {
    "version": [
-    20251127,
-    254
+    20251229,
+    1750
    ],
-   "commit": "debcd15126d1f1ce97325b8cffc6c79c81c63d66",
-   "sha256": "0yfbwn2icyfpwk7h88iabq6ql3k9gvg3pxzc2b8jk4bpgma807ph"
+   "commit": "1e6ec79fa69d51c405000caef270a6944ef9cdc5",
+   "sha256": "0bd5i6609rczn4n3w1dgln6z6ii7crwj7zgdvn4dgkvchl57jrj2"
   },
   "stable": {
    "version": [
@@ -80065,11 +80467,11 @@
   "repo": "laurynas-biveinis/mcp-server-lib.el",
   "unstable": {
    "version": [
-    20251103,
-    541
+    20260116,
+    1406
    ],
-   "commit": "847bcb180b6c035ee07f497e0ffc8092b3e54c4a",
-   "sha256": "00jl2n0zj0x6gbxdx4q7abv5yn7x15ycc05mszdl1sx935k2z74q"
+   "commit": "8c494fbb79cc7aba789d5ca583e3736345b39a15",
+   "sha256": "00fq3bgpir2c7ppjp1nnb75xzrfaa9pksxscqhb1pkqpkd52ka6d"
   },
   "stable": {
    "version": [
@@ -80234,11 +80636,11 @@
   "repo": "ideasman42/emacs-meep",
   "unstable": {
    "version": [
-    20251216,
-    648
+    20260114,
+    2349
    ],
-   "commit": "7326cf40194d41362044fff9fe171b7369273142",
-   "sha256": "0jkghdmgrmp17hfy1l426yzb73gmwqfqw1zkm522pnbnnvh3lzsf"
+   "commit": "a9ddd7bb069115353d41ec352427509b07fa634f",
+   "sha256": "05v6s022apmv5ag5lvahh5z5lhajjh5h2n0rbmgr9cx8mws99364"
   }
  },
  {
@@ -80804,16 +81206,16 @@
   "repo": "seblemaguer/metal-archives.el",
   "unstable": {
    "version": [
-    20240824,
-    1023
+    20260101,
+    1230
    ],
    "deps": [
     "alert",
     "ht",
     "request"
    ],
-   "commit": "c474246c0c6b688a34e69c04261d4cd993189dc3",
-   "sha256": "1fb4i8a7wc6akiiv8d386h4b7lrqvlq1jpy5rzj70jkb092lmnlv"
+   "commit": "da7c1efcc3d4859019de8fa030899fe191e33608",
+   "sha256": "16ic9i6dbxym4wnxjhd87wa0zp8ylwqwlknzrzzrmgg37fp4i0gq"
   }
  },
  {
@@ -81092,20 +81494,20 @@
   "repo": "daut/miasma-theme.el",
   "unstable": {
    "version": [
-    20250513,
-    2310
+    20260113,
+    1800
    ],
-   "commit": "7eda5d6889716811e7d5fd51edaff9ed7b09ce15",
-   "sha256": "0ncy7z5gdpvq6l8b81am6czysygfyvqm2lpswgv1536xcs6iilkd"
+   "commit": "998aa50769722f1a92f99124d76a1689c2d9eaf1",
+   "sha256": "1zhs482f0j0wjg3mwps3g6nlrw67f2wyab2wcqxg41inxb7msm9v"
   },
   "stable": {
    "version": [
     1,
     6,
-    1
+    6
    ],
-   "commit": "7eda5d6889716811e7d5fd51edaff9ed7b09ce15",
-   "sha256": "0ncy7z5gdpvq6l8b81am6czysygfyvqm2lpswgv1536xcs6iilkd"
+   "commit": "998aa50769722f1a92f99124d76a1689c2d9eaf1",
+   "sha256": "1zhs482f0j0wjg3mwps3g6nlrw67f2wyab2wcqxg41inxb7msm9v"
   }
  },
  {
@@ -81563,26 +81965,26 @@
   "repo": "tarsius/minions",
   "unstable": {
    "version": [
-    20251211,
-    1945
+    20260101,
+    1837
    ],
    "deps": [
     "compat"
    ],
-   "commit": "4e27da98ab8f6dc5b56a9e5e2b537f5230da7af7",
-   "sha256": "1yzp8d3g23p71cc8mw16qrj61w9799d908c3mxjwmyy7366s3ssa"
+   "commit": "5b73cd443c28a6e9c8e5ddd60ada38afdf40dfb9",
+   "sha256": "0kl269rq1abjcpnxffd8xgcdw3bwgcq31bzfvmp8wvdnkdpfi3ci"
   },
   "stable": {
    "version": [
     1,
-    1,
-    2
+    2,
+    0
    ],
    "deps": [
     "compat"
    ],
-   "commit": "7bd15dd0a12e898db6b24b03d4aa797f525fb0e8",
-   "sha256": "06s2gd47q2lp4lj0ycrjihhn41ws9d3mh6ap9a7gz3b0blifpb4i"
+   "commit": "5b73cd443c28a6e9c8e5ddd60ada38afdf40dfb9",
+   "sha256": "0kl269rq1abjcpnxffd8xgcdw3bwgcq31bzfvmp8wvdnkdpfi3ci"
   }
  },
  {
@@ -81778,14 +82180,14 @@
   "repo": "eki3z/mise.el",
   "unstable": {
    "version": [
-    20250910,
-    1021
+    20251229,
+    1550
    ],
    "deps": [
     "inheritenv"
    ],
-   "commit": "60ef63466d07417a9ef956af363baae39c9ddf34",
-   "sha256": "1f0kshl9hkx5ssdkygiymgkgm6cvmmm8zrjkziqvlzy5kn01nmym"
+   "commit": "849c44b36594c80c57a555c5671dd1a5a83d3184",
+   "sha256": "1647cvw0lr1xs6wh1h11q859p90mpzf80gr92jlrb7h7wbpnl7vr"
   },
   "stable": {
    "version": [
@@ -82132,6 +82534,30 @@
   }
  },
  {
+  "ename": "mock-fs",
+  "commit": "bfff832c78e97142a897b13e4bbd2989a3a8298c",
+  "sha256": "1yxf35gqab6m9mfb72k76lcq20qq8akkl8ridcy7y3nr25xnndk2",
+  "fetcher": "codeberg",
+  "repo": "trevoke/mock-fs.el",
+  "unstable": {
+   "version": [
+    20260111,
+    410
+   ],
+   "commit": "c1a4b1f923bed627aea5579acd782e91243e7cdc",
+   "sha256": "10cg7gsf0iba8jh9gxvykrhc0ai3rnnwwjrcc0jnasn8fxfpkyz1"
+  },
+  "stable": {
+   "version": [
+    0,
+    10,
+    1
+   ],
+   "commit": "c1a4b1f923bed627aea5579acd782e91243e7cdc",
+   "sha256": "10cg7gsf0iba8jh9gxvykrhc0ai3rnnwwjrcc0jnasn8fxfpkyz1"
+  }
+ },
+ {
   "ename": "mocker",
   "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
   "sha256": "1c44ws77r0sp9b46a2xk39039m28mf8sqd46dbzwsms5glkwl82c",
@@ -82264,26 +82690,26 @@
   "repo": "tarsius/mode-line-debug",
   "unstable": {
    "version": [
-    20251101,
-    2033
+    20260101,
+    1838
    ],
    "deps": [
     "compat"
    ],
-   "commit": "f68cfa2ea28ce2dc6f40d4c93a44a701510e8e04",
-   "sha256": "07lh6nvhdayzpf9bhz9b9r25a9z14rqayjimr9wy557kg4iy8cqm"
+   "commit": "a6c26f9d8b574edd3001b8abc6c4801048428385",
+   "sha256": "0nggr6pwl34qhdjh7dxh88fa35i4d3nhan9w1xwa2fvmjycbayvg"
   },
   "stable": {
    "version": [
     1,
     5,
-    1
+    2
    ],
    "deps": [
     "compat"
    ],
-   "commit": "f68cfa2ea28ce2dc6f40d4c93a44a701510e8e04",
-   "sha256": "07lh6nvhdayzpf9bhz9b9r25a9z14rqayjimr9wy557kg4iy8cqm"
+   "commit": "a6c26f9d8b574edd3001b8abc6c4801048428385",
+   "sha256": "0nggr6pwl34qhdjh7dxh88fa35i4d3nhan9w1xwa2fvmjycbayvg"
   }
  },
  {
@@ -82294,11 +82720,11 @@
   "repo": "ideasman42/emacs-mode-line-idle",
   "unstable": {
    "version": [
-    20251213,
-    954
+    20260106,
+    30
    ],
-   "commit": "a024ff2cad890ce83d08dafbd9fc4754ceda3100",
-   "sha256": "04v5dvn5dmd7p6pd36cam262j2ywjbvpihfb4cbg476rayq9q7vn"
+   "commit": "4af21d0edf553c7f6c0ced61295bd402d6f3283a",
+   "sha256": "0466b4r85jz5ck3pwr4sl3s8w7a2jg5liacamkwxxdxzl4hlk87v"
   }
  },
  {
@@ -82462,20 +82888,20 @@
   "repo": "protesilaos/modus-themes",
   "unstable": {
    "version": [
-    20251219,
-    1306
+    20260113,
+    431
    ],
-   "commit": "46d4b492664bdaafc814c4a5017da995a8d0d1ee",
-   "sha256": "1d09gybic2ivly8bp9171gfrrvabz74wwwr1s4avzldrswxrmdii"
+   "commit": "8a45a1393aa68cf93f1a973b00d87e3e9de4833d",
+   "sha256": "1wikmp0l438kicsy4w55xmdnmq6inizglclf79pa7qjsc4rd6bbd"
   },
   "stable": {
    "version": [
     5,
-    1,
+    2,
     0
    ],
-   "commit": "4fd8cdfc552e7e1e6a96625a752ab612706b15e3",
-   "sha256": "1acabx4nkbkvm643fjjw2d4yv6h0vdz3rca814sc6wxjybqnvzac"
+   "commit": "d1037f1322487e5686fff655dcd88aa644b2ad51",
+   "sha256": "1iqbi71h9xajsw4330157dfs10npfi1z2ads99vr7n5pll7060rc"
   }
  },
  {
@@ -82653,11 +83079,11 @@
   "repo": "ideasman42/emacs-mono-complete",
   "unstable": {
    "version": [
-    20251126,
-    1132
+    20260105,
+    209
    ],
-   "commit": "71d46dc015ccdb33b07b2ac31b6b433c651faa02",
-   "sha256": "19lf2sp20b0kflah00iwm7qki2y6lgdaq0ql6s04pb4ws0ps6gqr"
+   "commit": "12eb3f326f49212787be6e34a69e830652c8a9be",
+   "sha256": "1p9bac7196cjfxqsxigcpjxxswvhrpy8cxpxhyd5n8mw8yp7nl5w"
   }
  },
  {
@@ -82824,26 +83250,26 @@
   "repo": "tarsius/moody",
   "unstable": {
    "version": [
-    20251101,
-    2036
+    20260101,
+    1838
    ],
    "deps": [
     "compat"
    ],
-   "commit": "c88c360065ccb8371df2bbf12bffbd13afe60234",
-   "sha256": "0nay6mpphb8ri0b92jjj15h9dfff2nwl9rwsdjfay976qdnfffmi"
+   "commit": "82f65014dcdfc7178464c282b5c9ec5f7016c945",
+   "sha256": "1ash61h0w26yzjgxzi8ga4baki35724h75nf3ivp8hlgpcnnb8rj"
   },
   "stable": {
    "version": [
     1,
     2,
-    1
+    2
    ],
    "deps": [
     "compat"
    ],
-   "commit": "c88c360065ccb8371df2bbf12bffbd13afe60234",
-   "sha256": "0nay6mpphb8ri0b92jjj15h9dfff2nwl9rwsdjfay976qdnfffmi"
+   "commit": "82f65014dcdfc7178464c282b5c9ec5f7016c945",
+   "sha256": "1ash61h0w26yzjgxzi8ga4baki35724h75nf3ivp8hlgpcnnb8rj"
   }
  },
  {
@@ -82936,11 +83362,11 @@
   "repo": "Melchizedek6809/morgentau-theme",
   "unstable": {
    "version": [
-    20220319,
-    1049
+    20260106,
+    303
    ],
-   "commit": "a8da5640b4a9b72a3136901d0a1a03071d9fcb00",
-   "sha256": "1ksfw4slhbwsvydb3qvdwlb5nh47zv420akrssavw7527c657rkj"
+   "commit": "2395b8af83fbec097ef747a23a67305159808efb",
+   "sha256": "1yvg5v8qwwd8nrs1hk5s6wvjjpff1ifqf3nrhc28kn62ap9ilr2g"
   }
  },
  {
@@ -82951,20 +83377,20 @@
   "repo": "tarsius/morlock",
   "unstable": {
    "version": [
-    20251101,
-    2037
+    20260101,
+    1839
    ],
-   "commit": "02759c4d05ef6ec6b05707dab5bfe9a148a2c5ac",
-   "sha256": "11xwiz5vbxjprnhi1glx7scpf7cdr6d7srvmyb1y1j0mxh0k5ijv"
+   "commit": "4ec0253ffbac4764b90457bb3b887b0a07badb20",
+   "sha256": "03n4vrlik3mid9jvvn36q856a48dghpcjcdhkjfshxdialywfdza"
   },
   "stable": {
    "version": [
     2,
     1,
-    2
+    3
    ],
-   "commit": "02759c4d05ef6ec6b05707dab5bfe9a148a2c5ac",
-   "sha256": "11xwiz5vbxjprnhi1glx7scpf7cdr6d7srvmyb1y1j0mxh0k5ijv"
+   "commit": "4ec0253ffbac4764b90457bb3b887b0a07badb20",
+   "sha256": "03n4vrlik3mid9jvvn36q856a48dghpcjcdhkjfshxdialywfdza"
   }
  },
  {
@@ -83159,20 +83585,20 @@
   "repo": "amnn/move-mode",
   "unstable": {
    "version": [
-    20241118,
-    1527
+    20251224,
+    1152
    ],
-   "commit": "6e4aaf6aae1e9b4aee096557c9f7b1f3550a1e59",
-   "sha256": "0fdksdq8dmi9ixmsn7yyc7y50kfqsv2zbv8gqg4ir6d0jqbrvnhz"
+   "commit": "e72e2d5102669b82ba70599fb64e64241d49376d",
+   "sha256": "11zy1zdc7999d75m5lpyayb3021b0zr7j2fq8kzhzfmc4k709w5q"
   },
   "stable": {
    "version": [
     1,
     1,
-    1
+    2
    ],
-   "commit": "6e4aaf6aae1e9b4aee096557c9f7b1f3550a1e59",
-   "sha256": "0fdksdq8dmi9ixmsn7yyc7y50kfqsv2zbv8gqg4ir6d0jqbrvnhz"
+   "commit": "e72e2d5102669b82ba70599fb64e64241d49376d",
+   "sha256": "11zy1zdc7999d75m5lpyayb3021b0zr7j2fq8kzhzfmc4k709w5q"
   }
  },
  {
@@ -83384,15 +83810,15 @@
   "repo": "mpdel/mpdel",
   "unstable": {
    "version": [
-    20250922,
-    929
+    20260114,
+    725
    ],
    "deps": [
     "libmpdel",
     "navigel"
    ],
-   "commit": "006ccab29492cda567112be76e84e40e51d1f70b",
-   "sha256": "1i7ymg0ls984vjmzjz0sbg280i47c6j79vr725x94xdpj6ci35qr"
+   "commit": "64cf50aca68064c2857ed0e5a8fddb2075d97090",
+   "sha256": "0wbvbban7qxi0i55vmvizfvdqpcmaxizgpsa9mmhl9j64ffpygq2"
   },
   "stable": {
    "version": [
@@ -84216,14 +84642,14 @@
   "repo": "magnars/multiple-cursors.el",
   "unstable": {
    "version": [
-    20251006,
-    2038
+    20260117,
+    1733
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "9017f3be6b00c1d82e33409db4a178133fb39d47",
-   "sha256": "1j4dd7fc78xjry2z2v4bsrwhmsg78rwdcdh3ipzdyjc6h1b1p3vd"
+   "commit": "ddd677091afc7d65ce56d11866e18aeded110ada",
+   "sha256": "0pscmm432szl9gh8kghwllavyya6i6dvj7rfh9n1vnn2p8v6w313"
   },
   "stable": {
    "version": [
@@ -84743,20 +85169,52 @@
   "repo": "mekeor/nael",
   "unstable": {
    "version": [
-    20251217,
-    1400
+    20260114,
+    2208
    ],
-   "commit": "7a8fb2615a10f57380bb83fad1f0c12775c4b6c5",
-   "sha256": "0dxbv0v2mpc69p5xig33mavnap9hcyzcrrqz61drbzva4cd7lln0"
+   "commit": "97114434492e3fa1b3c2795d3120ca78628d9765",
+   "sha256": "1mgd46z8a8nv5qd8lgd11c20iy6lhb0ww2mr5rfj1f8rd7avf37a"
   },
   "stable": {
    "version": [
     0,
-    6,
-    4
+    8,
+    0
    ],
-   "commit": "5524ce167c3f2e8de318c3b0d46a048cb981e129",
-   "sha256": "110zspf6wgzfbabhxc2aw3cn9464xyj8j7rjka6qcvp04yx7iw73"
+   "commit": "1a462a61a3599c436c9284a23cae4ff8815a84da",
+   "sha256": "1gck1p27vfl9rswbdpszxi3111wqx9f26ks3nh18cryd9v885cr1"
+  }
+ },
+ {
+  "ename": "nael-lsp",
+  "commit": "7070be6f68d9eb732abeea68d10257aa56d82a18",
+  "sha256": "1qjsic777s0wfj0njn18kpdw33v1kz4c6kdkvcg58j2kb81fsyjk",
+  "fetcher": "codeberg",
+  "repo": "mekeor/nael",
+  "unstable": {
+   "version": [
+    20260114,
+    1519
+   ],
+   "deps": [
+    "lsp-mode",
+    "nael"
+   ],
+   "commit": "1a462a61a3599c436c9284a23cae4ff8815a84da",
+   "sha256": "1gck1p27vfl9rswbdpszxi3111wqx9f26ks3nh18cryd9v885cr1"
+  },
+  "stable": {
+   "version": [
+    0,
+    8,
+    0
+   ],
+   "deps": [
+    "lsp-mode",
+    "nael"
+   ],
+   "commit": "1a462a61a3599c436c9284a23cae4ff8815a84da",
+   "sha256": "1gck1p27vfl9rswbdpszxi3111wqx9f26ks3nh18cryd9v885cr1"
   }
  },
  {
@@ -85435,11 +85893,11 @@
   "repo": "rainstormstudio/nerd-icons.el",
   "unstable": {
    "version": [
-    20251214,
-    1318
+    20260117,
+    1631
    ],
-   "commit": "081f6f4f99b9460b63b5a2a6087b62fefd06a5d0",
-   "sha256": "078lac0zdi7xzrgr3rc6xri05w6ch9iva5whyra5mxmkf89fn531"
+   "commit": "14b9fb4b48a08806836bc93f09cf44565aa9f152",
+   "sha256": "1b7sar1k206a89np69xsngr04km5cab20y4sassjh4bjr1fdmfr2"
   },
   "stable": {
    "version": [
@@ -86091,11 +86549,11 @@
   "repo": "mrcnski/nimbus-theme",
   "unstable": {
    "version": [
-    20251201,
-    2205
+    20260112,
+    41
    ],
-   "commit": "fb35c0c89e7da72945d3ee6f72042f25920adb04",
-   "sha256": "00g509drv53h10bd0r24i52vvdz7wh2ljsx1kwybsd1pgnxx8qs0"
+   "commit": "1ee3e643a01129263833ee5538e5df1fefb25cde",
+   "sha256": "0a4w8pvwmpjb0lflxccvp67gr16xb458hzkj7zjkm44iq7i55qy1"
   },
   "stable": {
    "version": [
@@ -86577,26 +87035,26 @@
   "repo": "emacscollective/no-littering",
   "unstable": {
    "version": [
-    20251127,
-    229
+    20260101,
+    1839
    ],
    "deps": [
     "compat"
    ],
-   "commit": "5b568cab7f8340deecb02a5c59d55885fc7d147c",
-   "sha256": "0yf51ylz8w5v0jrj39c2nnvkxs656r59yx3xi66drf2prq9dqmsm"
+   "commit": "f854fc971df346b65d58a9aebb89f20cf0a6fc77",
+   "sha256": "0ps1hl8mygc9qi7qpmzd9jav2zm64i659xrmk1yx55r6hqk51f5z"
   },
   "stable": {
    "version": [
     1,
     8,
-    2
+    3
    ],
    "deps": [
     "compat"
    ],
-   "commit": "3bd74a519de3ef50a92b53f50b17398b5f328a9a",
-   "sha256": "1yi3nwivi39c744nbwhlgc0pkh5p9kdylwv3ca52r683fm63l7jb"
+   "commit": "f854fc971df346b65d58a9aebb89f20cf0a6fc77",
+   "sha256": "0ps1hl8mygc9qi7qpmzd9jav2zm64i659xrmk1yx55r6hqk51f5z"
   }
  },
  {
@@ -87073,11 +87531,11 @@
   "url": "https://git.notmuchmail.org/git/notmuch",
   "unstable": {
    "version": [
-    20250620,
-    1557
+    20260114,
+    2256
    ],
-   "commit": "63665f1ebd6eff7753b7798add657fd6dbd110d6",
-   "sha256": "0103y9ssm8cqgv3vv81fljvxs028p3vr9wdmnfv6s6b70iaw31mv"
+   "commit": "97a2bad36a35399681f6c5f5a2b4390e6429d5ae",
+   "sha256": "0bnb19ikls0f9732z30zp5dig2ndv08sr2ly6ddhdm1lmvjkq6wb"
   },
   "stable": {
    "version": [
@@ -87096,28 +87554,28 @@
   "repo": "tarsius/notmuch-addr",
   "unstable": {
    "version": [
-    20251101,
-    2052
+    20260101,
+    1842
    ],
    "deps": [
     "compat",
     "notmuch"
    ],
-   "commit": "0883cd753f0a7a204f41c7311d3282ca3e53f869",
-   "sha256": "0cyi4x0zgvmz2kvrxkmdlgwv81qfq917i3shvml94rgxmk8calnz"
+   "commit": "f4cb7f273b44faa4c0c5c85b2d740086ca709c56",
+   "sha256": "17nbzpq69drksjbi2ckwnp837kjapsg0s0y8xd1m3p706cvsnd6i"
   },
   "stable": {
    "version": [
     1,
     1,
-    2
+    3
    ],
    "deps": [
     "compat",
     "notmuch"
    ],
-   "commit": "0883cd753f0a7a204f41c7311d3282ca3e53f869",
-   "sha256": "0cyi4x0zgvmz2kvrxkmdlgwv81qfq917i3shvml94rgxmk8calnz"
+   "commit": "f4cb7f273b44faa4c0c5c85b2d740086ca709c56",
+   "sha256": "17nbzpq69drksjbi2ckwnp837kjapsg0s0y8xd1m3p706cvsnd6i"
   }
  },
  {
@@ -87188,28 +87646,28 @@
   "repo": "tarsius/notmuch-maildir",
   "unstable": {
    "version": [
-    20251101,
-    2053
+    20260101,
+    1843
    ],
    "deps": [
     "compat",
     "notmuch"
    ],
-   "commit": "f4982d49d05d3b76db55462ec0f7cfee35f92d20",
-   "sha256": "061xabwvhzkmpvcaqcz47cryj29zcmxvz3sliyvnj0fnqnbpg407"
+   "commit": "ef3952c785cc4bc41366d798bff5edad1a945553",
+   "sha256": "0an2y57q45dmwm0jp884m6bfnl2x6r1fxb41ckznylcmvwbn3km2"
   },
   "stable": {
    "version": [
     1,
     3,
-    1
+    2
    ],
    "deps": [
     "compat",
     "notmuch"
    ],
-   "commit": "f4982d49d05d3b76db55462ec0f7cfee35f92d20",
-   "sha256": "061xabwvhzkmpvcaqcz47cryj29zcmxvz3sliyvnj0fnqnbpg407"
+   "commit": "ef3952c785cc4bc41366d798bff5edad1a945553",
+   "sha256": "0an2y57q45dmwm0jp884m6bfnl2x6r1fxb41ckznylcmvwbn3km2"
   }
  },
  {
@@ -87220,30 +87678,30 @@
   "repo": "tarsius/notmuch-transient",
   "unstable": {
    "version": [
-    20251101,
-    2054
+    20260101,
+    1843
    ],
    "deps": [
     "compat",
     "notmuch",
     "transient"
    ],
-   "commit": "09861654f1a25a46849f5653a4e9651d9a093ecd",
-   "sha256": "0a8324xcfd8nql0w9mbr97mi2hyf0mya9xa53iw1my8zmwdvwf9l"
+   "commit": "a1e18fa9202248c3c6264147bd0e82cda0a03a53",
+   "sha256": "014j9nga950bil2q0iwbrkyr6gl90hwcjfmfg9jjlci6l8mbwk7c"
   },
   "stable": {
    "version": [
     1,
     1,
-    2
+    3
    ],
    "deps": [
     "compat",
     "notmuch",
     "transient"
    ],
-   "commit": "09861654f1a25a46849f5653a4e9651d9a093ecd",
-   "sha256": "0a8324xcfd8nql0w9mbr97mi2hyf0mya9xa53iw1my8zmwdvwf9l"
+   "commit": "a1e18fa9202248c3c6264147bd0e82cda0a03a53",
+   "sha256": "014j9nga950bil2q0iwbrkyr6gl90hwcjfmfg9jjlci6l8mbwk7c"
   }
  },
  {
@@ -87790,6 +88248,29 @@
    ],
    "commit": "afe2b8c3b5421b4c292d182dcf77079b278e93d8",
    "sha256": "1qamw4x3yrygy8qkicy6smxksnsfkkp76hlnivswh7dm3fr23v6m"
+  }
+ },
+ {
+  "ename": "oai",
+  "commit": "c726b8b2a8db2f008123086f72ec31c99f91c7ea",
+  "sha256": "1kg3hkka9hp4w2jqg6b7170d2afdgvmlyx51sl05pdqynb3i3zzv",
+  "fetcher": "github",
+  "repo": "Anoncheg1/emacs-oai",
+  "unstable": {
+   "version": [
+    20260118,
+    1516
+   ],
+   "commit": "5f2ca47f35a52ebd8f7d6dab9deb463acaee62d4",
+   "sha256": "0l1c8vydjcvfikgp31c226d8kljsq13p20m5s40srh8ny8x7qzd9"
+  },
+  "stable": {
+   "version": [
+    0,
+    1
+   ],
+   "commit": "268eda829b16b9000eebbcc30f021c47338a9757",
+   "sha256": "09bgnvg5rbja03qc7rnp280sqx3nkk4q94ma430wmksrxwn9g3sn"
   }
  },
  {
@@ -88733,15 +89214,15 @@
   "repo": "shg/ob-julia-vterm.el",
   "unstable": {
    "version": [
-    20250619,
-    1430
+    20251226,
+    916
    ],
    "deps": [
     "julia-vterm",
     "queue"
    ],
-   "commit": "bc0f851d4a64f1659021b480f61cdac024ce76fe",
-   "sha256": "05micnsynwqhqqkhknkvpan3lxcx97rqrjy7197fpxns3i2768ha"
+   "commit": "dbcabdf4502a7b6089b0537bc7ea8ef4f4526233",
+   "sha256": "1y8wvc8fs9npdjnpj1gjd8f4h7npzczqdzfifbxkb21y32wpvbi3"
   },
   "stable": {
    "version": [
@@ -89619,11 +90100,11 @@
   "repo": "ideasman42/emacs-theme-oblivion",
   "unstable": {
    "version": [
-    20240320,
-    1152
+    20260108,
+    1348
    ],
-   "commit": "8b7ed6627ee3c838acd2ec9bfd5a6fb02228edfb",
-   "sha256": "1qp8216c6spjyjbnj0x3w150fisnxzy5yzhgkihip352kf5ah54j"
+   "commit": "2a07e4fad23dbe6844dc565193fb04b033c319d4",
+   "sha256": "0xzmrg90qdd9m18q1zhs0lkv5isdy0049wxdap26bzawjsi3l4mg"
   }
  },
  {
@@ -89691,11 +90172,11 @@
   "repo": "tarides/ocaml-eglot",
   "unstable": {
    "version": [
-    20251219,
-    1518
+    20260119,
+    1135
    ],
-   "commit": "ca06dee696552d72eb968a3cb385a88663ff56dc",
-   "sha256": "0ixhb45rgidj0h9b6grp42lihfaak7y41nv81hs8bf66ds3nb5xw"
+   "commit": "5aff883db323c7b083964f286fe134e96b0c9458",
+   "sha256": "1adjg47qp52ngi5w50383icp8qb0i23f5xmr43qbn88knz9jb7gv"
   },
   "stable": {
    "version": [
@@ -89945,26 +90426,26 @@
   "repo": "oer/oer-reveal",
   "unstable": {
    "version": [
-    20250826,
-    1503
+    20260116,
+    1531
    ],
    "deps": [
     "org-re-reveal"
    ],
-   "commit": "20456112467fa6c962b242d1d6d4ddcc66488bd3",
-   "sha256": "16fmsczxzl19042i3qr48x3cynh9dj8kj9xglliq6a67nyz8c548"
+   "commit": "47b626bcb7f1b2d2a5a1e4a740a659a89c2b2b1f",
+   "sha256": "123vhavra0c8iah1rjdhpc8lbmh3slskz0kjwb6f01rkkn7pwwyk"
   },
   "stable": {
    "version": [
     4,
-    34,
-    0
+    35,
+    1
    ],
    "deps": [
     "org-re-reveal"
    ],
-   "commit": "20456112467fa6c962b242d1d6d4ddcc66488bd3",
-   "sha256": "16fmsczxzl19042i3qr48x3cynh9dj8kj9xglliq6a67nyz8c548"
+   "commit": "47b626bcb7f1b2d2a5a1e4a740a659a89c2b2b1f",
+   "sha256": "123vhavra0c8iah1rjdhpc8lbmh3slskz0kjwb6f01rkkn7pwwyk"
   }
  },
  {
@@ -90030,30 +90511,30 @@
   "repo": "tarsius/ol-notmuch",
   "unstable": {
    "version": [
-    20251101,
-    2058
+    20260101,
+    1844
    ],
    "deps": [
     "compat",
     "notmuch",
     "org"
    ],
-   "commit": "7655f5ea25ea40b7d0453ae6531cae59e5ea592f",
-   "sha256": "0cdi73vfikhm8gcj1y05b07fvzvninz811yppb3kyhdis8kzc7qk"
+   "commit": "8f717329388935538fe433b9a15f1599edd9fcd5",
+   "sha256": "0vlb6wgp314n6ilzfhz3j3lkzdpv4y0mngp6l2q04np9cqffkvf3"
   },
   "stable": {
    "version": [
     2,
     1,
-    2
+    3
    ],
    "deps": [
     "compat",
     "notmuch",
     "org"
    ],
-   "commit": "7655f5ea25ea40b7d0453ae6531cae59e5ea592f",
-   "sha256": "0cdi73vfikhm8gcj1y05b07fvzvninz811yppb3kyhdis8kzc7qk"
+   "commit": "8f717329388935538fe433b9a15f1599edd9fcd5",
+   "sha256": "0vlb6wgp314n6ilzfhz3j3lkzdpv4y0mngp6l2q04np9cqffkvf3"
   }
  },
  {
@@ -90463,6 +90944,30 @@
    ],
    "commit": "b8ee8cea45c9b34820fcb951f522f13e3736d216",
    "sha256": "1i7xhv2a22n6lq0n1pd494g1a5s7sv52i2gblg6s9h87dnb4r9l6"
+  }
+ },
+ {
+  "ename": "once",
+  "commit": "fd01feff426c13b35c6831809a8c8ea00e9a399f",
+  "sha256": "18pwygffhw8ayywwj0kjq1s336f8gyh41dv8kz8qapvr46qxn7pp",
+  "fetcher": "github",
+  "repo": "meedstrom/once",
+  "unstable": {
+   "version": [
+    20260105,
+    1940
+   ],
+   "commit": "65c654a18855df21a2f8f4721e2beabab4d29949",
+   "sha256": "0n5crsp9k029zb9hv9qmf4s72xhx5r3n2g1f6437h60v9a6as8x1"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    0
+   ],
+   "commit": "b311e20ade96185176b02939a6e51fe61491e524",
+   "sha256": "05w4c5wb0yqa4wv7fx0gyxh7xrd3p7i85h88p3dxd5rdjmws4cm1"
   }
  },
  {
@@ -90895,14 +91400,14 @@
   "repo": "oantolin/orderless",
   "unstable": {
    "version": [
-    20251128,
-    2028
+    20260117,
+    1749
    ],
    "deps": [
     "compat"
    ],
-   "commit": "26a384894678a1e51e3bf914af3699a61794fb57",
-   "sha256": "109yywz0z0k91hxv785s6wxw5vxss42falwqk5r1bw1ggwc69sz0"
+   "commit": "225dbcba32ab079f78e4146cbfd7d4dfb58840a3",
+   "sha256": "0hdb9q787889jmv1i0nkcbizrhqm4gqn7vl7bxnixlqfc3r0xlrg"
   },
   "stable": {
    "version": [
@@ -91076,14 +91581,14 @@
   "repo": "rksm/org-ai",
   "unstable": {
    "version": [
-    20251203,
-    1121
+    20260107,
+    1110
    ],
    "deps": [
     "websocket"
    ],
-   "commit": "28a974c3bf55dc5e6b364707fcb2f0e75550d1c1",
-   "sha256": "0h749sf86qqxl8y66g8n9k5i4ndw7wpybzxnl9k42z4dak4jb073"
+   "commit": "71a6ea50555531f627a69aa0584d3a19060050a4",
+   "sha256": "12k7slj7pd00a7j1zm87vvd0jk6bnn62rmg9pbkdl0r5n289q9p0"
   },
   "stable": {
    "version": [
@@ -91358,26 +91863,26 @@
   "repo": "yilkalargaw/org-auto-tangle",
   "unstable": {
    "version": [
-    20220812,
-    2327
+    20251230,
+    1416
    ],
    "deps": [
     "async"
    ],
-   "commit": "2494a6f78c9db5311123abc7cad119851a29a55c",
-   "sha256": "1kn1jsbv97ps280lcdx19d6hs7pvz7q9ng67xlb1kwjb680pa7rl"
+   "commit": "b4e7abc019179df473ecddf0af80561ddad8fc58",
+   "sha256": "1wv1ih2w4w93pfr0mqpi6fqpsk0170qzhqhr039hblif8bwxmb71"
   },
   "stable": {
    "version": [
     0,
-    6,
+    7,
     0
    ],
    "deps": [
     "async"
    ],
-   "commit": "2494a6f78c9db5311123abc7cad119851a29a55c",
-   "sha256": "1kn1jsbv97ps280lcdx19d6hs7pvz7q9ng67xlb1kwjb680pa7rl"
+   "commit": "b4e7abc019179df473ecddf0af80561ddad8fc58",
+   "sha256": "1wv1ih2w4w93pfr0mqpi6fqpsk0170qzhqhr039hblif8bwxmb71"
   }
  },
  {
@@ -91581,15 +92086,15 @@
   "url": "https://repo.or.cz/org-bookmarks.git",
   "unstable": {
    "version": [
-    20251113,
-    351
+    20260102,
+    1353
    ],
    "deps": [
     "nerd-icons",
     "seq"
    ],
-   "commit": "b3a46dc78175f7398502050420e5ea7d237a736f",
-   "sha256": "14khm57964ykdx2dcd9w7ddy18ksx4f5x8igppmn6gcln7l069rs"
+   "commit": "b54d1e296bb0fcaf33452838de83f69c1ab58f0d",
+   "sha256": "0lc6nkmx79vmsynkwpdigncr758q6c1cvsmbni7cdwl1hmqhyfzr"
   },
   "stable": {
    "version": [
@@ -91787,14 +92292,14 @@
   "repo": "colonelpanic8/org-project-capture",
   "unstable": {
    "version": [
-    20230830,
-    1733
+    20260118,
+    807
    ],
    "deps": [
     "org"
    ],
-   "commit": "bf1c30b750020ab8dd634dd66b2c7b76c56286c5",
-   "sha256": "1wvw5y5s37p9j0m2ljp7n1s1casbhiyrcnfpvdghvdd0fk8wcybp"
+   "commit": "4303dd869b0d638bd09014702803cde50f4e7fed",
+   "sha256": "10vxb0d6b31dmd7xqhr15syzlvzify6qmbz25ca6pp8rjkdkrxjv"
   },
   "stable": {
    "version": [
@@ -92078,14 +92583,14 @@
   "url": "https://repo.or.cz/org-contacts.git",
   "unstable": {
    "version": [
-    20250905,
-    335
+    20260114,
+    754
    ],
    "deps": [
     "org"
    ],
-   "commit": "41f10b9ab07f267613d77e98ef7a33b1772292b0",
-   "sha256": "1aqvq1wca7csi7mrgy1gvy1lgq6ybi9ap030zwk697hvz8i0d59g"
+   "commit": "690ae7e735e16eee6969ef4d79cdff021a621db1",
+   "sha256": "1vjalaqlib5k2alflajckdc41q59mfb4q6c7jbprqr3yzl4gff02"
   }
  },
  {
@@ -92177,15 +92682,15 @@
   "repo": "emacsomancer/org-daily-reflection",
   "unstable": {
    "version": [
-    20251208,
-    558
+    20260102,
+    35
    ],
    "deps": [
     "compat",
     "org"
    ],
-   "commit": "d72170fd1cf9b605a13a80b9aa2d5301d6232033",
-   "sha256": "1wc2syy24902n8lncqljw4wlgk8q0n961gqv65ig7y6vwf4ng5qk"
+   "commit": "4f7a2a3b068de2ecee23634a340334fc873421b1",
+   "sha256": "0806sv56wkx21pbfp6m7w20q3v9wg4ihvhslk8rxm4jk8jwmn8d1"
   }
  },
  {
@@ -92800,34 +93305,36 @@
   "repo": "Trevoke/org-gtd.el",
   "unstable": {
    "version": [
-    20231224,
-    1639
+    20260117,
+    1854
    ],
    "deps": [
+    "compat",
+    "dag-draw",
     "f",
     "org",
-    "org-agenda-property",
     "org-edna",
     "transient"
    ],
-   "commit": "f82eb971db0008b773a57c207120751f913bde6b",
-   "sha256": "0ffwc6zv0y3kwj4a3nzd2dj7jq51lck3kqzgl0il54hyg9fpm7ll"
+   "commit": "21ba4b1c03a0b9e6feec1b3f1f85ccb682adf867",
+   "sha256": "1bbcil0h4ha7s9b4xnrmpdcza94yrq3pq6fpgc2xs5bj8dbip7bq"
   },
   "stable": {
    "version": [
+    4,
     3,
-    0,
-    0
+    1
    ],
    "deps": [
+    "compat",
+    "dag-draw",
     "f",
     "org",
-    "org-agenda-property",
     "org-edna",
     "transient"
    ],
-   "commit": "578e83b0f67cb57dd1b10e9eea4f40d2e925b9b9",
-   "sha256": "012alf2kn0anxfc83irl6bprmnz3zsdaiavx4nqryc25b17m1bpb"
+   "commit": "21ba4b1c03a0b9e6feec1b3f1f85ccb682adf867",
+   "sha256": "1bbcil0h4ha7s9b4xnrmpdcza94yrq3pq6fpgc2xs5bj8dbip7bq"
   }
  },
  {
@@ -92997,21 +93504,21 @@
   "repo": "marcIhm/org-index",
   "unstable": {
    "version": [
-    20250914,
-    850
+    20260112,
+    1658
    ],
    "deps": [
     "dash",
     "org",
     "s"
    ],
-   "commit": "77bdcefab4cfc673844e21eaea7b446e40498ef6",
-   "sha256": "1m0x34g9fgmiphaimi617wv67f4npciwsgh2nqsc7yij0rp9hx77"
+   "commit": "ccef23d8318bcccd1638f5b85176475c85275f83",
+   "sha256": "06zaavj9g6fzlxm3hn1pj1sxcp9qczf9c6v0i3lw3klz21d1jab1"
   },
   "stable": {
    "version": [
     7,
-    5,
+    6,
     0
    ],
    "deps": [
@@ -93019,8 +93526,8 @@
     "org",
     "s"
    ],
-   "commit": "77bdcefab4cfc673844e21eaea7b446e40498ef6",
-   "sha256": "1m0x34g9fgmiphaimi617wv67f4npciwsgh2nqsc7yij0rp9hx77"
+   "commit": "ccef23d8318bcccd1638f5b85176475c85275f83",
+   "sha256": "06zaavj9g6fzlxm3hn1pj1sxcp9qczf9c6v0i3lw3klz21d1jab1"
   }
  },
  {
@@ -93286,16 +93793,16 @@
   "repo": "SqrtMinusOne/org-journal-tags",
   "unstable": {
    "version": [
-    20250824,
-    823
+    20260102,
+    1551
    ],
    "deps": [
     "magit-section",
     "org-journal",
     "transient"
    ],
-   "commit": "e815fe09e05a53482b86470c774422c2d49e2754",
-   "sha256": "05ylc3fibqs8lgfvq9qimqm2nsy99p0cvysvxlaiw8xawqi1c8k9"
+   "commit": "945347b7a2daae463498f12300b13b583a8792d4",
+   "sha256": "0w1qwvg1jgd1yqi0srggbzi14lsand2z2vkdz243zn7h40vj2g17"
   },
   "stable": {
    "version": [
@@ -93414,15 +93921,15 @@
   "url": "https://repo.or.cz/org-link-beautify.git",
   "unstable": {
    "version": [
-    20251211,
-    429
+    20260106,
+    1116
    ],
    "deps": [
     "nerd-icons",
     "qrencode"
    ],
-   "commit": "4083d40165f6f2b4564e09d051001315de24dcb7",
-   "sha256": "0lav5547v3427xdhx4z3xapp301y8ps8k32dy9dyp1kxnz7mqh4w"
+   "commit": "62955313268e27744ac2117ed5be9d2c362ded05",
+   "sha256": "0r43rlvc37l96h8bhkw8x1sswjqzk13svq9k85wrh1y3l57p8haf"
   },
   "stable": {
    "version": [
@@ -93507,19 +94014,19 @@
   "repo": "Anoncheg1/emacs-org-links",
   "unstable": {
    "version": [
-    20251218,
-    1721
+    20260116,
+    1316
    ],
-   "commit": "bc174233f9c11c74cdd15a678d91427ff58715ad",
-   "sha256": "06bmpl60s9sb6k7snqihi9nfcyj1mzpr3jpjxkkd14cp72r5wisb"
+   "commit": "b1bb0da38ce14d31148abe9e733212747b0b5dc4",
+   "sha256": "06r3yjc48qa6dcarghg62pnzwkv3af8yy38ghihp4bxw5qni8gpa"
   },
   "stable": {
    "version": [
     0,
-    2
+    3
    ],
-   "commit": "8b2e05682efb88d35f8342795d6e49c4f2549687",
-   "sha256": "0c78qig3j3riyj326bbp3qh0ma1lf300yn4ymvwkd1wbkgh9hgj2"
+   "commit": "c6e8cc6753d3b880b09a6e28f244ada48debfb2b",
+   "sha256": "1vnqg43f94viixlqqjj0vfrpshzj3inpn36j5ds3f3icjzg7i16z"
   }
  },
  {
@@ -93762,27 +94269,27 @@
   "repo": "minad/org-modern",
   "unstable": {
    "version": [
-    20251219,
-    1424
+    20260117,
+    1652
    ],
    "deps": [
     "compat",
     "org"
    ],
-   "commit": "55b5bbeb1eb9483d0cb43f4803615c380bf3b1ed",
-   "sha256": "0s5sh1hiwmnpyj5jvy93wi1aqf85dznz7rr9kbm77zcfsyqhnly2"
+   "commit": "9bbc44cc7e085dea24e96f0cc0332ed7fcf349ca",
+   "sha256": "01p5k85hj677x2vk7j7a88gchp51ybiaj6iqmdhxivmcw3lb6ibi"
   },
   "stable": {
    "version": [
     1,
-    11
+    12
    ],
    "deps": [
     "compat",
     "org"
    ],
-   "commit": "55b5bbeb1eb9483d0cb43f4803615c380bf3b1ed",
-   "sha256": "0s5sh1hiwmnpyj5jvy93wi1aqf85dznz7rr9kbm77zcfsyqhnly2"
+   "commit": "9bbc44cc7e085dea24e96f0cc0332ed7fcf349ca",
+   "sha256": "01p5k85hj677x2vk7j7a88gchp51ybiaj6iqmdhxivmcw3lb6ibi"
   }
  },
  {
@@ -93998,16 +94505,16 @@
   "repo": "meedstrom/org-node",
   "unstable": {
    "version": [
-    20251218,
-    306
+    20260119,
+    1746
    ],
    "deps": [
     "llama",
     "magit-section",
     "org-mem"
    ],
-   "commit": "3956804cc0cc19fba0d98b2eb9b76056feda77ae",
-   "sha256": "08nxg96hkn8k4ikzvx0whx8x955mrl85dh493mq90m73sffi9scg"
+   "commit": "7eba767815447105d9369d70fb30b9ce5c8e1ad3",
+   "sha256": "1127bc8x5zi6cl5ak8qay01aniscn94i908b52bzf3sz57cyknyj"
   },
   "stable": {
    "version": [
@@ -94085,15 +94592,15 @@
   "repo": "org-noter/org-noter",
   "unstable": {
    "version": [
-    20250730,
-    30
+    20260108,
+    2346
    ],
    "deps": [
     "cl-lib",
     "org"
    ],
-   "commit": "aafa08a49c4c3311d9b17864629aceeff02d33da",
-   "sha256": "12874pcl0rivlhj8jw3ih88gpgz179mr60hacw3dxf7h2ksylwch"
+   "commit": "81765d267e51efd8b4f5b7276000332ba3eabbf5",
+   "sha256": "06d03bv14awz5vm8y85b2wdg1vf22d4zj5s3bcz8y7qinvyfy9pm"
   },
   "stable": {
    "version": [
@@ -94449,16 +94956,16 @@
   "repo": "colonelpanic8/org-project-capture",
   "unstable": {
    "version": [
-    20230830,
-    1733
+    20260118,
+    807
    ],
    "deps": [
     "dash",
     "org-category-capture",
     "s"
    ],
-   "commit": "581ca06383b957e2927c24290debd3cf83355456",
-   "sha256": "1p3llbksn60cjf7f5v67j92jsrg4nccw4hq5va3nl9dnapnb1k92"
+   "commit": "4303dd869b0d638bd09014702803cde50f4e7fed",
+   "sha256": "10vxb0d6b31dmd7xqhr15syzlvzify6qmbz25ca6pp8rjkdkrxjv"
   },
   "stable": {
    "version": [
@@ -94483,8 +94990,8 @@
   "repo": "colonelpanic8/org-project-capture",
   "unstable": {
    "version": [
-    20230817,
-    851
+    20260118,
+    807
    ],
    "deps": [
     "dash",
@@ -94492,8 +94999,8 @@
     "org-project-capture",
     "projectile"
    ],
-   "commit": "4ca2667d498fa259772e46ff5e101285446d70b6",
-   "sha256": "1p56ng1v0795bkgkk18w6494hvq5j3j6h48yhr8smz69k46amm3y"
+   "commit": "4303dd869b0d638bd09014702803cde50f4e7fed",
+   "sha256": "10vxb0d6b31dmd7xqhr15syzlvzify6qmbz25ca6pp8rjkdkrxjv"
   },
   "stable": {
    "version": [
@@ -94519,15 +95026,15 @@
   "repo": "colonelpanic8/org-project-capture",
   "unstable": {
    "version": [
-    20230817,
-    801
+    20260118,
+    807
    ],
    "deps": [
     "helm",
     "org-projectile"
    ],
-   "commit": "214a6068c467323a795b27996c1e7b75ae42dc68",
-   "sha256": "1fdbxwmrs96118hrm8sbfdbpfigankdqklq011pykf9lhc4627nv"
+   "commit": "4303dd869b0d638bd09014702803cde50f4e7fed",
+   "sha256": "10vxb0d6b31dmd7xqhr15syzlvzify6qmbz25ca6pp8rjkdkrxjv"
   },
   "stable": {
    "version": [
@@ -94710,28 +95217,28 @@
   "repo": "oer/org-re-reveal",
   "unstable": {
    "version": [
-    20251222,
-    1526
+    20260116,
+    1525
    ],
    "deps": [
     "htmlize",
     "org"
    ],
-   "commit": "80bee1b270b142e3d9fd0b6ab94e42ba388a7b74",
-   "sha256": "19w33kxqgiwj3yjd1q5zxcm34hcmvcb7wjbaz1ks0yydwfjjgbgj"
+   "commit": "07bd4a2bfab91ccd289633e9261c9a1a4e515b2a",
+   "sha256": "057gva3l54jkfddni8haiaf6pkkd9czfygnw8mfb2xs53cg3m1n8"
   },
   "stable": {
    "version": [
     3,
-    37,
-    1
+    38,
+    0
    ],
    "deps": [
     "htmlize",
     "org"
    ],
-   "commit": "9485d2e1693d5d8bcb4806fdc7923496554f18e7",
-   "sha256": "1rnc240ibxgl103c50xc7aiigcqfhlqwwvzp658n4q8f1qr77y8v"
+   "commit": "07bd4a2bfab91ccd289633e9261c9a1a4e515b2a",
+   "sha256": "057gva3l54jkfddni8haiaf6pkkd9czfygnw8mfb2xs53cg3m1n8"
   }
  },
  {
@@ -94956,20 +95463,20 @@
   "repo": "TomoeMami/org-repeat-by-cron.el",
   "unstable": {
    "version": [
-    20251028,
-    807
+    20260118,
+    526
    ],
-   "commit": "36a5ea61ac6bc97aa83d766440fb87540899864c",
-   "sha256": "1y4ssh2363xshhhdziww2s1bjhw9p329bawwfrs73x3ykndvx65c"
+   "commit": "414d872ed71642fdd0dee6c2163665db7fc4dab0",
+   "sha256": "0z9d3606x5j3dgkakzbdrl3474ppsdyqkiq5pgrh5m2qwx1vzj0v"
   },
   "stable": {
    "version": [
     1,
     0,
-    2
+    4
    ],
-   "commit": "36a5ea61ac6bc97aa83d766440fb87540899864c",
-   "sha256": "1y4ssh2363xshhhdziww2s1bjhw9p329bawwfrs73x3ykndvx65c"
+   "commit": "414d872ed71642fdd0dee6c2163665db7fc4dab0",
+   "sha256": "0z9d3606x5j3dgkakzbdrl3474ppsdyqkiq5pgrh5m2qwx1vzj0v"
   }
  },
  {
@@ -95075,8 +95582,8 @@
   "repo": "org-roam/org-roam",
   "unstable": {
    "version": [
-    20251125,
-    729
+    20260103,
+    1921
    ],
    "deps": [
     "compat",
@@ -95085,8 +95592,8 @@
     "magit-section",
     "org"
    ],
-   "commit": "f4ba41cf3d59084e182a5186d432afc9aa3fc423",
-   "sha256": "0kax0a1i98ffr8fama79sfdk6gx60qpd190g7b2scv2bwbglcbnj"
+   "commit": "b95d04cbd223e369b9578b0dc47bbdd376d40dc3",
+   "sha256": "1l7z8sc6mxx09r19z88j1qb4iz9gagsy39v2v852q4ayg50ad6gh"
   },
   "stable": {
    "version": [
@@ -95208,6 +95715,39 @@
    ],
    "commit": "f628fef081394f159f196f4350132aecb3edb8cc",
    "sha256": "1ssxvy6y79f035whk9b8jg1vqsy6vymgq9yrzbxv06g5vsggvlh5"
+  }
+ },
+ {
+  "ename": "org-roam-timeline",
+  "commit": "75d28aac7bdb2bb59d6756a83b22a4008482cbac",
+  "sha256": "1a86kcjasd5kh99gdmmsis7s7kxxqndwqbw0bqkh5ks64wbmzcpx",
+  "fetcher": "github",
+  "repo": "GerardoCendejas/org-roam-timeline",
+  "unstable": {
+   "version": [
+    20260103,
+    123
+   ],
+   "deps": [
+    "json-mode",
+    "org-roam",
+    "simple-httpd"
+   ],
+   "commit": "8252fb48d482c55c662eaa2e757b035479eb32e7",
+   "sha256": "0qsw32hxh8kllp6f3ic5vac8g9m4qq06pv8rjy9z5sxid73c1416"
+  },
+  "stable": {
+   "version": [
+    1,
+    0
+   ],
+   "deps": [
+    "json-mode",
+    "org-roam",
+    "simple-httpd"
+   ],
+   "commit": "8252fb48d482c55c662eaa2e757b035479eb32e7",
+   "sha256": "0qsw32hxh8kllp6f3ic5vac8g9m4qq06pv8rjy9z5sxid73c1416"
   }
  },
  {
@@ -95484,8 +96024,8 @@
   "repo": "tanrax/org-social.el",
   "unstable": {
    "version": [
-    20251218,
-    930
+    20260116,
+    749
    ],
    "deps": [
     "emojify",
@@ -95493,13 +96033,13 @@
     "request",
     "seq"
    ],
-   "commit": "b8d9e0586a8cfdfaa610f830ad8da77fb45afaf8",
-   "sha256": "0iqyv6fbqnnxd2lk1inj9jryk8bkp7mpha5awb961yf9yxsd8kha"
+   "commit": "83015d1402c28cd1395b18a104dfbc4f1357a83c",
+   "sha256": "0s6bqyi7qy3i97hsn6hr3k1dwk1ws7l92w1ixldhrhfjx26ynqfj"
   },
   "stable": {
    "version": [
     2,
-    8
+    10
    ],
    "deps": [
     "emojify",
@@ -95507,8 +96047,8 @@
     "request",
     "seq"
    ],
-   "commit": "08dbb4ac30c8260deaecc7d14d732aa80624be20",
-   "sha256": "051k9l5w78xzs2j6md89fdablj13lvn62cn1r6cqirp2dd1nnlva"
+   "commit": "d4cfe777975519ae2908416eb58c4f1b4cb33b43",
+   "sha256": "1h7bqqa3v0ah4ai2m6chz6932l5gq6rx7nc8mjxiiydkq1rjhgxi"
   }
  },
  {
@@ -95592,15 +96132,15 @@
   "repo": "bohonghuang/org-srs",
   "unstable": {
    "version": [
-    20251217,
-    1414
+    20251223,
+    1556
    ],
    "deps": [
     "fsrs",
     "org"
    ],
-   "commit": "6b66dce1b8729558b9e7d7e775e51e05c4e398ec",
-   "sha256": "04ypgpfypq2lxrxdcsjgav9kfp74y3q9pn6vhj09j6zaf98m11r7"
+   "commit": "c0aff45392b1f836fd943467cc266cef50899a44",
+   "sha256": "0bvczpn93afdng9xnr3licgmv3yw4rdmsbn45206r756738capn9"
   }
  },
  {
@@ -95930,14 +96470,14 @@
   "url": "https://repo.or.cz/org-tag-beautify.git",
   "unstable": {
    "version": [
-    20251202,
-    947
+    20260103,
+    934
    ],
    "deps": [
     "nerd-icons"
    ],
-   "commit": "20c750de61540c144155c1dbe1cae00313215fa1",
-   "sha256": "1sq2m3d2gabmhm44w7mas906njhqgy6b0k1fa83kz8wf7as7q88p"
+   "commit": "de02883b9ad339539482d30450074ca572709d90",
+   "sha256": "1wmrvqflmgwszrm5kmnj71bdbsn28fddmrqwzmczqz80h9nnfi4p"
   }
  },
  {
@@ -96936,8 +97476,8 @@
   "repo": "jcs-elpa/organize-imports-java",
   "unstable": {
    "version": [
-    20250101,
-    1012
+    20260101,
+    601
    ],
    "deps": [
     "dash",
@@ -96945,8 +97485,8 @@
     "ht",
     "s"
    ],
-   "commit": "6221c85b37d7baee27288848fa38d5519cdeafd5",
-   "sha256": "16ffv1il866i8az6lddkhpjdvbslhsab2xk34byb08f817bczbq4"
+   "commit": "0782a1814104c556a39ac13f0d64f7a9d787899d",
+   "sha256": "06lrq3bwr6y24wcgl54j7ksbx52zklfha4ba4fzdibkk7znhwyyc"
   },
   "stable": {
    "version": [
@@ -97004,8 +97544,8 @@
   "repo": "magit/orgit",
   "unstable": {
    "version": [
-    20251123,
-    1801
+    20260101,
+    1851
    ],
    "deps": [
     "compat",
@@ -97013,22 +97553,23 @@
     "magit",
     "org"
    ],
-   "commit": "0444b8659620e5100ab8d09694c6ffe6841b24cd",
-   "sha256": "0yhpihk9hbymncm15xmvnidsb67bmm0swz86nkzs1k0i5drr8mrc"
+   "commit": "24c8fe48c477d561c2ce1720223f8c5aec664f4e",
+   "sha256": "0p1k171nmzscnzfrlc3paq94gbx46f52fx7djkr88xv7cgd5qgw4"
   },
   "stable": {
    "version": [
     2,
     1,
-    0
+    1
    ],
    "deps": [
     "compat",
+    "cond-let",
     "magit",
     "org"
    ],
-   "commit": "9a171dfc7775c9286318b26710fcbf223fbde056",
-   "sha256": "1w5g75mqigfjcwywhdlv6dqpj173wzkagaxsq38kx1j4p7i0sl2p"
+   "commit": "24c8fe48c477d561c2ce1720223f8c5aec664f4e",
+   "sha256": "0p1k171nmzscnzfrlc3paq94gbx46f52fx7djkr88xv7cgd5qgw4"
   }
  },
  {
@@ -97075,8 +97616,8 @@
   "repo": "magit/orgit-forge",
   "unstable": {
    "version": [
-    20251123,
-    1809
+    20260101,
+    1854
    ],
    "deps": [
     "compat",
@@ -97086,24 +97627,25 @@
     "org",
     "orgit"
    ],
-   "commit": "8b3de493a5b6db36c441202d1ba5b95a5be4dd91",
-   "sha256": "0qscfv6dwbdi7avmvbvrga0sv0qy6n92wmmcdq470fdicqyzgrv4"
+   "commit": "c2116b8701498bd11d8674065a5429d844985e46",
+   "sha256": "02cka68jrxcdzm12j7912zfgjj5ayw9avm6r59j59nc2kin3khmc"
   },
   "stable": {
    "version": [
     1,
     1,
-    0
+    1
    ],
    "deps": [
     "compat",
+    "cond-let",
     "forge",
     "magit",
     "org",
     "orgit"
    ],
-   "commit": "964a81d1e4e95a61e6304237172889b222fca845",
-   "sha256": "153z3g3nvggk8a7vpdhr2dm0pvgrypsalk51z7nwspv2cmb6daq3"
+   "commit": "c2116b8701498bd11d8674065a5429d844985e46",
+   "sha256": "02cka68jrxcdzm12j7912zfgjj5ayw9avm6r59j59nc2kin3khmc"
   }
  },
  {
@@ -97114,30 +97656,30 @@
   "repo": "tarsius/orglink",
   "unstable": {
    "version": [
-    20251101,
-    2047
+    20260101,
+    1845
    ],
    "deps": [
     "compat",
     "org",
     "seq"
    ],
-   "commit": "1f76298c90ee1c7f4b1c77ab2389f304ea75fc8b",
-   "sha256": "1bwyfpql49jns953skl4ndyzrx8y6i71ngb9y3fr7zaal2rcrwl2"
+   "commit": "0de830edc6ffc0b07b95284f545ffe7d7c37dfb8",
+   "sha256": "11173ja0cga82fp7qxw900l8wg5fhygi7d5qn0vi5hrh1rwyg9da"
   },
   "stable": {
    "version": [
     1,
     2,
-    8
+    9
    ],
    "deps": [
     "compat",
     "org",
     "seq"
    ],
-   "commit": "1f76298c90ee1c7f4b1c77ab2389f304ea75fc8b",
-   "sha256": "1bwyfpql49jns953skl4ndyzrx8y6i71ngb9y3fr7zaal2rcrwl2"
+   "commit": "0de830edc6ffc0b07b95284f545ffe7d7c37dfb8",
+   "sha256": "11173ja0cga82fp7qxw900l8wg5fhygi7d5qn0vi5hrh1rwyg9da"
   }
  },
  {
@@ -97283,11 +97825,11 @@
   "repo": "tbanel/orgaggregate",
   "unstable": {
    "version": [
-    20251216,
-    1352
+    20260109,
+    837
    ],
-   "commit": "710bcf8705aaf94ff749f41eead9d7a774a7d788",
-   "sha256": "0fkh8i4wv8yb1qciypd50mp347na46c32k94lgy7sawvlk7zh2hk"
+   "commit": "ec32afaf3942ff30d9284fbcc594511ca9269393",
+   "sha256": "0mb1hhp5mk0lmc6nd14nv2s09s1zb2dvqgzin73xr247vsgh8ykf"
   }
  },
  {
@@ -97298,11 +97840,11 @@
   "repo": "tbanel/orgtblasciiplot",
   "unstable": {
    "version": [
-    20230122,
-    816
+    20260111,
+    1140
    ],
-   "commit": "4160128045b271bc1aef3d14dbf0c5b53ae58bd2",
-   "sha256": "1zhhppk05av94i77s16mrjbbc55gvcsm8sk6l7rdfrsfaislabmw"
+   "commit": "56d27e6ab021d8aad59372480d4eaedb19850c2d",
+   "sha256": "0b9l10avwkhl146nrmda0xhiy6m20y1jllv2p91kcv16ng7xradl"
   }
  },
  {
@@ -97313,11 +97855,11 @@
   "repo": "tbanel/orgtblfit",
   "unstable": {
    "version": [
-    20250403,
-    2031
+    20260109,
+    925
    ],
-   "commit": "5d9a7efd23fdee4c6c79a74770cafba931c16c67",
-   "sha256": "1cxi469ggl7nmg1v0d55akka6lqsr5s12sm4a0ydyi6r5vbc9nwq"
+   "commit": "987e1a8de9debb416c61a3e2e35b79c1bd9fa568",
+   "sha256": "1hjvmanxh05pnni6aw7jbcbil2ir9nb6lcb45shc6js79l8217l8"
   }
  },
  {
@@ -97328,11 +97870,11 @@
   "repo": "tbanel/orgtbljoin",
   "unstable": {
    "version": [
-    20251216,
-    931
+    20260109,
+    917
    ],
-   "commit": "efc557bdb2dd4edeeabb473476d0dc2b207ea28d",
-   "sha256": "1882ckz78gaki4qsizyqak66bhi00grsy93p4gzmm0djqb25zjs7"
+   "commit": "66d02c1d197a9506f8df7a7e35f760bdbbcddb3b",
+   "sha256": "1q8aclyk3hhwa3cw8lxrlskpifv2rvi790nj5v804w12cnzwk8p4"
   }
  },
  {
@@ -97491,25 +98033,25 @@
   "repo": "minad/osm",
   "unstable": {
    "version": [
-    20251221,
-    1844
+    20260109,
+    1817
    ],
    "deps": [
     "compat"
    ],
-   "commit": "5cd646e6e5bffe53acccf3fc06cf74eb5227a9da",
-   "sha256": "0bwjqzk8s2jfmyqcsfq6j67l3cjq748mvk8dz9l3b40a7y95qwhg"
+   "commit": "7880b450138b3d260480e3e527fb3178cc8e2bc9",
+   "sha256": "0f2c1zhps2ln6xhsqwc67axp6d2hnnqckdr8xlppgzxbd4q7p4yn"
   },
   "stable": {
    "version": [
-    1,
-    12
+    2,
+    1
    ],
    "deps": [
     "compat"
    ],
-   "commit": "5cd646e6e5bffe53acccf3fc06cf74eb5227a9da",
-   "sha256": "0bwjqzk8s2jfmyqcsfq6j67l3cjq748mvk8dz9l3b40a7y95qwhg"
+   "commit": "7880b450138b3d260480e3e527fb3178cc8e2bc9",
+   "sha256": "0f2c1zhps2ln6xhsqwc67axp6d2hnnqckdr8xlppgzxbd4q7p4yn"
   }
  },
  {
@@ -97838,11 +98380,11 @@
   "repo": "jamescherti/outline-indent.el",
   "unstable": {
    "version": [
-    20251103,
-    1434
+    20260114,
+    1604
    ],
-   "commit": "832595bc0f6699171e9ebcafce3952e2a151cb26",
-   "sha256": "1f8s2w54abanb3vykyymsm8fqmwlgjhq0hcbd1z7r56p3pbamm90"
+   "commit": "9f5b72d22be8cccc1873f7b65ca9e0acad0b1e10",
+   "sha256": "05y0knsww8wha59i1yhxvmmgb19j50rppfkb2dw0n36bvbxhvr46"
   },
   "stable": {
    "version": [
@@ -97877,26 +98419,26 @@
   "repo": "tarsius/outline-minor-faces",
   "unstable": {
    "version": [
-    20251101,
-    1934
+    20260101,
+    1824
    ],
    "deps": [
     "compat"
    ],
-   "commit": "67a100641d0da0e75bd1f69b760e2b6c39fcb920",
-   "sha256": "0ipwgs6vg4pmabvmhnh4m5477xkqbs25v4qjq2ci0118yxma1fif"
+   "commit": "ad3ec4620b79ae5c3e840ed1f47f892c5f917d8c",
+   "sha256": "00l2pmvyglbl6440fkk0sm31a5l7gss4pmdnw1ar7vaqz4afwi4d"
   },
   "stable": {
    "version": [
     1,
     2,
-    1
+    2
    ],
    "deps": [
     "compat"
    ],
-   "commit": "67a100641d0da0e75bd1f69b760e2b6c39fcb920",
-   "sha256": "0ipwgs6vg4pmabvmhnh4m5477xkqbs25v4qjq2ci0118yxma1fif"
+   "commit": "ad3ec4620b79ae5c3e840ed1f47f892c5f917d8c",
+   "sha256": "00l2pmvyglbl6440fkk0sm31a5l7gss4pmdnw1ar7vaqz4afwi4d"
   }
  },
  {
@@ -98721,16 +99263,16 @@
   "repo": "emacsorphanage/ox-pandoc",
   "unstable": {
    "version": [
-    20250424,
-    908
+    20260113,
+    1929
    ],
    "deps": [
     "dash",
     "ht",
     "org"
    ],
-   "commit": "5766c70b6db5a553829ccdcf52fcf3c6244e443d",
-   "sha256": "1di51izd09x4z5ph3sqrlfllvmbcj77q421wndbs3q8z0w5a74q2"
+   "commit": "1caeb56a4be26597319e7288edbc2cabada151b4",
+   "sha256": "1wj9hmgi1xqyx3kc73rxj5w4a5lp861blkdvvg99b7abp2dp7xi1"
   },
   "stable": {
    "version": [
@@ -99410,14 +99952,14 @@
   "repo": "melpa/package-build",
   "unstable": {
    "version": [
-    20251205,
-    1541
+    20260115,
+    1042
    ],
    "deps": [
     "compat"
    ],
-   "commit": "bc2764a38de2790dd55a91bc14a5a3165f4ada72",
-   "sha256": "1b5kpzxa42z03d3id8sjpljvkj0s4349k1214qs9z73px12yv8j3"
+   "commit": "79cff850383c875119da351567ea4713875f269f",
+   "sha256": "1yqxj6dd7zckmy2hp1lyr3prcqg2qh8w5f7rd2jb53p5xwmnr8qy"
   },
   "stable": {
    "version": [
@@ -99565,30 +100107,6 @@
    ],
    "commit": "25a8c30210f6bd94634a7ff743a2f8be391ed3b3",
    "sha256": "0wklzqwds2dxf41g677rr9b5n3hviza5145j6aknj2mjjvsrb0zi"
-  }
- },
- {
-  "ename": "pact-mode",
-  "commit": "b8e11b488c937ac9290f2e6acde92a87024a9012",
-  "sha256": "1awmczhz4cl2vxrn0h1wqkrhy1n9p4j3ayksvgifr4cfhqlsxk6v",
-  "fetcher": "github",
-  "repo": "kadena-io/pact-mode",
-  "unstable": {
-   "version": [
-    20201219,
-    2223
-   ],
-   "commit": "f48a4faf5f8f8435423bda3888eca6ee67ee13a9",
-   "sha256": "1cmw2pxnzdd3y3f78a6l6770z2nmh0f8mydfw13fh5yfqdhv4vgx"
-  },
-  "stable": {
-   "version": [
-    0,
-    0,
-    5
-   ],
-   "commit": "5df7032cf9b61ae5aff36ac7d2a23b2ab0e00904",
-   "sha256": "0hdg5b3mnld8pcfiawn51dc65dfws6gr7j4fvjc2gnhypy36l8xl"
   }
  },
  {
@@ -99837,11 +100355,11 @@
   "repo": "joostkremers/pandoc-mode",
   "unstable": {
    "version": [
-    20251029,
-    1925
+    20260114,
+    1255
    ],
-   "commit": "8d6e976b465cb4fa59d12efe8159b781a57f915e",
-   "sha256": "068gwrgxvbm7p8i6qz3njkigxfxffmyx6bsga74vq7fmr3wcxyjb"
+   "commit": "8f46da90228a9ce22de24da234ba53860257640a",
+   "sha256": "185qhkaas4pzv80afzjmp9l9ypgiqkmkw98idpa0d4kz5pjbrr1m"
   },
   "stable": {
    "version": [
@@ -100083,26 +100601,26 @@
   "repo": "tarsius/paren-face",
   "unstable": {
    "version": [
-    20251101,
-    2048
+    20260101,
+    1846
    ],
    "deps": [
     "compat"
    ],
-   "commit": "b121bc08ecb0c11a89705ed9f77c5343e2baec04",
-   "sha256": "0bs5hdn7agyr0r0ywblpihp4x3gn89xdfvzsb8wlyd0gvc2rx6g9"
+   "commit": "2c279a236404b2eebacb435aa92d5e9c97939c03",
+   "sha256": "06ypi3hgrr9rigcb9gy5j4l9f3z7lnz1rssv1pqda55srkvcp39x"
   },
   "stable": {
    "version": [
     1,
     2,
-    2
+    3
    ],
    "deps": [
     "compat"
    ],
-   "commit": "b121bc08ecb0c11a89705ed9f77c5343e2baec04",
-   "sha256": "0bs5hdn7agyr0r0ywblpihp4x3gn89xdfvzsb8wlyd0gvc2rx6g9"
+   "commit": "2c279a236404b2eebacb435aa92d5e9c97939c03",
+   "sha256": "06ypi3hgrr9rigcb9gy5j4l9f3z7lnz1rssv1pqda55srkvcp39x"
   }
  },
  {
@@ -100137,11 +100655,11 @@
   "repo": "tarsius/paren-face",
   "unstable": {
    "version": [
-    20251101,
-    2048
+    20260101,
+    1846
    ],
-   "commit": "b121bc08ecb0c11a89705ed9f77c5343e2baec04",
-   "sha256": "0bs5hdn7agyr0r0ywblpihp4x3gn89xdfvzsb8wlyd0gvc2rx6g9"
+   "commit": "2c279a236404b2eebacb435aa92d5e9c97939c03",
+   "sha256": "06ypi3hgrr9rigcb9gy5j4l9f3z7lnz1rssv1pqda55srkvcp39x"
   }
  },
  {
@@ -100152,14 +100670,14 @@
   "repo": "justinbarclay/parinfer-rust-mode",
   "unstable": {
    "version": [
-    20251209,
-    617
+    20260101,
+    1949
    ],
    "deps": [
     "track-changes"
    ],
-   "commit": "40b4b9f226f115b8eec245ac8f97e43d1bfafa0f",
-   "sha256": "1yjxms5qnz79vxwyna5xh2wpyfaqdn0lasij4w32qhgpyw6c6l0f"
+   "commit": "6ee9f905c41f6368689ad12aa99516b9ee4fb06d",
+   "sha256": "0pini8nwnd69mziww5hwia3ick17ba5p3xblb2jx6rz30304pmgj"
   },
   "stable": {
    "version": [
@@ -100182,20 +100700,20 @@
   "repo": "dp12/parrot",
   "unstable": {
    "version": [
-    20220101,
-    518
+    20260111,
+    2133
    ],
-   "commit": "1d381f24d74242018e306d1a0c891bed9a465ac3",
-   "sha256": "0jvnaplab6bsq9pv89zl6amrs39ay6qlzgm0lls6ij9bbrsyjlvp"
+   "commit": "c2700b1d42f94f8cb574a0f96a143f4865b180b6",
+   "sha256": "17jyjv68j5lh6bvgph18rx8jkkfhbsikfcgjh1pgnsajw5s9rws5"
   },
   "stable": {
    "version": [
     1,
-    1,
-    1
+    2,
+    0
    ],
-   "commit": "13757524f1c708b866f4aaab5a9fb3599a1c4f56",
-   "sha256": "02anyi6mhw457pwsna3ycn1yxsavsmp6p96ffpwg1s7qidc44a4s"
+   "commit": "c2700b1d42f94f8cb574a0f96a143f4865b180b6",
+   "sha256": "17jyjv68j5lh6bvgph18rx8jkkfhbsikfcgjh1pgnsajw5s9rws5"
   }
  },
  {
@@ -100221,14 +100739,14 @@
   "repo": "jcs-elpa/parse-it",
   "unstable": {
    "version": [
-    20250101,
-    1011
+    20260101,
+    602
    ],
    "deps": [
     "s"
    ],
-   "commit": "19df0d8d67f0f3b73d80ad2db57a1790f3e43beb",
-   "sha256": "0nl47mlhl27y4cz6qvbch7g3da8jlx08ll7jb99jhn390p4syhxc"
+   "commit": "d65d74f4d057b0c7754424065c2e796dc0f89f6e",
+   "sha256": "1r5bp2v53lq1vmag4drqx20yzqzdibvvqx6l57r9w1g319rx16xs"
   },
   "stable": {
    "version": [
@@ -100375,16 +100893,16 @@
   "repo": "NicolasPetton/pass",
   "unstable": {
    "version": [
-    20250721,
-    1935
+    20260109,
+    1144
    ],
    "deps": [
     "f",
     "password-store",
     "password-store-otp"
    ],
-   "commit": "7651389c52919f5e0e41d9217b29c7166e3a45c2",
-   "sha256": "1nzwa4z7nm1m0y6sjp1nhargp6ah4hp5z7vaxfffgsb4hxcsawcs"
+   "commit": "de4adfaeba5eb4d1facaf75f582f1ba36373299a",
+   "sha256": "1by7rr1rjw8slxvkkkcg7g8qkwaz1bm0ylzj81p2rxi8xw3f2jq5"
   },
   "stable": {
    "version": [
@@ -100398,6 +100916,30 @@
    ],
    "commit": "35e3f86e96878520e690513cdbc1b2753b173e72",
    "sha256": "0jc8j421mlflspg24jvrqc2n3y5n3cpk3hjy560il8g36xi1049p"
+  }
+ },
+ {
+  "ename": "pass-coffin",
+  "commit": "7911819ede33c2c1ee2f3316df79012bb5b784d5",
+  "sha256": "0l02096hgg6clrn6n0g2kjyqqwcv293zr64l020lg7bdnz0gm1gf",
+  "fetcher": "codeberg",
+  "repo": "rch/emacs-pass-coffin",
+  "unstable": {
+   "version": [
+    20251231,
+    1407
+   ],
+   "commit": "202c9e3b67c5e0fe8d3631436c8c95f61586f88f",
+   "sha256": "1cbfr90dlf9ns2m35m38skmnx316iyb3w6kj03ycdxy9blfkrgqi"
+  },
+  "stable": {
+   "version": [
+    1,
+    0,
+    0
+   ],
+   "commit": "202c9e3b67c5e0fe8d3631436c8c95f61586f88f",
+   "sha256": "1cbfr90dlf9ns2m35m38skmnx316iyb3w6kj03ycdxy9blfkrgqi"
   }
  },
  {
@@ -101116,28 +101658,28 @@
   "repo": "vedang/pdf-tools",
   "unstable": {
    "version": [
-    20240429,
-    407
+    20260102,
+    1101
    ],
    "deps": [
     "let-alist",
     "tablist"
    ],
-   "commit": "30b50544e55b8dbf683c2d932d5c33ac73323a16",
-   "sha256": "1ci9g8aj77a34pgp21d768pglfw1h0dcw68d61xxlzwrrclzfhgx"
+   "commit": "e4b7f1f37cf59ddf025d609ffcdabe732a6e99ba",
+   "sha256": "0rxws42pjh4gw74qp55yril7bqnyfrs6k76xl2y5l625z28hlfyi"
   },
   "stable": {
    "version": [
     1,
-    1,
+    3,
     0
    ],
    "deps": [
     "let-alist",
     "tablist"
    ],
-   "commit": "a9c9a12c3ecf2005fa641059368ac8284f507620",
-   "sha256": "1v861fpzck3ky21m4g42h6a6y0cbhc4sjzpzqx0zxd7sfi7rn768"
+   "commit": "5245f092e35712df6559a7782a93bb61896175dd",
+   "sha256": "0lf6ksly7w27n00ymrgxn1xyzpx9bmld4dzn90ki07yph6js7h8x"
   }
  },
  {
@@ -101175,6 +101717,24 @@
    ],
    "commit": "5a1947c01a3edecc9e0fe7629041a2f53e0610c9",
    "sha256": "1b9zzvfsprf7x0v7l4dabdh5qdfhl7mm30vvqah8l10jvlf2wlc7"
+  }
+ },
+ {
+  "ename": "pdffontetc",
+  "commit": "c6d8128dec5648e57628dcd86bb2f7fd295ffc0d",
+  "sha256": "00vvn0ib34snvml4dpfq5hzvckwhdpps6f6y1bh6skwyvx8mzc32",
+  "fetcher": "github",
+  "repo": "emacsomancer/pdffontetc",
+  "unstable": {
+   "version": [
+    20260107,
+    2304
+   ],
+   "deps": [
+    "pdf-tools"
+   ],
+   "commit": "4adb8a339434f7c485dc38736c7c6461018876d4",
+   "sha256": "1ka1dd9fnif3c4hlms6cqymsqb5sb7n7fz4r37rimmvbqihbnkdz"
   }
  },
  {
@@ -101431,11 +101991,11 @@
   "repo": "jamescherti/persist-text-scale.el",
   "unstable": {
    "version": [
-    20250915,
-    132
+    20260114,
+    1606
    ],
-   "commit": "235e37b1ca38816b3bb882f7a40bb109e8739ea8",
-   "sha256": "1k2p7z95j331kw77q68151400723c6w4afjgrbgdjfj52przsxrk"
+   "commit": "4d7d58b75f6d998a69da1dd7d444642dfec38cf3",
+   "sha256": "1vnfq8vjhxjh5mkblv73dycbj4z690wmj1mzfyivjz20nfcrfavy"
   },
   "stable": {
    "version": [
@@ -101825,25 +102385,25 @@
   "repo": "emarsden/pg-el",
   "unstable": {
    "version": [
-    20251126,
-    1322
+    20251226,
+    1404
    ],
    "deps": [
     "peg"
    ],
-   "commit": "5545383173cf5db5276be07cf15801fd5a7b93a5",
-   "sha256": "0amwa4jnp7nlkq7ai5h18dqa60xjvalb4pmcwg8xa0prv4gs016w"
+   "commit": "d0062a20788b48dba693368faee62b5e42ef5961",
+   "sha256": "04m0200lwkdycp55i0mraxhm4y6si6d5q9d0bwp6kqwxrcpsks7a"
   },
   "stable": {
    "version": [
     0,
-    61
+    62
    ],
    "deps": [
     "peg"
    ],
-   "commit": "14a2041ed1076b6b24b96b2e6f0f14ebc4f1ac4d",
-   "sha256": "09fd0rc3fwxxsc9bdvnq0fy6ikp5ml5hadd7d8y8s7p6qz0k44zr"
+   "commit": "e63d6c7552dab58a056283b2292c7af6322f9703",
+   "sha256": "0fjzrn5b4s00km71ya98vwwfyvd4rvcywxdxqzy5xfrv8crm92w6"
   }
  },
  {
@@ -102282,16 +102842,16 @@
   "repo": "emacs-php/phpactor.el",
   "unstable": {
    "version": [
-    20251112,
-    706
+    20251226,
+    855
    ],
    "deps": [
     "async",
     "composer",
     "php-runtime"
    ],
-   "commit": "d0dd8d739812d60f0765276d22add93dc7c61bb9",
-   "sha256": "13xyaymsz37v6gx71f085v7irfm5rvwbsb2547fjs740ps5w2810"
+   "commit": "a4371b525afd5cd74c24461c50a489a1f459bd38",
+   "sha256": "11iz49m0hgrinp3x5sgjl6b43h0s280v577p9rh4jng5bjxp6nnp"
   },
   "stable": {
    "version": [
@@ -102407,6 +102967,36 @@
    ],
    "commit": "4212307bbcfd8accd2abfa7e4ab55a6751a0b11b",
    "sha256": "1silbfmv85r73pbc7f5cm4znc6644ngihfnhibk1fgp9j0rf7ahc"
+  }
+ },
+ {
+  "ename": "pi-coding-agent",
+  "commit": "c48dc93e13d7990c27f8225d2034c392d8d55979",
+  "sha256": "0h3iynz6gl6qrh621avkzdm3jlnx6j835cg6y9qhmgj2scqd229n",
+  "fetcher": "github",
+  "repo": "dnouri/pi-coding-agent",
+  "unstable": {
+   "version": [
+    20260117,
+    2159
+   ],
+   "deps": [
+    "markdown-mode"
+   ],
+   "commit": "b734fe0b2007126bf2c33bf0ef7cb1c45d8bd365",
+   "sha256": "1vrd9b22q9w6z82m4ixzmwfbnibckzdbwmzmqmxi8g2l4czgp68h"
+  },
+  "stable": {
+   "version": [
+    1,
+    1,
+    0
+   ],
+   "deps": [
+    "markdown-mode"
+   ],
+   "commit": "1bcb63da9014121159fd43bd20d691a38e951bc0",
+   "sha256": "1w62wh3di14g6xcip8znb4p4ffnsm9irim3jlf26gkmv1pgd01ag"
   }
  },
  {
@@ -103516,11 +104106,11 @@
   "repo": "emacsmirror/po-mode",
   "unstable": {
    "version": [
-    20231006,
-    1425
+    20260102,
+    409
    ],
-   "commit": "ca125eba813a6b29b5fbe7ea8a2e3d92f225ab8c",
-   "sha256": "0367gim5wvr3hpc7jwqfkzvjhpd9bqdkwgnbqbvbml5n3jgn93zn"
+   "commit": "5500e864a5aab5254efd7da11b57faefec08134e",
+   "sha256": "0af84q303f11xbbmkz8qy24yg4rby43d40lxkg8zlh9r200yp03v"
   },
   "stable": {
    "version": [
@@ -104218,16 +104808,16 @@
   "repo": "SqrtMinusOne/pomm.el",
   "unstable": {
    "version": [
-    20250202,
-    1202
+    20251223,
+    1344
    ],
    "deps": [
     "alert",
     "seq",
     "transient"
    ],
-   "commit": "ee7b60c65e3d15e0fcf2169ff3ba4b43ebaa65d6",
-   "sha256": "1q8rak8gbmwbnm3r4cvd92bkdbwp5x28jk8vyw1sgpif71wizm01"
+   "commit": "f198afa7519c365d1d929e7f468caed415df1c43",
+   "sha256": "0spj2xb083avqn3kq44gc8q8ljmqbhmi8r2azw04xkizzm1v1d2n"
   },
   "stable": {
    "version": [
@@ -104436,11 +105026,11 @@
   "repo": "auto-complete/popup-el",
   "unstable": {
    "version": [
-    20250101,
-    843
+    20251231,
+    1622
    ],
-   "commit": "7a05700a37aae66d2b24f0cd8851f65383a5cf96",
-   "sha256": "1mphrwcdfcknkp874v4yk1pczqb65dyhgjlqwm3c8c2gx3map3mx"
+   "commit": "45a0b759076ce4139aba36dde0a2904136282e73",
+   "sha256": "0igk52f90n831pxmwk7piyk1g5sagl0qpqwwi9yi0iwsbl7if7bp"
   },
   "stable": {
    "version": [
@@ -104576,11 +105166,11 @@
   "repo": "emacsorphanage/popwin",
   "unstable": {
    "version": [
-    20240925,
-    752
+    20260103,
+    1800
    ],
-   "commit": "58adcd0ca7c3dbd58626ec7019252d64cbc73042",
-   "sha256": "1mqwzc6fwhwq1kl8b3i1hm2ylfh8blrxrw6mzr5wyifbwpg7dq10"
+   "commit": "f7a39759180fa88f3890c3c5f35379ab086e04fa",
+   "sha256": "0pqpip52f7wdk9ghq1pki51lm4gpxv82hfir02jp5jzcq5ik7fmk"
   },
   "stable": {
    "version": [
@@ -104590,6 +105180,21 @@
    ],
    "commit": "215d6cb509b11c63394a20666565cd9e9b2c2eab",
    "sha256": "1x1iimzbwb5izbia6aj6xv49jybzln2qxm5ybcrcq7xync5swiv1"
+  }
+ },
+ {
+  "ename": "porg",
+  "commit": "1a4c846de699c4b21fe6b280faaa15de28982ea1",
+  "sha256": "1lsbjmc0bxj0dl27la42fnxawl7zdc7mmn7k513s5bq9jlshvrxj",
+  "fetcher": "github",
+  "repo": "laluxx/porg",
+  "unstable": {
+   "version": [
+    20251230,
+    410
+   ],
+   "commit": "557fecde1f02fa7ffb13b0dc5da3432171946086",
+   "sha256": "1qh0lrcc0wlhkmz5rk805jn4pfbj8jx6rshc52myqia8shabdg7c"
   }
  },
  {
@@ -105662,11 +106267,11 @@
   "repo": "ideasman42/emacs-prog-face-refine",
   "unstable": {
    "version": [
-    20250913,
-    2251
+    20251224,
+    840
    ],
-   "commit": "c9981a933e2a60ed59b61f1c8134c347010f8cc8",
-   "sha256": "0zbfprcp22m7511rkfa2jbdxm5ygm4wv28kzhw1xfmsw7w8fk2ca"
+   "commit": "67237a7f4ad6da0a044b99c37da1eac4b3f0f906",
+   "sha256": "00k163zd7h1fzkvqs567yvn55nrq4ryrdmzd03xhwk7zw7c2vmw7"
   }
  },
  {
@@ -105737,11 +106342,11 @@
   "repo": "jcs-elpa/project-abbrev",
   "unstable": {
    "version": [
-    20250101,
-    1011
+    20260101,
+    602
    ],
-   "commit": "05eaf3a0f00b68d427b76cd0410519783999807d",
-   "sha256": "0sl8jrg7gscbc3914nx8cn32fr00xvlihy1aza04b5lf0k0l3qcg"
+   "commit": "25ae8a4ea43221955ae3d038dccbda90c43840ae",
+   "sha256": "0d1z85x4j3jccy7dh8w4zbhyvlq57lnjvl5zj231b53ynk03zmky"
   },
   "stable": {
    "version": [
@@ -106007,11 +106612,11 @@
   "repo": "bbatsov/projectile",
   "unstable": {
    "version": [
-    20250704,
-    908
+    20260109,
+    1335
    ],
-   "commit": "5c1b32d9548982d470c3fd48639fb0ec8d239c50",
-   "sha256": "122lxq9c2d78mlf40z4g2gm93hm3q9rv6jcjlrw52h031zimwsgn"
+   "commit": "f19262ae3f2764f10a4d087497058cdb9a0fd3df",
+   "sha256": "1gxsnsirf2nfmsg5j9iibya4r9drdmhni63fpf9k0mcmzkj4sfjv"
   },
   "stable": {
    "version": [
@@ -106524,11 +107129,11 @@
   "repo": "ProofGeneral/PG",
   "unstable": {
    "version": [
-    20251120,
-    1746
+    20260113,
+    1228
    ],
-   "commit": "d60382db080370501bfe81d2a4f069035c8372a7",
-   "sha256": "0brab0dqhsla1hw2dzwmg7abnf3pf46csqlpwnm4i0qh7bi6h92z"
+   "commit": "e164eca4e94fe9db750e1a350bb462be30c4469a",
+   "sha256": "0xf98l2bszm2y0kn55m93r0gzpgi8wh9mw2rsfczxvq68jhlywld"
   },
   "stable": {
    "version": [
@@ -106637,10 +107242,10 @@
   "stable": {
    "version": [
     33,
-    2
+    4
    ],
-   "commit": "7ccf2060af4cd13c44a8659d0999be6c7a98fcc1",
-   "sha256": "08qwz574h9l2q7bj63v43y1lpidsmb5cv2z71dwlv52mmw2rc2sa"
+   "commit": "edaa823d8b36a8656d7b2b9241b7d0bfe50af878",
+   "sha256": "1lgrfnxdzp5jjfal2apkqwq37wf6g7jn2cvgv5iypsvf9f4nfrzy"
   }
  },
  {
@@ -106809,15 +107414,15 @@
   "repo": "thierryvolpiatto/psession",
   "unstable": {
    "version": [
-    20250307,
-    1629
+    20260105,
+    456
    ],
    "deps": [
     "async",
     "cl-lib"
    ],
-   "commit": "371e23c9cc1ad5d8ccb149ccdaf6500935f27da1",
-   "sha256": "0js23n82xhygg6hwzsy93y9jyicjp14n1vdplyskbc5g6386sa0m"
+   "commit": "ebe81c18f94bb74e0b795bbe6d4fa9284ccbbf5e",
+   "sha256": "1w8walq9ss8ag6lqk9w22lfmc6ifcy5m22wjk6lsrlb52lp52dm2"
   },
   "stable": {
    "version": [
@@ -107368,11 +107973,11 @@
   "repo": "ideasman42/emacs-py-autopep8",
   "unstable": {
    "version": [
-    20251215,
-    1113
+    20260108,
+    1346
    ],
-   "commit": "262e0a55bdc486bdea03839d16fb05d975ab2750",
-   "sha256": "1m0n61shn1553wccd226q86spzrprwac38d9c9px27cxj8bcggdc"
+   "commit": "f07d487a6cd63a8c8a44ec8b5e93b762aca97566",
+   "sha256": "1gr88964n503hj4x91mpysvn145n9ns07l77dgpv8drc08qzxnyk"
   },
   "stable": {
    "version": [
@@ -107544,6 +108149,24 @@
    ],
    "commit": "a878304202ad827a1f3de3dce1badd9ca8731146",
    "sha256": "1mmzqdigxx46my0h9497l25cjydy3vykg6slxkch4dzvhhlbap48"
+  }
+ },
+ {
+  "ename": "pyasm-mode",
+  "commit": "b0f254a0ddc8d32c575ac35f94d92969de6a054c",
+  "sha256": "0i3bqxvpi0r6572251c3j2h2lp3l822r7dbphxvwdv3rq4m7fxsv",
+  "fetcher": "github",
+  "repo": "rocky/emacs-pyasm-mode",
+  "unstable": {
+   "version": [
+    20260117,
+    2029
+   ],
+   "deps": [
+    "compat"
+   ],
+   "commit": "3d3dc5a820a488a1fb9618fda5d7307a5eae75ec",
+   "sha256": "03ywy2wi76dhna0sxzs9nrppfcxkqvvzh32k74a6ydbcvkk46al3"
   }
  },
  {
@@ -107730,28 +108353,28 @@
   "repo": "tumashu/pyim",
   "unstable": {
    "version": [
-    20251125,
-    839
+    20251230,
+    809
    ],
    "deps": [
     "async",
     "xr"
    ],
-   "commit": "bc85ecc3b2521d05c7585df97939f7c0ec5b1496",
-   "sha256": "0kimpayh9g4snvyn61iydc8ldmaska1xz7mr0x0v6k24r6xmqpvd"
+   "commit": "a56c8d992c872addcfc295c409a7bae70d00af87",
+   "sha256": "1sv46dxhwsr21l83y6an76yhclngpa22jkhdhnzl952p418k9vd4"
   },
   "stable": {
    "version": [
     5,
     3,
-    5
+    6
    ],
    "deps": [
     "async",
     "xr"
    ],
-   "commit": "bc85ecc3b2521d05c7585df97939f7c0ec5b1496",
-   "sha256": "0kimpayh9g4snvyn61iydc8ldmaska1xz7mr0x0v6k24r6xmqpvd"
+   "commit": "a56c8d992c872addcfc295c409a7bae70d00af87",
+   "sha256": "1sv46dxhwsr21l83y6an76yhclngpa22jkhdhnzl952p418k9vd4"
   }
  },
  {
@@ -108297,16 +108920,16 @@
   "repo": "wbolster/emacs-python-pytest",
   "unstable": {
    "version": [
-    20250726,
-    1726
+    20260117,
+    2218
    ],
    "deps": [
     "dash",
     "s",
     "transient"
    ],
-   "commit": "ed2ecee09d1cccb4245842860d91940cb2fda769",
-   "sha256": "1787bks1zi47qglib42vnlqa7m4899n5vh1ics0013ldd89jqrr1"
+   "commit": "78b5ea1d19c7e365ac00649d13c733954b11f822",
+   "sha256": "1s7slp14lrb4iik847ybk6dsqvcb4r1b50hx3pv3hn63rvpwc5jq"
   },
   "stable": {
    "version": [
@@ -108516,11 +109139,11 @@
   "repo": "psaris/q-mode",
   "unstable": {
    "version": [
-    20251220,
-    1731
+    20260110,
+    1639
    ],
-   "commit": "626743cb7da52e23f10290e579a31f10f68d1295",
-   "sha256": "00pg8pmmri8nhjpw2pj9qw6pgp8z8pgcmqap239sdxcjihm50gi2"
+   "commit": "ce1c5e827c29f7799b699aa0a476f4f06a1cf7ff",
+   "sha256": "064xqqr2fdk037dnasibmayx9jsi3g6m36xbdmdp8niil5250xv8"
   }
  },
  {
@@ -108554,19 +109177,19 @@
   "repo": "ruediger/qrencode-el",
   "unstable": {
    "version": [
-    20240922,
-    1231
+    20260109,
+    2234
    ],
-   "commit": "4bbb1f331d7e394470e3fbf172329a9b70174cc8",
-   "sha256": "00z0jdsjbind7c0354mlmmni5hx8malclxf1ggbjklx5ibc0jna5"
+   "commit": "023c61309e8f9e7b27fd28fe4d71a2217b2f3f9d",
+   "sha256": "0ivcdr89531yps6izk7fs7xqrz00m4b02c5rrbjalz33sj06ss41"
   },
   "stable": {
    "version": [
     1,
-    2
+    3
    ],
-   "commit": "d7896e9594d45d7b2622d4617ff9cb7037378167",
-   "sha256": "0yrshahci319lnjdpsksdy11a69k1n91qk9r2zfyhqmng09s6i0y"
+   "commit": "023c61309e8f9e7b27fd28fe4d71a2217b2f3f9d",
+   "sha256": "0ivcdr89531yps6izk7fs7xqrz00m4b02c5rrbjalz33sj06ss41"
   }
  },
  {
@@ -108736,15 +109359,15 @@
   "repo": "quelpa/quelpa-leaf",
   "unstable": {
    "version": [
-    20250101,
-    904
+    20251231,
+    1621
    ],
    "deps": [
     "leaf",
     "quelpa"
    ],
-   "commit": "e800fc73c3aa0a2a4bfe9552a5d45f34e4d98cd3",
-   "sha256": "1jzv1xxf7yg12pckq23x0x0rqg0ngq5dhpqw6xmqshcngsnzxvqa"
+   "commit": "f9e9ef474a2f259d092c7262771e10d17aefbd7f",
+   "sha256": "1mf8b7va1l844y1scxm3ngalmvh3f86b5cy5yipa91djq5wpn3j3"
   },
   "stable": {
    "version": [
@@ -108815,11 +109438,11 @@
   "repo": "jamescherti/quick-fasd.el",
   "unstable": {
    "version": [
-    20251103,
-    1434
+    20260114,
+    1535
    ],
-   "commit": "98b53d3dbf8446002948d4e81181510ac5b55829",
-   "sha256": "1rca23s8x4jh2v1n41bdsgq7gyjyhqnk11cnzsr9q53041ijlvi3"
+   "commit": "7f295404a9d5f93450c071e6226d8f52e574ab8b",
+   "sha256": "1b2hkvzisxdv46iyf5b3pfyw3s99v57klm5clscpwbzh8n4dnmza"
   },
   "stable": {
    "version": [
@@ -108869,11 +109492,11 @@
   "repo": "jamescherti/quick-sdcv.el",
   "unstable": {
    "version": [
-    20251202,
-    1728
+    20260114,
+    1535
    ],
-   "commit": "43385cddb1e0cad978ac007079f33a788cc5457a",
-   "sha256": "1r881b5j207376zj73z9y54r8v0hjizh0lz8wckfsz2dhyqa00ri"
+   "commit": "10be5e6d499da524000d1b6891080d01d5b9a949",
+   "sha256": "1fyshazwr9pkfwf72imbbl2nnvif6f0qgpq6s2ivwc0vj1087wh4"
   },
   "stable": {
    "version": [
@@ -108927,14 +109550,14 @@
   "repo": "emacsorphanage/quickrun",
   "unstable": {
    "version": [
-    20250503,
-    2058
+    20260103,
+    1800
    ],
    "deps": [
     "ht"
    ],
-   "commit": "bae8efb8c5bc428e4df731b5c214aae478c707da",
-   "sha256": "1ci1flsa8c5ydmkrxnync1zkf6d26ld08h9n71ffzpxhkdxgph8v"
+   "commit": "9199e222f95104ee83e115a9d5ac159d86816706",
+   "sha256": "0id73ph00n9vc24phfmdivnsil2flmkv8wlmqfdpz7lcf1242bsl"
   },
   "stable": {
    "version": [
@@ -109128,14 +109751,14 @@
   "repo": "greghendershott/racket-mode",
   "unstable": {
    "version": [
-    20251220,
-    1436
+    20260117,
+    1713
    ],
    "deps": [
     "compat"
    ],
-   "commit": "577af47246e1ce9fe5c17847eefe0e9513ca7049",
-   "sha256": "10nybls7gmdfl29f7gc6cx3dddhgvrkhnv45rda58spixwijdl2l"
+   "commit": "71f27c643dadf70847e447e773760df6df48fe5a",
+   "sha256": "1a2h6hmylh1hih7ndn4avp9x462vgc45pf7w325kd7kkz8m6sy39"
   }
  },
  {
@@ -109439,11 +110062,11 @@
   "repo": "punassuming/ranger.el",
   "unstable": {
    "version": [
-    20251109,
-    5
+    20260117,
+    2303
    ],
-   "commit": "8774f1bbb2754df7ae79dab8b75a6ce9285cc926",
-   "sha256": "0a4vj854dj28k5z818zqvks4qyqq5asnbpmgv6qq3gi9nrmz9sdz"
+   "commit": "8a7e0f246049789953b65e2776bfdf2a80d25bca",
+   "sha256": "0yqcy83hf9bmrf405inn1csw3w0pjr3w8jsnxhhba2wkl5k14va1"
   },
   "stable": {
    "version": [
@@ -109895,19 +110518,20 @@
   "repo": "ChillarAnand/real-auto-save",
   "unstable": {
    "version": [
-    20200505,
-    1537
+    20260107,
+    1112
    ],
-   "commit": "8e51241e5ba7b07b91d8188c14cf193017640292",
-   "sha256": "0yn0ibbda8bjqjhiqhmbvv7p8c52n65mi95v91nkfcj60hwyglnq"
+   "commit": "b74a9fd408196c9333b465852c76525df0371ad1",
+   "sha256": "00jpkj0prb1yvjykhbwm67dz6ldridj56lczq3yxj296sq3im6g7"
   },
   "stable": {
    "version": [
-    0,
-    4
+    26,
+    1,
+    0
    ],
-   "commit": "879144ca7e9bfa09a4fb57d5fe92a80250311f1e",
-   "sha256": "1ka5q2q18hgh7wl5yn04489121bq4nx369rz8nb7dr5l14cas0xm"
+   "commit": "b74a9fd408196c9333b465852c76525df0371ad1",
+   "sha256": "00jpkj0prb1yvjykhbwm67dz6ldridj56lczq3yxj296sq3im6g7"
   }
  },
  {
@@ -109933,16 +110557,16 @@
   "repo": "realgud/realgud",
   "unstable": {
    "version": [
-    20251024,
-    2145
+    20260111,
+    1242
    ],
    "deps": [
     "load-relative",
     "loc-changes",
     "test-simple"
    ],
-   "commit": "56a8d82830ad65c9cbb9c694617f078f007281ac",
-   "sha256": "1n232jphfgqbb44p806bpgg2wisbmr5iz09js71knk7n5gslrz25"
+   "commit": "5fb027b628ebe9b54bcba8b0749dfa768275a77f",
+   "sha256": "13sxikl82bz0an0s2nl62w4x5pnhk4mj8bl30y14qy86gpvp4p8j"
   },
   "stable": {
    "version": [
@@ -110025,15 +110649,15 @@
   "repo": "realgud/realgud-lldb",
   "unstable": {
    "version": [
-    20241119,
-    209
+    20260105,
+    1658
    ],
    "deps": [
     "load-relative",
     "realgud"
    ],
-   "commit": "deacd070e8ab8830f4d577fee37136ad89183d13",
-   "sha256": "1yn51aavvz5v4l27afzqbmh77fi1gpqsb89l7ladlv1d6fbzh3z9"
+   "commit": "2521026a8dc8f1b6ce491a580be21808f6f5f1df",
+   "sha256": "0jc2gyws4w33gq01iaklk8h2lf0mi8cc43q3ffy1jdkplwdp7d1b"
   },
   "stable": {
    "version": [
@@ -110204,11 +110828,11 @@
   "repo": "xendk/reaper",
   "unstable": {
    "version": [
-    20250123,
-    619
+    20260116,
+    2011
    ],
-   "commit": "7515ef42e0bfb0fd45d2e283e654271fe20cf447",
-   "sha256": "0lgsyabksiqlsh0m7x0ngryxkjpwl2lx42apjnpcbhl0ddwz9qhm"
+   "commit": "747d53b4a7db77648931ae1396151ae447404b08",
+   "sha256": "04qjplbm5wj0iy1b473yz3angkb7x78gs0yg951222a004fzg9a9"
   },
   "stable": {
    "version": [
@@ -110252,11 +110876,11 @@
   "repo": "nickdrozd/reazon",
   "unstable": {
    "version": [
-    20211229,
-    1733
+    20260101,
+    1930
    ],
-   "commit": "da3c4a8acf236eddb73348056e08bea330e868c0",
-   "sha256": "1q57qqg8cd5rhn841afk7qg2v9r141bm8b1hnaci6wpy3zw5gm8s"
+   "commit": "377e879202943eba10b812f372d6cb00aa344fe9",
+   "sha256": "167z0pq26c2170cviqfc69b6a7205lc4rr4sqw04l5irzm1vxgw6"
   },
   "stable": {
    "version": [
@@ -110409,11 +111033,11 @@
   "repo": "ideasman42/emacs-recomplete",
   "unstable": {
    "version": [
-    20251214,
-    1150
+    20260108,
+    1321
    ],
-   "commit": "be53d7b0c5734c90e45252ba24d5913ee178a925",
-   "sha256": "03qf3wmz64598k7b7fj3pqdkw6jcf1dapagibdbshikvfa95zcyc"
+   "commit": "d580e7f0bdf885d3cc5948197ff6e1f4785aa712",
+   "sha256": "13gpjxb3bnl4lffs0rdxb87sxpvmm1lqmy7i8ylcxzz4rq8z0g2z"
   }
  },
  {
@@ -110471,14 +111095,14 @@
   "repo": "thierryvolpiatto/rectangle-utils",
   "unstable": {
    "version": [
-    20240830,
-    306
+    20260105,
+    501
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "0d9c5dcef2d660cf6b67fc52f18a720d02514f01",
-   "sha256": "0gqw2k715idgipbdkgyyh3kakw2cblgmxcxjqr4b1ga5fzqjzvs8"
+   "commit": "309034e06fcab69eff094709ba98af9d607dbcbc",
+   "sha256": "13ihnli9i1rrcc1j4dcm00q8yf5f3iqyyyhx8y45r8xy3pw7pyhn"
   },
   "stable": {
    "version": [
@@ -110524,14 +111148,14 @@
   "repo": "minad/recursion-indicator",
   "unstable": {
    "version": [
-    20250921,
-    1714
+    20260101,
+    1342
    ],
    "deps": [
     "compat"
    ],
-   "commit": "91140813d5f54f2ab56116914a10d1f7aae65826",
-   "sha256": "1jrkhljpcqmhr3frkrjf0wm6nk9d4dvp41j5i1is2sd0nmcl1s64"
+   "commit": "0f5fc36ea6c1312708b00ee3ac9817511150fc0b",
+   "sha256": "111ymis99rc5g91xzhqv2wfqp9fkdqldin4s37fb0hir9jmdsc5z"
   },
   "stable": {
    "version": [
@@ -111056,11 +111680,11 @@
   "repo": "ideasman42/emacs-repeat-fu",
   "unstable": {
    "version": [
-    20251126,
-    529
+    20260108,
+    1320
    ],
-   "commit": "7efdeecb1eff76f2ae8d5b38d7572b7821b572e1",
-   "sha256": "10aaavnn81i27a3lr2a4y5ni1m9az4nvqrk6fpwi6pd0alkic0sn"
+   "commit": "a08e8774e757202dc1aa453892c88e961b8240d9",
+   "sha256": "1vc6xbihi4rqfiivvl79j2lijkdbvk6b2717byllzyngbrip5i50"
   }
  },
  {
@@ -111744,15 +112368,15 @@
   "repo": "jcs-elpa/reveal-in-folder",
   "unstable": {
    "version": [
-    20250101,
-    1011
+    20260101,
+    602
    ],
    "deps": [
     "f",
     "s"
    ],
-   "commit": "f3b7d1edcf8534152ce205bf45d7cae2b7793263",
-   "sha256": "139xhkmalqfbxcqi2ci3zglrh7rzgm8azww41jfqlcgssyj7r9w0"
+   "commit": "70c9ba29705ce6a0fc7a718cc4d6016b9691d408",
+   "sha256": "160a4j2n89m73si7h5r9ljxmx657v3g643y4f1a1iww7kw24kbg6"
   },
   "stable": {
    "version": [
@@ -112808,11 +113432,11 @@
   "repo": "vs-123/royal-hemlock-theme",
   "unstable": {
    "version": [
-    20251222,
-    933
+    20260110,
+    903
    ],
-   "commit": "e31295dc931b13004548b5e6acec2d13511115b9",
-   "sha256": "1h0ygwv8q9s5mjcfzj20i6rzhlrvnb6ba4h9jd5wacrbgj71grrl"
+   "commit": "50c01627b7132feb6549e9498a41e12a8d53add7",
+   "sha256": "0fasipvx9b3q64cxmqkw347ii5bggih9mmc0s74zy7z7rzk276i7"
   }
  },
  {
@@ -112913,11 +113537,11 @@
   "repo": "Andersbakken/rtags",
   "unstable": {
    "version": [
-    20250801,
-    1701
+    20251228,
+    2249
    ],
-   "commit": "a09caa2d56aa9523222243764e99477458447913",
-   "sha256": "0l41pxshr3086jz8lsmf6wqzjz246ldkgcyyi1mf85g9gn5ncj0x"
+   "commit": "829a6298d6bfba8ed541570fcbe3daf5ce3135d0",
+   "sha256": "1qzd08sc3kg0cmfssdbdn595iwwalxhb5b43dsamzgfc3xhd7qap"
   },
   "stable": {
    "version": [
@@ -113526,20 +114150,20 @@
   "repo": "dunmaksim/emacs-russian-techwriter-input-method",
   "unstable": {
    "version": [
-    20251010,
-    538
+    20260101,
+    1209
    ],
-   "commit": "a568c8a3f409f7f9b5cb12143f277af78fef9a26",
-   "sha256": "0h6apa5xxzllq5ly7hfw63w0h6sy1g172i0v0mx5wl0sndqqyjh1"
+   "commit": "10a82cb6e92db1e7c5c86d024a74a718d8d17005",
+   "sha256": "1kam71x2wd79xfrgbma73nsm9p725n5xaq0z65igrf6mva5l621j"
   },
   "stable": {
    "version": [
     1,
     0,
-    1
+    2
    ],
-   "commit": "0798a620136e7cb6a33e5c2952ed658a65633f9d",
-   "sha256": "1vm8a5w1kppi9zcq4gq1jqafkxq1lcvf9rd89fj0xda86ch79y4q"
+   "commit": "10a82cb6e92db1e7c5c86d024a74a718d8d17005",
+   "sha256": "1kam71x2wd79xfrgbma73nsm9p725n5xaq0z65igrf6mva5l621j"
   }
  },
  {
@@ -113565,11 +114189,11 @@
   "repo": "rust-lang/rust-mode",
   "unstable": {
    "version": [
-    20250705,
-    1444
+    20260118,
+    536
    ],
-   "commit": "f7334861bfc1d3dbcfbde464751837be2ec09ef3",
-   "sha256": "0cw03vbjq7wdkvpbc31lf9ppndc9yfgzx3mb1hzymzbjdp3g66pm"
+   "commit": "4adb3a729653315ed3efcf3e89f20d940dfe0e2d",
+   "sha256": "028s0nh2y1jgmni3ypr8vy1531wh5pjrhd2f78a86xim9nkamdx5"
   },
   "stable": {
    "version": [
@@ -113999,11 +114623,11 @@
   "repo": "Kyure-A/satysfi-ts-mode",
   "unstable": {
    "version": [
-    20240319,
-    321
+    20260109,
+    532
    ],
-   "commit": "b40d55ebd6ffeadadb85aabaf2e636110c85370c",
-   "sha256": "0l6n116nrvka2vpwkhd7pzrzjxmcjl4m8fscbk3rjl26xq139mpc"
+   "commit": "24bb037c8a45b3cd291f83cc4886cf9118c06777",
+   "sha256": "1p20mbx271c9n971lv43pj9h73xvy2ybh0gvdw5qygraaiiksf2z"
   }
  },
  {
@@ -114201,25 +114825,40 @@
   "repo": "openscad/emacs-scad-mode",
   "unstable": {
    "version": [
-    20251007,
-    1702
+    20260117,
+    1653
    ],
    "deps": [
     "compat"
    ],
-   "commit": "b130730a3123387e69c85cf10633701ea447fa2a",
-   "sha256": "0k77jncalzvhmcdb2nn8j0h4xba8p805xnciid2r93w2dj1swnz6"
+   "commit": "546d1507cd131f55ca930de7ae1518884e8221f4",
+   "sha256": "19mn6z98c8s7mspa7j8xw7za33gmpsy4iw2r9xiggdv7yh6mh8h8"
   },
   "stable": {
    "version": [
-    97,
+    98,
     0
    ],
    "deps": [
     "compat"
    ],
-   "commit": "44b4ac086bd01791ff2ccb25234b4e5d701bc10a",
-   "sha256": "1h86z2qn9q7ww2m7p992fx8abzdffcd3bcp3bmck3c9q2aksjl5j"
+   "commit": "546d1507cd131f55ca930de7ae1518884e8221f4",
+   "sha256": "19mn6z98c8s7mspa7j8xw7za33gmpsy4iw2r9xiggdv7yh6mh8h8"
+  }
+ },
+ {
+  "ename": "scad-ts-mode",
+  "commit": "d9512f35e339598254c46dd6cf0c1495d473a8d3",
+  "sha256": "188zji7ws9azn17x9hjq09q7nq3kivairlzw8303hgwzn3yxzh6z",
+  "fetcher": "github",
+  "repo": "yoshinari-nomura/scad-ts-mode",
+  "unstable": {
+   "version": [
+    20260112,
+    423
+   ],
+   "commit": "99e5e0f387de595f81aaf2d41572a8a851921e67",
+   "sha256": "125pay538hbxji9q5b7hmgvyfqzv7ygscdirjin5dk3lzkjx542x"
   }
  },
  {
@@ -114230,11 +114869,11 @@
   "repo": "hvesalai/emacs-scala-mode",
   "unstable": {
    "version": [
-    20241231,
-    839
+    20260118,
+    942
    ],
-   "commit": "661337d8aa0a0cb418184c83757661603de3b2e3",
-   "sha256": "1nmbgs0ibg1rq8s47f7znp3njcpmvcifkln800ph3hqpyf9lj33z"
+   "commit": "50bcafa181baec7054e27f4bca55d5f9277c6350",
+   "sha256": "1kvq9zsshx09aw88ji4gylp8w4mx0dwh1jz5dgkwgbqq8h8n23gx"
   },
   "stable": {
    "version": [
@@ -114652,11 +115291,11 @@
   "repo": "ideasman42/emacs-scroll-on-drag",
   "unstable": {
    "version": [
-    20251215,
-    1143
+    20260108,
+    1316
    ],
-   "commit": "86f335ff594aed225423d581bbe5690534c1dd12",
-   "sha256": "1lvksi2yivizqw833glic4sipyc1mm5is24i6z4l91i326krr6y2"
+   "commit": "eb38193bbcbf7559f3fb3b1d5d5f86b713786689",
+   "sha256": "1b0a5xa10gcrfl7409n6iqaw7bpbsrdz2d599s2mhnjs1b9fd9rq"
   }
  },
  {
@@ -114667,11 +115306,11 @@
   "repo": "ideasman42/emacs-scroll-on-jump",
   "unstable": {
    "version": [
-    20251213,
-    1140
+    20260108,
+    1309
    ],
-   "commit": "4dd1cd66f36072e2a124afc5d32286f2db39a4a3",
-   "sha256": "1y43ward556r55rpw80d8fspcwb65p72cc27xl53piy6rsjgcggk"
+   "commit": "3e4e13fab04ab5acc7653d0474bf7b8b685d07d3",
+   "sha256": "1pa6s6c0k5ng6w1j3ms8vmg01dxasp51a474j337xg5c4pl5g9x6"
   }
  },
  {
@@ -114768,20 +115407,20 @@
   "repo": "precompute/sculpture-themes",
   "unstable": {
    "version": [
-    20250530,
-    1425
+    20260112,
+    2109
    ],
-   "commit": "a536e4a3e19b609a529cbb380aa0403e0afc4050",
-   "sha256": "0yssyc7w50kgl65wq9pckwmaxqf5n78114yfsilrvdz3hxa9wzra"
+   "commit": "ce17fba2d12775e9596386b237158b8ca531a186",
+   "sha256": "0cw2727p0j23h4smqrilhnpsz8rif64m3mc56dynfk3lf40f0j5d"
   },
   "stable": {
    "version": [
     1,
     7,
-    1
+    3
    ],
-   "commit": "a536e4a3e19b609a529cbb380aa0403e0afc4050",
-   "sha256": "0yssyc7w50kgl65wq9pckwmaxqf5n78114yfsilrvdz3hxa9wzra"
+   "commit": "ce17fba2d12775e9596386b237158b8ca531a186",
+   "sha256": "0cw2727p0j23h4smqrilhnpsz8rif64m3mc56dynfk3lf40f0j5d"
   }
  },
  {
@@ -114883,15 +115522,15 @@
   "repo": "jcs-elpa/searcher",
   "unstable": {
    "version": [
-    20250101,
-    1011
+    20260101,
+    602
    ],
    "deps": [
     "dash",
     "f"
    ],
-   "commit": "12008a7a9e03980e86cfa6d9589665c70ec0ad4d",
-   "sha256": "0rw9rnaspj11ccrxnih50gy8a6gzn2sbq4lnx31kn68v7qp7j07f"
+   "commit": "b9ffe260b8d5303a83e73ed44f81d77fb260c43d",
+   "sha256": "1x6k9q27inh4wsxvvp4lqybj5jd08c35in2dr3xbx843g5b4b2d2"
   },
   "stable": {
    "version": [
@@ -115139,20 +115778,19 @@
   "repo": "Anoncheg/selected-window-contrast",
   "unstable": {
    "version": [
-    20250108,
-    1338
+    20260118,
+    1901
    ],
-   "commit": "a913fda9fcb2e73cfa213444ca811c388b5fcc6c",
-   "sha256": "0j5lpykjhjddai0hji1qcsaxbxr0n2wi2jf7pb2sxz9b17c570d6"
+   "commit": "0f23c16e99516d30bdb374a645f2a27c8b91eabb",
+   "sha256": "16b47s5bddpi9xafvdlc1vpjj7dx7b7l6vcz9hgjzk3l4rhq8s4p"
   },
   "stable": {
    "version": [
     0,
-    0,
-    4
+    1
    ],
-   "commit": "078242b001fe0799200932c41c08e48f8b19ab7d",
-   "sha256": "0ksabq4mi1hppshjkka6yr2h11aq514zgq6v6k5vbyrw0i90ywgi"
+   "commit": "c64c770f9663c6d2651ade64766f15d439b542cc",
+   "sha256": "19w6aa6ia4x1m0amj2al7g2as824vkvfxk00pqjkash1a5lwm33c"
   }
  },
  {
@@ -115242,14 +115880,14 @@
   "repo": "jerryxgh/semantic-thrift",
   "unstable": {
    "version": [
-    20251221,
-    1454
+    20260103,
+    340
    ],
    "deps": [
     "thrift"
    ],
-   "commit": "102f1bfa25347bf41a393e28102e94b58e7d50f6",
-   "sha256": "0a1pscknj78ki87krmzkcsv01zs43zg3g7fgk95gvn9va56l6xln"
+   "commit": "75d972e91ac97f1378eb6891300361044dfc6624",
+   "sha256": "1mhv8za2ks5zhwfqijm06bc3yj8hypc7k2l98iw1i1r6896xxrvz"
   }
  },
  {
@@ -116086,20 +116724,20 @@
   "repo": "xenodium/shell-maker",
   "unstable": {
    "version": [
-    20251211,
-    958
+    20260116,
+    1019
    ],
-   "commit": "63f178f925b535668eb68257016a01dca9d1cf30",
-   "sha256": "13hw8qx8mxd89q7my18xbpg6v4nn2zbdffypv9vqy66sc5vz4fwj"
+   "commit": "6eafe72de916cb3e75deb4f7220085ac3e775a11",
+   "sha256": "1knswylikwipg8aqb7dip2jm1l8q3sxj8q0af31ipn92v6wh9bks"
   },
   "stable": {
    "version": [
     0,
     84,
-    4
+    8
    ],
-   "commit": "63f178f925b535668eb68257016a01dca9d1cf30",
-   "sha256": "13hw8qx8mxd89q7my18xbpg6v4nn2zbdffypv9vqy66sc5vz4fwj"
+   "commit": "6eafe72de916cb3e75deb4f7220085ac3e775a11",
+   "sha256": "1knswylikwipg8aqb7dip2jm1l8q3sxj8q0af31ipn92v6wh9bks"
   }
  },
  {
@@ -116377,11 +117015,11 @@
   "repo": "ideasman42/emacs-shift-number",
   "unstable": {
    "version": [
-    20251126,
-    348
+    20260103,
+    831
    ],
-   "commit": "bb14d9609fed47000b76ecc8393285abff1bb766",
-   "sha256": "09l9c462q8wl4d28fcbk6cs4ya1fvfl1h5gm1257sa187x7r8bh1"
+   "commit": "a71f5c3c77affc27a3d0bf16886a8a3b03c05044",
+   "sha256": "03xv2y03xn08mb2hmqd5kljqa4jsfwg3l89micc6xvvkl1slimsj"
   },
   "stable": {
    "version": [
@@ -116419,11 +117057,11 @@
   "repo": "emacs-w3m/emacs-w3m",
   "unstable": {
    "version": [
-    20251201,
-    711
+    20251228,
+    2352
    ],
-   "commit": "50975789096b096af24d13c10b52bc2b6cbd3074",
-   "sha256": "1i3xizrvfhxg01k5iy3x3a100w0mfx48nz9sb86w25jp4jkzwvxa"
+   "commit": "ec18c21418bf7c1be159bd3cf7e79a370d4be1f3",
+   "sha256": "00rkvr6cpisma5r6g88bq0im7qh9l30fy8r4g4wgs1k53lai7k68"
   }
  },
  {
@@ -116510,11 +117148,11 @@
   "repo": "jcs-elpa/show-eol",
   "unstable": {
    "version": [
-    20250101,
-    1011
+    20260101,
+    602
    ],
-   "commit": "117060c077dca1facb7ea8942ea866d0621ef5ce",
-   "sha256": "1vhkdkww38fxaqiynm2l0f1nqmhxw074a9qfk3yi9vfrn6r8k2q6"
+   "commit": "b484d2771f09666e2bccd0b19a8a1c9a1e16f614",
+   "sha256": "1g46mgv1kfhs5f6jdh74wbq34f2qh1nm12wy0gi770h59x5hnx8n"
   },
   "stable": {
    "version": [
@@ -116539,6 +117177,21 @@
    ],
    "commit": "c7328b85655688d257b769192d26b9f5c9bbe26d",
    "sha256": "1kw9xfhyl0qx76ihkg86ncf4vw2frz4478cyw2s4shgs2bvd7dbb"
+  }
+ },
+ {
+  "ename": "show-inactive-region",
+  "commit": "45a8b231fbdd98db228acea1f31ea9c8692701c6",
+  "sha256": "083cnwsbz9ndmhzs3lvlr57w7yfxmb703063q5ifbcbc6k2z5q4j",
+  "fetcher": "codeberg",
+  "repo": "ideasman42/emacs-show-inactive-region",
+  "unstable": {
+   "version": [
+    20260115,
+    1215
+   ],
+   "commit": "e5e5db361ee93da72d96f2cc3d7c1c5bf52fbb96",
+   "sha256": "00h2fbg3k0vrmb1x87pk0g0bf785ldrpdx9186h0rhix4550vpfb"
   }
  },
  {
@@ -116624,15 +117277,15 @@
   "repo": "chenyanming/shrface",
   "unstable": {
    "version": [
-    20250923,
-    958
+    20251224,
+    957
    ],
    "deps": [
     "language-detection",
     "org"
    ],
-   "commit": "6d5b730c09cbbb070abadab1b2039677b74e3c62",
-   "sha256": "18ksyr57ca5sdrngi16rskpffjys73qlx7dka58mrcvl8pbdpndy"
+   "commit": "9016f3d7276c29feeb49337f765d9fa5f889adf0",
+   "sha256": "0s8m3l2xphkcpvpjh2ads1p5kfasn8aja1xzbbhzlq96cm3yrxaa"
   },
   "stable": {
    "version": [
@@ -116780,20 +117433,20 @@
   "repo": "riscy/shx-for-emacs",
   "unstable": {
    "version": [
-    20240512,
-    1515
+    20251225,
+    43
    ],
-   "commit": "ae32d2f6917e16c8feb8b7372267449179abd608",
-   "sha256": "1gkfh5zhcxi9xwffc8ydbn6879h20ddfwvk6279dysg15gasb551"
+   "commit": "019975297b4abbf9474172f4981e565152e9aa34",
+   "sha256": "1f137fj5gcpnwk9a0rp92lvg2rpzdxb0dh4l25hr35lghbj2bcpw"
   },
   "stable": {
    "version": [
     1,
     5,
-    0
+    2
    ],
-   "commit": "63e0feb8eca13691d4ebd5cf3a3ddef4d7675ece",
-   "sha256": "1cb5w6p9gnfxgh8qp7yj2f5ibpk1b4b5af3ynldaaj6yfpa8hqzn"
+   "commit": "019975297b4abbf9474172f4981e565152e9aa34",
+   "sha256": "1f137fj5gcpnwk9a0rp92lvg2rpzdxb0dh4l25hr35lghbj2bcpw"
   }
  },
  {
@@ -116888,11 +117541,11 @@
   "repo": "ideasman42/emacs-sidecar-locals",
   "unstable": {
    "version": [
-    20251209,
-    1502
+    20260108,
+    324
    ],
-   "commit": "0a370c10b07782c891bda2f9c65d5661050281fd",
-   "sha256": "0dn6w513fxz6m26k0cqik3d3aaqq3ja3fq125idcb5isiv47j68z"
+   "commit": "0c969ab64bee11cce0917474eaf693418810712a",
+   "sha256": "0flkjl4v23zbp8jnqrsmdjxamll9kkjys4az8w4i79hj1c3a5ajm"
   }
  },
  {
@@ -116903,14 +117556,14 @@
   "repo": "emacs-sideline/sideline",
   "unstable": {
    "version": [
-    20250517,
-    508
+    20260101,
+    540
    ],
    "deps": [
     "ht"
    ],
-   "commit": "6c0562c5abfa9eb16320cec755ffe09ebc26c0cc",
-   "sha256": "1hr5978i7g9px8jy5rmhl7avcxw4agrqrnwwnccak08l945n72fj"
+   "commit": "b4ada1ddf7da96c2e87453130f6ff7b7d577810f",
+   "sha256": "1kw3294cz43425zmayv7jsfy9q9466jirdkyfagfh27v20bcp6vy"
   },
   "stable": {
    "version": [
@@ -116933,15 +117586,15 @@
   "repo": "emacs-sideline/sideline-blame",
   "unstable": {
    "version": [
-    20250704,
-    251
+    20260101,
+    541
    ],
    "deps": [
     "sideline",
     "vc-msg"
    ],
-   "commit": "33b0699a5c9843a03b76cf6de19b5860738a9ac5",
-   "sha256": "071irj2nbr213j7n726avkj9ar0nphbnhrxpxini6l93rdxyp6kk"
+   "commit": "107479557021dbfcb27ad26a8e357c73e9b1249e",
+   "sha256": "1knq5wfnc73vvh16mznd0dj8qijxnqx1f0n3wrfp2pljfqnsgcmv"
   },
   "stable": {
    "version": [
@@ -116965,16 +117618,16 @@
   "repo": "emacs-sideline/sideline-eglot",
   "unstable": {
    "version": [
-    20251214,
-    646
+    20260101,
+    541
    ],
    "deps": [
     "eglot",
     "ht",
     "sideline"
    ],
-   "commit": "1ca026df95ab463581c52f2eb516d788402bf734",
-   "sha256": "1vlhf01sbvx7z55fhbyvzh138ssi00xmn9336xwsqdz75ckagg35"
+   "commit": "aeb1991a7f25301438806a06c588e7e732c6f533",
+   "sha256": "1jc016xm9ibpnahg248fg7z5hsj9zqs8mvvmdfdgvf9a1mz09yhr"
   },
   "stable": {
    "version": [
@@ -116998,16 +117651,16 @@
   "repo": "emacs-sideline/sideline-flycheck",
   "unstable": {
    "version": [
-    20250201,
-    1746
+    20260101,
+    541
    ],
    "deps": [
     "flycheck",
     "ht",
     "sideline"
    ],
-   "commit": "886b0d923aeaac5e6e4cd4ab42ee6a6a18553907",
-   "sha256": "1x23any4bdgwfwd10d68cjb8ymka5z8q7wfp3mmmg7461718vrz2"
+   "commit": "5a4d63210acf735829b08164897fef6a2abc8bab",
+   "sha256": "0mk7xbkhrknkc8wbkjbnsd2v12gzbrgpvwi7yzrj01dlmjqn9268"
   },
   "stable": {
    "version": [
@@ -117032,14 +117685,14 @@
   "repo": "emacs-sideline/sideline-flymake",
   "unstable": {
    "version": [
-    20250514,
-    2147
+    20260101,
+    541
    ],
    "deps": [
     "sideline"
    ],
-   "commit": "46f6cdd69bfa6825cf06f71f9417de8364280353",
-   "sha256": "1hvc0psjmwgf2lavjjzpgjzmnqbmdj5nb3jqlwak72zzrir146j8"
+   "commit": "ad296589a97ad7225f3f1e9519443577b2c5a49b",
+   "sha256": "0zhdnzf3chw9apk6d8yd0yx700p6shjkc7ywxkbksgwb53bxbx3j"
   },
   "stable": {
    "version": [
@@ -117062,8 +117715,8 @@
   "repo": "emacs-sideline/sideline-lsp",
   "unstable": {
    "version": [
-    20250805,
-    922
+    20260101,
+    542
    ],
    "deps": [
     "dash",
@@ -117072,8 +117725,8 @@
     "s",
     "sideline"
    ],
-   "commit": "fed3ab896be6b508ce3e37994600dd56af993185",
-   "sha256": "0rp5wr8h1fsa3l6hambzakxqhd5vw4rpkg6rc32pcmnzxyx7c4sr"
+   "commit": "dfa29a7b27e5ab64788c76544444f678ae4db18d",
+   "sha256": "027r0hfqw89pnknw1qmmgzmjixbg0dzk1vgsicnvdqgxr22lraym"
   },
   "stable": {
    "version": [
@@ -117570,8 +118223,8 @@
   "repo": "magit/sisyphus",
   "unstable": {
    "version": [
-    20251101,
-    2122
+    20260101,
+    1900
    ],
    "deps": [
     "compat",
@@ -117580,14 +118233,14 @@
     "llama",
     "magit"
    ],
-   "commit": "8fe6d76d3d31db60149173c1054961c2757c9f74",
-   "sha256": "0aj1q1ggq20n4b77pyi4a44g8ibmb0l918imwmsj83mih51535kc"
+   "commit": "7774ea7030fb7b2793eff41a8cae1e80c2ed955a",
+   "sha256": "0j8cz9gmb49x60hi0fq4swkr0nyyahda35nj7pqn9brpgiihaang"
   },
   "stable": {
    "version": [
     0,
-    3,
-    1
+    4,
+    0
    ],
    "deps": [
     "compat",
@@ -117596,8 +118249,8 @@
     "llama",
     "magit"
    ],
-   "commit": "8fe6d76d3d31db60149173c1054961c2757c9f74",
-   "sha256": "0aj1q1ggq20n4b77pyi4a44g8ibmb0l918imwmsj83mih51535kc"
+   "commit": "7774ea7030fb7b2793eff41a8cae1e80c2ed955a",
+   "sha256": "0j8cz9gmb49x60hi0fq4swkr0nyyahda35nj7pqn9brpgiihaang"
   }
  },
  {
@@ -117840,8 +118493,8 @@
   "repo": "emacs-slack/emacs-slack",
   "unstable": {
    "version": [
-    20251216,
-    2218
+    20260115,
+    1525
    ],
    "deps": [
     "alert",
@@ -117853,8 +118506,8 @@
     "ts",
     "websocket"
    ],
-   "commit": "8a649a4ad9558c7dc1c5773871c1de9107b475f3",
-   "sha256": "1ki2379ga41dxspagvq94sbpds9krp74bba6w2rgva2bfcghzdb9"
+   "commit": "a35c605a2fe98e95d82a80f0f320fd4913418f52",
+   "sha256": "0sjrql913wykmc0bsbfn5ni1s35z8r4kaccaqlam54ypgwalv6wb"
   }
  },
  {
@@ -117912,14 +118565,14 @@
   "repo": "slime/slime",
   "unstable": {
    "version": [
-    20251220,
-    0
+    20260119,
+    505
    ],
    "deps": [
     "macrostep"
    ],
-   "commit": "9b59a6dcf1c1210463b5a68ff3db21f8af62233d",
-   "sha256": "0cg71pd33iac88rf62ysif6gz7h90n8v07541hiwhhhspwkginjw"
+   "commit": "71707c2bb7d60dc813cdfb2efdce0b948ed2d3ab",
+   "sha256": "15i4k192vmbfcrkdjfvhb8ncds12fzl4cf6inl0l4153sx10g623"
   },
   "stable": {
    "version": [
@@ -118425,11 +119078,11 @@
   "repo": "zenitani/elisp",
   "unstable": {
    "version": [
-    20251123,
-    1819
+    20251229,
+    2123
    ],
-   "commit": "a306b00bdf64470c9256b7ec5a5920b708b2b17a",
-   "sha256": "07wwfhs0hs0ikj3n0vm3ryd3vahwpzma29i1lmw5splxyd34sfid"
+   "commit": "9f5e8387b0d703a11bff6133d2c5b556d8be0a17",
+   "sha256": "1x6vk41dpinvidim347vfkzzfj4rpjwmy6ar4lml8vh7k74yav1j"
   }
  },
  {
@@ -119221,16 +119874,16 @@
   "repo": "danielfm/smudge",
   "unstable": {
    "version": [
-    20251222,
-    1613
+    20251224,
+    1549
    ],
    "deps": [
     "oauth2",
     "request",
     "simple-httpd"
    ],
-   "commit": "3a0657580feab7dd4dd4ed0ddc84edc12e410a93",
-   "sha256": "12shi4lrr7ay21mh5nyfi1ix7ziahzsaraylmplzg6fh1gm9n3bw"
+   "commit": "dcca1b9ac15886060788df83c7da63faa5ae027f",
+   "sha256": "0nkr0fy6c7jbjjcfywsw4klil305wjyirnafhgjvq5jrx95zs0m7"
   }
  },
  {
@@ -119614,14 +120267,14 @@
   "repo": "hlissner/emacs-solaire-mode",
   "unstable": {
    "version": [
-    20240716,
-    1852
+    20251224,
+    423
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "c9334666bd208f3322e6118d30eba1b2438e2bb9",
-   "sha256": "05a1m2ljczj5fayr2kncfi8p55j2gwa2qpzjmzg63admdr87yp5g"
+   "commit": "e44f11a1ff7489ea7173119d62de99b88e29c918",
+   "sha256": "0cc9sxnafvrw0f4inlgpc2nlj62kcw5v12wri98l0xqpchaag0a3"
   },
   "stable": {
    "version": [
@@ -119998,15 +120651,15 @@
   "repo": "emacsorphanage/sound-wav",
   "unstable": {
    "version": [
-    20240925,
-    753
+    20260103,
+    1801
    ],
    "deps": [
     "cl-lib",
     "deferred"
    ],
-   "commit": "cf206c3b5b6e3f1531e3486aa9e214d11b638c4d",
-   "sha256": "1rzjjn9na4ndxmki6gdw8bdxaj1wzqili9v11c8cag9i5pgl4z8w"
+   "commit": "99eae68e7774ea1429cce1432facd47a95670254",
+   "sha256": "1k39p4dpa3sx39f32r8zmyr5v3hpsk6ipl6m14r83s3n7w3vp1gc"
   },
   "stable": {
    "version": [
@@ -120343,11 +120996,11 @@
   "repo": "gnuhack/spanish-holidays",
   "unstable": {
    "version": [
-    20241209,
-    1141
+    20251231,
+    1119
    ],
-   "commit": "a596ec68f26c06063718dc83132e2843107cfe5c",
-   "sha256": "1py204463crsjn0qjpz79ngyhk78la0wrhn03xmhb8nlpqmpv64q"
+   "commit": "783e75d933d2b1eb4eecd549afb4a8b6f97e67a9",
+   "sha256": "17qpdqljnidqiw33cz94nsjqz447hl3wkz3pz8wjdq4swnqmm2vf"
   }
  },
  {
@@ -120403,11 +121056,11 @@
   "repo": "aglet/sparkweather",
   "unstable": {
    "version": [
-    20251218,
-    1343
+    20260112,
+    1420
    ],
-   "commit": "88af2ea78f7a6d6c48fb24a298de24a36d88c94f",
-   "sha256": "0l4p9gkzfk10wj10qsvj22wz0rphsvjmqyvb7jp4brc3s8pzbwg0"
+   "commit": "967fbddc81ab04ff11baba9bd6739d74f5bc593a",
+   "sha256": "0m6hxzyh81qsjhikrvwy7nzskjv2zlsqxh4j5ms2mlpxz18ds0kc"
   },
   "stable": {
    "version": [
@@ -120457,11 +121110,11 @@
   "repo": "ideasman42/emacs-spatial-navigate",
   "unstable": {
    "version": [
-    20251126,
-    513
+    20251229,
+    1145
    ],
-   "commit": "51aee2673323bfe8afe3de30f81da860310b8d73",
-   "sha256": "19l78man04g4wgccr3ai7afslb531ll7m2x9kig05hn0q4w2fszn"
+   "commit": "9f61d3894c2f77b5fafa3f3529a39cb29cd67bc7",
+   "sha256": "039vch5s45z1966sxg73ymzd7525alnnj0lvxwhqj3ncb3w0416v"
   }
  },
  {
@@ -120472,11 +121125,11 @@
   "repo": "condy0919/spdx.el",
   "unstable": {
    "version": [
-    20251204,
-    102
+    20260117,
+    104
    ],
-   "commit": "ceda651cb18106404d7d8abfe10f2aa149ed19be",
-   "sha256": "0nfqwl2q5sbzv6xvkv4acifrif058ih3ssrpif9nvjzy4s2y4r6h"
+   "commit": "40c4691ed406ac2a905c94ec69c720f79a607389",
+   "sha256": "1358013fmpgg4hd8pm5xpfccf4rr1xlgvl43y4r3v5yndq93dfbx"
   }
  },
  {
@@ -120537,14 +121190,14 @@
   "repo": "dakra/speed-type",
   "unstable": {
    "version": [
-    20251221,
-    2156
+    20260112,
+    1339
    ],
    "deps": [
     "compat"
    ],
-   "commit": "f6a42cbd356250e7a257662e3f43c00d1fa8fed9",
-   "sha256": "0bnn4a0fpjh94xykifqy2j82rgapvmlvs0vllq0xcskjbvibmdc8"
+   "commit": "3b23b577f2bf76d44e6e5bcc72cba660ae4a4bda",
+   "sha256": "09x2jb54kmypqbzyw61ms7d434b3yqi2si4p0pj8fg13x5xs4qxy"
   },
   "stable": {
    "version": [
@@ -120611,11 +121264,11 @@
   "repo": "ideasman42/emacs-spell-fu",
   "unstable": {
    "version": [
-    20251126,
-    529
+    20260108,
+    1336
    ],
-   "commit": "437f594615c590c87cfb040b669cba7ca66e1f91",
-   "sha256": "1ci23whm2msh97cj4k88ala33i3xfx7y2hc6aqczln93bfjsbd09"
+   "commit": "94686051261a065574fc6535979f8ff08a37f0ee",
+   "sha256": "1gbyx1w0k1jwngp22qm7yl1wg82ciybnarcm3frqch7b472dpr7h"
   }
  },
  {
@@ -121265,11 +121918,11 @@
   "repo": "srfi-explorations/emacs-srfi",
   "unstable": {
    "version": [
-    20251208,
-    51
+    20260117,
+    910
    ],
-   "commit": "fbba26c984217f874bd1568bc988fb70bfebd312",
-   "sha256": "11m01bwc77zw37yrz7imhra1i0sazp8bjhxys4zvg8i33gsyhnlc"
+   "commit": "4a54c3b6b74663864696c4755a7653af1c959337",
+   "sha256": "1pbaz14ykdshvh44hs2yl5ldsrawznpc2wbhg6vkwsv3j2a32540"
   },
   "stable": {
    "version": [
@@ -121379,11 +122032,11 @@
   "repo": "peterhoeg/ssh-config-mode-el",
   "unstable": {
    "version": [
-    20250101,
-    820
+    20260108,
+    2149
    ],
-   "commit": "d0596f5fbeab3d2c3c30eb83527316403bc5b2f7",
-   "sha256": "1xs9ixp2bgbn2whjpj7l1n15fklivfh7544sgai61225jprckyak"
+   "commit": "f21726d6f44a0e769a15f0a94620078a326774f7",
+   "sha256": "0y8m7j2bwg4v2xbwfbdhfsxah47yfydyh61wybl5akmiwgm6101p"
   }
  },
  {
@@ -122123,11 +122776,11 @@
   "repo": "jamescherti/stripspace.el",
   "unstable": {
    "version": [
-    20251103,
-    1432
+    20260114,
+    1604
    ],
-   "commit": "c403debb88691cf7839f86f4d6d4a2815c9eeddf",
-   "sha256": "0yxdaqi35mpvyi1ndn5l930a25phr05554hg43n211rhgnd5zmz7"
+   "commit": "e2671ccdd30a950ed84105e872ec564d74bef3ba",
+   "sha256": "16j24j11jnrvqrqmh2yq4km769aa2v20kpnbd457wpnm90ab5vb0"
   },
   "stable": {
    "version": [
@@ -122517,30 +123170,32 @@
   "repo": "kiyoka/Sumibi",
   "unstable": {
    "version": [
-    20251206,
-    718
+    20260104,
+    1157
    ],
    "deps": [
     "deferred",
+    "markdown-mode",
     "popup",
     "unicode-escape"
    ],
-   "commit": "47ecde2e815e4540bbb110bee1c0d5c50569f6f8",
-   "sha256": "0h61h6975as0zbj1953vdi1sdd40hn2s81wwdmkpl8lyyvyhij60"
+   "commit": "581a6d61ecc6d627676f946f9703b0fc74685551",
+   "sha256": "1pkglyi25mdgh3i2b9xdqzmx1v0pl3hj28hljfsw1q1y5j5ldi8q"
   },
   "stable": {
    "version": [
-    4,
-    2,
+    5,
+    1,
     0
    ],
    "deps": [
     "deferred",
+    "markdown-mode",
     "popup",
     "unicode-escape"
    ],
-   "commit": "47ecde2e815e4540bbb110bee1c0d5c50569f6f8",
-   "sha256": "0h61h6975as0zbj1953vdi1sdd40hn2s81wwdmkpl8lyyvyhij60"
+   "commit": "581a6d61ecc6d627676f946f9703b0fc74685551",
+   "sha256": "1pkglyi25mdgh3i2b9xdqzmx1v0pl3hj28hljfsw1q1y5j5ldi8q"
   }
  },
  {
@@ -124080,11 +124735,11 @@
   "repo": "Bastillan/tabbymacs",
   "unstable": {
    "version": [
-    20251007,
-    1441
+    20260119,
+    2318
    ],
-   "commit": "b88bac22c923bebbbc7e52f10a25669a7680698c",
-   "sha256": "0yr9wmmqhv1svlf6yhwx8fnzxyxdzr3kil72sys9l8bablnajzg6"
+   "commit": "ad4b60ce83dea3ec548af4adbdb4beffe2722b5d",
+   "sha256": "0xhvhgp94rqmpklixwpddl9gy2xsnwmlx4cs1hsyjwvkalsrhb67"
   },
   "stable": {
    "version": [
@@ -124404,11 +125059,11 @@
   "repo": "saf-dmitry/taskpaper-mode",
   "unstable": {
    "version": [
-    20250823,
-    1538
+    20260117,
+    1144
    ],
-   "commit": "208e6832ca68b33263440c472386ca033ba2735c",
-   "sha256": "05banf0gsw8kab4d6vpibjw2vk4dkgwfsnd05qvqljawa3i0dc6a"
+   "commit": "19828a8048b0b7803a1b597e5bea26da9edf2895",
+   "sha256": "1lppb3kj53rc5ansnajcx6m1friy7g60qqbghpaw4hc5lw9kq22z"
   },
   "stable": {
    "version": [
@@ -124532,11 +125187,11 @@
   "repo": "kanchoku/tc",
   "unstable": {
    "version": [
-    20251202,
-    751
+    20260112,
+    1340
    ],
-   "commit": "4b7ed91922f3af55c56a986f6776cad153762254",
-   "sha256": "1kczirhq05v9cl6cfksfp2zk4x7cbpd90bz32f8nmx9m16va3bk2"
+   "commit": "5d84e847cf34545a88dc2e1555dac3aef771b21f",
+   "sha256": "06ymcfdpqq9x080jd8fvg84jdv22nwx8a411s8s45c637wmyhmxy"
   }
  },
  {
@@ -124610,15 +125265,15 @@
   "repo": "zevlg/telega.el",
   "unstable": {
    "version": [
-    20251128,
-    658
+    20260102,
+    1148
    ],
    "deps": [
     "transient",
     "visual-fill-column"
    ],
-   "commit": "55f01587e534feede0875aa0d94ffc5a4c6671af",
-   "sha256": "1mrg8g4qibyh4xkncq152ylgcq1qmnx2l32p1fvhp7h6f5lw49fn"
+   "commit": "e34fb226ec56b17f77a6eb99c22e98d82529d2de",
+   "sha256": "17cbf9pqnfqrzd92s7gb9yvm6c5hlis1i9x0vzlfk1a9lgvy0yc1"
   },
   "stable": {
    "version": [
@@ -124749,14 +125404,14 @@
   "repo": "minad/tempel",
   "unstable": {
    "version": [
-    20251130,
-    847
+    20260119,
+    1334
    ],
    "deps": [
     "compat"
    ],
-   "commit": "506a8d570c145f4df63a18921e34bac6bef3ebe0",
-   "sha256": "1d4flcfnszvl2nyxqav3ha42lx5mhj93f8r4l0gc4n3ir8x5y9f5"
+   "commit": "6ffc61939d461df590f6913176c22bfecdda82e1",
+   "sha256": "0xcgiqq9fm7p050bc1vlr8ihhyl3nnp17f9xp63bs459038dr595"
   },
   "stable": {
    "version": [
@@ -124778,14 +125433,14 @@
   "repo": "Crandel/tempel-collection",
   "unstable": {
    "version": [
-    20250410,
-    1607
+    20260102,
+    1417
    ],
    "deps": [
     "tempel"
    ],
-   "commit": "5cb6bc6b5856c70806ff6b2f952814ff702137c6",
-   "sha256": "0h295rh21v2li8l5ldajh3nb2fvphnr5lw7s0mmhvwzxg7wk8gnl"
+   "commit": "fb5759fbaadde45dd55c2c84dae3ead17212f7e0",
+   "sha256": "0vlnzaxh2cg91csv1mrz7cz9ilgrmsww3ifaqpm7zdfq2g76rm5y"
   }
  },
  {
@@ -124986,29 +125641,29 @@
   "repo": "calliecameron/term-alert",
   "unstable": {
    "version": [
-    20230407,
-    1715
+    20260117,
+    1413
    ],
    "deps": [
     "alert",
     "f",
     "term-cmd"
    ],
-   "commit": "8e7e744773e41355bcd9f5c911001be08bc79bec",
-   "sha256": "1lwsp5wpmss07hmpysvk3yifgzm5bk1rr7d1qmij46yn0r2q3wyk"
+   "commit": "093afcb21c79dc5c3ada1e7bed92325dd4dde701",
+   "sha256": "1iayzkfclv2ww1342fxjnip47cj48l97i427511lfa6jkij2nvia"
   },
   "stable": {
    "version": [
     1,
-    2
+    3
    ],
    "deps": [
     "alert",
     "f",
     "term-cmd"
    ],
-   "commit": "47af9e6fe483ef0d393098c145f499362a33292a",
-   "sha256": "1nv8ma8x9xkgsl95z7yysy8q1lb3xr0pd8a5sb01nlx8ks3clad4"
+   "commit": "093afcb21c79dc5c3ada1e7bed92325dd4dde701",
+   "sha256": "1iayzkfclv2ww1342fxjnip47cj48l97i427511lfa6jkij2nvia"
   }
  },
  {
@@ -125019,27 +125674,27 @@
   "repo": "calliecameron/term-cmd",
   "unstable": {
    "version": [
-    20230407,
-    1704
+    20260117,
+    1350
    ],
    "deps": [
     "dash",
     "f"
    ],
-   "commit": "26c5a8cb6b55ac0d6c6bc08f6ea1b1e53f6e2654",
-   "sha256": "04q7i9dbcbxylfy6qsxp6x1rg89ix9qdhpr6z2dc1w925bqv71m8"
+   "commit": "0596a96b0e5a4e8a5f828951fb6e2c1af03914c8",
+   "sha256": "1fiwz43zvjx8wlzjs68lhgwjd6bywsk8pnnhc120rs7v88d6qygg"
   },
   "stable": {
    "version": [
     1,
-    1
+    3
    ],
    "deps": [
     "dash",
     "f"
    ],
-   "commit": "6c9cbc659b70241d2ed1601eea34aeeca0646dac",
-   "sha256": "08qiipjsqc9dfbha6r2yijjbrg2s4i2mkn6zn5616086550v3kpj"
+   "commit": "0596a96b0e5a4e8a5f828951fb6e2c1af03914c8",
+   "sha256": "1fiwz43zvjx8wlzjs68lhgwjd6bywsk8pnnhc120rs7v88d6qygg"
   }
  },
  {
@@ -125534,14 +126189,14 @@
   "repo": "rocky/emacs-test-simple",
   "unstable": {
    "version": [
-    20251030,
-    2148
+    20260118,
+    2141
    ],
    "deps": [
-    "cl-lib"
+    "compat"
    ],
-   "commit": "da8ddb6fecb820c8e0809ac0892374e755e4efec",
-   "sha256": "18a9d1n2xc2fqimvsg0nkvizn7y7sb6ap5i9al526cp40l0yky3n"
+   "commit": "502b0d299724256b1bbb08dcff227ac528f1a01a",
+   "sha256": "1qp5ksgb9zybzcdy1j458waaiclmrb8rwlal4mck7cw1wq4sj683"
   },
   "stable": {
    "version": [
@@ -126020,21 +126675,21 @@
   "repo": "facebook/fbthrift",
   "unstable": {
    "version": [
-    20251214,
-    2308
+    20260119,
+    23
    ],
-   "commit": "a7aff05c9260c8a68d635d5f5f6583c8f73cfd7f",
-   "sha256": "171i8wsd9my6bicfs1ycsxv51nkvxafd6n34h8ldb5w4nnyga9kf"
+   "commit": "6703ee890ae89ff265f4a43373b91e72322af64b",
+   "sha256": "1zc9nywkn5glys8vhg6vd6n674r2v8y2k5hhxw31ci58qx4a67cg"
   },
   "stable": {
    "version": [
-    2025,
-    12,
-    15,
+    2026,
+    1,
+    19,
     0
    ],
-   "commit": "a7aff05c9260c8a68d635d5f5f6583c8f73cfd7f",
-   "sha256": "171i8wsd9my6bicfs1ycsxv51nkvxafd6n34h8ldb5w4nnyga9kf"
+   "commit": "6703ee890ae89ff265f4a43373b91e72322af64b",
+   "sha256": "1zc9nywkn5glys8vhg6vd6n674r2v8y2k5hhxw31ci58qx4a67cg"
   }
  },
  {
@@ -126084,15 +126739,15 @@
   "repo": "polhuang/ticktick.el",
   "unstable": {
    "version": [
-    20251205,
-    1345
+    20260117,
+    1242
    ],
    "deps": [
     "request",
     "simple-httpd"
    ],
-   "commit": "83692995ff14cf61b97ec7f68693c214c56b566b",
-   "sha256": "1jqqj7km1dbq0kncjddbcyzkmzfs3fbi270vfxd4i73fxxwdq1c5"
+   "commit": "b9b6319464bd63c43c5edab1d72e73eea4234093",
+   "sha256": "02xa26qhcyxvg4dpycpl0w818c0x8aayw9ln7gsl8cqi7n5mmcic"
   },
   "stable": {
    "version": [
@@ -126116,14 +126771,14 @@
   "repo": "uzu/tidal",
   "unstable": {
    "version": [
-    20250711,
-    1955
+    20260109,
+    1704
    ],
    "deps": [
     "haskell-mode"
    ],
-   "commit": "660ac746ec5c89da7ead100c0c46bf67e4037f41",
-   "sha256": "05xf1ifd24afqmxfs9kkhkc1m9sc2cs9q9xkyym6r3bywgi5zs4j"
+   "commit": "4e444a2d5118d67a0ef7a588a2b783b39d9b1357",
+   "sha256": "0yfv1pl8i256j7zy28af7x9yjgxk4bxmkbnh4j6s6bw3mfc2hx4w"
   },
   "stable": {
    "version": [
@@ -126307,11 +126962,20 @@
   "repo": "xenodium/time-zones",
   "unstable": {
    "version": [
-    20251103,
-    936
+    20251231,
+    1951
    ],
-   "commit": "23c866db6a3aecac5e860cda6010d9afc847e5c6",
-   "sha256": "0ivdvkvk9jsgb0yzqv54033n473s6r8pqdzdkygzddlhc3g4hk72"
+   "commit": "fd94705f04b1e5bc4a9b08ef9092fea839fe92d7",
+   "sha256": "1bc3i7ljl03dikl5ldsm2gvh3s1w49vrcn4r9r12a05x10f4k4jn"
+  },
+  "stable": {
+   "version": [
+    0,
+    5,
+    2
+   ],
+   "commit": "fd94705f04b1e5bc4a9b08ef9092fea839fe92d7",
+   "sha256": "1bc3i7ljl03dikl5ldsm2gvh3s1w49vrcn4r9r12a05x10f4k4jn"
   }
  },
  {
@@ -126525,11 +127189,11 @@
   "repo": "aimebertrand/timu-macos-theme",
   "unstable": {
    "version": [
-    20251102,
-    1635
+    20260118,
+    2236
    ],
-   "commit": "20f0a64549209457045602b16097e4630f56691d",
-   "sha256": "0p9nlwlra104zki20nf794ainz2gcjfk2v6rjzgnnh9a2q1666d3"
+   "commit": "5a1e080b831b18b01a012af661653e5ecdf0fad0",
+   "sha256": "1nny7fhbrjcyrk5a9aa5x39siqz1c9xjl31345yzvsnybq02gfd5"
   },
   "stable": {
    "version": [
@@ -126584,6 +127248,21 @@
    ],
    "commit": "a90616ae0b110920c8be134cb7ffacee75552ac7",
    "sha256": "1zh40hgw93lssk3f3k8h3jc0jglgsvm19h9a2151y0sv40fpi6as"
+  }
+ },
+ {
+  "ename": "timu-symbol-extract",
+  "commit": "cec6af56afa27946fbf94ff6011c81024076aea4",
+  "sha256": "04d03xx1c3iac30xjsqgdsbxs1scz4slyz2dnj57rkdhbhdq4pvc",
+  "fetcher": "gitlab",
+  "repo": "aimebertrand/timu-symbol-extract",
+  "unstable": {
+   "version": [
+    20260111,
+    1243
+   ],
+   "commit": "5f3b778eb7446ca2b366daacb9f1e71f1d89e097",
+   "sha256": "03r0n1sx5dc4gnd9af674m1rfq9rzn53w5ndv8dxvzlax28w24gc"
   }
  },
  {
@@ -126757,6 +127436,30 @@
    ],
    "commit": "532aa6978e994e2b069ffe37aaf9a0011a07dadc",
    "sha256": "1ypbv9jbdnwv3xjsfzq8i3nmqdvziynv2rqsd6fm2r1xw0q06xd6"
+  }
+ },
+ {
+  "ename": "tmpl-mode",
+  "commit": "7362de3f42a31a1cc92852640971c6b756d61ce8",
+  "sha256": "1xsk9qkg3zfhbkdm106b8amfxm1cgjzg6cijbkamqrc2x7vprazr",
+  "fetcher": "github",
+  "repo": "Lindydancer/tmpl-mode",
+  "unstable": {
+   "version": [
+    20260103,
+    1717
+   ],
+   "commit": "ff9883cfa3b63005c64d556a5a5c2f81aa312ea7",
+   "sha256": "017r16r12ljwbm6k6wqq0ih0s09fcv1kkjf8ci2vdj7jlqhb54k0"
+  },
+  "stable": {
+   "version": [
+    1,
+    0,
+    0
+   ],
+   "commit": "ff9883cfa3b63005c64d556a5a5c2f81aa312ea7",
+   "sha256": "017r16r12ljwbm6k6wqq0ih0s09fcv1kkjf8ci2vdj7jlqhb54k0"
   }
  },
  {
@@ -127043,20 +127746,20 @@
   "repo": "gongo/emacs-toml",
   "unstable": {
    "version": [
-    20250729,
-    635
+    20260117,
+    104
    ],
-   "commit": "8d8cefa2a0590ed4b68064a7a55a552c0a16a68a",
-   "sha256": "04kyzpb4gwvx7r1nkv8z63rl92nvc32kssv7ncpmb4la97lcq09k"
+   "commit": "96f79c96b9d7eabdf1a2be306e1b206f84df2ddc",
+   "sha256": "0wpazxc98qwcadgl2s24apysqsyr31f5xbfv623m8mir9bv1fsnx"
   },
   "stable": {
    "version": [
     0,
-    1,
+    2,
     0
    ],
-   "commit": "9633a6872928e737a2335aae1065768b23d8c3b3",
-   "sha256": "1b3bkla6i5nvanifxchph6ab6ldrskdf240hy4d27dkmmnr3pban"
+   "commit": "aa222ff8864f14410a042b822f59c588f6f60b05",
+   "sha256": "00dn0kfqjk8lzh7nyam3brq2vb70nmm32dkpj1nm2hrk4nmw1m4c"
   }
  },
  {
@@ -127124,20 +127827,20 @@
   "repo": "jamescherti/tomorrow-night-deepblue-theme.el",
   "unstable": {
    "version": [
-    20251015,
-    1359
+    20260114,
+    1535
    ],
-   "commit": "85084ded2c4f792aaed4a4a1687dadea0347c858",
-   "sha256": "1q3268qy1i3gv3xaqcr29kc7qcxi9z9a258vi218jqizva96gbkr"
+   "commit": "28170a5c5d9cec2af1531f12b284037fe7fd043c",
+   "sha256": "06k5ncmv6l8mz17ryrmwg32kc3zjm41d1rxkhgjw6gci1r0f0wrb"
   },
   "stable": {
    "version": [
     1,
     2,
-    3
+    4
    ],
-   "commit": "85084ded2c4f792aaed4a4a1687dadea0347c858",
-   "sha256": "1q3268qy1i3gv3xaqcr29kc7qcxi9z9a258vi218jqizva96gbkr"
+   "commit": "0c9ee6ba3b2fbdf4ab37cf486d9b0f1f7de09a71",
+   "sha256": "0jkpsaz02nwfivchfsz9rnfaf3v3bxgmhliw5vrbbgzrdiyxf8kd"
   }
  },
  {
@@ -127590,20 +128293,20 @@
   "repo": "saulotoledo/trailing-newline-indicator",
   "unstable": {
    "version": [
-    20251115,
-    2242
+    20260112,
+    1713
    ],
-   "commit": "9d4d8cba8ae20301458b9f9a4399c72951c70471",
-   "sha256": "03a89d2s92j119xh46lx08sbgsczapqm5n37xdhrr8arshwwqsk6"
+   "commit": "f53d9e139f734d9ea35a907a6c44b70795d81737",
+   "sha256": "0zld6218jzmjq5afz4525mjc4whi9lix571wn35jpgvf8y1y8lgd"
   },
   "stable": {
    "version": [
     0,
     3,
-    4
+    6
    ],
-   "commit": "9d4d8cba8ae20301458b9f9a4399c72951c70471",
-   "sha256": "03a89d2s92j119xh46lx08sbgsczapqm5n37xdhrr8arshwwqsk6"
+   "commit": "f53d9e139f734d9ea35a907a6c44b70795d81737",
+   "sha256": "0zld6218jzmjq5afz4525mjc4whi9lix571wn35jpgvf8y1y8lgd"
   }
  },
  {
@@ -127723,21 +128426,21 @@
   "repo": "magit/transient",
   "unstable": {
    "version": [
-    20251215,
-    2209
+    20260118,
+    1322
    ],
    "deps": [
     "compat",
     "cond-let",
     "seq"
    ],
-   "commit": "066b985b19afbcc8f2f344cebb8d2f4c626b1bdc",
-   "sha256": "09kd615qs5zwkhz45ivi00zlaxwbvy7vxswfif183kglwmq1lrp6"
+   "commit": "5d4a7e718c56cb1b3f99a4cd04d204d627f124b0",
+   "sha256": "1b2xkivmpjf9crv6n2rfcmd63ri58xs0hxk19placlldr9z9i9ih"
   },
   "stable": {
    "version": [
     0,
-    11,
+    12,
     0
    ],
    "deps": [
@@ -127745,8 +128448,8 @@
     "cond-let",
     "seq"
    ],
-   "commit": "0d3f8d4fb6d41b841126820a06ecc98579bd8265",
-   "sha256": "1a5wh5mrh2iqr5d98rcbnhg5cgj946c5lhcgxnsf7wkvnp7hvs34"
+   "commit": "1f7039ef8d548d6fe858084fcbeae7588eba4190",
+   "sha256": "1z5nqmjzwgyq1gdg2v9qmxjk8m9k74l9pz4w6qa95grpsddpb68j"
   }
  },
  {
@@ -127938,11 +128641,11 @@
   "repo": "jcs-elpa/transwin",
   "unstable": {
    "version": [
-    20250101,
-    1013
+    20260101,
+    603
    ],
-   "commit": "bcf4cc2e83ab771dcec43973106951c643637a91",
-   "sha256": "1k97zyjifk7ghpncd75h58d3rwix32i731z633hlxww85bc0d8l3"
+   "commit": "fb78576162d0446fc5765d180aba98b0730b1f37",
+   "sha256": "0490k6jkrsxxlfp6hcarb5pwdsvkxznw8iif8kb8rq21rl9dkb8l"
   },
   "stable": {
    "version": [
@@ -128022,28 +128725,28 @@
   "repo": "tarsius/tray",
   "unstable": {
    "version": [
-    20251130,
-    2326
+    20260101,
+    1847
    ],
    "deps": [
     "compat",
     "transient"
    ],
-   "commit": "e9133190502b5923859f590abf6e18e198b878ef",
-   "sha256": "1raiwnkxh245ia074sdmp2svfdl0ih3qy6635z6hmfd1a4iic0f5"
+   "commit": "b77e046b173008a95f9ba37f4d34c088f5f0a8ab",
+   "sha256": "0y6mrqnc652jfcxhwh5xxphd5cfk3rbngv88i791f531lyninrih"
   },
   "stable": {
    "version": [
     0,
     1,
-    7
+    8
    ],
    "deps": [
     "compat",
     "transient"
    ],
-   "commit": "ab03fad898e4a9e98ea0a782e7469973e2f5f54a",
-   "sha256": "15a56wsrmjp1if751nhvk0pyqvpbs8hsx3663avzhrrvq058r1c6"
+   "commit": "b77e046b173008a95f9ba37f4d34c088f5f0a8ab",
+   "sha256": "0y6mrqnc652jfcxhwh5xxphd5cfk3rbngv88i791f531lyninrih"
   }
  },
  {
@@ -128089,26 +128792,26 @@
   "repo": "emacs-tree-sitter/elisp-tree-sitter",
   "unstable": {
    "version": [
-    20220212,
-    1632
+    20260116,
+    9
    ],
    "deps": [
     "tsc"
    ],
-   "commit": "909717c685ff5a2327fa2ca8fb8a25216129361c",
-   "sha256": "1sdvz827v436qijs6xafakkfw2d16bvp8frymd818rppjc7a9dif"
+   "commit": "8f0bd387ad7a1cf7e8fdd5977d386a17ea70a82d",
+   "sha256": "1065s9rkzslplsh44l0a1b9bizflyqhsf8w02if8z0dw8zr507zc"
   },
   "stable": {
    "version": [
     0,
-    18,
-    0
+    19,
+    4
    ],
    "deps": [
     "tsc"
    ],
-   "commit": "909717c685ff5a2327fa2ca8fb8a25216129361c",
-   "sha256": "1sdvz827v436qijs6xafakkfw2d16bvp8frymd818rppjc7a9dif"
+   "commit": "8f0bd387ad7a1cf7e8fdd5977d386a17ea70a82d",
+   "sha256": "1065s9rkzslplsh44l0a1b9bizflyqhsf8w02if8z0dw8zr507zc"
   }
  },
  {
@@ -128201,26 +128904,26 @@
   "repo": "emacs-tree-sitter/tree-sitter-langs",
   "unstable": {
    "version": [
-    20251221,
-    1520
+    20260119,
+    1658
    ],
    "deps": [
     "tree-sitter"
    ],
-   "commit": "b9910d9a67cd4012fb63c2797692941366a00d2b",
-   "sha256": "1qz95ycxivp8p9lxzmrxb2c41wl9filjsxb6lgzhnbhnrqxv3a2g"
+   "commit": "94c368b26870ef05e2953db91dd2b88d467c13b8",
+   "sha256": "009gq18yb2xyf32xspc00i2dzyswaadm37hbibsrvkb76aq9fj30"
   },
   "stable": {
    "version": [
     0,
-    12,
-    331
+    13,
+    17
    ],
    "deps": [
     "tree-sitter"
    ],
-   "commit": "b9910d9a67cd4012fb63c2797692941366a00d2b",
-   "sha256": "1qz95ycxivp8p9lxzmrxb2c41wl9filjsxb6lgzhnbhnrqxv3a2g"
+   "commit": "94c368b26870ef05e2953db91dd2b88d467c13b8",
+   "sha256": "009gq18yb2xyf32xspc00i2dzyswaadm37hbibsrvkb76aq9fj30"
   }
  },
  {
@@ -128297,8 +129000,8 @@
   "repo": "Alexander-Miller/treemacs",
   "unstable": {
    "version": [
-    20250907,
-    1320
+    20251226,
+    1307
    ],
    "deps": [
     "ace-window",
@@ -128310,8 +129013,8 @@
     "pfuture",
     "s"
    ],
-   "commit": "05333cc23ca4349cd839cf1c18e1eaef1f6b70ec",
-   "sha256": "0bglrc7lwgv1wmbybbcs7ncnlc5nwa7n3mr1ffhmh37z6srwlba3"
+   "commit": "2ab5a3c89fa01bbbd99de9b8986908b2bc5a7b49",
+   "sha256": "0lgskbcnxbs4qvv1pwykpjwlc400gkk0606s9ksj0zkczz5671fn"
   },
   "stable": {
    "version": [
@@ -128950,20 +129653,20 @@
   "repo": "emacs-tree-sitter/elisp-tree-sitter",
   "unstable": {
    "version": [
-    20220212,
-    1632
+    20260116,
+    9
    ],
-   "commit": "909717c685ff5a2327fa2ca8fb8a25216129361c",
-   "sha256": "1sdvz827v436qijs6xafakkfw2d16bvp8frymd818rppjc7a9dif"
+   "commit": "8f0bd387ad7a1cf7e8fdd5977d386a17ea70a82d",
+   "sha256": "1065s9rkzslplsh44l0a1b9bizflyqhsf8w02if8z0dw8zr507zc"
   },
   "stable": {
    "version": [
     0,
-    18,
-    0
+    19,
+    4
    ],
-   "commit": "909717c685ff5a2327fa2ca8fb8a25216129361c",
-   "sha256": "1sdvz827v436qijs6xafakkfw2d16bvp8frymd818rppjc7a9dif"
+   "commit": "8f0bd387ad7a1cf7e8fdd5977d386a17ea70a82d",
+   "sha256": "1065s9rkzslplsh44l0a1b9bizflyqhsf8w02if8z0dw8zr507zc"
   }
  },
  {
@@ -129158,6 +129861,30 @@
    ],
    "commit": "4e72482b21750f495bffa6785b873d86743e9c0a",
    "sha256": "0y7m5m1q1wx23786mi2y38i6qw922qczd40qmjd2vr5xzndphn5j"
+  }
+ },
+ {
+  "ename": "turepo",
+  "commit": "ee4bc882f6ca9730037874408e038b96fce9e0bd",
+  "sha256": "0jxnacmw1jyajnk0k6ggpqhkb3caw3ijka1xwair9jr4mb1dj8r2",
+  "fetcher": "github",
+  "repo": "swarnimcodes/turepo",
+  "unstable": {
+   "version": [
+    20260106,
+    1210
+   ],
+   "commit": "4d75992fce9a78b4b8a2baedefc856d5a248576a",
+   "sha256": "179ngcz4s9rsg5jxbyszllx85ki4qzv9f9sx5acq7w07y1vx7j3c"
+  },
+  "stable": {
+   "version": [
+    0,
+    2,
+    0
+   ],
+   "commit": "4d75992fce9a78b4b8a2baedefc856d5a248576a",
+   "sha256": "179ngcz4s9rsg5jxbyszllx85ki4qzv9f9sx5acq7w07y1vx7j3c"
   }
  },
  {
@@ -129362,15 +130089,15 @@
   "repo": "tmalsburg/txl.el",
   "unstable": {
    "version": [
-    20250709,
-    1113
+    20260104,
+    1659
    ],
    "deps": [
     "guess-language",
     "request"
    ],
-   "commit": "ad0ff6b9b66465457709c9f79d881b7e0ddbd352",
-   "sha256": "13qsqhxvvbqv9mbb76y8j4vp6jb5hsj2i77v2sjs4dhi2s2hzgf6"
+   "commit": "e368746afba6d8ec170f479d06a10c4e2a9e2eee",
+   "sha256": "0za90idb0plcm9zhxb4k4a6m5crrjv61b1b64kzyl0vjlyxxhlfw"
   }
  },
  {
@@ -129404,11 +130131,11 @@
   "repo": "pradyuman/typespec-ts-mode",
   "unstable": {
    "version": [
-    20250127,
-    834
+    20251227,
+    2213
    ],
-   "commit": "92f9a9e18876069cb176011d05854c6934cf5143",
-   "sha256": "0vssvhd2smh7k41wkzj1iki1k9k0cj67d1841smbkvbn0m8lgvkf"
+   "commit": "fcd43e13568c61772dbb344c6391c2933bd0a72e",
+   "sha256": "1xqssx6lvds261ym68pq6aq11njbr4qxajn0snblzidh53mvlk3i"
   }
  },
  {
@@ -129840,11 +130567,11 @@
   "repo": "jdtsmith/ultra-scroll",
   "unstable": {
    "version": [
-    20251216,
-    59
+    20260113,
+    2343
    ],
-   "commit": "21c568b1a26e597714ad65b40f246dd6e9f71fdd",
-   "sha256": "041jfjfck7lkf3zcbm3gkz8v0w8r3bbw0incvriskbl2iws0ap9i"
+   "commit": "bfd7871bb5b1c05ee586883a1bbda4311e3a40f0",
+   "sha256": "1b2sads7nkwaq9ac3ah5w1kvxffdhzb59byv0y0vjgzwq1q9h5b9"
   },
   "stable": {
    "version": [
@@ -129999,11 +130726,11 @@
   "repo": "ideasman42/emacs-undo-fu",
   "unstable": {
    "version": [
-    20251126,
-    509
+    20260108,
+    323
    ],
-   "commit": "4af1999bf3560a8fc35d1d4c1e5fd216266986a6",
-   "sha256": "18hcka7qsacrymxyvny8m975k196qkkc4a836pxq71j5bidjgyn9"
+   "commit": "b4ce5ed20c1cf0591e497e6998a7634a172726fa",
+   "sha256": "0km2kw1h49pnl1ja6fz83qkvcd3d5dnj0ckqw69p5d5p1jy9m64l"
   }
  },
  {
@@ -130014,11 +130741,11 @@
   "repo": "ideasman42/emacs-undo-fu-session",
   "unstable": {
    "version": [
-    20251210,
-    2129
+    20260108,
+    1313
    ],
-   "commit": "6b9ac96b6932a4ae10737caffd39a84d4e11d683",
-   "sha256": "0m5h314qbs72wiyhyd4nlwwh8m6l8y8kf8kld7s21a4wh7zcvrw8"
+   "commit": "34ae31308d2f290f87a330c76a627b7fe8ebb720",
+   "sha256": "174q13v7vrq5rfbpb8b1shv2qnsnhwpc59za2r2laph6hi0f0r4l"
   }
  },
  {
@@ -130044,14 +130771,14 @@
   "repo": "emacsorphanage/undohist",
   "unstable": {
    "version": [
-    20240925,
-    754
+    20260103,
+    1801
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "fd11900663f307958dc7e1d7ea1b0004f6cdb4d0",
-   "sha256": "1i5xkcmnwmphylwk2xzr2b4iidz6cwh1k25nh24768l9j2yxxfd5"
+   "commit": "8ff68451ff65da9dcc035607f82a0bac5cf4a545",
+   "sha256": "1afqhk7sfjhp946nqs3rd4cp4wyv2h7v28vhvacaqg09bxnbmxqk"
   },
   "stable": {
    "version": [
@@ -130411,14 +131138,14 @@
   "repo": "tbanel/uniline",
   "unstable": {
    "version": [
-    20251213,
-    1143
+    20260109,
+    823
    ],
    "deps": [
     "hydra"
    ],
-   "commit": "0002d5bd96bbbf721ac57c7ecdeaa632d477d083",
-   "sha256": "14yskfazwlxwyxv1xiwsjd68rqhvwvrwfb0clpisgqyfbdvna6p3"
+   "commit": "2aeee8f787ccbbb3da32100bceeb5d6c660aef7a",
+   "sha256": "0djaqcjcgi49zp0jlgfih8km55kp2i7166a8bp2nlz7lk813nvaj"
   }
  },
  {
@@ -130474,11 +131201,11 @@
   "repo": "fmguerreiro/unison-ts-mode",
   "unstable": {
    "version": [
-    20251209,
-    856
+    20260113,
+    846
    ],
-   "commit": "f8d291e8be9b2a3259d59e2d469660465a3d5deb",
-   "sha256": "184j5c3c2akqbwxk0j1aql5xyrwr14ml5ilnas65ybi80q9hnplm"
+   "commit": "7f0ed7c03d98fefc88c420bc49c423c66db186d7",
+   "sha256": "13sy6kj29hlaqfdkk2hv86yi1i3wv6ibywf5sm9ndqnw8a8r50pv"
   },
   "stable": {
    "version": [
@@ -130561,14 +131288,14 @@
   "repo": "swflint/emacs-universal-sidecar",
   "unstable": {
    "version": [
-    20251029,
-    1934
+    20260114,
+    112
    ],
    "deps": [
     "magit-section"
    ],
-   "commit": "01b12aecca0ce66f5427e7fe65012d37e7e128b2",
-   "sha256": "1gm5337d87mm3y41f787wadk7kmkdrw4rq9anb3wqhx8sn6j63gh"
+   "commit": "f908972efcbb6c7318c13671f94e5e5e69a45166",
+   "sha256": "1c88hnlcich9m2hjgh8ly797qp6dx40nfp63iwqzk4mhasy3vrzb"
   },
   "stable": {
    "version": [
@@ -131056,6 +131783,21 @@
   }
  },
  {
+  "ename": "use-package-treesit",
+  "commit": "6bd38f4fc3fc5fcac41f0bd874fbd5d2ec20dd9f",
+  "sha256": "074f33dm3szcy9lkw5xrkp2ddn93h770kwg5h5v4asqqsmfbdbrf",
+  "fetcher": "github",
+  "repo": "domq/use-package-treesit",
+  "unstable": {
+   "version": [
+    20260118,
+    1521
+   ],
+   "commit": "c4c2b251f3c932edc87ade3523700782c0cafcd2",
+   "sha256": "0jxxgd1lkpllzg7aasj3fqqi3k590yv256ryi2n4q5fn442irgs7"
+  }
+ },
+ {
   "ename": "use-proxy",
   "commit": "e9fb7f05b76517aa918fbd08a52719d1692d6dfc",
   "sha256": "05j06mbbyb4imlg480y29cfwkmpn93qdjd7jx687lrikg2z0ypbc",
@@ -131093,11 +131835,11 @@
   "repo": "jcs-elpa/use-ttf",
   "unstable": {
    "version": [
-    20250624,
-    1031
+    20260101,
+    603
    ],
-   "commit": "762a10f270430b278d48fd290100f0b899e5b9f5",
-   "sha256": "0cj11hs5nlv8hcxsb1m8dwwidw4xf7czw6gclg3f15qq87aw18wj"
+   "commit": "af34fb0d5cc46851b7b567fe171759724b3cdfd4",
+   "sha256": "1wkgnlyv3pa7l4wair4f6zv06z7227sq7x7alc5ll75k7mn4r69h"
   },
   "stable": {
    "version": [
@@ -131151,11 +131893,11 @@
   "repo": "ideasman42/emacs-utimeclock",
   "unstable": {
    "version": [
-    20251215,
-    1027
+    20260108,
+    1319
    ],
-   "commit": "f0a1bb2aa2050d3772b25216c9939160aa56be4c",
-   "sha256": "0ply422yrkn8r1vzsgnz1kxib4vvqd1v817qb4hy2cvxz2d0g612"
+   "commit": "210b417d17770c7814c6177e9c787234807e65d0",
+   "sha256": "0krhz7hzdjmqrnjyg4njbx9ap6g3xmmqhgl63m7s1hp3y9aw68wz"
   }
  },
  {
@@ -131456,11 +132198,11 @@
   "stable": {
    "version": [
     0,
-    1,
+    2,
     0
    ],
-   "commit": "acec08c32c4acad306ed67b57d082d9e0d0f284e",
-   "sha256": "01hlnhqhys8qzfwhza1ypc436zg5lhlkx5yy71bhmrbmyfzfh0fr"
+   "commit": "f055e8572b2e4d7a700392b8a71bacbfdc8e442a",
+   "sha256": "1x7jzvg1dxv381qlqdsa3knj3i4xcv6gy16834wzpfkfz6jb0240"
   }
  },
  {
@@ -131965,11 +132707,11 @@
   "repo": "federicotdn/verb",
   "unstable": {
    "version": [
-    20251216,
-    1822
+    20251222,
+    2151
    ],
-   "commit": "ec93e0b18f3b65f6f9517e4001ff1c0c643b32cd",
-   "sha256": "0jiaqqfg5maxw0y0v7vjihr6x5qvfj1x9542hqzn8gyywq0ii3qy"
+   "commit": "f45e31b2bcdea2a859bb28cbb1819469978457c9",
+   "sha256": "1izr1km3ysh0cdlli1r36b3y5m5kl1wmhi95qsidc701mlb0749n"
   },
   "stable": {
    "version": [
@@ -132197,25 +132939,25 @@
   "repo": "minad/vertico",
   "unstable": {
    "version": [
-    20251115,
-    1826
+    20260118,
+    743
    ],
    "deps": [
     "compat"
    ],
-   "commit": "8cff876a15203d24c42e19585fe6dcce8f735bbe",
-   "sha256": "167kxzp9j6xffblzqqdrbr1bpgkxnlkvkb3szsksrjy25qzkl5sy"
+   "commit": "c12c8f842fd184db44fb2b835b0f954bbc90c7a6",
+   "sha256": "0klr2v6xhs7vkh5rsjpl58mgvnz25g12zq5jrplbcq4s2v6119xj"
   },
   "stable": {
    "version": [
     2,
-    6
+    7
    ],
    "deps": [
     "compat"
    ],
-   "commit": "8cff876a15203d24c42e19585fe6dcce8f735bbe",
-   "sha256": "167kxzp9j6xffblzqqdrbr1bpgkxnlkvkb3szsksrjy25qzkl5sy"
+   "commit": "c12c8f842fd184db44fb2b835b0f954bbc90c7a6",
+   "sha256": "0klr2v6xhs7vkh5rsjpl58mgvnz25g12zq5jrplbcq4s2v6119xj"
   }
  },
  {
@@ -132460,20 +133202,20 @@
   "repo": "jamescherti/vim-tab-bar.el",
   "unstable": {
    "version": [
-    20251222,
-    1240
+    20260114,
+    1604
    ],
-   "commit": "ec31b75a972e4ab112fcf43faf90f312dc8b42a7",
-   "sha256": "1ckivlzpiaaxcy9w68p98gbhd8qajyi8lmkwr3wrqq6aal7x5gwn"
+   "commit": "64917611b8223fdfe080882738b64f5a2c90ff98",
+   "sha256": "1vwznly9c6l81fyhmfgdciqrzql69lirdn3adjfswq7hxa98284f"
   },
   "stable": {
    "version": [
     1,
-    0,
-    9
+    1,
+    0
    ],
-   "commit": "ec339632e0fa52045fc4bdc7fcfaee60d6e8eff1",
-   "sha256": "0cvjx9fw5aznbkw6di450x3hpbk491rl2a4hshxhbm6j5bp5bfjx"
+   "commit": "41f57f059bd89c8209a405afa2914482c9e9b306",
+   "sha256": "1lbx0v0xdwgnz8k8xyx2961xmygfdjri0fxhm5dyjz9wilcdas68"
   }
  },
  {
@@ -132674,11 +133416,11 @@
   "repo": "ideasman42/emacs-visible-mark",
   "unstable": {
    "version": [
-    20251126,
-    345
+    20251228,
+    614
    ],
-   "commit": "af4e38bb919e1d5aaaa9bb10877530a96038342f",
-   "sha256": "1q88kzm8682m2bf9zg6138412hzwlr0riqnnfwi40y6ql8igki1k"
+   "commit": "1954c15a790701cdac5734318bd3b1ab4c87d3f9",
+   "sha256": "0vr1r1d801d4m2yj7jfnk94xlj56w8bic3zj0k586wwn5fyk5cbb"
   }
  },
  {
@@ -132801,6 +133543,30 @@
    ],
    "commit": "64fce4fd7d3df297be52045992e44591d49f4d52",
    "sha256": "1bvaw44mkiz6yq1r5hvayfp0iaxqcwbzihdrbizyynm4qjzspca1"
+  }
+ },
+ {
+  "ename": "visual-shorthands",
+  "commit": "472158b05c10903cf99e62bc4bb64589361dde60",
+  "sha256": "0kkyhw5q9533adnpqmifx1r96am5xp59vakdc850ixxh0z34r94a",
+  "fetcher": "github",
+  "repo": "gggion/visual-shorthands.el",
+  "unstable": {
+   "version": [
+    20260104,
+    2221
+   ],
+   "commit": "0511154773533ec2e3c25efa5515ea548ee7e9e1",
+   "sha256": "1x7abjfmb492bv9y1s0pkc55dl57gbx9sbrdbv37k839s8nj9lpk"
+  },
+  "stable": {
+   "version": [
+    0,
+    4,
+    0
+   ],
+   "commit": "1b2ca9df5b66ef3e48b331fa8d17c1458f24505d",
+   "sha256": "0m8s70y4mxgk2dfby4kfg0020ndv94q7r9pg0iwjlxpzgidcw5ps"
   }
  },
  {
@@ -132932,11 +133698,11 @@
   "repo": "emacs-vs/vs-dark-theme",
   "unstable": {
    "version": [
-    20251222,
-    912
+    20260101,
+    1429
    ],
-   "commit": "f2ce0e490b7fd939aea3700a67247fa934209396",
-   "sha256": "1lzfj8h26q2jd1syg90idrvrpml86mklqaw29y7z2syvx09vf5dj"
+   "commit": "ce1442aa8ee8cdc37f29011fb0f88401918bb889",
+   "sha256": "11m59imwcv0bx80ci1ir5k2dh3qkivm6ri4xv0ci7zby4rjixi2w"
   },
   "stable": {
    "version": [
@@ -132955,11 +133721,11 @@
   "repo": "emacs-vs/vs-light-theme",
   "unstable": {
    "version": [
-    20251222,
-    912
+    20260101,
+    1430
    ],
-   "commit": "64bf2ddc6235a299ca84651e732df355e35c9f59",
-   "sha256": "0sbqfbp13sk1arx2hr5xslcpkg9bf04p5y5b3pqsdm6mqsckjgir"
+   "commit": "3403f6843a87adc38b46993db41610c2db1606f7",
+   "sha256": "1v363zsi4k9bkdhdi9qpk7q4p5wmhvd78f4x52jbsy6v3jn5vzd9"
   },
   "stable": {
    "version": [
@@ -133080,14 +133846,14 @@
   "repo": "jixiuf/vterm-toggle",
   "unstable": {
    "version": [
-    20230912,
-    246
+    20260110,
+    529
    ],
    "deps": [
     "vterm"
    ],
-   "commit": "06cb4f3c565e46470a3c4505c11e26066d869715",
-   "sha256": "03npflmahhl6fmkjl5y9bx9bg26614zn796k59p3d872mqj1w2vi"
+   "commit": "81d031f153c5fa656c744cd518b7d54c54506706",
+   "sha256": "1p9q4c2lrwckswk33wv4rymm8ixq6chn3bpzz577qs1q408sq34m"
   }
  },
  {
@@ -133183,6 +133949,30 @@
   }
  },
  {
+  "ename": "vui",
+  "commit": "6e08b5a1ad6a1319e6b25b014d977bcda535ef11",
+  "sha256": "1n0jz9g424brg3fpr8pqd71gl3dcjf37jwld4rjn9gk1q7bcvq0i",
+  "fetcher": "github",
+  "repo": "d12frosted/vui.el",
+  "unstable": {
+   "version": [
+    20260119,
+    714
+   ],
+   "commit": "c5547a204dac1c8149127e9142a293f0d23761a6",
+   "sha256": "15ggd6gd9k3hald1c8fb7jcvkb1d83y2k3nja1ky936rypg713ii"
+  },
+  "stable": {
+   "version": [
+    1,
+    0,
+    0
+   ],
+   "commit": "67c508c0f2dd6773a590df47c355edb3911f0bcb",
+   "sha256": "05jny12ncjr7ybwab8lmshjjhcrsax67063xbfv7ri6j5kdk5r52"
+  }
+ },
+ {
   "ename": "vuiet",
   "commit": "4f63056cf2f637fcb3426851501eeff5e6f40bb3",
   "sha256": "0hf99rgzhi66in3lr0pl3g8g56l00zcvz1qgclfsbw1yb9ig626y",
@@ -133228,8 +134018,8 @@
   "repo": "d12frosted/vulpea",
   "unstable": {
    "version": [
-    20251220,
-    1845
+    20260106,
+    747
    ],
    "deps": [
     "dash",
@@ -133237,23 +134027,89 @@
     "org",
     "s"
    ],
-   "commit": "ba602ce38e3c24b47ead0fb8b915e5950c77be4b",
-   "sha256": "0y0gdgc2d4p1gb1081qbl4wl2a0m20a6db5i0mhpnjqshq7z88g5"
+   "commit": "8a7ffece1b683e7c7439e05419e942d93d536348",
+   "sha256": "1hbpmwl28538fykvz97rjg2zf3s1bk3sf46g1139gn1vf5f8px20"
   },
   "stable": {
    "version": [
+    2,
     0,
-    4,
     0
    ],
    "deps": [
     "dash",
+    "emacsql",
     "org",
-    "org-roam",
     "s"
    ],
-   "commit": "15d5451cd51a88cc4241391466ad4a6d5eb61951",
-   "sha256": "1npgw0akgj2liga8ii9xxfb9gv9zfvwj8zf8saih3bpaw4bginj7"
+   "commit": "89ed53b762acf0c2d1985ff1501db7eac6ef412f",
+   "sha256": "166brn15x3l59mbvl6lb5136fdyfr4zbmb4k9v5ii35ikcw29b3f"
+  }
+ },
+ {
+  "ename": "vulpea-journal",
+  "commit": "2c6c70cec8e6cbb515e1904f140e3e8d0eb0d6f0",
+  "sha256": "1ddaw0q95qws3zb95wjcd60c5yrw28a9xzpx243vgvc2zixff3bg",
+  "fetcher": "github",
+  "repo": "d12frosted/vulpea-journal",
+  "unstable": {
+   "version": [
+    20260118,
+    1223
+   ],
+   "deps": [
+    "dash",
+    "vulpea",
+    "vulpea-ui"
+   ],
+   "commit": "2d3b5b473669ab2b24b085ed632eb30770cd1cb8",
+   "sha256": "06l39x7sbl2agcgbwjgiksigczhc91gxkfa5pd2dg7y9j1k7wh6i"
+  },
+  "stable": {
+   "version": [
+    1,
+    0,
+    0
+   ],
+   "deps": [
+    "dash",
+    "vulpea",
+    "vulpea-ui"
+   ],
+   "commit": "1c674c4769d501269e3aae60dc31745fa8adfa2d",
+   "sha256": "0acg4gwg4hxnfc6cvh9sssi9pjvg7w16dyypffygkwwdyx85gqsf"
+  }
+ },
+ {
+  "ename": "vulpea-ui",
+  "commit": "ec536b6f324914f2770709fc6888bb4f36c61def",
+  "sha256": "19q4l9wbhl8742yzy68nzvm215g07rrcijiiwrbarrkkz2v67qhr",
+  "fetcher": "github",
+  "repo": "d12frosted/vulpea-ui",
+  "unstable": {
+   "version": [
+    20260118,
+    1232
+   ],
+   "deps": [
+    "vui",
+    "vulpea"
+   ],
+   "commit": "2b07223f4e40cf309ad7215295afabc6ac9ecad7",
+   "sha256": "0yl0181smpqdc4q4lcyh168gvs0xdcyygypmkiy9lip97jpdjkjm"
+  },
+  "stable": {
+   "version": [
+    1,
+    0,
+    0
+   ],
+   "deps": [
+    "vui",
+    "vulpea"
+   ],
+   "commit": "39c842e47bd523b5cc37a13838277b3154fed920",
+   "sha256": "12r506748rs84ihb0cn27rjmqh6nklzkqd49xiljixfidw9vkg5d"
   }
  },
  {
@@ -133540,8 +134396,8 @@
   "repo": "chenyanming/wallabag.el",
   "unstable": {
    "version": [
-    20251007,
-    1036
+    20251226,
+    1223
    ],
    "deps": [
     "emacsql",
@@ -133549,8 +134405,8 @@
     "request",
     "s"
    ],
-   "commit": "798379d3a7210cb03abe6e470b59c212bb467632",
-   "sha256": "01sp9pvylvcpb30l9iz5xs2pingv1h1hnws3di7q07y6dfzpan9f"
+   "commit": "ff44e102ab467dd5abf021b3e3581be0c4358d18",
+   "sha256": "0bmz8ca75jb92rwgwj99d0hy5dsvh833pyqdd3f85690w7wax5wk"
   }
  },
  {
@@ -133872,14 +134728,14 @@
   "repo": "hsolg/emacs-weather-scout",
   "unstable": {
    "version": [
-    20250427,
-    2030
+    20251226,
+    1713
    ],
    "deps": [
     "persist"
    ],
-   "commit": "11c749204d6720a3265fe0a32dcf81777fd18455",
-   "sha256": "05agfay28bvc30nc0pwh3jvia2fmq6psv2aa5abivppqya396rrs"
+   "commit": "45163ef767452dea4bb9bb75e481bd1ca37acf6d",
+   "sha256": "1z3gw9ihqkmfajigpn7yn1byn4v7z2nglvc6zpp60yi44jhwdncj"
   }
  },
  {
@@ -134212,20 +135068,20 @@
   "repo": "xgqt/xgqt-elisp-lib-websearch",
   "unstable": {
    "version": [
-    20251026,
-    2108
+    20251225,
+    1437
    ],
-   "commit": "7d5700b1f0b9e276ab423e06f3f98d661c67b022",
-   "sha256": "1zd59bamd58296r1iig7c5dib3gnkkm4irhjhx6k125jzyfgbjar"
+   "commit": "d3403903f54d0ff5dd88d6675dae9bc9d738a32b",
+   "sha256": "1crh4rav2rwwhaxfs47czl6k1mpg236ljr6d1fsimpj0ya311h4k"
   },
   "stable": {
    "version": [
-    2,
-    1,
+    3,
+    0,
     1
    ],
-   "commit": "5120cec3c36ddcdaceb5235c0b52eecbc3b37fcb",
-   "sha256": "0q6y2347w4mfshnxjvkk4vm0bmi24zpz7kc0irk0cl7hxa20025d"
+   "commit": "d3403903f54d0ff5dd88d6675dae9bc9d738a32b",
+   "sha256": "1crh4rav2rwwhaxfs47czl6k1mpg236ljr6d1fsimpj0ya311h4k"
   }
  },
  {
@@ -134321,11 +135177,11 @@
   "repo": "thierryvolpiatto/wfnames",
   "unstable": {
    "version": [
-    20240820,
-    906
+    20260105,
+    458
    ],
-   "commit": "3652cbd131b23df541e306b9c20a65111f05806d",
-   "sha256": "0swh8s8g3d8v00rlpak0d02ar96c6iivp7f5drahggi56jp46b80"
+   "commit": "6ea49841ab76f44c0164b9f4722da2f9d46228da",
+   "sha256": "1agbwnhgagfrgz5w47x8b4i6x8qdvv03f08p1fi44wsld2h0xvwr"
   },
   "stable": {
    "version": [
@@ -134931,15 +135787,15 @@
   "repo": "progfolio/wikinforg",
   "unstable": {
    "version": [
-    20250809,
-    56
+    20260101,
+    1716
    ],
    "deps": [
     "org",
     "wikinfo"
    ],
-   "commit": "edf2fc770e32e82a9ffa226ce602dbb9636d9ac5",
-   "sha256": "0vb9br9n237m59dq76m6adad8p3vbs30y6lbs6i07369j2qaw7l7"
+   "commit": "9f1b72c2f2e5648f9b736470e350750b8726884c",
+   "sha256": "1lh3hqvxyg946hijzh9xi0lcr91hzc254vqm3mz0g4l0r0fp5hs9"
   }
  },
  {
@@ -135436,26 +136292,26 @@
   "repo": "magit/with-editor",
   "unstable": {
    "version": [
-    20251101,
-    2100
+    20260101,
+    1848
    ],
    "deps": [
     "compat"
    ],
-   "commit": "dbc694406c2fd8e9d3e6ffbc4f8aff4e8c28029f",
-   "sha256": "0x4qw9yd0kzg2kkm8wjm9l0ikzb9aj9v5s753bjp3bajal94jw3q"
+   "commit": "76ecbb2107efcbad48210a393b90193bcf4008aa",
+   "sha256": "1mbhrcqbiilp4flna4gav7n4cw46gmxvr15wwr0r9jj5vmsjx4i2"
   },
   "stable": {
    "version": [
     3,
     4,
-    7
+    8
    ],
    "deps": [
     "compat"
    ],
-   "commit": "dbc694406c2fd8e9d3e6ffbc4f8aff4e8c28029f",
-   "sha256": "0x4qw9yd0kzg2kkm8wjm9l0ikzb9aj9v5s753bjp3bajal94jw3q"
+   "commit": "76ecbb2107efcbad48210a393b90193bcf4008aa",
+   "sha256": "1mbhrcqbiilp4flna4gav7n4cw46gmxvr15wwr0r9jj5vmsjx4i2"
   }
  },
  {
@@ -135770,11 +136626,11 @@
   "repo": "progfolio/wordel",
   "unstable": {
    "version": [
-    20250803,
-    2033
+    20260101,
+    1717
    ],
-   "commit": "e1686812cc72467df2845407b1ffd6cf55e49743",
-   "sha256": "0x107h7yxc33p9s8xkpk7xq3n91b0xz26srp2ly0xi6jjawnqd2q"
+   "commit": "e31bc8b285984c12efb9a667b080f9b9c570d7d7",
+   "sha256": "1bzblzhaykglbwkw8x78wpqw72x5z4dsy1njfyxarh7fp2927ba5"
   }
  },
  {
@@ -136110,10 +136966,10 @@
  },
  {
   "ename": "ws-butler",
-  "commit": "3b41910f55e0c8e10668c788614cd61c480e860b",
-  "sha256": "1amzz3xjxf3gp7qfxf33pclk82iwnlcm462iy4fz3ikvck08cbbz",
+  "commit": "37c02f3ef7d26b244e7c7b28cb165d22b1bdb263",
+  "sha256": "1aaah26z83misgz7rwzwdbq37752d23cnz4cryhk3710jghh3xgp",
   "fetcher": "git",
-  "url": "https://git.savannah.gnu.org/git/emacs/nongnu.git",
+  "url": "https://https.git.savannah.gnu.org/git/elpa/nongnu.git",
   "unstable": {
    "version": [
     20250310,
@@ -136815,11 +137671,11 @@
   "repo": "ideasman42/emacs-xref-rst",
   "unstable": {
    "version": [
-    20251126,
-    344
+    20260108,
+    1306
    ],
-   "commit": "b21455d2b9949c6ae2787d31d2c3f2703ec8688f",
-   "sha256": "0gk4321zqsbrqrmb7sg8isls09sgsrgcpqj3sln414zxgwl7zjdw"
+   "commit": "2d1ed3f31b64a9e10a757dedf06f1b514894d67f",
+   "sha256": "157cfapjp8ip3maqlnbdndlk6j9sr0lrdcl67fvmcxnflabrssff"
   }
  },
  {
@@ -137153,20 +138009,20 @@
   "repo": "zkry/yaml.el",
   "unstable": {
    "version": [
-    20251029,
-    2056
+    20260113,
+    653
    ],
-   "commit": "3fbeaee97dce3c76a18b02a28c58777cbcdadf2f",
-   "sha256": "15rkbyxz7zzkizj77ml4j6h2i2fmxf8hr4xa8zwpi8al8s3ja2vk"
+   "commit": "f2369fb4985ed054be47ae111760ff2075dff72a",
+   "sha256": "1fb7hgb6r0pk30w2vdcci494rrn337ibjvq7xj1ihj2cv2xk8pdb"
   },
   "stable": {
    "version": [
     1,
     2,
-    1
+    3
    ],
-   "commit": "d3762199e6d525e26b49c8263648229bdb512247",
-   "sha256": "1gp3076cf32vq8925c38xpd9cxnndlx5xazagh34irrq6dvb2y10"
+   "commit": "f2369fb4985ed054be47ae111760ff2075dff72a",
+   "sha256": "1fb7hgb6r0pk30w2vdcci494rrn337ibjvq7xj1ihj2cv2xk8pdb"
   }
  },
  {
@@ -137426,11 +138282,11 @@
   "repo": "emacsorphanage/yascroll",
   "unstable": {
    "version": [
-    20240925,
-    750
+    20260103,
+    1801
    ],
-   "commit": "9e02ac558eccb2a911640762f5df81c89230e81d",
-   "sha256": "1wrxd6bdfpabrk15ga5kgjgcnccch1iqndxdxg7vnw8ywz3wmydx"
+   "commit": "c0a302e6a44169c290564174c48298572f418f62",
+   "sha256": "1ja00f23gi7said8q8a6hcaj98nb95qmbw2l2yqkcvs9qd3mmlh5"
   },
   "stable": {
    "version": [
@@ -137804,25 +138660,6 @@
    ],
    "commit": "7d890ab3f012b1a48a0e8e437f5fcaeba9825fdc",
    "sha256": "0jw23i4irc1fcmgbqqs3nhji1llvgpv3bgy3b41l7fpcva9x933w"
-  }
- },
- {
-  "ename": "ynab",
-  "commit": "5c5e5994ae49ce92bf059c27dedab6d6b2d20a5a",
-  "sha256": "1sm5jf3ydh2zbs2x8fjlv1xvidxnbpwpgyr0fxgsl160ssdp5k06",
-  "fetcher": "github",
-  "repo": "thoreinstein/ynab.el",
-  "unstable": {
-   "version": [
-    20200607,
-    2008
-   ],
-   "deps": [
-    "cl-lib",
-    "ts"
-   ],
-   "commit": "2c6beb4d2c4996017f6b3c62c26db52a61e5c479",
-   "sha256": "07bb1hlya07p6s6ymjl3vfv99xln3vrp78h4sda5va52vj1935rs"
   }
  },
  {
@@ -139048,11 +139885,11 @@
   "repo": "emacsorphanage/zoom-window",
   "unstable": {
    "version": [
-    20240925,
-    754
+    20260103,
+    1801
    ],
-   "commit": "fca88b971aea55e3d3944050213c3a1243178c8b",
-   "sha256": "0m03vp9qybbh9i7ppr9njmcngzgzdlh3n2gdlxzmfgx54mh70lgq"
+   "commit": "8a0ae04de53583949a58e0aa8e7f64f03be7c9f8",
+   "sha256": "1s5nyqd6n08algjylhc1h94b0sir5n6dqbhfwllp7l5vlvf25hq8"
   },
   "stable": {
    "version": [
@@ -139071,14 +139908,14 @@
   "repo": "thierryvolpiatto/zop-to-char",
   "unstable": {
    "version": [
-    20160212,
-    1554
+    20260105,
+    452
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "816ea90337db0545a2f0a5079f4d7b3a2822af7d",
-   "sha256": "14waf3g7b92k3qd5088w4pn0wcspxjfkbswlzf7nnkjliw1yh0kf"
+   "commit": "09885546aa2ee8b78953f54fd14f23f834cf2dfd",
+   "sha256": "0jli8h7i4jnf00aazffdnsjwdmqsq19gmn4snxidy7m4iqyz3j55"
   },
   "stable": {
    "version": [


### PR DESCRIPTION
emacs-overlay commit: eef2d9bd3261c04add778a10b26554caee631c81
new build failure:
- [ ] gumshoe: [upstream report][1]

[1]: https://github.com/Overdr0ne/gumshoe/issues/22

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
