### PR TITLE
python3Packages.dissect-{cstruct,cobaltstrike,database,util}: update license

### DIFF
--- a/pkgs/development/python-modules/dissect-cobaltstrike/default.nix
+++ b/pkgs/development/python-modules/dissect-cobaltstrike/default.nix
@@ -80,7 +80,7 @@ buildPythonPackage rec {
     description = "Dissect module implementing a parser for Cobalt Strike related data";
     homepage = "https://github.com/fox-it/dissect.cobaltstrike";
     changelog = "https://github.com/fox-it/dissect.cobaltstrike/releases/tag/${src.tag}";
-    license = lib.licenses.agpl3Only;
+    license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
   };
 }

--- a/pkgs/development/python-modules/dissect-cstruct/default.nix
+++ b/pkgs/development/python-modules/dissect-cstruct/default.nix
@@ -32,7 +32,7 @@ buildPythonPackage rec {
     description = "Dissect module implementing a parser for C-like structures";
     homepage = "https://github.com/fox-it/dissect.cstruct";
     changelog = "https://github.com/fox-it/dissect.cstruct/releases/tag/${src.tag}";
-    license = lib.licenses.agpl3Only;
+    license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ fab ];
   };
 }

--- a/pkgs/development/python-modules/dissect-database/default.nix
+++ b/pkgs/development/python-modules/dissect-database/default.nix
@@ -42,7 +42,7 @@ buildPythonPackage rec {
     description = "Dissect module implementing a parser for various database formats";
     homepage = "https://github.com/fox-it/dissect.database";
     changelog = "https://github.com/fox-it/dissect.database/releases/tag/${src.tag}";
-    license = lib.licenses.agpl3Only;
+    license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ fab ];
   };
 }

--- a/pkgs/development/python-modules/dissect-util/default.nix
+++ b/pkgs/development/python-modules/dissect-util/default.nix
@@ -37,7 +37,7 @@ buildPythonPackage rec {
     description = "Dissect module implementing various utility functions for the other Dissect modules";
     homepage = "https://github.com/fox-it/dissect.util";
     changelog = "https://github.com/fox-it/dissect.util/releases/tag/${src.tag}";
-    license = lib.licenses.agpl3Only;
+    license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ fab ];
     mainProgram = "dump-nskeyedarchiver";
   };


### PR DESCRIPTION
I noticed some of the meta license fields of dissect packages were outdated and decided to update them. 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.

-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
