### PR TITLE
gurobi: 13.0.0 -> 13.0.1

### DIFF
--- a/pkgs/by-name/gu/gurobi/package.nix
+++ b/pkgs/by-name/gu/gurobi/package.nix
@@ -16,14 +16,14 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "gurobi";
-  version = "13.0.0";
+  version = "13.0.1";
 
   src = fetchurl {
     url = "https://packages.gurobi.com/${lib.versions.majorMinor version}/gurobi${version}_${platform}.tar.gz";
     hash =
       {
-        aarch64-linux = "sha256-0wFhMzLK1QViDc0ZLM/oVemtRW0g+FRJRFFOL/eiOFE=";
-        x86_64-linux = "sha256-mEVUVXCeizSzQDLtkNS/EkaxT0MToxL3x3UGb/XB9lI=";
+        aarch64-linux = "sha256-MQDqu95e+fJ00FGtYVw2FlkZ6uhl5eTFefpsA0ti+jI=";
+        x86_64-linux = "sha256-7GIyF6xfoGV3madS7XwCshQfu5wP80Ep1uH4yaj+Ttg=";
       }
       .${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
   };

--- a/pkgs/development/python-modules/gurobipy/default.nix
+++ b/pkgs/development/python-modules/gurobipy/default.nix
@@ -10,21 +10,26 @@ let
   format = "wheel";
   pyShortVersion = "cp" + builtins.replaceStrings [ "." ] [ "" ] python.pythonVersion;
   platforms = rec {
-    aarch64-darwin = "macosx_10_13_universal2";
+    aarch64-darwin =
+      if pyShortVersion == "cp314" then "macosx_10_15_universal2" else "macosx_10_13_universal2";
     aarch64-linux = "manylinux_2_26_aarch64";
     x86_64-darwin = aarch64-darwin;
     x86_64-linux = "manylinux2014_x86_64.manylinux_2_17_x86_64";
   };
   platform = platforms.${stdenv.system} or (throw "Unsupported system: ${stdenv.system}");
   hashes = rec {
-    cp312-aarch64-darwin = "sha256-qbdDlsAHHrRDijyLgYZMVKjoqxBPEFhNf+ZHQ0Qo+08=";
-    cp312-aarch64-linux = "sha256-1cfo6K3h1l6hzbHNIK2H0Y9uejjyFWAYlczUSvyTLOE=";
+    cp312-aarch64-darwin = "sha256-hQ9VN5Wl8RQ53ShE5q/LqzgNsZHX27W7b05rGeH95jc=";
+    cp312-aarch64-linux = "sha256-wKQjIAmhM+Smk3XzzlR8ZtwxJpr8hvbV15QTfSMxuE8=";
     cp312-x86_64-darwin = cp312-aarch64-darwin;
-    cp312-x86_64-linux = "sha256-nXcNqkw/Chn+tmcRa1GaQSjTgn3wdnaUbskLOyOSEpo=";
-    cp313-aarch64-darwin = "sha256-9anXslqv9KIxf/Dt7xCAqF6/tQFDlWwOMkQookmXDBE=";
-    cp313-aarch64-linux = "sha256-0x5gOK+m0LygVFuh6hGfNyaWXclNdfuBppqq7Pu3FoI=";
+    cp312-x86_64-linux = "sha256-yISDKQFJYKZAxXE2vyrcanXcc3FvUHKcpshtaLnwtrI=";
+    cp313-aarch64-darwin = "sha256-j8E8zsPr1m4q7p1i4ihUuzPSczbRKuZGWp0C/oNx0Lc=";
+    cp313-aarch64-linux = "sha256-QvHfssbnKwoBmcqqBbOP2wLclJ7xol6054n8XqUtk44=";
     cp313-x86_64-darwin = cp313-aarch64-darwin;
-    cp313-x86_64-linux = "sha256-rSAMw5aAp+Emz2Xlo2GXrbVsvKRw/CcxcF441N/IsTw=";
+    cp313-x86_64-linux = "sha256-wVm6yMfrL0rMgVebo/WGAyb7LKOp139g8U0GhgCbRoc=";
+    cp314-aarch64-darwin = "sha256-QCytKZtPSzdGDKg0LjFbJS/y5whqa8mcotNfecYXPVw=";
+    cp314-aarch64-linux = "sha256-qHAOVJwmZ6ojUDSmFJrxaiE4unwfns0VtVdUcEq2zq8=";
+    cp314-x86_64-darwin = cp314-aarch64-darwin;
+    cp314-x86_64-linux = "sha256-WUSCCjJ4uWTwxIsasIOizEmZ9HuZBoWVV0F3wPiXOCY=";
   };
   hash =
     hashes."${pyShortVersion}-${stdenv.system}"
@@ -32,7 +37,7 @@ let
 in
 buildPythonPackage rec {
   pname = "gurobipy";
-  version = "13.0.0";
+  version = "13.0.1";
   inherit format;
 
   src = fetchPypi {


### PR DESCRIPTION
https://pypi.org/project/gurobipy/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
