### PR TITLE
sptk: 4.2 -> 4.4, fix install failure for dangling symlinks

### DIFF
--- a/pkgs/by-name/sp/sptk/package.nix
+++ b/pkgs/by-name/sp/sptk/package.nix
@@ -4,31 +4,39 @@
   cmake,
   fetchFromGitHub,
   fetchpatch,
+  python3,
 }:
 
 stdenv.mkDerivation rec {
   pname = "sptk";
-  version = "4.2";
+  version = "4.4";
 
   src = fetchFromGitHub {
     owner = "sp-nitech";
     repo = "SPTK";
     rev = "v${version}";
-    hash = "sha256-lIyOcN2AR3ilUZ9stpicjbwlredbwgGPwmMICxZEijU=";
+    hash = "sha256-QdaXIFsFXL9/CtUJlOaUKOTmG/nm6ibBEsVfzW9pT/U=";
   };
 
   patches = [
-    # Fix gcc-13 build failure:
-    #   https://github.com/sp-nitech/SPTK/pull/57
+    # fix dangling symlinks: https://github.com/sp-nitech/SPTK/pull/90
     (fetchpatch {
-      name = "gcc-13.patch";
-      url = "https://github.com/sp-nitech/SPTK/commit/060bc2ad7a753c1f9f9114a70d4c4337b91cb7e0.patch";
-      hash = "sha256-QfzpIS63LZyTHAaMGUZh974XLRNZLQG3om7ZJJ4RlgE=";
+      name = "fix-dangling.patch";
+      url = "https://github.com/sp-nitech/SPTK/commit/8798c94d19e930c0947a7d1d0bc9e59a02aab567.patch";
+      hash = "sha256-G7yyJ0uiVzcP6wQVwiDpWVZOJmOpKZRfNyoETt3xam4=";
     })
   ];
 
   nativeBuildInputs = [
     cmake
+  ];
+
+  buildInputs = [
+    (python3.withPackages (ps: [
+      ps.numpy
+      ps.plotly
+      ps.scipy
+    ]))
   ];
 
   doCheck = true;


### PR DESCRIPTION
Without the change the build fails as https://hydra.nixos.org/build/318191976:

    ERROR: noBrokenSymlinks: the symlink /nix/store/h8v4y5s72czz0hd701jmf6kjj7bq81w4-sptk-4.2/bin/gspecgram points to /build directory: /build/source/src/draw/gspecgram.py

Changes:
- https://github.com/sp-nitech/SPTK/releases/tag/v4.3
- https://github.com/sp-nitech/SPTK/releases/tag/v4.4


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
