### PR TITLE
python314Packages.cs50: fix build for python 3.14

### DIFF
--- a/pkgs/development/python-modules/cs50/default.nix
+++ b/pkgs/development/python-modules/cs50/default.nix
@@ -13,14 +13,14 @@
 
 buildPythonPackage rec {
   pname = "cs50";
-  version = "9.4.0";
+  version = "9.5.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "cs50";
     repo = "python-cs50";
     tag = "v${version}";
-    hash = "sha256-g7ws5ikzLt2ciS0QTPTJDRAqePyYPDCYIpJuwnWHJNQ=";
+    hash = "sha256-jJji5EyvKfJ9vkzETsh0CJ9WIi7hWF2amHrOvf4/JbI=";
   };
 
   build-system = [


### PR DESCRIPTION
~~Waiting on: https://github.com/cs50/python-cs50/pull/198~~

Related: https://github.com/NixOS/nixpkgs/issues/475732


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
