### PR TITLE
cheesecutter: Fix build, modernise

### DIFF
--- a/pkgs/by-name/ch/cheesecutter/1001-cheesecutter-Pin-C-standard-to-C99.patch
+++ b/pkgs/by-name/ch/cheesecutter/1001-cheesecutter-Pin-C-standard-to-C99.patch
@@ -1,0 +1,58 @@
+From 91e2418c37fce511eeaa1d1bb34a0d7a25668d40 Mon Sep 17 00:00:00 2001
+From: OPNA2608 <opna2608@protonmail.com>
+Date: Tue, 20 Jan 2026 15:29:03 +0100
+Subject: [PATCH] Makefile.{dmd,ldc}: Pin C standard to C99
+
+Code is definitely not C23-compatible, and I imagine C99 is *prolly* what this was initially targeting.
+---
+ Makefile.dmd | 4 ++--
+ Makefile.ldc | 4 ++--
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/Makefile.dmd b/Makefile.dmd
+index 24a1d06..7c1b7c2 100644
+--- a/Makefile.dmd
++++ b/Makefile.dmd
+@@ -3,7 +3,7 @@ COMFLAGS=
+ DLINK=$(COMFLAGS) 
+ VERSION=$(shell cat Version)
+ DFLAGS=$(COMFLAGS) -I./src -J./src/c64 -J./src/font -O
+-CFLAGS=$(COMFLAGS) -O1
++CFLAGS=$(COMFLAGS) -O1 -std=c99
+ CXXFLAGS=-I./src -O3
+ COMPILE.d = $(DC) $(DFLAGS) -c -of$@
+ OUTPUT_OPTION=
+@@ -21,7 +21,7 @@ $(TARGET): $(C64OBJS) $(OBJS) $(CXX_OBJS)
+ 	$(CXX) $(CXXFLAGS) -c $< -o $@
+ 
+ .c.o : $(C_SRCS)
+-	$(CC) -c $< -o $@
++	$(CC) $(CFLAGS) -c $< -o $@
+ 
+ ct: $(C64OBJS) $(CTOBJS)
+ 
+diff --git a/Makefile.ldc b/Makefile.ldc
+index b89077a..a6c4714 100644
+--- a/Makefile.ldc
++++ b/Makefile.ldc
+@@ -6,7 +6,7 @@ LIBS=-L-ldl -L-lstdc++
+ COMFLAGS=-O2
+ VERSION=$(shell cat Version)
+ DFLAGS=$(COMFLAGS) -I./src -J./src/c64 -J./src/font
+-CFLAGS=$(COMFLAGS)
++CFLAGS=$(COMFLAGS) -std=c99
+ CXXFLAGS=$(COMFLAGS) -I./src 
+ COMPILE.d = $(DC) $(DFLAGS) -c
+ DC=ldc2
+@@ -28,7 +28,7 @@ ccutter:$(C64OBJS) $(OBJS) $(CXX_OBJS)
+ 	$(CXX) $(CXXFLAGS) -c $< -o $@
+ 
+ .c.o : $(C_SRCS)
+-	$(CC) -c $< -o $@
++	$(CC) $(CFLAGS) -c $< -o $@
+ 
+ ct: $(C64OBJS) $(CTOBJS)
+ 
+-- 
+2.51.2
+

--- a/pkgs/by-name/ch/cheesecutter/package.nix
+++ b/pkgs/by-name/ch/cheesecutter/package.nix
@@ -9,13 +9,13 @@
 }:
 stdenv.mkDerivation {
   pname = "cheesecutter";
-  version = "unstable-2021-02-27";
+  version = "2.9-beta-3-unstable-2021-02-27";
 
   src = fetchFromGitHub {
     owner = "theyamo";
     repo = "CheeseCutter";
     rev = "84450d3614b8fb2cabda87033baab7bedd5a5c98";
-    sha256 = "sha256:0q4a791nayya6n01l0f4kk497rdq6kiq0n72fqdpwqy138pfwydn";
+    hash = "sha256-tnnuLhrBY34bduJYgOM0uOWTyJzEARqANcp7ZUM6imA=";
   };
 
   patches = [
@@ -24,19 +24,29 @@ stdenv.mkDerivation {
 
     ./0001-Drop-baked-in-build-date-for-r13y.patch
   ]
-  ++ lib.optional stdenv.hostPlatform.isDarwin ./0002-Prepend-libSDL.dylib-to-macOS-SDL-loader.patch;
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    ./0002-Prepend-libSDL.dylib-to-macOS-SDL-loader.patch
+  ];
+
+  strictDeps = true;
 
   nativeBuildInputs = [
     acme
     ldc
   ]
-  ++ lib.optional (!stdenv.hostPlatform.isDarwin) patchelf;
+  ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
+    patchelf
+  ];
 
   buildInputs = [ SDL ];
+
+  enableParallelBuilding = true;
 
   makefile = "Makefile.ldc";
 
   installPhase = ''
+    runHook preInstall
+
     for exe in {ccutter,ct2util}; do
       install -D $exe $out/bin/$exe
     done
@@ -48,6 +58,8 @@ stdenv.mkDerivation {
     for res in $(ls icons | sed -e 's/cc//g' -e 's/.png//g'); do
       install -Dm444 icons/cc$res.png $out/share/icons/hicolor/''${res}x''${res}/apps/cheesecutter.png
     done
+
+    runHook postInstall
   '';
 
   postFixup =
@@ -74,5 +86,6 @@ stdenv.mkDerivation {
       "x86_64-darwin"
     ];
     maintainers = with lib.maintainers; [ OPNA2608 ];
+    mainProgram = "ccutter";
   };
 }

--- a/pkgs/by-name/ch/cheesecutter/package.nix
+++ b/pkgs/by-name/ch/cheesecutter/package.nix
@@ -19,6 +19,9 @@ stdenv.mkDerivation {
   };
 
   patches = [
+    # https://github.com/theyamo/CheeseCutter/pull/60
+    ./1001-cheesecutter-Pin-C-standard-to-C99.patch
+
     ./0001-Drop-baked-in-build-date-for-r13y.patch
   ]
   ++ lib.optional stdenv.hostPlatform.isDarwin ./0002-Prepend-libSDL.dylib-to-macOS-SDL-loader.patch;


### PR DESCRIPTION
https://github.com/theyamo/CheeseCutter/pull/60

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
