### PR TITLE
lima-full: init at 2.0.3

### DIFF
--- a/pkgs/by-name/co/colima/package.nix
+++ b/pkgs/by-name/co/colima/package.nix
@@ -5,7 +5,7 @@
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
-  lima,
+  lima-full,
   makeWrapper,
   procps,
   qemu,
@@ -62,9 +62,7 @@ buildGoModule rec {
       --prefix PATH : ${
         lib.makeBinPath [
           # Suppress warning on `colima start`: https://github.com/abiosoft/colima/issues/1333
-          (lima.override {
-            withAdditionalGuestAgents = true;
-          })
+          lima-full
           qemu
         ]
       }

--- a/pkgs/by-name/li/lima-full/package.nix
+++ b/pkgs/by-name/li/lima-full/package.nix
@@ -1,0 +1,7 @@
+{
+  lima,
+}:
+
+lima.override {
+  withAdditionalGuestAgents = true;
+}

--- a/pkgs/by-name/li/lima/package.nix
+++ b/pkgs/by-name/li/lima/package.nix
@@ -21,7 +21,7 @@
 }:
 
 buildGoModule (finalAttrs: {
-  pname = "lima";
+  pname = "lima" + lib.optionalString withAdditionalGuestAgents "-full";
 
   inherit (callPackage ./source.nix { }) version src vendorHash;
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR aims to make it easy to use `lima-additional-guestagents` in nix-shell.
This issue was reported in https://github.com/NixOS/nixpkgs/pull/479581#issuecomment-3753349539.

As far as I see, while using additional agents is not the majority, the number of users is not small. I think this change is useful for them.

I want to keep this PR simple, so I will **omit** the following ideas for now:

- Hiding `lima-additional-guestagents` from users.
- Using `symlinkJoin` to build the `lima-full` package to reuse build results from the `lima` package.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

CC:
- package maintainer: @voanhduy1512
- upstream maintainer: @AkihiroSuda ref: https://github.com/lima-vm/lima/issues/3563