### PR TITLE
ffmpegthumbnailer: 2.2.3 -> 2.3.0

### DIFF
--- a/pkgs/by-name/ff/ffmpegthumbnailer/package.nix
+++ b/pkgs/by-name/ff/ffmpegthumbnailer/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   cmake,
   pkg-config,
   ffmpeg-headless,
@@ -12,22 +11,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "ffmpegthumbnailer";
-  version = "2.2.3";
+  version = "2.3.0";
 
   src = fetchFromGitHub {
     owner = "dirkvdb";
     repo = "ffmpegthumbnailer";
-    tag = finalAttrs.version;
-    hash = "sha256-1hVPtCPwfovCtA6aagViUJkYTCFuiFkOqGEqMHIoZe8=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-h8B12FItvSrYgy6t78A02DL96Az4BxtW8brFKkZLH9o=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "ffmpeg-8-fix.patch";
-      url = "https://github.com/dirkvdb/ffmpegthumbnailer/commit/df789ec326ae0f2c619f91c8f2fc8b5e45b50a70.patch";
-      hash = "sha256-PArrcKuaWWA6/H59MbdC36B57GSvvp5sHz24QLTBZYw=";
-    })
-  ];
 
   nativeBuildInputs = [
     cmake
@@ -40,7 +31,10 @@ stdenv.mkDerivation (finalAttrs: {
     libjpeg
   ];
 
-  cmakeFlags = [ "-DENABLE_THUMBNAILER=ON" ];
+  cmakeFlags = [
+    "-DENABLE_THUMBNAILER=ON"
+    "-DENABLE_AUDIO_THUMBNAILER=ON"
+  ];
 
   # https://github.com/dirkvdb/ffmpegthumbnailer/issues/215
   postPatch = ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[Changelog](https://github.com/dirkvdb/ffmpegthumbnailer/compare/v2.2.3...v2.3.0)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
