### PR TITLE
python3Packages.ruamel-yaml-string: disable on python>=3.14

### DIFF
--- a/pkgs/development/python-modules/ruamel-yaml-string/default.nix
+++ b/pkgs/development/python-modules/ruamel-yaml-string/default.nix
@@ -1,18 +1,22 @@
 {
   lib,
   buildPythonPackage,
+  pythonAtLeast,
   fetchPypi,
   setuptools,
   ruamel-yaml,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "ruamel-yaml-string";
   version = "0.1.1";
   pyproject = true;
 
+  # ImportError: cannot import name 'Str' from 'ast'
+  disabled = pythonAtLeast "3.14";
+
   src = fetchPypi {
-    inherit version;
+    inherit (finalAttrs) version;
     pname = "ruamel.yaml.string";
     hash = "sha256-enrtzAVdRcAE04t1b1hHTr77EGhR9M5WzlhBVwl4Q1A=";
   };
@@ -29,4 +33,4 @@ buildPythonPackage rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fbeffa ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

cc @fedeinthemix

```
Executing pypaBuildPhase
Creating a wheel...
pypa build flags: --no-isolation --outdir dist/ --wheel
* Getting build dependencies for wheel...
Traceback (most recent call last):
  File "/nix/store/f75plbpx9zslh1vdknqx6b24k5m3lg86-python3.14-pyproject-hooks-1.2.0/lib/python3.14/site-packages/pyproject_hooks/_in_process/_in_process.py", line 389, in <module>
    main()
    ~~~~^^
  File "/nix/store/f75plbpx9zslh1vdknqx6b24k5m3lg86-python3.14-pyproject-hooks-1.2.0/lib/python3.14/site-packages/pyproject_hooks/_in_process/_in_process.py", line 373, in main
    json_out["return_val"] = hook(**hook_input["kwargs"])
                             ~~~~^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/f75plbpx9zslh1vdknqx6b24k5m3lg86-python3.14-pyproject-hooks-1.2.0/lib/python3.14/site-packages/pyproject_hooks/_in_process/_in_process.py", line 143, in get_requires_for_build_wheel
    return hook(config_settings)
  File "/nix/store/nka950z7rk9smv94ywkvswx1nxwh1n7r-python3.14-setuptools-80.9.0/lib/python3.14/site-packages/setuptools/build_meta.py", line 331, in get_requires_for_build_wheel
    return self._get_build_requires(config_settings, requirements=[])
           ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/nka950z7rk9smv94ywkvswx1nxwh1n7r-python3.14-setuptools-80.9.0/lib/python3.14/site-packages/setuptools/build_meta.py", line 301, in _get_build_requires
    self.run_setup()
    ~~~~~~~~~~~~~~^^
  File "/nix/store/nka950z7rk9smv94ywkvswx1nxwh1n7r-python3.14-setuptools-80.9.0/lib/python3.14/site-packages/setuptools/build_meta.py", line 512, in run_setup
    super().run_setup(setup_script=setup_script)
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/nka950z7rk9smv94ywkvswx1nxwh1n7r-python3.14-setuptools-80.9.0/lib/python3.14/site-packages/setuptools/build_meta.py", line 317, in run_setup
    exec(code, locals())
    ~~~~^^^^^^^^^^^^^^^^
  File "<string>", line 79, in <module>
ImportError: cannot import name 'Str' from 'ast' (/nix/store/pmb8clh66mryha2ijzz3dg969drrkgj7-python3-3.14.2/lib/python3.14/ast.py)
```

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
