### PR TITLE
python3Packages.{magika,rembg,markitdown}: fix build on aarch64-linux by disabling tests

### DIFF
--- a/pkgs/development/python-modules/markitdown/default.nix
+++ b/pkgs/development/python-modules/markitdown/default.nix
@@ -1,15 +1,22 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
+
+  # build-system
   hatchling,
+
+  # dependencies
   beautifulsoup4,
   defusedxml,
   ffmpeg-headless,
+  lxml,
   magika,
   mammoth,
   markdownify,
   numpy,
+  olefile,
   openai,
   openpyxl,
   pandas,
@@ -20,15 +27,20 @@
   python-pptx,
   requests,
   speechrecognition,
-  youtube-transcript-api,
-  olefile,
   xlrd,
-  lxml,
+  youtube-transcript-api,
+
+  # tests
   pytestCheckHook,
+
+  # passthru
   gitUpdater,
 }:
 
-buildPythonPackage rec {
+let
+  isNotAarch64Linux = !(stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64);
+in
+buildPythonPackage (finalAttrs: {
   pname = "markitdown";
   version = "0.1.4";
   pyproject = true;
@@ -36,11 +48,11 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "microsoft";
     repo = "markitdown";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-WKA2eY8wY3SM9xZ7Cek5eUcJbO5q6eMDx2aTKfQnFvE=";
   };
 
-  sourceRoot = "${src.name}/packages/markitdown";
+  sourceRoot = "${finalAttrs.src.name}/packages/markitdown";
 
   build-system = [ hatchling ];
 
@@ -71,7 +83,12 @@ buildPythonPackage rec {
     youtube-transcript-api
   ];
 
-  pythonImportsCheck = [ "markitdown" ];
+  # aarch64-linux fails cpuinfo test, because /sys/devices/system/cpu/ does not exist in the sandbox:
+  # terminate called after throwing an instance of 'onnxruntime::OnnxRuntimeException'
+  #
+  # -> Skip all tests that require importing markitdown
+  pythonImportsCheck = lib.optionals isNotAarch64Linux [ "markitdown" ];
+  doCheck = isNotAarch64Linux;
 
   nativeCheckInputs = [ pytestCheckHook ];
 
@@ -88,8 +105,8 @@ buildPythonPackage rec {
   meta = {
     description = "Python tool for converting files and office documents to Markdown";
     homepage = "https://github.com/microsoft/markitdown";
-    changelog = "https://github.com/microsoft/markitdown/releases/tag/${src.tag}";
+    changelog = "https://github.com/microsoft/markitdown/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = [ ];
   };
-}
+})


### PR DESCRIPTION
## Things done

Importing `onnxruntime` in the sandbox crashes:
```
terminate called after throwing an instance of 'onnxruntime::OnnxRuntimeException'
```

See https://github.com/NixOS/nixpkgs/pull/481039

cc @mihaimaruseac

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
