### PR TITLE
[25.11] python3Packages.weasyprint: 66.0 -> 68.0

### DIFF
--- a/pkgs/development/python-modules/pillow/default.nix
+++ b/pkgs/development/python-modules/pillow/default.nix
@@ -44,14 +44,14 @@
 
 buildPythonPackage rec {
   pname = "pillow";
-  version = "12.0.0";
+  version = "12.1.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "python-pillow";
     repo = "pillow";
     tag = version;
-    hash = "sha256-58mjwHErEZPkkGBVZznkkMQN5Zo4ZBBiXnhqVp1F81g=";
+    hash = "sha256-QGtuxKpkx2FScQHj9lH4mhEAo6jE+NAR2sR5/zvHUuA=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/tinycss2/default.nix
+++ b/pkgs/development/python-modules/tinycss2/default.nix
@@ -11,7 +11,7 @@
 
 buildPythonPackage rec {
   pname = "tinycss2";
-  version = "1.4.0";
+  version = "1.5.1";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -22,7 +22,7 @@ buildPythonPackage rec {
     tag = "v${version}";
     # for tests
     fetchSubmodules = true;
-    hash = "sha256-GVymUobWAE0YS65lti9dXRIIGpx0YkwF/vSb3y7cpYY=";
+    hash = "sha256-ZVmdHrqfF5fvBvHLaG2B4m1zek4wfEYArkntWzOqhfM=";
   };
 
   build-system = [ flit-core ];

--- a/pkgs/development/python-modules/weasyprint/default.nix
+++ b/pkgs/development/python-modules/weasyprint/default.nix
@@ -32,7 +32,7 @@
 
 buildPythonPackage rec {
   pname = "weasyprint";
-  version = "66.0";
+  version = "68.0";
   pyproject = true;
 
   __darwinAllowLocalNetworking = true;
@@ -41,7 +41,7 @@ buildPythonPackage rec {
     owner = "Kozea";
     repo = "WeasyPrint";
     tag = "v${version}";
-    hash = "sha256-wmEDVEbikBpOQ5394IBPWQRjWZOLfMzEGxTtq4tt2Tw=";
+    hash = "sha256-kAJgSQz1RKrPwzO7I5xHXyXcXYJtvca9izjrAgTy3ek=";
   };
 
   patches = [
@@ -98,6 +98,10 @@ buildPythonPackage rec {
     "test_visibility_3"
     "test_visibility_4"
     "test_woff_simple"
+    # AssertionError
+    "test_2d_transform"
+    # Reported upstream: https://github.com/Kozea/WeasyPrint/issues/2666
+    "test_text_stroke"
   ];
 
   FONTCONFIG_FILE = "${fontconfig.out}/etc/fonts/fonts.conf";

--- a/pkgs/development/python-modules/weasyprint/library-paths.patch
+++ b/pkgs/development/python-modules/weasyprint/library-paths.patch
@@ -1,14 +1,14 @@
 diff --git a/weasyprint/text/ffi.py b/weasyprint/text/ffi.py
-index b5a9cf2..9380a79 100644
+index f57da3c..c50e41d 100644
 --- a/weasyprint/text/ffi.py
 +++ b/weasyprint/text/ffi.py
-@@ -444,25 +444,12 @@ if hasattr(os, 'add_dll_directory') and not hasattr(sys, 'frozen'):  # pragma: n
+@@ -473,25 +473,12 @@ if hasattr(os, 'add_dll_directory') and not hasattr(sys, 'frozen'):  # pragma: n
          with suppress((OSError, FileNotFoundError)):
              os.add_dll_directory(dll_directory)
  
 -gobject = _dlopen(
 -    ffi, 'libgobject-2.0-0', 'gobject-2.0-0', 'gobject-2.0',
--    'libgobject-2.0.so.0', 'libgobject-2.0.dylib', 'libgobject-2.0-0.dll')
+-    'libgobject-2.0.so.0', 'libgobject-2.0.0.dylib', 'libgobject-2.0-0.dll')
 -pango = _dlopen(
 -    ffi, 'libpango-1.0-0', 'pango-1.0-0', 'pango-1.0', 'libpango-1.0.so.0',
 -    'libpango-1.0.dylib', 'libpango-1.0-0.dll')
@@ -25,12 +25,12 @@ index b5a9cf2..9380a79 100644
 -pangoft2 = _dlopen(
 -    ffi, 'libpangoft2-1.0-0', 'pangoft2-1.0-0', 'pangoft2-1.0',
 -    'libpangoft2-1.0.so.0', 'libpangoft2-1.0.dylib', 'libpangoft2-1.0-0.dll')
-+gobject = _dlopen(ffi, "@gobject@")
-+pango = _dlopen(ffi, "@pango@")
-+harfbuzz = _dlopen(ffi, "@harfbuzz@")
-+harfbuzz_subset = _dlopen(ffi, "@harfbuzz_subset@", allow_fail=True)
-+fontconfig = _dlopen(ffi, "@fontconfig@")
-+pangoft2 = _dlopen(ffi, "@pangoft2@")
++gobject = _dlopen(ffi, '@gobject@')
++pango = _dlopen(ffi, '@pango@')
++harfbuzz = _dlopen(ffi, '@harfbuzz@')
++harfbuzz_subset = _dlopen(ffi, '@harfbuzz_subset@', allow_fail=True)
++fontconfig = _dlopen(ffi, '@fontconfig@')
++pangoft2 = _dlopen(ffi, '@pangoft2@')
  
  gobject.g_type_init()
  


### PR DESCRIPTION
Backport of #481900 to release-25.11 (security-related).

Cherry-picked commits:
- python3Packages.tinycss2: 1.4.0 -> 1.5.1 (from d1ce5aaadfd4539bcedaa8542d6ec202458ca686)
- python3Packages.pillow: 12.0.0 -> 12.1.0 (from 63bf1339ff574ea1edc78995b818d827dbbe4e8f)
- python3Packages.weasyprint: 66.0 -> 68.0 (from c6eda5ca8b0fa9a0254b43fdc8249afb797a80d5)

Tested: nix build .#python3Packages.weasyprint

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
