### PR TITLE
wrapQtAppsHook: wrap once per output instead of only the first output

### DIFF
--- a/pkgs/development/libraries/qt-5/hooks/wrap-qt-apps-hook.sh
+++ b/pkgs/development/libraries/qt-5/hooks/wrap-qt-apps-hook.sh
@@ -1,5 +1,7 @@
 if [[ -z "${__nix_wrapQtAppsHook-}" ]]; then
-__nix_wrapQtAppsHook=1  # Don't run this hook more than once.
+__nix_wrapQtAppsHook=1
+# wrap only once per output
+declare -a qtWrapperDoneForOuputs
 
 # Inherit arguments given in mkDerivation
 qtWrapperArgs=( ${qtWrapperArgs-} )
@@ -72,12 +74,17 @@ wrapQtAppsHook() {
     # skip this hook when requested
     [ -z "${dontWrapQtApps-}" ] || return 0
 
-    # guard against running multiple times (e.g. due to propagation)
-    [ -z "$wrapQtAppsHookHasRun" ] || return 0
-    wrapQtAppsHookHasRun=1
+    local doneOutput
+    for doneOutput in "${qtWrapperDoneForOuputs[@]}"; do
+      if [ "$doneOutput" = "$prefix" ]; then
+        nixWarnLog "Warning: attempted to wrapQtAppsHook $prefix a second time"
+        return 0
+      fi
+    done
+    qtWrapperDoneForOuputs+=("$prefix")
 
     local targetDirs=( "$prefix/bin" "$prefix/sbin" "$prefix/libexec" "$prefix/Applications" "$prefix/"*.app )
-    echo "wrapping Qt applications in ${targetDirs[@]}"
+    echo "wrapping Qt applications in ${targetDirs[*]}"
 
     for targetDir in "${targetDirs[@]}"
     do


### PR DESCRIPTION
the `wrapQtAppsHook` function is called for each output, with prefix set to the path of the output. As a result, with the previous code it would only wrap the first output. Instead, ensure the code is called only once on each output.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`. (on `kdePackages.kate`)
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
