### PR TITLE
python3Packages.{qcengine,qcelemental}: updates

### DIFF
--- a/pkgs/development/python-modules/qcelemental/default.nix
+++ b/pkgs/development/python-modules/qcelemental/default.nix
@@ -2,8 +2,10 @@
   stdenv,
   buildPythonPackage,
   lib,
+  pythonAtLeast,
   fetchPypi,
   poetry-core,
+  setuptools,
   ipykernel,
   networkx,
   numpy,
@@ -16,15 +18,18 @@
 
 buildPythonPackage rec {
   pname = "qcelemental";
-  version = "0.29.0";
+  version = "0.30.0";
   pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-v2NO5lLn2V6QbikZiVEyJCM7HXBcJq/qyG5FHzFrPAQ=";
+    hash = "sha256-nIW38ReKgE1FA0r55TOOsAOlvtAV3fIQexTsyqx4r4g=";
   };
 
-  build-system = [ poetry-core ];
+  build-system = [
+    poetry-core
+    setuptools
+  ];
 
   dependencies = [
     numpy
@@ -49,7 +54,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "qcelemental" ];
 
   meta = {
-    broken = stdenv.hostPlatform.isDarwin;
+    broken = stdenv.hostPlatform.isDarwin || pythonAtLeast "3.14"; # https://github.com/MolSSI/QCElemental/issues/375
     description = "Periodic table, physical constants and molecule parsing for quantum chemistry";
     homepage = "https://github.com/MolSSI/QCElemental";
     changelog = "https://github.com/MolSSI/QCElemental/blob/v${version}/docs/changelog.rst";

--- a/pkgs/development/python-modules/qcengine/default.nix
+++ b/pkgs/development/python-modules/qcengine/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  pythonAtLeast,
   ipykernel,
   msgpack,
   networkx,
@@ -19,12 +20,12 @@
 
 buildPythonPackage rec {
   pname = "qcengine";
-  version = "0.33.0";
+  version = "0.34.0";
   pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-Ute8puO2qc679ttZgzQRnVO8OuBmYnqLT3y7faHpRgA=";
+    hash = "sha256-VKULy45bYn5TmxU7TbOVK98r0pRMWAwissmgx0Ee/8w=";
   };
 
   build-system = [ setuptools ];
@@ -60,5 +61,6 @@ buildPythonPackage rec {
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ sheepforce ];
     mainProgram = "qcengine";
+    broken = pythonAtLeast "3.14"; # https://github.com/MolSSI/QCEngine/issues/481
   };
 }


### PR DESCRIPTION
This updates both qcelemental and qcengine to the latest releases. Unfortunately both don't work with Python 3.14 yet. The upstream issues are not fixed yet, see https://github.com/MolSSI/QCElemental/issues/375 and https://github.com/MolSSI/QCEngine/issues/481 .

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
