### PR TITLE
Revert "ci/github-script/bot: skip mergeability checks temporarily"

### DIFF
--- a/ci/github-script/bot.js
+++ b/ci/github-script/bot.js
@@ -145,22 +145,10 @@ module.exports = async ({ github, context, core, dry }) => {
 
     // This API request is important for the merge-conflict label, because it triggers the
     // creation of a new test merge commit. This is needed to actually determine the state of a PR.
-    //
-    // NOTE (2025-12-15): Temporarily skipping mergeability checks here
-    // on GitHub’s request to measure the impact of the resulting ref
-    // writes on their internal metrics; merge conflicts resulting from
-    // changes to target branches will not have labels applied for the
-    // duration. The label should still be updated on pushes.
-    //
-    // TODO: Restore mergeability checks in some form after a few days
-    // or when we hear back from GitHub.
     const pull_request = (
       await github.rest.pulls.get({
         ...context.repo,
         pull_number,
-        // Undocumented parameter (as of 2025-12-15), added by GitHub
-        // for us; stability unclear.
-        skip_mergeability_checks: true,
       })
     ).data
 


### PR DESCRIPTION
Apparently any effects from this change haven’t shown up noticeably in GitHub’s metrics, to the point where they’re not sure if it was taking effect on the backend. Our contact is going to look at getting something into the API response to help debug whether it’s actually working or not, but agreed that we should just revert for now. Since they have apparently reduced replica sync issues further through other changes on their end, there shouldn’t be any urgent need to make any changes here anyway.

This reverts commit 18b30c8ce1eed9ff2e86128036b674e9e3796aaa.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
