### PR TITLE
mender-artifact: init at 4.2.0

### DIFF
--- a/pkgs/by-name/me/mender-artifact/package.nix
+++ b/pkgs/by-name/me/mender-artifact/package.nix
@@ -1,0 +1,74 @@
+{
+  fetchFromGitHub,
+  buildGoModule,
+  pkg-config,
+  lib,
+  openssl,
+  versionCheckHook,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "mender-artifact";
+  version = "4.3.0";
+
+  src = fetchFromGitHub {
+    owner = "mendersoftware";
+    repo = "mender-artifact";
+    tag = finalAttrs.version;
+    hash = "sha256-J1aOX3CSxkTnGnMGOa7bdhM/pPh5JIRxWkgr8bGRQFY=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    openssl
+  ];
+
+  vendorHash = null;
+
+  checkPhase =
+    let
+      disabledTestPaths = [
+        # Nearly entire test module fails for different reasons
+        "github.com/mendersoftware/mender-artifact/cli"
+      ];
+      disabledTest = [
+        # Expected nil, but got: &exec.Error{Name:"/usr/local/sbin/bin/ls"
+        "TestGetBinaryPath"
+      ];
+      patternDisabledTestPaths = builtins.concatStringsSep "|" disabledTestPaths;
+      patternDisabledTest = builtins.concatStringsSep "|" disabledTest;
+    in
+    ''
+      runHook preCheck
+
+      go test $(go list ./... | grep -v -E '${patternDisabledTestPaths}') -skip=$'${patternDisabledTest}'
+
+      runHook postCheck
+    '';
+
+  ldflags = [
+    "-s"
+    "-X github.com/mendersoftware/mender-artifact/cli.Version=${finalAttrs.version}"
+  ];
+
+  doInstallCheck = true;
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+
+  __structuredAttrs = true;
+
+  meta = {
+    homepage = "https://mender.io";
+    changelog = "https://github.com/mendersoftware/mender-artifact/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    description = "Library for managing Mender artifact files";
+    mainProgram = "mender-artifact";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ skohtv ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Add mender-artifact package

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
