### PR TITLE
ci: auto add '8.has: package (new)' and '8.has: package (update)' labels

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -97,7 +97,7 @@ jobs:
           github.event_name == 'pull_request_target' &&
           !contains(fromJSON(inputs.headBranch).type, 'development')
         with:
-          repo-token: ${{ steps.app-token.outputs.token }}
+          repo-token: ${{ steps.app-token.outputs.token || github.token }}
           configuration-path: .github/labeler.yml # default
           sync-labels: true
 
@@ -107,7 +107,7 @@ jobs:
           github.event_name == 'pull_request_target' &&
           !contains(fromJSON(inputs.headBranch).type, 'development')
         with:
-          repo-token: ${{ steps.app-token.outputs.token }}
+          repo-token: ${{ steps.app-token.outputs.token || github.token }}
           configuration-path: .github/labeler-no-sync.yml
           sync-labels: false
 
@@ -120,7 +120,7 @@ jobs:
           github.event_name == 'pull_request_target' &&
           contains(fromJSON(inputs.headBranch).type, 'development')
         with:
-          repo-token: ${{ steps.app-token.outputs.token }}
+          repo-token: ${{ steps.app-token.outputs.token || github.token }}
           configuration-path: .github/labeler-development-branches.yml
           sync-labels: true
 

--- a/ci/github-script/bot.js
+++ b/ci/github-script/bot.js
@@ -121,6 +121,11 @@ module.exports = async ({ github, context, core, dry }) => {
       return []
     }
 
+    // Forks don't have NixOS teams, return empty list
+    if (isFork) {
+      return []
+    }
+
     if (!members[team_slug]) {
       members[team_slug] = github.paginate(github.rest.teams.listMembersInOrg, {
         org: context.repo.owner,

--- a/ci/github-script/bot.js
+++ b/ci/github-script/bot.js
@@ -344,6 +344,15 @@ module.exports = async ({ github, context, core, dry }) => {
       evalLabels['8.has: package (new)'] =
         hasNewPackages && commitsIndicateNewPackage
 
+      // Label package update PRs: "packagename: X.Y.Z -> A.B.C"
+      // Matches versions like: 1.2.3, 0-unstable-2024-01-15, 1.3rc1, alpha, unstable
+      // Exclude NixOS module commits like "nixos/ncps: types.str -> types.path"
+      const updatePackagePattern = /(?<!nixos\/\S+): [\w.-]+ (->|→) [\w.-]+/
+      const commitsIndicateUpdate = commitMessages.some((msg) =>
+        updatePackagePattern.test(msg),
+      )
+      evalLabels['8.has: package (update)'] = commitsIndicateUpdate
+
       // TODO: Get "changed packages" information from list of changed by-name files
       // in addition to just the Eval results, to make this work for these packages
       // when Eval results have expired as well.


### PR DESCRIPTION
Also fixes some issues i encountered in my fork
- [x] no maintainer map for forks: https://github.com/qweered/nixpkgs/actions/runs/21228401061/job/61081619397?pr=2
- [x] no teams: https://github.com/qweered/nixpkgs/actions/runs/21228563569/job/61082119591?pr=2
- [x] no token fallback: https://github.com/qweered/nixpkgs/actions/runs/21228890775/job/61083218153?pr=2

Tested:
- [x] New package tested in https://github.com/qweered/nixpkgs/pull/2
- [x] Package update tested in https://github.com/qweered/nixpkgs/pull/3
- [x] Fits CONTRIBUTING.md, pkgs/README.md, maintainers/README.md and other READMEs.