### PR TITLE
zettlr: 3.4.4 -> 4.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15908,6 +15908,12 @@
       { fingerprint = "9C68 989F ECF9 8993 3225  96DD 970A 6794 990C 52AE"; }
     ];
   };
+  maj0e = {
+    email = "contact@markusjoerg.com";
+    github = "maj0e";
+    githubId = 57637846;
+    name = "Markus Jörg";
+  };
   majesticmullet = {
     email = "hoccthomas@gmail.com.au";
     github = "MajesticMullet";

--- a/pkgs/by-name/ze/zettlr/package.nix
+++ b/pkgs/by-name/ze/zettlr/package.nix
@@ -8,11 +8,11 @@
 # Based on https://gist.github.com/msteen/96cb7df66a359b827497c5269ccbbf94 and joplin-desktop nixpkgs.
 let
   pname = "zettlr";
-  version = "3.4.4";
+  version = "4.1.0";
 
   src = fetchurl {
     url = "https://github.com/Zettlr/Zettlr/releases/download/v${version}/Zettlr-${version}-x86_64.appimage";
-    hash = "sha256-ApgmHl9WoAmWl03tqv01D0W8orja25f7KZUFLhlZloQ=";
+    hash = "sha256-/6x2HhwW0+A7/CYC+HUCsJ2u1tp4zno6XjpvBLogUKU=";
   };
   appimageContents = appimageTools.extractType2 {
     inherit pname version src;

--- a/pkgs/by-name/ze/zettlr/package.nix
+++ b/pkgs/by-name/ze/zettlr/package.nix
@@ -41,6 +41,7 @@ appimageTools.wrapType2 rec {
     description = "Markdown editor for writing academic texts and taking notes";
     homepage = "https://www.zettlr.com";
     platforms = [ "x86_64-linux" ];
+    maintainers = with lib.maintainers; [ maj0e ];
     license = lib.licenses.gpl3;
     mainProgram = "zettlr";
   };

--- a/pkgs/by-name/ze/zettlr/package.nix
+++ b/pkgs/by-name/ze/zettlr/package.nix
@@ -3,6 +3,7 @@
   lib,
   fetchurl,
   makeWrapper,
+  nix-update-script,
 }:
 
 # Based on https://gist.github.com/msteen/96cb7df66a359b827497c5269ccbbf94 and joplin-desktop nixpkgs.
@@ -36,6 +37,8 @@ appimageTools.wrapType2 rec {
     substituteInPlace $out/share/applications/Zettlr.desktop \
       --replace-fail 'Exec=AppRun' 'Exec=${pname}'
   '';
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Markdown editor for writing academic texts and taking notes";


### PR DESCRIPTION
Hi,

this PR updates the zettlr note taking tool from v3.4.4 to v4.1.0.

The version in nixpkgs hasn't been updated for some time, so I have been using a newer version through an overlay. I haven't observed any problems, so just updating the version and hash seems to be fine.

Best regards,
maj0e

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
