### PR TITLE
python3Packages.angr: 9.2.154 -> 9.2.194

### DIFF
--- a/pkgs/development/python-modules/archinfo/default.nix
+++ b/pkgs/development/python-modules/archinfo/default.nix
@@ -7,7 +7,7 @@
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "archinfo";
   version = "9.2.194";
   pyproject = true;
@@ -17,7 +17,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "angr";
     repo = "archinfo";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-6qjgR2i53Lvmw69oyShps7Io3sHsX+skuc3DZsv8VNw=";
   };
 
@@ -33,4 +33,4 @@ buildPythonPackage rec {
     license = lib.licenses.bsd2;
     maintainers = with lib.maintainers; [ fab ];
   };
-}
+})

--- a/pkgs/development/python-modules/archinfo/default.nix
+++ b/pkgs/development/python-modules/archinfo/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  backports-strenum,
   buildPythonPackage,
   fetchFromGitHub,
   pytestCheckHook,
@@ -10,7 +9,7 @@
 
 buildPythonPackage rec {
   pname = "archinfo";
-  version = "9.2.154";
+  version = "9.2.194";
   pyproject = true;
 
   disabled = pythonOlder "3.12";
@@ -19,7 +18,7 @@ buildPythonPackage rec {
     owner = "angr";
     repo = "archinfo";
     tag = "v${version}";
-    hash = "sha256-Vks7Rjd8x2zeHnJPs0laH56S4b8pnR1cK82SpK+XOgE=";
+    hash = "sha256-6qjgR2i53Lvmw69oyShps7Io3sHsX+skuc3DZsv8VNw=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/pyvex/default.nix
+++ b/pkgs/development/python-modules/pyvex/default.nix
@@ -5,13 +5,14 @@
   buildPythonPackage,
   buildPackages,
   cffi,
-  fetchPypi,
+  fetchFromGitHub,
   pycparser,
   pythonOlder,
   setuptools,
   scikit-build-core,
   cmake,
   ninja,
+  pytestCheckHook,
 }:
 
 buildPythonPackage rec {
@@ -21,9 +22,12 @@ buildPythonPackage rec {
 
   disabled = pythonOlder "3.11";
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-obM8FsChD5ZR8O8CNgKsqC+x9+1WjFMscUUtLi91oQA=";
+  src = fetchFromGitHub {
+    owner = "angr";
+    repo = "pyvex";
+    tag = "v${version}";
+    hash = "sha256-65ZjHXxYGfZPUFG1eloGa51CSyo4XTVMs3O3n8le69Q=";
+    fetchSubmodules = true;
   };
 
   build-system = [
@@ -61,11 +65,11 @@ buildPythonPackage rec {
     export CC=${stdenv.cc.targetPrefix}cc
   '';
 
-  # No tests are available on PyPI, GitHub release has tests
-  # Switch to GitHub release after all angr parts are present
-  doCheck = false;
-
   pythonImportsCheck = [ "pyvex" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
 
   meta = {
     description = "Python interface to libVEX and VEX IR";

--- a/pkgs/development/python-modules/pyvex/default.nix
+++ b/pkgs/development/python-modules/pyvex/default.nix
@@ -9,21 +9,27 @@
   pycparser,
   pythonOlder,
   setuptools,
+  scikit-build-core,
+  cmake,
+  ninja,
 }:
 
 buildPythonPackage rec {
   pname = "pyvex";
-  version = "9.2.154";
+  version = "9.2.194";
   pyproject = true;
 
   disabled = pythonOlder "3.11";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-a3ei2w66v18QKAofpPvDUoM42zHRHPrNQic+FE+rLKY=";
+    hash = "sha256-obM8FsChD5ZR8O8CNgKsqC+x9+1WjFMscUUtLi91oQA=";
   };
 
-  build-system = [ setuptools ];
+  build-system = [
+    setuptools
+    scikit-build-core
+  ];
 
   dependencies = [
     bitstring
@@ -33,7 +39,13 @@ buildPythonPackage rec {
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
 
-  nativeBuildInputs = [ cffi ];
+  nativeBuildInputs = [
+    cffi
+    cmake
+    ninja
+  ];
+
+  dontUseCmakeConfigure = true;
 
   postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
     substituteInPlace vex/Makefile-gcc \
@@ -47,8 +59,6 @@ buildPythonPackage rec {
 
   preBuild = ''
     export CC=${stdenv.cc.targetPrefix}cc
-    substituteInPlace pyvex_c/Makefile \
-      --replace-fail 'AR=ar' 'AR=${stdenv.cc.targetPrefix}ar'
   '';
 
   # No tests are available on PyPI, GitHub release has tests

--- a/pkgs/development/python-modules/pyvex/default.nix
+++ b/pkgs/development/python-modules/pyvex/default.nix
@@ -15,7 +15,7 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pyvex";
   version = "9.2.194";
   pyproject = true;
@@ -25,7 +25,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "angr";
     repo = "pyvex";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-65ZjHXxYGfZPUFG1eloGa51CSyo4XTVMs3O3n8le69Q=";
     fetchSubmodules = true;
   };
@@ -81,4 +81,4 @@ buildPythonPackage rec {
     ];
     maintainers = with lib.maintainers; [ fab ];
   };
-}
+})


### PR DESCRIPTION
### Todo

- [ ] angr
  - [ ] cle
    - [x] archinfo https://github.com/NixOS/nixpkgs/pull/435784
    - [ ] uefi-firmware: init
  - [x] pyvex https://github.com/NixOS/nixpkgs/pull/404829
- [ ] remove ailment (merged to angr) https://github.com/NixOS/nixpkgs/pull/436234

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
