### PR TITLE
btrsync: init at 0.3

### DIFF
--- a/pkgs/by-name/bt/btrsync/package.nix
+++ b/pkgs/by-name/bt/btrsync/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3Packages,
+  btrfs-progs,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "btrsync";
+  version = "0.3";
+  disable = python3Packages.pythonOlder "3.9";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "andreittr";
+    repo = "btrsync";
+    tag = "v${version}";
+    hash = "sha256-1LpHO70Yli9VG1UeqPZWM2qUMUbSbdgNP/r7FhUY/h4=";
+  };
+
+  build-system = [ python3Packages.setuptools ];
+
+  propagatedBuildInputs = [ btrfs-progs ];
+
+  nativeCheckInputs = [ python3Packages.pytestCheckHook ];
+
+  meta = {
+    description = "btrfs replication made easy";
+    homepage = "https://github.com/andreittr/btrsync";
+    changelog = "https://github.com/andreittr/btrsync/blob/${src.tag}/CHANGELOG.md";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "btrsync";
+    maintainers = with lib.maintainers; [ bcyran ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

> [btrfs](https://btrfs.wiki.kernel.org/) is a modern Linux Copy-on-Write (COW) filesystem supporting powerful features such as snapshotting and incremental serialization. This makes it easy to efficiently replicate related snapshots from one filesystem to another by transferring only the differences between them.

@andreittr FYI

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
