### PR TITLE
gnome-{settings-daemon,control-center,shell}: fix crash with hands-free profile

### DIFF
--- a/pkgs/by-name/gn/gnome-control-center/package.nix
+++ b/pkgs/by-name/gn/gnome-control-center/package.nix
@@ -3,6 +3,7 @@
   lib,
   stdenv,
   replaceVars,
+  fetchpatch,
   accountsservice,
   adwaita-icon-theme,
   blueprint-compiler,
@@ -88,6 +89,15 @@ stdenv.mkDerivation (finalAttrs: {
       gcm = gnome-color-manager;
       inherit glibc tzdata shadow;
       inherit cups networkmanagerapplet;
+    })
+
+    # Fix crash when switching to hands-free mode on a bluetooth headset
+    (fetchpatch {
+      name = "fix-bluetooth-handsfree-crash.patch";
+      url = "https://gitlab.gnome.org/GNOME/libgnome-volume-control/-/merge_requests/31.patch";
+      hash = "sha256-jFbItlXT05nnp825R/HvsWDFxAMzL4z36CsxhQ2sEIY=";
+      stripLen = 1;
+      extraPrefix = "subprojects/gvc/";
     })
   ];
 

--- a/pkgs/by-name/gn/gnome-settings-daemon/package.nix
+++ b/pkgs/by-name/gn/gnome-settings-daemon/package.nix
@@ -2,6 +2,7 @@
   stdenv,
   lib,
   replaceVars,
+  fetchpatch,
   buildPackages,
   fetchurl,
   meson,
@@ -55,6 +56,15 @@ stdenv.mkDerivation (finalAttrs: {
 
     (replaceVars ./fix-paths.patch {
       inherit tzdata;
+    })
+
+    # Fix crash when switching to hands-free mode on a bluetooth headset
+    (fetchpatch {
+      name = "fix-bluetooth-handsfree-crash.patch";
+      url = "https://gitlab.gnome.org/GNOME/libgnome-volume-control/-/merge_requests/31.patch";
+      hash = "sha256-jFbItlXT05nnp825R/HvsWDFxAMzL4z36CsxhQ2sEIY=";
+      stripLen = 1;
+      extraPrefix = "subprojects/gvc/";
     })
   ];
 

--- a/pkgs/by-name/gn/gnome-shell/package.nix
+++ b/pkgs/by-name/gn/gnome-shell/package.nix
@@ -111,6 +111,15 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://src.fedoraproject.org/rpms/gnome-shell/raw/dcd112d9708954187e7490564c2229d82ba5326f/f/0001-gdm-Work-around-failing-fingerprint-auth.patch";
       hash = "sha256-mgXty5HhiwUO1UV3/eDgWtauQKM0cRFQ0U7uocST25s=";
     })
+
+    # Fix crash when switching to hands-free mode on a bluetooth headset
+    (fetchpatch {
+      name = "fix-bluetooth-handsfree-crash.patch";
+      url = "https://gitlab.gnome.org/GNOME/libgnome-volume-control/-/merge_requests/31.patch";
+      hash = "sha256-jFbItlXT05nnp825R/HvsWDFxAMzL4z36CsxhQ2sEIY=";
+      stripLen = 1;
+      extraPrefix = "subprojects/gvc/";
+    })
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
Applies https://gitlab.gnome.org/GNOME/libgnome-volume-control/-/merge_requests/31 to all projects that depend on libgnome-volume-control.

Fixes #475202.

Alternative to #482761.

Fixes a crash in GNOME when a user switches to a hands-free bluetooth profile.

Note: All commits are bundled into a single PR to ensure that the behavior is consistent across all packages. Extracting each commit to a different PR could lead users to have some of the packages with the unpatched version and the other packages with the patched version.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
