### PR TITLE
ci: Don't run non-reproducible doc urls check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
           - runner: ubuntu-24.04-arm
             name: aarch64-linux
             systems: aarch64-linux
-            builds: [shell, manual-nixos, manual-nixpkgs, manual-nixpkgs-tests]
+            builds: [shell, manual-nixos, manual-nixpkgs]
             desc: shell, docs
           - runner: macos-14
             name: darwin
@@ -90,11 +90,7 @@ jobs:
 
       - name: Build Nixpkgs manual
         if: contains(matrix.builds, 'manual-nixpkgs') && !cancelled()
-        run: nix-build-uncached nixpkgs/untrusted/ci --arg nixpkgs ./nixpkgs/untrusted-pinned -A manual-nixpkgs -A manual-nixpkgs-tests
-
-      - name: Build Nixpkgs manual tests
-        if: contains(matrix.builds, 'manual-nixpkgs-tests') && !cancelled()
-        run: nix-build-uncached nixpkgs/untrusted/ci --arg nixpkgs ./nixpkgs/untrusted-pinned -A manual-nixpkgs-tests
+        run: nix-build-uncached nixpkgs/untrusted/ci --arg nixpkgs ./nixpkgs/untrusted-pinned -A manual-nixpkgs
 
       - name: Build lib tests
         if: contains(matrix.builds, 'lib-tests') && !cancelled()

--- a/ci/default.nix
+++ b/ci/default.nix
@@ -172,7 +172,6 @@ rec {
   lib-tests = import ../lib/tests/release.nix { inherit pkgs; };
   manual-nixos = (import ../nixos/release.nix { }).manual.${system} or null;
   manual-nixpkgs = (import ../doc { inherit pkgs; });
-  manual-nixpkgs-tests = (import ../doc { inherit pkgs; }).tests;
   nixpkgs-vet = pkgs.callPackage ./nixpkgs-vet.nix {
     nix = pkgs.nixVersions.latest;
   };

--- a/doc/doc-support/package.nix
+++ b/doc/doc-support/package.nix
@@ -168,6 +168,7 @@ stdenvNoCC.mkDerivation (
         };
 
       tests = {
+        # Don't run this in CI because it's not reproducible
         manpage-urls = callPackage ../tests/manpage-urls.nix { };
       };
     };


### PR DESCRIPTION
Causes non-reproducible CI failures: https://github.com/NixOS/nixpkgs/actions/runs/21102527291/job/60688698991?pr=480436

Motivation: https://github.com/NixOS/nixpkgs/pull/480141

Ping @dyegoaurelio @MattSturgeon
 
## Things done

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
