### PR TITLE
Cargo c setup hook

### DIFF
--- a/pkgs/by-name/ca/cargo-c/package.nix
+++ b/pkgs/by-name/ca/cargo-c/package.nix
@@ -8,11 +8,20 @@
   stdenv,
   libiconv,
   rav1e,
+  makeSetupHook,
+  buildPackages,
 }:
 
 let
   # this version may need to be updated along with package version
   cargoVersion = "0.90.0";
+  sh = makeSetupHook {
+    name = "setup-hook";
+    substitutions = {
+      inherit (stdenv.targetPlatform.rust) rustcTargetSpec;
+      inherit (buildPackages.rust.envVars) setEnv;
+    };
+  } ./setup-hook.sh;
 in
 rustPlatform.buildRustPackage rec {
   pname = "cargo-c";
@@ -47,6 +56,8 @@ rustPlatform.buildRustPackage rec {
 
     runHook postInstallCheck
   '';
+
+  setupHook = "${sh}/nix-support/setup-hook";
 
   passthru = {
     tests = {

--- a/pkgs/by-name/ca/cargo-c/setup-hook.sh
+++ b/pkgs/by-name/ca/cargo-c/setup-hook.sh
@@ -1,0 +1,155 @@
+# shellcheck shell=bash disable=SC2154
+
+cargocBuildHook() {
+    echo "Executing cargocBuildHook"
+
+    # Let stdenv handle stripping, for consistency and to not break
+    # separateDebugInfo.
+    export "CARGO_PROFILE_${cargoBuildType@U}_STRIP"=false
+
+    if [ -n "${buildAndTestSubdir-}" ]; then
+        # ensure the output doesn't end up in the subdirectory
+        CARGO_TARGET_DIR="$(pwd)/target"
+        export CARGO_TARGET_DIR
+
+        pushd "${buildAndTestSubdir}" || exit
+    fi
+
+    local flagsArray=()
+
+    flagsArray+=(
+        "-j$NIX_BUILD_CORES"
+        "--target=@rustcTargetSpec@"
+        "--frozen"
+    )
+
+    if [ "${cargoBuildType}" != "debug" ]; then
+        flagsArray+=("--profile" "${cargoBuildType}")
+    fi
+
+    if [ -n "${cargoBuildNoDefaultFeatures-}" ]; then
+        flagsArray+=("--no-default-features")
+    fi
+
+    if [ -n "${cargoBuildFeatures-}" ]; then
+        flagsArray+=("--features=$(concatStringsSep "," cargoBuildFeatures)")
+    fi
+
+    concatTo flagsArray cargoCFlags
+
+    echoCmd 'cargocBuildHook flags' "${flagsArray[@]}"
+
+    @setEnv@ cargo cbuild "${flagsArray[@]}"
+
+    echo "Finished cargocBuildHook"
+}
+
+cargocCheckHook() {
+    echo "Executing cargocCheckHook"
+
+    # Let stdenv handle stripping, for consistency and to not break
+    # separateDebugInfo.
+    export "CARGO_PROFILE_${cargoBuildType@U}_STRIP"=false
+
+    if [ -n "${buildAndTestSubdir-}" ]; then
+        # ensure the output doesn't end up in the subdirectory
+        CARGO_TARGET_DIR="$(pwd)/target"
+        export CARGO_TARGET_DIR
+
+        pushd "${buildAndTestSubdir}" || exit
+    fi
+
+    local flagsArray=()
+
+    flagsArray+=(
+        "-j$NIX_BUILD_CORES"
+        "--target=@rustcTargetSpec@"
+        "--frozen"
+    )
+
+    if [ "${cargoBuildType}" != "debug" ]; then
+        flagsArray+=("--profile" "${cargoBuildType}")
+    fi
+
+    if [ -n "${cargoBuildNoDefaultFeatures-}" ]; then
+        flagsArray+=("--no-default-features")
+    fi
+
+    if [ -n "${cargoBuildFeatures-}" ]; then
+        flagsArray+=("--features=$(concatStringsSep "," cargoBuildFeatures)")
+    fi
+
+    concatTo flagsArray cargoCFlags
+
+    echoCmd 'cargocCheckHook flags' "${flagsArray[@]}"
+
+    @setEnv@ cargo ctest "${flagsArray[@]}"
+
+    echo "Finished cargocCheckHook"
+}
+
+cargocInstallHook() {
+    echo "Executing cargocInstallHook"
+
+    # Let stdenv handle stripping, for consistency and to not break
+    # separateDebugInfo.
+    export "CARGO_PROFILE_${cargoBuildType@U}_STRIP"=false
+
+    if [ -n "${buildAndTestSubdir-}" ]; then
+        # ensure the output doesn't end up in the subdirectory
+        CARGO_TARGET_DIR="$(pwd)/target"
+        export CARGO_TARGET_DIR
+
+        pushd "${buildAndTestSubdir}" || exit
+    fi
+
+    local flagsArray=()
+
+    if [ -z "${dontAddPrefix-}" ]; then
+        flagsArray+=("--prefix=$prefix")
+    fi
+
+    flagsArray+=(
+        "-j$NIX_BUILD_CORES"
+        "--target=@rustcTargetSpec@"
+        "--frozen"
+        "--libdir=${!outputLib}/lib"
+        "--includedir=${!outputInclude}/include"
+        "--bindir=${!outputBin}/bin"
+        "--pkgconfigdir=${!outputDev}/lib/pkgconfig"
+        "--datarootdir=${!outputBin}/share"
+        "--datadir=${!outputBin}/share"
+    )
+
+    if [ "${cargoBuildType}" != "debug" ]; then
+        flagsArray+=("--profile" "${cargoBuildType}")
+    fi
+
+    if [ -n "${cargoBuildNoDefaultFeatures-}" ]; then
+        flagsArray+=("--no-default-features")
+    fi
+
+    if [ -n "${cargoBuildFeatures-}" ]; then
+        flagsArray+=("--features=$(concatStringsSep "," cargoBuildFeatures)")
+    fi
+
+    concatTo flagsArray cargoCFlags
+
+    echoCmd 'cargocInstallHook flags' "${flagsArray[@]}"
+
+    @setEnv@ cargo cinstall "${flagsArray[@]}"
+
+    echo "Finished cargocInstallHook"
+}
+
+if [ -z "${dontUseCargocBuild-}" ]; then
+    postBuildHooks+=(cargocBuildHook)
+fi
+
+if [ -z "${dontUseCargocCheck-}" ]; then
+    postCheckHooks+=(cargocCheckHook)
+fi
+
+if [ -z "${dontUseCargocInstall-}" ]; then
+    postInstallHooks+=(cargocInstallHook)
+fi

--- a/pkgs/by-name/hd/hdr10plus/package.nix
+++ b/pkgs/by-name/hd/hdr10plus/package.nix
@@ -1,17 +1,10 @@
 {
   lib,
-  stdenv,
-  buildPackages,
   rustPlatform,
   hdr10plus_tool,
   cargo-c,
   fontconfig,
 }:
-
-let
-  inherit (lib) optionals concatStringsSep;
-  inherit (buildPackages.rust.envVars) setEnv;
-in
 rustPlatform.buildRustPackage (finalAttrs: {
   __structuredAttrs = true;
 
@@ -30,72 +23,13 @@ rustPlatform.buildRustPackage (finalAttrs: {
   nativeBuildInputs = [ cargo-c ];
   buildInputs = [ fontconfig ];
 
+  dontCargoBuild = true;
+  dontCargoInstall = true;
+  dontCargoCheck = true;
+
   cargoCFlags = [
     "--package=hdr10plus"
-    "--frozen"
-    "--prefix=${placeholder "out"}"
-    "--includedir=${placeholder "dev"}/include"
-    "--pkgconfigdir=${placeholder "dev"}/lib/pkgconfig"
-    "--target=${stdenv.hostPlatform.rust.rustcTarget}"
   ];
-
-  # mirror Cargo flags
-  cargoCBuildFlags =
-    optionals (finalAttrs.cargoBuildType != "debug") [
-      "--profile=${finalAttrs.cargoBuildType}"
-    ]
-    ++ optionals (finalAttrs.cargoBuildNoDefaultFeatures) [
-      "--no-default-features"
-    ]
-    ++ optionals (finalAttrs.cargoBuildFeatures != [ ]) [
-      "--features=${concatStringsSep "," finalAttrs.cargoBuildFeatures}"
-    ];
-
-  cargoCTestFlags =
-    optionals (finalAttrs.cargoCheckType != "debug") [
-      "--profile=${finalAttrs.cargoCheckType}"
-    ]
-    ++ optionals (finalAttrs.cargoCheckNoDefaultFeatures) [
-      "--no-default-features"
-    ]
-    ++ optionals (finalAttrs.cargoCheckFeatures != [ ]) [
-      "--features=${concatStringsSep "," finalAttrs.cargoCheckFeatures}"
-    ];
-
-  configurePhase = ''
-    runHook preConfigure
-
-    # let stdenv handle stripping
-    export "CARGO_PROFILE_''${cargoBuildType@U}_STRIP"=false
-
-    prependToVar cargoCFlags -j "$NIX_BUILD_CORES"
-
-    runHook postConfigure
-  '';
-
-  buildPhase = ''
-    runHook preBuild
-
-    ${setEnv} cargo cbuild "''${cargoCFlags[@]}" "''${cargoCBuildFlags[@]}"
-
-    runHook postBuild
-  '';
-
-  checkPhase = ''
-    runHook preCheck
-
-    ${setEnv} cargo ctest "''${cargoCFlags[@]}" "''${cargoCTestFlags[@]}"
-
-    runHook postCheck
-  '';
-
-  installPhase = ''
-    runHook preInstall
-
-    ${setEnv} cargo cinstall "''${cargoCFlags[@]}" "''${cargoCBuildFlags[@]}"
-
-    runHook postInstall
-  '';
 
   passthru.tests = {
     inherit hdr10plus_tool;

--- a/pkgs/by-name/li/libdovi/package.nix
+++ b/pkgs/by-name/li/libdovi/package.nix
@@ -3,8 +3,6 @@
   rustPlatform,
   fetchCrate,
   cargo-c,
-  buildPackages,
-  stdenv,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -23,25 +21,11 @@ rustPlatform.buildRustPackage rec {
     ln -s ${./Cargo.lock} Cargo.lock
   '';
 
+  dontCargoBuild = true;
+  dontCargoInstall = true;
+  dontCargoCheck = true;
+
   nativeBuildInputs = [ cargo-c ];
-
-  buildPhase = ''
-    runHook preBuild
-    ${buildPackages.rust.envVars.setEnv} cargo cbuild -j $NIX_BUILD_CORES --release --frozen --prefix=${placeholder "out"} --target ${stdenv.hostPlatform.rust.rustcTarget}
-    runHook postBuild
-  '';
-
-  installPhase = ''
-    runHook preInstall
-    ${buildPackages.rust.envVars.setEnv} cargo cinstall -j $NIX_BUILD_CORES --release --frozen --prefix=${placeholder "out"} --target ${stdenv.hostPlatform.rust.rustcTarget}
-    runHook postInstall
-  '';
-
-  checkPhase = ''
-    runHook preCheck
-    ${buildPackages.rust.envVars.setEnv} cargo ctest -j $NIX_BUILD_CORES --release --frozen --prefix=${placeholder "out"} --target ${stdenv.hostPlatform.rust.rustcTarget}
-    runHook postCheck
-  '';
 
   meta = {
     description = "C library for Dolby Vision metadata parsing and writing";

--- a/pkgs/by-name/ra/rav1e/package.nix
+++ b/pkgs/by-name/ra/rav1e/package.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  buildPackages,
   stdenv,
   rustPlatform,
   fetchCrate,
@@ -41,14 +40,6 @@ rustPlatform.buildRustPackage rec {
   '';
 
   checkType = "debug";
-
-  postBuild = ''
-    ${buildPackages.rust.envVars.setEnv} cargo cbuild --release --frozen --prefix=${placeholder "out"} --target ${stdenv.hostPlatform.rust.rustcTarget}
-  '';
-
-  postInstall = ''
-    ${buildPackages.rust.envVars.setEnv} cargo cinstall --release --frozen --prefix=${placeholder "out"} --target ${stdenv.hostPlatform.rust.rustcTarget}
-  '';
 
   passthru = {
     tests.version = testers.testVersion { package = rav1e; };

--- a/pkgs/by-name/ya/yara-x/package.nix
+++ b/pkgs/by-name/ya/yara-x/package.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  buildPackages,
   stdenv,
   fetchFromGitHub,
   rustPlatform,
@@ -30,14 +29,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     cargo-c
   ];
 
-  postBuild = ''
-    ${buildPackages.rust.envVars.setEnv} cargo cbuild --release --frozen --prefix=${placeholder "out"} --target ${stdenv.hostPlatform.rust.rustcTarget}
-  '';
-
-  postInstall = ''
-    ${buildPackages.rust.envVars.setEnv} cargo cinstall --release --frozen --prefix=${placeholder "out"} --target ${stdenv.hostPlatform.rust.rustcTarget}
-  ''
-  + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd yr \
       --bash <($out/bin/yr completion bash) \
       --fish <($out/bin/yr completion fish) \


### PR DESCRIPTION
Fixes #482012

Adds setup hook for a [cargo-c](https://crates.io/crates/cargo-c) cargo applet.

The applet allows one to generate a header, pkg-config file and a cdynlib with nothing but cargo (no need for extra build systems like Meson). The sequence of cargo-c commands is always the same:

```bash
cargo cbuild
cargo ctest
cargo cinstall
```

## Changes to existing derivations

Derivations that previously invoked cargo-c inside the `buildPhase` (like hdr10plus and libdovi), thus disabling `cargoBuildHook`, now have to disable `cargoBuildHook` explicitly via `dontCargoBuild = true;` (same goes for `cargoCheckHook` and `cargoInstallHook`).

Derivations that invoked cargo-c inside the `postBuild` don't need any additional modifications.

## TODO

- [x] Rebuild affected derivations:
  - [x] [hdr10plus](https://github.com/NixOS/nixpkgs/blob/bde09022887110deb780067364a0818e89258968/pkgs/by-name/hd/hdr10plus/package.nix#L79)
  - [x] [libdovi](https://github.com/NixOS/nixpkgs/blob/bde09022887110deb780067364a0818e89258968/pkgs/by-name/li/libdovi/package.nix#L30)
  - [x] [rav1e](https://github.com/NixOS/nixpkgs/blob/bde09022887110deb780067364a0818e89258968/pkgs/by-name/ra/rav1e/package.nix#L46)
  - [x] [rustls-ffi](https://github.com/NixOS/nixpkgs/blob/bde09022887110deb780067364a0818e89258968/pkgs/by-name/ru/rustls-ffi/package.nix#L45)
  - [x] [yara-x](https://github.com/NixOS/nixpkgs/blob/bde09022887110deb780067364a0818e89258968/pkgs/by-name/ya/yara-x/package.nix#L34)
- [ ] Add tests?
- [ ] Document this setup hook.
- [ ] Run `nixpkgs-review` on this PR. See [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage).
- [ ] Test cross-compilation.

