### PR TITLE
nix-bisect: 0.4.1 -> 0.4.2

### DIFF
--- a/pkgs/by-name/ni/nix-bisect/package.nix
+++ b/pkgs/by-name/ni/nix-bisect/package.nix
@@ -6,17 +6,17 @@
 
 let
   pname = "nix-bisect";
-  version = "0.4.1-unstable-2024-04-19";
+  version = "0.4.2";
 in
 python3.pkgs.buildPythonApplication {
   inherit pname version;
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "timokau";
+    owner = "KiaraGrouwstra";
     repo = "nix-bisect";
-    rev = "4f26082fec0817acbfa8cc6ca4c25caaf77ddcd2";
-    hash = "sha256-zyeE1jYo/9NEG8fB4gQBAR01siP4tyLvjjHN1yUS4Ug=";
+    tag = "v${version}";
+    hash = "sha256-JHywmX6Bp24OXCDRYuM0PEgVNPFRwYsge198u9e+lQs=";
   };
 
   build-system = with python3.pkgs; [ setuptools ];
@@ -33,7 +33,8 @@ python3.pkgs.buildPythonApplication {
 
   meta = {
     description = "Bisect nix builds";
-    homepage = "https://github.com/timokau/nix-bisect";
+    homepage = "https://github.com/KiaraGrouwstra/nix-bisect";
     license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kiara ];
   };
 }


### PR DESCRIPTION
Switches out `nix-bisect` to a [fork](https://github.com/lheckemann/nix-bisect/compare/master...KiaraGrouwstra:nix-bisect:v0.4.2) that notably [adds](https://github.com/KiaraGrouwstra/nix-bisect/releases/tag/v0.4.2) support for bisecting flake-based builds.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
