### PR TITLE
audacity: remove pcre from build inputs

### DIFF
--- a/pkgs/by-name/au/audacity/package.nix
+++ b/pkgs/by-name/au/audacity/package.nix
@@ -33,7 +33,6 @@
   libuuid,
   ffmpeg,
   soundtouch,
-  pcre,
   portaudio, # given up fighting their portaudio.patch?
   portmidi,
   linuxHeaders,
@@ -115,7 +114,6 @@ stdenv.mkDerivation (finalAttrs: {
     lv2
     mpg123
     opusfile
-    pcre
     portmidi
     rapidjson
     serd


### PR DESCRIPTION
Per issue https://github.com/NixOS/nixpkgs/issues/356387 we would like to remove pcre from nixpkgs.
## Things done

Removed pcre from build inputs. It wasn't used anywhere. Built the package and ran it on aarch64 darwin + built on x86 NixOS

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
