### PR TITLE
flopoco: fix build with gcc 15

### DIFF
--- a/pkgs/by-name/sc/scalp/package.nix
+++ b/pkgs/by-name/sc/scalp/package.nix
@@ -24,6 +24,7 @@ stdenv.mkDerivation rec {
   };
 
   postPatch = ''
+    sed -i "1i\#include <cstdint>" src/ScaLP/Solver.cpp
     substituteInPlace CMakeLists.txt \
       --replace-fail "cmake_minimum_required (VERSION 3.3.2)" "cmake_minimum_required (VERSION 3.5)" \
       --replace-fail "\''$ORIGIN" "\''${CMAKE_INSTALL_PREFIX}/lib" \

--- a/pkgs/by-name/so/sollya/package.nix
+++ b/pkgs/by-name/so/sollya/package.nix
@@ -30,6 +30,10 @@ stdenv.mkDerivation rec {
     "--with-xml2-config=${lib.getExe' (lib.getDev libxml2) "xml2-config"}"
   ];
 
+  makeFlags = [
+    "CFLAGS=-std=c17"
+  ];
+
   doCheck = true;
 
   meta = {

--- a/pkgs/by-name/wc/wcpg/package.nix
+++ b/pkgs/by-name/wc/wcpg/package.nix
@@ -35,6 +35,10 @@ stdenv.mkDerivation rec {
     mpfr
   ];
 
+  makeFlags = [
+    "CFLAGS=-std=c17"
+  ];
+
   meta = {
     description = "Worst-Case Peak-Gain library";
     homepage = "https://github.com/fixif/WCPG";


### PR DESCRIPTION
This PR fixes three dependencies of flopoco so that it builds.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
