### PR TITLE
rauthy: 0.33.4 -> 0.34.0

### DIFF
--- a/pkgs/by-name/ra/rauthy/package.nix
+++ b/pkgs/by-name/ra/rauthy/package.nix
@@ -8,24 +8,24 @@
   pkg-config,
   perl,
   wasm-pack,
-  wasm-bindgen-cli_0_2_106,
+  wasm-bindgen-cli_0_2_108,
   binaryen,
   lld,
 }:
 let
-  version = "0.33.4";
+  version = "0.34.0";
   pname = "rauthy";
 
   src = fetchFromGitHub {
     owner = "sebadob";
     repo = "rauthy";
     tag = "v${version}";
-    hash = "sha256-MhurQyfB+ydIdnCAu5+h6EeKwPHyQix0dDYIvaV3Juk=";
+    hash = "sha256-ZYugnemiZpa8gmXCRgZc/9att/vUribC1+vpS7vhgl8=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src pname version;
-    hash = "sha256-rFJHXWr50dLHILSgAHLCzgiD543r6xctjw60MOOR7HU=";
+    hash = "sha256-ixl4mlQJw8Gr7Rrnm8B2Iz8xI7IAne8OR9Dri0k3kqY=";
   };
 
   # Wasm modules are needed to build the frontend and are part of the main Rust repo.
@@ -40,7 +40,7 @@ let
     nativeBuildInputs = [
       writableTmpDirAsHomeHook
       wasm-pack
-      wasm-bindgen-cli_0_2_106
+      wasm-bindgen-cli_0_2_108
       binaryen
       lld
     ];
@@ -77,7 +77,7 @@ let
       "-p2"
     ];
 
-    npmDepsHash = "sha256-rTN+CbwnX157qqPLpUfjoCofFiwKYJJH9Oy0MeRFWXE=";
+    npmDepsHash = "sha256-F8/zbqI7Nmm8GLtkL25QDX222yzhlg7NA32tpBa8b5o=";
 
     preBuild = ''
       mkdir -p ./src/wasm/


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Diff: https://github.com/sebadob/rauthy/compare/v0.33.4...v0.34.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
