### PR TITLE
various: rotate maintainership

### DIFF
--- a/nixos/modules/services/networking/pangolin.nix
+++ b/nixos/modules/services/networking/pangolin.nix
@@ -554,7 +554,6 @@ in
 
   meta.maintainers = with lib.maintainers; [
     jackr
-    sigmasquadron
     water-sucks
   ];
 }

--- a/pkgs/by-name/an/anubis/package.nix
+++ b/pkgs/by-name/an/anubis/package.nix
@@ -90,7 +90,6 @@ buildGoModule (finalAttrs: {
       knightpp
       soopyc
       ryand56
-      sigmasquadron
       defelo
     ];
     mainProgram = "anubis";

--- a/pkgs/by-name/bt/btop/package.nix
+++ b/pkgs/by-name/bt/btop/package.nix
@@ -67,6 +67,7 @@ stdenv.mkDerivation (finalAttrs: {
       khaneliman
       rmcgibbo
       ryan4yin
+      sigmasquadron
     ];
     mainProgram = "btop";
   };

--- a/pkgs/by-name/fo/fosrl-gerbil/package.nix
+++ b/pkgs/by-name/fo/fosrl-gerbil/package.nix
@@ -32,7 +32,6 @@ buildGoModule rec {
     license = lib.licenses.agpl3Only;
     maintainers = with lib.maintainers; [
       jackr
-      sigmasquadron
       water-sucks
     ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/fo/fosrl-newt/package.nix
+++ b/pkgs/by-name/fo/fosrl-newt/package.nix
@@ -41,7 +41,6 @@ buildGoModule rec {
     maintainers = with lib.maintainers; [
       fab
       jackr
-      sigmasquadron
       water-sucks
     ];
     mainProgram = "newt";

--- a/pkgs/by-name/fo/fosrl-olm/package.nix
+++ b/pkgs/by-name/fo/fosrl-olm/package.nix
@@ -31,7 +31,6 @@ buildGoModule rec {
     license = lib.licenses.agpl3Only;
     maintainers = with lib.maintainers; [
       jackr
-      sigmasquadron
       water-sucks
     ];
     mainProgram = "olm";

--- a/pkgs/by-name/fo/fosrl-pangolin/package.nix
+++ b/pkgs/by-name/fo/fosrl-pangolin/package.nix
@@ -167,7 +167,6 @@ buildNpmPackage (finalAttrs: {
     license = lib.licenses.agpl3Only;
     maintainers = with lib.maintainers; [
       jackr
-      sigmasquadron
       water-sucks
     ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/st/starsector/package.nix
+++ b/pkgs/by-name/st/starsector/package.nix
@@ -106,6 +106,7 @@ stdenv.mkDerivation rec {
     maintainers = with lib.maintainers; [
       bbigras
       rafaelrc
+      sigmasquadron
     ];
   };
 }


### PR DESCRIPTION
Removing my maintainer entry from some packages, namely Pangolin, and adding it to others that I've been involved in or wish to keep a closer eye on. Should be a zero-rebuild PR.

Closes #437073
Closes #428592

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
