### PR TITLE
yubikey-manager: 5.8.0 -> 5.9.0 

### DIFF
--- a/pkgs/by-name/yu/yubikey-manager/package.nix
+++ b/pkgs/by-name/yu/yubikey-manager/package.nix
@@ -9,14 +9,14 @@
 
 python3Packages.buildPythonPackage rec {
   pname = "yubikey-manager";
-  version = "5.8.0";
+  version = "5.9.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Yubico";
     repo = "yubikey-manager";
     tag = version;
-    hash = "sha256-Z3krdKP6hhhIxN7nl/k5r30jFVC0kZK9Z6Aqllp/KrA=";
+    hash = "sha256-8SWuhuFeMRIskJRxeb67gA3gdhSDf/vnrYHra6t71Bc=";
   };
 
   postPatch = ''
@@ -33,11 +33,12 @@ python3Packages.buildPythonPackage rec {
   ];
 
   dependencies = with python3Packages; [
-    cryptography
-    pyscard
-    fido2
     click
+    cryptography
+    fido2
     keyring
+    pyscard
+    python-pskc
   ];
 
   postInstall = ''
@@ -50,8 +51,9 @@ python3Packages.buildPythonPackage rec {
   '';
 
   nativeCheckInputs = with python3Packages; [
-    pytestCheckHook
+    astroid
     makefun
+    pytestCheckHook
   ];
 
   meta = {

--- a/pkgs/development/python-modules/python-pskc/default.nix
+++ b/pkgs/development/python-modules/python-pskc/default.nix
@@ -1,0 +1,61 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  lib,
+  cryptography,
+  defusedxml,
+  lxml,
+  pytest-cov-stub,
+  pytestCheckHook,
+  python-dateutil,
+  setuptools,
+  signxml,
+}:
+
+buildPythonPackage rec {
+  pname = "python-pskc";
+  version = "1.4";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "arthurdejong";
+    repo = "python-pskc";
+    tag = version;
+    hash = "sha256-WBpS0EJA4arAn7O47ZHq3sBOd9D4tjYZKIi24xX5Hvs=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    cryptography
+    python-dateutil
+  ];
+
+  optional-dependencies = {
+    defuse = [ defusedxml ];
+    lxml = [ lxml ];
+    signature = [ signxml ];
+  };
+
+  nativeCheckInputs = [
+    pytest-cov-stub
+    pytestCheckHook
+  ]
+  ++ lib.concatAttrValues optional-dependencies;
+
+  preCheck = ''
+    export TZ=Europe/Amsterdam
+  '';
+
+  pythonImportsCheck = [ "pskc" ];
+
+  meta = {
+    changelog = "https://github.com/arthurdejong/python-pskc/releases/tag/${version}";
+    description = "Python module for handling PSKC files";
+    homepage = "https://github.com/arthurdejong/python-pskc";
+    license = lib.licenses.lgpl21Plus;
+    maintainers = [ ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15551,6 +15551,8 @@ self: super: with self; {
 
   python-prctl = callPackage ../development/python-modules/python-prctl { };
 
+  python-pskc = callPackage ../development/python-modules/python-pskc { };
+
   python-ptrace = callPackage ../development/python-modules/python-ptrace { };
 
   python-rabbitair = callPackage ../development/python-modules/python-rabbitair { };


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
