### PR TITLE
phase-cli: 1.20.0 -> 1.21.2

### DIFF
--- a/pkgs/by-name/ph/phase-cli/package.nix
+++ b/pkgs/by-name/ph/phase-cli/package.nix
@@ -7,14 +7,14 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "phase-cli";
-  version = "1.20.0";
+  version = "1.21.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "phasehq";
     repo = "cli";
     tag = "v${version}";
-    hash = "sha256-vhjDXQutRdkeeId2shPWFtoZGH6FXvQcWhH8MLe9JqI=";
+    hash = "sha256-nj6vSq+2pquZ5A77EG9s2IXUsmAz41xD1OkaVHrKLIA=";
   };
 
   build-system = with python3Packages; [
@@ -31,6 +31,7 @@ python3Packages.buildPythonApplication rec {
     pyyaml
     toml
     python-hcl2
+    botocore
   ];
 
   nativeCheckInputs = [
@@ -51,7 +52,10 @@ python3Packages.buildPythonApplication rec {
     homepage = "https://github.com/phasehq/cli";
     changelog = "https://github.com/phasehq/cli/releases/tag/${src.tag}";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ genga898 ];
+    maintainers = with lib.maintainers; [
+      genga898
+      medv
+    ];
     mainProgram = "phase";
   };
 }


### PR DESCRIPTION

- Fixed [broken build](https://nixpkgs-update-logs.nix-community.org/phase-cli/2026-01-18.log) due to missing runtime python dependency `botocore` added upstream in [1.21.0](https://github.com/phasehq/cli/commit/c13c6af70a6cb98b7fca31b0fb1b622d81a1baa4)
- Updated `phase-cli` from last successfully built `1.20.0` to `1.21.2`
- Did not have quick access to `nixpkgs-review` flow, done manually to unblock other work

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
