### PR TITLE
rocm-modules: use clr.localGpuTargets everywhere

### DIFF
--- a/pkgs/development/rocm-modules/hipcub/default.nix
+++ b/pkgs/development/rocm-modules/hipcub/default.nix
@@ -11,7 +11,7 @@
   gbenchmark,
   buildTests ? false,
   buildBenchmarks ? false,
-  gpuTargets ? [ ],
+  gpuTargets ? clr.localGpuTargets or [ ],
 }:
 
 # CUB can also be used as a backend instead of rocPRIM.

--- a/pkgs/development/rocm-modules/hipfft/default.nix
+++ b/pkgs/development/rocm-modules/hipfft/default.nix
@@ -15,7 +15,7 @@
   buildTests ? false,
   buildBenchmarks ? false,
   buildSamples ? false,
-  gpuTargets ? [ ],
+  gpuTargets ? clr.localGpuTargets or [ ],
 }:
 
 # Can also use cuFFT

--- a/pkgs/development/rocm-modules/hiprand/default.nix
+++ b/pkgs/development/rocm-modules/hiprand/default.nix
@@ -9,7 +9,7 @@
   rocrand,
   gtest,
   buildTests ? false,
-  gpuTargets ? [ ],
+  gpuTargets ? clr.localGpuTargets or [ ],
 }:
 
 stdenv.mkDerivation (finalAttrs: {

--- a/pkgs/development/rocm-modules/hipsparse/default.nix
+++ b/pkgs/development/rocm-modules/hipsparse/default.nix
@@ -13,7 +13,7 @@
   buildTests ? false,
   buildBenchmarks ? false,
   buildSamples ? false,
-  gpuTargets ? [ ],
+  gpuTargets ? clr.localGpuTargets or [ ],
 }:
 
 # This can also use cuSPARSE as a backend instead of rocSPARSE

--- a/pkgs/development/rocm-modules/mivisionx/default.nix
+++ b/pkgs/development/rocm-modules/mivisionx/default.nix
@@ -25,7 +25,7 @@
   useOpenCL ? false,
   useCPU ? false,
   buildDocs ? false, # Needs internet
-  gpuTargets ? [ ],
+  gpuTargets ? clr.localGpuTargets or [ ],
 }:
 
 stdenv.mkDerivation (finalAttrs: {

--- a/pkgs/development/rocm-modules/rocalution/default.nix
+++ b/pkgs/development/rocm-modules/rocalution/default.nix
@@ -17,7 +17,7 @@
   buildTests ? false,
   buildBenchmarks ? false,
   buildSamples ? false,
-  gpuTargets ? [ ], # gpuTargets = [ "gfx803" "gfx900:xnack-" "gfx906:xnack-" ... ]
+  gpuTargets ? clr.localGpuTargets or [ ], # gpuTargets = [ "gfx803" "gfx900:xnack-" "gfx906:xnack-" ... ]
 }:
 
 stdenv.mkDerivation (finalAttrs: {

--- a/pkgs/development/rocm-modules/rocprim/default.nix
+++ b/pkgs/development/rocm-modules/rocprim/default.nix
@@ -10,7 +10,7 @@
   gbenchmark,
   buildTests ? false,
   buildBenchmarks ? false,
-  gpuTargets ? [ ],
+  gpuTargets ? clr.localGpuTargets or [ ],
 }:
 
 stdenv.mkDerivation (finalAttrs: {

--- a/pkgs/development/rocm-modules/rocthrust/default.nix
+++ b/pkgs/development/rocm-modules/rocthrust/default.nix
@@ -10,7 +10,7 @@
   gtest,
   buildTests ? false,
   buildBenchmarks ? false,
-  gpuTargets ? [ ],
+  gpuTargets ? clr.localGpuTargets or [ ],
 }:
 
 stdenv.mkDerivation (finalAttrs: {

--- a/pkgs/development/rocm-modules/rocwmma/default.nix
+++ b/pkgs/development/rocm-modules/rocwmma/default.nix
@@ -14,7 +14,7 @@
   buildExtendedTests ? false,
   buildBenchmarks ? false,
   buildSamples ? false,
-  gpuTargets ? [ ],
+  gpuTargets ? clr.localGpuTargets or [ ],
 }:
 
 stdenv.mkDerivation (finalAttrs: {

--- a/pkgs/development/rocm-modules/rpp/default.nix
+++ b/pkgs/development/rocm-modules/rpp/default.nix
@@ -14,7 +14,7 @@
   buildDocs ? false, # Needs internet
   useOpenCL ? false,
   useCPU ? false,
-  gpuTargets ? [ ],
+  gpuTargets ? clr.localGpuTargets or [ ],
 }:
 
 stdenv.mkDerivation (finalAttrs: {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Use `clr.localGpuTargets` as default gpu targets everywhere.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
