### PR TITLE
alttab: fix `gcc-15` build

### DIFF
--- a/pkgs/by-name/al/alttab/package.nix
+++ b/pkgs/by-name/al/alttab/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   coreutils,
   fetchFromGitHub,
+  fetchpatch,
   autoconf,
   automake,
   pkg-config,
@@ -27,6 +28,15 @@ stdenv.mkDerivation rec {
     tag = "v${version}";
     sha256 = "sha256-1+hk0OeSriXPyefv3wOgeiW781PL4VP5Luvt+RS5jmg=";
   };
+
+  patches = [
+    # Fix gcc-15 build failure: https://github.com/sagb/alttab/pull/178
+    (fetchpatch {
+      name = "gcc-15.patch";
+      url = "https://github.com/sagb/alttab/commit/665e3e369f74ab0075c22a46a3cb3a9f76bdd762.patch";
+      hash = "sha256-7l74kXs0bAyozBbgOEzDSY+4NE2pjdVfWda0XiPvCz4=";
+    })
+  ];
 
   nativeBuildInputs = [
     autoconf


### PR DESCRIPTION
Without the change the build fails on `master` as
https://hydra.nixos.org/build/317969520:

    alttab.c:536:25: error: too many arguments to function 'getOffendingModifiersMask'; expected 0, have 1
      536 |     g.ignored_modmask = getOffendingModifiersMask(dpy); // or 0 for g.debug
          |                         ^~~~~~~~~~~~~~~~~~~~~~~~~ ~~~


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
