### PR TITLE
python3Packages.executorch: fix build with GCC 15

### DIFF
--- a/pkgs/development/python-modules/executorch/default.nix
+++ b/pkgs/development/python-modules/executorch/default.nix
@@ -125,6 +125,7 @@ buildPythonPackage (finalAttrs: {
     "pytest-xdist"
   ];
   pythonRelaxDeps = [
+    "scikit-learn"
     "torchao"
   ];
   dependencies = [

--- a/pkgs/development/python-modules/executorch/default.nix
+++ b/pkgs/development/python-modules/executorch/default.nix
@@ -46,7 +46,7 @@
   writableTmpDirAsHomeHook,
   yaspin,
 }:
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "executorch";
   version = "1.0.1";
   pyproject = true;
@@ -54,7 +54,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "pytorch";
     repo = "executorch";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
 
     # The ExecuTorch repo must be cloned into a directory named exactly `executorch`.
     # See https://github.com/pytorch/executorch/issues/6475 for progress on a fix for this restriction.
@@ -63,7 +63,6 @@ buildPythonPackage rec {
     fetchSubmodules = true;
     hash = "sha256-h+nmipFDO/cdPTQXrjM5EkH//wHKBAvlDIp6SBbGN/8=";
   };
-  # src = /home/gaetan/nix/nixpkgs-packages/executorch;
 
   postPatch =
     # Hardcode the default flatc binary path to the nixpkgs flatc
@@ -89,7 +88,7 @@ buildPythonPackage rec {
     '';
 
   env = {
-    BUILD_VERSION = version;
+    BUILD_VERSION = finalAttrs.version;
   };
 
   build-system = [
@@ -194,7 +193,7 @@ buildPythonPackage rec {
   meta = {
     description = "On-device AI across mobile, embedded and edge for PyTorch";
     homepage = "https://github.com/pytorch/executorch";
-    changelog = "https://github.com/pytorch/executorch/releases/tag/v${version}";
+    changelog = "https://github.com/pytorch/executorch/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ GaetanLepage ];
     badPlatforms = [
@@ -204,4 +203,4 @@ buildPythonPackage rec {
       lib.systems.inspect.patterns.isDarwin
     ];
   };
-}
+})

--- a/pkgs/development/python-modules/executorch/default.nix
+++ b/pkgs/development/python-modules/executorch/default.nix
@@ -85,6 +85,15 @@ buildPythonPackage (finalAttrs: {
         --replace-fail \
           "CMAKE_MINIMUM_REQUIRED(VERSION 3.5 FATAL_ERROR)" \
           "CMAKE_MINIMUM_REQUIRED(VERSION 3.10 FATAL_ERROR)"
+    ''
+    # Fix build with GCC>=15
+    + ''
+      substituteInPlace third-party/flatcc/include/flatcc/portable/grisu3_print.h \
+        --replace-fail \
+          'static char hexdigits[16] = "0123456789ABCDEF";' \
+          'static char hexdigits[17] = "0123456789ABCDEF";'
+
+      sed -i "1i #include <cstdint>" backends/apple/coreml/runtime/inmemoryfs/memory_buffer.hpp
     '';
 
   env = {

--- a/pkgs/development/python-modules/torchtune/default.nix
+++ b/pkgs/development/python-modules/torchtune/default.nix
@@ -35,7 +35,7 @@
   writableTmpDirAsHomeHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "torchtune";
   version = "0.6.1";
   pyproject = true;
@@ -43,7 +43,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "meta-pytorch";
     repo = "torchtune";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-evhQBpZiUXriL0PAYkEzGypH21iRs37Ix6Nl5YAyeQ0=";
   };
 
@@ -134,11 +134,11 @@ buildPythonPackage rec {
   meta = {
     description = "PyTorch native post-training library";
     homepage = "https://github.com/meta-pytorch/torchtune";
-    changelog = "https://github.com/meta-pytorch/torchtune/releases/tag/${src.tag}";
+    changelog = "https://github.com/meta-pytorch/torchtune/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [
       GaetanLepage
       sarahec
     ];
   };
-}
+})


### PR DESCRIPTION
## Things done

- **python3Packages.torchtune: use finalAttrs pattern**
- **python3Packages.executorch: use finalAttrs pattern**
- **python3Packages.executorch: fix build with GCC 15**
- **python3Packages.executorch: relax scikit-learn dependency**

---

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
