### PR TITLE
intel2200BGFirmware: split doc output

### DIFF
--- a/pkgs/by-name/in/intel2200BGFirmware/package.nix
+++ b/pkgs/by-name/in/intel2200BGFirmware/package.nix
@@ -13,13 +13,18 @@ stdenvNoCC.mkDerivation rec {
     hash = "sha256-xoGMEcGMwDDVX/g/ZLK62P7vSF53QvhPlKYdgRpiWL0=";
   };
 
+  outputs = [
+    "out"
+    "doc"
+  ];
+
   installPhase = ''
     runHook preInstall
 
     install -D -m644 ipw2200-bss.fw     $out/lib/firmware/ipw2200-bss.fw
     install -D -m644 ipw2200-ibss.fw    $out/lib/firmware/ipw2200-ibss.fw
     install -D -m644 ipw2200-sniffer.fw $out/lib/firmware/ipw2200-sniffer.fw
-    install -D -m644 LICENSE.ipw2200-fw $out/share/doc/intel2200BGFirmware/LICENSE
+    install -D -m644 LICENSE.ipw2200-fw ''${!outputDoc}/share/doc/intel2200BGFirmware/LICENSE
 
     runHook postInstall
   '';


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test