### PR TITLE
swt: 4.34 -> 4.38

### DIFF
--- a/pkgs/by-name/sw/swt/package.nix
+++ b/pkgs/by-name/sw/swt/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
   # NOTE: In case you wish to override, don't override version, override
   # `fullVersion`.
   version = builtins.elemAt (lib.splitString "-" finalAttrs.fullVersion) 1;
-  fullVersion = "R-4.34-202411201800";
+  fullVersion = "R-4.38-202512010920";
 
   hardeningDisable = [ "format" ];
 
@@ -23,17 +23,17 @@ stdenv.mkDerivation (finalAttrs: {
     # equal on all linux systems as well as all darwin systems. Even though each
     # of these zip archives themselves contains a different hash.
     x86_64-linux.platform = "gtk-linux-x86_64";
-    x86_64-linux.hash = "sha256-lKAB2aCI3dZdt3pE7uSvSfxc8vc3oMSTCx5R+71Aqdk=";
+    x86_64-linux.hash = "sha256-XR3BfYlnF4/ZAVc1awoJwOVnVNf6bYMmedMsPYdcYnU=";
     aarch64-linux.platform = "gtk-linux-aarch64";
-    aarch64-linux.hash = "sha256-lKAB2aCI3dZdt3pE7uSvSfxc8vc3oMSTCx5R+71Aqdk=";
+    aarch64-linux.hash = "sha256-XR3BfYlnF4/ZAVc1awoJwOVnVNf6bYMmedMsPYdcYnU=";
     ppc64le-linux.platform = "gtk-linux-ppc64le";
-    ppc64le-linux.hash = "sha256-lKAB2aCI3dZdt3pE7uSvSfxc8vc3oMSTCx5R+71Aqdk=";
+    ppc64le-linux.hash = "sha256-XR3BfYlnF4/ZAVc1awoJwOVnVNf6bYMmedMsPYdcYnU=";
     riscv64-linux.platform = "gtk-linux-riscv64";
-    riscv64-linux.hash = "sha256-lKAB2aCI3dZdt3pE7uSvSfxc8vc3oMSTCx5R+71Aqdk=";
+    riscv64-linux.hash = "sha256-XR3BfYlnF4/ZAVc1awoJwOVnVNf6bYMmedMsPYdcYnU=";
     x86_64-darwin.platform = "cocoa-macosx-x86_64";
-    x86_64-darwin.hash = "sha256-Uns3fMoetbZAIrL/N0eVd42/3uygXakDdxpaxf5SWDI=";
+    x86_64-darwin.hash = "sha256-UofSPPozhIiqmRW6/ZckgZZTUtEn/+CIWvrj2ieih5M=";
     aarch64-darwin.platform = "cocoa-macosx-aarch64";
-    aarch64-darwin.hash = "sha256-jvxmoRFGquYClPgMqWi2ylw26YiGSG5bONnM1PcjlTM=";
+    aarch64-darwin.hash = "sha256-Ko4yi1hTofn7mGk3ZFWMyFRA4JYLy0PRCEn0LwvVTV0=";
   };
   passthru.srcMetadata =
     finalAttrs.passthru.srcMetadataByPlatform.${stdenv.hostPlatform.system} or null;

--- a/pkgs/by-name/sw/swt/package.nix
+++ b/pkgs/by-name/sw/swt/package.nix
@@ -18,6 +18,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   hardeningDisable = [ "format" ];
 
+  passthru.updateScript = ./update.sh;
   passthru.srcMetadataByPlatform = {
     # Note: This may look like an error but the content of the src.zip is in fact
     # equal on all linux systems as well as all darwin systems. Even though each

--- a/pkgs/by-name/sw/swt/update.sh
+++ b/pkgs/by-name/sw/swt/update.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl gnused nix-prefetch unzip
+
+set -e
+
+FULL_VERSION="${1:-R-4.38-202512010920}"
+VERSION=$(echo "$FULL_VERSION" | sed -E 's/R-([0-9]+\.[0-9]+)-.*/\1/')
+BASE_URL="https://download.eclipse.org/eclipse/downloads/drops4/${FULL_VERSION}/swt-${VERSION}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PACKAGE_NIX=$SCRIPT_DIR"/package.nix"
+
+printf "Updating to version = %s; fullVersion = %s;" "$VERSION" "$FULL_VERSION"
+sed -i "s/fullVersion = \".*\";/fullVersion = \"$FULL_VERSION\";/" "$PACKAGE_NIX"
+
+PLATFORMS=(
+  "x86_64-linux|gtk-linux-x86_64|true"
+  "aarch64-linux|gtk-linux-aarch64|true"
+  "ppc64le-linux|gtk-linux-ppc64le|true"
+  "riscv64-linux|gtk-linux-riscv64|true"
+  "x86_64-darwin|cocoa-macosx-x86_64|false"
+  "aarch64-darwin|cocoa-macosx-aarch64|false"
+)
+
+for item in "${PLATFORMS[@]}"; do
+  IFS='|' read -r NIX_PLAT E_PLAT IS_LINUX <<<"$item"
+  URL="${BASE_URL}-${E_PLAT}.zip"
+
+  HASH=""
+  if [ "$IS_LINUX" == "true" ]; then
+    HASH=$(nix-prefetch-url --type sha256 --unpack --name "source" "$URL" 2>/dev/null)
+    TMP_DIR=$(mktemp -d)
+    curl -sL "$URL" -o "$TMP_DIR/outer.zip"
+    unzip -q "$TMP_DIR/outer.zip" src.zip -d "$TMP_DIR"
+    mkdir "$TMP_DIR/out"
+    unzip -q "$TMP_DIR/src.zip" -d "$TMP_DIR/out"
+    HASH=$(nix hash path "$TMP_DIR/out")
+    rm -rf "$TMP_DIR"
+  else
+    HASH=$(nix-prefetch-url --type sha256 --unpack "$URL" 2>/dev/null)
+    HASH=$(nix hash to-sri --type sha256 "$HASH")
+  fi
+
+  sed -i "s|$NIX_PLAT.hash = \".*\";|$NIX_PLAT.hash = \"$HASH\";|" "$PACKAGE_NIX"
+done


### PR DESCRIPTION
Resolves #482155

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
