### PR TITLE
wrangler_1: mark as vulnerable; wrangler: 4.59.3 -> 4.60.0

### DIFF
--- a/pkgs/by-name/wr/wrangler/package.nix
+++ b/pkgs/by-name/wr/wrangler/package.nix
@@ -19,13 +19,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "wrangler";
-  version = "4.59.3";
+  version = "4.60.0";
 
   src = fetchFromGitHub {
     owner = "cloudflare";
     repo = "workers-sdk";
     rev = "wrangler@${finalAttrs.version}";
-    hash = "sha256-DKKngT58p8x+Qzl550468JDOQuymQmzPwkLL/iB7Aa4=";
+    hash = "sha256-lRdQrUgEr7KS/05BXZW7h3JS91d3gM8w+RLlaLC98RU=";
   };
 
   pnpmDeps = fetchPnpmDeps {

--- a/pkgs/by-name/wr/wrangler_1/package.nix
+++ b/pkgs/by-name/wr/wrangler_1/package.nix
@@ -41,6 +41,9 @@ rustPlatform.buildRustPackage rec {
     description = "CLI tool designed for folks who are interested in using Cloudflare Workers";
     mainProgram = "wrangler";
     homepage = "https://github.com/cloudflare/wrangler";
+    knownVulnerabilities = [
+      "CVE-2026-0933: Malicious backdoor via a command injection allowing unauthorized remote code execution"
+    ];
     license = with lib.licenses; [
       asl20 # or
       mit


### PR DESCRIPTION
Fixes: https://github.com/NixOS/nixpkgs/issues/482399 
Motivation: [CVE-2026-0933](https://nvd.nist.gov/vuln/detail/CVE-2026-0933)

Changes:
- **wrangler_1: mark as vulnerable** Users know it's a vulnerable package fixes CVE-2026-0933. Might be best to consider in another pr to remove wrangler_1 from unstable (26.05).
- **wrangler: 4.59.3 -> 4.60.0** Updates the package.
    - [Compare Changes](https://github.com/cloudflare/workers-sdk/compare/wrangler@4.59.3...wrangler@4.60.0)
    - [Release](https://github.com/cloudflare/workers-sdk/releases/tag/wrangler%404.60.0)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
[CVE]: https://nvd.nist.gov/vuln/detail/CVE-2026-0933