### PR TITLE
python3Packages.certbot-dns-wedos: init at 2.4

### DIFF
--- a/pkgs/development/python-modules/certbot-dns-wedos/default.nix
+++ b/pkgs/development/python-modules/certbot-dns-wedos/default.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  acme,
+  certbot,
+  setuptools,
+  requests,
+  pytz,
+}:
+
+buildPythonPackage rec {
+  pname = "certbot-dns-wedos";
+  version = "2.4";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit version;
+    pname = "certbot_dns_wedos";
+    hash = "sha256-Sle3hoBLwVPF30caCyYtt3raY5Gs9ekg0DthvHxvB4E=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    certbot
+    acme
+    requests
+    pytz
+  ];
+
+  pythonImportsCheck = [ "certbot_dns_wedos" ];
+
+  meta = {
+    description = "Wedos DNS Authenticator plugin for Certbot";
+    homepage = "https://github.com/clazzor/certbot-dns-wedos";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.tsandrini ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6592,6 +6592,7 @@ with pkgs;
       certbot-dns-ovh
       certbot-dns-rfc2136
       certbot-dns-route53
+      certbot-dns-wedos
       certbot-nginx
     ]
   );

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2557,6 +2557,8 @@ self: super: with self; {
 
   certbot-dns-route53 = callPackage ../development/python-modules/certbot-dns-route53 { };
 
+  certbot-dns-wedos = callPackage ../development/python-modules/certbot-dns-wedos { };
+
   certbot-nginx = callPackage ../development/python-modules/certbot-nginx { };
 
   certifi = callPackage ../development/python-modules/certifi { };


### PR DESCRIPTION
Adds support for the https://github.com/clazzor/certbot-dns-wedos certbot plugin used for DNS-01 challenges for the Czech Domain/DNS/etc... hosting provider https://vedos.cz/en/ (and also other potential requests for the Wedos API https://kb.vedos.cz/en/wapi-manual/)

This won't probably be used by a ton of people, but I know a few people that would appreciate this and I, myself, have been running this on my personal and work servers, so I am committed to maintaining this! <3

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

NOTE: Also not sure if this should be included in `certbot-full` or not, as of now I added it, but we can remove it ofc.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
