### PR TITLE
python3Packages.hydra-core: skip failing test on python>=3.14

### DIFF
--- a/pkgs/development/python-modules/detectron2/default.nix
+++ b/pkgs/development/python-modules/detectron2/default.nix
@@ -44,20 +44,18 @@
   pytest-mock,
   pytestCheckHook,
   torchvision,
+  pythonAtLeast,
 }:
 
-let
+buildPythonPackage (finalAttrs: {
   pname = "detectron2";
   version = "0.6";
-in
-buildPythonPackage {
-  inherit pname version;
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "facebookresearch";
     repo = "detectron2";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-TosuUZ1hJrXF3VGzsGO2hmQJitGUxe7FyZyKjNh+zPA=";
   };
 
@@ -188,6 +186,12 @@ buildPythonPackage {
     "test_apply_deltas_tracing"
     "test_imagelist_padding_tracing"
     "test_roi_pooler_tracing"
+  ]
+  ++ lib.optionals (pythonAtLeast "3.14") [
+    # AttributeError: '...' object has no attribute '__annotations__'
+    "test_default_anchor_generator_centered"
+    "test_scriptability_cpu"
+    "test_scriptable_cpu"
   ];
 
   pythonImportsCheck = [ "detectron2" ];
@@ -198,4 +202,4 @@ buildPythonPackage {
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ happysalada ];
   };
-}
+})

--- a/pkgs/development/python-modules/hydra-core/default.nix
+++ b/pkgs/development/python-modules/hydra-core/default.nix
@@ -24,7 +24,7 @@
   pythonAtLeast,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "hydra-core";
   version = "1.3.2";
   pyproject = true;
@@ -32,7 +32,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "facebookresearch";
     repo = "hydra";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-kD4BStnstr5hwyAOxdpPzLAJ9MZqU/CPiHkaD2HnUPI=";
   };
 
@@ -87,9 +87,51 @@ buildPythonPackage rec {
   ++ lib.optionals (pythonAtLeast "3.13") [
     # AssertionError: Regex pattern did not match
     "test_failure"
+  ]
+  ++ lib.optionals (pythonAtLeast "3.14") [
+    # AssertionError: Regex pattern did not match
+    "test_partial_failure"
+
+    # AssertionError: Mismatch between expected and actual text
+    "test_write_protect_config_node"
+
+    # ValueError: badly formed help string
+    "TestBasicLauncherIntegration"
+    "test_cli_error"
+    "test_completion_plugin"
+    "test_completion_plugin_multirun"
+    "test_configuring_experiments"
+    "test_examples_using_the_config_object"
+    "test_extending_configs"
+    "test_file_completion"
+    "test_missing_default_value"
+    "test_multi_select"
+    "test_searchpath_addition"
+    "test_tutorial_config_file"
+    "test_tutorial_config_file_bad_key"
+    "test_tutorial_config_groups"
+    "test_tutorial_defaults"
+    "test_tutorial_logging"
+    "test_tutorial_simple_cli_app"
+    "test_tutorial_working_directory"
+    "test_tutorial_working_directory_original_cwd"
+    "test_with_flags"
   ];
 
-  disabledTestPaths = [ "tests/test_hydra.py" ];
+  disabledTestPaths = [
+    "tests/test_hydra.py"
+  ]
+  ++ lib.optionals (pythonAtLeast "3.14") [
+    # ValueError: badly formed help string
+    "tests/test_callbacks.py"
+    "tests/test_env_defaults.py"
+    "tests/test_examples/test_advanced_package_overrides.py"
+    "tests/test_examples/test_basic_sweep.py"
+    "tests/test_examples/test_configure_hydra.py"
+    "tests/test_examples/test_experimental.py"
+    "tests/test_examples/test_instantiate_examples.py"
+    "tests/test_examples/test_structured_configs_tutorial.py"
+  ];
 
   pythonImportsCheck = [
     "hydra"
@@ -100,8 +142,8 @@ buildPythonPackage rec {
   meta = {
     description = "Framework for configuring complex applications";
     homepage = "https://hydra.cc";
-    changelog = "https://github.com/facebookresearch/hydra/blob/v${version}/NEWS.md";
+    changelog = "https://github.com/facebookresearch/hydra/blob/${finalAttrs.src.tag}/NEWS.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ bcdarwin ];
   };
-}
+})

--- a/pkgs/development/python-modules/hydra-joblib-launcher/default.nix
+++ b/pkgs/development/python-modules/hydra-joblib-launcher/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildPythonPackage,
-  fetchFromGitHub,
+  pythonAtLeast,
 
   # build-system
   setuptools,
@@ -14,20 +14,23 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "hydra-joblib-launcher";
   pyproject = true;
 
   inherit (hydra-core) version src;
 
-  sourceRoot = "${src.name}/plugins/hydra_joblib_launcher";
+  # _pickle.PicklingError: Could not pickle the task to send it to the workers
+  disabled = pythonAtLeast "3.14";
+
+  sourceRoot = "${finalAttrs.src.name}/plugins/hydra_joblib_launcher";
 
   # get rid of deprecated "read_version" dependency, no longer in Nixpkgs:
   postPatch = ''
     substituteInPlace pyproject.toml --replace-fail ', "read-version"' ""
     substituteInPlace setup.py  \
       --replace-fail 'from read_version import read_version' ""  \
-      --replace-fail 'version=read_version("hydra_plugins/hydra_joblib_launcher", "__init__.py"),' 'version="${version}",'
+      --replace-fail 'version=read_version("hydra_plugins/hydra_joblib_launcher", "__init__.py"),' 'version="${finalAttrs.version}",'
   '';
 
   build-system = [
@@ -52,4 +55,4 @@ buildPythonPackage rec {
     homepage = "https://hydra.cc/docs/plugins/joblib_launcher";
     maintainers = with lib.maintainers; [ bcdarwin ];
   };
-}
+})


### PR DESCRIPTION
## Things done

- **python3Packages.hydra-core: skip failing test on python>=3.14**
- **python3Packages.detectron2: skip failing test on python>=3.14**
- **python3Packages.hydra-joblib-launcher: disable on python>=3.14**

cc @bcdarwin

Tracking: #475732

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
