### PR TITLE
napari: 0.6.4 -> 0.6.6

### DIFF
--- a/pkgs/development/python-modules/napari/default.nix
+++ b/pkgs/development/python-modules/napari/default.nix
@@ -41,23 +41,34 @@
   typing-extensions,
   vispy,
   wrapt,
+
+  # tests
+  hypothesis,
+  pretend,
+  pyautogui,
+  pytest-pretty,
+  pytest-qt,
+  pytestCheckHook,
+  writableTmpDirAsHomeHook,
+  xarray,
+  zarr,
 }:
 
 mkDerivationWith buildPythonPackage rec {
   pname = "napari";
-  version = "0.6.4";
+  version = "0.6.6";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "napari";
     repo = "napari";
     tag = "v${version}";
-    hash = "sha256-SmFDIj170CWRuQ/rQX+Nc3cME4GCItNGkxIPPWIn7AA=";
+    hash = "sha256-F0l6GWyZ6n4HNZW7XyUk4ZBPQfrAW4DWixCaRHViDPI=";
   };
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace-fail "scikit-image[data]>=0.19.1" "scikit-image"
+      --replace-fail '"--maxfail=5", ' ""
   '';
 
   build-system = [
@@ -67,6 +78,11 @@ mkDerivationWith buildPythonPackage rec {
 
   nativeBuildInputs = [ wrapQtAppsHook ];
 
+  pythonRelaxDeps = [
+    "app-model"
+    "psygnal"
+    "vispy"
+  ];
   dependencies = [
     app-model
     appdirs
@@ -103,6 +119,82 @@ mkDerivationWith buildPythonPackage rec {
   postFixup = ''
     wrapQtApp $out/bin/napari
   '';
+
+  preCheck = ''
+    rm src/napari/__init__.py
+  '';
+
+  nativeCheckInputs = [
+    hypothesis
+    pretend
+    pyautogui
+    pytest-pretty
+    pytest-qt
+    pytestCheckHook
+    writableTmpDirAsHomeHook
+    xarray
+    zarr
+  ];
+
+  disabledTestPaths = [
+    # Require DISPLAY access
+    "src/napari/_qt/"
+
+    # AttributeError: 'Selection' object has no attribute 'replace_selection'
+    "src/napari/layers/shapes/_tests/test_shapes.py"
+    "src/napari/layers/shapes/_tests/test_shapes_key_bindings.py"
+    "src/napari/layers/shapes/_tests/test_shapes_mouse_bindings.py"
+
+    # Fatal Python error: Aborted
+    "src/napari/_tests/test_adding_removing.py"
+    "src/napari/_tests/test_advanced.py"
+    "src/napari/_tests/test_cli.py"
+    "src/napari/_tests/test_conftest_fixtures.py"
+    "src/napari/_tests/test_function_widgets.py"
+    "src/napari/_tests/test_key_bindings.py"
+    "src/napari/_tests/test_layer_utils_with_qt.py"
+    "src/napari/_tests/test_mouse_bindings.py"
+    "src/napari/_tests/test_multiple_viewers.py"
+    "src/napari/_tests/test_notebook_display.py"
+    "src/napari/_tests/test_top_level_availability.py"
+    "src/napari/_tests/test_with_screenshot.py"
+    "src/napari/_vispy/"
+  ];
+
+  enabledTestPaths = [
+    "src/napari/_tests/"
+  ];
+
+  disabledTests = [
+    # Failed: DID NOT WARN. No warnings of type (<class 'FutureWarning'>,) were emitted.
+    "test_PublicOnlyProxy"
+
+    # NameError: name 'utils' is not defined
+    "test_create_func_deprecated"
+    "test_create_func_renamed"
+    "test_create_func"
+
+    # AttributeError: 'Selection' object has no attribute 'replace_selection'
+    "test_add_empty_shapes_layer"
+    "test_update_data_updates_layer_extent_cache"
+
+    # Fatal Python error: Aborted
+    "test_add_layer_data_to_viewer_optional"
+    "test_from_layer_data_tuple_accept_deprecating_dict"
+    "test_layers_populate_immediately"
+    "test_magicgui_add_data"
+    "test_magicgui_add_future_data"
+    "test_magicgui_add_layer"
+    "test_magicgui_add_layer_inheritance"
+    "test_magicgui_add_threadworker"
+    "test_magicgui_data_updated"
+    "test_magicgui_get_data"
+    "test_magicgui_get_viewer"
+    "test_make_napari_viewer"
+    "test_singlescreen_window_settings"
+    "test_sys_info"
+    "test_view"
+  ];
 
   meta = {
     description = "Fast, interactive, multi-dimensional image viewer";

--- a/pkgs/development/python-modules/pytest-pretty/default.nix
+++ b/pkgs/development/python-modules/pytest-pretty/default.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  hatchling,
+
+  # dependencies
+  pytest,
+  rich,
+
+  # tests
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pytest-pretty";
+  version = "1.3.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "samuelcolvin";
+    repo = "pytest-pretty";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-vJ75zpY0xlTQbi7qTHyqHZ7AMb7bLlM6SNq2b7zcQYs=";
+  };
+
+  build-system = [
+    hatchling
+  ];
+
+  dependencies = [
+    pytest
+    rich
+  ];
+
+  pythonImportsCheck = [ "pytest_pretty" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  meta = {
+    description = "Pytest plugin for pretty printing the test summary";
+    homepage = "https://github.com/samuelcolvin/pytest-pretty";
+    changelog = "https://github.com/samuelcolvin/pytest-pretty/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15102,6 +15102,8 @@ self: super: with self; {
 
   pytest-postgresql = callPackage ../development/python-modules/pytest-postgresql { };
 
+  pytest-pretty = callPackage ../development/python-modules/pytest-pretty { };
+
   pytest-pudb = callPackage ../development/python-modules/pytest-pudb { };
 
   pytest-pycodestyle = callPackage ../development/python-modules/pytest-pycodestyle { };


### PR DESCRIPTION
## Things done

- **python3Packages.pytest-pretty: init at 1.3.0**
- **napari: 0.6.4 -> 0.6.6**

Diff: https://github.com/napari/napari/compare/v0.6.4...v0.6.6
Changelog: https://github.com/napari/napari/releases/tag/v0.6.6

cc @SomeoneSerge

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
