### PR TITLE
Containerd: fix go124 symlink resolution

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -393,6 +393,7 @@ in
   console-xkb-and-i18n = runTest ./console-xkb-and-i18n.nix;
   consul = runTest ./consul.nix;
   consul-template = runTest ./consul-template.nix;
+  containerd = runTest ./containerd.nix;
   containers-bridge = runTest ./containers-bridge.nix;
   containers-custom-pkgs = runTest ./containers-custom-pkgs.nix;
   containers-ephemeral = runTest ./containers-ephemeral.nix;

--- a/nixos/tests/containerd.nix
+++ b/nixos/tests/containerd.nix
@@ -1,0 +1,80 @@
+{ lib, pkgs, ... }:
+
+let
+  # Create passwd file
+  etcFiles = pkgs.runCommand "containerd-symlink-passwd" { } ''
+        mkdir -p $out/etc
+        cat > $out/etc/passwd <<'EOF'
+    root:x:0:0:root:/root:/bin/sh
+    testuser:x:1000:0:test user:/home/testuser:/bin/sh
+    EOF
+  '';
+
+  passwdSymlinkImage = pkgs.dockerTools.buildLayeredImage {
+    name = "nixos-symlink-passwd-test";
+    tag = "latest";
+
+    contents = [
+      pkgs.busybox
+      etcFiles
+    ];
+
+    extraCommands = ''
+      mkdir -p etc home/testuser
+      rm -f etc/passwd
+      ln -sf ${etcFiles}/etc/passwd etc/passwd
+      test -L etc/passwd
+    '';
+
+    config = {
+      # Forces containerd to read /etc/passwd in the rootfs
+      User = "testuser";
+      Cmd = [
+        "/bin/sh"
+        "-lc"
+        "id -u; echo OK"
+      ];
+    };
+  };
+in
+{
+  name = "containerd";
+  meta.maintainers = with lib.maintainers; [ eskytthe ];
+
+  nodes = {
+    machine =
+      { ... }:
+      {
+        virtualisation.containerd.enable = true;
+        environment.systemPackages = [
+          pkgs.containerd
+          pkgs.gnugrep
+          pkgs.coreutils
+        ];
+      };
+  };
+
+  testScript = ''
+    start_all()
+
+    machine.wait_for_unit("containerd.service")
+    machine.wait_until_succeeds("${pkgs.containerd}/bin/ctr version")
+
+    machine.succeed("${pkgs.containerd}/bin/ctr images import --no-unpack ${passwdSymlinkImage}")
+    machine.succeed("${pkgs.containerd}/bin/ctr images ls")
+
+    ref = machine.succeed("${pkgs.containerd}/bin/ctr images ls -q | ${pkgs.gnugrep}/bin/grep -E '(^|/)nixos-symlink-passwd-test(:|@)' | head -n 1").strip()
+    print("Imported image ref: " + ref)
+    assert ref != ""
+
+    # Runtime test of fix(oci): handle absolute symlinks in rootfs user lookup for /etc/passwd
+    # https://github.com/containerd/containerd/pull/12732
+    # TODO: Still issue for /etc/group:
+    # https://github.com/containerd/containerd/issues/12683#issuecomment-3773170623
+    out = machine.succeed("${pkgs.containerd}/bin/ctr run --rm --net-host --snapshotter native " + ref + " container1")
+    print("ctr run output:\\n" + out)
+    # User id and return string from Cmd in image
+    assert "1000" in out
+    assert "OK" in out
+  '';
+}

--- a/nixos/tests/containerd.nix
+++ b/nixos/tests/containerd.nix
@@ -1,15 +1,18 @@
 { lib, pkgs, ... }:
 
 let
-  # Create passwd file
+  # Create passwd + group files - for symlink to absolute /nix/store/... paths
   etcFiles = pkgs.runCommand "containerd-symlink-passwd" { } ''
-        mkdir -p $out/etc
-        cat > $out/etc/passwd <<'EOF'
-    root:x:0:0:root:/root:/bin/sh
-    testuser:x:1000:0:test user:/home/testuser:/bin/sh
+            mkdir -p $out/etc
+            cat > $out/etc/passwd <<'EOF'
+        root:x:0:0:root:/root:/bin/sh
+        testuser:x:1000:0:test user:/home/testuser:/bin/sh
+        EOF
+
+            cat > $out/etc/group <<'EOF'
+    root:x:0:
     EOF
   '';
-
   passwdSymlinkImage = pkgs.dockerTools.buildLayeredImage {
     name = "nixos-symlink-passwd-test";
     tag = "latest";
@@ -24,10 +27,13 @@ let
       rm -f etc/passwd
       ln -sf ${etcFiles}/etc/passwd etc/passwd
       test -L etc/passwd
+
+      ln -sf ${etcFiles}/etc/group  etc/group
+      test -L etc/group
     '';
 
     config = {
-      # Forces containerd to read /etc/passwd in the rootfs
+      # Forces containerd to read /etc/passwd and group in the rootfs
       User = "testuser";
       Cmd = [
         "/bin/sh"

--- a/pkgs/by-name/co/containerd/package.nix
+++ b/pkgs/by-name/co/containerd/package.nix
@@ -5,6 +5,7 @@
   btrfs-progs,
   buildGoModule,
   fetchFromGitHub,
+  fetchpatch2,
   go-md2man,
   kubernetes,
   nix-update-script,
@@ -30,6 +31,22 @@ buildGoModule rec {
     tag = "v${version}";
     hash = "sha256-fDOfN0XESrBTDW7Nxj9niqU93BQ5/JaGLwAR3u6Xaik=";
   };
+
+  patches = [
+    # fix(oci): handle absolute symlinks in rootfs user lookup
+    # https://github.com/containerd/containerd/pull/12732
+    (fetchpatch2 {
+      # PR #12732 commit 85b5418… (the actual fix)
+      url = "https://github.com/containerd/containerd/commit/85b5418ef5a6adeac95c910bf8c33ae0fb7bbecb.patch";
+      hash = "sha256-M6kxUbf8JECta8pfFlvZ7F51ZS4aK9IEkwy7kbfdHM0=";
+    })
+
+    (fetchpatch2 {
+      # PR #12732 commit 9bbb130… (tests / coverage)
+      url = "https://github.com/containerd/containerd/commit/9bbb1309f051e54b51484fa0efbfe93e26223a2d.patch";
+      hash = "sha256-QK+WGJRjJxro26MF04yGYcfAtNvoAZqAUYg8UzEOVqM=";
+    })
+  ];
 
   postPatch = ''
     patchShebangs .

--- a/pkgs/by-name/co/containerd/package.nix
+++ b/pkgs/by-name/co/containerd/package.nix
@@ -46,6 +46,11 @@ buildGoModule rec {
       url = "https://github.com/containerd/containerd/commit/9bbb1309f051e54b51484fa0efbfe93e26223a2d.patch";
       hash = "sha256-QK+WGJRjJxro26MF04yGYcfAtNvoAZqAUYg8UzEOVqM=";
     })
+    (fetchpatch2 {
+      # fix(oci): apply absolute symlink resolution to /etc/group #12925
+      url = "https://github.com/containerd/containerd/commit/fc406dbc5ce50d05e37557e58eb00106d416b014.patch";
+      hash = "sha256-Z/3GJHyrhv6UbGsFMzwLJljz4O68GLSvojRBjo/GEpI=";
+    })
   ];
 
   postPatch = ''


### PR DESCRIPTION
1) Containerd: Patch for fix(oci): handle absolute symlinks in rootfs user lookup     https://github.com/containerd/containerd/pull/12732 - containerd issue: https://github.com/containerd/containerd/issues/12683. Discovered during upgrade test of k8s and containerd to NixOS 25.11.

Note: This patch do only handle the /etc/passwd problem. There is ongoing work on the similar /etc/group problem - https://github.com/containerd/containerd/issues/12683#issuecomment-3773307996

2) Added nix pkgs test for basis containerd  and the patch. Without patch test break:
```
machine # ctr: mount callback failed on /tmp/containerd-mount213994424: openat etc/passwd: path escapes from parent
machine: output:
!!! Traceback (most recent call last):
!!!   File "<string>", line 17, in <module>
!!!     out = machine.succeed("/nix/store/pifs5r3phrnf0yr7mav6h20cqwka1n1n-containerd-2.2.1/bin/ctr run --rm --net-host --snapshotter native " + ref + " container1")
!!!
!!! RequestedAssertionFailed: command `/nix/store/pifs5r3phrnf0yr7mav6h20cqwka1n1n-containerd-2.2.1/bin/ctr run --rm --net-host --snapshotter native docker.io/library/nixos-symlink-passwd-test:latest container1` failed (exit code 1)
An exception has occurred, use %tb to see the full traceback.

SystemExit: 1
``` 

Note 1: Test do only handle the /etc/passwd problem. I can extend the test for /etc/group later if wanted.

Note2: I have added myself as maintainer of the test. Feel free to add others or/and remove me.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

- nix fmt on files

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
