### PR TITLE
vimPluginsUpdater: don't define `passthru.updateScript`

### DIFF
--- a/pkgs/applications/editors/vim/plugins/utils/updater.nix
+++ b/pkgs/applications/editors/vim/plugins/utils/updater.nix
@@ -6,8 +6,6 @@
   nix-prefetch-git,
   nurl,
   python3Packages,
-  vimPluginsUpdater,
-  writeShellScript,
 
   # optional
   neovim-unwrapped,
@@ -49,11 +47,6 @@ buildPythonApplication {
 
   shellHook = ''
     export PYTHONPATH=pkgs/applications/editors/vim/plugins:$PYTHONPATH
-  '';
-
-  passthru.updateScript = writeShellScript "updateScript" ''
-    # don't saturate the update bot connection
-    ${lib.getExe vimPluginsUpdater} --proc 2 update
   '';
 
   meta.mainProgram = "vim-plugins-updater";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The idea originally was to automate Vim plugin updates, but it never worked out. And it turns out our updater still wastes @r-ryantm's resources 
https://nixpkgs-update-logs.nix-community.org/vimPluginsUpdater/2026-01-22.log


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
