### PR TITLE
opentelemetry-collector-releases: 0.124.0 -> 0.142.0

### DIFF
--- a/pkgs/tools/misc/opentelemetry-collector/releases.nix
+++ b/pkgs/tools/misc/opentelemetry-collector/releases.nix
@@ -26,7 +26,11 @@ let
     owner = "open-telemetry";
     repo = "opentelemetry-collector-releases";
     rev = "v${version}";
-    hash = "sha256-/I6kYm/j2hO2OAZaWVIRYI1ejBTGMI3PzTjRLcmwziQ=";
+    hash =
+      {
+        "0.142.0" = "sha256-OwLsf1jBy5K3vKYf0WHUr1ZCzFMSuJPaO79BvN+69G4=";
+      }
+      .${version};
   };
 
   # Then from this src, we use the tool to generate some go code, including
@@ -148,26 +152,58 @@ in
 lib.recurseIntoAttrs {
   otelcol = mkDistribution {
     name = "otelcol";
-    sourceHash = "sha256-XGQIHkRfCSdEnZlhodN38BKZGkgOPuUnxveG4yX0rMw=";
-    vendorHash = "sha256-0i+eHVBwYvEKf4kXfyOuN/gEkDk2/5s7+3HQjYCtI94=";
+    sourceHash =
+      {
+        "0.142.0" = "sha256-yJt77K49C1ciu5ab2O4czK/rtjmxhI5JOXJw8N0141w=";
+      }
+      .${version} or lib.fakeHash;
+    vendorHash =
+      {
+        "0.142.0" = "sha256-k9ZeUrrVXGBjztmNHUnOUyUWc9UDB1byMEmMJte7vcc=";
+      }
+      .${version} or lib.fakeHash;
   };
 
   otelcol-contrib = mkDistribution {
     name = "otelcol-contrib";
-    sourceHash = "sha256-87VmiafluGem4p5hRP+UmPuSJeXdXjZkubWzqhXtyJg=";
-    vendorHash = "sha256-/qSXvt8oQ0C3V49an7TNUw0bcNVnXd5Qmz5oCRp+KTE=";
+    sourceHash =
+      {
+        "0.142.0" = "sha256-J9zWL4N1eAn4H6/TQ+WY9gVBokb2k2NiqIk08X5zIw4=";
+      }
+      .${version} or lib.fakeHash;
+    vendorHash =
+      {
+        "0.142.0" = "sha256-saw1RLgu2OzJYQsno9mIYknybsFQFUA0dLYRuyZ7BDk=";
+      }
+      .${version} or lib.fakeHash;
     proxyVendor = true; # hash mismatch between linux and darwin
   };
 
   otelcol-k8s = mkDistribution {
     name = "otelcol-k8s";
-    sourceHash = "sha256-B5NbbQBIz3RZ/+jSxNhuY+zpfhHlg26cvUlMqlYXtq0=";
-    vendorHash = "sha256-2dGNrsskrCh76bTMuPYcRH+bMl/sE+KVn2mOqcF2PeI=";
+    sourceHash =
+      {
+        "0.142.0" = "sha256-UZBAoX6h5hFQQuop68nlQAer/zqtUxO2mSlOYkKYses=";
+      }
+      .${version} or lib.fakeHash;
+    vendorHash =
+      {
+        "0.142.0" = "sha256-zGQyY+1WRUGrpBLJ4vG+x4VhF1+Twce5ku6CqODqlt8=";
+      }
+      .${version} or lib.fakeHash;
   };
 
   otelcol-otlp = mkDistribution {
     name = "otelcol-otlp";
-    sourceHash = "sha256-c83fzhC4XbvRHZ3XwXQgwsyW1TDiDs0T/bX3h53n2RE=";
-    vendorHash = "sha256-QVNQFsaACvlByQWwpl2emSIrL+how78WtU51YJ2AvAU=";
+    sourceHash =
+      {
+        "0.142.0" = "sha256-5rYrAPGvS+zSkW/1uDCYGSeDkr1JG6z8h34gvS5uW9Y=";
+      }
+      .${version} or lib.fakeHash;
+    vendorHash =
+      {
+        "0.142.0" = "sha256-18EihuH7eAlqvwsj8E9ofazH1Kyu1YXwJh/nshokZ+c=";
+      }
+      .${version} or lib.fakeHash;
   };
 }


### PR DESCRIPTION
Currently, all versions of `pkgs.opentelemetry-collector` and `pkgs.opentelemetry-collector-contrib` past v0.124.0 are still v0.124.0, via the fixed-output derivation hashes. More detail in <https://github.com/NixOS/nixpkgs/issues/480348>.

I'm using lookup tables to force errors when `builder.nix` is updated without a matching update to `releases.nix`. The GitHub source hash is easy to figure out in advance, so that will error at eval time. The ones that depend on it use lib.fakeHash so I could easily grab the new hashes from my test machine.

Change logs:

- <https://github.com/open-telemetry/opentelemetry-collector/blob/v0.142.0/CHANGELOG.md>

- <https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.142.0/CHANGELOG.md>

Note for backporting: There is a panic on startup in opentelemetry-collector-contrib injected in v0.133.0 and fixed in v0.136.0:
<https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.136.0/CHANGELOG.md#-bug-fixes->


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
