### PR TITLE
github/labeler: fix auto-tag backport for .github/actions

### DIFF
--- a/.github/labeler-no-sync.yml
+++ b/.github/labeler-no-sync.yml
@@ -26,7 +26,7 @@
   - all:
       - changed-files:
           - any-glob-to-any-file:
-              - .github/actions/*
+              - .github/actions/**/*
               - .github/workflows/*
               - .github/labeler*.yml
               - ci/**/*.*


### PR DESCRIPTION
As observed in https://github.com/NixOS/nixpkgs/pull/482470#issuecomment-3781925048, `.github/actions/*` does not match deeply nested files like `.github/actions/checkout/action.yml`. Instead, we need a recursive glob like `**/*`.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
