### PR TITLE
ghostty: update themes dependency, fix build

### DIFF
--- a/pkgs/by-name/gh/ghostty/deps.nix
+++ b/pkgs/by-name/gh/ghostty/deps.nix
@@ -169,11 +169,11 @@ linkFarm name [
     };
   }
   {
-    name = "N-V-__8AALIsAwDyo88G5mGJGN2lSVmmFMx4YePfUvp_2o3Y";
+    name = "N-V-__8AAIdIAwDt5PxH-cwCxEcTfw4jBV8sR6fZ_XLh-cR7";
     path = fetchZigArtifact {
       name = "iterm2_themes";
-      url = "https://github.com/mbadolato/iTerm2-Color-Schemes/releases/download/release-20251002-142451-4a5043e/ghostty-themes.tgz";
-      hash = "sha256-GsEWVt4wMzp6+7N5I+QVuhCVJ70cFrdADwUds59AKnw=";
+      url = "https://github.com/mbadolato/iTerm2-Color-Schemes/releases/download/release-20260112-150707-28c8f5b/ghostty-themes.tgz";
+      hash = "sha256-NIqF12KqXhIrP+LyBtg6WtkHxNUdWOyziAdq8S45RrU=";
     };
   }
   {

--- a/pkgs/by-name/gh/ghostty/package.nix
+++ b/pkgs/by-name/gh/ghostty/package.nix
@@ -5,6 +5,7 @@
   bzip2,
   callPackage,
   fetchFromGitHub,
+  fetchpatch2,
   fontconfig,
   freetype,
   glib,
@@ -47,6 +48,16 @@ stdenv.mkDerivation (finalAttrs: {
     tag = "v${finalAttrs.version}";
     hash = "sha256-0tmLOJCrrEnVc/ZCp/e646DTddXjv249QcSwkaukL30=";
   };
+
+  # Replace the defunct iTerm2 themes dependency with a newer version
+  # Remove when 1.2.4 or 1.3.0 is released
+  patches = [
+    (fetchpatch2 {
+      name = "fix-iterm2-themes-ref.patch";
+      url = "https://github.com/pluiedev/ghostty/commit/dc51adc52661bbcacebe5e70b62b5041e3ee56a5.patch";
+      hash = "sha256-0DrP4zN26pjeBawoi9U8y6VM/NlfhPmo27Iy5OsMj0s=";
+    })
+  ];
 
   deps = callPackage ./deps.nix {
     name = "${finalAttrs.pname}-cache-${finalAttrs.version}";


### PR DESCRIPTION
See ghostty-org/ghostty#9606, #467368 

Since a 1.2.4 release is somewhat unlikely, with the 1.3.0 release scheduled in 6–7 weeks, let's patch this now so that people who don't use `cache.nixos.org` (or mirrors thereof) aren't stuck with a broken build or being forced to use the flake.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
