### PR TITLE
tdarr: init at 2.58.02

### DIFF
--- a/pkgs/by-name/td/tdarr/package.nix
+++ b/pkgs/by-name/td/tdarr/package.nix
@@ -1,0 +1,153 @@
+{
+  lib,
+  stdenv,
+  fetchzip,
+  autoPatchelfHook,
+  makeWrapper,
+  ffmpeg,
+  handbrake,
+  mkvtoolnix,
+  ccextractor,
+  gtk3,
+  libayatana-appindicator,
+  wayland,
+  libxkbcommon,
+  mesa,
+  libxcb,
+  leptonica,
+  glib,
+  gobject-introspection,
+  libX11,
+  libxcursor,
+  libxfixes,
+  tesseract4,
+  libredirect,
+}:
+let
+  version = "2.58.02";
+
+  platform = {
+    x86_64-linux = "linux_x64";
+    aarch64-linux = "linux_arm64";
+    x86_64-darwin = "darwin_x64";
+    aarch64-darwin = "darwin_arm64";
+  }.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+
+  hashes = {
+    linux_x64 = {
+      server = "sha256-+nxwSGAkA+BPf481N6KHW7s0iJzoGFPWp0XCbsVEwrI=";
+      node = "sha256-+vD5oaoYh/bOCuk/Bxc8Fsm9UnFICownSKvg9i726nk=";
+    };
+    linux_arm64 = {
+      server = "sha256-Z8UBt05UWmDDdPZoFtXJIzTK7qmU14Yr3I+sukaWpsM=";
+      node = "sha256-JjeFcoWxhb9g10Xn2EZgNdEEoQonAeKMLhxT2YIlSls=";
+    };
+    darwin_x64 = {
+      server = "sha256-qdLiNRsKNnYoHni8CRDIxzqa7KibRYwcsc6o4QLEN1M=";
+      node = "sha256-fdGejGmW8dybTzk4u3LJq2fYjrF2mFEC2BKFPWy3udc=";
+    };
+    darwin_arm64 = {
+      server = "sha256-bImM62q9SgEJj9oHAIaZLvd7jXXbl1K7W63IyA7OXlw=";
+      node = "sha256-fjqv48pEEkyQFPMtJJ4IJ65PJDBN+Gf1oTwHuvjgJPg=";
+    };
+  };
+
+  serverSrc = fetchzip {
+    url = "https://storage.tdarr.io/versions/${version}/${platform}/Tdarr_Server.zip";
+    sha256 = hashes.${platform}.server;
+    stripRoot = false;
+  };
+
+  nodeSrc = fetchzip {
+    url = "https://storage.tdarr.io/versions/${version}/${platform}/Tdarr_Node.zip";
+    sha256 = hashes.${platform}.node;
+    stripRoot = false;
+  };
+
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "tdarr";
+  inherit version;
+
+  dontUnpack = true;
+
+  nativeBuildInputs = [ makeWrapper ]
+    ++ lib.optionals stdenv.isLinux [ autoPatchelfHook ];
+
+  buildInputs = lib.optionals stdenv.isLinux ([
+    stdenv.cc.cc.lib
+    gtk3
+    libayatana-appindicator
+    wayland
+    libxkbcommon
+    libxcb
+    mesa
+    tesseract4
+    leptonica
+    glib
+    gobject-introspection
+    libX11
+    libxcursor
+    libxfixes
+    libredirect
+  ]);
+
+  preInstall = ''
+    mkdir -p $out/{bin,share/tdarr/{server,node}}
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    # Copy Server contents (files are at root of serverSrc)
+    cp -r ${serverSrc}/* $out/share/tdarr/server/
+
+    # Copy Node contents (files are at root of nodeSrc)
+    cp -r ${nodeSrc}/* $out/share/tdarr/node/
+
+    # Make files writable so we can remove bundled binaries
+    chmod -R +w $out/share/tdarr
+
+    # Remove bundled ffmpeg and ccextractor, since we are using the one from nixpkgs
+    rm -rf $out/share/tdarr/server/assets/app/ffmpeg
+    rm -rf $out/share/tdarr/server/assets/app/ccextractor
+    rm -rf $out/share/tdarr/node/assets/app/ffmpeg
+    rm -rf $out/share/tdarr/node/assets/app/ccextractor
+
+    chmod +x $out/share/tdarr/server/Tdarr_Server
+    chmod +x $out/share/tdarr/node/Tdarr_Node
+
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    makeWrapper $out/share/tdarr/server/Tdarr_Server $out/bin/tdarr-server \
+      --prefix PATH : ${lib.makeBinPath [ ffmpeg handbrake mkvtoolnix ccextractor ]} \
+      --run "export rootDataPath=\''${rootDataPath:-/var/lib/tdarr/server}" \
+      --run "mkdir -p \"\$rootDataPath\"/configs \"\$rootDataPath\"/logs" \
+      --run "cd \"\$rootDataPath\"" \
+      --set-default handbrakePath "${handbrake}/bin/HandBrakeCLI" \
+      --set-default ffmpegPath "${ffmpeg}/bin/ffmpeg" \
+      --set-default mkvpropeditPath "${mkvtoolnix}/bin/mkvpropedit" \
+      --set-default ffprobePath "${ffmpeg}/bin/ffprobe" \
+      --set-default ccextractorPath "${ccextractor}/bin/ccextractor"
+
+    makeWrapper $out/share/tdarr/node/Tdarr_Node $out/bin/tdarr-node \
+      --prefix PATH : ${lib.makeBinPath [ ffmpeg handbrake mkvtoolnix ccextractor ]} \
+      --run "export rootDataPath=\''${rootDataPath:-/var/lib/tdarr/node}" \
+      --run "mkdir -p \"\$rootDataPath\"/configs \"\$rootDataPath\"/logs \"\$rootDataPath\"/assets/app/plugins" \
+      --run "cd \"\$rootDataPath\"" \
+      --set-default handbrakePath "${handbrake}/bin/HandBrakeCLI" \
+      --set-default ffmpegPath "${ffmpeg}/bin/ffmpeg" \
+      --set-default ffprobePath "${ffmpeg}/bin/ffprobe" \
+      --set-default mkvpropeditPath "${mkvtoolnix}/bin/mkvpropedit"
+  '';
+
+  meta = {
+    description = "Distributed transcode automation using FFmpeg/HandBrake";
+    homepage = "https://tdarr.io";
+    license = lib.licenses.unfree;
+    platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+    maintainers = with lib.maintainers; [ mistyttm ];
+  };
+})

--- a/pkgs/by-name/td/tdarr/update-hashes.sh
+++ b/pkgs/by-name/td/tdarr/update-hashes.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+# Extract version from package.nix (or default.nix) in the same directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NIX_FILE="${SCRIPT_DIR}/package.nix"
+
+# Try package.nix first, fall back to default.nix
+if [[ ! -f "$NIX_FILE" ]]; then
+    NIX_FILE="${SCRIPT_DIR}/default.nix"
+fi
+
+# Extract version using nix-instantiate
+VERSION=$(nix-instantiate --eval --expr "(import ${NIX_FILE} {}).version or (import ${NIX_FILE} {}).pname" 2>/dev/null | tr -d '"')
+
+# Fallback: try to grep for version = "..." pattern
+if [[ -z "$VERSION" ]]; then
+    VERSION=$(grep -oP '(?<=version = ")[^"]+' "$NIX_FILE" 2>/dev/null)
+fi
+
+if [[ -z "$VERSION" ]]; then
+    echo "Error: Could not extract version from $NIX_FILE" >&2
+    exit 1
+fi
+
+echo "Using version: $VERSION" >&2
+
+fetch_and_convert() {
+    local url=$1
+    local hash=$(nix-prefetch-url "$url" 2>/dev/null)
+    nix hash to-sri --type sha256 "$hash"
+}
+
+echo "hashes = {"
+echo "  linux_x64 = {"
+echo "    server = \"$(fetch_and_convert https://storage.tdarr.io/versions/$VERSION/linux_x64/Tdarr_Server.zip)\";"
+echo "    node = \"$(fetch_and_convert https://storage.tdarr.io/versions/$VERSION/linux_x64/Tdarr_Node.zip)\";"
+echo "  };"
+echo "  linux_arm64 = {"
+echo "    server = \"$(fetch_and_convert https://storage.tdarr.io/versions/$VERSION/linux_arm64/Tdarr_Server.zip)\";"
+echo "    node = \"$(fetch_and_convert https://storage.tdarr.io/versions/$VERSION/linux_arm64/Tdarr_Node.zip)\";"
+echo "  };"
+echo "  darwin_x64 = {"
+echo "    server = \"$(fetch_and_convert https://storage.tdarr.io/versions/$VERSION/darwin_x64/Tdarr_Server.zip)\";"
+echo "    node = \"$(fetch_and_convert https://storage.tdarr.io/versions/$VERSION/darwin_x64/Tdarr_Node.zip)\";"
+echo "  };"
+echo "  darwin_arm64 = {"
+echo "    server = \"$(fetch_and_convert https://storage.tdarr.io/versions/$VERSION/darwin_arm64/Tdarr_Server.zip)\";"
+echo "    node = \"$(fetch_and_convert https://storage.tdarr.io/versions/$VERSION/darwin_arm64/Tdarr_Node.zip)\";"
+echo "  };"
+echo "};"


### PR DESCRIPTION
Following discussions in #273459, #344525, and https://github.com/HaveAGitGat/Tdarr/issues/941, I've managed to make a working package for the server and node, and a hopefully working module configuration. The package has infrastructure to support `x86-64_linux`, `arm64_linux`, `x86-64_darwin`, and `arm64_darwin`. I could only test on `x86-64_linux` as that's the only machine I own. 

By default, the package tries to make a data directory in `/var/lib/tdarr`, however this will not work if run under the normal user due to `/var/lib` being owned by root. The server and node will have to be run under either root, or a specially created tdarr user with pre-made tdarr owned `/var/lib/tdarr` directory. However, the `rootDataPath` can be overridden with an environment variable (`rootDataPath=/mnt/location/`).

Given the package is closed source the hashes will need to be manually updated on every update, I've included an updater shell script to automatically find and convert all hashes into sha256.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [X] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
