### PR TITLE
mysql84: 8.4.7 -> 8.4.8, mysql80: 8.0.44 -> 8.0.45

### DIFF
--- a/pkgs/by-name/my/mysql84/package.nix
+++ b/pkgs/by-name/my/mysql84/package.nix
@@ -27,11 +27,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "mysql";
-  version = "8.4.7";
+  version = "8.4.8";
 
   src = fetchurl {
     url = "https://dev.mysql.com/get/Downloads/MySQL-${lib.versions.majorMinor finalAttrs.version}/mysql-${finalAttrs.version}.tar.gz";
-    hash = "sha256-wL8zqUzbkI8UmuoHl6/7GxOSYszw4Ll4ehckYgdULmk=";
+    hash = "sha256-vp2Wzfh/J2lSos3ZYPEGuWCohg5GwRXtOcG18uA4eiA=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/servers/sql/mysql/8.0.x.nix
+++ b/pkgs/servers/sql/mysql/8.0.x.nix
@@ -30,11 +30,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "mysql";
-  version = "8.0.44";
+  version = "8.0.45";
 
   src = fetchurl {
     url = "https://dev.mysql.com/get/Downloads/MySQL-${lib.versions.majorMinor finalAttrs.version}/mysql-${finalAttrs.version}.tar.gz";
-    hash = "sha256-YJUi7R/vzlqziN7CXg0bzhMjgtom4rd7aPB0HApkE1Y=";
+    hash = "sha256-tDXyLmWMj8k7gWmPo0uaVjJaMEs/Pf+H8n+2dMkKu8s=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Fixes:
* CVE-2026-21968
* CVE-2026-21936
* CVE-2026-21937
* CVE-2026-21941
* CVE-2026-21948
* CVE-2026-21964

Changes:
https://dev.mysql.com/doc/relnotes/mysql/8.4/en/news-8-4-8.html
https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-45.html

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 482423`
Commit: `3da0a2663c07be0ade71e54782f3b5ef063fd6ba`

---
### `x86_64-linux`
<details>
  <summary>:x: 2 packages failed to build:</summary>
  <ul>
    <li>sympa</li>
    <li>vep</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 36 packages built:</summary>
  <ul>
    <li>exim</li>
    <li>libmysqlconnectorcpp</li>
    <li>longview</li>
    <li>mylvmbackup</li>
    <li>mysql-workbench</li>
    <li>mysql80</li>
    <li>mysql80.static</li>
    <li>mysql84</li>
    <li>mysql84.static</li>
    <li>opendmarc</li>
    <li>opendmarc.bin</li>
    <li>opendmarc.dev</li>
    <li>opendmarc.doc</li>
    <li>percona-toolkit</li>
    <li>percona-xtrabackup (percona-xtrabackup_8_4)</li>
    <li>percona-xtrabackup_8_0</li>
    <li>perlPackages.DBDmysql (perl5Packages.DBDmysql)</li>
    <li>perlPackages.DBDmysql.devdoc (perl5Packages.DBDmysql.devdoc)</li>
    <li>perlPackages.MinionBackendmysql (perl5Packages.MinionBackendmysql)</li>
    <li>perlPackages.MinionBackendmysql.devdoc (perl5Packages.MinionBackendmysql.devdoc)</li>
    <li>perlPackages.Mojomysql (perl5Packages.Mojomysql)</li>
    <li>perlPackages.Mojomysql.devdoc (perl5Packages.Mojomysql.devdoc)</li>
    <li>perlPackages.PerconaToolkit (perl5Packages.PerconaToolkit)</li>
    <li>perlPackages.Testmysqld (perl5Packages.Testmysqld)</li>
    <li>perlPackages.Testmysqld.devdoc (perl5Packages.Testmysqld.devdoc)</li>
    <li>perlPackages.maatkit (perl5Packages.maatkit)</li>
    <li>python313Packages.mysql-connector</li>
    <li>python313Packages.mysql-connector.dist</li>
    <li>python314Packages.mysql-connector</li>
    <li>python314Packages.mysql-connector.dist</li>
    <li>sqitchMysql</li>
    <li>sqlit-tui</li>
    <li>sqlit-tui.dist</li>
    <li>sqlite3-to-mysql</li>
    <li>sqlite3-to-mysql.dist</li>
    <li>zoneminder</li>
  </ul>
</details>

---
<details>
<summary>Error logs: `x86_64-linux`</summary>
<details>
<summary>sympa</summary>
<pre>find: &#x27;po/sympa/add-lang.pl&#x27;: No such file or directory
applying patch /nix/store/npcmkdk30if0xgwkbcysvdlfkfn7sa0j-make-docs.patch
patching file doc/Makefile.am
Hunk #1 succeeded at 93 (offset 10 lines).
Running phase: autoreconfPhase
@nix { &quot;action&quot;: &quot;setPhase&quot;, &quot;phase&quot;: &quot;autoreconfPhase&quot; }
autoreconf: export WARNINGS=
autoreconf: Entering directory &#x27;.&#x27;
autoreconf: configure.ac: not using Gettext
autoreconf: running: aclocal --force 
configure.ac:30: warning: macro &#x27;AM_PO_SUBDIRS&#x27; not found in library
autoreconf: configure.ac: tracing
autoreconf: configure.ac: not using Libtool
autoreconf: configure.ac: not using Intltool
autoreconf: configure.ac: not using Gtkdoc
autoreconf: running: /nix/store/i6vhgvkyljmgncgwff2jl1f0qyw2gjjb-autoconf-2.72/bin/autoconf --force
configure.ac:30: error: possibly undefined macro: AM_PO_SUBDIRS
      If this token and others are legitimate, please use m4_pattern_allow.
      See the Autoconf documentation.
autoreconf: error: /nix/store/i6vhgvkyljmgncgwff2jl1f0qyw2gjjb-autoconf-2.72/bin/autoconf failed with exit status: 1</pre>
</details>
</details>


[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
