### PR TITLE
python3Packages.essent-dynamic-pricing: 0.2.7 -> 0.3.1

### DIFF
--- a/pkgs/development/python-modules/essent-dynamic-pricing/default.nix
+++ b/pkgs/development/python-modules/essent-dynamic-pricing/default.nix
@@ -11,14 +11,14 @@
 
 buildPythonPackage rec {
   pname = "essent-dynamic-pricing";
-  version = "0.2.7";
+  version = "0.3.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "jaapp";
     repo = "py-essent-dynamic-pricing";
-    tag = version;
-    hash = "sha256-jYSyFZ4b6zyfIvT9KkvffH2CteHgy844O76UjUcaTq0=";
+    tag = "v${version}";
+    hash = "sha256-98dh9XNXIVDI0w0/RqEGnDbDpQQoaZz/TvMIl6t3c3o=";
   };
 
   build-system = [ hatchling ];
@@ -36,6 +36,7 @@ buildPythonPackage rec {
   ];
 
   meta = {
+    changelog = "https://github.com/jaapp/py-essent-dynamic-pricing/releases/tag/${src.tag}";
     description = "Async client for Essent dynamic energy prices";
     homepage = "https://github.com/jaapp/py-essent-dynamic-pricing";
     license = lib.licenses.mit;


### PR DESCRIPTION
Diff: https://github.com/jaapp/py-essent-dynamic-pricing/compare/0.2.7...v0.3.1

Changelog: https://github.com/jaapp/py-essent-dynamic-pricing/releases/tag/v0.3.1


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
