### PR TITLE
rke2: clarify documentation

### DIFF
--- a/pkgs/applications/networking/cluster/rke2/README.md
+++ b/pkgs/applications/networking/cluster/rke2/README.md
@@ -33,7 +33,8 @@ release channel tied to each Kubernetes minor version, e.g. `v1.32`.
 
 Nixpkgs follows active minor version release channels (typically 4 at a time) and sets aliases for
 `rke2_stable` and `rke2_latest` accordingly. The [update-script](./update-script.sh) takes care of
-updating the aliases automatically.
+updating the aliases automatically, but these updates **should not be backported** to release
+channels as they can cause breakage on multi-node clusters.
 
 For further information visit the
 [RKE2 release channels documentation](https://docs.rke2.io/upgrades/manual_upgrade?_highlight=manua#release-channels).
@@ -64,7 +65,8 @@ by doing the following:
 2. Add a new package block to [default.nix](./default.nix), you can copy an existing block from a
    previous release and update the version numbers
    - `rke2_1_35 = ...`
-3. Run the update script for the new package
+3. Add the package reference to [pkgs/top-level/all-packages.nix](/pkgs/top-level/all-packages.nix)
+4. Run the update script for the new package
    - `./pkgs/applications/networking/cluster/rke2/update-script.sh 35`
 
 New minor versions are **not** backported to stable release channels.

--- a/pkgs/applications/networking/cluster/rke2/default.nix
+++ b/pkgs/applications/networking/cluster/rke2/default.nix
@@ -45,7 +45,7 @@ rec {
     }
   ) extraArgs;
 
-  # Automatically set by update script
+  # Automatically set by update script, changes shouldn't be backported
   rke2_stable = rke2_1_34;
   rke2_latest = rke2_1_35;
 }


### PR DESCRIPTION
Clarified alias updates on release channels as discussed in #481167, also added a missing step to the new minor version packaging process.

cc @rorosen @zimbatm @stefan-bordei
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
