### PR TITLE
abc-verifier: 0.55 -> 0.61

### DIFF
--- a/pkgs/by-name/ab/abc-verifier/package.nix
+++ b/pkgs/by-name/ab/abc-verifier/package.nix
@@ -8,17 +8,22 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "abc-verifier";
-  version = "0.55";
+  version = "0.61";
 
   src = fetchFromGitHub {
     owner = "yosyshq";
     repo = "abc";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-Ib6bZSPQmpI1UOsUG733TH6W6v+UnLyagdjUc8MreKw=";
+    hash = "sha256-j/JmEJa29mT/XQmVL/adVbj4S+AAgpga1jbEinCN16w=";
   };
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [ readline ];
+
+  cmakeFlags = [
+    # This prevents CMake from trying to download googletest during the build
+    (lib.cmakeBool "ABC_SKIP_TESTS" true)
+  ];
 
   installPhase = ''
     runHook preInstall
@@ -30,7 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
   passthru.rev = finalAttrs.src.rev;
 
   meta = {
-    description = "Tool for squential logic synthesis and formal verification";
+    description = "Tool for sequential logic synthesis and formal verification";
     homepage = "https://people.eecs.berkeley.edu/~alanmi/abc";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [

--- a/pkgs/development/interpreters/acl2/default.nix
+++ b/pkgs/development/interpreters/acl2/default.nix
@@ -3,6 +3,7 @@
   stdenv,
   callPackage,
   fetchFromGitHub,
+  fetchpatch,
   runCommandLocal,
   makeWrapper,
   replaceVars,
@@ -50,6 +51,12 @@ stdenv.mkDerivation rec {
   libipasir = callPackage ./libipasirglucose4 { };
 
   patches = [
+    # The upstream fix for the input-files macro regression
+    (fetchpatch {
+      url = "https://github.com/acl2/acl2/commit/be39e7835f1c68008c17188d2f65eeaef61632fa.patch";
+      sha256 = "sha256-pZ/r0vlyJz7ymYfrVtHDxsLdw0M/MJStBH42ZLO7Fs4=";
+    })
+
     (replaceVars ./0001-path-changes-for-nix.patch {
       libipasir = "${libipasir}/lib/${libipasir.libname}";
       libssl = "${lib.getLib openssl}/lib/libssl${stdenv.hostPlatform.extensions.sharedLibrary}";


### PR DESCRIPTION
Diff: https://github.com/yosyshq/abc/compare/v0.55...v0.61


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
