### PR TITLE
gitlab: 18.6.3 -> 18.6.4

### DIFF
--- a/pkgs/by-name/gi/gitaly/package.nix
+++ b/pkgs/by-name/gi/gitaly/package.nix
@@ -7,7 +7,7 @@
 }:
 
 let
-  version = "18.6.3";
+  version = "18.6.4";
   package_version = "v${lib.versions.major version}";
   gitaly_package = "gitlab.com/gitlab-org/gitaly/${package_version}";
 
@@ -21,7 +21,7 @@ let
       owner = "gitlab-org";
       repo = "gitaly";
       rev = "v${version}";
-      hash = "sha256-zZho0cN/ePViLo4KtBNIHIHUbpbPI8jj88zY8cCacaU=";
+      hash = "sha256-SH1NXP5OcJF2MCCSCEjCT2GXjHxy1i9QtPZZCJ92rY8=";
     };
 
     vendorHash = "sha256-+5CTncYwtGlScFvVc3QaEScfuqMqvsjnGhggM1HMhNU=";

--- a/pkgs/by-name/gi/gitlab-container-registry/package.nix
+++ b/pkgs/by-name/gi/gitlab-container-registry/package.nix
@@ -6,7 +6,7 @@
 
 buildGo124Module rec {
   pname = "gitlab-container-registry";
-  version = "4.33.0";
+  version = "4.34.0";
   rev = "v${version}-gitlab";
 
   # nixpkgs-update: no auto update
@@ -14,10 +14,10 @@ buildGo124Module rec {
     owner = "gitlab-org";
     repo = "container-registry";
     inherit rev;
-    hash = "sha256-6FcnzlQQSeM8l2jH5dG9g0rmnEvAg2FWB8ZpKYBBhE4=";
+    hash = "sha256-KGw9kVsAePhEQ+kINgcMhGw7pSioOnqNWFnjQKu/XmY=";
   };
 
-  vendorHash = "sha256-YfpqspLh+lV+MVZtn8iHQuE+DkZrcOq6hDt20SqkKfw=";
+  vendorHash = "sha256-g4h1m7b7dkdTcSfwTZH4Z5P9RBKme441Ucg4aPIqLSY=";
 
   checkFlags =
     let

--- a/pkgs/by-name/gi/gitlab-pages/package.nix
+++ b/pkgs/by-name/gi/gitlab-pages/package.nix
@@ -6,14 +6,14 @@
 
 buildGoModule rec {
   pname = "gitlab-pages";
-  version = "18.6.3";
+  version = "18.6.4";
 
   # nixpkgs-update: no auto update
   src = fetchFromGitLab {
     owner = "gitlab-org";
     repo = "gitlab-pages";
     rev = "v${version}";
-    hash = "sha256-+MxG6cWZfNN1Kfx0eLEevWR8q23pnsmS73B4aquKrSc=";
+    hash = "sha256-FMXfF/NpwivtfZh+r7gcVXKFCeshxHBKRNFnbCxSz1U=";
   };
 
   vendorHash = "sha256-AL6V2LPzCGo/7IuY8msip35OScfocp3zO2ZzM8cZfnU=";

--- a/pkgs/by-name/gi/gitlab/data.json
+++ b/pkgs/by-name/gi/gitlab/data.json
@@ -1,17 +1,17 @@
 {
-  "version": "18.6.3",
-  "repo_hash": "1ims6fy3zjnrappy1kkb02b8s2vldr18dz7ick176ljk042lqa5g",
+  "version": "18.6.4",
+  "repo_hash": "0jj2wfh37p92dj6fnwv098qaaph9sblqc09mjrz6f5142ijlmxj9",
   "yarn_hash": "19fhh3457mvls3g4swyzr2dh9q46z2zinjyw5v6sjjhfmrqs921d",
   "frontend_islands_yarn_hash": "0m64xhlybjlax33k5rmj9kxcj1vzqqygybyz1yzzx9pd87570k2h",
   "owner": "gitlab-org",
   "repo": "gitlab",
-  "rev": "v18.6.3-ee",
+  "rev": "v18.6.4-ee",
   "passthru": {
-    "GITALY_SERVER_VERSION": "18.6.3",
-    "GITLAB_KAS_VERSION": "18.6.3",
-    "GITLAB_PAGES_VERSION": "18.6.3",
+    "GITALY_SERVER_VERSION": "18.6.4",
+    "GITLAB_KAS_VERSION": "18.6.4",
+    "GITLAB_PAGES_VERSION": "18.6.4",
     "GITLAB_SHELL_VERSION": "14.45.3",
     "GITLAB_ELASTICSEARCH_INDEXER_VERSION": "5.10.1",
-    "GITLAB_WORKHORSE_VERSION": "18.6.3"
+    "GITLAB_WORKHORSE_VERSION": "18.6.4"
   }
 }

--- a/pkgs/by-name/gi/gitlab/gitlab-workhorse/default.nix
+++ b/pkgs/by-name/gi/gitlab/gitlab-workhorse/default.nix
@@ -10,7 +10,7 @@ in
 buildGoModule rec {
   pname = "gitlab-workhorse";
 
-  version = "18.6.3";
+  version = "18.6.4";
 
   # nixpkgs-update: no auto update
   src = fetchFromGitLab {


### PR DESCRIPTION
https://about.gitlab.com/releases/2026/01/21/patch-release-gitlab-18-8-2-released/


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
