### PR TITLE
electron-source: updates, use yarn-berry; electron-{bin,chromedriver}: updates

### DIFF
--- a/pkgs/development/tools/electron/binary/info.json
+++ b/pkgs/development/tools/electron/binary/info.json
@@ -12,35 +12,35 @@
     },
     "37": {
         "hashes": {
-            "aarch64-darwin": "62d8cd68fec502201db9d4aa940ef9e3ad0004f27e46d6f56c8cf8924da477e7",
-            "aarch64-linux": "deebbca4a0348ff7dd8564ee413bf7ed0d99c8d71951881286115e82bc4f22ba",
-            "armv7l-linux": "1c53701c915b4180bf09557374944a93050a601c2d36ec5ef014f1f1f620e4ab",
+            "aarch64-darwin": "24529be1f2f87c587d06c7474607f1b57d1184b3f45d916cac33791de3a70014",
+            "aarch64-linux": "37a228821184136fa86a8727bec19ab400524dd7d4bca78937de5d50704592d1",
+            "armv7l-linux": "db4c1f6c8f012ddd15965c5f8837a61b65d0c3f8f296d81e3f0bf7158ef9779f",
             "headers": "0lwcdw882hjb2vhj9vvngkwq5l6nrh7d2hr9adpqdm1any4rssl5",
-            "x86_64-darwin": "334478ae40a5a1ea2bc33ec787352073d15f50eb7a164dfbc1f9e7abb203ded8",
-            "x86_64-linux": "f773866342de11ba59ca73bb3cf373302839cc3e41c94f6a3ed7c13c110b3b5c"
+            "x86_64-darwin": "e545e2a41e5fd7d28bf1349b4f60f1bcfd8e4c216f57b2d3e698ec1c00b719cf",
+            "x86_64-linux": "c0b4edd6bd9858cda4cf7ab299e69a2d3ecd2e5fcca78507bc0851ba35614660"
         },
-        "version": "37.10.2"
+        "version": "37.10.3"
     },
     "38": {
         "hashes": {
-            "aarch64-darwin": "90ac7f8b3a6b6efb83fb5e3b85498456932a2897b862b689312ddde8d9d203c1",
-            "aarch64-linux": "0aa21bf35d9c7214b0809f85a101472a92bc7b93cf6bc0fd019b94ba309c9b09",
-            "armv7l-linux": "6ea202c53a5db24c1a50a939e54aa0ba87987eea462e33c5a25530bd243e8532",
-            "headers": "03ml730a2gli6cmr2lnzbjw9apx2zpgviap4xzw5xa9m76jvdc8h",
-            "x86_64-darwin": "c72b7b42b53f154a928b3b6778422ec27ac4123040366aabda80cdce67038470",
-            "x86_64-linux": "d43bd3ff3f7f9f56825f66a29165ff620d84695d4d06769855acf02c4baa7b9c"
+            "aarch64-darwin": "b91e12ec6695f969ccf792d95dc7ea5da35f399cec2bed4d7b25d8a1f545b5de",
+            "aarch64-linux": "73e87c432fa52b9005e12e23a1fcffcfada853de19492f905c50dbb46fd778df",
+            "armv7l-linux": "a78ff548aa93586ce01c6406f49d1f8979a30542f286d05adb56e61a3147bba5",
+            "headers": "1f1381qc705fv50sbm0g5f6wm8pkwqvrbhb1kvi3i9mk2910y14m",
+            "x86_64-darwin": "459dd05f00c29d435112596f87bc5bd0aeb16796dff0744e5421086417877d24",
+            "x86_64-linux": "fe428cd212680e1d6df61fa67efc260b9221d089c7a14c9863f18bcbeace5628"
         },
-        "version": "38.7.1"
+        "version": "38.7.2"
     },
     "39": {
         "hashes": {
-            "aarch64-darwin": "2128a27c1b0fd80be9d608fb293639f76611b4108eca1e045c933fd04097a7b1",
-            "aarch64-linux": "c58c5904d6015cbbfa5f04fbda5c83b9a276a3565b5f3fa166795c789b055cdd",
-            "armv7l-linux": "d7c2f0b5038c49b1e637f8dbda945be4e6f3a6d7ebf802543e6ef5093c9641ff",
-            "headers": "0gaz44jv57aava01fvl35kqdl5yaf6ca7dzsx5f279qkpfyrhx2k",
-            "x86_64-darwin": "f8085a04dc35bfe0c32c36e6feffde07de16459bf36dfab422760181717f5ac0",
-            "x86_64-linux": "5eb51ebcb60487c4fc3a5b74ffb57a03eefd48def32200adf310ffaba4153d64"
+            "aarch64-darwin": "064edf951e0ab546809e217a417401023fd7e3b662de8be0316e8173f6f3db6d",
+            "aarch64-linux": "468d3096630953a52fc051abd48714004b58ac550f9c7e798c256c774811b0f2",
+            "armv7l-linux": "37a889a488e7a64d86961ad774f20e3cbb5dd965d76a6efd98c83488c33964e0",
+            "headers": "0ywhsg295d390mgm1dd64jgzag35gib65b3ybzilsg58d4gvvp5g",
+            "x86_64-darwin": "484c7f39235ea6c2c87b2ce5149436daa4eec97c9a6b11dc662f01ec1b81969e",
+            "x86_64-linux": "a676357322bdf28153ba3ad67e8558dd54d76757fe2b1ad48c53f4a5e20614c6"
         },
-        "version": "39.2.3"
+        "version": "39.3.0"
     }
 }

--- a/pkgs/development/tools/electron/chromedriver/info.json
+++ b/pkgs/development/tools/electron/chromedriver/info.json
@@ -12,35 +12,35 @@
     },
     "37": {
         "hashes": {
-            "aarch64-darwin": "30cfb8b90b0fad7cd0ef473fc03e761d28f98e1a398ff255956e3704c6da0727",
-            "aarch64-linux": "8a536ad3e2d2f0b9e99fc3085a9990f6d70c1de676d0f57219d2094ef1805ffd",
-            "armv7l-linux": "b8d774cf0188324538412201be8827d4224d658129eaf5e66f91c0448cc633f2",
+            "aarch64-darwin": "aa9dda4d536fd98e2620eb39de689e441fe799869c29e53db5c2c4351f1b4aba",
+            "aarch64-linux": "e7e4b0b21d8e685ef5ad32d8281025fc80cf4cb5bd9476642c26d702c8f3a59e",
+            "armv7l-linux": "f14f0122e94d6df6f04f682c4e14d1f21608b256b5c90c34c6567e3487b904dc",
             "headers": "0lwcdw882hjb2vhj9vvngkwq5l6nrh7d2hr9adpqdm1any4rssl5",
-            "x86_64-darwin": "9d3655a3c4a409c9d422e762a913bf6d19c5ca728ac1de5a13e6c6e98c4b263a",
-            "x86_64-linux": "2a1fcc98587a23b4022c4d921016f24126ab1071b395760a0339de5f019f9771"
+            "x86_64-darwin": "20e0fa9b41808153dbf54c1c44d3c6f136a35295b9f7d5ee3b3f32397cbc6319",
+            "x86_64-linux": "ced6d8721ce57a3fa10d2bc614e4d49ab031c46629ed5af03a253ce7def8b747"
         },
-        "version": "37.10.2"
+        "version": "37.10.3"
     },
     "38": {
         "hashes": {
-            "aarch64-darwin": "3faa6337db37dbb0e3e11fe66a6c93087bb5db79df25d2f1296a28edad8b2958",
-            "aarch64-linux": "bf0078dd84a4af9c636ecad448f824ebc2a99da10376746d8b1b600746e84de0",
-            "armv7l-linux": "8d41e3c53f5ab9d06b36a2a456cb35604802f1246adb100490a7770bef29a165",
-            "headers": "03ml730a2gli6cmr2lnzbjw9apx2zpgviap4xzw5xa9m76jvdc8h",
-            "x86_64-darwin": "c4ff20f9b683e1907072302c0cfc38ec0c47eca75b71098d916a6a82d87ff1bb",
-            "x86_64-linux": "997ab3fd934c1ac0ab479565e1def9b2eb6fe6d8a23fd585c8d62250ef05c704"
+            "aarch64-darwin": "6327236404c59f28ae0892d3898d240fe5e40c944019196afd1c9f03b3cc4a5a",
+            "aarch64-linux": "1e29832d58ed5582869cee4739b442b6641a4d36bdf350e12cfbd54b9ab7f773",
+            "armv7l-linux": "016b3f9d1f526f6943440379d431185f69ac4501d0f8acfa3b728dcc8944ab03",
+            "headers": "1f1381qc705fv50sbm0g5f6wm8pkwqvrbhb1kvi3i9mk2910y14m",
+            "x86_64-darwin": "4a5e11cf313bc337b1ba373643b55801869f7245ddff1287fee3dfa1d3d8c0be",
+            "x86_64-linux": "e083831cec7c952bab51cf49ff380558195edd01678a21eb71a67eddbebf87c1"
         },
-        "version": "38.7.1"
+        "version": "38.7.2"
     },
     "39": {
         "hashes": {
-            "aarch64-darwin": "1e88807c749e69c9a1b2abef105cf30dbec4fddc365afcaa624b1e2df80fe636",
-            "aarch64-linux": "8de5ed25a12029ca999455c1cadf28341ec5e0de87a3a0c27dbb24df99f154b1",
-            "armv7l-linux": "766b16d8b1297738a0d1fa7e44d992142558f6e12820197746913385590f033e",
-            "headers": "0gaz44jv57aava01fvl35kqdl5yaf6ca7dzsx5f279qkpfyrhx2k",
-            "x86_64-darwin": "5cadee0db7684ae48a7f9f4f1310c3f6e1518b0fa88cf3efb36f58984763d43d",
-            "x86_64-linux": "f35049fe3d8dbfdb7c541b59bdca6982b571761bb8cb7fc85515ceaea9451de9"
+            "aarch64-darwin": "3d5ef8b78ce4f35320a76a241bbc67f7a1922cedbfe338de111e5fd617677ca8",
+            "aarch64-linux": "e0f1fa67b9f1ba8f15b2fc0aa0570e80d68261286a19862638a4f26c6966ecf2",
+            "armv7l-linux": "8a4f46da6a51c97e3296c13aa480a7714e7bd5e8fa46876526ece89c8ae5b182",
+            "headers": "0ywhsg295d390mgm1dd64jgzag35gib65b3ybzilsg58d4gvvp5g",
+            "x86_64-darwin": "ed1951ecc55949c65452e1f8cd29b2348c8fd7932c2b1e11279987525b4658bc",
+            "x86_64-linux": "44e15ac6c421e7bc7b36c55721085e5ccd4996c0770785dc78c55baaf4f73322"
         },
-        "version": "39.2.3"
+        "version": "39.3.0"
     }
 }

--- a/pkgs/development/tools/electron/info.json
+++ b/pkgs/development/tools/electron/info.json
@@ -56,10 +56,10 @@
             },
             "src/electron": {
                 "args": {
-                    "hash": "sha256-I8C0lT1VnNP4fSMp5LReFe8tQj/3IM1Ko6SohY187Cc=",
+                    "hash": "sha256-ssEFUO6UFZI5/a49oPbYXMhYCyHnE+HGK8H26jKN5JE=",
                     "owner": "electron",
                     "repo": "electron",
-                    "tag": "v37.10.2"
+                    "tag": "v37.10.3"
                 },
                 "fetcher": "fetchFromGitHub"
             },
@@ -1326,10 +1326,10 @@
                 "fetcher": "fetchFromGitiles"
             }
         },
-        "electron_yarn_hash": "0hm126bl9cscs2mjb3yx2yr4b22agqp9r0c5kv25r3lvc020r9pk",
+        "electron_yarn_hash": "sha256-ouaxVsLQ+IapxTJxM7KFuLq9PSsMRhPwrWYT/opxE0I=",
         "modules": "136",
         "node": "22.21.1",
-        "version": "37.10.2"
+        "version": "37.10.3"
     },
     "38": {
         "chrome": "140.0.7339.249",
@@ -1388,10 +1388,10 @@
             },
             "src/electron": {
                 "args": {
-                    "hash": "sha256-1C17jQP8TFxBTHhIz+fHB83OFOykzZToPOrwzl+NN9Q=",
+                    "hash": "sha256-gSW1dI2PBGaLleuekWEI8Om/HE+V7w7QPy3wWxfN0V0=",
                     "owner": "electron",
                     "repo": "electron",
-                    "tag": "v38.7.1"
+                    "tag": "v38.7.2"
                 },
                 "fetcher": "fetchFromGitHub"
             },
@@ -2650,13 +2650,13 @@
                 "fetcher": "fetchFromGitiles"
             }
         },
-        "electron_yarn_hash": "1knhw3blk3bl2a8nl58ik272qj2q0cpqiih5gcsds1na3bbkbn2z",
+        "electron_yarn_hash": "sha256-R5AHeNFOeH7ZXipzM9u08KG5zJhkDDTW4kGt3BYYN64=",
         "modules": "139",
         "node": "22.21.1",
-        "version": "38.7.1"
+        "version": "38.7.2"
     },
     "39": {
-        "chrome": "142.0.7444.175",
+        "chrome": "142.0.7444.265",
         "chromium": {
             "deps": {
                 "gn": {
@@ -2665,15 +2665,15 @@
                     "version": "0-unstable-2025-09-18"
                 }
             },
-            "version": "142.0.7444.175"
+            "version": "142.0.7444.265"
         },
         "chromium_npm_hash": "sha256-i1eQ4YlrWSgY522OlFtGDDPmxE2zd1hDM03AzR8RafE=",
         "deps": {
             "src": {
                 "args": {
-                    "hash": "sha256-nRZWCvoGYS4gxoJidkKGqTMGUuFfXfhIrHc3j/xRlaI=",
+                    "hash": "sha256-VJKx61JTIGg4j/kNqtOWkYOsy0xYYZbuyoiKFVcbZgc=",
                     "postFetch": "rm -rf $(find $out/third_party/blink/web_tests ! -name BUILD.gn -mindepth 1 -maxdepth 1); rm -r $out/content/test/data; rm -rf $out/courgette/testdata; rm -r $out/extensions/test/data; rm -r $out/media/test/data; ",
-                    "tag": "142.0.7444.175",
+                    "tag": "142.0.7444.265",
                     "url": "https://chromium.googlesource.com/chromium/src.git"
                 },
                 "fetcher": "fetchFromGitiles"
@@ -2712,10 +2712,10 @@
             },
             "src/electron": {
                 "args": {
-                    "hash": "sha256-Zvu8Puh7j/u84cigKtfhOjBcxIYKJAv1mmbmIFRwdNY=",
+                    "hash": "sha256-udrEpPg2LDThZDTXJ1jpkIEiDwlD7lRUJsV6HSwN0i8=",
                     "owner": "electron",
                     "repo": "electron",
-                    "tag": "v39.2.3"
+                    "tag": "v39.3.0"
                 },
                 "fetcher": "fetchFromGitHub"
             },
@@ -2745,8 +2745,8 @@
             },
             "src/third_party/angle": {
                 "args": {
-                    "hash": "sha256-PM7msE9678QFyr7qp47Bc0vTntsSCeB/cirg9ME6TZk=",
-                    "rev": "7b27cb13556246035dfc7b308702b1b20710df47",
+                    "hash": "sha256-CCjQue8xv/t81I3ncqS6Ib3hjcs+FKCB+yvNUE+A+Dc=",
+                    "rev": "7628a2726022fc768f2464ed5060bbc97e13f77a",
                     "url": "https://chromium.googlesource.com/angle/angle.git"
                 },
                 "fetcher": "fetchFromGitiles"
@@ -3009,8 +3009,8 @@
             },
             "src/third_party/devtools-frontend/src": {
                 "args": {
-                    "hash": "sha256-qiucde85rKA7TefveIa++sOF+MzT56pe8pHUUCj9Zeo=",
-                    "rev": "f063edc91e3610a60fb9d486ae8694f2a11fcd17",
+                    "hash": "sha256-4SIqiDQtelkjdzTSDfB5GCymh+24MoiN77NNCxTV6qU=",
+                    "rev": "747b0d1aebe33e5fc3d32677eb88315ab000eb5e",
                     "url": "https://chromium.googlesource.com/devtools/devtools-frontend"
                 },
                 "fetcher": "fetchFromGitiles"
@@ -3991,16 +3991,16 @@
             },
             "src/v8": {
                 "args": {
-                    "hash": "sha256-jECAfgeAgdkhbI/8BgT9TakR9Ylha2zPznjZzibPQbE=",
-                    "rev": "baea8d627b70725fb777ebc1074f8ec4110ef6cb",
+                    "hash": "sha256-FNEyH9sT59A0SFRloRMbK1YOy/slwtAz2/+T4mlCdWs=",
+                    "rev": "8fa4e7c7469cd4d321e2241b86f684d52197a615",
                     "url": "https://chromium.googlesource.com/v8/v8.git"
                 },
                 "fetcher": "fetchFromGitiles"
             }
         },
-        "electron_yarn_hash": "19mpwfjb85d9kw1awiymj47h06rjk6vxqcgfajh612cgwkbz4m6f",
+        "electron_yarn_hash": "sha256-veyZGCQJO23iQk4gmFo5oLASxamiYm4tAQSUS12IGxg=",
         "modules": "140",
         "node": "22.21.1",
-        "version": "39.2.3"
+        "version": "39.3.0"
     }
 }

--- a/pkgs/development/tools/electron/update.py
+++ b/pkgs/development/tools/electron/update.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env nix-shell
-#! nix-shell -i python -p python3.pkgs.joblib python3.pkgs.click python3.pkgs.click-log nix nurl prefetch-yarn-deps prefetch-npm-deps gclient2nix
+#! nix-shell -i python -p python3.pkgs.joblib python3.pkgs.click python3.pkgs.click-log nix nurl prefetch-npm-deps yarn-berry_4.yarn-berry-fetcher nix-prefetch-git gclient2nix
 """
 electron updater
 
@@ -115,12 +115,12 @@ def get_chromium_gn_source(chromium_tag: str) -> dict:
 
 @memory.cache
 def get_electron_yarn_hash(electron_tag: str) -> str:
-    print(f"prefetch-yarn-deps", file=sys.stderr)
+    print(f"yarn-berry-fetcher prefetch", file=sys.stderr)
     with tempfile.TemporaryDirectory() as tmp_dir:
         with open(tmp_dir + "/yarn.lock", "w") as f:
             f.write(get_electron_file(electron_tag, "yarn.lock"))
         return (
-            subprocess.check_output(["prefetch-yarn-deps", tmp_dir + "/yarn.lock"])
+            subprocess.check_output(["yarn-berry-fetcher", "prefetch", tmp_dir + "/yarn.lock"])
             .decode("utf-8")
             .strip()
         )


### PR DESCRIPTION
https://github.com/electron/electron/releases

Upstream migrated to using Yarn v4: https://github.com/electron/electron/pull/48243
The logic was luckily backported to earlier electron versions, so the tooling doesn't need to be changed to support yarn v1 and v4 at the same time.

After this, I think we should work on adding `electron_40` (https://github.com/NixOS/nixpkgs/pull/482336)
and also the removal of the `electron_37` source build / marking electron_37 as insecure. 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
