### PR TITLE
hcloud-upload-image: init at 1.3.0

### DIFF
--- a/pkgs/by-name/hc/hcloud-upload-image/package.nix
+++ b/pkgs/by-name/hc/hcloud-upload-image/package.nix
@@ -1,0 +1,51 @@
+{
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+  lib,
+  stdenv,
+}:
+
+buildGoModule rec {
+  pname = "hcloud-upload-image";
+  version = "1.3.0";
+
+  src = fetchFromGitHub {
+    owner = "apricote";
+    repo = "hcloud-upload-image";
+    tag = "v${version}";
+    hash = "sha256-1u9tpzciYjB/EgBI81pg9w0kez7hHZON7+AHvfKW7k0=";
+  };
+
+  vendorHash = "sha256-IdOAUBPg0CEuHd2rdc7jOlw0XtnAhr3PVPJbnFs2+x4=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${version}"
+  ];
+
+  subPackages = [ "." ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    for shell in bash fish zsh; do
+      $out/bin/hcloud-upload-image completion $shell > hcloud.$shell
+      installShellCompletion hcloud.$shell
+    done
+  '';
+
+  env.GOWORK = "off";
+
+  meta = {
+    changelog = "https://github.com/apricote/hcloud-upload-image/releases/tag/v${version}";
+    description = "Quickly upload any raw disk images into your Hetzner Cloud projects";
+    mainProgram = "hcloud-upload-image";
+    homepage = "https://github.com/apricote/hcloud-upload-image";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      sshine
+    ];
+  };
+}


### PR DESCRIPTION
Add the hcloud-upload-image CLI to nixpkgs. Current version is 1.3.0.

It uses Hetzner's snapshot functionality to upload custom ISOs for VMs.

https://github.com/apricote/hcloud-upload-image

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
