### PR TITLE
lctime: 0.0.27 -> 0.0.28; use finalAttrs & add changelog

### DIFF
--- a/pkgs/by-name/lc/lctime/package.nix
+++ b/pkgs/by-name/lc/lctime/package.nix
@@ -9,17 +9,17 @@
   writableTmpDirAsHomeHook,
 }:
 
-python3Packages.buildPythonApplication rec {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "lctime";
-  version = "0.0.27";
+  version = "0.0.28";
   pyproject = true;
 
   src = fetchFromGitea {
     domain = "codeberg.org";
     owner = "librecell";
     repo = "lctime";
-    tag = version;
-    hash = "sha256-KKZhsKNTr+J5+rLUdlwGMsUCa6NYY1X9yaujPe1c0Do=";
+    tag = finalAttrs.version;
+    hash = "sha256-Td56NtqcI8763hw/XVxLP7+qExraapN9ULD3ZolfR6M=";
   };
 
   build-system = with python3Packages; [
@@ -32,7 +32,6 @@ python3Packages.buildPythonApplication rec {
     liberty-parser
     networkx
     numpy
-    pyspice
     scipy
     sympy
   ];
@@ -77,7 +76,7 @@ python3Packages.buildPythonApplication rec {
         ''
           cd "$HOME"
 
-          cp -R "${src}/tests/"* .
+          cp -R "${finalAttrs.src}/tests/"* .
           patchShebangs *.sh
 
           mkdir -p $out
@@ -94,8 +93,9 @@ python3Packages.buildPythonApplication rec {
       cc-by-sa-40
       cc0
     ];
+    changelog = "https://codeberg.org/librecell/lctime/releases/tag/${finalAttrs.src.tag}";
     maintainers = with lib.maintainers; [ eljamm ];
     teams = with lib.teams; [ ngi ];
     mainProgram = "lctime";
   };
-}
+})


### PR DESCRIPTION
Supersedes and closes https://github.com/NixOS/nixpkgs/pull/480919

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
