### PR TITLE
python3Packages.assay: fix for python 3.14; python3Packages.skyfield: 1.53 -> 1.54

### DIFF
--- a/pkgs/development/python-modules/assay/default.nix
+++ b/pkgs/development/python-modules/assay/default.nix
@@ -3,12 +3,13 @@
   buildPythonPackage,
   fetchFromGitHub,
   pythonAtLeast,
+  setuptools,
 }:
 
 buildPythonPackage {
   pname = "assay";
   version = "0-unstable-2024-05-09";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "brandon-rhodes";
@@ -16,6 +17,13 @@ buildPythonPackage {
     rev = "74617d70e77afa09f58b3169cf496679ac5d5621";
     hash = "sha256-zYpLtcXZ16EJWKSCqxFkSz/G9PwIZEQGBrYiJKuqnc4=";
   };
+
+  build-system = [ setuptools ];
+
+  postPatch = lib.optionalString (pythonAtLeast "3.14") ''
+    substituteInPlace assay/assertion.py \
+      --replace-fail "op.load_assertion_error" "op.load_common_constant"
+  '';
 
   pythonImportsCheck = [ "assay" ];
 

--- a/pkgs/development/python-modules/skyfield/default.nix
+++ b/pkgs/development/python-modules/skyfield/default.nix
@@ -1,7 +1,6 @@
 {
   lib,
   buildPythonPackage,
-  pythonOlder,
   fetchFromGitHub,
   setuptools,
   certifi,
@@ -16,14 +15,14 @@
 
 buildPythonPackage rec {
   pname = "skyfield";
-  version = "1.53";
+  version = "1.54";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "skyfielders";
     repo = "python-skyfield";
     rev = version;
-    hash = "sha256-CQe+ik6HciOUaRpFp8Cx6cOlOFzeVoMVJrk7+rdcQEo=";
+    hash = "sha256-oZEmc8BVqs3eSaqrjyR/wQu1WTLv4A0a/dpEZduCXqk=";
   };
 
   # Fix broken tests on "exotic" platforms.


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
See tracking https://github.com/NixOS/nixpkgs/issues/475732
Changelog: https://github.com/skyfielders/python-skyfield/blob/master/CHANGELOG.rst#v154--2026-january-18

`skyfield` doesn't build because its dependency `assay` hasn't been updated in a while
There's a fix found by @scottshambaugh in https://github.com/skyfielders/python-skyfield/pull/1100 to allow `assay` to work for Python >= 3.14

The version update from 1.53 to 1.54 is not part of the fix, I can move it to a separate PR if it's prefered.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
