### PR TITLE
metalang99: init at 1.13.5, datatype99: init at 1.6.5, slice99: init at 0.7.8, interface99: init at 1.0.2

### DIFF
--- a/pkgs/by-name/da/datatype99/package.nix
+++ b/pkgs/by-name/da/datatype99/package.nix
@@ -1,0 +1,47 @@
+{
+  fetchFromGitHub,
+  lib,
+  metalang99,
+  nix-update-script,
+  stdenvNoCC,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "datatype99";
+  version = "1.6.5";
+
+  src = fetchFromGitHub {
+    owner = "hirrolot";
+    repo = "datatype99";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-gO59yaz7q4qem9Ij2ia7/x1wwPbVloLlmln8h/YlSkI=";
+  };
+
+  dontBuild = true;
+
+  propagatedBuildInputs = [ metalang99 ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 datatype99.h --target-directory="$out"/include
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Algebraic data types (ADT) for C99";
+    longDescription = ''
+      Safe, intuitive ADT with exhaustive pattern matching and
+      compile-time introspection facilities.  No external tools
+      required, pure C99.
+    '';
+    homepage = "https://github.com/hirrolot/datatype99";
+    changelog = "https://github.com/hirrolot/datatype99/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ yiyu ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/in/interface99/package.nix
+++ b/pkgs/by-name/in/interface99/package.nix
@@ -1,0 +1,47 @@
+{
+  fetchFromGitHub,
+  lib,
+  metalang99,
+  nix-update-script,
+  stdenvNoCC,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "interface99";
+  version = "1.0.2";
+
+  src = fetchFromGitHub {
+    owner = "hirrolot";
+    repo = "interface99";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-TEyInO0k3efBtufUanGOj/3Sejhf8RMXvjYOxB/MSRk=";
+  };
+
+  dontBuild = true;
+
+  propagatedBuildInputs = [ metalang99 ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 interface99.h --target-directory="$out"/include
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Full-featured interfaces for C99";
+    longDescription = ''
+      Full-featured interfaces inspired by Rust and Golang.  Multiple
+      inheritance, superinterfaces, and default implementations
+      supported.  No external tools required, pure C99.
+    '';
+    homepage = "https://github.com/hirrolot/interface99";
+    changelog = "https://github.com/hirrolot/interface99/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ yiyu ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/me/metalang99/package.nix
+++ b/pkgs/by-name/me/metalang99/package.nix
@@ -1,0 +1,55 @@
+{
+  fetchFromGitHub,
+  lib,
+  nix-update-script,
+  stdenvNoCC,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "metalang99";
+  version = "1.13.5";
+
+  src = fetchFromGitHub {
+    owner = "hirrolot";
+    repo = "metalang99";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-BuJlqjqWqI7KAa0n1tyZBH0e/Q8hA9zqFq80wICg4sc=";
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir $out
+    cp --recursive include $out
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Full-blown preprocessor metaprogramming";
+    longDescription = ''
+      Metalang99 is a firm foundation for writing reliable and
+      maintainable metaprograms in pure C99.  It is implemented as an
+      interpreted FP language atop of preprocessor macros: just
+      `#include <metalang99.h>` and you are ready to go.  Metalang99
+      features algebraic data types, pattern matching, recursion,
+      currying, and collections; in addition, it provides means for
+      compile-time error reporting and debugging.  With our built-in
+      syntax checker, macro errors should be perfectly comprehensible,
+      enabling you for convenient development.
+
+      Currently, Metalang99 is used at OpenIPC as an indirect
+      dependency of Datatype99 and Interface99; this includes an RTSP
+      1.0 implementation along with ~50k lines of private code.
+    '';
+    homepage = "https://github.com/hirrolot/metalang99";
+    changelog = "https://github.com/hirrolot/metalang99/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ yiyu ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/sl/slice99/package.nix
+++ b/pkgs/by-name/sl/slice99/package.nix
@@ -1,0 +1,45 @@
+{
+  fetchFromGitHub,
+  lib,
+  metalang99,
+  nix-update-script,
+  stdenvNoCC,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "slice99";
+  version = "0.7.8";
+
+  src = fetchFromGitHub {
+    owner = "hirrolot";
+    repo = "slice99";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-9mfZaDw1QWkfuyAMZpN6mZDbMDPSAw0TnqwJKYzzwkk=";
+  };
+
+  dontBuild = true;
+
+  propagatedBuildInputs = [ metalang99 ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 slice99.h --target-directory="$out"/include
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Memory slices for C99";
+    longDescription = ''
+      This library provides array slicing facilities for pure C99.
+    '';
+    homepage = "https://github.com/hirrolot/slice99";
+    changelog = "https://github.com/hirrolot/slice99/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ yiyu ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
