### PR TITLE
python3Packages.codeowners: init at 0.8.0

### DIFF
--- a/pkgs/development/python-modules/codeowners/default.nix
+++ b/pkgs/development/python-modules/codeowners/default.nix
@@ -1,0 +1,61 @@
+{
+  buildPythonPackage,
+  fetchPypi,
+  gitMinimal,
+  lib,
+
+  # build system
+  poetry-core,
+  setuptools,
+
+  # dependencies
+  typing-extensions,
+
+  # test dependencies
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "codeowners";
+  version = "0.8.0";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "codeowners";
+    inherit (finalAttrs) version;
+    hash = "sha256-ZQVydXS2fbSDKj0NXkHA9+uA+IWO4nmW6FseBG+SZvg=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "poetry>=0.12" "poetry-core" \
+      --replace-fail "poetry.masonry.api" "poetry.core.masonry.api"
+  '';
+
+  build-system = [
+    poetry-core
+    setuptools
+  ];
+
+  dependencies = [
+    typing-extensions
+  ];
+
+  pythonImportsCheck = [ "codeowners" ];
+
+  nativeCheckInputs = [
+    gitMinimal
+    pytestCheckHook
+  ];
+
+  meta = {
+    changelog = "https://github.com/sbdchd/codeowners/blob/master/CHANGELOG.md";
+    description = "Python library for codeowners files";
+    homepage = "https://github.com/sbdchd/codeowners";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      de11n
+      despsyched
+    ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2896,6 +2896,8 @@ self: super: with self; {
 
   cocotb-bus = callPackage ../development/python-modules/cocotb-bus { };
 
+  codeowners = callPackage ../development/python-modules/codeowners { };
+
   codepy = callPackage ../development/python-modules/codepy { };
 
   coffea = callPackage ../development/python-modules/coffea { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
