### PR TITLE
QuadProgpp: unstable-2023-01-20 -> 1.2.2-unstable-2025-12-03

### DIFF
--- a/pkgs/by-name/qu/QuadProgpp/package.nix
+++ b/pkgs/by-name/qu/QuadProgpp/package.nix
@@ -7,25 +7,18 @@
 
 stdenv.mkDerivation {
   pname = "quadprogpp";
-  version = "unstable-2023-01-20";
+  version = "1.2.2-unstable-2025-12-03";
 
   src = fetchFromGitHub {
     owner = "liuq";
     repo = "QuadProgpp";
-    rev = "4c51d91deb5af251957edf9454bfb74279a4544e";
-    hash = "sha256-uozwuTAOPsRwYM9KyG3V0hwcmaPpfZPID9Wdd4olsvY=";
+    rev = "0c25447365c980876fdc395f55d60300a5e5793c";
+    hash = "sha256-yXKctOTBbUNiSM2j7hKfSvd1i7FH7kcgP990DXVkrRY=";
   };
 
   nativeBuildInputs = [
     cmake
   ];
-
-  postPatch = ''
-    # Inline https://github.com/liuq/QuadProgpp/pull/32
-    substituteInPlace CMakeLists.txt --replace-fail \
-      'cmake_minimum_required(VERSION 3.0)' \
-      'cmake_minimum_required(VERSION 3.10)'
-  '';
 
   meta = {
     description = "C++ library for Quadratic Programming";


### PR DESCRIPTION
https://github.com/liuq/QuadProgpp/pull/20

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
