### PR TITLE
nixos/qbittorrent: copy config instead of symlinking to nix store

### DIFF
--- a/nixos/modules/services/torrent/qbittorrent.nix
+++ b/nixos/modules/services/torrent/qbittorrent.nix
@@ -53,7 +53,7 @@ let
       else
         mkKeyValueDefault { } sep k v;
   };
-  configFile = pkgs.writeText "qBittorrent.conf" (gendeepINI cfg.serverConfig);
+  configContent = gendeepINI cfg.serverConfig;
 in
 {
   options.services.qbittorrent = {
@@ -154,10 +154,10 @@ in
             mode = "755";
             inherit (cfg) user group;
           };
-          "${cfg.profileDir}/qBittorrent/config/qBittorrent.conf"."L+" = mkIf (cfg.serverConfig != { }) {
-            mode = "1400";
+          "${cfg.profileDir}/qBittorrent/config/qBittorrent.conf"."f+" = mkIf (cfg.serverConfig != { }) {
+            mode = "600";
             inherit (cfg) user group;
-            argument = "${configFile}";
+            argument = configContent;
           };
         };
       };
@@ -170,7 +170,7 @@ in
           "nss-lookup.target"
         ];
         wantedBy = [ "multi-user.target" ];
-        restartTriggers = optionals (cfg.serverConfig != { }) [ configFile ];
+        restartTriggers = optionals (cfg.serverConfig != { }) [ configContent ];
 
         serviceConfig = {
           Type = "simple";


### PR DESCRIPTION
The `serverConfig` option generates a declarative config file, but the current implementation uses a tmpfiles `L+` rule to create a symlink to the config in the nix store. This doesn't work because:
1. qBittorrent reads its config and then writes back to it at runtime
2. The nix store is read-only
3. qBittorrent silently falls back to default/stale settings
This PR changes the approach to use `ExecStartPre` to copy the declarative config to the runtime location before qBittorrent starts. With this change, WebUI changes won't persist across service restarts.

I came across this issue when trying to get qBittorrent working again once Vuetorrent was updated. Because of the update, the nix store path changed, breaking the WebUI.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
