### PR TITLE
samba: fix dylib linking of the Darwin build

### DIFF
--- a/pkgs/servers/samba/4.x.nix
+++ b/pkgs/servers/samba/4.x.nix
@@ -294,7 +294,7 @@ stdenv.mkDerivation (finalAttrs: {
   ''
   + lib.optionalString stdenv.hostPlatform.isDarwin ''
     install_name_tool -id \$BIN \$BIN
-    for old_rpath in \$(otool -L \$BIN | grep /private/tmp/ | awk '{print \$1}'); do
+    for old_rpath in \$(otool -L \$BIN | grep "$NIX_BUILD_TOP" | awk '{print \$1}'); do
       new_rpath=\$(find \$SAMBA_LIBS -name \$(basename \$old_rpath) | head -n 1)
       install_name_tool -change \$old_rpath \$new_rpath \$BIN
     done


### PR DESCRIPTION
On MacOS (Darwin), the binaries from the Samba package are broken:

```
> /nix/store/w4vgzhvsznb2f1mb2j4g037q1gaqgv9z-samba-4.22.6/bin/smbclient
dyld[52804]: Library not loaded: /nix/var/nix/builds/nix-52094-3497865619/samba-4.22.6/bin/default/source3/libsecrets3-private-samba.dylib
  Referenced from: <015B8952-F7C2-38A3-A12D-48AEFA0E75CE> /nix/store/w4vgzhvsznb2f1mb2j4g037q1gaqgv9z-samba-4.22.6/bin/smbclient
  Reason: tried: '/nix/var/nix/builds/nix-52094-3497865619/samba-4.22.6/bin/default/source3/libsecrets3-private-samba.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/nix/var/nix/builds/nix-52094-3497865619/samba-4.22.6/bin/default/source3/libsecrets3-private-samba.dylib' (no such file), '/nix/var/nix/builds/nix-52094-3497865619/samba-4.22.6/bin/default/source3/libsecrets3-private-samba.dylib' (no such file)
zsh: abort      /nix/store/w4vgzhvsznb2f1mb2j4g037q1gaqgv9z-samba-4.22.6/bin/smbclient
```

The reason was that Samba would link multiple dylibs with an absolute path, and the fix phase of the build would miss fixing those. The paths remained with the prefix of the build phase, i.e. `/nix/var/nix/builds/nix-52094-3497865619/samba-4.22.6` in my case:

```
 > otool -L /nix/store/w4vgzhvsznb2f1mb2j4g037q1gaqgv9z-samba-4.22.6/bin/smbclient
/nix/store/w4vgzhvsznb2f1mb2j4g037q1gaqgv9z-samba-4.22.6/bin/smbclient:
	/nix/var/nix/builds/nix-52094-3497865619/samba-4.22.6/bin/default/source3/libsecrets3-private-samba.dylib (compatibility version 0.0.0, current version 0.0.0)
	/nix/var/nix/builds/nix-52094-3497865619/samba-4.22.6/bin/default/libcli/smb/libcli-smb-common-private-samba.dylib (compatibility version 0.0.0, current version 0.0.0)
	/nix/var/nix/builds/nix-52094-3497865619/samba-4.22.6/bin/default/source3/libmsrpc3-private-samba.dylib (compatibility version 0.0.0, current version 0.0.0)
	/nix/var/nix/builds/nix-52094-3497865619/samba-4.22.6/bin/default/lib/cmdline/libcmdline-private-samba.dylib (compatibility version 0.0.0, current version 0.0.0)
	...
	/nix/var/nix/builds/nix-52094-3497865619/samba-4.22.6/bin/default/source4/cluster/libcluster-private-samba.dylib (compatibility version 0.0.0, current version 0.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1345.100.2)
	/nix/store/y8vg2kwrjars521zhvjzg0cnsi6wp0qx-tdb-1.4.14/lib/libtdb.dylib (compatibility version 0.0.0, current version 0.0.0)
	/nix/store/6nmmi317rg2bnybndbgc944dpg5cnl5a-libiconv-109.100.2/lib/libiconv.2.dylib (compatibility version 7.0.0, current version 7.0.0)
	/nix/store/fkg4bcwdw22jj6aw8ylq23zv2jj32ak3-libbsd-0.12.2/lib/libbsd.0.dylib (compatibility version 13.0.0, current version 13.2.0)
	...
	/nix/store/axw3iz1kfaq6nir6jj1vk5a0g1nfg0wk-gettext-0.25.1/lib/libintl.8.dylib (compatibility version 13.0.0, current version 13.4.0)

```

## Things done

Changed the hardcoded post-fixup lookup path for "build path prefixes" `/private/tmp/` in the case of `stdenv.hostPlatform.isDarwin` to `$NIX_BUILD_TOP`. I'm not sure about the exact history of Nix on MacOS, but it seems that the `/private/tmp` path isn't used for builds anymore, at least it isn't for the distribution I am using.

Ran the build, and verified the binaries to work correctly now.

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
