### PR TITLE
inav-configurator: 5.1.0 -> 9.0.0

### DIFF
--- a/pkgs/by-name/in/inav-configurator/package.nix
+++ b/pkgs/by-name/in/inav-configurator/package.nix
@@ -4,19 +4,19 @@
   fetchurl,
   makeDesktopItem,
   copyDesktopItems,
-  nwjs,
+  electron,
   wrapGAppsHook3,
   gsettings-desktop-schemas,
   gtk3,
+  unzip,
 }:
-
 stdenv.mkDerivation rec {
   pname = "inav-configurator";
-  version = "5.1.0";
+  version = "9.0.0";
 
   src = fetchurl {
-    url = "https://github.com/iNavFlight/inav-configurator/releases/download/${version}/INAV-Configurator_linux64_${version}.tar.gz";
-    sha256 = "sha256-ZvZxQICa5fnJBTx0aW/hqQCuhQW9MkcVa2sOjPYaPXM=";
+    url = "https://github.com/iNavFlight/inav-configurator/releases/download/${version}/INAV-Configurator_linux_x64_${version}.zip";
+    sha256 = "sha256-n56QE0ZJ2slL0WZbnBl2pEgAUoDMuh467gWt+eRwa9c=";
   };
 
   icon = fetchurl {
@@ -27,6 +27,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     copyDesktopItems
     wrapGAppsHook3
+    unzip
   ];
 
   buildInputs = [
@@ -34,17 +35,19 @@ stdenv.mkDerivation rec {
     gtk3
   ];
 
+  unpackCmd = "unzip $src";
+
   installPhase = ''
     runHook preInstall
 
     mkdir -p $out/bin \
-             $out/opt/${pname}
+             $out/opt/inav-configurator
 
-    cp -r inav-configurator $out/opt/inav-configurator/
+    cp -r "." $out/opt/inav-configurator/
     install -m 444 -D $icon $out/share/icons/hicolor/128x128/apps/${pname}.png
 
     chmod +x $out/opt/inav-configurator/inav-configurator
-    makeWrapper ${nwjs}/bin/nw $out/bin/${pname} --add-flags $out/opt/inav-configurator/inav-configurator
+    makeWrapper ${electron}/bin/electron $out/bin/inav-configurator --add-flags $out/opt/inav-configurator/resources/app
 
     runHook postInstall
   '';


### PR DESCRIPTION
Is there a reason why the version is currently at 5.1.0?
If not I would like to update to the current version 9.0.0.

inav-configurator changed from nwjs to electron and they use zip compression instead of tar, so I changed the package accordingly.

I'm relatively new to nix and nixos and I just tested it on my computer by making an inav-configurator.nix file and building it.
But I don't know if this is the right method to do that, so maybe someone should test it properly.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

