### PR TITLE
phantom: init at 0-unstable-2025-12-22

### DIFF
--- a/pkgs/by-name/ph/phantom/package.nix
+++ b/pkgs/by-name/ph/phantom/package.nix
@@ -1,0 +1,53 @@
+{
+  stdenv,
+  fetchFromGitea,
+  qt6,
+  cmark-gfm,
+  cmake,
+  pkg-config,
+  lib,
+}:
+
+stdenv.mkDerivation {
+  pname = "phantom";
+  version = "0.0.0-unstable-2025-12-22";
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "ItsZariep";
+    repo = "Phantom";
+    rev = "7bba1e0a2d9b33d881fb999bb543324d14355505";
+    hash = "sha256-KjQX6Hxp4hcRJWRF/CDxZGQtzQqozGWxxHn0VpOzR0U=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    qt6.wrapQtAppsHook
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    qt6.qtbase
+    qt6.qtwebengine
+    cmark-gfm
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp phantom-qt $out/bin
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Markdown editor with support for multi-tab";
+    homepage = "https://codeberg.org/ItsZariep/Phantom";
+    license = licenses.gpl3Only;
+    mainProgram = "phantom";
+    platforms = platforms.all;
+    maintainers = with maintainers; [ reylak ];
+  };
+}


### PR DESCRIPTION
Packaged Phantom, a Markdown editor with multi-tab support and can be more efficient for editing multiple documents.

[Source code](https://codeberg.org/ItsZariep/Phantom)
[Developer](https://codeberg.org/ItsZariep)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.