### PR TITLE
rebels-in-the-sky: 1.5.1 -> 1.6.0

### DIFF
--- a/pkgs/by-name/re/rebels-in-the-sky/disable-radio.patch
+++ b/pkgs/by-name/re/rebels-in-the-sky/disable-radio.patch
@@ -1,24 +1,20 @@
 diff --git a/assets/data/stream_data.json b/assets/data/stream_data.json
-index c049ec7..fe51488 100644
+index 6069c5d..fe51488 100644
 --- a/assets/data/stream_data.json
 +++ b/assets/data/stream_data.json
-@@ -1,18 +1 @@
+@@ -1,14 +1 @@
 -[
 -    {
 -        "name": "Radio Frittura",
--        "url_string": "https://radio.frittura.org/frittura.ogg"
+-        "url_string": "https://radio.frittura.org/rebels"
 -    },
 -    {
 -        "name": "Matt Johnson radio",
 -        "url_string": "https://us2.internet-radio.com/proxy/mattjohnsonradio?mp=/stream"
 -    },
 -    {
--        "name" : "Lofi 24/7",
+-        "name": "Lofi 24/7",
 -        "url_string": "http://usa9.fastcast4u.com/proxy/jamz?mp=/1"
--    },
--    {
--        "name" : "Radio Sarajevo",
--        "url_string": "https://cast2.asurahosting.com/proxy/balkanhi/stream"
 -    }
 -]
 \ No newline at end of file

--- a/pkgs/by-name/re/rebels-in-the-sky/package.nix
+++ b/pkgs/by-name/re/rebels-in-the-sky/package.nix
@@ -14,16 +14,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rebels-in-the-sky";
-  version = "1.5.1";
+  version = "1.6.0";
 
   src = fetchFromGitHub {
     owner = "ricott1";
     repo = "rebels-in-the-sky";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-VyQfwZWvutc5BnAi6BbIfgRm5G4xBre76cyraQSvn6o=";
+    hash = "sha256-P0GPdMTOomqNQ6WLfZnASO1FiD7DJTHj/a8eoYzAvAY=";
   };
 
-  cargoHash = "sha256-PL5WhqCLlH482uDoWETfwHarz3e2NJ0vezDMs52QavQ=";
+  cargoHash = "sha256-Ldy/1Gv1qguWQ2lLk0jiiq7nM9r85LY7pXkXf2nCUA0=";
 
   patches = lib.optionals (!withRadio) [
     ./disable-radio.patch


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
