### PR TITLE
nixos/pdns-recursor: remove old-settings

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -275,11 +275,11 @@ Alongside many enhancements to NixOS modules and general system improvements, th
   and thus doesn't qualify as default.
 
 - PowerDNS Recursor has been updated to version 5.1.2, which comes with a new YAML configuration format (`recursor.yml`)
-  and deprecates the previous format (`recursor.conf`). Accordingly, the NixOS option `services.pdns-recursor.settings`
-  has been renamed to [old-settings](#opt-services.pdns-recursor.old-settings) and will be provided for backward compatibility
-  until the next NixOS release. Users are asked to migrate their settings to the new [yaml-settings](#opt-services.pdns-recursor.old-settings)
+  and deprecates the previous format (`recursor.conf`). Accordingly, the NixOS option {option}`services.pdns-recursor.settings`
+  has been renamed to `old-settings` and will be provided for backward compatibility
+  until the next NixOS release. Users are asked to migrate their settings to the new `yaml-settings`.
   option following this [guide](https://doc.powerdns.com/recursor/appendices/yamlconversion.html).
-  Note that options other than `services.pdns-recursor.settings` are unaffacted by this change.
+  Note that options other than {option}`services.pdns-recursor.settings` are unaffacted by this change.
 
 - The `virtualisation.hypervGuest.videoMode` option has been removed. Standard tooling can now be used to configure display modes for Hyper-V VMs.
 

--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -97,6 +97,8 @@ of pulling the upstream container image from Docker Hub. If you want the old beh
 
 - `pdns` has been updated to version [v5.0.x](https://doc.powerdns.com/authoritative/changelog/5.0.html), which introduces breaking changes. Check out the [Upgrade Notes](https://doc.powerdns.com/authoritative/upgrading.html#to-5-0-0) for details.
 
+- In the PowerDNS Recursor module, following the deprecation period started with NixOS 25.05, the option {option}`services.pdns-recursor.old-settings` has been removed and {option}`services.pdns-recursor.yaml-settings` consequently renamed to [](#opt-services.pdns-recursor.settings).
+
 - `services.angrr` now uses TOML for configuration. Define policies with `services.angrr.settings` (generate TOML file) or point to a file using `services.angrr.configFile`. The legacy options `services.angrr.period`, `services.angrr.ownedOnly`, and `services.angrr.removeRoot` have been removed. See `man 5 angrr` and the description of `services.angrr.settings` options for examples and details.
 
 - `services.pingvin-share` has been removed as the `pingvin-share.backend` package was broken and the project was archived upstream.

--- a/nixos/tests/pdns-recursor.nix
+++ b/nixos/tests/pdns-recursor.nix
@@ -7,7 +7,6 @@
   nodes.server = {
     services.pdns-recursor.enable = true;
     services.pdns-recursor.exportHosts = true;
-    services.pdns-recursor.old-settings.dnssec-log-bogus = true;
     networking.hosts."192.0.2.1" = [ "example.com" ];
   };
 
@@ -18,8 +17,5 @@
 
     with subtest("can resolve names"):
       assert "192.0.2.1" in server.succeed("host example.com localhost")
-
-    with subtest("old-settings have been merged in"):
-      server.succeed("${lib.getExe pkgs.yq-go} -e .dnssec.log_bogus /etc/pdns-recursor/recursor.yml")
   '';
 }


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] `pdns-recursor.tests`
  - [x] manual
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
