### PR TITLE
python3Packages.jax: 0.8.2 -> 0.9.2

### DIFF
--- a/pkgs/development/python-modules/bambi/default.nix
+++ b/pkgs/development/python-modules/bambi/default.nix
@@ -36,6 +36,14 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-Vjv62cYDIuTLE7MxRt4Havy7DMOiMTyIixbs4LGFGGs=";
   };
 
+  # TypeError: NDArray.record() missing 1 required keyword-only argument: 'in_warmup'
+  postPatch = ''
+    substituteInPlace bambi/backend/pymc.py \
+      --replace-fail \
+        "strace.record(point=dict(zip(varnames, value)))" \
+        "strace.record(point=dict(zip(varnames, value)), in_warmup=False)"
+  '';
+
   build-system = [
     setuptools
     setuptools-scm

--- a/pkgs/development/python-modules/blackjax/default.nix
+++ b/pkgs/development/python-modules/blackjax/default.nix
@@ -15,11 +15,12 @@
   typing-extensions,
 
   # checks
+  chex,
   pytestCheckHook,
   pytest-xdist,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "blackjax";
   version = "1.3";
   pyproject = true;
@@ -27,7 +28,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "blackjax-devs";
     repo = "blackjax";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-ystvPfIsnMFYkC+LNtcRQsI19i/y/905SnPSApM8v4E=";
   };
 
@@ -46,6 +47,7 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
+    chex
     pytestCheckHook
     pytest-xdist
   ];
@@ -83,8 +85,8 @@ buildPythonPackage rec {
   meta = {
     homepage = "https://blackjax-devs.github.io/blackjax";
     description = "Sampling library designed for ease of use, speed and modularity";
-    changelog = "https://github.com/blackjax-devs/blackjax/releases/tag/${version}";
+    changelog = "https://github.com/blackjax-devs/blackjax/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ bcdarwin ];
   };
-}
+})

--- a/pkgs/development/python-modules/brax/default.nix
+++ b/pkgs/development/python-modules/brax/default.nix
@@ -36,16 +36,16 @@
   transforms3d,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "brax";
-  version = "0.14.0";
+  version = "0.14.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "brax";
-    tag = "v${version}";
-    hash = "sha256-CkRXEYtlP8IhEZ7lVnpxlwiyLdICAfILwHfRUfuub08=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-/oznBa44xKl+9T1YrTVhCbuKZj16V1BTlnmCGRbF45g=";
   };
 
   build-system = [
@@ -88,6 +88,11 @@ buildPythonPackage rec {
     "testModelEncoding1"
     "testTrain"
     "testTrainDomainRandomize"
+
+    # ValueError: Error: no decoder found for mesh file 'meshes/pyramid.stl'
+    "test_convex_convex"
+    "test_dumps"
+    "test_dumps_invalidstate_raises"
   ]
   ++ lib.optionals stdenv.hostPlatform.isAarch64 [
     # Flaky:
@@ -100,9 +105,7 @@ buildPythonPackage rec {
     "brax/generalized/constraint_test.py"
   ];
 
-  pythonImportsCheck = [
-    "brax"
-  ];
+  pythonImportsCheck = [ "brax" ];
 
   meta = {
     description = "Massively parallel rigidbody physics simulation on accelerator hardware";
@@ -110,4 +113,4 @@ buildPythonPackage rec {
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ nim65s ];
   };
-}
+})

--- a/pkgs/development/python-modules/clu/default.nix
+++ b/pkgs/development/python-modules/clu/default.nix
@@ -19,6 +19,7 @@
   wrapt,
 
   # tests
+  chex,
   keras,
   pytestCheckHook,
   tensorflow,
@@ -26,7 +27,7 @@
   torch,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "clu";
   version = "0.0.12";
   pyproject = true;
@@ -34,7 +35,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "google";
     repo = "CommonLoopUtils";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-ntqRz3fCXMf0EDQsddT68Mdi105ECBVQpVsStzk2kvQ=";
   };
 
@@ -59,6 +60,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "clu" ];
 
   nativeCheckInputs = [
+    chex
     keras
     pytestCheckHook
     tensorflow
@@ -76,8 +78,8 @@ buildPythonPackage rec {
   meta = {
     description = "Common training loops in JAX";
     homepage = "https://github.com/google/CommonLoopUtils";
-    changelog = "https://github.com/google/CommonLoopUtils/blob/${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/google/CommonLoopUtils/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ GaetanLepage ];
   };
-}
+})

--- a/pkgs/development/python-modules/distrax/default.nix
+++ b/pkgs/development/python-modules/distrax/default.nix
@@ -20,7 +20,7 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "distrax";
   version = "0.1.7";
   pyproject = true;
@@ -28,7 +28,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "google-deepmind";
     repo = "distrax";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-R6rGGNzup3O6eZ2z4vygYWTjroE/Irt3aog8Op+0hco=";
   };
 
@@ -57,6 +57,9 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "distrax" ];
 
   disabledTests = [
+    # execnet.gateway_base.DumpError: can't serialize <class 'method'>
+    "test_raises_on_invalid_input_shape"
+
     # Flaky: AssertionError: 1 not less than 0.7000000000000001
     "test_von_mises_sample_uniform_ks_test"
 
@@ -124,7 +127,7 @@ buildPythonPackage rec {
   meta = {
     description = "Probability distributions in JAX";
     homepage = "https://github.com/deepmind/distrax";
-    changelog = "https://github.com/google-deepmind/distrax/releases/tag/v${version}";
+    changelog = "https://github.com/google-deepmind/distrax/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ onny ];
     badPlatforms = [
@@ -132,4 +135,4 @@ buildPythonPackage rec {
       lib.systems.inspect.patterns.isDarwin
     ];
   };
-}
+})

--- a/pkgs/development/python-modules/equinox/default.nix
+++ b/pkgs/development/python-modules/equinox/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
 
@@ -39,12 +38,6 @@ buildPythonPackage rec {
       --replace-fail "speed < 0.5" "speed < 1" \
       --replace-fail "speed < 1" "speed < 20" \
       --replace-fail "speed < 2" "speed < 20"
-  ''
-  # Fix jax 0.8.2 compat
-  # Fix submitted upstream: https://github.com/patrick-kidger/equinox/pull/1162
-  + ''
-    substituteInPlace equinox/_ad.py equinox/internal/_primitive.py \
-      --replace-fail "jax.core.get_aval(" "jax.typeof("
   '';
 
   build-system = [ hatchling ];
@@ -69,12 +62,11 @@ buildPythonPackage rec {
   ];
 
   disabledTests = [
-    # Failed: DID NOT WARN. No warnings of type (<class 'Warning'>,) were emitted.
-    "test_jax_transform_warn"
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    # SystemError: nanobind::detail::nb_func_error_except(): exception could not be translated!
-    "test_filter"
+    #  ValueError: The spec of NamedSharding passed to with_sharding_constraint can only refer to
+    # Auto axes of the mesh.
+    # https://github.com/patrick-kidger/equinox/issues/1171
+    "test_sharding_no_inside_jit"
+    "test_sharding_only_inside_jit"
   ];
 
   pythonImportsCheck = [ "equinox" ];

--- a/pkgs/development/python-modules/equinox/default.nix
+++ b/pkgs/development/python-modules/equinox/default.nix
@@ -19,16 +19,16 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "equinox";
-  version = "0.13.2";
+  version = "0.13.6";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "patrick-kidger";
     repo = "equinox";
-    tag = "v${version}";
-    hash = "sha256-d7IqRuohcZ3IYpbjm76Ir6I33zI5dnHvX5eX2WjSJQk=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-OETWXAcCp945mMrpC8U4gSBvEeQX8RoUGZR4irBs7Ak=";
   };
 
   # Relax speed constraints on tests that can fail on busy builders
@@ -61,21 +61,27 @@ buildPythonPackage rec {
     "-Wignore::DeprecationWarning"
   ];
 
+  disabledTestPaths = [
+    # ValueError: not enough values to unpack (expected 2, got 0)
+    "tests/test_finalise_jaxpr.py"
+  ];
+
   disabledTests = [
-    #  ValueError: The spec of NamedSharding passed to with_sharding_constraint can only refer to
-    # Auto axes of the mesh.
-    # https://github.com/patrick-kidger/equinox/issues/1171
-    "test_sharding_no_inside_jit"
-    "test_sharding_only_inside_jit"
+    # Failed: DID NOT WARN. No warnings of type (<class 'Warning'>,) were emitted.
+    # Reported upstream: https://github.com/patrick-kidger/equinox/issues/1186
+    "test_jax_transform_warn"
+
+    # Flaky: AssertionError: Non-linear scaling detected
+    "test_speed_buffer_while"
   ];
 
   pythonImportsCheck = [ "equinox" ];
 
   meta = {
     description = "JAX library based around a simple idea: represent parameterised functions (such as neural networks) as PyTrees";
-    changelog = "https://github.com/patrick-kidger/equinox/releases/tag/v${version}";
+    changelog = "https://github.com/patrick-kidger/equinox/releases/tag/${finalAttrs.src.tag}";
     homepage = "https://github.com/patrick-kidger/equinox";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ GaetanLepage ];
   };
-}
+})

--- a/pkgs/development/python-modules/flax/default.nix
+++ b/pkgs/development/python-modules/flax/default.nix
@@ -13,13 +13,11 @@
   numpy,
   optax,
   orbax-checkpoint,
+  orbax-export,
   pyyaml,
   rich,
   tensorstore,
   typing-extensions,
-
-  # optional-dependencies
-  matplotlib,
 
   # tests
   cloudpickle,
@@ -36,16 +34,16 @@
   tomlq,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "flax";
-  version = "0.12.2";
+  version = "0.12.6";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "flax";
-    tag = "v${version}";
-    hash = "sha256-Wdfc35/iah98C5WNYZWiAd2FJUJlyGLJ8xELpuYD3GU=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-rIDfF9W8cxF0njH4e4uhqURQ0C4N8Boe76u6meMgC34=";
   };
 
   build-system = [
@@ -60,16 +58,13 @@ buildPythonPackage rec {
     numpy
     optax
     orbax-checkpoint
+    orbax-export
     pyyaml
     rich
     tensorstore
     treescope
     typing-extensions
   ];
-
-  optional-dependencies = {
-    all = [ matplotlib ];
-  };
 
   pythonImportsCheck = [ "flax" ];
 
@@ -132,8 +127,8 @@ buildPythonPackage rec {
   meta = {
     description = "Neural network library for JAX";
     homepage = "https://github.com/google/flax";
-    changelog = "https://github.com/google/flax/releases/tag/v${version}";
+    changelog = "https://github.com/google/flax/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ ndl ];
   };
-}
+})

--- a/pkgs/development/python-modules/flowmc/default.nix
+++ b/pkgs/development/python-modules/flowmc/default.nix
@@ -19,7 +19,7 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "flowmc";
   version = "0.4.5";
   pyproject = true;
@@ -27,7 +27,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "kazewong";
     repo = "flowMC";
-    tag = "flowMC-${version}";
+    tag = "flowMC-${finalAttrs.version}";
     hash = "sha256-D3K9cvmUvwsVAjvXdSDgYlqrzTYXVlSVQbfx7TANz8A=";
   };
 
@@ -59,11 +59,22 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
+  disabledTestPaths = [
+    # ValueError: Expected None, got JitTracer(bool[3,2])
+    "test/integration/test_quickstart.py"
+  ];
+
+  disabledTests = [
+    # ValueError: Expected None, got JitTracer(bool[3,2])
+    "test_rqSpline"
+    "test_training"
+  ];
+
   meta = {
     description = "Normalizing-flow enhanced sampling package for probabilistic inference in Jax";
     homepage = "https://github.com/kazewong/flowMC";
-    changelog = "https://github.com/kazewong/flowMC/releases/tag/flowMC-${version}";
+    changelog = "https://github.com/kazewong/flowMC/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ GaetanLepage ];
   };
-}
+})

--- a/pkgs/development/python-modules/jax-cuda12-pjrt/default.nix
+++ b/pkgs/development/python-modules/jax-cuda12-pjrt/default.nix
@@ -31,7 +31,7 @@ let
   );
 
 in
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "jax-cuda12-pjrt";
   inherit version;
   pyproject = false;
@@ -50,8 +50,8 @@ buildPythonPackage rec {
       .${stdenv.hostPlatform.system};
     hash =
       {
-        x86_64-linux = "sha256-47q0HKfEjkFj255+/ScbOqhfD+RfXtBwjWu+2TpZ+Xc=";
-        aarch64-linux = "sha256-cXobGWpkJAnOGV3fAxwgu+rcyIb1Xkmh0/SSc3Ou7a4=";
+        x86_64-linux = "sha256-vbPqvuQ1rJZ6/4su7aL3uc2B7QA/En301vHlX6XZRoQ=";
+        aarch64-linux = "sha256-I+V0uCdbYBUoV0JyDxrX28bw4VlcsJ47sh2HgXlTlT8=";
       }
       .${stdenv.hostPlatform.system};
   };
@@ -102,4 +102,4 @@ buildPythonPackage rec {
     # https://jax.readthedocs.io/en/latest/installation.html#pip-installation-nvidia-gpu-cuda-installed-locally-harder
     broken = !(lib.versionAtLeast cudaPackages.cudnn.version "9.1");
   };
-}
+})

--- a/pkgs/development/python-modules/jax-cuda12-pjrt/default.nix
+++ b/pkgs/development/python-modules/jax-cuda12-pjrt/default.nix
@@ -50,8 +50,8 @@ buildPythonPackage (finalAttrs: {
       .${stdenv.hostPlatform.system};
     hash =
       {
-        x86_64-linux = "sha256-vbPqvuQ1rJZ6/4su7aL3uc2B7QA/En301vHlX6XZRoQ=";
-        aarch64-linux = "sha256-I+V0uCdbYBUoV0JyDxrX28bw4VlcsJ47sh2HgXlTlT8=";
+        x86_64-linux = "sha256-nNvDxXNoWnJ0R8fItiimuDpZZS+2/0c+ehhjYEUWepY=";
+        aarch64-linux = "sha256-griB7iY3VWLtbknERLVLL5JNdiqslfUeW9eUy9H+oEQ=";
       }
       .${stdenv.hostPlatform.system};
   };

--- a/pkgs/development/python-modules/jax-cuda12-pjrt/default.nix
+++ b/pkgs/development/python-modules/jax-cuda12-pjrt/default.nix
@@ -50,8 +50,8 @@ buildPythonPackage (finalAttrs: {
       .${stdenv.hostPlatform.system};
     hash =
       {
-        x86_64-linux = "sha256-nNvDxXNoWnJ0R8fItiimuDpZZS+2/0c+ehhjYEUWepY=";
-        aarch64-linux = "sha256-griB7iY3VWLtbknERLVLL5JNdiqslfUeW9eUy9H+oEQ=";
+        x86_64-linux = "sha256-U2owUpInbFdF77un61dXaEnFp8dzmKOp5h/TG69RAvA=";
+        aarch64-linux = "sha256-VvSifl8ZypFMD0QCU5RpqpLQG/cTNqzQ7Y/dwgqRvI0=";
       }
       .${stdenv.hostPlatform.system};
   };

--- a/pkgs/development/python-modules/jax-cuda12-plugin/default.nix
+++ b/pkgs/development/python-modules/jax-cuda12-plugin/default.nix
@@ -39,42 +39,42 @@ let
     "3.11-x86_64-linux" = getSrcFromPypi {
       platform = "manylinux_2_27_x86_64";
       dist = "cp311";
-      hash = "sha256-CwozBM5+SUrNjZxZNJDBEqMs22AQ/hr8WE2eQf2GMWc=";
+      hash = "sha256-iTh3d+FyGqq97aGKV3r8fP5O4KscN7MmG9Ryq43wcvc=";
     };
     "3.11-aarch64-linux" = getSrcFromPypi {
       platform = "manylinux_2_27_aarch64";
       dist = "cp311";
-      hash = "sha256-cNMyIkhK1cN1uPg1e3wjysuET27Pw5Vn+N1H/eboeFg=";
+      hash = "sha256-ocPzEElPn3vmLyuEJXBcPEZvKmIbTk29v7Fa2aevvcA=";
     };
     "3.12-x86_64-linux" = getSrcFromPypi {
       platform = "manylinux_2_27_x86_64";
       dist = "cp312";
-      hash = "sha256-IBZYYbPT5m67LA9jpUfR1e4X6kSsO+cVPHkIycqMiPM=";
+      hash = "sha256-NJNtd+1oWdoIwugYpRVMx++1hFHZ0Ew+zVtE02BfvfI=";
     };
     "3.12-aarch64-linux" = getSrcFromPypi {
       platform = "manylinux_2_27_aarch64";
       dist = "cp312";
-      hash = "sha256-QD1eB3MbXNrDvZ+z9Ei9hIAGLLLAq2HqKtI/zQplR5o=";
+      hash = "sha256-3i6vpuutVBA/CccRAOTkb36gl+jRGUWe+R6OWxTLn6I=";
     };
     "3.13-x86_64-linux" = getSrcFromPypi {
       platform = "manylinux_2_27_x86_64";
       dist = "cp313";
-      hash = "sha256-gsZ5i+Zr+MdzOGkY5MjlzYEZdT87+zyku8RoGCg3UMY=";
+      hash = "sha256-ZnkKIJR/f2RqKkqcXvghdW0sM/uZ3iqA5hKIwI3BeJo=";
     };
     "3.13-aarch64-linux" = getSrcFromPypi {
       platform = "manylinux_2_27_aarch64";
       dist = "cp313";
-      hash = "sha256-Y3OH3DQIzSBFYmaFAvnpX3bG7d4KbS5I8FUWLcKuvw0=";
+      hash = "sha256-mNfwbW7TH/5Ug2A1gv/fyAsTG9fjl+YStiTiG/ad4uI=";
     };
     "3.14-x86_64-linux" = getSrcFromPypi {
       platform = "manylinux_2_27_x86_64";
       dist = "cp314";
-      hash = "sha256-pYmLrB2KtgILVFRkQCVkCfLGa8u7OhCZykc8hIQ63a0=";
+      hash = "sha256-lELFh5/7QAfiU7p+cThmQls7pwg2PNuxoRM4KZwye70=";
     };
     "3.14-aarch64-linux" = getSrcFromPypi {
       platform = "manylinux_2_27_aarch64";
       dist = "cp314";
-      hash = "sha256-WMUUc/xiLgMTgDWYX3QYM1ZNcKS9WiF49htizaoy/5Q=";
+      hash = "sha256-6pHYc/E6Y8QBwoOk9e6HC4EcsrgSLi9qp9Wr+iRBDzM=";
     };
   };
 in

--- a/pkgs/development/python-modules/jax-cuda12-plugin/default.nix
+++ b/pkgs/development/python-modules/jax-cuda12-plugin/default.nix
@@ -39,42 +39,42 @@ let
     "3.11-x86_64-linux" = getSrcFromPypi {
       platform = "manylinux_2_27_x86_64";
       dist = "cp311";
-      hash = "sha256-iTh3d+FyGqq97aGKV3r8fP5O4KscN7MmG9Ryq43wcvc=";
+      hash = "sha256-0uHOs02KZ+MS2F5A5pqaI0Z1KffcagwsTRoY6x68tCk=";
     };
     "3.11-aarch64-linux" = getSrcFromPypi {
       platform = "manylinux_2_27_aarch64";
       dist = "cp311";
-      hash = "sha256-ocPzEElPn3vmLyuEJXBcPEZvKmIbTk29v7Fa2aevvcA=";
+      hash = "sha256-oAxosFJqTpbx9tzJrwy+PkwwlpBq9+VLbY3JBkjAubs=";
     };
     "3.12-x86_64-linux" = getSrcFromPypi {
       platform = "manylinux_2_27_x86_64";
       dist = "cp312";
-      hash = "sha256-NJNtd+1oWdoIwugYpRVMx++1hFHZ0Ew+zVtE02BfvfI=";
+      hash = "sha256-BE8rr9OR6CTQvt9AbVcpQ6zd8p3AZZw4T69Kim0HKsg=";
     };
     "3.12-aarch64-linux" = getSrcFromPypi {
       platform = "manylinux_2_27_aarch64";
       dist = "cp312";
-      hash = "sha256-3i6vpuutVBA/CccRAOTkb36gl+jRGUWe+R6OWxTLn6I=";
+      hash = "sha256-TkEvqionVUPOFMn2AMRzOxvFHysNdlBgyF0EtV8hcFg=";
     };
     "3.13-x86_64-linux" = getSrcFromPypi {
       platform = "manylinux_2_27_x86_64";
       dist = "cp313";
-      hash = "sha256-ZnkKIJR/f2RqKkqcXvghdW0sM/uZ3iqA5hKIwI3BeJo=";
+      hash = "sha256-3LeOJhu5Efvxds8xGBdsAwz5aqqlKO7HViEGJseO9oM=";
     };
     "3.13-aarch64-linux" = getSrcFromPypi {
       platform = "manylinux_2_27_aarch64";
       dist = "cp313";
-      hash = "sha256-mNfwbW7TH/5Ug2A1gv/fyAsTG9fjl+YStiTiG/ad4uI=";
+      hash = "sha256-r1Jg0LnX1y+IvZGc7VR3+lEwUImbFvgQN35K5Oh2feg=";
     };
     "3.14-x86_64-linux" = getSrcFromPypi {
       platform = "manylinux_2_27_x86_64";
       dist = "cp314";
-      hash = "sha256-lELFh5/7QAfiU7p+cThmQls7pwg2PNuxoRM4KZwye70=";
+      hash = "sha256-mq3bsTWgPJ6CbUfMoz+4rmHWi6wZyIGkM3TOqEIGNw8=";
     };
     "3.14-aarch64-linux" = getSrcFromPypi {
       platform = "manylinux_2_27_aarch64";
       dist = "cp314";
-      hash = "sha256-6pHYc/E6Y8QBwoOk9e6HC4EcsrgSLi9qp9Wr+iRBDzM=";
+      hash = "sha256-t6cxqMF7nwpkD5TEI3k1ZdSK/m4of8nZ4K97Ei5CesE=";
     };
   };
 in

--- a/pkgs/development/python-modules/jax-cuda12-plugin/default.nix
+++ b/pkgs/development/python-modules/jax-cuda12-plugin/default.nix
@@ -39,42 +39,42 @@ let
     "3.11-x86_64-linux" = getSrcFromPypi {
       platform = "manylinux_2_27_x86_64";
       dist = "cp311";
-      hash = "sha256-qN7q6sJFY5tNyN5h4JYO+kMv9bDpXPda0ujWuAyayiU=";
+      hash = "sha256-1Vd82Ge9kmd2nkU7rYUNSAeoQ5a8l29jKlFe29d+SEs=";
     };
     "3.11-aarch64-linux" = getSrcFromPypi {
       platform = "manylinux_2_27_aarch64";
       dist = "cp311";
-      hash = "sha256-OeCtsKTL0nwK35hweMYp+gR1QqJlgPuLJT8Ni6A7wdk=";
+      hash = "sha256-s5VfN10XkC8NJ+cFlnLNGWOlU0WVOkJpnk4HjOxyWtw=";
     };
     "3.12-x86_64-linux" = getSrcFromPypi {
       platform = "manylinux_2_27_x86_64";
       dist = "cp312";
-      hash = "sha256-9MId5FB7HEQvThC+sSPkuRYFW/9MAQJymqKkny7Q/Ig=";
+      hash = "sha256-iKVZCNd1sG3akqjE9MAVd44lulw2BbV/hLAAUvZujvE=";
     };
     "3.12-aarch64-linux" = getSrcFromPypi {
       platform = "manylinux_2_27_aarch64";
       dist = "cp312";
-      hash = "sha256-KEPKQnhhehmfnwo9mS2GhPq+i+r5iP95PsGdg2vcrcQ=";
+      hash = "sha256-sozPBbzAvHzLy9Mm2AKEZXTPbaA5FY52FHvZb1xvEYk=";
     };
     "3.13-x86_64-linux" = getSrcFromPypi {
       platform = "manylinux_2_27_x86_64";
       dist = "cp313";
-      hash = "sha256-OJyJYham1K94cJqPTKdZFqtP97v0sa9cCdzpgjwAO3M=";
+      hash = "sha256-vX3+0Xv6nQ4wFvjCpnZ8dHnZHhvf33kW6ysHQ1zEZY4=";
     };
     "3.13-aarch64-linux" = getSrcFromPypi {
       platform = "manylinux_2_27_aarch64";
       dist = "cp313";
-      hash = "sha256-0b8zdIGciofpDfBLcUQnLlrAcnpeH8SHJTHFLjh8Djg=";
+      hash = "sha256-uaJwhdiTzFnCsoaxeJdV+Rzz6rHeobW+nmMvTJc5og4=";
     };
     "3.14-x86_64-linux" = getSrcFromPypi {
       platform = "manylinux_2_27_x86_64";
       dist = "cp314";
-      hash = "sha256-VYiCVcMl+Yr5Yc9fZlyoIj0ONjY+tUT8AoYne+IyTo8=";
+      hash = "sha256-U1F0LA/LIdqeCUoZZasg/eUlhih392kYpJCxtWZk1To=";
     };
     "3.14-aarch64-linux" = getSrcFromPypi {
       platform = "manylinux_2_27_aarch64";
       dist = "cp314";
-      hash = "sha256-0ErFz/SNGPhJfZnCWibxW7LfO6KHpOXrhsYcifBYwvk=";
+      hash = "sha256-MyEmmeG7sb7V0q4Urp/3Kh7tLQkqUearzAJ4prK4KHQ=";
     };
   };
 in

--- a/pkgs/development/python-modules/jax-cuda12-plugin/default.nix
+++ b/pkgs/development/python-modules/jax-cuda12-plugin/default.nix
@@ -39,42 +39,42 @@ let
     "3.11-x86_64-linux" = getSrcFromPypi {
       platform = "manylinux_2_27_x86_64";
       dist = "cp311";
-      hash = "sha256-0uHOs02KZ+MS2F5A5pqaI0Z1KffcagwsTRoY6x68tCk=";
+      hash = "sha256-qN7q6sJFY5tNyN5h4JYO+kMv9bDpXPda0ujWuAyayiU=";
     };
     "3.11-aarch64-linux" = getSrcFromPypi {
       platform = "manylinux_2_27_aarch64";
       dist = "cp311";
-      hash = "sha256-oAxosFJqTpbx9tzJrwy+PkwwlpBq9+VLbY3JBkjAubs=";
+      hash = "sha256-OeCtsKTL0nwK35hweMYp+gR1QqJlgPuLJT8Ni6A7wdk=";
     };
     "3.12-x86_64-linux" = getSrcFromPypi {
       platform = "manylinux_2_27_x86_64";
       dist = "cp312";
-      hash = "sha256-BE8rr9OR6CTQvt9AbVcpQ6zd8p3AZZw4T69Kim0HKsg=";
+      hash = "sha256-9MId5FB7HEQvThC+sSPkuRYFW/9MAQJymqKkny7Q/Ig=";
     };
     "3.12-aarch64-linux" = getSrcFromPypi {
       platform = "manylinux_2_27_aarch64";
       dist = "cp312";
-      hash = "sha256-TkEvqionVUPOFMn2AMRzOxvFHysNdlBgyF0EtV8hcFg=";
+      hash = "sha256-KEPKQnhhehmfnwo9mS2GhPq+i+r5iP95PsGdg2vcrcQ=";
     };
     "3.13-x86_64-linux" = getSrcFromPypi {
       platform = "manylinux_2_27_x86_64";
       dist = "cp313";
-      hash = "sha256-3LeOJhu5Efvxds8xGBdsAwz5aqqlKO7HViEGJseO9oM=";
+      hash = "sha256-OJyJYham1K94cJqPTKdZFqtP97v0sa9cCdzpgjwAO3M=";
     };
     "3.13-aarch64-linux" = getSrcFromPypi {
       platform = "manylinux_2_27_aarch64";
       dist = "cp313";
-      hash = "sha256-r1Jg0LnX1y+IvZGc7VR3+lEwUImbFvgQN35K5Oh2feg=";
+      hash = "sha256-0b8zdIGciofpDfBLcUQnLlrAcnpeH8SHJTHFLjh8Djg=";
     };
     "3.14-x86_64-linux" = getSrcFromPypi {
       platform = "manylinux_2_27_x86_64";
       dist = "cp314";
-      hash = "sha256-mq3bsTWgPJ6CbUfMoz+4rmHWi6wZyIGkM3TOqEIGNw8=";
+      hash = "sha256-VYiCVcMl+Yr5Yc9fZlyoIj0ONjY+tUT8AoYne+IyTo8=";
     };
     "3.14-aarch64-linux" = getSrcFromPypi {
       platform = "manylinux_2_27_aarch64";
       dist = "cp314";
-      hash = "sha256-t6cxqMF7nwpkD5TEI3k1ZdSK/m4of8nZ4K97Ei5CesE=";
+      hash = "sha256-0ErFz/SNGPhJfZnCWibxW7LfO6KHpOXrhsYcifBYwvk=";
     };
   };
 in

--- a/pkgs/development/python-modules/jax/default.nix
+++ b/pkgs/development/python-modules/jax/default.nix
@@ -41,7 +41,7 @@ let
 in
 buildPythonPackage (finalAttrs: {
   pname = "jax";
-  version = "0.9.0";
+  version = "0.9.0.1";
   pyproject = true;
 
   src = fetchFromGitHub {
@@ -49,7 +49,7 @@ buildPythonPackage (finalAttrs: {
     repo = "jax";
     # google/jax contains tags for jax and jaxlib. Only use jax tags!
     tag = "jax-v${finalAttrs.version}";
-    hash = "sha256-XbwtXtozkCoQDiioqBmAWfmYuZOtBQGUr4JDNLu6RH0=";
+    hash = "sha256-6JFXDUeDPLKgl/+5O1WQm1LCvxmp8Kje9L647m9EtiM=";
   };
 
   patches = [

--- a/pkgs/development/python-modules/jax/default.nix
+++ b/pkgs/development/python-modules/jax/default.nix
@@ -39,17 +39,17 @@
 let
   usingMKL = blas.implementation == "mkl" || lapack.implementation == "mkl";
 in
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "jax";
-  version = "0.8.2";
+  version = "0.9.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "jax";
     # google/jax contains tags for jax and jaxlib. Only use jax tags!
-    tag = "jax-v${version}";
-    hash = "sha256-WKdFEhOxJPLjOXOChZbLRGcw0GFeg/TT/FT6M72C6bo=";
+    tag = "jax-v${finalAttrs.version}";
+    hash = "sha256-XbwtXtozkCoQDiioqBmAWfmYuZOtBQGUr4JDNLu6RH0=";
   };
 
   patches = [
@@ -73,7 +73,7 @@ buildPythonPackage rec {
     opt-einsum
     scipy
   ]
-  ++ lib.optionals cudaSupport optional-dependencies.cuda;
+  ++ lib.optionals cudaSupport finalAttrs.passthru.optional-dependencies.cuda;
 
   optional-dependencies = rec {
     cuda = [ jax-cuda12-plugin ];
@@ -194,4 +194,4 @@ buildPythonPackage rec {
       samuela
     ];
   };
-}
+})

--- a/pkgs/development/python-modules/jax/default.nix
+++ b/pkgs/development/python-modules/jax/default.nix
@@ -41,7 +41,7 @@ let
 in
 buildPythonPackage (finalAttrs: {
   pname = "jax";
-  version = "0.9.0.1";
+  version = "0.9.1";
   pyproject = true;
 
   src = fetchFromGitHub {
@@ -49,7 +49,7 @@ buildPythonPackage (finalAttrs: {
     repo = "jax";
     # google/jax contains tags for jax and jaxlib. Only use jax tags!
     tag = "jax-v${finalAttrs.version}";
-    hash = "sha256-6JFXDUeDPLKgl/+5O1WQm1LCvxmp8Kje9L647m9EtiM=";
+    hash = "sha256-Q6pjHl102OIlGphRO4GwaWz0Kbj/4JAfIUoOdEKh8Zw=";
   };
 
   patches = [

--- a/pkgs/development/python-modules/jax/default.nix
+++ b/pkgs/development/python-modules/jax/default.nix
@@ -41,7 +41,7 @@ let
 in
 buildPythonPackage (finalAttrs: {
   pname = "jax";
-  version = "0.9.1";
+  version = "0.9.2";
   pyproject = true;
 
   src = fetchFromGitHub {
@@ -49,7 +49,7 @@ buildPythonPackage (finalAttrs: {
     repo = "jax";
     # google/jax contains tags for jax and jaxlib. Only use jax tags!
     tag = "jax-v${finalAttrs.version}";
-    hash = "sha256-Q6pjHl102OIlGphRO4GwaWz0Kbj/4JAfIUoOdEKh8Zw=";
+    hash = "sha256-/vLCTAF46M1H0Q64RLM7+IFMofmjZmZ4IFzvm/y7zkg=";
   };
 
   patches = [

--- a/pkgs/development/python-modules/jaxlib/bin.nix
+++ b/pkgs/development/python-modules/jaxlib/bin.nix
@@ -18,7 +18,7 @@
 }:
 
 let
-  version = "0.9.0";
+  version = "0.9.0.1";
   inherit (python) pythonVersion;
 
   # As of 2023-06-06, google/jax upstream is no longer publishing CPU-only wheels to their GCS bucket. Instead the
@@ -49,65 +49,65 @@ let
       "3.11-x86_64-linux" = getSrcFromPypi {
         platform = "manylinux_2_27_x86_64";
         dist = "cp311";
-        hash = "sha256-n566AUWQQ1zsX6H2ryMQoaBduY1hMx0Y1rJ4/1QkzTM=";
+        hash = "sha256-3JXuMq4r1O2UetAhj9ZXa1CmDORbYHFNf/L9n6GV7Z4=";
       };
       "3.11-aarch64-linux" = getSrcFromPypi {
         platform = "manylinux_2_27_aarch64";
         dist = "cp311";
-        hash = "sha256-HyGRW0O3EfCrs8NdJjVr3NFqaCYdV/yP7+NwvG38q0o=";
+        hash = "sha256-xKw8/XqqzDfzemozLuAJ3uOeO1CBu0tHP0EFg0Nr5VM=";
       };
       "3.11-aarch64-darwin" = getSrcFromPypi {
         platform = "macosx_11_0_arm64";
         dist = "cp311";
-        hash = "sha256-J3DiJQ55IxEfXiiBPlk0kv3j30AYW1C9yLxBuGa5mo4=";
+        hash = "sha256-X/LFUNqyECeO06O5ZFSxkQigLgeVYlvlbcpaGByYM8k=";
       };
 
       "3.12-x86_64-linux" = getSrcFromPypi {
         platform = "manylinux_2_27_x86_64";
         dist = "cp312";
-        hash = "sha256-kyWOi7+tOPkgemSXl+B79uf7MKjezmexSF+dVQxZEh8=";
+        hash = "sha256-4OSgok75jsAhuROZH72gmuuWSBsbwOUwCgM5qtIWsiY=";
       };
       "3.12-aarch64-linux" = getSrcFromPypi {
         platform = "manylinux_2_27_aarch64";
         dist = "cp312";
-        hash = "sha256-oZ4K03UWEZAHPRIiGzULPaKfl9nnKwvGQA0Nvxcc2l8=";
+        hash = "sha256-Xqjr1iFltvGPibAvq3SeAvXFhMKhxwPwRZLU2AP56YE=";
       };
       "3.12-aarch64-darwin" = getSrcFromPypi {
         platform = "macosx_11_0_arm64";
         dist = "cp312";
-        hash = "sha256-PI0TvXSlX55UNVh3MLHuBnsX/EwpuJf0Z8CVADxjs30=";
+        hash = "sha256-Nwe/ClhBDafAU8Fexu/uH+EucDYUFuBV5BCbgEH0EZs=";
       };
 
       "3.13-x86_64-linux" = getSrcFromPypi {
         platform = "manylinux_2_27_x86_64";
         dist = "cp313";
-        hash = "sha256-aroYQYLEXkA7YtwmmgR0faVdoR2XWGJpcQGZIEJi1Ow=";
+        hash = "sha256-VN0tNMa+xPCZ+Iii94lQaaR8O6hqqnewt46cP575SPE=";
       };
       "3.13-aarch64-linux" = getSrcFromPypi {
         platform = "manylinux_2_27_aarch64";
         dist = "cp313";
-        hash = "sha256-fali/L38GAk+o3HPtUIPxwtR0xYNFb7wt4DmMSatJcA=";
+        hash = "sha256-tzuF+SfZsAbwdiLVZ2CS6rkWZFxIBP7WVo2l+0pUHfw=";
       };
       "3.13-aarch64-darwin" = getSrcFromPypi {
         platform = "macosx_11_0_arm64";
         dist = "cp313";
-        hash = "sha256-q89Qyp8PAV91YDX/AIA/XQT0KWR3X5NkINevvyO2HFw=";
+        hash = "sha256-6FfK/dEuGEk9ltSikO0xqp2ZoNwwVrS0KXTA80LJuww=";
       };
 
       "3.14-x86_64-linux" = getSrcFromPypi {
         platform = "manylinux_2_27_x86_64";
         dist = "cp314";
-        hash = "sha256-iB24QkNe1AZjwFB0X97PT3tIULFzinU4hQ0U6JR5gRU=";
+        hash = "sha256-5h6IAy7rMTOccurZ7WDGFTzSIiUSYkyq3qZ8NQx4Qy4=";
       };
       "3.14-aarch64-linux" = getSrcFromPypi {
         platform = "manylinux_2_27_aarch64";
         dist = "cp314";
-        hash = "sha256-trHqCQKTwuYt9kw/1NRvhfYLsYuCU7NYemLuU60UaQ8=";
+        hash = "sha256-gjSM7hUh1hIwOMTDvur6IHbI9K4pojO4q/+dbci0QUU=";
       };
       "3.14-aarch64-darwin" = getSrcFromPypi {
         platform = "macosx_11_0_arm64";
         dist = "cp314";
-        hash = "sha256-MEYIFOhebP2hQnJv/LBtQhq2AJPKJIxyVsLs/RCoH9Y=";
+        hash = "sha256-QycuUuXInbxPAsfMtv+l1YegmsjbUWPLDEPhJbcHUSk=";
       };
     };
 in

--- a/pkgs/development/python-modules/jaxlib/bin.nix
+++ b/pkgs/development/python-modules/jaxlib/bin.nix
@@ -18,7 +18,7 @@
 }:
 
 let
-  version = "0.8.2";
+  version = "0.9.0";
   inherit (python) pythonVersion;
 
   # As of 2023-06-06, google/jax upstream is no longer publishing CPU-only wheels to their GCS bucket. Instead the
@@ -49,65 +49,65 @@ let
       "3.11-x86_64-linux" = getSrcFromPypi {
         platform = "manylinux_2_27_x86_64";
         dist = "cp311";
-        hash = "sha256-zPd9qReiCTUkfJkGkd7Py90Gwl7wrJTZFKBKrbIvcUw=";
+        hash = "sha256-n566AUWQQ1zsX6H2ryMQoaBduY1hMx0Y1rJ4/1QkzTM=";
       };
       "3.11-aarch64-linux" = getSrcFromPypi {
         platform = "manylinux_2_27_aarch64";
         dist = "cp311";
-        hash = "sha256-u4m+RSsbgI0/iPwBxBWzZKJgvkzHrBIMA4AJ9hUKMtw=";
+        hash = "sha256-HyGRW0O3EfCrs8NdJjVr3NFqaCYdV/yP7+NwvG38q0o=";
       };
       "3.11-aarch64-darwin" = getSrcFromPypi {
         platform = "macosx_11_0_arm64";
         dist = "cp311";
-        hash = "sha256-SQvwywKcc8ZclDESS4bNyVCC28H7dvxUnSTXXaM+VFQ=";
+        hash = "sha256-J3DiJQ55IxEfXiiBPlk0kv3j30AYW1C9yLxBuGa5mo4=";
       };
 
       "3.12-x86_64-linux" = getSrcFromPypi {
         platform = "manylinux_2_27_x86_64";
         dist = "cp312";
-        hash = "sha256-K5eJvQj4sMxaXBKuiW/kMtWULjLkFwkbi1qWqab9XPE=";
+        hash = "sha256-kyWOi7+tOPkgemSXl+B79uf7MKjezmexSF+dVQxZEh8=";
       };
       "3.12-aarch64-linux" = getSrcFromPypi {
         platform = "manylinux_2_27_aarch64";
         dist = "cp312";
-        hash = "sha256-OxblDFtzDJ3QpJ5V8az6pyKwCxrwUipZFVjcwEZCUvI=";
+        hash = "sha256-oZ4K03UWEZAHPRIiGzULPaKfl9nnKwvGQA0Nvxcc2l8=";
       };
       "3.12-aarch64-darwin" = getSrcFromPypi {
         platform = "macosx_11_0_arm64";
         dist = "cp312";
-        hash = "sha256-Aj3m8/Vtoq9wN5cJllAFhjMf21C1MOy7VLlmbaYzvQA=";
+        hash = "sha256-PI0TvXSlX55UNVh3MLHuBnsX/EwpuJf0Z8CVADxjs30=";
       };
 
       "3.13-x86_64-linux" = getSrcFromPypi {
         platform = "manylinux_2_27_x86_64";
         dist = "cp313";
-        hash = "sha256-G/vPbD3iIXhPpM22dloJ1xy0KYsVYms9BAmz382Khmc=";
+        hash = "sha256-aroYQYLEXkA7YtwmmgR0faVdoR2XWGJpcQGZIEJi1Ow=";
       };
       "3.13-aarch64-linux" = getSrcFromPypi {
         platform = "manylinux_2_27_aarch64";
         dist = "cp313";
-        hash = "sha256-fDBPOgFpZbnR9SOaigOZpzkl9WBP6RTFymbs9zS/ZCI=";
+        hash = "sha256-fali/L38GAk+o3HPtUIPxwtR0xYNFb7wt4DmMSatJcA=";
       };
       "3.13-aarch64-darwin" = getSrcFromPypi {
         platform = "macosx_11_0_arm64";
         dist = "cp313";
-        hash = "sha256-TQBtuWvgIMgWUhKhIWNy+KysT/T4+wZ3Q9aU7yswGs4=";
+        hash = "sha256-q89Qyp8PAV91YDX/AIA/XQT0KWR3X5NkINevvyO2HFw=";
       };
 
       "3.14-x86_64-linux" = getSrcFromPypi {
         platform = "manylinux_2_27_x86_64";
         dist = "cp314";
-        hash = "sha256-5ql9+wIy7tmiu244KOT2gtusGn/qhAv9pXTK4tv1+vk=";
+        hash = "sha256-iB24QkNe1AZjwFB0X97PT3tIULFzinU4hQ0U6JR5gRU=";
       };
       "3.14-aarch64-linux" = getSrcFromPypi {
         platform = "manylinux_2_27_aarch64";
         dist = "cp314";
-        hash = "sha256-aBCN/w3nStxGgBa+mhn4Dv5IxmDA1aEiKHCUtEsJKvw=";
+        hash = "sha256-trHqCQKTwuYt9kw/1NRvhfYLsYuCU7NYemLuU60UaQ8=";
       };
       "3.14-aarch64-darwin" = getSrcFromPypi {
         platform = "macosx_11_0_arm64";
         dist = "cp314";
-        hash = "sha256-vv+wBOfutcmvskQ54rLPRaTuPj6K30XjVe3yr2Ks+Lg=";
+        hash = "sha256-MEYIFOhebP2hQnJv/LBtQhq2AJPKJIxyVsLs/RCoH9Y=";
       };
     };
 in

--- a/pkgs/development/python-modules/jaxlib/bin.nix
+++ b/pkgs/development/python-modules/jaxlib/bin.nix
@@ -18,7 +18,7 @@
 }:
 
 let
-  version = "0.9.0.1";
+  version = "0.9.1";
   inherit (python) pythonVersion;
 
   # As of 2023-06-06, google/jax upstream is no longer publishing CPU-only wheels to their GCS bucket. Instead the
@@ -49,65 +49,65 @@ let
       "3.11-x86_64-linux" = getSrcFromPypi {
         platform = "manylinux_2_27_x86_64";
         dist = "cp311";
-        hash = "sha256-3JXuMq4r1O2UetAhj9ZXa1CmDORbYHFNf/L9n6GV7Z4=";
+        hash = "sha256-lyOTSM2V1bM1b0dfqDdAjkyg3yZFVAnq7l+NQvREnHU=";
       };
       "3.11-aarch64-linux" = getSrcFromPypi {
         platform = "manylinux_2_27_aarch64";
         dist = "cp311";
-        hash = "sha256-xKw8/XqqzDfzemozLuAJ3uOeO1CBu0tHP0EFg0Nr5VM=";
+        hash = "sha256-3BCFRQ39WC1khCamXlvYf38vFNrWamvaSqziZHH0UL8=";
       };
       "3.11-aarch64-darwin" = getSrcFromPypi {
         platform = "macosx_11_0_arm64";
         dist = "cp311";
-        hash = "sha256-X/LFUNqyECeO06O5ZFSxkQigLgeVYlvlbcpaGByYM8k=";
+        hash = "sha256-KXawnDoLl0A5EuniqIiTxMbmYpl04pQZQ+mh/049sIw=";
       };
 
       "3.12-x86_64-linux" = getSrcFromPypi {
         platform = "manylinux_2_27_x86_64";
         dist = "cp312";
-        hash = "sha256-4OSgok75jsAhuROZH72gmuuWSBsbwOUwCgM5qtIWsiY=";
+        hash = "sha256-4quMl74wNUo05k0XBm3w/OfR0PQPekjt7Rnp6DeJb10=";
       };
       "3.12-aarch64-linux" = getSrcFromPypi {
         platform = "manylinux_2_27_aarch64";
         dist = "cp312";
-        hash = "sha256-Xqjr1iFltvGPibAvq3SeAvXFhMKhxwPwRZLU2AP56YE=";
+        hash = "sha256-+A6K6tNGFoNlcCfhToFOW90Avozo4FwKXbhkA9spfC4=";
       };
       "3.12-aarch64-darwin" = getSrcFromPypi {
         platform = "macosx_11_0_arm64";
         dist = "cp312";
-        hash = "sha256-Nwe/ClhBDafAU8Fexu/uH+EucDYUFuBV5BCbgEH0EZs=";
+        hash = "sha256-zqf5ihpVj6tc+PVp5VZ6PCiGZ90iMmGtrrlkXDfkrYs=";
       };
 
       "3.13-x86_64-linux" = getSrcFromPypi {
         platform = "manylinux_2_27_x86_64";
         dist = "cp313";
-        hash = "sha256-VN0tNMa+xPCZ+Iii94lQaaR8O6hqqnewt46cP575SPE=";
+        hash = "sha256-2mDZZ7SsIISj41Na2YI5KJTda995yaVpeKughASljII=";
       };
       "3.13-aarch64-linux" = getSrcFromPypi {
         platform = "manylinux_2_27_aarch64";
         dist = "cp313";
-        hash = "sha256-tzuF+SfZsAbwdiLVZ2CS6rkWZFxIBP7WVo2l+0pUHfw=";
+        hash = "sha256-nojDUkizfVIZQj/43cpgxqVh5mXe1cT8vGHwdj4D8eM=";
       };
       "3.13-aarch64-darwin" = getSrcFromPypi {
         platform = "macosx_11_0_arm64";
         dist = "cp313";
-        hash = "sha256-6FfK/dEuGEk9ltSikO0xqp2ZoNwwVrS0KXTA80LJuww=";
+        hash = "sha256-6ZFbyqn/79QM0/2wioOxa3nx88m6GHiE9bRCrSpH/9E=";
       };
 
       "3.14-x86_64-linux" = getSrcFromPypi {
         platform = "manylinux_2_27_x86_64";
         dist = "cp314";
-        hash = "sha256-5h6IAy7rMTOccurZ7WDGFTzSIiUSYkyq3qZ8NQx4Qy4=";
+        hash = "sha256-IoehyJGxUsUuubc5JfV83gG+NdK6tNrZZz08g8WYLKg=";
       };
       "3.14-aarch64-linux" = getSrcFromPypi {
         platform = "manylinux_2_27_aarch64";
         dist = "cp314";
-        hash = "sha256-gjSM7hUh1hIwOMTDvur6IHbI9K4pojO4q/+dbci0QUU=";
+        hash = "sha256-Ux3/n6566hREnuVEzBQViAzIo0apKH00fb0bK1HYqr0=";
       };
       "3.14-aarch64-darwin" = getSrcFromPypi {
         platform = "macosx_11_0_arm64";
         dist = "cp314";
-        hash = "sha256-QycuUuXInbxPAsfMtv+l1YegmsjbUWPLDEPhJbcHUSk=";
+        hash = "sha256-MHG/ST9vSCB8VrHppb+JXirOvFvUD281RY5264vyEMc=";
       };
     };
 in

--- a/pkgs/development/python-modules/jaxlib/bin.nix
+++ b/pkgs/development/python-modules/jaxlib/bin.nix
@@ -18,7 +18,7 @@
 }:
 
 let
-  version = "0.9.1";
+  version = "0.9.2";
   inherit (python) pythonVersion;
 
   # As of 2023-06-06, google/jax upstream is no longer publishing CPU-only wheels to their GCS bucket. Instead the
@@ -49,65 +49,65 @@ let
       "3.11-x86_64-linux" = getSrcFromPypi {
         platform = "manylinux_2_27_x86_64";
         dist = "cp311";
-        hash = "sha256-lyOTSM2V1bM1b0dfqDdAjkyg3yZFVAnq7l+NQvREnHU=";
+        hash = "sha256-msmVtLoaru2uDWnzGZh9UV3K7NRQW2QrYxL54VQ5NR8=";
       };
       "3.11-aarch64-linux" = getSrcFromPypi {
         platform = "manylinux_2_27_aarch64";
         dist = "cp311";
-        hash = "sha256-3BCFRQ39WC1khCamXlvYf38vFNrWamvaSqziZHH0UL8=";
+        hash = "sha256-MG3lSh3nOGyAbHI+NWzjMtkj73SPinLWdP77dIEh1Nw=";
       };
       "3.11-aarch64-darwin" = getSrcFromPypi {
         platform = "macosx_11_0_arm64";
         dist = "cp311";
-        hash = "sha256-KXawnDoLl0A5EuniqIiTxMbmYpl04pQZQ+mh/049sIw=";
+        hash = "sha256-eF8XfD63jLfceXxV7VxLYxIUGEXJpoaVfkhLrL/OXog=";
       };
 
       "3.12-x86_64-linux" = getSrcFromPypi {
         platform = "manylinux_2_27_x86_64";
         dist = "cp312";
-        hash = "sha256-4quMl74wNUo05k0XBm3w/OfR0PQPekjt7Rnp6DeJb10=";
+        hash = "sha256-iLJ2px9PIHGx/S6SKr/WfIfGl3pVGhA2/rzqeNXvfiI=";
       };
       "3.12-aarch64-linux" = getSrcFromPypi {
         platform = "manylinux_2_27_aarch64";
         dist = "cp312";
-        hash = "sha256-+A6K6tNGFoNlcCfhToFOW90Avozo4FwKXbhkA9spfC4=";
+        hash = "sha256-/vAthGhjtybnJFKZOIOoWW6sMl8ioux+qSHaD7xVCbQ=";
       };
       "3.12-aarch64-darwin" = getSrcFromPypi {
         platform = "macosx_11_0_arm64";
         dist = "cp312";
-        hash = "sha256-zqf5ihpVj6tc+PVp5VZ6PCiGZ90iMmGtrrlkXDfkrYs=";
+        hash = "sha256-l8L75Yy+5KJ9lMpzXXCdIxspmrbtizsQdfUthk39MsE=";
       };
 
       "3.13-x86_64-linux" = getSrcFromPypi {
         platform = "manylinux_2_27_x86_64";
         dist = "cp313";
-        hash = "sha256-2mDZZ7SsIISj41Na2YI5KJTda995yaVpeKughASljII=";
+        hash = "sha256-ttUAPjrdXDRqNK6e3EcFjLwttgyO1cUAllIhdtrwHJ8=";
       };
       "3.13-aarch64-linux" = getSrcFromPypi {
         platform = "manylinux_2_27_aarch64";
         dist = "cp313";
-        hash = "sha256-nojDUkizfVIZQj/43cpgxqVh5mXe1cT8vGHwdj4D8eM=";
+        hash = "sha256-vvYe7zbtOM7BBp6pc/iK+eAzNeiE9lAew/5/YiKhVVs=";
       };
       "3.13-aarch64-darwin" = getSrcFromPypi {
         platform = "macosx_11_0_arm64";
         dist = "cp313";
-        hash = "sha256-6ZFbyqn/79QM0/2wioOxa3nx88m6GHiE9bRCrSpH/9E=";
+        hash = "sha256-UqADJQj4z1eRx6e+4UJTHucGw8BVGBF/sLbujV4X/ec=";
       };
 
       "3.14-x86_64-linux" = getSrcFromPypi {
         platform = "manylinux_2_27_x86_64";
         dist = "cp314";
-        hash = "sha256-IoehyJGxUsUuubc5JfV83gG+NdK6tNrZZz08g8WYLKg=";
+        hash = "sha256-PXFRFApJNvMhiy0bE0PdI3vShlz1FEKIS22C/ohKPec=";
       };
       "3.14-aarch64-linux" = getSrcFromPypi {
         platform = "manylinux_2_27_aarch64";
         dist = "cp314";
-        hash = "sha256-Ux3/n6566hREnuVEzBQViAzIo0apKH00fb0bK1HYqr0=";
+        hash = "sha256-vkYnxC1Erdf+F9KE71ef+NFZ48tpR/ZDd1jzQXfoeOY=";
       };
       "3.14-aarch64-darwin" = getSrcFromPypi {
         platform = "macosx_11_0_arm64";
         dist = "cp314";
-        hash = "sha256-MHG/ST9vSCB8VrHppb+JXirOvFvUD281RY5264vyEMc=";
+        hash = "sha256-urFo0lVVRkRhvQdzI0hPaQxHHmnOiww5o5+4Gz46i/A=";
       };
     };
 in

--- a/pkgs/development/python-modules/jaxopt/default.nix
+++ b/pkgs/development/python-modules/jaxopt/default.nix
@@ -21,7 +21,7 @@
   scikit-learn,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "jaxopt";
   version = "0.8.5";
   pyproject = true;
@@ -29,7 +29,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "google";
     repo = "jaxopt";
-    tag = "jaxopt-v${version}";
+    tag = "jaxopt-v${finalAttrs.version}";
     hash = "sha256-vPXrs8J81O+27w9P/fEFr7w4xClKb8T0IASD+iNhztQ=";
   };
 
@@ -83,8 +83,8 @@ buildPythonPackage rec {
   meta = {
     homepage = "https://jaxopt.github.io";
     description = "Hardware accelerated, batchable and differentiable optimizers in JAX";
-    changelog = "https://github.com/google/jaxopt/releases/tag/jaxopt-v${version}";
+    changelog = "https://github.com/google/jaxopt/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ bcdarwin ];
   };
-}
+})

--- a/pkgs/development/python-modules/jaxopt/default.nix
+++ b/pkgs/development/python-modules/jaxopt/default.nix
@@ -33,6 +33,23 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-vPXrs8J81O+27w9P/fEFr7w4xClKb8T0IASD+iNhztQ=";
   };
 
+  postPatch =
+    # TypeError: LogisticRegression.__init__() got an unexpected keyword argument 'multi_class'
+    ''
+      substituteInPlace jaxopt/_src/test_util.py \
+        --replace-fail "multi_class=multiclass," ""
+    ''
+    # AttributeError: jax.experimental.enable_x64 was removed in JAX v0.9.0; use jax.enable_x64(True) instead.
+    + ''
+      substituteInPlace \
+        tests/zoom_linesearch_test.py \
+        tests/lbfgsb_test.py \
+        tests/lbfgs_test.py \
+        --replace-fail \
+          "jax.experimental.enable_x64()" \
+          "jax.enable_x64(True)"
+    '';
+
   build-system = [ setuptools ];
 
   dependencies = [

--- a/pkgs/development/python-modules/jaxtyping/default.nix
+++ b/pkgs/development/python-modules/jaxtyping/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  pythonOlder,
 
   # build-system
   hatchling,
@@ -16,8 +17,9 @@
   jax,
   jaxlib,
   pytestCheckHook,
-  tensorflow,
   torch,
+  # python <= 3.12 only
+  tensorflow,
 
   # passthru
   jaxtyping,
@@ -25,14 +27,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "jaxtyping";
-  version = "0.3.5";
+  version = "0.3.9";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "patrick-kidger";
     repo = "jaxtyping";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-0Vt6UD1xQkwve6yDVi5XQCoJ/IsJWHCkGesj66myQq4=";
+    hash = "sha256-Ex84xtns3wtIodXdpC6/88Kn0I+33B7ScHPIc9C5tuY=";
   };
 
   build-system = [ hatchling ];
@@ -50,8 +52,10 @@ buildPythonPackage (finalAttrs: {
     jax
     jaxlib
     pytestCheckHook
-    tensorflow
     torch
+  ]
+  ++ lib.optionals (pythonOlder "3.13") [
+    tensorflow
   ];
 
   doCheck = false;

--- a/pkgs/development/python-modules/lineax/default.nix
+++ b/pkgs/development/python-modules/lineax/default.nix
@@ -18,16 +18,16 @@
   python,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "lineax";
-  version = "0.0.8";
+  version = "0.1.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "patrick-kidger";
     repo = "lineax";
-    tag = "v${version}";
-    hash = "sha256-VMTDCExgxfCcd/3UZAglfAxAFaSjzFJJuvSWJAx2tJs=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-oUqJRp4pge3t9g7o/9PCZTb7e4EPkBEGLclHMIdUqiw=";
   };
 
   build-system = [ hatchling ];
@@ -59,8 +59,8 @@ buildPythonPackage rec {
   meta = {
     description = "Linear solvers in JAX and Equinox";
     homepage = "https://github.com/patrick-kidger/lineax";
-    changelog = "https://github.com/patrick-kidger/lineax/releases/tag/${src.tag}";
+    changelog = "https://github.com/patrick-kidger/lineax/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ GaetanLepage ];
   };
-}
+})

--- a/pkgs/development/python-modules/numpyro/default.nix
+++ b/pkgs/development/python-modules/numpyro/default.nix
@@ -81,6 +81,12 @@ buildPythonPackage (finalAttrs: {
   ];
 
   disabledTests = [
+    # Failing with jax>=0.9.0
+    # TypeError: Error interpreting argument to closed_call as a JAX value
+    "test_provenance_call"
+    "test_provenance_closed_call"
+    "test_numpyrooptim_no_double_jit"
+
     # ValueError: Found unexpected Arrays on value of type <class 'list'> in static attribute 'layers'
     # of Pytree type '<class 'test_module.test_random_nnx_module_mcmc_sequence_params.<locals>.MLP'>'.
     # This is an error starting from Flax version 0.12.0.

--- a/pkgs/development/python-modules/optax/default.nix
+++ b/pkgs/development/python-modules/optax/default.nix
@@ -8,7 +8,6 @@
 
   # dependencies
   absl-py,
-  chex,
   jax,
   jaxlib,
   numpy,
@@ -17,16 +16,16 @@
   callPackage,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "optax";
-  version = "0.2.6";
+  version = "0.2.8";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "deepmind";
     repo = "optax";
-    tag = "v${version}";
-    hash = "sha256-+9Q/Amb60m65ZiJsmH93e6tQmpJlMyzVUL0A7q3mS8Y=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-dVmMacQx6V5lv0z4nWUTlekuEDqtIZlxJazAeA9UR+E=";
   };
 
   outputs = [
@@ -38,7 +37,6 @@ buildPythonPackage rec {
 
   dependencies = [
     absl-py
-    chex
     jax
     jaxlib
     numpy
@@ -61,8 +59,8 @@ buildPythonPackage rec {
   meta = {
     description = "Gradient processing and optimization library for JAX";
     homepage = "https://github.com/deepmind/optax";
-    changelog = "https://github.com/deepmind/optax/releases/tag/v${version}";
+    changelog = "https://github.com/deepmind/optax/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ ndl ];
   };
-}
+})

--- a/pkgs/development/python-modules/orbax-checkpoint/default.nix
+++ b/pkgs/development/python-modules/orbax-checkpoint/default.nix
@@ -149,6 +149,7 @@ buildPythonPackage (finalAttrs: {
     "orbax/checkpoint/_src/path/snapshot/snapshot_test.py"
 
     # Circular dependency flax
+    "orbax/checkpoint/_src/handlers/pytree_checkpoint_handler_test.py"
     "orbax/checkpoint/_src/metadata/empty_values_test.py"
     "orbax/checkpoint/_src/metadata/tree_rich_types_test.py"
     "orbax/checkpoint/_src/metadata/tree_test.py"
@@ -159,13 +160,12 @@ buildPythonPackage (finalAttrs: {
     "orbax/checkpoint/checkpoint_manager_test.py"
     "orbax/checkpoint/single_host_test.py"
     "orbax/checkpoint/transform_utils_test.py"
-    "orbax/checkpoint/_src/handlers/pytree_checkpoint_handler_test.py"
   ];
 
   meta = {
     description = "Orbax provides common utility libraries for JAX users";
     homepage = "https://github.com/google/orbax/tree/main/checkpoint";
-    changelog = "https://github.com/google/orbax/blob/v${finalAttrs.version}/checkpoint/CHANGELOG.md";
+    changelog = "https://github.com/google/orbax/blob/${finalAttrs.src.tag}/checkpoint/CHANGELOG.md";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ fab ];
   };

--- a/pkgs/development/python-modules/orbax-export/default.nix
+++ b/pkgs/development/python-modules/orbax-export/default.nix
@@ -1,0 +1,90 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+
+  # build-system
+  flit-core,
+
+  # dependencies
+  absl-py,
+  dataclasses-json,
+  etils,
+  jax,
+  jaxlib,
+  jaxtyping,
+  numpy,
+  orbax-checkpoint,
+  protobuf,
+  tensorflow,
+
+  # tests
+  chex,
+  flax,
+  pytestCheckHook,
+
+  # passthru
+  orbax-export,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "orbax-export";
+  version = "0.0.8";
+  pyproject = true;
+
+  # Tags on the GitHub repo don't match the Pypi releases for orbax-export
+  src = fetchPypi {
+    pname = "orbax_export";
+    inherit (finalAttrs) version;
+    hash = "sha256-VE7vVk4qbxfNEbEWf+vjSLe3z1bZV13plKM9VhPdVoo=";
+  };
+
+  build-system = [
+    flit-core
+  ];
+
+  dependencies = [
+    absl-py
+    dataclasses-json
+    etils
+    jax
+    jaxlib
+    jaxtyping
+    numpy
+    orbax-checkpoint
+    protobuf
+    tensorflow
+  ];
+
+  pythonImportsCheck = [
+    "orbax"
+    "orbax.export"
+    "orbax.export.bfloat16_toolkit.python"
+  ];
+
+  nativeCheckInputs = [
+    chex
+    flax
+    pytestCheckHook
+  ];
+
+  preCheck = ''
+    cd orbax/export
+    rm -rf ./**/__init__.py
+    rm -rf typing
+  '';
+
+  # Circular dependency with flax
+  doCheck = false;
+
+  passthru.tests.pytest = orbax-export.overridePythonAttrs {
+    doCheck = true;
+  };
+
+  meta = {
+    description = "Serialization library for JAX users, enabling the exporting of JAX models to the TensorFlow SavedModel format";
+    homepage = "https://github.com/google/orbax/tree/main/export";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+})

--- a/pkgs/development/python-modules/pytensor/default.nix
+++ b/pkgs/development/python-modules/pytensor/default.nix
@@ -90,6 +90,10 @@ buildPythonPackage (finalAttrs: {
 
     # AssertionError: equal_computations failed
     "test_infer_shape_db_handles_xtensor_lowering"
+
+    # Crashes with jax>=0.9.0
+    # in .../jax/_src/compiler.py", line 362 in backend_compile_and_load
+    "test_higher_order_derivatives"
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # Numerical assertion error

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11823,6 +11823,8 @@ self: super: with self; {
 
   orbax-checkpoint = callPackage ../development/python-modules/orbax-checkpoint { };
 
+  orbax-export = callPackage ../development/python-modules/orbax-export { };
+
   ordered-set = callPackage ../development/python-modules/ordered-set { };
 
   orderedmultidict = callPackage ../development/python-modules/orderedmultidict { };


### PR DESCRIPTION
## Things done

- **python3Packages.jax: 0.8.2 -> 0.9.0**
  - Diff: https://github.com/jax-ml/jax/compare/jax-v0.8.2...jax-v0.9.0
  - Changelog: https://github.com/jax-ml/jax/releases/tag/jax-v0.9.0
- **python3Packages.jax: 0.9.0 -> 0.9.0.1**
  - Diff: https://github.com/jax-ml/jax/compare/jax-v0.9.0...jax-v0.9.0.1
  - Changelog: https://github.com/jax-ml/jax/releases/tag/jax-v0.9.0.1
- **python3Packages.jax: 0.9.0.1 -> 0.9.1**
  - Diff: https://github.com/jax-ml/jax/compare/jax-v0.9.0.1...jax-v0.9.1
  - Changelog: https://github.com/jax-ml/jax/releases/tag/jax-v0.9.1
- **python3Packages.jax: 0.9.1 -> 0.9.2**
  - Diff: https://github.com/jax-ml/jax/compare/jax-v0.9.1...jax-v0.9.2
  - Changelog: https://github.com/jax-ml/jax/releases/tag/jax-v0.9.2
- **python3Packages.orbax-checkpoint: 0.11.30 -> 0.11.32**
  - Diff: https://github.com/google/orbax/compare/v0.11.30...v0.11.32
  - Changelog: https://github.com/google/orbax/blob/v0.11.32/checkpoint/CHANGELOG.md
- **python3Packages.jaxtyping: 0.3.5 -> 0.3.9**
  - Diff: https://github.com/patrick-kidger/jaxtyping/compare/v0.3.5...v0.3.9
  - Changelog: https://github.com/patrick-kidger/jaxtyping/releases/tag/v0.3.9
- **python3Packages.equinox: skip failing test**
- **python3Packages.equinox: 0.13.2 -> 0.13.5**
  - Diff: https://github.com/patrick-kidger/equinox/compare/v0.13.2...v0.13.5
  - Changelog: https://github.com/patrick-kidger/equinox/releases/tag/v0.13.5
- **python3Packages.orbax-export: init at 0.0.8**
- **python3Packages.flax: 0.12.2 -> 0.12.6**
  - Diff: https://github.com/google/flax/compare/v0.12.2...v0.12.6
  - Changelog: https://github.com/google/flax/releases/tag/v0.12.6
- **python3Packages.lineax: 0.0.8 -> 0.1.0**
  - Diff: https://github.com/patrick-kidger/lineax/compare/v0.0.8...v0.1.0
  - Changelog: https://github.com/patrick-kidger/lineax/releases/tag/v0.1.0
- **python3Packages.optax: 0.2.6 -> 0.2.7**
  - Diff: https://github.com/google-deepmind/optax/compare/v0.2.6...v0.2.7
  - Changelog: https://github.com/deepmind/optax/releases/tag/v0.2.7
- **python3Packages.optimistix: 0.0.11 -> 0.1.0**
  - Diff: https://github.com/patrick-kidger/optimistix/compare/v0.0.11...v0.1.0
  - Changelog: https://github.com/patrick-kidger/optimistix/releases/tag/v0.1.0
- **python3Packages.optax: 0.2.6 -> 0.2.8**
  - Diff: https://github.com/deepmind/optax/compare/v0.2.6...v0.2.8
  - Changelog: https://github.com/deepmind/optax/releases/tag/v0.2.8
- **python3Packages.distrax: skip failing test**
- **python3Packages.flowmc: skip failing tests**
- **python3Packages.numpyro: skip failing tests**
- **python3Packages.pytensor: skip crashing test**
- **python3Packages.clu: add missing chex test dependency**
- **python3Packages.bambi: fix broken test**

---

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
