### PR TITLE
[backport release-25.11] github/labeler: backport changes to labeler-no-sync

### DIFF
--- a/.github/labeler-no-sync.yml
+++ b/.github/labeler-no-sync.yml
@@ -26,7 +26,7 @@
   - all:
       - changed-files:
           - any-glob-to-any-file:
-              - .github/actions/*
+              - .github/actions/**/*
               - .github/workflows/*
               - .github/labeler*.yml
               - ci/**/*.*

--- a/.github/labeler-no-sync.yml
+++ b/.github/labeler-no-sync.yml
@@ -23,12 +23,13 @@
               - nixos/doc/**/*
 
 "backport release-25.11":
-  - any:
+  - all:
       - changed-files:
           - any-glob-to-any-file:
               - .github/actions/*
               - .github/workflows/*
               - ci/**/*.*
               - maintainers/github-teams.json
+      - base-branch: ['master']
 
 # keep-sorted end

--- a/.github/labeler-no-sync.yml
+++ b/.github/labeler-no-sync.yml
@@ -22,4 +22,13 @@
               - doc/**/*
               - nixos/doc/**/*
 
+"backport release-25.11":
+  - any:
+      - changed-files:
+          - any-glob-to-any-file:
+              - .github/actions/*
+              - .github/workflows/*
+              - ci/**/*.*
+              - maintainers/github-teams.json
+
 # keep-sorted end

--- a/.github/labeler-no-sync.yml
+++ b/.github/labeler-no-sync.yml
@@ -28,6 +28,7 @@
           - any-glob-to-any-file:
               - .github/actions/*
               - .github/workflows/*
+              - .github/labeler*.yml
               - ci/**/*.*
               - maintainers/github-teams.json
       - base-branch: ['master']


### PR DESCRIPTION
Manual backport of commits touching `.github/labeler-no-sync.yml`, to enable future automatic backports.

- https://github.com/NixOS/nixpkgs/pull/464873
- https://github.com/NixOS/nixpkgs/pull/472196
- https://github.com/NixOS/nixpkgs/pull/472781
- https://github.com/NixOS/nixpkgs/pull/482510

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
