### PR TITLE
oama: 0.20.2 -> 0.22.0

### DIFF
--- a/pkgs/by-name/oa/oama/generated-package.nix
+++ b/pkgs/by-name/oa/oama/generated-package.nix
@@ -10,6 +10,7 @@
   cryptohash-sha256,
   directory,
   fetchgit,
+  githash,
   hsyslog,
   http-conduit,
   http-types,
@@ -34,11 +35,11 @@
 }:
 mkDerivation {
   pname = "oama";
-  version = "0.20.2";
+  version = "0.22.0";
   src = fetchgit {
     url = "https://github.com/pdobsan/oama.git";
-    sha256 = "1zr2a77b3azdqyk6hzchhg573gwwb5h0d7x382srggm25lp3isk9";
-    rev = "bbe5a6d9f87659c8a24b6515694acf1b522a396b";
+    sha256 = "1lasr8psfsgc43in6lgaf7byvmdvanhg7idxijz504z6ga7v0pnj";
+    rev = "e419ef10ca4feacf4818c5cd9bd5e617f7ee2ee7";
     fetchSubmodules = true;
   };
   isLibrary = true;
@@ -51,6 +52,7 @@ mkDerivation {
     containers
     cryptohash-sha256
     directory
+    githash
     hsyslog
     http-conduit
     http-types
@@ -80,6 +82,7 @@ mkDerivation {
     containers
     cryptohash-sha256
     directory
+    githash
     hsyslog
     http-conduit
     http-types

--- a/pkgs/by-name/oa/oama/no-githash.patch
+++ b/pkgs/by-name/oa/oama/no-githash.patch
@@ -1,0 +1,43 @@
+--- a/lib/OAMa/CommandLine.hs
++++ b/lib/OAMa/CommandLine.hs
+@@ -10,31 +10,11 @@
+   versionInfo,
+ ) where
+ 
+-import Data.Time.Clock.POSIX qualified as TCP
+-import Data.Time.Format qualified as TF
+ import Data.Version (showVersion)
+ import Data.Yaml qualified as Yaml
+ import GHC.Generics
+-import GitHash
+ import Options.Applicative
+ import Paths_oama (version)
+-import Text.Printf
+-
+-gi :: GitInfo
+-gi = $$tGitInfoCwd
+-
+-_GIT_STATUS_INFO :: String
+-_GIT_STATUS_INFO =
+-  printf
+-    "%s %04d.%s%s"
+-    ( TF.formatTime
+-        TF.defaultTimeLocale
+-        "%Y-%m-%d"
+-        (TCP.posixSecondsToUTCTime (fromIntegral (giCommitTime gi)))
+-    )
+-    (giCommitCount gi)
+-    (take 8 (giHash gi))
+-    (if giDirty gi then " dirty" else "")
+ 
+ data Opts = Opts
+   { optConfig :: !String,
+@@ -65,7 +45,7 @@
+     )
+ 
+ versionInfo :: String
+-versionInfo = showVersion version <> printf " - %s" _GIT_STATUS_INFO
++versionInfo = showVersion version
+ 
+ versionOption :: Parser (a -> a)
+ versionOption = do

--- a/pkgs/by-name/oa/oama/package.nix
+++ b/pkgs/by-name/oa/oama/package.nix
@@ -16,6 +16,10 @@ let
     description = "OAuth credential MAnager";
     homepage = "https://github.com/pdobsan/oama";
 
+    patches = [
+      ./no-githash.patch
+    ];
+
     passthru.updateScript = ./update.sh;
 
     buildDepends = [


### PR DESCRIPTION
Release notes: https://github.com/pdobsan/oama/releases/tag/0.22.0
Changelog: https://github.com/pdobsan/oama/compare/bbe5a6d9f87659c8a24b6515694acf1b522a396b...0.22.0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
