### PR TITLE
python3Packages.ufo-extractor: init at 0.8.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -21523,6 +21523,12 @@
     githubId = 12017109;
     name = "Rabindra Dhakal";
   };
+  qb114514 = {
+    name = "qb114514";
+    email = "GNUqb114514@outlook.com";
+    github = "GNUqb114514";
+    githubId = 110373832;
+  };
   qbisi = {
     name = "qbisicwate";
     email = "qbisicwate@gmail.com";

--- a/pkgs/development/python-modules/ufo-extractor/default.nix
+++ b/pkgs/development/python-modules/ufo-extractor/default.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  buildPythonPackage,
+  setuptools,
+  setuptools-scm,
+  fonttools,
+  fontfeatures,
+  pytestCheckHook,
+  fetchFromGitHub,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "ufo-extractor";
+  version = "0.8.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "robotools";
+    repo = "extractor";
+    tag = finalAttrs.version;
+    hash = "sha256-SzNNRC2UxjyypgiM0iIicfemC67D6GW2jszNak8yCSM=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    fonttools
+    fontfeatures
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "extractor" ];
+
+  meta = {
+    description = "Tools for extracting data from font binaries into UFO objects";
+    homepage = "https://github.com/robotools/extractor";
+    license = lib.licenses.mit;
+    changelog = "https://github.com/robotools/extractor/releases/tag/${finalAttrs.src.tag}";
+    maintainers = with lib.maintainers; [
+      qb114514
+    ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20010,6 +20010,8 @@ self: super: with self; {
 
   ufmt = callPackage ../development/python-modules/ufmt { };
 
+  ufo-extractor = callPackage ../development/python-modules/ufo-extractor { };
+
   ufo2ft = callPackage ../development/python-modules/ufo2ft { };
 
   ufolib2 = callPackage ../development/python-modules/ufolib2 { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Tools for extracting data from font binaries into UFO objects.

This is a python package that is a dependent of a package uploaded in #483275.

Homepage: https://github.com/robotools/extractor
PyPI page: https://pypi.org/project/ufo-extractor/

I also added myself into the maintainer list.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
