### PR TITLE
nixos/geoclue2: add D-Bus policy to access wpa_supplicant

### DIFF
--- a/nixos/modules/services/desktops/geoclue2.nix
+++ b/nixos/modules/services/desktops/geoclue2.nix
@@ -254,7 +254,27 @@ in
 
     environment.systemPackages = [ cfg.package ];
 
-    services.dbus.packages = [ cfg.package ];
+    services.dbus.packages = [
+      cfg.package
+    ]
+    ++ lib.optionals cfg.enableWifi [
+      # Allow geoclue to access wpa_supplicant for WiFi-based geolocation
+      (pkgs.writeTextFile {
+        name = "geoclue-wpa-dbus-policy";
+        destination = "/share/dbus-1/system.d/geoclue-wpa.conf";
+        text = ''
+          <!DOCTYPE busconfig PUBLIC
+            "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+            "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+          <busconfig>
+            <policy user="geoclue">
+              <allow send_destination="fi.w1.wpa_supplicant1"/>
+              <allow receive_sender="fi.w1.wpa_supplicant1"/>
+            </policy>
+          </busconfig>
+        '';
+      })
+    ];
 
     systemd.packages = [ cfg.package ];
 


### PR DESCRIPTION
When WiFi-based geolocation is enabled, geoclue needs to communicate with wpa_supplicant via D-Bus to scan WiFi networks. However, wpa_supplicant's default D-Bus policy only allows root access.

This adds a D-Bus policy that allows the geoclue user to send requests to and receive responses from wpa_supplicant when enableWifi is true.

Without this fix, geoclue reports "No WiFi networks found" and falls back to less accurate IP-based geolocation.

Ported from https://github.com/domenkozar/homelab/commit/4b608ef5c80f862945615d25afd8738b9370e0ba