### PR TITLE
librewolf-bin-unwrapped: 146.0.1-1 -> 147.0.1-3, fix update script

### DIFF
--- a/pkgs/by-name/li/librewolf-bin-unwrapped/package.nix
+++ b/pkgs/by-name/li/librewolf-bin-unwrapped/package.nix
@@ -22,7 +22,6 @@ let
   binaryName = "librewolf";
 
   mozillaPlatforms = {
-    i686-linux = "linux-i686";
     x86_64-linux = "linux-x86_64";
     aarch64-linux = "linux-arm64";
   };
@@ -44,10 +43,9 @@ stdenv.mkDerivation {
   inherit pname version;
 
   src = fetchurl {
-    url = "https://gitlab.com/api/v4/projects/44042130/packages/generic/librewolf/${version}/librewolf-${version}-${arch}-package.tar.xz";
+    url = "https://codeberg.org/api/packages/librewolf/generic/librewolf/${version}/librewolf-${version}-${arch}-package.tar.xz";
     hash =
       {
-        i686-linux = "sha256-Z8dQhYH3PuKI2vXQ2nQ4CmyNyDxtAirX0YVxI0r5n3w=";
         x86_64-linux = "sha256-pRpSHAkLQpg80pOfUBvGBujr4fDDg4wpltVIw9wrlBE=";
         aarch64-linux = "sha256-BTqzBAohy+kcWou2WKStoAykcqV1DYfLRNbjUF/TTIY=";
       }

--- a/pkgs/by-name/li/librewolf-bin-unwrapped/package.nix
+++ b/pkgs/by-name/li/librewolf-bin-unwrapped/package.nix
@@ -36,7 +36,7 @@ let
 
   pname = "librewolf-bin-unwrapped";
 
-  version = "146.0.1-1";
+  version = "147.0.1-3";
 in
 
 stdenv.mkDerivation {
@@ -46,8 +46,8 @@ stdenv.mkDerivation {
     url = "https://codeberg.org/api/packages/librewolf/generic/librewolf/${version}/librewolf-${version}-${arch}-package.tar.xz";
     hash =
       {
-        x86_64-linux = "sha256-pRpSHAkLQpg80pOfUBvGBujr4fDDg4wpltVIw9wrlBE=";
-        aarch64-linux = "sha256-BTqzBAohy+kcWou2WKStoAykcqV1DYfLRNbjUF/TTIY=";
+        x86_64-linux = "sha256-SPGUDTwdEi9ztH9MiFxtiY+xn3258znyu6yw5a9J/YE=";
+        aarch64-linux = "sha256-a6xFoZbBtoFgZFYGmz8IIvBsVP+qKTX32ufmQGdtMBk=";
       }
       .${stdenv.hostPlatform.system} or throwSystem;
   };

--- a/pkgs/by-name/li/librewolf-bin-unwrapped/update.sh
+++ b/pkgs/by-name/li/librewolf-bin-unwrapped/update.sh
@@ -3,7 +3,7 @@
 
 set -eou pipefail
 
-latestVersion=$(curl ${GITLAB_TOKEN:+-H "Private-Token: $GITLAB_TOKEN"} -sL https://gitlab.com/api/v4/projects/44042130/releases | jq -r '.[0].tag_name')
+latestVersion=$(curl ${CODEBERG_TOKEN:+-H "Authorization: token $CODEBERG_TOKEN"} -H 'accept: application/json' -sL https://codeberg.org/api/v1/repos/librewolf/bsys6/releases/latest | jq -r '.tag_name')
 currentVersion=$(nix-instantiate --eval -E "with import ./. {}; librewolf-bin-unwrapped.version or (lib.getVersion librewolf-bin-unwrapped)" | tr -d '"')
 
 echo "latest  version: $latestVersion"
@@ -15,10 +15,9 @@ if [[ "$latestVersion" == "$currentVersion" ]]; then
 fi
 
 for i in \
-    "i686-linux linux-i686" \
     "x86_64-linux linux-x86_64" \
     "aarch64-linux linux-arm64"; do
     set -- $i
-    hash=$(nix --extra-experimental-features nix-command hash convert --to sri --hash-algo sha256 $(curl ${GITLAB_TOKEN:+-H "Private-Token: $GITLAB_TOKEN"} -sL https://gitlab.com/api/v4/projects/44042130/packages/generic/librewolf/$latestVersion/librewolf-$latestVersion-$2-package.tar.xz.sha256sum))
+    hash=$(nix --extra-experimental-features nix-command hash convert --to sri --hash-algo sha256 $(curl ${CODEBERG_TOKEN:+-H "Authorization: token $CODEBERG_TOKEN"} -sL https://codeberg.org/api/packages/librewolf/generic/librewolf/$latestVersion/librewolf-$latestVersion-$2-package.tar.xz.sha256sum))
     update-source-version librewolf-bin-unwrapped $latestVersion $hash --system=$1 --ignore-same-version
 done


### PR DESCRIPTION
- **librewolf-bin-unwrapped: fix update script**
- **librewolf-bin-unwrapped: 146.0.1-1 -> 147.0.1-3**

screenshot from working browser:

<img width="506" height="237" alt="image" src="https://github.com/user-attachments/assets/8ffed986-0e7e-4e6b-b736-65c877d899b8" />


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
