### PR TITLE
python3Packages.readability-lxml: 0.8.4 -> 0.8.4.1

### DIFF
--- a/pkgs/development/python-modules/readability-lxml/default.nix
+++ b/pkgs/development/python-modules/readability-lxml/default.nix
@@ -1,8 +1,8 @@
 {
-  stdenv,
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  poetry-core,
   pytestCheckHook,
   chardet,
   cssselect,
@@ -13,35 +13,30 @@
 
 buildPythonPackage rec {
   pname = "readability-lxml";
-  version = "0.8.4";
-  format = "setuptools";
+  version = "0.8.4.1";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "buriy";
     repo = "python-readability";
-    rev = "v${version}";
-    hash = "sha256-6A4zpe3GvHHf235Ovr2RT/cJgj7bWasn96yqy73pVgY=";
+    rev = "${version}";
+    hash = "sha256-tL0OnvCrbrpBvcy+6RJ+u/BDdra+MnVT51DSAeYxJbc=";
   };
 
-  propagatedBuildInputs = [
+  build-system = [ poetry-core ];
+
+  pythonRelaxDeps = [ "lxml" ];
+
+  dependencies = [
     chardet
     cssselect
     lxml
     lxml-html-clean
   ];
 
-  postPatch = ''
-    substituteInPlace setup.py --replace 'sys.platform == "darwin"' "False"
-  '';
-
   nativeCheckInputs = [
     pytestCheckHook
     timeout-decorator
-  ];
-
-  disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [
-    # Test is broken on darwin. Fix in master from https://github.com/buriy/python-readability/pull/178
-    "test_many_repeated_spaces"
   ];
 
   meta = {


### PR DESCRIPTION
- Remove obsolete postPatch (darwin-specific code removed upstream)
- Remove disabledTests (test fixed upstream via buriy/python-readability#178)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
