### PR TITLE
memos: fixed broken module

### DIFF
--- a/nixos/modules/services/misc/memos.nix
+++ b/nixos/modules/services/misc/memos.nix
@@ -113,6 +113,55 @@ in
           Restart = "always";
           RestartSec = 3;
           ExecStart = "${lib.getExe cfg.package}";
+          LimitNOFILE = 65536;
+          NoNewPrivileges = true;
+          LockPersonality = true;
+          RemoveIPC = true;
+          ReadWritePaths = [
+            cfg.settings.dataDir
+          ];
+          ProtectSystem = "strict";
+          PrivateUsers = true;
+          ProtectHome = true;
+          PrivateTmp = true;
+          PrivateDevices = true;
+          ProtectHostname = true;
+          ProtectClock = true;
+          UMask = "0077";
+          ProtectKernelTunables = true;
+          ProtectKernelModules = true;
+          ProtectControlGroups = true;
+          ProtectProc = "invisible";
+          SystemCallFilter = [
+            " " # This is needed to clear the SystemCallFilter existing definitions
+            "~@reboot"
+            "~@swap"
+            "~@obsolete"
+            "~@mount"
+            "~@module"
+            "~@debug"
+            "~@cpu-emulation"
+            "~@clock"
+            "~@raw-io"
+            "~@privileged"
+            "~@resources"
+          ];
+          CapabilityBoundingSet = [
+            " " # Reset all capabilities to an empty set
+          ];
+          RestrictAddressFamilies = [
+            " " # This is needed to clear the RestrictAddressFamilies existing definitions
+            "none" # Remove all addresses families
+            "AF_UNIX"
+            "AF_INET"
+            "AF_INET6"
+          ];
+          DevicePolicy = "closed";
+          ProtectKernelLogs = true;
+          SystemCallArchitectures = "native";
+          RestrictNamespaces = true;
+          RestrictRealtime = true;
+          RestrictSUIDSGID = true;
         };
       };
     };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
The Memos module is in a pretty broken state right now. I tried to use it on my homelab but I quickly ran into problems and frustrations.

The first things was that the module has an option to open the firewall. This option is broken as it tries to evaluate `      services.memos.port` which is not an option that exists. This means if you enable the `openFirewall` option the module breaks.

Secondly the module is very inconsistent and weird in the way it implements its settings. It for example has the option
`services.memos.dataDir` which just sets `services.memos.settings.MEMOS_DATA`. But then there is also `services.memos.environmentFile` which is just generated from `services.memos.settings`. So that means that there are three ways to set the settings of Memos which are all spaghettified together.

I think it would make sense to have the settings in `services.memos.settings` with more nix style setting name like `dataDir` instead of `MEMOS_DATA`. Then you could use `services.memos.environmentFile` to pass secrets to the application. However I do not know enough about Memos to know if it even uses any secrets right now.

Third the default settings set are not the default settings of Memos. For example the module define the default port to be 5230 but Memos uses 8081 by default. This applies to various other default settings of this module and leads to unexpected behavior. I think there should be consistency between Memos default settings and the Nix module default settings.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

I fixed the port issue and there is now a port option. I also made the module more nix style and made all the settings go in `services.memos.settings` such that all the weird `MEMOS_*` are abstracted away. I also implemented all the settings with the correct types that Memos expects. The default values are now the same as the Memos default values. I also implemented the systemd service to reflect the on recommended systemd service in the Memos documentation.

This is a breaking fix but the module is pretty new and in a pretty unusable state right now. So I think it should be merged soon rather than later. As this is also a general cleanup for the module that makes it easier to maintain in the future. The next release of Memos will contain changes to its setting names so an update of this module is necessary by that point anyway.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
