### PR TITLE
ci/github-script/bot: handle deleted maintainer accounts gracefully

### DIFF
--- a/ci/github-script/bot.js
+++ b/ci/github-script/bot.js
@@ -133,6 +133,11 @@ module.exports = async ({ github, context, core, dry }) => {
           id,
         })
         .then((resp) => resp.data)
+        .catch((e) => {
+          // User may have deleted their account
+          if (e.status === 404) return null
+          throw e
+        })
     }
 
     return users[id]

--- a/ci/github-script/reviewers.js
+++ b/ci/github-script/reviewers.js
@@ -42,9 +42,15 @@ async function handleReviewers({
   }
 
   const users = new Set([
-    ...(await Promise.all(
-      maintainers.map(async (id) => (await getUser(id)).login.toLowerCase()),
-    )),
+    ...(
+      await Promise.all(
+        maintainers.map(async (id) => {
+          const user = await getUser(id)
+          // User may have deleted their account
+          return user?.login?.toLowerCase()
+        }),
+      )
+    ).filter(Boolean),
     ...owners
       .filter((handle) => handle && !handle.includes('/'))
       .map((handle) => handle.toLowerCase()),


### PR DESCRIPTION
## Summary

When a maintainer deletes their GitHub account, the bot crashes with a 404 error when trying to fetch their user info via `/user/{id}`. This caused the scheduled bot workflow to fail repeatedly (11 consecutive failures over ~3 hours) until manual intervention.

**Root cause:** User `normalcea` (GitHub ID `190049873`) was the maintainer of `qlementine-icons` and was requested for review on PR #481026. After they deleted their account, every bot run tried to look up their user ID and crashed.

**Fix:** Return `null` from `getUser()` for 404 responses and filter out null users when building the reviewers list.

## Testing performed

- [x] Verified that `/user/190049873` returns 404
- [x] Code review of changes
- [ ] Monitor next bot runs after merge

## Related

- Failing runs: https://github.com/NixOS/nixpkgs/actions/runs/21172390098
- Successful run after manual intervention: https://github.com/NixOS/nixpkgs/actions/runs/21173195526