### PR TITLE
stalwart-mail: 0.14.1 -> 0.15.4

### DIFF
--- a/pkgs/by-name/st/stalwart-mail/package.nix
+++ b/pkgs/by-name/st/stalwart-mail/package.nix
@@ -21,16 +21,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "stalwart-mail" + (lib.optionalString stalwartEnterprise "-enterprise");
-  version = "0.14.1";
+  version = "0.15.4";
 
   src = fetchFromGitHub {
     owner = "stalwartlabs";
     repo = "stalwart";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Wsk4n6jLOAFhxYb5Hw8XvQem0xccGGoD729nRz3bRF0=";
+    hash = "sha256-MIy1/8r5CMrTbVTjLFuUneoL3J38kZIgUMweoeaf3L0=";
   };
 
-  cargoHash = "sha256-LFXpv8/rHQwzdKEyS4VplQSwFUnZrgv0qDIhZUOGfpo=";
+  cargoHash = "sha256-jVD11wz9Ab1E9KdNG4kp8Jqm2rJ2aUWuFTAOBga6Fgg=";
 
   depsBuildBuild = [
     pkg-config
@@ -61,9 +61,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "postgres"
     "mysql"
     "rocks"
-    "elastic"
     "s3"
     "redis"
+    "azure"
+    "nats"
   ]
   ++ lib.optionals withFoundationdb [ "foundationdb" ]
   ++ lib.optionals stalwartEnterprise [ "enterprise" ];
@@ -87,7 +88,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     mkdir -p $out/lib/systemd/system
 
     substitute resources/systemd/stalwart-mail.service $out/lib/systemd/system/stalwart-mail.service \
-      --replace "__PATH__" "$out"
+      --replace-fail "__PATH__" "$out"
   '';
 
   checkFlags = lib.forEach [
@@ -169,6 +170,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
     #   left: ElementEnd
     #  right: Bytes([...])
     "responses::tests::parse_responses"
+    # thread 'store::search_tests' (912386) panicked at tests/src/store/mod.rs:116:10:
+    # Missing store type. Try running `STORE=<store_type> cargo test`: NotPresent
+    "store::search_tests"
   ] (test: "--skip=${test}");
 
   doCheck = !(stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64);

--- a/pkgs/by-name/st/stalwart-mail/webadmin.nix
+++ b/pkgs/by-name/st/stalwart-mail/webadmin.nix
@@ -17,13 +17,13 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "webadmin";
-  version = "0.1.32";
+  version = "0.1.37";
 
   src = fetchFromGitHub {
     owner = "stalwartlabs";
     repo = "webadmin";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-HmQBMU7o0A20SY4tBw4SPVfHFfw8e0JsNQDNdZcex24=";
+    hash = "sha256-82QvuLkp6j6nJs7jX4NRcnxZ+KNv9RREpM+x8dicfGo=";
   };
 
   npmDeps = fetchNpmDeps {
@@ -31,7 +31,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     hash = "sha256-na1HEueX8w7kuDp8LEtJ0nD1Yv39cyk6sEMpS1zix2s=";
   };
 
-  cargoHash = "sha256-a2+3uNNSLfb81QXjZfftbwpgjORPRSgC056U3FINP4o=";
+  cargoHash = "sha256-qYIg1BthkpS77I6duYGGX168Y/IO8Mx4SWMQbE0BwDA=";
 
   postPatch = ''
     # Using local tailwindcss for compilation


### PR DESCRIPTION
* diff: https://github.com/stalwartlabs/stalwart/compare/v0.14.1...v0.15.4
* changelog: https://github.com/stalwartlabs/stalwart/releases/tag/v0.15.4
* remove `elastic` since it's no longer a feature and included by
  default (see: https://github.com/stalwartlabs/stalwart/discussions/2632#discussioncomment-15458542)
* add `azure` and `nats` build features to align with upstream (see: https://github.com/stalwartlabs/stalwart/blob/659419212050bab50f600493fbe48a28aed44ac5/Dockerfile.build#L127)

Resolves: https://github.com/NixOS/nixpkgs/issues/473375

stalwart.webadmin: 0.1.32 -> 0.1.37

* diff: https://github.com/stalwartlabs/webadmin/compare/v0.1.32...v0.1.37
* changelog: https://github.com/stalwartlabs/webadmin/releases/tag/v0.1.37

Related to: https://github.com/NixOS/nixpkgs/issues/473375

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
