### PR TITLE
nixos/tor: fixes

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -77,6 +77,11 @@ of pulling the upstream container image from Docker Hub. If you want the old beh
 
 - Support for `reiserfs` in nixpkgs has been removed, following the removal in Linux 6.13.
 
+- `services.tor` no longer bind mounts Unix sockets of onion services into its chroot
+because it was not reliable. Users should do it themselves using either `JoinsNamespaceOf=` and Unix sockets in `/tmp`
+or `BindPaths=` from a persistent parent directory of each Unix socket.
+See <https://github.com/NixOS/nixpkgs/issues/481673>.
+
 - support for `ecryptfs` in nixpkgs has been removed.
 
 - The `networking.wireless` module has been security hardened: the `wpa_supplicant` daemon now runs under an unprivileged user with restricted access to the system.

--- a/nixos/modules/services/security/tor.nix
+++ b/nixos/modules/services/security/tor.nix
@@ -1497,7 +1497,6 @@ in
           "~@timer"
         ];
         SystemCallArchitectures = "native";
-        SystemCallErrorNumber = "EPERM";
       };
     };
 

--- a/nixos/modules/services/security/tor.nix
+++ b/nixos/modules/services/security/tor.nix
@@ -636,7 +636,31 @@ in
         };
 
         onionServices = lib.mkOption {
-          description = (descriptionGeneric "HiddenServiceDir");
+          description = descriptionGeneric "HiddenServiceDir" + ''
+            :::{.warning}
+            Because `tor.service` runs in its own `RootDirectory=`,
+            when using a onion service to reverse-proxy to a Unix socket,
+            you need to make that Unix socket available
+            within the mount namespace of `tor.service`.
+
+            When you can configure your service to create its socket in `/tmp`,
+            this can be done with:
+            ```nix
+            systemd.services.''${your-service} = {
+              unitConfig.JoinsNamespaceOf = [ "tor.service" ];`
+              serviceConfig.PrivateTmp = true;
+            };
+            ```
+            Otherwise, you can use:
+            ```nix
+            systemd.services.tor.serviceConfig.BindPaths = [ "/path/to/your-service/socket/directory" ];
+            ```
+            but you have to be sure that `/path/to/socket/directory`
+            exists before `tor.service` is started
+            and is not deleted and recreated between restarts of `your-service`,
+            or you'll need to restart `tor.service` to refresh the `BindPaths=`.
+            :::
+          '';
           default = { };
           example = {
             "example.org/www" = {
@@ -1416,18 +1440,6 @@ in
         RootDirectoryStartOnly = true;
         #InaccessiblePaths = [ "-+${runDir}/root" ];
         UMask = "0066";
-        BindPaths = [
-          stateDir
-        ]
-        ++ lib.filter (x: x != null) (
-          lib.catAttrs "unix" (
-            lib.filter (x: x != null) (
-              lib.catAttrs "target" (
-                lib.concatMap (onionService: onionService.map) (lib.attrValues cfg.relay.onionServices)
-              )
-            )
-          )
-        );
         BindReadOnlyPaths = [
           builtins.storeDir
           "/etc"

--- a/nixos/modules/services/security/tor.nix
+++ b/nixos/modules/services/security/tor.nix
@@ -1441,9 +1441,9 @@ in
         #InaccessiblePaths = [ "-+${runDir}/root" ];
         UMask = "0066";
         BindReadOnlyPaths = [
-          builtins.storeDir
           "/etc"
         ]
+        ++ lib.optional (!config.systemd.services.tor.confinement.enable) builtins.storeDir
         ++ lib.optionals config.services.resolved.enable [
           "/run/systemd/resolve/stub-resolv.conf"
           "/run/systemd/resolve/resolv.conf"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
- [X] Fixes https://github.com/NixOS/nixpkgs/issues/481673
Note that `stateDir` is also removed from `BindPaths=` because `StateDirectory=` already does that.
- [X] Remove `builtins.storeDir` from `BindReadOnlyPaths=` to not undermine `systemd-confinement`.
- [X] Remove custom `SystemCallErrorNumber=`, because there's not reason to change it.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [X] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

Ping @kevincox as reporter of https://github.com/NixOS/nixpkgs/issues/481673
Ping @pacien as author of https://github.com/NixOS/nixpkgs/pull/440889