### PR TITLE
micro: 2.0.14 -> 2.0.15

### DIFF
--- a/pkgs/by-name/mi/micro/package.nix
+++ b/pkgs/by-name/mi/micro/package.nix
@@ -15,16 +15,17 @@
 let
   self = buildGoModule {
     pname = "micro";
-    version = "2.0.14";
+    version = "2.0.15";
 
     src = fetchFromGitHub {
-      owner = "zyedidia";
+      owner = "micro-editor";
       repo = "micro";
       rev = "v${self.version}";
-      hash = "sha256-avLVl6mn0xKgIy0BNnPZ8ypQhn8Ivj7gTgWbebDSjt0=";
+      hash = "sha256-4C6TtMU6PIYX7lO+o4GRVnIsKnYJxjAqPdoOyAwi7Gc=";
     };
 
-    vendorHash = "sha256-ePhObvm3m/nT+7IyT0W6K+y+9UNkfd2kYjle2ffAd9Y=";
+    vendorHash = "sha256-bkPd6zB9e4q6N20wbKS8n8zGGITOoScajdPYv7Race0=";
+    proxyVendor = true;
 
     nativeBuildInputs = [ installShellFiles ];
 
@@ -38,6 +39,8 @@ let
     ldflags =
       let
         t = "github.com/zyedidia/micro/v2/internal";
+        # TODO: switch to this once the source code uses it, passthru.tests.version checks for this
+        # t = "github.com/micro-editor/micro/v2/internal";
       in
       [
         "-s"
@@ -68,7 +71,7 @@ let
 
     meta = {
       homepage = "https://micro-editor.github.io";
-      changelog = "https://github.com/zyedidia/micro/releases/";
+      changelog = "https://github.com/micro-editor/micro/releases/";
       description = "Modern and intuitive terminal-based text editor";
       longDescription = ''
         micro is a terminal-based text editor that aims to be easy to use and


### PR DESCRIPTION
This PR updates `micro` to the latest release. The repo owner has also changed, updated too.
Link to to changelog: https://github.com/micro-editor/micro/releases/tag/v2.0.15

CC: @pbsds (maintainer)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
