### PR TITLE
python313Packages.awsiotsdk: 1.27.0 -> 1.28.0

### DIFF
--- a/pkgs/development/python-modules/awsiotsdk/default.nix
+++ b/pkgs/development/python-modules/awsiotsdk/default.nix
@@ -8,7 +8,7 @@
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "awsiotsdk";
   version = "1.28.0";
   pyproject = true;
@@ -16,13 +16,13 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "aws";
     repo = "aws-iot-device-sdk-python-v2";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-Cs+MbI/23bPvdZNaze7ENyEZNT/AVYsPz/dEEzaAy8c=";
   };
 
   postPatch = ''
     substituteInPlace awsiot/__init__.py \
-      --replace-fail  "__version__ = '1.0.0-dev'" "__version__ = '${version}'"
+      --replace-fail  "__version__ = '1.0.0-dev'" "__version__ = '${finalAttrs.version}'"
   '';
 
   pythonRelaxDeps = [ "awscrt" ];
@@ -46,8 +46,8 @@ buildPythonPackage rec {
   meta = {
     description = "Next generation AWS IoT Client SDK for Python using the AWS Common Runtime";
     homepage = "https://github.com/aws/aws-iot-device-sdk-python-v2";
-    changelog = "https://github.com/aws/aws-iot-device-sdk-python-v2/releases/tag/${src.tag}";
+    changelog = "https://github.com/aws/aws-iot-device-sdk-python-v2/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ fab ];
   };
-}
+})

--- a/pkgs/development/python-modules/awsiotsdk/default.nix
+++ b/pkgs/development/python-modules/awsiotsdk/default.nix
@@ -10,14 +10,14 @@
 
 buildPythonPackage rec {
   pname = "awsiotsdk";
-  version = "1.27.0";
+  version = "1.28.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "aws";
     repo = "aws-iot-device-sdk-python-v2";
     tag = "v${version}";
-    hash = "sha256-CafecTMRNIKQ2FB13SLJwtYwysNMG5DYl2xfHnejApU=";
+    hash = "sha256-Cs+MbI/23bPvdZNaze7ENyEZNT/AVYsPz/dEEzaAy8c=";
   };
 
   postPatch = ''


### PR DESCRIPTION
Diff: https://github.com/aws/aws-iot-device-sdk-python-v2/compare/v1.27.0...v1.28.0

Changelog: https://github.com/aws/aws-iot-device-sdk-python-v2/releases/tag/v1.28.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
