### PR TITLE
sabnzbd: create intermediate tmpfile for config merge

### DIFF
--- a/nixos/modules/services/networking/sabnzbd/default.nix
+++ b/nixos/modules/services/networking/sabnzbd/default.nix
@@ -541,6 +541,8 @@ in
             -o '${cfg.user}' -g '${cfg.group}' \
             "$tmpfile" \
             ${iniPathQuoted}
+
+          rm "$tmpfile"
         '';
       };
 

--- a/nixos/modules/services/networking/sabnzbd/default.nix
+++ b/nixos/modules/services/networking/sabnzbd/default.nix
@@ -13,7 +13,6 @@ let
     mkOptionDefault
     mkIf
     literalExpression
-    optionalString
     types
     ;
   inherit (lib.generators)
@@ -79,7 +78,6 @@ let
       mkSection = (
         depth: attrs:
         let
-          atoms = extractAtoms attrs;
           sections = extractSections attrs;
           sectionHeadingLeft = lib.concatStrings (lib.replicate (depth + 1) "[");
           sectionHeadingRight = lib.concatStrings (lib.replicate (depth + 1) "]");
@@ -531,11 +529,18 @@ in
 
           ${lib.toShellVar "files" files}
 
+          tmpfile=$(mktemp)
+
           ${lib.getExe (pkgs.python3.withPackages (py: [ py.configobj ]))} \
             ${./config_merge.py} \
-            "''${files[@]}" | \
-          install -D -m ${if cfg.allowConfigWrite then "600" else "400"} \
-            -o '${cfg.user}' -g '${cfg.group}' /dev/stdin ${iniPathQuoted}
+            "''${files[@]}" \
+            > "$tmpfile"
+
+          install -D \
+            -m ${if cfg.allowConfigWrite then "600" else "400"} \
+            -o '${cfg.user}' -g '${cfg.group}' \
+            "$tmpfile" \
+            ${iniPathQuoted}
         '';
       };
 


### PR DESCRIPTION
The current script for merging declaractive config, secrets, and UI-set preferences for sabnzbd deletes UI-set preferences. Thix fix renders to an intermediate file before overwriting the config file.

Fixes a bug mentioned in  #416165 and #482562 


## Things done

- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.