### PR TITLE
pinnacle: init at 0.2.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4608,6 +4608,13 @@
     githubId = 53847249;
     name = "Casey Avila";
   };
+  cassandracomar = {
+    name = "Cassandra Comar";
+    github = "cassandracomar";
+    githubId = 320772;
+    email = "cass@mountclare.net";
+    keys = [ { fingerprint = "104E E74E 24A0 372B EAF5  5533 B019 18F7 7E04 AC99"; } ];
+  };
   castorNova2 = {
     email = "solemnsquire@gmail.com";
     github = "castorNova2";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -354,6 +354,7 @@
   ./programs/wayland/mangowc.nix
   ./programs/wayland/miracle-wm.nix
   ./programs/wayland/niri.nix
+  ./programs/wayland/pinnacle.nix
   ./programs/wayland/river.nix
   ./programs/wayland/sway.nix
   ./programs/wayland/uwsm.nix

--- a/nixos/modules/programs/wayland/pinnacle.nix
+++ b/nixos/modules/programs/wayland/pinnacle.nix
@@ -1,0 +1,70 @@
+{
+  pkgs,
+  config,
+  lib,
+  ...
+}:
+let
+  cfg = config.programs.pinnacle;
+  inherit (lib.options) mkEnableOption mkPackageOption;
+in
+{
+  options.programs.pinnacle = {
+    enable = mkEnableOption "pinnacle";
+    package = mkPackageOption pkgs "pinnacle" {
+      default = "pinnacle";
+      example = "pkgs.pinnacle";
+      extraDescription = "package containing the pinnacle server binary";
+    };
+    xdg-portals.enable = mkEnableOption "enable xdg-portals for pinnacle";
+    withUWSM = mkEnableOption ''
+      manage the pinnacle session with [UWSM](https://github.com/Vladimir-csp/uwsm) instead
+      of independent systemd services and targets.
+    '';
+  };
+
+  config = lib.mkIf cfg.enable (
+    lib.mkMerge [
+      {
+        environment.systemPackages = [
+          cfg.package
+          pkgs.protobuf
+          cfg.package.lua-client-api
+        ];
+        environment.pathsToLink = [
+          # For /run/current-system/sw/share/pinnacle protobuf files - for
+          # pinnacle to be able to launch with a non-default config out of the
+          # box.
+          "/share/pinnacle"
+        ];
+        xdg.portal = lib.mkIf cfg.xdg-portals.enable {
+          enable = true;
+          wlr.enable = true;
+          configPackages = [ cfg.package ];
+          extraPortals = [
+            pkgs.xdg-desktop-portal-wlr
+            pkgs.xdg-desktop-portal-gtk
+            pkgs.gnome-keyring
+          ];
+        };
+      }
+      (lib.mkIf (cfg.withUWSM) {
+        programs.uwsm.enable = true;
+        # Configure UWSM to launch Pinnacle from a display manager like SDDM
+        programs.uwsm.waylandCompositors = {
+          pinnacle = {
+            prettyName = "Pinnacle";
+            comment = "Pinnacle compositor managed by UWSM";
+            binPath = "/run/current-system/sw/bin/pinnacle";
+            extraArgs = [ "--session" ];
+          };
+        };
+      })
+      (lib.mkIf (!cfg.withUWSM) {
+        services.displayManager.sessionPackages = [ cfg.package ];
+      })
+    ]
+  );
+
+  meta.maintainers = with lib.maintainers; [ cassandracomar ];
+}

--- a/pkgs/by-name/pi/pinnacle/package.nix
+++ b/pkgs/by-name/pi/pinnacle/package.nix
@@ -1,0 +1,170 @@
+{
+  rustPlatform,
+  lib,
+  pkg-config,
+  wayland,
+  lua54Packages,
+  lua5_4,
+  extraLuaPackages ? (ps: [ ]),
+  protobuf,
+  seatd,
+  systemdLibs,
+  libxkbcommon,
+  mesa,
+  xwayland,
+  libinput,
+  libdisplay-info,
+  git,
+  libgbm,
+  rustc,
+  cargo,
+  makeWrapper,
+  callPackage,
+  libglvnd,
+  autoPatchelfHook,
+  libxcursor,
+  libxi,
+  libxrandr,
+  libx11,
+  fetchFromGitHub,
+}:
+let
+  version = "0.2.4";
+  pinnacle-src = fetchFromGitHub {
+    owner = "pinnacle-comp";
+    repo = "pinnacle";
+    tag = "v${version}";
+    sha256 = "sha256-T8wZjgOTzYKfYUV1ShLBIi2xoCdVn9I7sux/pDH+8ic=";
+  };
+  buildRustConfig = callPackage ./pinnacle-config.nix { inherit pinnacle-src; };
+
+  meta = {
+    description = "A WIP Smithay-based Wayland compositor, inspired by AwesomeWM and configured in Lua or Rust";
+    homepage = "https://pinnacle-comp.github.io/pinnacle/";
+    license = lib.licenses.gpl3;
+    mainProgram = "pinnacle";
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ cassandracomar ];
+  };
+
+  lua-client-api = lua54Packages.buildLuarocksPackage rec {
+    inherit meta version;
+    pname = "pinnacle-client-api";
+    src = pinnacle-src;
+    sourceRoot = "${src.name}/api/lua";
+    knownRockspec = "${pinnacle-src}/api/lua/rockspecs/pinnacle-api-0.2.4-1.rockspec";
+    propagatedBuildInputs = with lua54Packages; [
+      cqueues
+      http
+      lua-protobuf
+      compat53
+      luaposix
+    ];
+
+    postInstall = ''
+      mkdir -p $out/share/pinnacle/protobuf/pinnacle
+      cp -rL --no-preserve ownership,mode ../../api/protobuf/pinnacle $out/share/pinnacle/protobuf
+      mkdir -p $out/share/pinnacle/snowcap/protobuf/snowcap
+      cp -rL --no-preserve ownership,mode ../../snowcap/api/protobuf/snowcap $out/share/pinnacle/snowcap/protobuf
+      mkdir -p $out/share/pinnacle/protobuf/google
+      cp -rL --no-preserve ownership,mode ../../api/protobuf/google $out/share/pinnacle/protobuf
+      mkdir -p $out/share/pinnacle/snowcap/protobuf/google
+      cp -rL --no-preserve ownership,mode ../../snowcap/api/protobuf/google $out/share/pinnacle/snowcap/protobuf
+    '';
+  };
+in
+rustPlatform.buildRustPackage (finalAttrs: {
+  inherit meta version;
+
+  pname = "pinnacle-server";
+  src = pinnacle-src;
+  cargoHash = "sha256-hM19RB2+ejC+OFU4keH+PKWYf5NRUXJ1W33eSUhKR/g=";
+
+  buildInputs = [
+    wayland
+
+    # libs
+    seatd.dev
+    systemdLibs.dev
+    libxkbcommon
+    libinput
+    mesa
+    xwayland
+    libdisplay-info
+    libgbm
+    lua5_4
+
+    # winit on x11
+    libxcursor
+    libxrandr
+    libxi
+    libx11
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
+    protobuf
+    lua54Packages.luarocks
+    lua5_4
+    lua-client-api
+    git
+    wayland
+    makeWrapper
+    autoPatchelfHook
+  ];
+
+  checkFeatures = [ "testing" ];
+  checkNoDefaultFeatures = true;
+  cargoTestFlags = [
+    "--exclude"
+    "wlcs_pinnacle"
+    "--all"
+    "--"
+    "--skip"
+    "process_spawn"
+  ];
+
+  preCheck = ''
+    export LD_LIBRARY_PATH="${lib.makeLibraryPath [ wayland ]}";
+    export XDG_RUNTIME_DIR=$(mktemp -d)
+  '';
+
+  postInstall = ''
+    wrapProgram $out/bin/pinnacle --prefix PATH ":" ${
+      lib.makeBinPath [
+        rustc
+        cargo
+        finalAttrs.passthru.luaEnv
+        xwayland
+      ]
+    }
+    install -m755 ./resources/pinnacle-session $out/bin/pinnacle-session
+    mkdir -p $out/share/wayland-sessions
+    install -m644 ./resources/pinnacle.desktop $out/share/wayland-sessions/pinnacle.desktop
+    patchShebangs $out/bin/pinnacle-session
+    mkdir -p $out/share/xdg-desktop-portal
+    install -m644 ./resources/pinnacle-portals.conf $out/share/xdg-desktop-portal/pinnacle-portals.conf
+    install -m644 ./resources/pinnacle-portals.conf $out/share/xdg-desktop-portal/pinnacle-uwsm-portals.conf
+  '';
+
+  runtimeDependencies = [
+    wayland
+    mesa
+    libglvnd # libEGL
+  ];
+
+  passthru = {
+    luaEnv = lua5_4.withPackages (
+      ps:
+      [
+        finalAttrs.passthru.lua-client-api
+        ps.cjson
+      ]
+      ++ (extraLuaPackages ps)
+    );
+    inherit buildRustConfig;
+    providedSessions = [ "pinnacle" ];
+    lua-client-api = lua-client-api;
+  };
+  __structuredAttrs = true;
+})

--- a/pkgs/by-name/pi/pinnacle/pinnacle-config.nix
+++ b/pkgs/by-name/pi/pinnacle/pinnacle-config.nix
@@ -1,0 +1,36 @@
+{
+  rustPlatform,
+  protobuf,
+  pkg-config,
+  seatd,
+  libxkbcommon,
+  libinput,
+  lua5_4,
+  libdisplay-info,
+  libgbm,
+  pinnacle-src,
+}:
+args:
+rustPlatform.buildRustPackage (
+  (removeAttrs args [
+    "nativeBuildInputs"
+    "buildInputs"
+  ])
+  // {
+    PINNACLE_PROTOBUF_API_DEFS = "${pinnacle-src}/api/protobuf";
+    PINNACLE_PROTOBUF_SNOWCAP_API_DEFS = "${pinnacle-src}/snowcap/api/protobuf";
+
+    nativeBuildInputs = (args.nativeBuildInputs or [ ]) ++ [
+      protobuf
+      pkg-config
+    ];
+    buildInputs = (args.buildInputs or [ ]) ++ [
+      seatd.dev
+      libxkbcommon
+      libinput
+      lua5_4
+      libdisplay-info
+      libgbm
+    ];
+  }
+)


### PR DESCRIPTION
[pinnacle](https://github.com/pinnacle-comp/pinnacle) is a new wayland compositor written in rust and configured in either lua or rust, inspired by AwesomeWM. this PR adds the package for the server with associated functions for building either the rust or lua configs.

I've also included a nixos module to set up pinnacle as an available session. a user service/targets are still required to actually run the compositor -- these are best configured via home-manager, using a module I intend to PR to home-manager once this PR has been merged into nixpkgs.

this package and modules have been tested via pinnacle-comp/pinnacle's flake already. I've also confirmed that the package builds in-tree in nixpkgs.

existing [usage docs](https://pinnacle-comp.github.io/pinnacle/getting-started/installation#nixos) from upstream. we'll update these to refer to the package/module in nixpkgs once this PR has been merged.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
