### PR TITLE
gh-news: init at 0.3.0

### DIFF
--- a/pkgs/by-name/gh/gh-news/package.nix
+++ b/pkgs/by-name/gh/gh-news/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  openssl,
+  stdenv,
+  darwin,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "gh-news";
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    owner = "chmouel";
+    repo = "gh-news";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-yWjo2YqlcXGWMO3srxbC+gZ9RCGy5r/Bp2tj3gvYyI0=";
+  };
+
+  cargoHash = "sha256-Xh82YyCmkWQoSZzuLCeqcr306KWWoplsvr76HzKHRzc=";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    openssl
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    darwin.apple_sdk.frameworks.Security
+    darwin.apple_sdk.frameworks.SystemConfiguration
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "GitHub CLI extension to read your GitHub notifications in the terminal";
+    homepage = "https://github.com/chmouel/gh-news";
+    changelog = "https://github.com/chmouel/gh-news/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      vdemeester
+      chmouel
+    ];
+    mainProgram = "gh-news";
+  };
+})


### PR DESCRIPTION
gh-news is a GitHub CLI extension to read GitHub notifications in the terminal. It's a TUI (Terminal User Interface) built with Rust that provides an interactive way to manage GitHub notifications.

Homepage: https://github.com/chmouel/gh-news

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test