### PR TITLE
yaziPlugins.yatline: update to 25.5.31-unstable-2026-01-21

### DIFF
--- a/pkgs/by-name/ya/yazi/plugins/yatline/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/yatline/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "yatline.yazi";
-  version = "25.5.31-unstable-2025-06-12";
+  version = "25.5.31-unstable-2026-01-21";
 
   src = fetchFromGitHub {
     owner = "imsi32";
     repo = "yatline.yazi";
-    rev = "88bd1c58357d472fe7e8daf9904936771fc49795";
-    hash = "sha256-RkQKZQAa5U9eMWk1Q0doueJZiuP4elUJ0dM1XKLSnDo=";
+    rev = "3227a30b21f69b68df513754b5a00d6e75cece57";
+    hash = "sha256-yhptHABQ0alVab2i367D5grJyG7SrfHH8H4JuGeYFyk=";
   };
 
   meta = {


### PR DESCRIPTION
Update yatline plugin from 25.5.31-unstable-2025-06-12 to 25.5.31-unstable-2026-01-21.

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.