### PR TITLE
python3Packages.torchdata: skip failing tests on python>=3.14

### DIFF
--- a/pkgs/development/python-modules/torchdata/default.nix
+++ b/pkgs/development/python-modules/torchdata/default.nix
@@ -19,9 +19,10 @@
   parameterized,
   pytest-xdist,
   pytestCheckHook,
+  pythonAtLeast,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "torchdata";
   version = "0.11.0";
   pyproject = true;
@@ -29,7 +30,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "meta-pytorch";
     repo = "data";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-TSkZLL4WDSacuX4tl0+1bKSJCRI3LEhAyU3ztdlUvgk=";
   };
 
@@ -55,16 +56,24 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [
-    # RuntimeError: DataLoader timed out after 5 seconds
-    "test_ind_worker_queue"
-  ];
+  disabledTests =
+    lib.optionals (pythonAtLeast "3.14") [
+      # _pickle.PicklingError: Can't pickle local object <...worker_set_affinity at 0x7ffbcfa1ba00>
+      "test_set_affinity_in_worker_init"
+
+      # RuntimeError: DataLoader timed out after 5 seconds
+      "test_ind_worker_queue"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      # RuntimeError: DataLoader timed out after 5 seconds
+      "test_ind_worker_queue"
+    ];
 
   meta = {
     description = "Iterative enhancement to the PyTorch torch.utils.data.DataLoader and torch.utils.data.Dataset/IterableDataset";
     homepage = "https://github.com/meta-pytorch/data";
-    changelog = "https://github.com/meta-pytorch/data/releases/tag/${src.tag}";
+    changelog = "https://github.com/meta-pytorch/data/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ GaetanLepage ];
   };
-}
+})


### PR DESCRIPTION
## Things done

Tracking: #475732

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
