### PR TITLE
dockmate: init at 0.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -24468,7 +24468,7 @@
     name = "Johannes Klein";
   };
   sith-lord-vader = {
-    email = "abhiayush23@gmail.com";
+    email = "nixpkgs@xpertsre.rocks";
     github = "sith-lord-vader";
     githubId = 24388085;
     name = "Abhishek Adhikari";

--- a/pkgs/by-name/do/dockmate/package.nix
+++ b/pkgs/by-name/do/dockmate/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  buildGoModule,
+  dockmate,
+  fetchFromGitHub,
+  versionCheckHook,
+}:
+
+buildGoModule rec {
+  pname = "dockmate";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "shubh-io";
+    repo = "DockMate";
+    tag = "v${version}";
+    hash = "sha256-kepv8jY/hddRpJMhwr55k0R8CPBKtifjrGiRxoIUDXw=";
+  };
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+
+  vendorHash = "sha256-/votTA5Rn8beq1PgHpC01D01VjBIwciPVN5eNc8iZRM=";
+
+  # Skip tests that require a Docker daemon or interactive filesystem access,
+  # as these are unavailable in the restricted Nix build sandbox.
+  checkFlags = [
+    "-skip=TestDockerComposeCommandNoFiles|TestDockerComposeCommandSingleFile|TestDockerComposeCommandMultipleFiles|TestWritingToConfigFile"
+  ];
+
+  doInstallCheck = true;
+
+  meta = {
+    changelog = "https://github.com/shubh-io/DockMate/releases/tag/${src.tag}";
+    description = "Terminal-based Docker container manager that actually works";
+    homepage = "https://github.com/shubh-io/DockMate";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      sith-lord-vader
+    ];
+    mainProgram = "dockmate";
+  };
+}


### PR DESCRIPTION
## Description of changes
Added the ***[DockMate](https://github.com/shubh-io/DockMate)*** tool to nixpkgs. It is "A terminal-based Docker container manager that actually works." as quoted by [Shubhransh/Author](https://github.com/shubh-io). I have been using it on my Ubuntu VMs for a while and this PR adds it to nixpkgs to be used in Nix machines.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
