### PR TITLE
callHackageWithOptions, hackage2nixWithOptions: init

### DIFF
--- a/pkgs/development/haskell-modules/make-package-set.nix
+++ b/pkgs/development/haskell-modules/make-package-set.nix
@@ -277,18 +277,19 @@ package-set { inherit pkgs lib callPackage; } self
         revision = null;
         sha256 = null;
       },
+      extraCabal2nixOptions ? "",
     }:
     args:
     let
       pkgver = "${pkg}-${ver}";
-      firstRevision = self.callCabal2nix pkg (pkgs.fetchzip {
+      firstRevision = self.callCabal2nixWithOptions pkg (pkgs.fetchzip {
         url =
           if candidate then
             "mirror://hackage/${pkgver}/candidate/${pkgver}.tar.gz"
           else
             "mirror://hackage/${pkgver}/${pkgver}.tar.gz";
         inherit sha256;
-      }) args;
+      }) extraCabal2nixOptions args;
     in
     overrideCabal (orig: {
       revision = rev.revision;


### PR DESCRIPTION
This PR adds two new functions, `callHackageWithOptions` and `hackage2nixWithOptions`, to allow users to pass `extraCabal2nixOptions`. Additionally, it adds an extra argument to `callHackageDirect` to support this as well.

## Motivation

The use case arose when I tried to use <https://hackage.haskell.org/package/cryptostore> with the `use_crypton` flag enabled. Since `cryptostore` uses this flag to determine `build-depends` (of `cabal` fame), the flag must be passed to `cabal2nix` as an argument. I worked-around this by adding `cryptostore`’s source as a flake input and use `callCabal2nixWithOptions`, but it would be nice to be able to use `callHackage` instead.

## TODO

- [ ] Add docs

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
