### PR TITLE
python3Packages.cuda-bindings: init at 12.8.0

### DIFF
--- a/pkgs/development/python-modules/cuda-bindings/default.nix
+++ b/pkgs/development/python-modules/cuda-bindings/default.nix
@@ -1,0 +1,142 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  cudaPackages,
+  addDriverRunpath,
+
+  # build-system
+  cython,
+  setuptools,
+  pyclibrary,
+
+  # env
+  symlinkJoin,
+
+  # tests
+  numpy,
+  pytestCheckHook,
+
+  # passthru
+  cuda-bindings,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "cuda-bindings";
+  version = "12.8.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "NVIDIA";
+    repo = "cuda-python";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-7e9w70KkC6Pcvyu6Cwt5Asrc3W9TgsjiGvArRTer6Oc=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/cuda_bindings";
+
+  postPatch =
+    let
+      libCudaPath =
+        # Use cuda_compat to provide libcuda.so on pre-Thor Jetsons
+        if (cudaPackages.cuda_compat.meta.available or false) then
+          cudaPackages.cuda_compat
+
+        # Else, use the host CUDA driver library
+        else
+          addDriverRunpath.driverLink;
+    in
+    ''
+      substituteInPlace cuda/bindings/_internal/nvjitlink_linux.pyx \
+        --replace-fail \
+          'so_name = "libnvJitLink.so"' \
+          'so_name = "${lib.getLib cudaPackages.libnvjitlink}/lib/libnvJitLink.so"' \
+        --replace-fail \
+          "handle = dlopen('libcuda.so.1'" \
+          "handle = dlopen('${libCudaPath}/lib/libcuda.so.1'"
+
+      substituteInPlace cuda/bindings/_bindings/cydriver.pyx.in \
+        --replace-fail \
+          "path = 'libcuda.so.1'" \
+          "path = '${libCudaPath}/lib/libcuda.so.1'"
+
+      substituteInPlace cuda/bindings/_bindings/cynvrtc.pyx.in \
+        --replace-fail \
+          "dlfcn.dlopen('libnvrtc.so.12'" \
+          "dlfcn.dlopen('${lib.getLib cudaPackages.cuda_nvrtc}/lib/libnvrtc.so.12'"
+
+      substituteInPlace cuda/bindings/_lib/cyruntime/cyruntime.pyx.in \
+        --replace-fail \
+          "dlfcn.dlopen('libcudart.so.12'" \
+          "dlfcn.dlopen('${lib.getLib cudaPackages.cuda_cudart}/lib/libcudart.so.12'"
+    '';
+
+  preBuild = ''
+    export CUDA_PYTHON_PARALLEL_LEVEL=$NIX_BUILD_CORES
+  '';
+
+  build-system = [
+    cython
+    pyclibrary
+    setuptools
+  ];
+
+  env = {
+    CUDA_HOME = symlinkJoin {
+      name = "cuda-redist";
+      paths = with cudaPackages; [
+        (lib.getInclude cuda_cudart) # cuda_runtime.h
+        (lib.getInclude cuda_nvrtc) # nvrtc.h
+        (lib.getInclude cuda_profiler_api) # cudaProfiler.h, cuda_profiler_api.h
+      ];
+    };
+  };
+
+  buildInputs = [
+    cudaPackages.cuda_nvcc # crt/host_defines.h
+  ];
+
+  pythonImportsCheck = [
+    "cuda"
+    "cuda.cuda"
+    "cuda.cudart"
+    "cuda.nvrtc"
+  ];
+
+  preCheck = ''
+    rm -rf cuda
+  '';
+
+  nativeCheckInputs = [
+    numpy
+    pytestCheckHook
+  ];
+
+  enabledTestPaths = [
+    "tests/"
+  ];
+
+  disabledTestPaths = [
+    # The current driver shipped in NixOS (590.48.01) advertises CUDA 13.1, causing the following
+    # error:
+    # cuda.bindings._internal.utils.NotSupportedError: only CUDA 12 driver is supported
+    #
+    # Ideally, we should transition to cuda 13 across the whole nixpkgs tree.
+    "tests/test_nvjitlink.py"
+  ];
+
+  # Tests need access to a GPU
+  doCheck = false;
+  passthru.gpuCheck = cuda-bindings.overridePythonAttrs {
+    requiredSystemFeatures = [ "cuda" ];
+    doCheck = true;
+  };
+
+  meta = {
+    description = "CUDA Python: Performance meets Productivity";
+    homepage = "https://github.com/NVIDIA/cuda-python/tree/main/cuda_bindings";
+    changelog = "https://nvidia.github.io/cuda-python/${finalAttrs.version}/release/${finalAttrs.version}-notes.html";
+    license = lib.licenses.unfreeRedistributable; # NVIDIA Proprietary Software
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+})

--- a/pkgs/development/python-modules/pyclibrary/default.nix
+++ b/pkgs/development/python-modules/pyclibrary/default.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+  setuptools-scm,
+  pyparsing,
+
+  # tests
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pyclibrary";
+  version = "0.3.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "MatthieuDartiailh";
+    repo = "pyclibrary";
+    tag = finalAttrs.version;
+    hash = "sha256-RyIbRySRWSZwKP5G6yXYCOnfKOV0165aPyjMf3nSbOM=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    pyparsing
+  ];
+
+  pythonImportsCheck = [ "pyclibrary" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  meta = {
+    description = "C parser and ctypes automation for python";
+    homepage = "https://github.com/MatthieuDartiailh/pyclibrary";
+    changelog = "https://github.com/MatthieuDartiailh/pyclibrary/blob/${finalAttrs.src.tag}/CHANGES";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13147,6 +13147,8 @@ self: super: with self; {
 
   pycketcasts = callPackage ../development/python-modules/pycketcasts { };
 
+  pyclibrary = callPackage ../development/python-modules/pyclibrary { };
+
   pyclimacell = callPackage ../development/python-modules/pyclimacell { };
 
   pyclip = callPackage ../development/python-modules/pyclip { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3338,6 +3338,8 @@ self: super: with self; {
 
   cucumber-tag-expressions = callPackage ../development/python-modules/cucumber-tag-expressions { };
 
+  cuda-bindings = callPackage ../development/python-modules/cuda-bindings { };
+
   cupy = callPackage ../development/python-modules/cupy {
     cudaPackages =
       # CuDNN 9 is not supported:


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Add [cuda-bindings](https://github.com/NVIDIA/cuda-python/tree/v12.8.0/cuda_bindings), which is [required by torch 2.10.0](https://github.com/pytorch/pytorch/pull/167769).

- **python3Packages.pyclibrary: init at 0.3.0**
- **python3Packages.cuda-bindings: init at 12.8.0**


cc @NixOS/cuda-maintainers @NickCao 

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
