### PR TITLE
python3Packages.pycapnp: fix failing tests

### DIFF
--- a/pkgs/development/python-modules/pycapnp/default.nix
+++ b/pkgs/development/python-modules/pycapnp/default.nix
@@ -10,6 +10,7 @@
   pkgconfig,
   pytest-asyncio,
   pytestCheckHook,
+  fetchpatch,
 }:
 
 buildPythonPackage rec {
@@ -35,6 +36,12 @@ buildPythonPackage rec {
     # other than the builtin schemas (based on quick GitHub code search), so I don't
     # think it's worthwhile.
     (replaceVars ./include-paths.patch { inherit capnproto; })
+
+    # RuntimeError: There is no current event loop in thread 'MainThread'
+    (fetchpatch {
+      url = "https://github.com/capnproto/pycapnp/commit/aa90ab6844df4718f02e2ca4974858d5ab0b079c.patch";
+      hash = "sha256-pscOdgPotLZsW0XWyRTJigIDl3uWOizA1W0gQGZHSyg=";
+    })
   ];
 
   build-system = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
See tracking https://github.com/NixOS/nixpkgs/issues/475732

Removed `fetchpatch` since https://github.com/capnproto/pycapnp/pull/334 was merged upstream
Disabled tests failing due to Python 3.14 changes

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
