### PR TITLE
nixos/proton-vpn-daemon: init module; nixos/proton-vpn: init module

### DIFF
--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -148,6 +148,8 @@
 
 - Added `dell-bios-fan-control` package and service.
 
+- The `services.proton-vpn` and `services.proton-vpn-daemon` NixOS modules have been added to facilitate declarative management of the Proton VPN Linux client and its background daemon.
+
 - `openrgb` was updated to 1.0rc2, which now uses Plugin API version 4.
   Some existing OpenRGB plugins may be incompatible or require updates.
 

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1333,6 +1333,7 @@
   ./services/networking/privoxy.nix
   ./services/networking/prosody.nix
   ./services/networking/proton-vpn-daemon.nix
+  ./services/networking/proton-vpn.nix
   ./services/networking/pyload.nix
   ./services/networking/quassel.nix
   ./services/networking/quicktun.nix

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1332,6 +1332,7 @@
   ./services/networking/pptpd.nix
   ./services/networking/privoxy.nix
   ./services/networking/prosody.nix
+  ./services/networking/proton-vpn-daemon.nix
   ./services/networking/pyload.nix
   ./services/networking/quassel.nix
   ./services/networking/quicktun.nix

--- a/nixos/modules/services/networking/proton-vpn-daemon.nix
+++ b/nixos/modules/services/networking/proton-vpn-daemon.nix
@@ -1,0 +1,23 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.proton-vpn-daemon;
+in
+{
+  meta.maintainers = [ lib.maintainers.HeitorAugustoLN ];
+
+  options.services.proton-vpn-daemon = {
+    enable = lib.mkEnableOption "Proton VPN Daemon";
+    package = lib.mkPackageOption pkgs [ "python3Packages" "proton-vpn-daemon" ] { };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+    services.dbus.packages = [ cfg.package ];
+    systemd.packages = [ cfg.package ];
+  };
+}

--- a/nixos/modules/services/networking/proton-vpn.nix
+++ b/nixos/modules/services/networking/proton-vpn.nix
@@ -1,0 +1,23 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.proton-vpn;
+in
+{
+  meta.maintainers = [ lib.maintainers.HeitorAugustoLN ];
+
+  options.services.proton-vpn = {
+    enable = lib.mkEnableOption "Proton VPN";
+    package = lib.mkPackageOption pkgs "protonvpn-gui" { };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+    networking.firewall.checkReversePath = lib.mkDefault false;
+    services.proton-vpn-daemon.enable = lib.mkDefault true;
+  };
+}

--- a/pkgs/development/python-modules/proton-vpn-daemon/default.nix
+++ b/pkgs/development/python-modules/proton-vpn-daemon/default.nix
@@ -3,6 +3,8 @@
   buildPythonPackage,
   fetchFromGitHub,
   bcc,
+  coreutils,
+  python,
   dbus-fast,
   packaging,
   proton-core,
@@ -13,6 +15,7 @@
   pytestCheckHook,
   setuptools,
   systemd-python,
+  wireguard-tools,
 }:
 
 buildPythonPackage rec {
@@ -27,6 +30,11 @@ buildPythonPackage rec {
     hash = "sha256-0CqMGyaHjMktM3N1MfrELprZQZqJD1w/mFaOJvJApZQ=";
   };
 
+  postPatch = ''
+    substituteInPlace proton/vpn/daemon/split_tunneling/apps/socket_monitor.py \
+      --replace-fail "/usr/bin/wg" "${lib.getExe wireguard-tools}"
+  '';
+
   build-system = [
     setuptools
   ];
@@ -39,6 +47,7 @@ buildPythonPackage rec {
     proton-vpn-api-core
     psutil
     systemd-python
+    wireguard-tools
   ];
 
   # Needed for `pythonImportsCheck`, `postBuild` happens between `pythonImportsCheckPhase` and `pytestCheckPhase`.
@@ -46,6 +55,22 @@ buildPythonPackage rec {
     # Needed for Permission denied: '/homeless-shelter'
     export HOME=$(mktemp -d)
     export XDG_RUNTIME_DIR=$(mktemp -d)
+  '';
+
+  postInstall = ''
+    mkdir -p "$out/lib/systemd/system"
+    mkdir -p "$out/share/dbus-1/system-services"
+    mkdir -p "$out/share/dbus-1/system.d"
+
+    install -Dm644 rpmbuild/SOURCES/systemd.service "$out/lib/systemd/system/proton.VPN.service"
+    install -Dm644 rpmbuild/SOURCES/dbus.service "$out/share/dbus-1/system-services/me.proton.vpn.split_tunneling.service"
+    install -Dm644 rpmbuild/SOURCES/dbus.conf "$out/share/dbus-1/system.d/me.proton.vpn.split_tunneling.conf"
+
+    substituteInPlace "$out/lib/systemd/system/proton.VPN.service" \
+      --replace-fail "/usr/bin/python3" "${lib.getExe python}"
+
+    substituteInPlace "$out/share/dbus-1/system-services/me.proton.vpn.split_tunneling.service" \
+      --replace-fail "/bin/false" "${lib.getExe' coreutils "false"}"
   '';
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/proton-vpn-daemon/default.nix
+++ b/pkgs/development/python-modules/proton-vpn-daemon/default.nix
@@ -89,6 +89,9 @@ buildPythonPackage rec {
     homepage = "https://github.com/ProtonVPN/proton-vpn-daemon";
     license = lib.licenses.gpl3Only;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ anthonyroussel ];
+    maintainers = with lib.maintainers; [
+      anthonyroussel
+      HeitorAugustoLN
+    ];
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This should add support for split tunneling in NixOS

- `python3Packages.proton-vpn-daemon: add systemd service, dbus config and wireguard-tools`
- `python3Packages.proton-vpn-daemon: add HeitorAugustoLN as maintainer`
- `nixos/proton-vpn-daemon: init module`
- `nixos/proton-vpn: init module`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
