### PR TITLE
grpc: update version to latest release 1.75.1 -> 1.76.0

### DIFF
--- a/pkgs/by-name/gr/grpc/package.nix
+++ b/pkgs/by-name/gr/grpc/package.nix
@@ -26,13 +26,13 @@
 stdenv.mkDerivation rec {
   pname = "grpc";
   version = "1.76.0"; # N.B: if you change this, please update:
-  # pythonPackages.grpcio
-  # pythonPackages.grpcio-channelz
-  # pythonPackages.grpcio-health-checking
-  # pythonPackages.grpcio-reflection
-  # pythonPackages.grpcio-status
-  # pythonPackages.grpcio-testing
-  # pythonPackages.grpcio-tools
+  # python3Packages.grpcio
+  # python3Packages.grpcio-channelz
+  # python3Packages.grpcio-health-checking
+  # python3Packages.grpcio-reflection
+  # python3Packages.grpcio-status
+  # python3Packages.grpcio-testing
+  # python3Packages.grpcio-tools
 
   src = fetchFromGitHub {
     owner = "grpc";

--- a/pkgs/by-name/gr/grpc_cli/package.nix
+++ b/pkgs/by-name/gr/grpc_cli/package.nix
@@ -11,7 +11,7 @@
 
 stdenv.mkDerivation rec {
   pname = "grpc_cli";
-  version = "1.75.1";
+  version = "1.76.0";
   src = fetchFromGitHub {
     owner = "grpc";
     repo = "grpc";

--- a/pkgs/by-name/gr/grpc_cli/package.nix
+++ b/pkgs/by-name/gr/grpc_cli/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     owner = "grpc";
     repo = "grpc";
     rev = "v${version}";
-    hash = "sha256-SnKK52VLO4MM/ftfmzRV/LeLfOucdIyHMyWk6EKRfvM=";
+    hash = "sha256-f25ccZC0pJw00ETgxBtXU6+0OnlJsV7zXjK/ayiCIJY=";
     fetchSubmodules = true;
   };
   nativeBuildInputs = [


### PR DESCRIPTION
Required version bump for latest version of Nominal packages: https://github.com/NixOS/nixpkgs/pull/482317

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Updates the version of grpc and its associated libraries from `1.75.1` to `1.76.0`

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
