### PR TITLE
kdePackages.kio: 6.22.0 -> 6.22.1

### DIFF
--- a/pkgs/kde/generated/sources/frameworks.json
+++ b/pkgs/kde/generated/sources/frameworks.json
@@ -175,9 +175,9 @@
     "hash": "sha256-1u7emnWqSzPD6K/evcyWZM9CPv/qvmhLIdwcyXKKIHM="
   },
   "kio": {
-    "version": "6.22.0",
-    "url": "mirror://kde/stable/frameworks/6.22/kio-6.22.0.tar.xz",
-    "hash": "sha256-SwPxoHD3isKjQ/E4rF+Nm8zRGSdkqqRa5Jqn9JWZJpQ="
+    "version": "6.22.1",
+    "url": "mirror://kde/stable/frameworks/6.22/kio-6.22.1.tar.xz",
+    "hash": "sha256-BKr46ys7ysbZIfw6HQM9Z9+J2a+PaTVRhe3xr2HJM3A="
   },
   "kirigami": {
     "version": "6.22.0",


### PR DESCRIPTION

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test