### PR TITLE
python3Packages.simple-parsing: 0.1.7 -> 0.1.8

### DIFF
--- a/pkgs/development/python-modules/simple-parsing/default.nix
+++ b/pkgs/development/python-modules/simple-parsing/default.nix
@@ -2,10 +2,11 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  pythonAtLeast,
 
   # build-system
-  poetry-core,
-  poetry-dynamic-versioning,
+  hatchling,
+  uv-dynamic-versioning,
 
   # dependencies
   docstring-parser,
@@ -25,21 +26,21 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "simple-parsing";
-  version = "0.1.7";
+  version = "0.1.8";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "lebrice";
     repo = "SimpleParsing";
-    tag = "v${version}";
-    hash = "sha256-wHk3osr5CNmA/g9ipLy1dgvJoMy1zE/BAGD9ZATE+tc=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Nsr+I+BoVxockRGQAjG+ushRQ4CtWgkHrg5aVorSrvw=";
   };
 
   build-system = [
-    poetry-core
-    poetry-dynamic-versioning
+    hatchling
+    uv-dynamic-versioning
   ];
 
   dependencies = [
@@ -81,13 +82,22 @@ buildPythonPackage rec {
     "test_running_example_outputs_expected_without_arg"
     "test_subgroup_partial_with_nested_field"
     "test_weird_docstring_with_field_like"
+  ]
+  ++ lib.optionals (pythonAtLeast "3.14") [
+    # AssertionError ("usagepython314mpytesthmixed..." != "usagepython314mpytesthmixed")
+    "test_each_type_is_used_correctly"
+    "test_issue_46"
+    "test_issue_46_solution2"
+
+    # TypeError: dest= is required for options like '---------'
+    "test_pass_invalid_value_to_add_config_path_arg"
   ];
 
   meta = {
     description = "Simple, Elegant, Typed Argument Parsing with argparse";
-    changelog = "https://github.com/lebrice/SimpleParsing/releases/tag/v${version}";
+    changelog = "https://github.com/lebrice/SimpleParsing/releases/tag/${finalAttrs.src.tag}";
     homepage = "https://github.com/lebrice/SimpleParsing";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ GaetanLepage ];
   };
-}
+})


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/lebrice/SimpleParsing/compare/v0.1.7...v0.1.8
Changelog: https://github.com/lebrice/SimpleParsing/releases/tag/v0.1.8

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test