### PR TITLE
python3Packages.xsdata: 25.7 -> 26.1

### DIFF
--- a/pkgs/development/python-modules/xsdata/default.nix
+++ b/pkgs/development/python-modules/xsdata/default.nix
@@ -5,8 +5,6 @@
   replaceVars,
   ruff,
   click,
-  click-default-group,
-  docformatter,
   jinja2,
   toposort,
   typing-extensions,
@@ -18,14 +16,14 @@
 
 buildPythonPackage rec {
   pname = "xsdata";
-  version = "25.7";
+  version = "26.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "tefra";
     repo = "xsdata";
     tag = "v${version}";
-    hash = "sha256-npwJlyUYjoYzvwaZZK4PIqhJmTeYGDDfc4T4/ODcx4c=";
+    hash = "sha256-cMXLRk74y+yHYyIQqlUcMZawNfMXa5L17qhVkTpgEsk=";
   };
 
   patches = [
@@ -46,8 +44,6 @@ buildPythonPackage rec {
   optional-dependencies = {
     cli = [
       click
-      click-default-group
-      docformatter
       jinja2
       toposort
     ];
@@ -58,9 +54,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
   ]
-  ++ optional-dependencies.cli
-  ++ optional-dependencies.lxml
-  ++ optional-dependencies.soap;
+  ++ lib.concatAttrValues optional-dependencies;
 
   disabledTestPaths = [ "tests/integration/benchmarks" ];
 

--- a/pkgs/development/python-modules/xsdata/paths.patch
+++ b/pkgs/development/python-modules/xsdata/paths.patch
@@ -1,21 +1,22 @@
 diff --git a/xsdata/formats/dataclass/generator.py b/xsdata/formats/dataclass/generator.py
-index f30196b1..b7934b3d 100644
+index b9f1b0e9..c1ed4c72 100644
 --- a/xsdata/formats/dataclass/generator.py
 +++ b/xsdata/formats/dataclass/generator.py
-@@ -240,14 +240,14 @@ class DataclassGenerator(AbstractGenerator):
-         """
+@@ -240,7 +240,7 @@ class DataclassGenerator(AbstractGenerator):
+         ruff_config = Path(__file__).parent.joinpath("ruff.toml")
          commands = [
-             [
--                "ruff",
-+                "@ruff@",
-                 "format",
-                 "--config",
-                 f"line-length={self.config.output.max_line_length}",
-                 *file_paths,
-             ],
              [
 -                "ruff",
 +                "@ruff@",
                  "check",
                  "--config",
-                 f"line-length={self.config.output.max_line_length}",
+                 str(ruff_config),
+@@ -252,7 +252,7 @@ class DataclassGenerator(AbstractGenerator):
+                 *file_paths,
+             ],
+             [
+-                "ruff",
++                "@ruff@",
+                 "format",
+                 "--config",
+                 str(ruff_config),


### PR DESCRIPTION
Diff: https://github.com/tefra/xsdata/compare/v25.7...v26.1

Changelog: https://github.com/tefra/xsdata/blob/v26.1/CHANGES.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
