### PR TITLE
netgen-vlsi: 1.5.314 -> 1.5.315

### DIFF
--- a/pkgs/by-name/ne/netgen-vlsi/package.nix
+++ b/pkgs/by-name/ne/netgen-vlsi/package.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "netgen";
-  version = "1.5.314";
+  version = "1.5.315";
 
   src = fetchFromGitHub {
     owner = "RTimothyEdwards";
     repo = "netgen";
     tag = finalAttrs.version;
-    hash = "sha256-g8d/faYjhL6WXSShqWn9n+4cUJ8qKtqyEgyIRsrHo5o=";
+    hash = "sha256-dXCZm5zVwn23y7DLPSUrTKGMcu/FjdVKsyry59lEt7U=";
   };
 
   strictDeps = true;


### PR DESCRIPTION
- Built on platform:
  - [x] x86_64-linux
- Tested, as applicable:
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
