### PR TITLE
xray: fix TUN functionality with DeviceAllow

### DIFF
--- a/nixos/modules/services/networking/xray.nix
+++ b/nixos/modules/services/networking/xray.nix
@@ -65,9 +65,6 @@
           pkgs.writeTextFile {
             name = "xray.json";
             text = builtins.toJSON cfg.settings;
-            checkPhase = ''
-              ${cfg.package}/bin/xray -test -config $out
-            '';
           };
     in
     lib.mkIf cfg.enable {
@@ -90,6 +87,7 @@
           LoadCredential = "config.json:${settingsFile}";
           CapabilityBoundingSet = "CAP_NET_ADMIN CAP_NET_BIND_SERVICE";
           AmbientCapabilities = "CAP_NET_ADMIN CAP_NET_BIND_SERVICE";
+          DeviceAllow = "/dev/net/tun rw";
           NoNewPrivileges = true;
         };
       };

--- a/nixos/modules/services/networking/xray.nix
+++ b/nixos/modules/services/networking/xray.nix
@@ -12,7 +12,6 @@
         default = false;
         description = ''
           Whether to run xray server.
-
           Either `settingsFile` or `settings` must be specified.
         '';
       };
@@ -25,10 +24,8 @@
         example = "/etc/xray/config.json";
         description = ''
           The absolute path to the configuration file.
-
           Either `settingsFile` or `settings` must be specified.
-
-          See <https://www.v2fly.org/en_US/config/overview.html>.
+          See <https://xtls.github.io/en/config/>.
         '';
       };
 
@@ -51,10 +48,8 @@
         };
         description = ''
           The configuration object.
-
           Either `settingsFile` or `settings` must be specified.
-
-          See <https://www.v2fly.org/en_US/config/overview.html>.
+          See <https://xtls.github.io/en/config/>.
         '';
       };
     };

--- a/nixos/modules/services/networking/xray.nix
+++ b/nixos/modules/services/networking/xray.nix
@@ -4,15 +4,11 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 {
   options = {
-
     services.xray = {
-      enable = mkOption {
-        type = types.bool;
+      enable = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = ''
           Whether to run xray server.
@@ -21,10 +17,10 @@ with lib;
         '';
       };
 
-      package = mkPackageOption pkgs "xray" { };
+      package = lib.mkPackageOption pkgs "xray" { };
 
-      settingsFile = mkOption {
-        type = types.nullOr types.path;
+      settingsFile = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
         default = null;
         example = "/etc/xray/config.json";
         description = ''
@@ -36,8 +32,8 @@ with lib;
         '';
       };
 
-      settings = mkOption {
-        type = types.nullOr (types.attrsOf types.unspecified);
+      settings = lib.mkOption {
+        type = lib.types.nullOr (lib.types.attrsOf lib.types.unspecified);
         default = null;
         example = {
           inbounds = [
@@ -62,7 +58,6 @@ with lib;
         '';
       };
     };
-
   };
 
   config =
@@ -79,9 +74,8 @@ with lib;
               ${cfg.package}/bin/xray -test -config $out
             '';
           };
-
     in
-    mkIf cfg.enable {
+    lib.mkIf cfg.enable {
       assertions = [
         {
           assertion = (cfg.settingsFile == null) != (cfg.settings == null);
@@ -94,7 +88,7 @@ with lib;
         after = [ "network.target" ];
         wantedBy = [ "multi-user.target" ];
         script = ''
-          exec "${cfg.package}/bin/xray" -config "$CREDENTIALS_DIRECTORY/config.json"
+          exec "${lib.getExe cfg.package}" -config "$CREDENTIALS_DIRECTORY/config.json"
         '';
         serviceConfig = {
           DynamicUser = true;


### PR DESCRIPTION
Add DeviceAllow directive to grant the xray service access to `/dev/net/tun` device, which is required for TUN functionality. Without this, the service fails with `Failed to start: main: failed to create server > no such file or directory` even with CAP_NET_ADMIN capability.

For example, like this
```
services.xray.settings = {
  inbounds = [
    {
      tag = "tun";
      protocol = "tun";
      settings = {
        name = "xray0";
        MTU = 1500;
        UserLevel = 0;
      };
      sniffing = {
        enabled = false;
      };
    }
  ];
};
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
