### PR TITLE
[WIP] balatro-mod-manager: init at 0.3.8

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7094,6 +7094,11 @@
     githubId = 252042;
     keys = [ { fingerprint = "85F3 72DF 4AF3 EF13 ED34  72A3 0AAF 2901 E804 0715"; } ];
   };
+  drxxmy = {
+    name = "Vladislav";
+    github = "drxxmy";
+    githubId = 118668125;
+  };
   DrymarchonShaun = {
     name = "Shaun";
     email = "drymarchonshaun@protonmail.com";

--- a/pkgs/by-name/ba/balatro-mod-manager/package.nix
+++ b/pkgs/by-name/ba/balatro-mod-manager/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  appimageTools,
+  fetchurl,
+  ...
+}:
+
+let
+  version = "0.3.8";
+  pname = "balatro-mod-manager";
+
+  src = fetchurl {
+    url = "https://github.com/skyline69/balatro-mod-manager/releases/download/v${version}/Balatro.Mod.Manager_${version}_amd64.AppImage";
+    hash = "sha256-O03A4ErrJD31Ltn3BIQVBRb458dtj/zeORqln/gCd40=";
+  };
+
+  appimageContents = appimageTools.extract { inherit pname version src; };
+
+in
+appimageTools.wrapType2 rec {
+  inherit pname version src;
+
+  extraInstallCommands = ''
+    # install desktop file
+    install -m 444 -D "${appimageContents}/Balatro Mod Manager.desktop" "$out/share/applications/${pname}.desktop"
+
+    # install icons
+    if [ -d "${appimageContents}/usr/share/icons" ]; then
+      mkdir -p "$out/share/icons"
+      cp -r "${appimageContents}/usr/share/icons"/* "$out/share/icons/"
+    fi
+
+    # patch Exec line
+    substituteInPlace "$out/share/applications/${pname}.desktop" \
+      --replace-fail 'Exec=BMM' 'Exec=${meta.mainProgram}'
+  '';
+
+  meta = {
+    mainProgram = "balatro-mod-manager";
+    description = "Mod manager for Balatro";
+    homepage = "https://github.com/skyline69/balatro-mod-manager";
+    downloadPage = "https://github.com/skyline69/balatro-mod-manager/releases";
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [ drxxmy ];
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
# Balatro Mod Manager
- Description: A standalone mod management tool for Balatro.
- License: GPL-3.0 license
- Maintainer: [drxxmy](https://github.com/drxxmy)
- Upstream: https://github.com/skyline69/balatro-mod-manager

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test