### PR TITLE
harmonoid: 0.3.10 -> 0.3.21

### DIFF
--- a/pkgs/by-name/ha/harmonoid/package.nix
+++ b/pkgs/by-name/ha/harmonoid/package.nix
@@ -16,11 +16,12 @@
   mpv-unwrapped,
 }:
 let
-  version = "0.3.10";
+  version = "0.3.21";
   url_base = "https://github.com/alexmercerind2/harmonoid-releases/releases/download/v${version}";
   url =
     rec {
       x86_64-linux = "${url_base}/harmonoid-linux-x86_64.tar.gz";
+      aarch64-linux = "${url_base}/harmonoid-linux-aarch64.tar.gz";
       x86_64-darwin = "${url_base}/harmonoid-macos-universal.dmg";
       aarch64-darwin = x86_64-darwin;
     }
@@ -28,8 +29,9 @@ let
       or (throw "${stdenv.hostPlatform.system} is an unsupported platform");
   hash =
     rec {
-      x86_64-linux = "sha256-GTF9KrcTolCc1w/WT0flwlBCBitskFPaJuNUdxCW9gs=";
-      x86_64-darwin = "sha256-7qcUnYBasUqisEW56fq4JGgojBmfqycrDIMpCCWLxlc=";
+      x86_64-linux = "sha256-RZDRb/afXbalNbLBGaQgx5Qd4UEbNrvIsa3h+e6osJE=";
+      aarch64-linux = "sha256-1ys7uyCjXe4IBeXRk8mFjqmP9OottNefQrrtTkxq/qU=";
+      x86_64-darwin = "sha256-mo7Rj6c89KZrsL29i99x4E7b6soWlGUsC6KpSB7y5iY=";
       aarch64-darwin = x86_64-darwin;
     }
     .${stdenv.hostPlatform.system};
@@ -90,6 +92,7 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [ ivyfanchiang ];
     platforms = [
       "x86_64-linux"
+      "aarch64-linux"
       "x86_64-darwin"
       "aarch64-darwin"
     ];


### PR DESCRIPTION
this updates harmonoid to its latest available version, as well as adding support to aarch64, which was seemingly missing from the package at nixpkgs.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
