### PR TITLE
cgit-pink: fix build with GCC 15

### DIFF
--- a/pkgs/applications/version-management/cgit/common.nix
+++ b/pkgs/applications/version-management/cgit/common.nix
@@ -8,6 +8,7 @@
   description,
   maintainers,
   passthru ? { },
+  env ? { },
 }:
 
 {
@@ -39,6 +40,7 @@ stdenv.mkDerivation {
     src
     gitSrc
     passthru
+    env
     ;
 
   separateDebugInfo = true;

--- a/pkgs/applications/version-management/cgit/pink.nix
+++ b/pkgs/applications/version-management/cgit/pink.nix
@@ -21,6 +21,10 @@ callPackage (import ./common.nix rec {
     sha256 = "0w43a35mhc2qf2gjkxjlnkf2lq8g0snf34iy5gqx2678yq7llpa0";
   };
 
+  # C23 (which is the default since GCC 15) introduced the `unreachable` macro,
+  # which conflicts with a function called `unreachable` in the `gitSrc` tree.
+  env.NIX_CFLAGS_COMPILE = "-std=gnu17";
+
   homepage = "https://git.causal.agency/cgit-pink/about/";
   description = "cgit fork aiming for better maintenance";
   maintainers = with lib.maintainers; [ sternenseemann ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

C23 (which is the default since GCC 15, related to #475479) introduced the `unreachable` macro, which conflicts with a function called `unreachable` in the `gitSrc` tree. Set C standard to 17.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
