### PR TITLE
radicle-httpd: 0.22.0 -> 0.23.0

### DIFF
--- a/pkgs/by-name/ra/radicle-explorer/package.nix
+++ b/pkgs/by-name/ra/radicle-explorer/package.nix
@@ -62,7 +62,7 @@ lib.fix (
   self:
   lib.makeOverridable (
     {
-      npmDepsHash ? "sha256-7/DH0p66FTfC0N42FhWTqehg5m/yq929ANhL4jAt7Ss=",
+      npmDepsHash ? "sha256-nVfFeJXSPO1GVkBkWflARZl2Geyt5ARTn0HVglnPlc0=",
       patches ? [ ],
     }@args:
     buildNpmPackage {
@@ -75,7 +75,7 @@ lib.fix (
       # radicle-httpd using a more limited sparse checkout we need to carry a
       # separate hash.
       src = radicle-httpd.src.override {
-        hash = "sha256-PzokSJkcyFDAaih5gekp4GCQMm0sfF7fAK7iZbX1/S4=";
+        hash = "sha256-Zt9RiuloWmb1eL6f2Gotvy+FMTUvSokOEGOIBrBeO/E=";
         sparseCheckout = [ ];
       };
 

--- a/pkgs/by-name/ra/radicle-httpd/package.nix
+++ b/pkgs/by-name/ra/radicle-httpd/package.nix
@@ -15,7 +15,7 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "radicle-httpd";
-  version = "0.22.0";
+  version = "0.23.0";
 
   env.RADICLE_VERSION = finalAttrs.version;
 
@@ -25,12 +25,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
     repo = "z4V1sjrXqjvFdnCUbxPFqd5p4DtH5";
     tag = "releases/${finalAttrs.version}";
     sparseCheckout = [ "radicle-httpd" ];
-    hash = "sha256-NA5U+Ac6imbtNabvaeYATfUbbmT48uqWAcbJ+ukJcDs=";
+    hash = "sha256-OpDW6qJOHN4f4smhc1vNO0DRzJW6114gQV4K1ZNicag=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/radicle-httpd";
 
-  cargoHash = "sha256-9xyuoOuoFWu7oItQporJuGA8EIfEMrCvPaRPnwYMzmM=";
+  cargoHash = "sha256-m/2pP1mCU4SvPXU3qWOpbh3H/ykTOGgERYcP8Iu5DDs=";
 
   nativeBuildInputs = [
     asciidoctor
@@ -78,6 +78,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       repositories on a Radicle node via their web browser.
     '';
     homepage = "https://radicle.xyz";
+    changelog = "https://app.radicle.xyz/nodes/seed.radicle.xyz/rad:z4V1sjrXqjvFdnCUbxPFqd5p4DtH5/tree/radicle-httpd/CHANGELOG.md";
     # cargo.toml says MIT and asl20, LICENSE file says GPL3
     license = with lib.licenses; [
       gpl3Only


### PR DESCRIPTION
Changelog: https://app.radicle.xyz/nodes/seed.radicle.xyz/rad:z4V1sjrXqjvFdnCUbxPFqd5p4DtH5/tree/radicle-httpd/CHANGELOG.md

Closes #482360

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
