### PR TITLE
system-manager: init at 1.0.0

### DIFF
--- a/pkgs/by-name/sy/system-manager/package.nix
+++ b/pkgs/by-name/sy/system-manager/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  dbus,
+  pkg-config,
+  clippy,
+  nix,
+  cargo,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "system-manager";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "numtide";
+    repo = "system-manager";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Jjvn9gPmL6otZcaYjzE4cXLQFyzAEEsnpgwP3OoN8Gk=";
+  };
+
+  cargoHash = "sha256-A3A1RRx9U43u6wmzPE+yZwi08m7vcD5ccLC89TgDvOg=";
+
+  buildInputs = [ dbus ];
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  nativeCheckInputs = [
+    clippy
+    nix
+    cargo
+  ];
+
+  preCheck = ''
+    cargo clippy
+
+    # Stop the Nix command from trying to create /nix/var/nix/profiles.
+    #
+    # https://nix.dev/manual/nix/2.24/command-ref/new-cli/nix3-profile#profiles
+    export NIX_STATE_DIR=$TMPDIR
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Manage system config using nix on any distro";
+    homepage = "http://system-manager.net";
+    license = lib.licenses.mit;
+    mainProgram = "system-manager";
+    maintainers = with lib.maintainers; [ jfroche ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
