### PR TITLE
hdf5_2: init at 2.1.1

### DIFF
--- a/pkgs/by-name/hd/hdf5_2/package.nix
+++ b/pkgs/by-name/hd/hdf5_2/package.nix
@@ -1,0 +1,127 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  removeReferencesTo,
+  libaec,
+  zlib,
+  cppSupport ? true,
+  fortranSupport ? false,
+  gfortran,
+  mpiSupport ? false,
+  mpi,
+  enableShared ? !stdenv.hostPlatform.isStatic,
+  enableStatic ? stdenv.hostPlatform.isStatic,
+  javaSupport ? false,
+  jdk,
+  threadsafe ? false,
+  apiVersion ? null,
+}:
+
+# cpp and mpi options are mutually exclusive
+# "-DALLOW_UNSUPPORTED=ON" could be used to force the build.
+assert !cppSupport || !mpiSupport;
+
+# See https://github.com/HDFGroup/hdf5/blob/develop/CMakeLists.txt
+# for valid versions
+assert lib.elem apiVersion [
+  "v16"
+  "v18"
+  "v110"
+  "v112"
+  "v114"
+  "v200"
+  null
+];
+
+stdenv.mkDerivation (finalAttrs: {
+  version = "2.1.1";
+  pname =
+    "hdf5"
+    + lib.optionalString cppSupport "-cpp"
+    + lib.optionalString fortranSupport "-fortran"
+    + lib.optionalString mpiSupport "-mpi"
+    + lib.optionalString threadsafe "-threadsafe";
+
+  src = fetchFromGitHub {
+    owner = "HDFGroup";
+    repo = "hdf5";
+    rev = "${finalAttrs.version}";
+    hash = "sha256-vhsBjOQgzvz6+RbPrR6rRFBXFGkWJNCFjdzWFbu1/ik=";
+  };
+
+  patches = [ ./reproducible-build.patch ];
+
+  passthru = {
+    inherit
+      cppSupport
+      fortranSupport
+      mpiSupport
+      mpi
+      ;
+  };
+
+  outputs = [
+    "out"
+    "dev"
+    "bin"
+  ];
+
+  nativeBuildInputs = [
+    removeReferencesTo
+    cmake
+  ]
+  ++ lib.optional fortranSupport gfortran;
+
+  buildInputs = [
+    libaec
+    zlib
+  ]
+  ++ lib.optional javaSupport jdk;
+
+  propagatedBuildInputs = lib.optional mpiSupport mpi;
+
+  cmakeFlags = [
+    # (lib.cmakeBool "HDF5_USE_GNU_DIRS" true)
+    (lib.cmakeFeature "HDF5_INSTALL_CMAKE_DIR" "${placeholder "dev"}/lib/cmake")
+    (lib.cmakeFeature "HDF5_INSTALL_INCLUDE_DIR" "${placeholder "dev"}/include")
+    (lib.cmakeBool "BUILD_STATIC_LIBS" enableStatic)
+    (lib.cmakeBool "BUILD_SHARED_LIBS" enableShared)
+    (lib.cmakeBool "HDF5_ENABLE_SZIP_SUPPORT" true)
+    (lib.cmakeBool "HDF5_ENABLE_ZLIB_SUPPORT" true)
+    (lib.cmakeBool "HDF5_ENABLE_SZIP_ENCODING" true)
+    (lib.cmakeBool "HDF5_BUILD_WITH_INSTALL_NAME" stdenv.hostPlatform.isDarwin)
+    (lib.cmakeBool "HDF5_BUILD_CPP_LIB" cppSupport)
+    (lib.cmakeBool "HDF5_ENABLE_FORTRAN" fortranSupport)
+    (lib.cmakeBool "HDF5_ENABLE_PARALLEL" mpiSupport)
+    (lib.cmakeBool "HDF5_BUILD_JAVA" javaSupport)
+    (lib.cmakeBool "HDF5_ENABLE_THREADSAFE" threadsafe)
+    (lib.cmakeBool "HDF5_BUILD_HL_LIB" (!threadsafe)) # high-level API and threadsafe is unsupported
+
+    # broken in nixpkgs since around 1.14.3 -> 1.14.4.3
+    # https://github.com/HDFGroup/hdf5/issues/4208#issuecomment-2098698567
+    (lib.cmakeBool "HDF5_ENABLE_NONSTANDARD_FEATURE_FLOAT16" (
+      with stdenv.hostPlatform; !(isDarwin && isx86_64)
+    ))
+  ]
+  ++ lib.optional (apiVersion != null) (lib.cmakeFeature "HDF5_DEFAULT_API_VERSION" apiVersion);
+
+  postInstall = ''
+    moveToOutput 'bin/' "''${!outputBin}"
+  '';
+
+  meta = {
+    description = "Data model, library, and file format for storing and managing data";
+    longDescription = ''
+      HDF5 supports an unlimited variety of datatypes, and is designed for flexible and efficient
+      I/O and for high volume and complex data. HDF5 is portable and is extensible, allowing
+      applications to evolve in their use of HDF5. The HDF5 Technology suite includes tools and
+      applications for managing, manipulating, viewing, and analyzing data in the HDF5 format.
+    '';
+    license = lib.licenses.bsd3;
+    maintainers = [ lib.maintainers.markuskowa ];
+    homepage = "https://www.hdfgroup.org/HDF5/";
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/hd/hdf5_2/reproducible-build.patch
+++ b/pkgs/by-name/hd/hdf5_2/reproducible-build.patch
@@ -1,0 +1,26 @@
+diff --git a/src/H5build_settings.cmake.c.in b/src/H5build_settings.cmake.c.in
+index abd9737cb6..c46bc65a10 100644
+--- a/src/H5build_settings.cmake.c.in
++++ b/src/H5build_settings.cmake.c.in
+@@ -23,7 +23,7 @@ const char H5build_settings[]=
+     "                   HDF5 Version: @HDF5_PACKAGE_VERSION_STRING@\n"
+     "                  Configured on: @CONFIG_DATE@\n"
+     "                  Configured by: @CMAKE_GENERATOR@\n"
+-    "                    Host system: @CMAKE_HOST_SYSTEM@\n"
++    "                    Host system: \n"
+     "              Uname information: @CMAKE_SYSTEM_NAME@\n"
+     "                       Byte sex: @BYTESEX@\n"
+     "             Installation point: @CMAKE_INSTALL_PREFIX@\n"
+diff --git a/src/libhdf5.settings.in b/src/libhdf5.settings.in
+index e112119328..1bcc3a9c8e 100644
+--- a/src/libhdf5.settings.in
++++ b/src/libhdf5.settings.in
+@@ -6,7 +6,7 @@ General Information:
+                    HDF5 Version: @HDF5_PACKAGE_VERSION_STRING@
+                   Configured on: @CONFIG_DATE@
+                   Configured by: @CMAKE_GENERATOR@
+-                    Host system: @CMAKE_HOST_SYSTEM@
++                    Host system:
+               Uname information: @CMAKE_SYSTEM_NAME@
+                        Byte sex: @BYTESEX@
+              Installation point: @CMAKE_INSTALL_PREFIX@


### PR DESCRIPTION
Init [HDF5's 2.0 release](https://github.com/HDFGroup/hdf5/releases/tag/2.0.0) here as a separate package.
The new release currently breaks large consumers such as gdal and h5py.

I suggest we keep version 2.0 as a separate package until other major consumer packages are compatible.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test


CC @imincik 
