### PR TITLE
haskell.compiler.ghc9123: Don't apply backported ppc64 ELFv1 patch

### DIFF
--- a/pkgs/development/compilers/ghc/common-hadrian.nix
+++ b/pkgs/development/compilers/ghc/common-hadrian.nix
@@ -262,13 +262,19 @@
               "sha256-vtjT+TL/7sYPu4rcVV3xCqJQ+uqkyBbf9l0KIi97j/0=";
         })
       ]
-      ++ lib.optionals (lib.versionOlder version "9.14.1") [
-        (fetchpatch {
-          name = "ghc-rts-Fix-compile-on-powerpc64-elf-v1.patch";
-          url = "https://gitlab.haskell.org/ghc/ghc/-/commit/05e5785a3157c71e327a8e9bdc80fa7082918739.patch";
-          hash = "sha256-xP5v3cKhXeTRSFvRiKEn9hPxGXgVgykjTILKjh/pdDU=";
-        })
-      ]
+      ++
+        lib.optionals
+          (
+            (lib.versions.majorMinor version == "9.12" && lib.versionOlder version "9.12.3")
+            || (lib.versions.majorMinor version != "9.12" && lib.versionOlder version "9.14.1")
+          )
+          [
+            (fetchpatch {
+              name = "ghc-rts-Fix-compile-on-powerpc64-elf-v1.patch";
+              url = "https://gitlab.haskell.org/ghc/ghc/-/commit/05e5785a3157c71e327a8e9bdc80fa7082918739.patch";
+              hash = "sha256-xP5v3cKhXeTRSFvRiKEn9hPxGXgVgykjTILKjh/pdDU=";
+            })
+          ]
       # Fix build with gcc15
       # https://gitlab.haskell.org/ghc/ghc/-/issues/25662
       # https://gitlab.haskell.org/ghc/ghc/-/merge_requests/13863


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/462247#issuecomment-3777433957

Doesn't fail during the `patchPhase` anymore.

```
nix-repl> lib.filter (x: lib.hasInfix "powerpc64" (toString x)) haskell.compiler.ghc910.src.patches
[
  «derivation /nix/store/2md7qdqi2s7n3kxr61igmfdxpgq241cj-ghc-ppc-support-elf-v2-on-powerpc64-big-endian.patch.drv»
  «derivation /nix/store/al7a1bp1asnwwda3dbh5g2w93j6y9zw8-ghc-rts-Fix-compile-on-powerpc64-elf-v1.patch.drv»
]

nix-repl> lib.filter (x: lib.hasInfix "powerpc64" (toString x)) haskell.compiler.ghc912.src.patches 
[
  «derivation /nix/store/al7a1bp1asnwwda3dbh5g2w93j6y9zw8-ghc-rts-Fix-compile-on-powerpc64-elf-v1.patch.drv»
]

nix-repl> lib.filter (x: lib.hasInfix "powerpc64" (toString x)) haskell.compiler.ghc9123.src.patches
[ ]

nix-repl> lib.filter (x: lib.hasInfix "powerpc64" (toString x)) haskell.compiler.ghc914.src.patches  
[ ]
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
