### PR TITLE
klayout: 0.30.4-1 -> 0.30.5

### DIFF
--- a/pkgs/applications/misc/klayout/default.nix
+++ b/pkgs/applications/misc/klayout/default.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  installShellFiles,
   python3,
   ruby,
   wrapQtAppsHook,
@@ -16,13 +17,13 @@
 
 stdenv.mkDerivation rec {
   pname = "klayout";
-  version = "0.30.4-1";
+  version = "0.30.5";
 
   src = fetchFromGitHub {
     owner = "KLayout";
     repo = "klayout";
     rev = "v${version}";
-    hash = "sha256-EhIGxiXqo09/p8mA00RRvKgXJncVr4qguYSPyEC0fqc=";
+    hash = "sha256-WigRictn6CxOPId2YitlEm43vEw+dSRWdoareD9HtMc=";
   };
 
   postPatch = ''
@@ -31,10 +32,11 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [
-    which
+    (python3.withPackages (ps: [ ps.tomli ]))
+    installShellFiles
     perl
-    python3
     ruby
+    which
     wrapQtAppsHook
   ];
 
@@ -49,17 +51,25 @@ stdenv.mkDerivation rec {
   buildPhase = ''
     runHook preBuild
     mkdir -p $out/lib
-    ./build.sh -qt5 -prefix $out/lib -option -j$NIX_BUILD_CORES
+
+    # -qt5: Using Qt5 as per your previous configuration.
+    # -rpath: Ensures the klayout binary can find its internal libraries (tl, db, etc.)
+    #         in the nix store without needing LD_LIBRARY_PATH.
+    ./build.sh \
+      -qt5 \
+      -prefix $out/lib \
+      -option "-j$NIX_BUILD_CORES" \
+      -rpath $out/lib
+
     runHook postBuild
   '';
 
   postBuild =
     lib.optionalString stdenv.hostPlatform.isLinux ''
-      mkdir $out/bin
-
       install -Dm444 etc/klayout.desktop -t $out/share/applications
       install -Dm444 etc/logo.png $out/share/icons/hicolor/256x256/apps/klayout.png
-      mv $out/lib/klayout $out/bin/
+
+      installBin $out/lib/klayout
     ''
     + lib.optionalString stdenv.hostPlatform.isDarwin ''
       mkdir -p $out/Applications
@@ -79,10 +89,10 @@ stdenv.mkDerivation rec {
 
   env.NIX_CFLAGS_COMPILE = toString [ "-Wno-parentheses" ];
 
-  dontInstall = true; # Installation already happens as part of "build.sh"
+  # Installation is handled manually in buildPhase/postBuild via build.sh -prefix
+  dontInstall = true;
 
-  # Fix: "gsiDeclQMessageLogger.cc:126:42: error: format not a string literal
-  # and no format arguments [-Werror=format-security]"
+  # Fix for: "gsiDeclQMessageLogger.cc: error: format not a string literal"
   hardeningDisable = [ "format" ];
 
   meta = {


### PR DESCRIPTION
Diff: https://github.com/KLayout/klayout/compare/v0.30.4-1...v0.30.5

Changelog: https://www.klayout.de/development.html#0.30.5


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
