### PR TITLE
wannier90: relax numerical thresholds

### DIFF
--- a/pkgs/by-name/wa/wannier90/package.nix
+++ b/pkgs/by-name/wa/wannier90/package.nix
@@ -2,6 +2,7 @@
   stdenv,
   lib,
   gfortran,
+  perl,
   blas,
   lapack,
   python3,
@@ -15,7 +16,10 @@ stdenv.mkDerivation rec {
   pname = "wannier90";
   version = "3.1.0";
 
-  nativeBuildInputs = [ gfortran ];
+  nativeBuildInputs = [
+    gfortran
+    perl
+  ];
   buildInputs = [
     blas
     lapack
@@ -37,9 +41,11 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  # test cases are removed as error bounds of wannier90 are obviously to tight
+  # Increase all numerical thresholds by a factor of 5. The tests are not
+  # numerically stable enough with differen BLAS and LAPACK implementations and
+  # dynamic CPU detection.
   postPatch = ''
-    rm -r test-suite/tests/testpostw90_{fe_kpathcurv,fe_kslicecurv,si_geninterp,si_geninterp_wsdistance}
+    perl -i.bak -pe 's/(\d+\.\d+e[+-]?\d+)/sprintf("%.10e", $1 * 5)/ge' test-suite/tests/userconfig
     rm -r test-suite/tests/testw90_example26   # Fails without AVX optimizations
     patchShebangs test-suite/run_tests test-suite/testcode/bin/testcode.py
   '';


### PR DESCRIPTION
This relaxes the numerical thresholds in the wannie90 test suite by simply multiplying them all by a factor of 5 via a perl regex. The test suite was not numerically stable enough to pass with dynamic CPU detection in BLAS and LAPACK and would fail on some hardware generation by being slightly off.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
