### PR TITLE
sdl3-image: 3.2.6 -> 3.4.0, fix compilation with stb

### DIFF
--- a/pkgs/by-name/sd/sdl3-image/package.nix
+++ b/pkgs/by-name/sd/sdl3-image/package.nix
@@ -20,7 +20,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "sdl3-image";
-  version = "3.2.6";
+  version = "3.4.0";
 
   outputs = [
     "lib"
@@ -32,7 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "libsdl-org";
     repo = "SDL_image";
     tag = "release-${finalAttrs.version}";
-    hash = "sha256-CnUCqFq9ZaM/WQcmaCpQdjtjR9l5ymzgeqEJx7ZW/s4=";
+    hash = "sha256-XRPHDcJ49sZa7y8TCWfS2gPOhpGyUnMMXVqvjV9f8E0=";
   };
 
   strictDeps = true;
@@ -46,21 +46,19 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     sdl3
     libtiff
+    libpng
     libwebp
     libjxl
   ]
   ++ (lib.optional (!stdenv.hostPlatform.isDarwin) libavif)
-  ++ (lib.optionals (!enableSTB) [
-    libpng
-    libjpeg
-  ]);
+  ++ (lib.optional (!enableSTB) libjpeg);
 
   cmakeFlags = [
     # fail when a dependency could not be found
     (lib.cmakeBool "SDLIMAGE_STRICT" true)
     # disable shared dependencies as they're opened at runtime using SDL_LoadObject otherwise.
     (lib.cmakeBool "SDLIMAGE_DEPS_SHARED" false)
-    # disable stbi
+    # enable stb conditionally
     (lib.cmakeBool "SDLIMAGE_BACKEND_STB" enableSTB)
     # enable imageio backend
     (lib.cmakeBool "SDLIMAGE_BACKEND_IMAGEIO" enableImageIO)


### PR DESCRIPTION
Update sdl3-image to 3.4.0

Release details: https://github.com/libsdl-org/SDL_image/releases/tag/release-3.4.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
