### PR TITLE
ente-web: 1.2.22 -> 1.3.10

### DIFF
--- a/pkgs/by-name/en/ente-web/package.nix
+++ b/pkgs/by-name/en/ente-web/package.nix
@@ -1,9 +1,15 @@
 {
   lib,
   stdenv,
+  binaryen,
+  cargo,
   fetchFromGitHub,
   fetchYarnDeps,
   nodejs,
+  rustPlatform,
+  rustc,
+  wasm-bindgen-cli_0_2_106,
+  wasm-pack,
   yarnConfigHook,
   yarnBuildHook,
   nix-update-script,
@@ -19,43 +25,74 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "ente-web-${enteApp}";
-  version = "1.2.22";
+  version = "1.3.10";
 
   src = fetchFromGitHub {
     owner = "ente-io";
     repo = "ente";
-    sparseCheckout = [ "web" ];
+    sparseCheckout = [
+      "rust"
+      "web"
+    ];
     tag = "photos-v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-ckrACrgQ9qj6e44QifiUPtldBbDVrKv29s5oQ1Y+gvk=";
+    hash = "sha256-2f4A8RQFhXjPpHKvZACUmUcoukJ800yqTTMWBtLyIlI=";
   };
   sourceRoot = "${finalAttrs.src.name}/web";
 
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs)
+      pname
+      version
+      src
+      sourceRoot
+      cargoRoot
+      ;
+    hash = "sha256-dedLmQP15V+gAtycXx1fpWfjXWsTPLXPPcCIAcr/ME0=";
+  };
+  cargoRoot = "packages/wasm";
+
   offlineCache = fetchYarnDeps {
     yarnLock = "${finalAttrs.src}/web/yarn.lock";
-    hash = "sha256-omFNobZ+2hb1cEO2Gfn+F3oYy7UDSrtIY4cliQ80CUs=";
+    hash = "sha256-H9ZNnbY22BddJl3SDhg+cEN0IaBZtilBFBDUf+zOzV0=";
   };
 
   nativeBuildInputs = [
     yarnConfigHook
     yarnBuildHook
+    binaryen
+    cargo
+    rustPlatform.cargoSetupHook
+    rustc
+    rustc.llvmPackages.lld
     nodejs
+    wasm-bindgen-cli_0_2_106
+    wasm-pack
   ];
 
   # See: https://github.com/ente-io/ente/blob/main/web/apps/photos/.env
   env = extraBuildEnv;
 
-  # Replace hardcoded ente.io urls if desired
-  postPatch = lib.optionalString (enteMainUrl != null) ''
-    substituteInPlace \
-      apps/payments/src/services/billing.ts \
-      apps/photos/src/pages/shared-albums.tsx \
-      --replace-fail "https://ente.io" ${lib.escapeShellArg enteMainUrl}
+  postPatch = [
+    # Use our `wasm-pack` binary, rather than the Node version, which is
+    # just a wrapper that tries to download the actual binary
+    ''
+      substituteInPlace \
+        packages/wasm/package.json \
+        --replace-fail "wasm-pack " ${lib.escapeShellArg "${wasm-pack}/bin/wasm-pack "}
+    ''
+    # Replace hardcoded ente.io urls if desired
+    (lib.optionalString (enteMainUrl != null) ''
+      substituteInPlace \
+        apps/payments/src/services/billing.ts \
+        apps/photos/src/pages/shared-albums.tsx \
+        --replace-fail "https://ente.io" ${lib.escapeShellArg enteMainUrl}
 
-    substituteInPlace \
-      apps/accounts/src/pages/index.tsx \
-      --replace-fail "https://web.ente.io" ${lib.escapeShellArg enteMainUrl}
-  '';
+      substituteInPlace \
+        apps/accounts/src/pages/index.tsx \
+        --replace-fail "https://web.ente.io" ${lib.escapeShellArg enteMainUrl}
+    '')
+  ];
 
   yarnBuildScript = "build:${enteApp}";
   installPhase =
@@ -85,6 +122,7 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [
       pinpox
       oddlama
+      nicegamer7
     ];
     platforms = lib.platforms.all;
   };

--- a/pkgs/by-name/en/ente-web/package.nix
+++ b/pkgs/by-name/en/ente-web/package.nix
@@ -73,7 +73,7 @@ stdenv.mkDerivation (finalAttrs: {
   # See: https://github.com/ente-io/ente/blob/main/web/apps/photos/.env
   env = extraBuildEnv;
 
-  postPatch = [
+  postPatch =
     # Use our `wasm-pack` binary, rather than the Node version, which is
     # just a wrapper that tries to download the actual binary
     ''
@@ -82,7 +82,7 @@ stdenv.mkDerivation (finalAttrs: {
         --replace-fail "wasm-pack " ${lib.escapeShellArg "${wasm-pack}/bin/wasm-pack "}
     ''
     # Replace hardcoded ente.io urls if desired
-    (lib.optionalString (enteMainUrl != null) ''
+    + lib.optionalString (enteMainUrl != null) ''
       substituteInPlace \
         apps/payments/src/services/billing.ts \
         apps/photos/src/pages/shared-albums.tsx \
@@ -91,8 +91,7 @@ stdenv.mkDerivation (finalAttrs: {
       substituteInPlace \
         apps/accounts/src/pages/index.tsx \
         --replace-fail "https://web.ente.io" ${lib.escapeShellArg enteMainUrl}
-    '')
-  ];
+    '';
 
   yarnBuildScript = "build:${enteApp}";
   installPhase =


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Rust code was added in the v1.2.28 release, so this package has not been updating automatically since then. I updated the package definition so that it builds, but I'm not sure how exactly to test it. I use the Ente module on a VPS. If anyone has an idea on how to test this using the Ente module, let me know and I'll do that.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
