### PR TITLE
_1password-gui: 8.11.22 -> 8.12.0

### DIFF
--- a/pkgs/by-name/_1/_1password-gui/sources.json
+++ b/pkgs/by-name/_1/_1password-gui/sources.json
@@ -1,28 +1,28 @@
 {
   "stable": {
     "linux": {
-      "version": "8.11.22",
+      "version": "8.12.0",
       "sources": {
         "x86_64": {
-          "url": "https://downloads.1password.com/linux/tar/stable/x86_64/1password-8.11.22.x64.tar.gz",
-          "hash": "sha256-IYwCERJyL7l5qFFvTneTciKVT2PSkoeuzQsiMfdomV8="
+          "url": "https://downloads.1password.com/linux/tar/stable/x86_64/1password-8.12.0.x64.tar.gz",
+          "hash": "sha256-EiSrZHWXvBLhS+Gx519AvUmRH582P4/cF0huj+RHcMI="
         },
         "aarch64": {
-          "url": "https://downloads.1password.com/linux/tar/stable/aarch64/1password-8.11.22.arm64.tar.gz",
-          "hash": "sha256-PpsKuFNRVt/eYWvlmZxo6tyMC/gUfLrIAWYPoKIntrU="
+          "url": "https://downloads.1password.com/linux/tar/stable/aarch64/1password-8.12.0.arm64.tar.gz",
+          "hash": "sha256-/ykSp+//5SvLFH0BsjPNwAEapoBUTqxfaRKJw4R7eis="
         }
       }
     },
     "darwin": {
-      "version": "8.11.22",
+      "version": "8.12.0",
       "sources": {
         "x86_64": {
-          "url": "https://downloads.1password.com/mac/1Password-8.11.22-x86_64.zip",
-          "hash": "sha256-jyaAUZkRJ6Rl5zd9ppVZ6AkpzAXaw11KvpLdpftC6bM="
+          "url": "https://downloads.1password.com/mac/1Password-8.12.0-x86_64.zip",
+          "hash": "sha256-JcSNA9oEeEJk9bHxTwF08/KrJNu+UOSC5r0VJGmds+Y="
         },
         "aarch64": {
-          "url": "https://downloads.1password.com/mac/1Password-8.11.22-aarch64.zip",
-          "hash": "sha256-SH3QIJrfqEgKV0GhrLCKkbLmSK9n9OyBRBaGCTm3FrI="
+          "url": "https://downloads.1password.com/mac/1Password-8.12.0-aarch64.zip",
+          "hash": "sha256-fpu+CZ3iLXcGevWHLh/HVa2uoS/a1w/m0s4+awBzNI0="
         }
       }
     }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Mac: https://releases.1password.com/mac/stable/#1password-for-mac-8.12.0
Linux: https://releases.1password.com/mac/stable/#1password-for-mac-8.12.0
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
