### PR TITLE
framework-tool: Optionally build with NVIDIA support

### DIFF
--- a/pkgs/by-name/fr/framework-tool/package.nix
+++ b/pkgs/by-name/fr/framework-tool/package.nix
@@ -1,9 +1,12 @@
 {
+  config,
   lib,
   rustPlatform,
   fetchFromGitHub,
   pkg-config,
   udev,
+  autoAddDriverRunpath,
+  enableNVML ? config.cudaSupport,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -19,8 +22,22 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-W+k/PAcdwl9mvajB9D4SUH4o5VqpeD/BnK6ZEJzPpmI=";
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [
+    pkg-config
+  ]
+  ++ (lib.optionals enableNVML [
+    autoAddDriverRunpath
+  ]);
+
+  buildFeatures = lib.optionals enableNVML [
+    "nvidia"
+  ];
+
   buildInputs = [ udev ];
+
+  postFixup = lib.optionalString enableNVML ''
+    patchelf --add-needed libnvidia-ml.so "$out/bin/framework_tool"
+  '';
 
   meta = {
     description = "Swiss army knife for Framework laptops";


### PR DESCRIPTION
New feature in version 0.5.0 to support getting information from nvidia GPUs.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
