### PR TITLE
unixODBC: 2.3.12 -> 2.3.14

### DIFF
--- a/pkgs/by-name/un/unixODBC/package.nix
+++ b/pkgs/by-name/un/unixODBC/package.nix
@@ -2,24 +2,35 @@
   lib,
   stdenv,
   fetchurl,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation rec {
   pname = "unixODBC";
-  version = "2.3.12";
+  version = "2.3.14";
 
   src = fetchurl {
     urls = [
+      # GitHub tag format changed from "2.3.12" to "v2.3.13" starting with 2.3.13
+      "https://github.com/lurcher/unixODBC/releases/download/${
+        if lib.versionAtLeast version "2.3.13" then "v${version}" else version
+      }/${pname}-${version}.tar.gz"
       "ftp://ftp.unixodbc.org/pub/unixODBC/${pname}-${version}.tar.gz"
       "https://www.unixodbc.org/${pname}-${version}.tar.gz"
     ];
-    sha256 = "sha256-8hBQFEXOIb9ge6Ue+MEl4Q4i3/3/7Dd2RkYt9fAZFew=";
+    hash = "sha256-TigU3j4B/DCwufdeg7taupGrA4TulRKGUEu3AgVSR3E=";
   };
 
   configureFlags = [
     "--disable-gui"
     "--sysconfdir=/etc"
   ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex=^v?([0-9.]+)$"
+    ];
+  };
 
   meta = {
     description = "ODBC driver manager for Unix";


### PR DESCRIPTION
## Summary

Update unixODBC from 2.3.12 to 2.3.14.

**Changes:**
- Version bump: 2.3.12 → 2.3.14
- Add GitHub releases as primary source URL (tag format changed from `2.3.12` to `v2.3.13` starting with 2.3.13)
- Enable `nix-update-script` for automated updates
- Keep official website/FTP as fallback sources

**Release notes:** https://github.com/lurcher/unixODBC/releases/tag/v2.3.14

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-trivial changes: verified the build result (e.g., ran executables)
- [ ] Tested in a NixOS VM or container (for module changes)
- [ ] Tested compilation of all pkgs that depend on this change using `nixpkgs-review`
- [x] Read the [Nixpkgs contribution guide](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)
- [ ] This PR has an associated Hydra build (add the `2.status: merge-ready` label to start a build)