### PR TITLE
applewin: init at 1.30.21.0.b

### DIFF
--- a/pkgs/by-name/ap/applewin/package.nix
+++ b/pkgs/by-name/ap/applewin/package.nix
@@ -1,0 +1,106 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  ninja,
+  pkg-config,
+  ncurses,
+  libevdev,
+  SDL2,
+  SDL2_image,
+  libglvnd,
+  libslirp,
+  libdeflate,
+  zlib,
+  boost,
+  libpcap,
+  xxd,
+  libnl,
+  libtiff,
+  libjpeg,
+  libwebp,
+  libpng,
+  xz,
+  libsysprof-capture,
+  lerc,
+  libX11,
+  libXext,
+  qt6Packages,
+  qt6,
+  enableQt6 ? true,
+  enableNcurses ? true,
+  enableSdl2 ? true,
+  enableLibretro ? true,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "applewin";
+  version = "1.30.21.0.b";
+
+  src = fetchFromGitHub {
+    owner = "audetto";
+    repo = "AppleWin";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-g1780lODOsnjlUYzapvkmJMGh8ovOHRAfyl+1E1wHNY=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    pkg-config
+    xxd
+  ]
+  ++ lib.optionals enableQt6 [
+    qt6.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    ncurses
+    libevdev
+    SDL2
+    SDL2_image
+    libglvnd
+    libslirp
+    xz
+    lerc
+    libsysprof-capture
+    libdeflate
+    zlib
+    boost
+    libpcap
+    libnl
+    libtiff
+    libjpeg
+    libwebp
+    libpng
+    libX11
+    libXext
+  ]
+  ++ lib.optionals enableQt6 [
+    qt6Packages.qtbase
+    qt6Packages.qtmultimedia
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_APPLEN" enableNcurses)
+    (lib.cmakeBool "BUILD_QAPPLE" enableQt6)
+    (lib.cmakeBool "BUILD_SA2" enableSdl2)
+    (lib.cmakeBool "BUILD_LIBRETRO" enableLibretro)
+  ];
+
+  meta = {
+    description = "Apple II emulator for Linux";
+    longDescription = ''
+      AppleWin on Linux is a linux port of AppleWin that shares 100% of the code
+      of the core emulator and video generation. Audio, UI, scheduling and other
+      peripherals are reimplemented.
+    '';
+    homepage = "https://github.com/audetto/AppleWin";
+    license = lib.licenses.gpl2Only;
+    maintainers = [ lib.maintainers.matthewcroughan ];
+    platforms = lib.platforms.linux;
+    mainProgram = "qapple";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

It's not clear which bits from the buildInputs are actually used at runtime as I haven't fully tested the different backends yet, but the logs do complain about their absence if they are removed, though the build does not crash.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
