### PR TITLE
victoriatraces: 0.6.0 -> 0.7.0

### DIFF
--- a/nixos/tests/victoriatraces/otlp-ingestion.nix
+++ b/nixos/tests/victoriatraces/otlp-ingestion.nix
@@ -60,6 +60,9 @@ in
       services.victoriatraces = {
         enable = true;
         retentionPeriod = "1d";
+        extraOptions = [
+          "-search.latencyOffset=0s"
+        ];
       };
 
       environment.systemPackages = with pkgs; [
@@ -82,10 +85,10 @@ in
     """, timeout=10)
 
     # Query for traces from our test service
-    machine.succeed("""
+    machine.wait_until_succeeds("""
       curl -s 'http://localhost:10428/select/jaeger/api/traces?service=test-service' | \
       jq -e '.data[0].spans[0].operationName' | grep -q 'test-span'
-    """)
+    """, timeout=10)
 
     # Verify the trace has the expected attributes
     machine.succeed("""

--- a/pkgs/by-name/vi/victoriatraces/package.nix
+++ b/pkgs/by-name/vi/victoriatraces/package.nix
@@ -13,13 +13,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "VictoriaTraces";
-  version = "0.6.0";
+  version = "0.7.0";
 
   src = fetchFromGitHub {
     owner = "VictoriaMetrics";
     repo = "VictoriaTraces";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-gXdOPRC3oxMAimMc4v0CjTb224qiocFY9/1PFH4hbRw=";
+    hash = "sha256-MWPw2SJlqjQCyBYT++A0KcwccdpTP7Ome4RfA7lcjAM=";
   };
 
   vendorHash = null;


### PR DESCRIPTION
Closes #482237
ChangeLog: https://github.com/VictoriaMetrics/VictoriaTraces/releases/tag/v0.7.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
