### PR TITLE
awsdac: init at 0.22.4

### DIFF
--- a/pkgs/by-name/aw/awsdac/package.nix
+++ b/pkgs/by-name/aw/awsdac/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "awsdac";
+  version = "0.22.4";
+
+  src = fetchFromGitHub {
+    owner = "awslabs";
+    repo = "diagram-as-code";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-MhIGrkP/wpO+gf1SMSaO1CQVLRxFY48XQnnN6HELUtg=";
+  };
+
+  vendorHash = "sha256-1yQnjQfOY69lTpPjI9sA9SwdeMx+iAK6QUEVqQOnprY=";
+
+  subPackages = [ "cmd/awsdac" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${finalAttrs.version}"
+  ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "CLI tool for drawing AWS infrastructure diagrams through YAML code";
+    homepage = "https://github.com/awslabs/diagram-as-code";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ zelkourban ];
+    mainProgram = "awsdac";
+  };
+})


### PR DESCRIPTION
## Description of changes
Add awsdac - CLI tool for drawing AWS infrastructure diagrams through YAML code.

https://github.com/awslabs/diagram-as-code

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc