### PR TITLE
ocamlPackages.httpcats: init at 0.1.0

### DIFF
--- a/pkgs/development/ocaml-modules/httpcats/default.nix
+++ b/pkgs/development/ocaml-modules/httpcats/default.nix
@@ -1,0 +1,57 @@
+{
+  fetchFromGitHub,
+  buildDunePackage,
+  lib,
+  logs,
+  miou,
+  fmt,
+  h2,
+  h1,
+  ca-certs,
+  bstr,
+  tls-miou-unix,
+  dns-client-miou-unix,
+  happy-eyeballs-miou-unix,
+  mirage-crypto-rng-miou-unix,
+  alcotest,
+  digestif,
+}:
+
+buildDunePackage (finalAttrs: {
+  pname = "httpcats";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "robur-coop";
+    repo = "httpcats";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-t3gSfv73XYntle1dd4k9bv893pGStk1NHz62mAvcHAs=";
+  };
+
+  propagatedBuildInputs = [
+    h2
+    h1
+    ca-certs
+    bstr
+    tls-miou-unix
+    dns-client-miou-unix
+    happy-eyeballs-miou-unix
+  ];
+
+  doCheck = true;
+  checkInputs = [
+    logs
+    fmt
+    mirage-crypto-rng-miou-unix
+    alcotest
+    digestif
+  ];
+
+  meta = {
+    inherit (finalAttrs.src.meta) homepage;
+    description = "A simple HTTP client / server using h1, h2, and miou";
+    changelog = "https://github.com/robur-coop/httpcats/blob/${finalAttrs.src.tag}/CHANGES.md";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ rpqt ];
+  };
+})

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -825,6 +825,8 @@ let
 
         httpaf-lwt-unix = callPackage ../development/ocaml-modules/httpaf/lwt-unix.nix { };
 
+        httpcats = callPackage ../development/ocaml-modules/httpcats { };
+
         httpun = callPackage ../development/ocaml-modules/httpun { };
 
         httpun-eio = callPackage ../development/ocaml-modules/httpun/eio.nix { };


### PR DESCRIPTION
Library for HTTP client/server (HTTP/1.1 & h2) using Miou

https://github.com/robur-coop/httpcats

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
