### PR TITLE
python3Packages.exiv2: 0.17.5 -> 0.18.0

### DIFF
--- a/pkgs/development/python-modules/exiv2/default.nix
+++ b/pkgs/development/python-modules/exiv2/default.nix
@@ -8,30 +8,32 @@
   buildPythonPackage,
   setuptools,
   toml,
-  unittestCheckHook,
+  pytestCheckHook,
+  fetchpatch,
 }:
 buildPythonPackage rec {
   pname = "exiv2";
-  version = "0.17.5";
+  version = "0.18.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "jim-easterbrook";
     repo = "python-exiv2";
     tag = version;
-    hash = "sha256-MQNovei1Y8EZTF8hEyIWLaL2NbQPCB6FGbVfDHIvNVo=";
+    hash = "sha256-lYz0TWiiBtpwZ56Oiy2v8DFBXoofMv60hxsG0q7Cx9Y=";
   };
 
-  # FAIL: test_localisation (test_types.TestTypesModule.test_localisation)
-  # FAIL: test_TimeValue (test_value.TestValueModule.test_TimeValue)
-  postPatch = ''
-    substituteInPlace tests/test_value.py \
-      --replace-fail "def test_TimeValue(self):" "@unittest.skip('skipping')
-        def test_TimeValue(self):"
-    substituteInPlace tests/test_types.py \
-      --replace-fail "def test_localisation(self):" "@unittest.skip('skipping')
-        def test_localisation(self):"
-  '';
+  patches = [
+    # Disable refcount tests for python >= 3.14
+    (fetchpatch {
+      url = "https://github.com/jim-easterbrook/python-exiv2/commit/fe98ad09ff30f1b6cc5fd5dcc0769f9505c09166.patch";
+      hash = "sha256-+KepYfzocG6qkak+DwXFtCaMiLEAE+FegONgL4vo21o=";
+    })
+    (fetchpatch {
+      url = "https://github.com/jim-easterbrook/python-exiv2/commit/e0a5284620e8d020771bf8c1fa73d6113e662ebf.patch";
+      hash = "sha256-n/yfhP/Z4Is/+2bKsFZtcNXnQe61DjoE9Ryi2q9yTSA=";
+    })
+  ];
 
   build-system = [
     setuptools
@@ -45,12 +47,7 @@ buildPythonPackage rec {
   ];
 
   pythonImportsCheck = [ "exiv2" ];
-  nativeCheckInputs = [ unittestCheckHook ];
-  unittestFlagsArray = [
-    "-s"
-    "tests"
-    "-v"
-  ];
+  nativeCheckInputs = [ pytestCheckHook ];
 
   passthru.updateScript = gitUpdater { };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
See tracking https://github.com/NixOS/nixpkgs/issues/475732
Changelog: https://github.com/jim-easterbrook/python-exiv2/releases/tag/0.18.0

Some new tests dont work with Python >= 3.14, they've been skipped upstream
- https://github.com/jim-easterbrook/python-exiv2/commit/fe98ad09ff30f1b6cc5fd5dcc0769f9505c09166
- https://github.com/jim-easterbrook/python-exiv2/commit/e0a5284620e8d020771bf8c1fa73d6113e662ebf#diff-5e8784d4ba1a456a40d31b7c70531b1aab288d7d549ea5e776bd5ab87c04bcfb

As far as I can see, `disabledTests` didn't seem to work (which is why there were already tests disabled through `substituteInPlace`)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
