### PR TITLE
[25.11] dawarich: init at 0.37.3

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1585,6 +1585,7 @@
   ./services/web-apps/cryptpad.nix
   ./services/web-apps/dashy.nix
   ./services/web-apps/davis.nix
+  ./services/web-apps/dawarich.nix
   ./services/web-apps/dependency-track.nix
   ./services/web-apps/dex.nix
   ./services/web-apps/discourse.nix

--- a/nixos/modules/services/web-apps/dawarich.nix
+++ b/nixos/modules/services/web-apps/dawarich.nix
@@ -1,0 +1,706 @@
+{
+  lib,
+  pkgs,
+  config,
+  options,
+  ...
+}:
+
+let
+  cfg = config.services.dawarich;
+  opt = options.services.dawarich;
+
+  dataDir = "/var/lib/dawarich";
+
+  isRedisUnixSocket = lib.hasPrefix "/" cfg.redis.host;
+
+  redisEnv =
+    if isRedisUnixSocket then
+      {
+        REDIS_URL = "unix://${config.services.redis.servers.dawarich.unixSocket}";
+      }
+    else
+      {
+        # Does not support passwords, but upstream does not provide an adequate env variable
+        # Perhaps patch or make a PR upstream in the future
+        REDIS_URL = "redis://${cfg.redis.host}:${toString cfg.redis.port}";
+      };
+
+  env = {
+    RAILS_ENV = "production";
+    NODE_ENV = "production";
+    BUNDLE_USER_HOME = "/tmp/bundle"; # will use private tmp inside systemd unit
+
+    SELF_HOSTED = "true";
+    STORE_GEODATA = "true";
+    APPLICATION_PROTOCOL = "http";
+    TIME_ZONE = config.time.timeZone; # otherwise upstream forces it to Europe/London
+    DOMAIN = cfg.localDomain;
+    APPLICATION_HOSTS = "127.0.0.1,::1,${cfg.localDomain}";
+
+    BOOTSNAP_CACHE_DIR = "/var/cache/dawarich/precompile";
+    LD_PRELOAD = "${lib.getLib pkgs.jemalloc}/lib/libjemalloc.so";
+
+    DATABASE_USER = cfg.database.user;
+    DATABASE_HOST = cfg.database.host;
+    DATABASE_NAME = cfg.database.name;
+    DATABASE_PORT = toString cfg.database.port;
+
+    SMTP_SERVER = cfg.smtp.host;
+    SMTP_PORT = toString cfg.smtp.port;
+    SMTP_FROM = cfg.smtp.fromAddress;
+    SMTP_USERNAME = cfg.smtp.user;
+    PORT = toString cfg.webPort;
+  }
+  // redisEnv
+  // cfg.environment;
+
+  systemCallFilter =
+    let
+      allowedSystemCalls = [
+        "@cpu-emulation"
+        "@debug"
+        "@keyring"
+        "@ipc"
+        "@mount"
+        "@obsolete"
+        "@privileged"
+        "@setuid"
+      ];
+    in
+    [
+      ("~" + lib.concatStringsSep " " allowedSystemCalls)
+      "@chown"
+      "pipe"
+      "pipe2"
+    ];
+
+  cfgService = {
+    User = cfg.user;
+    Group = cfg.group;
+    WorkingDirectory = cfg.package;
+    CacheDirectory = "dawarich";
+    CacheDirectoryMode = "0750";
+    StateDirectory = "dawarich";
+    StateDirectoryMode = "0750";
+    LogsDirectory = "dawarich";
+    LogsDirectoryMode = "0750";
+    ProcSubset = "pid";
+    ProtectProc = "invisible";
+    UMask = "0027";
+    CapabilityBoundingSet = "";
+    NoNewPrivileges = true;
+    ProtectSystem = "strict";
+    ProtectHome = true;
+    PrivateTmp = true;
+    PrivateDevices = true;
+    PrivateUsers = true;
+    ProtectClock = true;
+    ProtectHostname = true;
+    ProtectKernelLogs = true;
+    ProtectKernelModules = true;
+    ProtectKernelTunables = true;
+    ProtectControlGroups = true;
+    RestrictAddressFamilies = [
+      "AF_UNIX"
+      "AF_INET"
+      "AF_INET6"
+      "AF_NETLINK"
+    ];
+    RestrictNamespaces = true;
+    LockPersonality = true;
+    MemoryDenyWriteExecute = false;
+    RestrictRealtime = true;
+    RestrictSUIDSGID = true;
+    RemoveIPC = true;
+    PrivateMounts = true;
+    SystemCallArchitectures = "native";
+    SystemCallFilter = systemCallFilter;
+
+    # ensure permissions to connect to the redis socket
+    SupplementaryGroups = lib.mkIf (cfg.redis.createLocally && isRedisUnixSocket) [
+      config.services.redis.servers.dawarich.group
+    ];
+  };
+
+  # Units that all Dawarich units After= and Requires= on
+  commonUnits =
+    lib.optional cfg.redis.createLocally "redis-dawarich.service"
+    ++ lib.optional cfg.database.createLocally "postgresql.target"
+    ++ lib.optional cfg.automaticMigrations "dawarich-init-db.service";
+
+  defaultSecretKeyBaseFile = "${dataDir}/secrets/secret-key-base";
+  needsGenCredentialsUnit = cfg.secretKeyBaseFile == null;
+  credentials = {
+    SECRET_KEY_BASE = lib.defaultTo defaultSecretKeyBaseFile cfg.secretKeyBaseFile;
+  }
+  // lib.optionalAttrs (cfg.database.passwordFile != null) {
+    DATABASE_PASSWORD = cfg.database.passwordFile;
+  }
+  // lib.optionalAttrs (cfg.smtp.passwordFile != null) {
+    SMTP_PASSWORD = cfg.smtp.passwordFile;
+  };
+  loadCredentialsIntoEnv = lib.concatMapAttrsStringSep "\n" (
+    name: _: ''export ${name}="$(systemd-creds cat ${name})"''
+  ) credentials;
+  loadCredentials = lib.mapAttrsToList (name: path: "${name}:${path}") credentials;
+
+  dawarichRails = pkgs.writeShellApplication {
+    name = "dawarich-rails";
+
+    text =
+      let
+        sourceExtraEnv = lib.concatMapStrings (p: "source ${p}\n") cfg.extraEnvFiles;
+        command = pkgs.writeShellScript "dawarich-rails-unwrapped" ''
+          ${sourceExtraEnv}
+          ${loadCredentialsIntoEnv}
+          export RAILS_ROOT="${cfg.package}"
+          exec ${lib.getExe' cfg.package "rails"} "$@"
+        '';
+        env' = lib.filterAttrs (_: value: value != null) env;
+        supplementaryGroups = lib.optionalString (cfg.redis.createLocally && isRedisUnixSocket) (
+          lib.escapeShellArg "--property=SupplementaryGroups=${config.services.redis.servers.dawarich.group}"
+        );
+      in
+      ''
+        exec ${lib.getExe' config.systemd.package "systemd-run"} \
+          ${
+            lib.escapeShellArgs (map (credential: "--property=LoadCredential=${credential}") loadCredentials)
+          } \
+          ${
+            lib.escapeShellArgs (lib.mapAttrsToList (name: value: "--setenv=${name}=${toString value}") env')
+          } \
+          --uid=${lib.escapeShellArg cfg.user} \
+          --gid=${lib.escapeShellArg cfg.group} \
+          ${supplementaryGroups} \
+          --working-directory=${lib.escapeShellArg cfg.package} \
+          --property=PrivateTmp=yes \
+          --pty \
+          --wait \
+          --collect \
+          --service-type=exec \
+          --quiet \
+          -- \
+          ${command} "$@"
+      '';
+  };
+  dawarichConsole = pkgs.writeShellScriptBin "dawarich-console" ''
+    exec ${lib.getExe dawarichRails} console "$@"
+  '';
+
+  sidekiqUnits = lib.attrsets.mapAttrs' (
+    name: processCfg:
+    lib.nameValuePair "dawarich-sidekiq-${name}" (
+      let
+        jobClassArgs = lib.concatMapStringsSep " " (c: "-q ${c}") processCfg.jobClasses;
+        jobClassLabel = lib.optionalString (
+          processCfg.jobClasses != [ ]
+        ) " (${lib.concatStringsSep ", " processCfg.jobClasses})";
+        threads = toString (if processCfg.threads == null then cfg.sidekiqThreads else processCfg.threads);
+      in
+      {
+        after = [
+          "network.target"
+        ]
+        ++ lib.optional needsGenCredentialsUnit "dawarich-init-credentials.service"
+        ++ commonUnits;
+        requires = lib.optional needsGenCredentialsUnit "dawarich-init-credentials.service" ++ commonUnits;
+        description = "Dawarich sidekiq${jobClassLabel}";
+        wantedBy = [ "dawarich.target" ];
+        environment = env // {
+          RAILS_MAX_THREADS = threads;
+        };
+        script = ''
+          ${loadCredentialsIntoEnv}
+
+          ${lib.getExe' cfg.package "sidekiq"} ${jobClassArgs} -c ${threads} -r ${cfg.package}
+        '';
+        serviceConfig = {
+          Restart = "always";
+          RestartSec = 20;
+          LoadCredential = loadCredentials;
+          EnvironmentFile = cfg.extraEnvFiles;
+          LimitNOFILE = "1024000";
+        }
+        // cfgService;
+      }
+    )
+  ) cfg.sidekiqProcesses;
+
+in
+{
+
+  options = {
+    services.dawarich = {
+      enable = lib.mkEnableOption "Dawarich, a self-hostable alternative to Google Location History";
+
+      configureNginx = lib.mkOption {
+        description = ''
+          Configure nginx as a reverse proxy for dawarich.
+          Alternatively you can configure a reverse-proxy of your choice to serve these paths:
+
+          `/ -> ''${pkgs.dawarich}/public`
+
+          `/ -> 127.0.0.1:{{ webPort }} `(If there was no file in the directory above.)
+
+          Make sure that websockets are forwarded properly. You might want to set up caching
+          of some requests. Take a look at dawarich's provided reverse proxy configurations at
+          `https://dawarich.app/docs/tutorials/reverse-proxy`.
+        '';
+        type = lib.types.bool;
+        default = true;
+      };
+
+      user = lib.mkOption {
+        description = ''
+          User under which dawarich runs. If it is set to "dawarich",
+          that user will be created, otherwise it should be set to the
+          name of a user created elsewhere.
+        '';
+        type = lib.types.str;
+        default = "dawarich";
+      };
+
+      group = lib.mkOption {
+        description = ''
+          Group under which dawarich runs.
+        '';
+        type = lib.types.str;
+        default = "dawarich";
+      };
+
+      webPort = lib.mkOption {
+        description = "TCP port used by the dawarich web service.";
+        type = lib.types.port;
+        default = 3000;
+      };
+
+      sidekiqThreads = lib.mkOption {
+        description = ''
+          Worker threads used by the dawarich-sidekiq-all service.
+          If `sidekiqProcesses` is configured and any processes specify null `threads`, this value is used.
+        '';
+        type = lib.types.int;
+        default = 5;
+      };
+
+      sidekiqProcesses = lib.mkOption {
+        description = ''
+          How many Sidekiq processes should be used to handle background jobs, and which job classes they handle.
+          Can be used to [speed up](https://dawarich.app/docs/FAQ/#how-to-speed-up-the-import-process) the import process.
+        '';
+        type =
+          with lib.types;
+          attrsOf (submodule {
+            options = {
+              jobClasses = lib.mkOption {
+                # https://github.com/Freika/dawarich/blob/0.37.2/config/sidekiq.yml
+                type = listOf (enum [
+                  "app_version_checking"
+                  "archival"
+                  "cache"
+                  "data_migrations"
+                  "default"
+                  "digests"
+                  "exports"
+                  "families"
+                  "imports"
+                  "mailers"
+                  "places"
+                  "points"
+                  "reverse_geocoding"
+                  "stats"
+                  "tracks"
+                  "trips"
+                  "visit_suggesting"
+                ]);
+                description = ''
+                  If not empty, which job classes should be executed by this process.
+                  *If left empty, all job classes will be executed by this process.*
+                '';
+              };
+              threads = lib.mkOption {
+                type = nullOr int;
+                description = ''
+                  Number of threads this process should use for executing jobs.
+                  If null, the configured `sidekiqThreads` are used.
+                '';
+              };
+            };
+          });
+        default = {
+          all = {
+            jobClasses = [ ];
+            threads = null;
+          };
+        };
+        example = {
+          all = {
+            jobClasses = [ ];
+            threads = null;
+          };
+          geocoding = {
+            jobClasses = [ "reverse_geocoding" ];
+            threads = 10;
+          };
+        };
+      };
+
+      localDomain = lib.mkOption {
+        description = "The domain serving your Dawarich instance.";
+        example = "dawarich.example.org";
+        type = lib.types.str;
+      };
+
+      secretKeyBaseFile = lib.mkOption {
+        description = ''
+          Path to file containing the secret key base.
+          A new secret key base can be generated by running:
+
+          `nix build -f '<nixpkgs>' dawarich; cd result; bin/bundle exec rails secret`
+
+          This file is loaded using systemd credentials, and therefore does not need to be
+          owned by the dawarich user.
+
+          If this option is null, it will be created at ${defaultSecretKeyBaseFile}
+          with a new secret key base.
+        '';
+        default = null;
+        type = lib.types.nullOr lib.types.str;
+      };
+
+      redis = {
+        createLocally = lib.mkOption {
+          description = ''
+            Whether to configure a local Redis server for Dawarich.
+            The connection is performed via Unix sockets by default,
+            but that can be changed by configuring {option}`${opt.redis.host}` and {option}`${opt.redis.port}`.
+          '';
+          type = lib.types.bool;
+          default = true;
+        };
+
+        host = lib.mkOption {
+          description = "The redis host Dawarich will connect to.";
+          type = lib.types.str;
+          default = config.services.redis.servers.dawarich.unixSocket;
+          defaultText = lib.literalExpression "config.services.redis.servers.dawarich.unixSocket";
+        };
+
+        port = lib.mkOption {
+          description = "The port of the redis server Dawarich will connect to. Set to zero to disable TCP and use Unix sockets instead.";
+          type = lib.types.port;
+          default = 0;
+        };
+      };
+
+      database = {
+        createLocally = lib.mkOption {
+          description = ''
+            Whether to configure a local PostgreSQL server and database for Dawarich.
+            The connection is performed via Unix sockets.
+          '';
+          type = lib.types.bool;
+          default = true;
+        };
+
+        host = lib.mkOption {
+          type = lib.types.str;
+          default = "/run/postgresql";
+          example = "127.0.0.1";
+          description = "Hostname or address of the postgresql server. If an absolute path is given here, it will be interpreted as a unix socket path.";
+        };
+
+        port = lib.mkOption {
+          type = lib.types.nullOr lib.types.port;
+          default = 5432;
+          description = "Port of the postgresql server.";
+        };
+
+        name = lib.mkOption {
+          type = lib.types.str;
+          default = "dawarich";
+          description = "The name of the dawarich database.";
+        };
+
+        user = lib.mkOption {
+          type = lib.types.str;
+          default = "dawarich";
+          description = "The database user for dawarich.";
+        };
+
+        passwordFile = lib.mkOption {
+          type = lib.types.nullOr lib.types.path;
+          default = null;
+          example = "/run/keys/dawarich-db-password";
+          description = ''
+            A file containing the password corresponding to {option}`${opt.database.user}`.
+          '';
+        };
+      };
+
+      smtp = {
+        host = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          default = null;
+          description = "SMTP host used when sending emails to users.";
+        };
+
+        port = lib.mkOption {
+          type = lib.types.port;
+          default = 25;
+          description = "SMTP port used when sending emails to users.";
+        };
+
+        fromAddress = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          default = null;
+          example = "dawarich@example.com";
+          description = ''"From" address used when sending emails to users.'';
+        };
+
+        user = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          default = null;
+          example = "dawarich@example.com";
+          description = "SMTP login name.";
+        };
+
+        passwordFile = lib.mkOption {
+          type = lib.types.nullOr lib.types.path;
+          default = null;
+          example = "/run/keys/dawarich-smtp-password";
+          description = ''
+            Path to file containing the SMTP password.
+          '';
+        };
+      };
+
+      package = lib.mkPackageOption pkgs "dawarich" { };
+
+      environment = lib.mkOption {
+        type =
+          with lib.types;
+          attrsOf (
+            nullOr (oneOf [
+              str
+              path
+              package
+            ])
+          );
+        default = { };
+        description = ''
+          Extra environment variables to pass to all dawarich services.
+        '';
+      };
+
+      extraEnvFiles = lib.mkOption {
+        type = with lib.types; listOf path;
+        default = [ ];
+        description = ''
+          Extra environment files to pass to all Dawarich services. Useful for passing down environment secrets.
+        '';
+        example = [ "/etc/dawarich/secret.env" ];
+      };
+
+      automaticMigrations = lib.mkOption {
+        description = "Whether to perform database migrations automatically";
+        type = lib.types.bool;
+        default = true;
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable (
+    lib.mkMerge [
+      {
+        assertions = [
+          {
+            assertion = !isRedisUnixSocket -> cfg.redis.port != 0;
+            message = ''
+              `services.dawarich.redis.port` needs to be configured if `services.dawarich.redis.host` is not a unix socket.
+            '';
+          }
+        ];
+
+        environment.systemPackages = [
+          dawarichConsole
+          dawarichRails
+        ];
+
+        systemd.targets.dawarich = {
+          description = "Target for all Dawarich services";
+          wantedBy = [ "multi-user.target" ];
+          after = [ "network.target" ];
+        };
+
+        systemd.services.dawarich-init-credentials = lib.mkIf needsGenCredentialsUnit {
+          script = ''
+            umask 077
+          ''
+          + lib.optionalString (cfg.secretKeyBaseFile == null) ''
+            if ! test -f ${defaultSecretKeyBaseFile}; then
+              mkdir -p $(dirname ${defaultSecretKeyBaseFile})
+              bin/bundle exec rails secret > ${defaultSecretKeyBaseFile}
+            fi
+          '';
+
+          environment = env;
+          serviceConfig = {
+            Type = "oneshot";
+            SyslogIdentifier = "dawarich-init-dirs";
+            # System Call Filtering
+            SystemCallFilter = [ "~@resources" ] ++ systemCallFilter;
+          }
+          // cfgService;
+
+          after = [ "network.target" ];
+        };
+
+        systemd.services.dawarich-init-db = lib.mkIf cfg.automaticMigrations {
+          script = ''
+            ${loadCredentialsIntoEnv}
+
+            # Run primary database migrations first (needed before other migrations)
+            echo "Running primary database migrations..."
+            rails db:migrate
+
+            # Run data migrations
+            echo "Running DATA migrations..."
+            rake data:migrate
+
+            echo "Running seeds..."
+            rails db:seed
+          '';
+          path = [ cfg.package ];
+          environment = env;
+          serviceConfig = {
+            Type = "oneshot";
+            LoadCredential = loadCredentials;
+            EnvironmentFile = cfg.extraEnvFiles;
+            WorkingDirectory = cfg.package;
+            # System Call Filtering
+            SystemCallFilter = [ "~@resources" ] ++ systemCallFilter;
+          }
+          // cfgService;
+          # both postgres and redis are needed for the migrations to work
+          after = [
+            "network.target"
+          ]
+          ++ lib.optional needsGenCredentialsUnit "dawarich-init-credentials.service"
+          ++ lib.optional cfg.database.createLocally "postgresql.target"
+          ++ lib.optional cfg.redis.createLocally "redis-dawarich.service";
+          requires =
+            lib.optional needsGenCredentialsUnit "dawarich-init-credentials.service"
+            ++ lib.optional cfg.database.createLocally "postgresql.target"
+            ++ lib.optional cfg.redis.createLocally "redis-dawarich.service";
+        };
+
+        systemd.services.dawarich-web = {
+          after = [
+            "network.target"
+          ]
+          ++ lib.optional needsGenCredentialsUnit "dawarich-init-credentials.service"
+          ++ commonUnits;
+          requires = lib.optional needsGenCredentialsUnit "dawarich-init-credentials.service" ++ commonUnits;
+          wantedBy = [ "dawarich.target" ];
+          description = "Dawarich web";
+          environment = env;
+          script = ''
+            ${loadCredentialsIntoEnv}
+
+            ${lib.getExe' cfg.package "rails"} server
+          '';
+          serviceConfig = {
+            Restart = "always";
+            RestartSec = 20;
+            LoadCredential = loadCredentials;
+            EnvironmentFile = cfg.extraEnvFiles;
+            WorkingDirectory = cfg.package;
+            # Runtime directory and mode
+            RuntimeDirectory = "dawarich-web";
+            RuntimeDirectoryMode = "0750";
+          }
+          // cfgService;
+        };
+
+        systemd.tmpfiles.settings."dawarich"."${dataDir}/imports/watched".d = {
+          group = "dawarich";
+          mode = "700";
+          user = "dawarich";
+        };
+
+        services.nginx = lib.mkIf cfg.configureNginx {
+          enable = true;
+          virtualHosts."${cfg.localDomain}" = {
+            root = "${cfg.package}/public/";
+
+            locations."/" = {
+              tryFiles = "$uri @proxy";
+            };
+
+            locations."@proxy" = {
+              proxyPass = "http://127.0.0.1:${toString cfg.webPort}";
+              recommendedProxySettings = true;
+              proxyWebsockets = true;
+            };
+          };
+        };
+
+        services.redis.servers = lib.mkIf cfg.redis.createLocally {
+          dawarich = {
+            enable = true;
+            port = cfg.redis.port;
+            bind = lib.mkIf (!isRedisUnixSocket) cfg.redis.host;
+          };
+        };
+
+        services.postgresql = lib.mkIf cfg.database.createLocally {
+          enable = true;
+          extensions = ps: with ps; [ postgis ];
+          ensureUsers = [
+            {
+              inherit (cfg.database) name;
+              ensureDBOwnership = true;
+            }
+          ];
+          ensureDatabases = [ cfg.database.name ];
+        };
+
+        systemd.services.postgresql-setup.serviceConfig.ExecStartPost =
+          let
+            # https://github.com/Freika/dawarich/blob/0.30.6/db/schema.rb#L15-L16
+            # https://postgis.net/documentation/getting_started/
+            sqlFile = pkgs.writeText "dawarich-postgres-setup.sql" ''
+              CREATE EXTENSION IF NOT EXISTS postgis;
+              SELECT postgis_extensions_upgrade();
+            '';
+          in
+          lib.mkIf cfg.database.createLocally [
+            ''
+              ${lib.getExe' config.services.postgresql.package "psql"} -d "${cfg.database.name}" -f "${sqlFile}"
+            ''
+          ];
+
+        users.users = lib.mkIf (cfg.user == "dawarich") {
+          dawarich = {
+            isSystemUser = true;
+            home = cfg.package;
+            inherit (cfg) group;
+          };
+        };
+        users.groups = lib.mkIf (cfg.group == "dawarich") { ${cfg.group} = { }; };
+      }
+      {
+        systemd.services = lib.mkMerge [
+          sidekiqUnits
+        ];
+      }
+    ]
+  );
+
+  meta.maintainers = with lib.maintainers; [
+    diogotcorreia
+  ];
+
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -446,6 +446,7 @@ in
   darling-dmg = runTest ./darling-dmg.nix;
   dashy = runTest ./web-apps/dashy.nix;
   davis = runTest ./davis.nix;
+  dawarich = runTest ./web-apps/dawarich.nix;
   db-rest = runTest ./db-rest.nix;
   dconf = runTest ./dconf.nix;
   ddns-updater = runTest ./ddns-updater.nix;

--- a/nixos/tests/web-apps/dawarich.nix
+++ b/nixos/tests/web-apps/dawarich.nix
@@ -1,0 +1,77 @@
+{ ... }:
+{
+  name = "dawarich-nixos";
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      services.dawarich = {
+        enable = true;
+        localDomain = "localhost";
+      };
+
+      environment.etc.geojson.source = pkgs.fetchurl {
+        url = "https://github.com/Freika/dawarich/raw/8c24764aa56a084e980e21bc2ffd13a72fd611db/spec/fixtures/files/geojson/export.json";
+        hash = "sha256-qI00E5ixKTRJduAD+qB3JzvrpoJmC55llNtSiPVyxz4=";
+      };
+    };
+
+  testScript = ''
+    import json
+
+    machine.wait_for_unit("dawarich.target")
+
+    machine.wait_for_open_port(3000) # Web
+    machine.succeed("curl --fail http://localhost/")
+
+    # Get API key via ruby console
+    api_key = machine.succeed("dawarich-rails runner \"puts User.find_by(email: 'demo@dawarich.app').api_key\"").strip().split("\n")[-1]
+
+    res = machine.succeed(f"curl -f -H 'Authorization: Bearer {api_key}' http://localhost/api/v1/users/me")
+    user_data = json.loads(res)
+    assert user_data['user']['email'] == 'demo@dawarich.app'
+
+    example_point = {
+      "locations": [
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              -122.40530871,
+              37.74430413
+            ]
+          },
+          "properties": {
+            "battery_state": "full",
+            "battery_level": 0.7,
+            "wifi": "dawarich_home",
+            "timestamp": "2025-01-17T21:03:01Z",
+            "horizontal_accuracy": 5,
+            "vertical_accuracy": -1,
+            "altitude": 0,
+            "speed": 92.088,
+            "speed_accuracy": 0,
+            "course": 27.07,
+            "course_accuracy": 0,
+            "track_id": "799F32F5-89BB-45FB-A639-098B1B95B09F",
+            "device_id": "8D5D4197-245B-4619-A88B-2049100ADE46"
+          }
+        }
+      ]
+    }
+    machine.succeed(f"curl -f -H 'Authorization: Bearer {api_key}' --json '{json.dumps(example_point)}' http://localhost/api/v1/points")
+
+    res = machine.succeed(f"curl -f -H 'Authorization: Bearer {api_key}' http://localhost/api/v1/points")
+    assert len(json.loads(res)) == 1
+
+    # Test watcher job import
+    import_dir = "/var/lib/dawarich/imports/watched/demo@dawarich.app"
+    machine.succeed(f"mkdir -p {import_dir} && cp /etc/geojson {import_dir}/example.json")
+
+    machine.succeed('dawarich-rails runner "Import::WatcherJob.perform_now"')
+    # job runs in the background so doesn't update immediately
+    res = machine.wait_until_succeeds(f"curl -f -H 'Authorization: Bearer {api_key}' http://localhost/api/v1/points | grep '\"id\":2'")
+    assert len(json.loads(res)) == 11
+  '';
+}

--- a/pkgs/by-name/da/dawarich/0001-build-ffi-gem.diff
+++ b/pkgs/by-name/da/dawarich/0001-build-ffi-gem.diff
@@ -1,0 +1,18 @@
+diff --git a/Gemfile.lock b/Gemfile.lock
+index d45a7657..d0a7b750 100644
+--- a/Gemfile.lock
++++ b/Gemfile.lock
+@@ -172,12 +172,7 @@ GEM
+       railties (>= 6.1.0)
+     fakeredis (0.1.4)
+     ffaker (2.25.0)
+-    ffi (1.17.2-aarch64-linux-gnu)
+-    ffi (1.17.2-arm-linux-gnu)
+-    ffi (1.17.2-arm64-darwin)
+-    ffi (1.17.2-x86-linux-gnu)
+-    ffi (1.17.2-x86_64-darwin)
+-    ffi (1.17.2-x86_64-linux-gnu)
++    ffi (1.17.2)
+     foreman (0.90.0)
+       thor (~> 1.4)
+     fugit (1.11.1)

--- a/pkgs/by-name/da/dawarich/0002-openssl-hotfix.diff
+++ b/pkgs/by-name/da/dawarich/0002-openssl-hotfix.diff
@@ -1,0 +1,32 @@
+diff --git a/Gemfile b/Gemfile
+index 36cf0d9c..fc914849 100644
+--- a/Gemfile
++++ b/Gemfile
+@@ -28,6 +28,7 @@ gem 'omniauth-github', '~> 2.0.0'
+ gem 'omniauth-google-oauth2'
+ gem 'omniauth_openid_connect'
+ gem 'omniauth-rails_csrf_protection'
++gem 'openssl'
+ gem 'parallel'
+ gem 'pg'
+ gem 'prometheus_exporter'
+diff --git a/Gemfile.lock b/Gemfile.lock
+index a32eb801..b2fc45bc 100644
+--- a/Gemfile.lock
++++ b/Gemfile.lock
+@@ -348,6 +348,7 @@ GEM
+       tzinfo
+       validate_url
+       webfinger (~> 2.0)
++    openssl (3.3.1)
+     optimist (3.2.1)
+     orm_adapter (0.5.0)
+     ostruct (0.6.1)
+@@ -665,6 +666,7 @@ DEPENDENCIES
+   omniauth-google-oauth2
+   omniauth-rails_csrf_protection
+   omniauth_openid_connect
++  openssl
+   parallel
+   pg
+   prometheus_exporter

--- a/pkgs/by-name/da/dawarich/gemset.nix
+++ b/pkgs/by-name/da/dawarich/gemset.nix
@@ -1,0 +1,3390 @@
+{
+  actioncable = {
+    dependencies = [
+      "actionpack"
+      "activesupport"
+      "nio4r"
+      "websocket-driver"
+      "zeitwerk"
+    ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "14vlhzrgfgmz0fvrvd81j9xfw8ig091yiwq496firapgxffd7jpq";
+      type = "gem";
+    };
+    version = "8.0.3";
+  };
+  actionmailbox = {
+    dependencies = [
+      "actionpack"
+      "activejob"
+      "activerecord"
+      "activestorage"
+      "activesupport"
+      "mail"
+    ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0bxxqqflmczwl4ivcqjwwsnrhljcalk1i2hj02qisr3wjgw4811a";
+      type = "gem";
+    };
+    version = "8.0.3";
+  };
+  actionmailer = {
+    dependencies = [
+      "actionpack"
+      "actionview"
+      "activejob"
+      "activesupport"
+      "mail"
+      "rails-dom-testing"
+    ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "08y7ihafq71879ncq963rwi541b0gafqx8h5ba26zab521qc7h3d";
+      type = "gem";
+    };
+    version = "8.0.3";
+  };
+  actionpack = {
+    dependencies = [
+      "actionview"
+      "activesupport"
+      "nokogiri"
+      "rack"
+      "rack-session"
+      "rack-test"
+      "rails-dom-testing"
+      "rails-html-sanitizer"
+      "useragent"
+    ];
+    groups = [
+      "default"
+      "development"
+      "staging"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1lsspr8nffzn8qpfmj654w1qja1915x6bnzzhpbjj1cy235j2g6n";
+      type = "gem";
+    };
+    version = "8.0.3";
+  };
+  actiontext = {
+    dependencies = [
+      "actionpack"
+      "activerecord"
+      "activestorage"
+      "activesupport"
+      "globalid"
+      "nokogiri"
+    ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1x4xd8h5sdwdm3rc8h2pxxmq4a0i0wa0gk6c56zq58pzc3xgsihw";
+      type = "gem";
+    };
+    version = "8.0.3";
+  };
+  actionview = {
+    dependencies = [
+      "activesupport"
+      "builder"
+      "erubi"
+      "rails-dom-testing"
+      "rails-html-sanitizer"
+    ];
+    groups = [
+      "default"
+      "development"
+      "staging"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0rnfn44g217n9hgvn4ga7l0hl149b91djnl07nzra7kxy1pr8wai";
+      type = "gem";
+    };
+    version = "8.0.3";
+  };
+  activejob = {
+    dependencies = [
+      "activesupport"
+      "globalid"
+    ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1dm1vc5vvk5pwq4x7sfh3g6qzzwbyac37ggh1mm1rzraharxv7j6";
+      type = "gem";
+    };
+    version = "8.0.3";
+  };
+  activemodel = {
+    dependencies = [ "activesupport" ];
+    groups = [
+      "default"
+      "development"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0z565q17fmhj4b9j689r0xx1s26w1xcw8z0qyb6h8v0wb8j0fsa0";
+      type = "gem";
+    };
+    version = "8.0.3";
+  };
+  activerecord = {
+    dependencies = [
+      "activemodel"
+      "activesupport"
+      "timeout"
+    ];
+    groups = [
+      "default"
+      "development"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1a6fng58lria02wlwiqjgqway0nx1wq31dsxn5xvbk7958xwd5cv";
+      type = "gem";
+    };
+    version = "8.0.3";
+  };
+  activerecord-postgis-adapter = {
+    dependencies = [
+      "activerecord"
+      "rgeo-activerecord"
+    ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "06xp91kanz3w2s89wqb97fzzzcpy79rfjjs4zq85m402zg2fm08w";
+      type = "gem";
+    };
+    version = "11.0.0";
+  };
+  activestorage = {
+    dependencies = [
+      "actionpack"
+      "activejob"
+      "activerecord"
+      "activesupport"
+      "marcel"
+    ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0plck0b57b9ni8n52hj5slv5n8i7w3nfwq6r47nkb2hjbpmsskjg";
+      type = "gem";
+    };
+    version = "8.0.3";
+  };
+  activesupport = {
+    dependencies = [
+      "base64"
+      "benchmark"
+      "bigdecimal"
+      "concurrent-ruby"
+      "connection_pool"
+      "drb"
+      "i18n"
+      "logger"
+      "minitest"
+      "securerandom"
+      "tzinfo"
+      "uri"
+    ];
+    groups = [
+      "default"
+      "development"
+      "staging"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "08vqq5y6vniz30p747xa8yfqb3cz8scqd8r65wij62v661gcw4d7";
+      type = "gem";
+    };
+    version = "8.0.3";
+  };
+  addressable = {
+    dependencies = [ "public_suffix" ];
+    groups = [
+      "default"
+      "development"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0cl2qpvwiffym62z991ynks7imsm87qmgxf0yfsmlwzkgi9qcaa6";
+      type = "gem";
+    };
+    version = "2.8.7";
+  };
+  aes_key_wrap = {
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "19bn0y70qm6mfj4y1m0j3s8ggh6dvxwrwrj5vfamhdrpddsz8ddr";
+      type = "gem";
+    };
+    version = "1.1.0";
+  };
+  ast = {
+    groups = [
+      "default"
+      "development"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "10yknjyn0728gjn6b5syynvrvrwm66bhssbxq8mkhshxghaiailm";
+      type = "gem";
+    };
+    version = "2.4.3";
+  };
+  attr_extras = {
+    groups = [
+      "default"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "09y83ygjsk4rva8bn9mfb4whjh7q2sl4093n6wnvm1axvnlwjvyr";
+      type = "gem";
+    };
+    version = "7.1.0";
+  };
+  attr_required = {
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "16fbwr6nmsn97n0a6k1nwbpyz08zpinhd6g7196lz1syndbgrszh";
+      type = "gem";
+    };
+    version = "1.0.2";
+  };
+  aws-eventstream = {
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1mvjjn8vh1c3nhibmjj9qcwxagj6m9yy961wblfqdmvhr9aklb3y";
+      type = "gem";
+    };
+    version = "1.3.2";
+  };
+  aws-partitions = {
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "06y8bc0iasxm2m9l6yz84kp7d0nka52z6adz4ia09rv1ry1czrm6";
+      type = "gem";
+    };
+    version = "1.1072.0";
+  };
+  aws-sdk-core = {
+    dependencies = [
+      "aws-eventstream"
+      "aws-partitions"
+      "aws-sigv4"
+      "jmespath"
+    ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1vmi65a22dq0rhjiydr94zwpn9hx3vib7vp922ccjg0vrih7mlzy";
+      type = "gem";
+    };
+    version = "3.215.1";
+  };
+  aws-sdk-kms = {
+    dependencies = [
+      "aws-sdk-core"
+      "aws-sigv4"
+    ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0xd3ddd9jiapkgv8im4pl9dcdy2ps7qjsssf2nz3q6sd1ca8x0di";
+      type = "gem";
+    };
+    version = "1.96.0";
+  };
+  aws-sdk-s3 = {
+    dependencies = [
+      "aws-sdk-core"
+      "aws-sdk-kms"
+      "aws-sigv4"
+    ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "10ziy8zslfjs0ihls7wiq6zvsncq89azh36rshmlylry1hhxjbxz";
+      type = "gem";
+    };
+    version = "1.177.0";
+  };
+  aws-sigv4 = {
+    dependencies = [ "aws-eventstream" ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1nx1il781qg58nwjkkdn9fw741cjjnixfsh389234qm8j5lpka2h";
+      type = "gem";
+    };
+    version = "1.11.0";
+  };
+  base64 = {
+    groups = [
+      "default"
+      "development"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0yx9yn47a8lkfcjmigk79fykxvr80r4m1i35q82sxzynpbm7lcr7";
+      type = "gem";
+    };
+    version = "0.3.0";
+  };
+  bcrypt = {
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "16a0g2q40biv93i1hch3gw8rbmhp77qnnifj1k0a6m7dng3zh444";
+      type = "gem";
+    };
+    version = "3.1.20";
+  };
+  benchmark = {
+    groups = [
+      "default"
+      "development"
+      "staging"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0v1337j39w1z7x9zs4q7ag0nfv4vs4xlsjx2la0wpv8s6hig2pa6";
+      type = "gem";
+    };
+    version = "0.5.0";
+  };
+  bigdecimal = {
+    groups = [
+      "default"
+      "development"
+      "staging"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "19y406nx17arzsbc515mjmr6k5p59afprspa1k423yd9cp8d61wb";
+      type = "gem";
+    };
+    version = "4.0.1";
+  };
+  bindata = {
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0n4ymlgik3xcg94h52dzmh583ss40rl3sn0kni63v56sq8g6l62k";
+      type = "gem";
+    };
+    version = "2.5.1";
+  };
+  bootsnap = {
+    dependencies = [ "msgpack" ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "003xl226y120cbq1n99805jw6w75gcz1gs941yz3h7li3qy3kqha";
+      type = "gem";
+    };
+    version = "1.18.6";
+  };
+  brakeman = {
+    dependencies = [ "racc" ];
+    groups = [
+      "development"
+      "staging"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "164l8dh3c22c8448hgd0zqhsffxvn4d9wad2zzipav29sssjd532";
+      type = "gem";
+    };
+    version = "7.1.1";
+  };
+  builder = {
+    groups = [
+      "default"
+      "development"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0pw3r2lyagsxkm71bf44v5b74f7l9r7di22brbyji9fwz791hya9";
+      type = "gem";
+    };
+    version = "3.3.0";
+  };
+  bundler-audit = {
+    dependencies = [ "thor" ];
+    groups = [
+      "development"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0j0h5cgnzk0ms17ssjkzfzwz65ggrs3lsp53a1j46p4616m1s1bk";
+      type = "gem";
+    };
+    version = "0.9.2";
+  };
+  byebug = {
+    groups = [
+      "default"
+      "development"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "07hsr9zzl2mvf5gk65va4smdizlk9rsiz8wwxik0p96cj79518fl";
+      type = "gem";
+    };
+    version = "12.0.0";
+  };
+  capybara = {
+    dependencies = [
+      "addressable"
+      "matrix"
+      "mini_mime"
+      "nokogiri"
+      "rack"
+      "rack-test"
+      "regexp_parser"
+      "xpath"
+    ];
+    groups = [ "test" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1vxfah83j6zpw3v5hic0j70h519nvmix2hbszmjwm8cfawhagns2";
+      type = "gem";
+    };
+    version = "3.40.0";
+  };
+  chartkick = {
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0jcr6rjfb3q0jpnivpl1dw7iz2mwvsxv0zh7ipr317qqhzgdfj18";
+      type = "gem";
+    };
+    version = "5.2.1";
+  };
+  chunky_png = {
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1znw5x86hmm9vfhidwdsijz8m38pqgmv98l9ryilvky0aldv7mc9";
+      type = "gem";
+    };
+    version = "1.4.0";
+  };
+  coderay = {
+    groups = [
+      "default"
+      "development"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0jvxqxzply1lwp7ysn94zjhh57vc14mcshw1ygw14ib8lhc00lyw";
+      type = "gem";
+    };
+    version = "1.1.3";
+  };
+  concurrent-ruby = {
+    groups = [
+      "default"
+      "development"
+      "staging"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1aymcakhzl83k77g2f2krz07bg1cbafbcd2ghvwr4lky3rz86mkb";
+      type = "gem";
+    };
+    version = "1.3.6";
+  };
+  connection_pool = {
+    groups = [
+      "default"
+      "development"
+      "staging"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1b8nlxr5z843ii7hfk6igpr5acw3k2ih9yjrgkyz2gbmallgjkz5";
+      type = "gem";
+    };
+    version = "2.5.5";
+  };
+  crack = {
+    dependencies = [
+      "bigdecimal"
+      "rexml"
+    ];
+    groups = [
+      "default"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0zjcdl5i6lw508r01dym05ibhkc784cfn93m1d26c7fk1hwi0jpz";
+      type = "gem";
+    };
+    version = "1.0.1";
+  };
+  crass = {
+    groups = [
+      "default"
+      "development"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0pfl5c0pyqaparxaqxi6s4gfl21bdldwiawrc0aknyvflli60lfw";
+      type = "gem";
+    };
+    version = "1.0.6";
+  };
+  cronex = {
+    dependencies = [
+      "tzinfo"
+      "unicode"
+    ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "11i1psgzcqzj4a7p62vy56i5p8s00d29y9rf9wf9blpshph99ir1";
+      type = "gem";
+    };
+    version = "0.15.0";
+  };
+  css-zero = {
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1jiihfxvfw0wl42m0jzpq94iqa2ra878dqllkk34w49pv0wsgrkz";
+      type = "gem";
+    };
+    version = "1.1.15";
+  };
+  csv = {
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1kfqg0m6vqs6c67296f10cr07im5mffj90k2b5dsm51liidcsvp9";
+      type = "gem";
+    };
+    version = "3.3.4";
+  };
+  data_migrate = {
+    dependencies = [
+      "activerecord"
+      "railties"
+    ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1ywg2qvpf1yxfbcdwmw2pl274i4bicjc4gsz6gaq5r0mklcb5f8q";
+      type = "gem";
+    };
+    version = "11.3.1";
+  };
+  database_consistency = {
+    dependencies = [ "activerecord" ];
+    groups = [ "development" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "19yf280vw91ji4prrbk17qy336l1y1jqvwsnhf3fc7yscim431sj";
+      type = "gem";
+    };
+    version = "2.0.6";
+  };
+  date = {
+    groups = [
+      "default"
+      "development"
+      "staging"
+      "test"
+    ];
+    platforms = [
+      {
+        engine = "maglev";
+      }
+      {
+        engine = "mingw";
+      }
+      {
+        engine = "mingw";
+      }
+      {
+        engine = "ruby";
+      }
+    ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1rbfqkzr6i8b6538z16chvrkgywf5p5vafsgmnbmvrmh0ingsx2y";
+      type = "gem";
+    };
+    version = "3.5.0";
+  };
+  debug = {
+    dependencies = [
+      "irb"
+      "reline"
+    ];
+    groups = [
+      "development"
+      "test"
+    ];
+    platforms = [
+      {
+        engine = "maglev";
+      }
+      {
+        engine = "mingw";
+      }
+      {
+        engine = "mingw";
+      }
+      {
+        engine = "ruby";
+      }
+    ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1wmfy5n5v2rzpr5vz698sqfj1gl596bxrqw44sahq4x0rxjdn98l";
+      type = "gem";
+    };
+    version = "1.11.0";
+  };
+  devise = {
+    dependencies = [
+      "bcrypt"
+      "orm_adapter"
+      "railties"
+      "responders"
+      "warden"
+    ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1y57fpcvy1kjd4nb7zk7mvzq62wqcpfynrgblj558k3hbvz4404j";
+      type = "gem";
+    };
+    version = "4.9.4";
+  };
+  diff-lcs = {
+    groups = [
+      "default"
+      "development"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0qlrj2qyysc9avzlr4zs1py3x684hqm61n4czrsk1pyllz5x5q4s";
+      type = "gem";
+    };
+    version = "1.6.2";
+  };
+  docile = {
+    groups = [
+      "default"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "07pj4z3h8wk4fgdn6s62vw1lwvhj0ac0x10vfbdkr9xzk7krn5cn";
+      type = "gem";
+    };
+    version = "1.4.1";
+  };
+  dotenv = {
+    groups = [
+      "default"
+      "development"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1hwjsddv666wpp42bip3fqx7c5qq6s8lwf74dj71yn7d1h37c4cy";
+      type = "gem";
+    };
+    version = "3.1.8";
+  };
+  dotenv-rails = {
+    dependencies = [
+      "dotenv"
+      "railties"
+    ];
+    groups = [
+      "development"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1i40g6kzwp8yxsxzpzgsq2hww9gxryl5lck1bwxshn4bd8id3ja6";
+      type = "gem";
+    };
+    version = "3.1.8";
+  };
+  drb = {
+    groups = [
+      "default"
+      "development"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0wrkl7yiix268s2md1h6wh91311w95ikd8fy8m5gx589npyxc00b";
+      type = "gem";
+    };
+    version = "2.2.3";
+  };
+  email_validator = {
+    dependencies = [ "activemodel" ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0106y8xakq6frv2xc68zz76q2l2cqvhfjc7ji69yyypcbc4kicjs";
+      type = "gem";
+    };
+    version = "2.2.4";
+  };
+  erb = {
+    groups = [
+      "default"
+      "development"
+      "staging"
+      "test"
+    ];
+    platforms = [
+      {
+        engine = "maglev";
+      }
+      {
+        engine = "mingw";
+      }
+      {
+        engine = "mingw";
+      }
+      {
+        engine = "ruby";
+      }
+    ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0y95ynlfngs0s5x1w6mwralszhbi9d75lcdbdkqk75wcklzqjc17";
+      type = "gem";
+    };
+    version = "6.0.0";
+  };
+  erubi = {
+    groups = [
+      "default"
+      "development"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1naaxsqkv5b3vklab5sbb9sdpszrjzlfsbqpy7ncbnw510xi10m0";
+      type = "gem";
+    };
+    version = "1.13.1";
+  };
+  et-orbi = {
+    dependencies = [ "tzinfo" ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1g785lz4z2k7jrdl7bnnjllzfrwpv9pyki94ngizj8cqfy83qzkc";
+      type = "gem";
+    };
+    version = "1.4.0";
+  };
+  factory_bot = {
+    dependencies = [ "activesupport" ];
+    groups = [
+      "default"
+      "development"
+      "staging"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1gpgcr5dfrq7hs3wafxaqrkx84zm2rlfwbwamd6p1d71mrfjjnff";
+      type = "gem";
+    };
+    version = "6.5.5";
+  };
+  factory_bot_rails = {
+    dependencies = [
+      "factory_bot"
+      "railties"
+    ];
+    groups = [
+      "development"
+      "staging"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0s3dpi8x754bwv4mlasdal8ffiahi4b4ajpccnkaipp4x98lik6k";
+      type = "gem";
+    };
+    version = "6.5.1";
+  };
+  fakeredis = {
+    groups = [ "test" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0xlkcavchj9l9457q4gfjynrzj3d9q9p8sxwclqrn4g2wjdc8vap";
+      type = "gem";
+    };
+    version = "0.1.4";
+  };
+  faraday = {
+    dependencies = [
+      "faraday-net_http"
+      "json"
+      "logger"
+    ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1ka175ci0q9ylpcy651pjj580diplkaskycn4n7jcmbyv7jwz6c6";
+      type = "gem";
+    };
+    version = "2.14.0";
+  };
+  faraday-follow_redirects = {
+    dependencies = [ "faraday" ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1nfmmnmqgbxci7dlca0qnwxn8j29yv7v8wm26m0f4l0kmcc13ynk";
+      type = "gem";
+    };
+    version = "0.4.0";
+  };
+  faraday-net_http = {
+    dependencies = [ "net-http" ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0fxbckg468dabkkznv48ss8zv14d9cd8mh1rr3m98aw7wzx5fmq9";
+      type = "gem";
+    };
+    version = "3.4.1";
+  };
+  ffaker = {
+    groups = [
+      "development"
+      "staging"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0h7crcdqddlds3kx0q3vsx3cm6s62psvfx98crasqnhrz2nwb1g4";
+      type = "gem";
+    };
+    version = "2.25.0";
+  };
+  ffi = {
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "19kdyjg3kv7x0ad4xsd4swy5izsbb1vl1rpb6qqcqisr5s23awi9";
+      type = "gem";
+    };
+    version = "1.17.2";
+  };
+  foreman = {
+    dependencies = [ "thor" ];
+    groups = [ "development" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0z0i7wn1x5ii3i9q9c4d3ps0d3zfw71llvaaf5caq1xn8wnmwrzz";
+      type = "gem";
+    };
+    version = "0.90.0";
+  };
+  fugit = {
+    dependencies = [
+      "et-orbi"
+      "raabro"
+    ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0s5gg88f2d5wpppgrgzfhnyi9y2kzprvhhjfh3q1bd79xmwg962q";
+      type = "gem";
+    };
+    version = "1.12.1";
+  };
+  geocoder = {
+    dependencies = [
+      "base64"
+      "csv"
+    ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      fetchSubmodules = false;
+      rev = "12ac3e659fc5b57c1ffd12f04b8cad2f73d0939c";
+      sha256 = "0k4wafl8f3v3vv3zzy1v9b4yiz3nz15zy41kg8j4fx1kbcvasgm1";
+      type = "git";
+      url = "https://github.com/Freika/geocoder.git";
+    };
+    version = "1.8.5";
+  };
+  globalid = {
+    dependencies = [ "activesupport" ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "04gzhqvsm4z4l12r9dkac9a75ah45w186ydhl0i4andldsnkkih5";
+      type = "gem";
+    };
+    version = "1.3.0";
+  };
+  gpx = {
+    dependencies = [
+      "csv"
+      "nokogiri"
+      "rake"
+    ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1cgm6dzzpslhgxcqcgqnpvargrq9d3v2xhxgan1l1cayc33pn837";
+      type = "gem";
+    };
+    version = "1.2.1";
+  };
+  groupdate = {
+    dependencies = [ "activesupport" ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0xv7zdaw799fvhbh0pdq2hi6lhvp1sid988l35l18s45yddqvamy";
+      type = "gem";
+    };
+    version = "6.7.0";
+  };
+  h3 = {
+    dependencies = [
+      "ffi"
+      "rgeo-geojson"
+      "zeitwerk"
+    ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1vgy9d5pafk2lkb9r1w3d3y6wbzdkc7ls5k83rc6r307cinjblwr";
+      type = "gem";
+    };
+    version = "3.7.4";
+  };
+  hashdiff = {
+    groups = [
+      "default"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1lbw8lqzjv17vnwb9vy5ki4jiyihybcc5h2rmcrqiz1xa6y9s1ww";
+      type = "gem";
+    };
+    version = "1.2.1";
+  };
+  hashie = {
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1nh3arcrbz1rc1cr59qm53sdhqm137b258y8rcb4cvd3y98lwv4x";
+      type = "gem";
+    };
+    version = "5.0.0";
+  };
+  httparty = {
+    dependencies = [
+      "csv"
+      "mini_mime"
+      "multi_xml"
+    ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0mbbjr774zxb2wcpbwc93l0i481bxk7ga5hpap76w3q1y9idvh9s";
+      type = "gem";
+    };
+    version = "0.23.1";
+  };
+  i18n = {
+    dependencies = [ "concurrent-ruby" ];
+    groups = [
+      "default"
+      "development"
+      "staging"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1994i044vdmzzkyr76g8rpl1fq1532wf0sb21xg5r1ilj5iphmr8";
+      type = "gem";
+    };
+    version = "1.14.8";
+  };
+  importmap-rails = {
+    dependencies = [
+      "actionpack"
+      "activesupport"
+      "railties"
+    ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "05767zlpfafsairdl1kgalfdjlvydjsd1qdd5447hcpqj885p7vj";
+      type = "gem";
+    };
+    version = "2.2.2";
+  };
+  io-console = {
+    groups = [
+      "default"
+      "development"
+      "test"
+    ];
+    platforms = [
+      {
+        engine = "maglev";
+      }
+      {
+        engine = "mingw";
+      }
+      {
+        engine = "mingw";
+      }
+      {
+        engine = "ruby";
+      }
+    ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1jszj95hazqqpnrjjzr326nn1j32xmsc9xvd97mbcrrgdc54858y";
+      type = "gem";
+    };
+    version = "0.8.1";
+  };
+  irb = {
+    dependencies = [
+      "pp"
+      "rdoc"
+      "reline"
+    ];
+    groups = [
+      "default"
+      "development"
+      "staging"
+      "test"
+    ];
+    platforms = [
+      {
+        engine = "maglev";
+      }
+      {
+        engine = "mingw";
+      }
+      {
+        engine = "mingw";
+      }
+      {
+        engine = "ruby";
+      }
+    ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1aja320qnimlnfc80wf2i2x8i99kl5sdzfacsfzzfzzs3vzysja3";
+      type = "gem";
+    };
+    version = "1.15.3";
+  };
+  jmespath = {
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1cdw9vw2qly7q7r41s7phnac264rbsdqgj4l0h4nqgbjb157g393";
+      type = "gem";
+    };
+    version = "1.6.2";
+  };
+  json = {
+    groups = [
+      "default"
+      "development"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "01fmiz052cvnxgdnhb3qwcy88xbv7l3liz0fkvs5qgqqwjp0c1di";
+      type = "gem";
+    };
+    version = "2.18.0";
+  };
+  json-jwt = {
+    dependencies = [
+      "activesupport"
+      "aes_key_wrap"
+      "base64"
+      "bindata"
+      "faraday"
+      "faraday-follow_redirects"
+    ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1k64mp59jlbqd5hyy46pf93s3yl1xdngfy8i8flq2hn5nhk91ybg";
+      type = "gem";
+    };
+    version = "1.17.0";
+  };
+  json-schema = {
+    dependencies = [ "addressable" ];
+    groups = [
+      "default"
+      "development"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1abl1a92zv9xxw3xb3hrzjpk8xiz2hp54lqmj6a2b900qs11mxxy";
+      type = "gem";
+    };
+    version = "5.0.1";
+  };
+  jwt = {
+    dependencies = [ "base64" ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1i8wmzgb5nfhvkx1f6bhdwfm7v772172imh439v3xxhkv3hllhp6";
+      type = "gem";
+    };
+    version = "2.10.1";
+  };
+  kaminari = {
+    dependencies = [
+      "activesupport"
+      "kaminari-actionview"
+      "kaminari-activerecord"
+      "kaminari-core"
+    ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0gia8irryvfhcr6bsr64kpisbgdbqjsqfgrk12a11incmpwny1y4";
+      type = "gem";
+    };
+    version = "1.2.2";
+  };
+  kaminari-actionview = {
+    dependencies = [
+      "actionview"
+      "kaminari-core"
+    ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "02f9ghl3a9b5q7l079d3yzmqjwkr4jigi7sldbps992rigygcc0k";
+      type = "gem";
+    };
+    version = "1.2.2";
+  };
+  kaminari-activerecord = {
+    dependencies = [
+      "activerecord"
+      "kaminari-core"
+    ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0c148z97s1cqivzbwrak149z7kl1rdmj7dxk6rpkasimmdxsdlqd";
+      type = "gem";
+    };
+    version = "1.2.2";
+  };
+  kaminari-core = {
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1zw3pg6kj39y7jxakbx7if59pl28lhk98fx71ks5lr3hfgn6zliv";
+      type = "gem";
+    };
+    version = "1.2.2";
+  };
+  language_server-protocol = {
+    groups = [
+      "default"
+      "development"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1k0311vah76kg5m6zr7wmkwyk5p2f9d9hyckjpn3xgr83ajkj7px";
+      type = "gem";
+    };
+    version = "3.17.0.5";
+  };
+  lint_roller = {
+    groups = [
+      "default"
+      "development"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "11yc0d84hsnlvx8cpk4cbj6a4dz9pk0r1k29p0n1fz9acddq831c";
+      type = "gem";
+    };
+    version = "1.1.0";
+  };
+  logger = {
+    groups = [
+      "default"
+      "development"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "00q2zznygpbls8asz5knjvvj2brr3ghmqxgr83xnrdj4rk3xwvhr";
+      type = "gem";
+    };
+    version = "1.7.0";
+  };
+  lograge = {
+    dependencies = [
+      "actionpack"
+      "activesupport"
+      "railties"
+      "request_store"
+    ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1qcsvh9k4c0cp6agqm9a8m4x2gg7vifryqr7yxkg2x9ph9silds2";
+      type = "gem";
+    };
+    version = "0.14.0";
+  };
+  loofah = {
+    dependencies = [
+      "crass"
+      "nokogiri"
+    ];
+    groups = [
+      "default"
+      "development"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0dx316q03x6rpdbl610rdaj2vfd5s8fanixk21j4gv3h5f230nk5";
+      type = "gem";
+    };
+    version = "2.24.1";
+  };
+  mail = {
+    dependencies = [
+      "logger"
+      "mini_mime"
+      "net-imap"
+      "net-pop"
+      "net-smtp"
+    ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0ha9sgkfqna62c1basc17dkx91yk7ppgjq32k4nhrikirlz6g9kg";
+      type = "gem";
+    };
+    version = "2.9.0";
+  };
+  marcel = {
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1vhb1sbzlq42k2pzd9v0w5ws4kjx184y8h4d63296bn57jiwzkzx";
+      type = "gem";
+    };
+    version = "1.1.0";
+  };
+  matrix = {
+    groups = [
+      "default"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1h2cgkpzkh3dd0flnnwfq6f3nl2b1zff9lvqz8xs853ssv5kq23i";
+      type = "gem";
+    };
+    version = "0.4.2";
+  };
+  method_source = {
+    groups = [
+      "default"
+      "development"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1igmc3sq9ay90f8xjvfnswd1dybj1s3fi0dwd53inwsvqk4h24qq";
+      type = "gem";
+    };
+    version = "1.1.0";
+  };
+  mini_mime = {
+    groups = [
+      "default"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1vycif7pjzkr29mfk4dlqv3disc5dn0va04lkwajlpr1wkibg0c6";
+      type = "gem";
+    };
+    version = "1.1.5";
+  };
+  mini_portile2 = {
+    groups = [
+      "default"
+      "development"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "12f2830x7pq3kj0v8nz0zjvaw02sv01bqs1zwdrc04704kwcgmqc";
+      type = "gem";
+    };
+    version = "2.8.9";
+  };
+  minitest = {
+    dependencies = [ "prism" ];
+    groups = [
+      "default"
+      "development"
+      "staging"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1fslin1vyh60snwygx8jnaj4kwhk83f3m0v2j2b7bsg2917wfm3q";
+      type = "gem";
+    };
+    version = "6.0.1";
+  };
+  msgpack = {
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "04ihgnwp2ka68v82a6jpk9yqmazfwnbk3vsz6sb040kq6gf53dzd";
+      type = "gem";
+    };
+    version = "1.7.3";
+  };
+  multi_json = {
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0pb1g1y3dsiahavspyzkdy39j4q377009f6ix0bh1ag4nqw43l0z";
+      type = "gem";
+    };
+    version = "1.15.0";
+  };
+  multi_xml = {
+    dependencies = [ "bigdecimal" ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0wyzwvch1a4c77g5zjwjhgf9z5inzngq42b197dm9qzqjb8dqjld";
+      type = "gem";
+    };
+    version = "0.8.0";
+  };
+  net-http = {
+    dependencies = [ "uri" ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1ysrwaabhf0sn24jrp0nnp51cdv0jf688mh5i6fsz63q2c6b48cn";
+      type = "gem";
+    };
+    version = "0.6.0";
+  };
+  net-imap = {
+    dependencies = [
+      "date"
+      "net-protocol"
+    ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0i24prs7yy1p1zdps2x1ksb7lmvbn2f0llxwdjdw3z2ksddx136b";
+      type = "gem";
+    };
+    version = "0.5.12";
+  };
+  net-pop = {
+    dependencies = [ "net-protocol" ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1wyz41jd4zpjn0v1xsf9j778qx1vfrl24yc20cpmph8k42c4x2w4";
+      type = "gem";
+    };
+    version = "0.1.2";
+  };
+  net-protocol = {
+    dependencies = [ "timeout" ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1a32l4x73hz200cm587bc29q8q9az278syw3x6fkc9d1lv5y0wxa";
+      type = "gem";
+    };
+    version = "0.2.2";
+  };
+  net-smtp = {
+    dependencies = [ "net-protocol" ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0dh7nzjp0fiaqq1jz90nv4nxhc2w359d7c199gmzq965cfps15pd";
+      type = "gem";
+    };
+    version = "0.5.1";
+  };
+  nio4r = {
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1a9www524fl1ykspznz54i0phfqya4x45hqaz67in9dvw1lfwpfr";
+      type = "gem";
+    };
+    version = "2.7.4";
+  };
+  nokogiri = {
+    dependencies = [
+      "mini_portile2"
+      "racc"
+    ];
+    groups = [
+      "default"
+      "development"
+      "staging"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1hcwwr2h8jnqqxmf8mfb52b0dchr7pm064ingflb78wa00qhgk6m";
+      type = "gem";
+    };
+    version = "1.18.10";
+  };
+  oauth2 = {
+    dependencies = [
+      "faraday"
+      "jwt"
+      "logger"
+      "multi_xml"
+      "rack"
+      "snaky_hash"
+      "version_gem"
+    ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0dcqwwlm8afr97mg1i633yia3hzd61f0j5csrspzsvf0mfp85qf4";
+      type = "gem";
+    };
+    version = "2.0.17";
+  };
+  oj = {
+    dependencies = [
+      "bigdecimal"
+      "ostruct"
+    ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1cajn3ylwhby1x51d9hbchm964qwb5zp63f7sfdm55n85ffn1ara";
+      type = "gem";
+    };
+    version = "3.16.11";
+  };
+  omniauth = {
+    dependencies = [
+      "hashie"
+      "logger"
+      "rack"
+      "rack-protection"
+    ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0g3n12k5npmmgai2cs3snimy6r7h0bvalhjxv0fjxlphjq25p822";
+      type = "gem";
+    };
+    version = "2.1.4";
+  };
+  omniauth-github = {
+    dependencies = [
+      "omniauth"
+      "omniauth-oauth2"
+    ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1m6a7kg3lxz2nm96prln2ja8r4wlm37m5vsy9199vnynqq5fgy4g";
+      type = "gem";
+    };
+    version = "2.0.1";
+  };
+  omniauth-google-oauth2 = {
+    dependencies = [
+      "jwt"
+      "oauth2"
+      "omniauth"
+      "omniauth-oauth2"
+    ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1pdf3bx036l6ggz6lkkykv77m9k4jypwsiw1q7874czwh2v50768";
+      type = "gem";
+    };
+    version = "1.2.1";
+  };
+  omniauth-oauth2 = {
+    dependencies = [
+      "oauth2"
+      "omniauth"
+    ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0y4y122xm8zgrxn5nnzwg6w39dnjss8pcq2ppbpx9qn7kiayky5j";
+      type = "gem";
+    };
+    version = "1.8.0";
+  };
+  omniauth-rails_csrf_protection = {
+    dependencies = [
+      "actionpack"
+      "omniauth"
+    ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1q2zvkw34vk1vyhn5kp30783w1wzam9i9g5ygsdjn2gz59kzsw0i";
+      type = "gem";
+    };
+    version = "1.0.2";
+  };
+  omniauth_openid_connect = {
+    dependencies = [
+      "omniauth"
+      "openid_connect"
+    ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "099xg7s6450wlfzs77mbdx78g3dp0glx5q6f44i78akf7283hbqz";
+      type = "gem";
+    };
+    version = "0.8.0";
+  };
+  openid_connect = {
+    dependencies = [
+      "activemodel"
+      "attr_required"
+      "email_validator"
+      "faraday"
+      "faraday-follow_redirects"
+      "json-jwt"
+      "mail"
+      "rack-oauth2"
+      "swd"
+      "tzinfo"
+      "validate_url"
+      "webfinger"
+    ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "10i13cn40jiiw8lslkv7bj1isinnwbmzlk6msgiph3gqry08702x";
+      type = "gem";
+    };
+    version = "2.3.1";
+  };
+  openssl = {
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0dzq3k5hmqlav2mwf7bc10mr1mlmlnpin498g7jhbhpdpa324s6n";
+      type = "gem";
+    };
+    version = "3.3.1";
+  };
+  optimist = {
+    groups = [
+      "default"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0kp3f8g7g7cbw5vfkmpdv71pphhpcxk3lpc892mj9apkd7ys1y4c";
+      type = "gem";
+    };
+    version = "3.2.1";
+  };
+  orm_adapter = {
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1fg9jpjlzf5y49qs9mlpdrgs5rpcyihq1s4k79nv9js0spjhnpda";
+      type = "gem";
+    };
+    version = "0.5.0";
+  };
+  ostruct = {
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "05xqijcf80sza5pnlp1c8whdaay8x5dc13214ngh790zrizgp8q9";
+      type = "gem";
+    };
+    version = "0.6.1";
+  };
+  pagy = {
+    dependencies = [
+      "json"
+      "yaml"
+    ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "08pikkvj916fw75l7ycmzb3gf1w9cp3h1jphls0pnqbphf1v3r4g";
+      type = "gem";
+    };
+    version = "43.2.2";
+  };
+  parallel = {
+    groups = [
+      "default"
+      "development"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0c719bfgcszqvk9z47w2p8j2wkz5y35k48ywwas5yxbbh3hm3haa";
+      type = "gem";
+    };
+    version = "1.27.0";
+  };
+  parser = {
+    dependencies = [
+      "ast"
+      "racc"
+    ];
+    groups = [
+      "default"
+      "development"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1mmb59323ldv6vxfmy98azgsla9k3di3fasvpb28hnn5bkx8fdff";
+      type = "gem";
+    };
+    version = "3.3.10.0";
+  };
+  patience_diff = {
+    dependencies = [ "optimist" ];
+    groups = [
+      "default"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0b42yr1yyph9knibnf7v896wzfqf9mmzlw00m3sgy0mghr20k4pl";
+      type = "gem";
+    };
+    version = "1.2.0";
+  };
+  pg = {
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0xf8i58shwvwlka4ld12nxcgqv0d5r1yizsvw74w5jaw83yllqaq";
+      type = "gem";
+    };
+    version = "1.6.2";
+  };
+  pp = {
+    dependencies = [ "prettyprint" ];
+    groups = [
+      "default"
+      "development"
+      "staging"
+      "test"
+    ];
+    platforms = [
+      {
+        engine = "maglev";
+      }
+      {
+        engine = "mingw";
+      }
+      {
+        engine = "mingw";
+      }
+      {
+        engine = "ruby";
+      }
+    ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1xlxmg86k5kifci1xvlmgw56x88dmqf04zfzn7zcr4qb8ladal99";
+      type = "gem";
+    };
+    version = "0.6.3";
+  };
+  prettyprint = {
+    groups = [
+      "default"
+      "development"
+      "test"
+    ];
+    platforms = [
+      {
+        engine = "maglev";
+      }
+      {
+        engine = "mingw";
+      }
+      {
+        engine = "mingw";
+      }
+      {
+        engine = "ruby";
+      }
+    ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "14zicq3plqi217w6xahv7b8f7aj5kpxv1j1w98344ix9h5ay3j9b";
+      type = "gem";
+    };
+    version = "0.2.0";
+  };
+  prism = {
+    groups = [
+      "default"
+      "development"
+      "staging"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "00silqnlzzm97gn21lm39q95hjn058waqky44j25r67p9drjy1hh";
+      type = "gem";
+    };
+    version = "1.7.0";
+  };
+  prometheus_exporter = {
+    dependencies = [ "webrick" ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "15vl8fw8vjnaj9g129dzrwk9nlrdqgffaj3rys4ba9ns2bqim9rq";
+      type = "gem";
+    };
+    version = "2.2.0";
+  };
+  pry = {
+    dependencies = [
+      "coderay"
+      "method_source"
+    ];
+    groups = [
+      "default"
+      "development"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0ssv704qg75mwlyagdfr9xxbzn1ziyqgzm0x474jkynk8234pm8j";
+      type = "gem";
+    };
+    version = "0.15.2";
+  };
+  pry-byebug = {
+    dependencies = [
+      "byebug"
+      "pry"
+    ];
+    groups = [
+      "development"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0wpa3jd46h44rjz3hjwl5c0zfx3jav4a64nm8h0g1iwv61yvn2hb";
+      type = "gem";
+    };
+    version = "3.11.0";
+  };
+  pry-rails = {
+    dependencies = [ "pry" ];
+    groups = [
+      "development"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0garafb0lxbm3sx2r9pqgs7ky9al58cl3wmwc0gmvmrl9bi2i7m6";
+      type = "gem";
+    };
+    version = "0.3.11";
+  };
+  psych = {
+    dependencies = [
+      "date"
+      "stringio"
+    ];
+    groups = [
+      "default"
+      "development"
+      "test"
+    ];
+    platforms = [
+      {
+        engine = "maglev";
+      }
+      {
+        engine = "mingw";
+      }
+      {
+        engine = "mingw";
+      }
+      {
+        engine = "ruby";
+      }
+    ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0vii1xc7x81hicdbp7dlllhmbw5w3jy20shj696n0vfbbnm2hhw1";
+      type = "gem";
+    };
+    version = "5.2.6";
+  };
+  public_suffix = {
+    groups = [
+      "default"
+      "development"
+      "staging"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1543ap9w3ydhx39ljcd675cdz9cr948x9mp00ab8qvq6118wv9xz";
+      type = "gem";
+    };
+    version = "6.0.2";
+  };
+  puma = {
+    dependencies = [ "nio4r" ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1pa9zpr51kqnsq549p6apvnr95s9flx6bnwqii24s8jg2b5i0p74";
+      type = "gem";
+    };
+    version = "7.1.0";
+  };
+  pundit = {
+    dependencies = [ "activesupport" ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1gcb23749jwggmgic4607ky6hm2c9fpkya980iihpy94m8miax73";
+      type = "gem";
+    };
+    version = "2.5.2";
+  };
+  raabro = {
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "10m8bln9d00dwzjil1k42i5r7l82x25ysbi45fwyv4932zsrzynl";
+      type = "gem";
+    };
+    version = "1.4.0";
+  };
+  racc = {
+    groups = [
+      "default"
+      "development"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0byn0c9nkahsl93y9ln5bysq4j31q8xkf2ws42swighxd4lnjzsa";
+      type = "gem";
+    };
+    version = "1.8.1";
+  };
+  rack = {
+    groups = [
+      "default"
+      "development"
+      "staging"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1xmnrk076sqymilydqgyzhkma3hgqhcv8xhy7ks479l2a3vvcx2x";
+      type = "gem";
+    };
+    version = "3.2.4";
+  };
+  rack-oauth2 = {
+    dependencies = [
+      "activesupport"
+      "attr_required"
+      "faraday"
+      "faraday-follow_redirects"
+      "json-jwt"
+      "rack"
+    ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0cn6a9v8nry9fx4zrzp1xakfp2n5xv5075j90q56m20k7zvjrq23";
+      type = "gem";
+    };
+    version = "2.3.0";
+  };
+  rack-protection = {
+    dependencies = [
+      "base64"
+      "logger"
+      "rack"
+    ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1b4bamcbpk29i7jvly3i7ayfj69yc1g03gm4s7jgamccvx12hvng";
+      type = "gem";
+    };
+    version = "4.2.1";
+  };
+  rack-session = {
+    dependencies = [
+      "base64"
+      "rack"
+    ];
+    groups = [
+      "default"
+      "development"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1sg4laz2qmllxh1c5sqlj9n1r7scdn08p3m4b0zmhjvyx9yw0v8b";
+      type = "gem";
+    };
+    version = "2.1.1";
+  };
+  rack-test = {
+    dependencies = [ "rack" ];
+    groups = [
+      "default"
+      "development"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0qy4ylhcfdn65a5mz2hly7g9vl0g13p5a0rmm6sc0sih5ilkcnh0";
+      type = "gem";
+    };
+    version = "2.2.0";
+  };
+  rackup = {
+    dependencies = [ "rack" ];
+    groups = [
+      "default"
+      "development"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "13brkq5xkj6lcdxj3f0k7v28hgrqhqxjlhd4y2vlicy5slgijdzp";
+      type = "gem";
+    };
+    version = "2.2.1";
+  };
+  rails = {
+    dependencies = [
+      "actioncable"
+      "actionmailbox"
+      "actionmailer"
+      "actionpack"
+      "actiontext"
+      "actionview"
+      "activejob"
+      "activemodel"
+      "activerecord"
+      "activestorage"
+      "activesupport"
+      "railties"
+    ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0igxnfy4xckvk2b6x17zrwa8xwnkxnpv36ca4wma7bhs5n1c10sx";
+      type = "gem";
+    };
+    version = "8.0.3";
+  };
+  rails-dom-testing = {
+    dependencies = [
+      "activesupport"
+      "minitest"
+      "nokogiri"
+    ];
+    groups = [
+      "default"
+      "development"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "07awj8bp7jib54d0khqw391ryw8nphvqgw4bb12cl4drlx9pkk4a";
+      type = "gem";
+    };
+    version = "2.3.0";
+  };
+  rails-html-sanitizer = {
+    dependencies = [
+      "loofah"
+      "nokogiri"
+    ];
+    groups = [
+      "default"
+      "development"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0q55i6mpad20m2x1lg5pkqfpbmmapk0sjsrvr1sqgnj2hb5f5z1m";
+      type = "gem";
+    };
+    version = "1.6.2";
+  };
+  rails_icons = {
+    dependencies = [
+      "nokogiri"
+      "rails"
+    ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0aixqyan3ik3z84135wn0zvvfb8krj4qxccsg9jbznjx0ywblhap";
+      type = "gem";
+    };
+    version = "1.4.0";
+  };
+  rails_pulse = {
+    dependencies = [
+      "css-zero"
+      "groupdate"
+      "pagy"
+      "rails"
+      "ransack"
+      "request_store"
+      "turbo-rails"
+    ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1mla44nhcpr57i4dqir173b3jyzfpvy9prnzyz5nlf0ny3hysk5s";
+      type = "gem";
+    };
+    version = "0.2.4";
+  };
+  railties = {
+    dependencies = [
+      "actionpack"
+      "activesupport"
+      "irb"
+      "rackup"
+      "rake"
+      "thor"
+      "tsort"
+      "zeitwerk"
+    ];
+    groups = [
+      "default"
+      "development"
+      "staging"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1lpiazaaq8di4lz9iqjqdrsnha6kfq6k35kd9nk9jhhksz51vqxc";
+      type = "gem";
+    };
+    version = "8.0.3";
+  };
+  rainbow = {
+    groups = [
+      "default"
+      "development"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0smwg4mii0fm38pyb5fddbmrdpifwv22zv3d3px2xx497am93503";
+      type = "gem";
+    };
+    version = "3.1.1";
+  };
+  rake = {
+    groups = [
+      "default"
+      "development"
+      "staging"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "175iisqb211n0qbfyqd8jz2g01q6xj038zjf4q0nm8k6kz88k7lc";
+      type = "gem";
+    };
+    version = "13.3.1";
+  };
+  ransack = {
+    dependencies = [
+      "activerecord"
+      "activesupport"
+      "i18n"
+    ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0gd6nwr0xlvgas21p1qgw90cg27xdi70988dw5q8a20rzhvarska";
+      type = "gem";
+    };
+    version = "4.4.1";
+  };
+  rdoc = {
+    dependencies = [
+      "erb"
+      "psych"
+      "tsort"
+    ];
+    groups = [
+      "default"
+      "development"
+      "staging"
+      "test"
+    ];
+    platforms = [
+      {
+        engine = "maglev";
+      }
+      {
+        engine = "mingw";
+      }
+      {
+        engine = "mingw";
+      }
+      {
+        engine = "ruby";
+      }
+    ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0p4z1cs2zvkkvl0xiiy76ys1ipbhx0df15241jx7gnp61317qdbi";
+      type = "gem";
+    };
+    version = "6.16.1";
+  };
+  redis = {
+    dependencies = [ "redis-client" ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1bpsh5dbvybsa8qnv4dg11a6f2zn4sndarf7pk4iaayjgaspbrmm";
+      type = "gem";
+    };
+    version = "5.4.1";
+  };
+  redis-client = {
+    dependencies = [ "connection_pool" ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "16vplvxrsaq6as1hzw71mkfcpjdphk0m662k36vrilq2f9dgndhk";
+      type = "gem";
+    };
+    version = "0.26.2";
+  };
+  regexp_parser = {
+    groups = [
+      "default"
+      "development"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "192mzi0wgwl024pwpbfa6c2a2xlvbh3mjd75a0sakdvkl60z64ya";
+      type = "gem";
+    };
+    version = "2.11.3";
+  };
+  reline = {
+    dependencies = [ "io-console" ];
+    groups = [
+      "default"
+      "development"
+      "staging"
+      "test"
+    ];
+    platforms = [
+      {
+        engine = "maglev";
+      }
+      {
+        engine = "mingw";
+      }
+      {
+        engine = "mingw";
+      }
+      {
+        engine = "ruby";
+      }
+    ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0d8q5c4nh2g9pp758kizh8sfrvngynrjlm0i1zn3cnsnfd4v160i";
+      type = "gem";
+    };
+    version = "0.6.3";
+  };
+  request_store = {
+    dependencies = [ "rack" ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1jw89j9s5p5cq2k7ffj5p4av4j4fxwvwjs1a4i9g85d38r9mvdz1";
+      type = "gem";
+    };
+    version = "1.7.0";
+  };
+  responders = {
+    dependencies = [
+      "actionpack"
+      "railties"
+    ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "06ilkbbwvc8d0vppf8ywn1f79ypyymlb9krrhqv4g0q215zaiwlj";
+      type = "gem";
+    };
+    version = "3.1.1";
+  };
+  rexml = {
+    groups = [
+      "default"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0hninnbvqd2pn40h863lbrn9p11gvdxp928izkag5ysx8b1s5q0r";
+      type = "gem";
+    };
+    version = "3.4.4";
+  };
+  rgeo = {
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1mfxgxhsk4hpxh0ahk9yk593qiminv91gnfxkyixgm0nh6kn56ay";
+      type = "gem";
+    };
+    version = "3.0.1";
+  };
+  rgeo-activerecord = {
+    dependencies = [
+      "activerecord"
+      "rgeo"
+    ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "151hzz2amv4xn3ka5ab3rm3ghbyip8fqsa5m6jkpbf38qn6jz8n8";
+      type = "gem";
+    };
+    version = "8.0.0";
+  };
+  rgeo-geojson = {
+    dependencies = [
+      "multi_json"
+      "rgeo"
+    ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "045jf6v7zhnj0mc5whkkh11w33khr3zcd564zklyyhscpphjrvff";
+      type = "gem";
+    };
+    version = "2.2.0";
+  };
+  rqrcode = {
+    dependencies = [
+      "chunky_png"
+      "rqrcode_core"
+    ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1bwqy1iwbyn1091mg203is5ngsnvfparwa1wh89s1sgnfmirkmg2";
+      type = "gem";
+    };
+    version = "3.1.0";
+  };
+  rqrcode_core = {
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1ayrj7pwbv1g6jg5vvx6rq05lr1kbkfzbzqplj169aapmcivhh0y";
+      type = "gem";
+    };
+    version = "2.0.0";
+  };
+  rspec-core = {
+    dependencies = [ "rspec-support" ];
+    groups = [
+      "default"
+      "development"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1r6zbis0hhbik1ck8kh58qb37d1qwij1x1d2fy4jxkzryh3na4r5";
+      type = "gem";
+    };
+    version = "3.13.3";
+  };
+  rspec-expectations = {
+    dependencies = [
+      "diff-lcs"
+      "rspec-support"
+    ];
+    groups = [
+      "default"
+      "development"
+      "staging"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0dl8npj0jfpy31bxi6syc7jymyd861q277sfr6jawq2hv6hx791k";
+      type = "gem";
+    };
+    version = "3.13.5";
+  };
+  rspec-mocks = {
+    dependencies = [
+      "diff-lcs"
+      "rspec-support"
+    ];
+    groups = [
+      "default"
+      "development"
+      "staging"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0klv9mibmnfqw92w5bc1bab1x4dai60xfh0xz0mhgicibsp3gcbq";
+      type = "gem";
+    };
+    version = "3.13.6";
+  };
+  rspec-rails = {
+    dependencies = [
+      "actionpack"
+      "activesupport"
+      "railties"
+      "rspec-core"
+      "rspec-expectations"
+      "rspec-mocks"
+      "rspec-support"
+    ];
+    groups = [
+      "development"
+      "staging"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1kis8dfxlvi6gdzrv9nsn3ckw0c2z7armhni917qs1jx7yjkjc8i";
+      type = "gem";
+    };
+    version = "8.0.2";
+  };
+  rspec-support = {
+    groups = [
+      "default"
+      "development"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0hrzdcklbl8pv721cq906yfl38fmqmlnh33ff8l752z1ys9y6q9a";
+      type = "gem";
+    };
+    version = "3.13.3";
+  };
+  rswag-api = {
+    dependencies = [
+      "activesupport"
+      "railties"
+    ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "04ssahiw9fn3dvxzp7gbrlnc51dlcz9fbc14c2mvi2hncmmk72vj";
+      type = "gem";
+    };
+    version = "2.17.0";
+  };
+  rswag-specs = {
+    dependencies = [
+      "activesupport"
+      "json-schema"
+      "railties"
+      "rspec-core"
+    ];
+    groups = [
+      "development"
+      "staging"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1qx9mxhnwz8ia9ry1fwn3hzc2zg7n774gvm4whgp9y49vzvbvcm3";
+      type = "gem";
+    };
+    version = "2.17.0";
+  };
+  rswag-ui = {
+    dependencies = [
+      "actionpack"
+      "railties"
+    ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "04ij8kr28qg70f3511vks38rnhcyww0y9xhrypwxswc1bsdpnw2z";
+      type = "gem";
+    };
+    version = "2.17.0";
+  };
+  rubocop = {
+    dependencies = [
+      "json"
+      "language_server-protocol"
+      "lint_roller"
+      "parallel"
+      "parser"
+      "rainbow"
+      "regexp_parser"
+      "rubocop-ast"
+      "ruby-progressbar"
+      "unicode-display_width"
+    ];
+    groups = [
+      "default"
+      "development"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0wz2np5ck54vpwcz18y9x7w80c308wza7gmfcykysq59ajkadw89";
+      type = "gem";
+    };
+    version = "1.82.1";
+  };
+  rubocop-ast = {
+    dependencies = [
+      "parser"
+      "prism"
+    ];
+    groups = [
+      "default"
+      "development"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1zbikzd6237fvlzjfxdlhwi2vbmavg1cc81y6cyr581365nnghs9";
+      type = "gem";
+    };
+    version = "1.49.0";
+  };
+  rubocop-rails = {
+    dependencies = [
+      "activesupport"
+      "lint_roller"
+      "rack"
+      "rubocop"
+      "rubocop-ast"
+    ];
+    groups = [ "development" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "08kf3nhhhxcwb9shb4bv7jxr1mjrs63fwpywppmgy9cbwip29zqh";
+      type = "gem";
+    };
+    version = "2.34.2";
+  };
+  ruby-progressbar = {
+    groups = [
+      "default"
+      "development"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0cwvyb7j47m7wihpfaq7rc47zwwx9k4v7iqd9s1xch5nm53rrz40";
+      type = "gem";
+    };
+    version = "1.13.0";
+  };
+  rubyzip = {
+    groups = [
+      "default"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0g2vx9bwl9lgn3w5zacl52ax57k4zqrsxg05ixf42986bww9kvf0";
+      type = "gem";
+    };
+    version = "3.2.2";
+  };
+  securerandom = {
+    groups = [
+      "default"
+      "development"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1cd0iriqfsf1z91qg271sm88xjnfd92b832z49p1nd542ka96lfc";
+      type = "gem";
+    };
+    version = "0.4.1";
+  };
+  selenium-webdriver = {
+    dependencies = [
+      "base64"
+      "logger"
+      "rexml"
+      "rubyzip"
+      "websocket"
+    ];
+    groups = [ "test" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "16rmdnc8c779gmphv7n4rcx8bc6yv24i555lzqx2drmrqk721jbg";
+      type = "gem";
+    };
+    version = "4.35.0";
+  };
+  sentry-rails = {
+    dependencies = [
+      "railties"
+      "sentry-ruby"
+    ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1rkp3wpikhwvypabw578rqk5660xkv741jl59dvk34h9b1z9g8g1";
+      type = "gem";
+    };
+    version = "6.2.0";
+  };
+  sentry-ruby = {
+    dependencies = [
+      "bigdecimal"
+      "concurrent-ruby"
+    ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "05xcf7dwqd59nklk29r4dmdjjpy8hb19rccls5mm7l50ldca7f6p";
+      type = "gem";
+    };
+    version = "6.2.0";
+  };
+  shoulda-matchers = {
+    dependencies = [ "activesupport" ];
+    groups = [ "test" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0i1zkr4rsvf8pz1x38wkb82nsjx28prmyb5blsmw86pd5cmmfszg";
+      type = "gem";
+    };
+    version = "6.5.0";
+  };
+  sidekiq = {
+    dependencies = [
+      "connection_pool"
+      "json"
+      "logger"
+      "rack"
+      "redis-client"
+    ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1mjcm3csall2idnza3w9gvayq3fbpz0k1jsmhsdpgxj6ipddik1p";
+      type = "gem";
+    };
+    version = "8.0.10";
+  };
+  sidekiq-cron = {
+    dependencies = [
+      "cronex"
+      "fugit"
+      "globalid"
+      "sidekiq"
+    ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1b2aqj17izziipb6wvsa8jr60ng8w8mal7acfkf316i8faikvawn";
+      type = "gem";
+    };
+    version = "2.3.1";
+  };
+  sidekiq-limit_fetch = {
+    dependencies = [ "sidekiq" ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "09wbzaa1sq2xxzm18f6xxj084m6g31bl9fx99kqw92fvs6sjy93x";
+      type = "gem";
+    };
+    version = "4.4.1";
+  };
+  simplecov = {
+    dependencies = [
+      "docile"
+      "simplecov-html"
+      "simplecov_json_formatter"
+    ];
+    groups = [ "test" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "198kcbrjxhhzca19yrdcd6jjj9sb51aaic3b0sc3pwjghg3j49py";
+      type = "gem";
+    };
+    version = "0.22.0";
+  };
+  simplecov-html = {
+    groups = [
+      "default"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "02zi3rwihp7rlnp9x18c9idnkx7x68w6jmxdhyc0xrhjwrz0pasx";
+      type = "gem";
+    };
+    version = "0.13.1";
+  };
+  simplecov_json_formatter = {
+    groups = [
+      "default"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0a5l0733hj7sk51j81ykfmlk2vd5vaijlq9d5fn165yyx3xii52j";
+      type = "gem";
+    };
+    version = "0.1.4";
+  };
+  snaky_hash = {
+    dependencies = [
+      "hashie"
+      "version_gem"
+    ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0mnllrwhs7psw6xxs8x5yx85k12qjfdgs8zs0bxm70bfascx58r5";
+      type = "gem";
+    };
+    version = "2.0.3";
+  };
+  sprockets = {
+    dependencies = [
+      "concurrent-ruby"
+      "rack"
+    ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "15rzfzd9dca4v0mr0bbhsbwhygl0k9l24iqqlx0fijig5zfi66wm";
+      type = "gem";
+    };
+    version = "4.2.1";
+  };
+  sprockets-rails = {
+    dependencies = [
+      "actionpack"
+      "activesupport"
+      "sprockets"
+    ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "17hiqkdpcjyyhlm997mgdcr45v35j5802m5a979i5jgqx5n8xs59";
+      type = "gem";
+    };
+    version = "3.5.2";
+  };
+  stackprof = {
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "03788mbipmihq2w7rznzvv0ks0s9z1321k1jyr6ffln8as3d5xmg";
+      type = "gem";
+    };
+    version = "0.2.27";
+  };
+  stimulus-rails = {
+    dependencies = [ "railties" ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "01nbcxyi1mhikq8yjl0g9swy1cpzx146pli6w16gcfpkl7zpcmkn";
+      type = "gem";
+    };
+    version = "1.3.4";
+  };
+  stringio = {
+    groups = [
+      "default"
+      "development"
+      "staging"
+      "test"
+    ];
+    platforms = [
+      {
+        engine = "maglev";
+      }
+      {
+        engine = "mingw";
+      }
+      {
+        engine = "mingw";
+      }
+      {
+        engine = "ruby";
+      }
+    ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1v74k5yw7ndikr53wgbjn6j51p83qnzqbn9z4b53r102jcx3ri4r";
+      type = "gem";
+    };
+    version = "3.1.8";
+  };
+  strong_migrations = {
+    dependencies = [ "activerecord" ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "09llhlw9ddsjyv6c59z3yjwdhrxc2q60a60wjvqhrhhy96dkmjlb";
+      type = "gem";
+    };
+    version = "2.5.1";
+  };
+  super_diff = {
+    dependencies = [
+      "attr_extras"
+      "diff-lcs"
+      "patience_diff"
+    ];
+    groups = [ "test" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1qc3682i373ccml000xvi9pdksj3rb9v9znagjs762iypp3nwrkm";
+      type = "gem";
+    };
+    version = "0.17.0";
+  };
+  swd = {
+    dependencies = [
+      "activesupport"
+      "attr_required"
+      "faraday"
+      "faraday-follow_redirects"
+    ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0m86fzmwgw0vc8p6fwvnsdbldpgbqdz9cbp2zj9z06bc4jjf5nsc";
+      type = "gem";
+    };
+    version = "2.0.3";
+  };
+  tailwindcss-rails = {
+    dependencies = [
+      "railties"
+      "tailwindcss-ruby"
+    ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "02vg7lbb95ixx9m6bgm2x0nrcm4dxyl0dcsd7ygg6z7bamz32yg8";
+      type = "gem";
+    };
+    version = "3.3.2";
+  };
+  tailwindcss-ruby = {
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "09y40d93pi8s5yp076yzj5sf1vjifq0a4mrlmx379ggi8p6bfks6";
+      type = "gem";
+    };
+    version = "3.4.17";
+  };
+  thor = {
+    groups = [
+      "default"
+      "development"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0gcarlmpfbmqnjvwfz44gdjhcmm634di7plcx2zdgwdhrhifhqw7";
+      type = "gem";
+    };
+    version = "1.4.0";
+  };
+  timeout = {
+    groups = [
+      "default"
+      "development"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1nqf9rg974k4bjji7aggalg8pfvbkd9hys4hv5y450jb21qgkxph";
+      type = "gem";
+    };
+    version = "0.4.4";
+  };
+  tsort = {
+    groups = [
+      "default"
+      "development"
+      "staging"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "17q8h020dw73wjmql50lqw5ddsngg67jfw8ncjv476l5ys9sfl4n";
+      type = "gem";
+    };
+    version = "0.2.0";
+  };
+  turbo-rails = {
+    dependencies = [
+      "actionpack"
+      "railties"
+    ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "15gafkrlg8rdk2fra0w3rjc1jwicbdjv24grr5qn97z57kfv9jyb";
+      type = "gem";
+    };
+    version = "2.0.20";
+  };
+  tzinfo = {
+    dependencies = [ "concurrent-ruby" ];
+    groups = [
+      "default"
+      "development"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "16w2g84dzaf3z13gxyzlzbf748kylk5bdgg3n1ipvkvvqy685bwd";
+      type = "gem";
+    };
+    version = "2.0.6";
+  };
+  unicode = {
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1mx9lwzy021lpcqql5kn4yi20njhf5h7c7wxm2fx51p1r2zr9wj2";
+      type = "gem";
+    };
+    version = "0.4.4.5";
+  };
+  unicode-display_width = {
+    dependencies = [ "unicode-emoji" ];
+    groups = [
+      "default"
+      "development"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0hiwhnqpq271xqari6mg996fgjps42sffm9cpk6ljn8sd2srdp8c";
+      type = "gem";
+    };
+    version = "3.2.0";
+  };
+  unicode-emoji = {
+    groups = [
+      "default"
+      "development"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "03zqn207zypycbz5m9mn7ym763wgpk7hcqbkpx02wrbm1wank7ji";
+      type = "gem";
+    };
+    version = "4.2.0";
+  };
+  uri = {
+    groups = [
+      "default"
+      "development"
+      "staging"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1ijpbj7mdrq7rhpq2kb51yykhrs2s54wfs6sm9z3icgz4y6sb7rp";
+      type = "gem";
+    };
+    version = "1.1.1";
+  };
+  useragent = {
+    groups = [
+      "default"
+      "development"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0i1q2xdjam4d7gwwc35lfnz0wyyzvnca0zslcfxm9fabml9n83kh";
+      type = "gem";
+    };
+    version = "0.16.11";
+  };
+  validate_url = {
+    dependencies = [
+      "activemodel"
+      "public_suffix"
+    ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0lblym140w5n88ijyfgcvkxvpfj8m6z00rxxf2ckmmhk0x61dzkj";
+      type = "gem";
+    };
+    version = "1.0.15";
+  };
+  version_gem = {
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "195r5qylwxwqbllnpli9c2pzin0lky6h3fw912h88g2lmri0j6hc";
+      type = "gem";
+    };
+    version = "1.1.9";
+  };
+  warden = {
+    dependencies = [ "rack" ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1l7gl7vms023w4clg02pm4ky9j12la2vzsixi2xrv9imbn44ys26";
+      type = "gem";
+    };
+    version = "1.2.9";
+  };
+  webfinger = {
+    dependencies = [
+      "activesupport"
+      "faraday"
+      "faraday-follow_redirects"
+    ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0p39802sfnm62r4x5hai8vn6d1wqbxsxnmbynsk8rcvzwyym4yjn";
+      type = "gem";
+    };
+    version = "2.1.3";
+  };
+  webmock = {
+    dependencies = [
+      "addressable"
+      "crack"
+      "hashdiff"
+    ];
+    groups = [ "test" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1mqw7ca931zmqgad0fq4gw7z3gwb0pwx9cmd1b12ga4hgjsnysag";
+      type = "gem";
+    };
+    version = "3.26.1";
+  };
+  webrick = {
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "12d9n8hll67j737ym2zw4v23cn4vxyfkb6vyv1rzpwv6y6a3qbdl";
+      type = "gem";
+    };
+    version = "1.9.1";
+  };
+  websocket = {
+    groups = [
+      "default"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0dr78vh3ag0d1q5gfd8960g1ca9g6arjd2w54mffid8h4i7agrxp";
+      type = "gem";
+    };
+    version = "1.2.11";
+  };
+  websocket-driver = {
+    dependencies = [
+      "base64"
+      "websocket-extensions"
+    ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0qj9dmkmgahmadgh88kydb7cv15w13l1fj3kk9zz28iwji5vl3gd";
+      type = "gem";
+    };
+    version = "0.8.0";
+  };
+  websocket-extensions = {
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0hc2g9qps8lmhibl5baa91b4qx8wqw872rgwagml78ydj8qacsqw";
+      type = "gem";
+    };
+    version = "0.1.5";
+  };
+  with_advisory_lock = {
+    dependencies = [
+      "activerecord"
+      "zeitwerk"
+    ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "001sswk3d1n8nf4pzxxc4rvxw47q05m0harl50ys25b18nxqai6z";
+      type = "gem";
+    };
+    version = "7.0.2";
+  };
+  xpath = {
+    dependencies = [ "nokogiri" ];
+    groups = [
+      "default"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0bh8lk9hvlpn7vmi6h4hkcwjzvs2y0cmkk3yjjdr8fxvj6fsgzbd";
+      type = "gem";
+    };
+    version = "3.2.0";
+  };
+  yaml = {
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0hhr8z9m9yq2kf7ls0vf8ap1hqma1yd72y2r13b88dffwv8nj3i4";
+      type = "gem";
+    };
+    version = "0.4.0";
+  };
+  zeitwerk = {
+    groups = [
+      "default"
+      "development"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "119ypabas886gd0n9kiid3q41w76gz60s8qmiak6pljpkd56ps5j";
+      type = "gem";
+    };
+    version = "2.7.3";
+  };
+}

--- a/pkgs/by-name/da/dawarich/package.nix
+++ b/pkgs/by-name/da/dawarich/package.nix
@@ -1,0 +1,139 @@
+{
+  lib,
+  applyPatches,
+  bundlerEnv,
+  fetchFromGitHub,
+  fetchNpmDeps,
+  nodejs,
+  npmHooks,
+  ruby_3_4,
+  stdenv,
+  tailwindcss_3,
+  gemset ? import ./gemset.nix,
+  sources ? lib.importJSON ./sources.json,
+  unpatchedSource ? fetchFromGitHub {
+    owner = "Freika";
+    repo = "dawarich";
+    tag = sources.version;
+    inherit (sources) hash;
+  },
+}:
+let
+  ruby = ruby_3_4;
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "dawarich";
+  inherit (sources) version;
+
+  # Use `applyPatches` here because bundix in the update script (see ./update.sh)
+  # needs to run on the already patched Gemfile and Gemfile.lock.
+  # Only patches changing these two files should be here;
+  # patches for other parts of the application should go directly into mkDerivation.
+  src = applyPatches {
+    src = unpatchedSource;
+    patches = [
+      # bundix and bundlerEnv fail with system-specific gems
+      ./0001-build-ffi-gem.diff
+      # openssl 3.6.0 breaks ruby openssl gem
+      # See https://github.com/NixOS/nixpkgs/issues/456753
+      # and https://github.com/ruby/openssl/issues/949#issuecomment-3370358680
+      ./0002-openssl-hotfix.diff
+    ];
+    postPatch = ''
+      substituteInPlace ./Gemfile \
+        --replace-fail "ruby File.read('.ruby-version').strip" "ruby '>= 3.4.0'"
+    '';
+  };
+
+  postPatch = ''
+    # move import directory to a more convenient place, otherwise its behind systemd private tmp
+    substituteInPlace ./app/services/imports/watcher.rb \
+      --replace-fail 'tmp/imports/watched' 'storage/imports/watched'
+  '';
+
+  dawarichGems = bundlerEnv {
+    name = "${finalAttrs.pname}-gems-${finalAttrs.version}";
+    inherit gemset ruby;
+    inherit (finalAttrs) version;
+    gemdir = finalAttrs.src;
+  };
+
+  npmDeps = fetchNpmDeps {
+    inherit (finalAttrs) src;
+    hash = sources.npmHash;
+  };
+
+  RAILS_ENV = "production";
+  NODE_ENV = "production";
+  REDIS_URL = ""; # build error if not defined
+  TAILWINDCSS_INSTALL_DIR = "${tailwindcss_3}/bin";
+
+  nativeBuildInputs = [
+    nodejs
+    npmHooks.npmConfigHook
+    finalAttrs.dawarichGems
+    finalAttrs.dawarichGems.wrappedRuby
+  ];
+  propagatedBuildInputs = [
+    finalAttrs.dawarichGems.wrappedRuby
+  ];
+  buildInputs = [
+    finalAttrs.dawarichGems
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    patchShebangs bin/
+    for b in $(ls $dawarichGems/bin/)
+    do
+      if [ ! -f bin/$b ]; then
+        ln -s $dawarichGems/bin/$b bin/$b
+      fi
+    done
+
+    SECRET_KEY_BASE_DUMMY=1 bundle exec rake assets:precompile
+
+    rm -rf node_modules tmp log storage
+    ln -s /var/log/dawarich log
+    ln -s /var/lib/dawarich storage
+    ln -s /tmp tmp
+
+    # delete more files unneeded at runtime
+    rm -rf docker docs screenshots package.json package-lock.json *.md *.example
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    # tests are not needed at runtime
+    rm -rf spec e2e
+    # delete artifacts from patching
+    rm *.orig
+
+    mkdir -p $out
+    mv .{ruby*,app_version} $out/
+    mv * $out/
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    # TODO tests
+    # run with: nix-shell ./maintainers/scripts/update.nix --argstr package dawarich
+    updateScript = ./update.sh;
+  };
+
+  meta = {
+    changelog = "https://github.com/Freika/dawarich/blob/${finalAttrs.version}/CHANGELOG.md";
+    description = "Self-hostable alternative to Google Location History (Google Maps Timeline)";
+    homepage = "https://dawarich.app/";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [
+      diogotcorreia
+    ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/da/dawarich/package.nix
+++ b/pkgs/by-name/da/dawarich/package.nix
@@ -4,6 +4,7 @@
   bundlerEnv,
   fetchFromGitHub,
   fetchNpmDeps,
+  nixosTests,
   nodejs,
   npmHooks,
   ruby_3_4,
@@ -121,7 +122,9 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru = {
-    # TODO tests
+    tests = {
+      inherit (nixosTests) dawarich;
+    };
     # run with: nix-shell ./maintainers/scripts/update.nix --argstr package dawarich
     updateScript = ./update.sh;
   };

--- a/pkgs/by-name/da/dawarich/sources.json
+++ b/pkgs/by-name/da/dawarich/sources.json
@@ -1,0 +1,5 @@
+{
+  "version": "0.37.3",
+  "hash": "sha256-cZBT3ek5mzHbPr4aVHU47SNstEuBnpBNaCfaAe/IAEw=",
+  "npmHash": "sha256-wDe1Zx9HyheS76ltLtDQ+f4M7ohu/pyRuRaGGCnhkQI="
+}

--- a/pkgs/by-name/da/dawarich/update.sh
+++ b/pkgs/by-name/da/dawarich/update.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env nix-shell
+#! nix-shell -i bash -p bundix curl jq nix-update nix-prefetch-github prefetch-npm-deps gnused
+set -e
+set -o pipefail
+
+OWNER="Freika"
+REPO="dawarich"
+
+old_version=$(nix-instantiate --eval -A 'dawarich.version' default.nix | tr -d '"')
+version=$(curl -s ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} "https://api.github.com/repos/$OWNER/$REPO/releases/latest" | jq -r ".tag_name")
+
+echo "Updating to $version"
+
+if [[ "$old_version" == "$version" ]]; then
+    echo "Already up to date!"
+    exit 0
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+
+echo "Fetching source code $REVISION"
+JSON=$(nix-prefetch-github "$OWNER" "$REPO" --rev "refs/tags/$version" 2>/dev/null)
+HASH=$(echo "$JSON" | jq -r .hash)
+
+cat > "$SCRIPT_DIR/sources.json" << EOF
+{
+  "version": "$version",
+  "hash": "$HASH",
+  "npmHash": "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+}
+EOF
+
+SOURCE_DIR="$(nix-build --no-out-link -A dawarich.src)"
+
+echo "Creating gemset.nix"
+bundix --lockfile="$SOURCE_DIR/Gemfile.lock" --gemfile="$SOURCE_DIR/Gemfile" --gemset="$SCRIPT_DIR/gemset.nix"
+nixfmt "$SCRIPT_DIR/gemset.nix"
+
+NPM_HASH="$(prefetch-npm-deps "$SOURCE_DIR/package-lock.json" 2>/dev/null)"
+sed -i "s;sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=;$NPM_HASH;g" "$SCRIPT_DIR/sources.json"

--- a/pkgs/development/ruby-modules/gem-config/default.nix
+++ b/pkgs/development/ruby-modules/gem-config/default.nix
@@ -91,6 +91,7 @@
   fribidi,
   harfbuzz,
   bison,
+  h3_3,
   flex,
   pango,
   python3,
@@ -636,6 +637,21 @@ in
       # For >= v1.48.0
       substituteInPlace src/ruby/ext/grpc/extconf.rb \
         --replace 'apple_toolchain = ' 'apple_toolchain = false && '
+    '';
+  };
+
+  h3 = attrs: {
+    # This gem attempts to build h3 using cmake, but fails because that is not in the path
+    # Use h3 from nixpkgs instead, and reduce closure size by deleting the h3 source code
+    dontBuild = false; # allow applying patches
+    postPatch = ''
+      substituteInPlace ext/h3/Makefile \
+        --replace-fail 'cd src; cmake . -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DBUILD_SHARED_LIBS=true -DBUILD_FILTERS=OFF -DBUILD_BENCHMARKS=OFF -DENABLE_LINTING=OFF; make' ':'
+      substituteInPlace lib/h3/bindings/base.rb \
+        --replace-fail '__dir__ + "/../../../ext/h3/src/lib"' '"${h3_3}/lib"'
+    '';
+    postInstall = ''
+      rm -rf $out/${ruby.gemPath}/gems/h3-${attrs.version}/ext/h3/src
     '';
   };
 


### PR DESCRIPTION
Backport of https://github.com/NixOS/nixpkgs/pull/423867

Dropped the release notes commit since it isn't relevant for backporting (and had conflicts).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
