### PR TITLE
lib: re-export missing builtins in lib

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -105,6 +105,22 @@ let
       # network
       network = callLibs ./network;
 
+      inherit (builtins)
+        getContext
+        hasContext
+        convertHash
+        hashString
+        hasFile
+        parseDrvName
+        placeholder
+        fromJSON
+        fromTOML
+        toFile
+        toJSON
+        toString
+        toXML
+        tryEval
+        ;
       inherit (self.trivial)
         id
         const
@@ -112,6 +128,8 @@ let
         concat
         "or"
         and
+        mul
+        div
         xor
         bitAnd
         bitOr
@@ -163,6 +181,8 @@ let
         pathExists
         genericClosure
         readFile
+        ceil
+        floor
         ;
       inherit (self.fixedPoints)
         fix
@@ -326,7 +346,6 @@ let
         escape
         escapeShellArg
         escapeShellArgs
-        isPath
         isStorePath
         isStringLike
         isValidPosixName
@@ -419,6 +438,9 @@ let
         pathType
         pathIsDirectory
         pathIsRegularFile
+        baseNameOf
+        dirOf
+        isPath
         packagesFromDirectoryRecursive
         ;
       inherit (self.sources)
@@ -433,6 +455,7 @@ let
         pathIsGitRepo
         revOrTag
         repoRevToName
+        filterSource
         ;
       inherit (self.modules)
         evalModules
@@ -563,6 +586,7 @@ let
         imap
         ;
       inherit (self.versions)
+        compareVersions
         splitVersion
         ;
       inherit (self.network.ipv6)

--- a/lib/filesystem.nix
+++ b/lib/filesystem.nix
@@ -25,6 +25,11 @@ let
 in
 
 {
+  inherit (builtins)
+    baseNameOf
+    dirOf
+    isPath
+    ;
 
   /**
     The type of a path. The path needs to exist and be accessible.

--- a/lib/sources.nix
+++ b/lib/sources.nix
@@ -529,4 +529,6 @@ in
 
     trace
     ;
+
+  inherit (builtins) filterSource;
 }

--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -27,6 +27,8 @@ in
     isFloat
     add
     sub
+    mul
+    div
     lessThan
     seq
     deepSeq
@@ -34,6 +36,8 @@ in
     bitAnd
     bitOr
     bitXor
+    ceil
+    floor
     ;
 
   ## Simple (higher order) functions

--- a/lib/versions.nix
+++ b/lib/versions.nix
@@ -3,6 +3,8 @@
 
 rec {
 
+  inherit (builtins) compareVersions;
+
   /**
     Break a version string into its component parts.
 


### PR DESCRIPTION
Closes #369215

I just rebased @asakura PR #398857 against master

CC @infinisil @stepbrobd

This PR just re-exports the missing builtins in lib.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
