### PR TITLE
bintools-wrapper: Also define `RC<suffix>`

### DIFF
--- a/pkgs/build-support/bintools-wrapper/setup-hook.sh
+++ b/pkgs/build-support/bintools-wrapper/setup-hook.sh
@@ -55,7 +55,7 @@ fi
 export NIX_BINTOOLS${role_post}=@out@
 
 for cmd in \
-    ar as ld nm objcopy objdump readelf ranlib strip strings size windres
+    ar as ld nm objcopy objdump readelf ranlib strip strings size windres rc
 do
     if
         PATH=$_PATH type -p "@targetPrefix@${cmd}" > /dev/null
@@ -63,6 +63,16 @@ do
         export "${cmd^^}${role_post}=@targetPrefix@${cmd}";
     fi
 done
+
+# If there is no `<prefix>rc`, but there is a `<prefix>windres`, define
+# `RC<suffix>=${WINDRES<suffix>}`.
+if
+    [[ ! -v "RC${role_post}" ]] && [[ -v "WINDRES${role_post}" ]]
+then
+    windres_var="WINDRES${role_post}"
+    export "RC${role_post}=${!windres_var}"
+    unset -v windres_var
+fi
 
 # If unset, assume the default hardening flags.
 : ${NIX_HARDENING_ENABLE="@default_hardening_flags_str@"}

--- a/pkgs/by-name/zl/zlib-ng/package.nix
+++ b/pkgs/by-name/zl/zlib-ng/package.nix
@@ -45,10 +45,7 @@ stdenv.mkDerivation rec {
     "-DBUILD_SHARED_LIBS=ON"
     "-DINSTALL_UTILS=ON"
   ]
-  ++ lib.optionals withZlibCompat [ "-DZLIB_COMPAT=ON" ]
-  ++ lib.optional (
-    stdenv.hostPlatform.isWindows || stdenv.hostPlatform.isCygwin
-  ) "-DCMAKE_RC_COMPILER=${stdenv.cc.targetPrefix}windres";
+  ++ lib.optionals withZlibCompat [ "-DZLIB_COMPAT=ON" ];
 
   meta = {
     description = "Zlib data compression library for the next generation systems";


### PR DESCRIPTION
Additionally, if there is a `windres` but no `rc`, `RC<suffix>` is defined to point to `WINDRES<suffix>`.

My justification is essentially what I wrote in https://github.com/mesonbuild/meson/pull/15438. Microsoft recommends `RC`, CMake only supports `RC`, and Meson now supports both. In addition, CMake and Meson are fine with "reversed" usage like `RC=windres` and `WINDRES=rc`, so this simple defaulting logic should be fine.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
