### PR TITLE
rapidraw: 1.4.5 -> 1.4.11

### DIFF
--- a/pkgs/by-name/ra/rapidraw/package.nix
+++ b/pkgs/by-name/ra/rapidraw/package.nix
@@ -125,6 +125,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
       --replace-fail 'if !is_valid' 'if false'
   '';
 
+  # Fix dyld error about onnxruntime not being loaded on darwin during cargo test
+  preCheck = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    export DYLD_LIBRARY_PATH="${onnxruntime}/lib:$DYLD_LIBRARY_PATH"
+  '';
+
   dontWrapGApps = true;
 
   # needs to be declared twice annoyingly

--- a/pkgs/by-name/ra/rapidraw/package.nix
+++ b/pkgs/by-name/ra/rapidraw/package.nix
@@ -132,8 +132,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   dontWrapGApps = true;
 
-  # needs to be declared twice annoyingly
-  ORT_STRATEGY = "system";
+  env = {
+    ORT_STRATEGY = "system";
+  };
 
   postInstall = lib.optionalString stdenv.hostPlatform.isLinux ''
     # Patch the .desktop file to set the Categories field
@@ -144,16 +145,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
     # link the .so file
     ln -sf ${onnxruntime}/lib/libonnxruntime.so $out/lib/RapidRAW/resources/libonnxruntime.so
-
-    # remove the .dylib file
-    rm -rf $out/lib/RapidRAW/resources/libonnxruntime.dylib
   '';
 
   postFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
     wrapGApp $out/bin/rapidraw \
       --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath finalAttrs.buildInputs} \
-      --set ORT_STRATEGY "system" \
-      --set ORT_DYLIB_PATH "${onnxruntime}/lib/libonnxruntime.so"
+      --set ORT_STRATEGY "system"
   '';
 
   meta = {

--- a/pkgs/by-name/ra/rapidraw/package.nix
+++ b/pkgs/by-name/ra/rapidraw/package.nix
@@ -42,13 +42,13 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rapidraw";
-  version = "1.4.5";
+  version = "1.4.11";
 
   src = fetchFromGitHub {
     owner = "CyberTimon";
     repo = "RapidRAW";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-WG9Dlo7yRt+QZGA5112+BX3HHhjV0XW5nrj7PUORUFE=";
+    hash = "sha256-Jd/t3PWvUaQuTHqd4A4vqAfzR2QpZ/j1352gLyuqRxQ=";
     fetchSubmodules = true;
 
     # darwin/linux hash mismatch in rawler submodule
@@ -58,11 +58,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
     '';
   };
 
-  cargoHash = "sha256-6oI88cvlCR6TBiAAUka+Q8bkoYyTXvpMDNMfwlPjtIU=";
+  cargoHash = "sha256-ijyrq2BwNeJM8eM6yc5jmCicpLndhtKVlwHviMwpFS4=";
 
   npmDeps = fetchNpmDeps {
     inherit (finalAttrs) src;
-    hash = "sha256-w806JHqy2ZLFcfYVm09VKnLd7BpLI1houfMYbY3sHe0=";
+    hash = "sha256-jenSEANarab/oQnC80NoM1jWmvdeXF3bJ9I/vOGcBb0=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Changelog: https://github.com/CyberTimon/RapidRAW/compare/v1.4.5...v1.4.11

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
