### PR TITLE
outguess: fix build

### DIFF
--- a/pkgs/by-name/ou/outguess/package.nix
+++ b/pkgs/by-name/ou/outguess/package.nix
@@ -22,6 +22,17 @@ stdenv.mkDerivation (finalAttrs: {
 
   configureFlags = [ "--with-generic-jconfig" ];
 
+  # Fix build with modern compilers (GCC 14+)
+  # The bundled jpeg-6b-steg library uses K&R-style function declarations
+  # that are incompatible with modern C standards
+  postPatch = ''
+    substituteInPlace src/jpeg-6b-steg/jmorecfg.h \
+      --replace-fail '#define JMETHOD(type,methodname,arglist)  type (*methodname) ()' \
+                     '#define JMETHOD(type,methodname,arglist)  type (*methodname) arglist'
+    substituteInPlace src/jpeg-6b-steg/jpeglib.h \
+      --replace-fail '#ifdef HAVE_PROTOTYPES' '#if 1  /* Force ANSI prototypes */'
+  '';
+
   meta = {
     description = "Universal steganographic tool that allows the insertion of hidden information into the redundant bits of data sources";
     homepage = "https://github.com/resurrecting-open-source-projects/outguess";


### PR DESCRIPTION
outguess does not build with the current version of GCC. Added a postPatch to remove K&R-style function declarations. Package now compiles but has otherwise been minimally tested.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
