### PR TITLE
oakctl: 0.13.2 -> 0.16.5

### DIFF
--- a/pkgs/by-name/oa/oakctl/package.nix
+++ b/pkgs/by-name/oa/oakctl/package.nix
@@ -9,26 +9,26 @@
 }:
 
 let
-  version = "0.13.2";
+  version = "0.16.5";
 
   # Note: Extracted from install script
   # https://oakctl-releases.luxonis.com/oakctl-installer.sh
   sources = {
     x86_64-linux = fetchurl {
       url = "https://oakctl-releases.luxonis.com/data/${version}/linux_x86_64/oakctl";
-      hash = "sha256-uS7CUnj9+/kBwGaaZA9P6R2//vhZ1cJW+lhkQePZ0is=";
+      hash = "sha256-bTa/0jwYuRNLNYjqHlAjIbbIAdY7Qyq3m0I6GFnEW0s=";
     };
     aarch64-linux = fetchurl {
       url = "https://oakctl-releases.luxonis.com/data/${version}/linux_aarch64/oakctl";
-      hash = "sha256-+WFSV3TALeJtdcxkcduaN8tWGLCrOxvs3UV6cOr1xAI=";
+      hash = "sha256-RiZXHOxYJZHhIdIGGwO5BTDaoj4NYl0nZZbK3ULUhLI=";
     };
     aarch64-darwin = fetchurl {
       url = "https://oakctl-releases.luxonis.com/data/${version}/darwin_arm64/oakctl";
-      hash = "sha256-OgVmfYcRNVcLGjEbxdVUtsV45vICj+jKPQJ578aRwZs=";
+      hash = "sha256-tJl9OKhaY9dIxkN+tsbQ3isyAfFPSDOqkgLgDDaRaSg=";
     };
     x86_64-darwin = fetchurl {
       url = "https://oakctl-releases.luxonis.com/data/${version}/darwin_x86_64/oakctl";
-      hash = "sha256-KjJxwMRLs0XqiOTHjke+dSVKBftwBDYppjrqsbf0Qe8=";
+      hash = "sha256-xjmMqECqZ+ukXAPRKoJ1m1y7ABMIltw9u236q9k56/o=";
     };
   };
 


### PR DESCRIPTION
Update the tool to newer version. See [release notes](https://docs.luxonis.com/software-v3/oak-apps/oakctl/#Release%20Notes%20for%20oakctl).

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
